### PR TITLE
Use gorhom bottom sheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3422,6 +3422,45 @@
         "react-native": "*"
       }
     },
+    "node_modules/@gorhom/bottom-sheet": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@gorhom/bottom-sheet/-/bottom-sheet-5.1.6.tgz",
+      "integrity": "sha512-0b5tQj4fTaZAjST1PnkCp0p7d8iRqMezibTcqc8Kkn3N23Vn6upORNTD1fH0bLfwRt6e0WnZ7DjAmq315lrcKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@gorhom/portal": "1.0.14",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-native": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": ">=2.16.1",
+        "react-native-reanimated": ">=3.16.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gorhom/portal": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@gorhom/portal/-/portal-1.0.14.tgz",
+      "integrity": "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A==",
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@hutson/parse-repository-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
@@ -7422,7 +7461,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.73.0.tgz",
       "integrity": "sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==",
       "deprecated": "This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "react-native": "*"
@@ -19869,6 +19908,24 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
@@ -21300,17 +21357,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-native-actions-sheet": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/react-native-actions-sheet/-/react-native-actions-sheet-0.9.7.tgz",
-      "integrity": "sha512-rjUwxUr5dxbdSLDtLDUFAdSlFxpNSpJsbXLhHkBzEBMxEMPUhRT3zqbvKqsPj0JUkjwuRligxrhbIJZkg/6ZDw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": "*",
-        "react-native-gesture-handler": "*",
-        "react-native-safe-area-context": "*"
       }
     },
     "node_modules/react-native-builder-bob": {
@@ -25408,6 +25454,7 @@
       "version": "5.3.10",
       "license": "MIT",
       "dependencies": {
+        "@gorhom/bottom-sheet": "^5.1.6",
         "@react-native-async-storage/async-storage": "^2.1.2",
         "axios": "^1.9.0",
         "expo-font": "^13.3.1",
@@ -25415,7 +25462,6 @@
         "form-data": "^4.0.0",
         "invariant": "^2.2.4",
         "jwt-decode": "^4.0.0",
-        "react-native-actions-sheet": "^0.9.7",
         "react-native-safe-area-context": "^5.4.0",
         "react-test-renderer": "^18.3.1",
         "sonner": "^2.0.4",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -68,6 +68,7 @@
         "bootstrap": "yarn install && yarn example"
     },
     "dependencies": {
+        "@gorhom/bottom-sheet": "^5.1.6",
         "@react-native-async-storage/async-storage": "^2.1.2",
         "axios": "^1.9.0",
         "expo-font": "^13.3.1",
@@ -75,7 +76,6 @@
         "form-data": "^4.0.0",
         "invariant": "^2.2.4",
         "jwt-decode": "^4.0.0",
-        "react-native-actions-sheet": "^0.9.7",
         "react-native-safe-area-context": "^5.4.0",
         "react-test-renderer": "^18.3.1",
         "sonner": "^2.0.4",

--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -434,7 +434,6 @@ const OxyBottomSheet: React.FC<OxyProviderProps> = ({
             snapPoints={snapPoints}
             enablePanDownToClose
             backdropComponent={renderBackdrop}
-            enableInternalToaster={true}
             handleComponent={() => (
                 <Animated.View
                     style={{
@@ -510,6 +509,9 @@ const OxyBottomSheet: React.FC<OxyProviderProps> = ({
                     />
                 </Animated.View>
             </BottomSheetScrollView>
+            <View style={styles.toasterContainer}>
+                <Toaster position="top-center" swipeToDismissDirection="left" offset={15} />
+            </View>
         </BottomSheetModal>
     );
 };

--- a/packages/services/src/ui/components/bottomSheet/index.tsx
+++ b/packages/services/src/ui/components/bottomSheet/index.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 
-// Export our custom bottom sheet components
-// This replaces the @gorhom/bottom-sheet dependency with our own implementation
-export { BottomSheetModal } from './BottomSheetModal';
-export type { BottomSheetModalRef, BottomSheetModalProps } from './BottomSheetModal';
-export { BottomSheetBackdrop } from './BottomSheetBackdrop';
-export type { BottomSheetBackdropProps } from './BottomSheetBackdrop';
-export { BottomSheetModalProvider } from './BottomSheetModalProvider';
-export type { BottomSheetModalProviderProps } from './BottomSheetModalProvider';
-export { BottomSheetView } from './BottomSheetView';
-export type { BottomSheetViewProps } from './BottomSheetView';
-export { BottomSheetScrollView } from './BottomSheetScrollView';
-export type { BottomSheetScrollViewProps } from './BottomSheetScrollView';
+// Re-export bottom sheet components from @gorhom/bottom-sheet
+export {
+  BottomSheetModal,
+  BottomSheetBackdrop,
+  BottomSheetModalProvider,
+  BottomSheetView,
+  BottomSheetScrollView,
+} from '@gorhom/bottom-sheet';
+
+export type {
+  BottomSheetModalProps,
+  BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+export type { BottomSheetModalMethods as BottomSheetModalRef } from '@gorhom/bottom-sheet/lib/typescript/types';


### PR DESCRIPTION
## Summary
- use `@gorhom/bottom-sheet` instead of a custom implementation
- drop `react-native-actions-sheet`
- embed the internal toast component directly inside `OxyProvider`

## Testing
- `npm run test -w @oxyhq/services` *(fails: Missing script "test")*
- `npx tsc -p packages/services/tsconfig.json --noEmit` *(fails: cannot find module '../../lib/sonner', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685240b5b51083289bc5e26b67174754