### PR TITLE
Fix bottom sheet jitter

### DIFF
--- a/packages/services/src/ui/components/bottomSheet/BottomSheetModal.tsx
+++ b/packages/services/src/ui/components/bottomSheet/BottomSheetModal.tsx
@@ -408,6 +408,12 @@ export const BottomSheetModal = forwardRef<BottomSheetModalRef, BottomSheetModal
               bounces={false}
             >
               <View onLayout={(event) => {
+                if (isPanning) {
+                  // Ignore layout changes while actively dragging to prevent
+                  // jitter from rapid height recalculations
+                  return;
+                }
+
                 const height = event.nativeEvent.layout.height;
                 // Update only if height has meaningfully changed to avoid rapid state updates.
                 // Using a small threshold like 1px.


### PR DESCRIPTION
## Summary
- avoid recalculating content height while dragging the sheet

## Testing
- `npx --yes biome lint packages/services/src/ui/components/bottomSheet/BottomSheetModal.tsx | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6851a3546c90832880158b853c07a4b1