### PR TITLE
Add user profile endpoints

### DIFF
--- a/packages/services/src/__tests__/ui/screens/AccountSettingsScreen.test.tsx
+++ b/packages/services/src/__tests__/ui/screens/AccountSettingsScreen.test.tsx
@@ -15,10 +15,10 @@ jest.mock('../../../ui/context/OxyContext', () => ({
       avatar: { url: 'https://example.com/avatar.jpg' }
     },
     oxyServices: {
-      updateUser: jest.fn(() => Promise.resolve({ 
-        id: '123', 
-        username: 'testuser', 
-        email: 'test@example.com' 
+      updateProfile: jest.fn(() => Promise.resolve({
+        id: '123',
+        username: 'testuser',
+        email: 'test@example.com'
       }))
     },
     isLoading: false
@@ -31,10 +31,10 @@ jest.mock('../../../ui/components/Avatar', () => 'Avatar');
 
 describe('AccountSettingsScreen', () => {
   const mockOxyServices = {
-    updateUser: jest.fn(() => Promise.resolve({ 
-      id: '123', 
-      username: 'testuser', 
-      email: 'test@example.com' 
+    updateProfile: jest.fn(() => Promise.resolve({
+      id: '123',
+      username: 'testuser',
+      email: 'test@example.com'
     }))
   } as unknown as OxyServices;
 

--- a/packages/services/src/core/index.ts
+++ b/packages/services/src/core/index.ts
@@ -485,6 +485,33 @@ export class OxyServices {
   }
 
   /**
+   * Get the currently authenticated user's profile
+   * @returns User data for the current user
+   */
+  async getCurrentUser(): Promise<User> {
+    try {
+      const res = await this.client.get('/users/me');
+      return res.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
+   * Update the authenticated user's profile
+   * @param updates - Object containing fields to update
+   * @returns Updated user data
+   */
+  async updateProfile(updates: Record<string, any>): Promise<User> {
+    try {
+      const res = await this.client.put('/users/me', updates);
+      return res.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  /**
    * Update user profile (requires auth)
    * @param userId - User ID to update (must match authenticated user or have admin rights)
    * @param updates - Object containing fields to update

--- a/packages/services/src/ui/screens/AccountSettingsScreen.tsx
+++ b/packages/services/src/ui/screens/AccountSettingsScreen.tsx
@@ -107,7 +107,7 @@ const AccountSettingsScreen: React.FC<BaseScreenProps> = ({
                 updates.avatar = { url: avatarUrl };
             }
 
-            await oxyServices.updateUser(user.id, updates);
+            await oxyServices.updateProfile(updates);
             toast.success('Profile updated successfully');
             
             animateSaveButton(1); // Scale back to normal


### PR DESCRIPTION
## Summary
- add `/users/me` endpoints on the API for fetching and updating the current user
- expose `getCurrentUser` and `updateProfile` client methods
- use the new `updateProfile` method in account settings UI
- update tests to mock the new method

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run -w @oxyhq/services typescript` *(fails: cannot find module '../../lib/sonner')*

------
https://chatgpt.com/codex/tasks/task_e_6853d7f5c6dc832895f6bdd8695ccec0