### PR TITLE
Add password visibility toggles

### DIFF
--- a/packages/services/src/ui/screens/SignInScreen.tsx
+++ b/packages/services/src/ui/screens/SignInScreen.tsx
@@ -34,6 +34,7 @@ const SignInScreen: React.FC<BaseScreenProps> = ({
     const [password, setPassword] = useState('');
     const [errorMessage, setErrorMessage] = useState('');
     const [userProfile, setUserProfile] = useState<any>(null);
+    const [showPassword, setShowPassword] = useState(false);
 
     // Multi-step form states
     const [currentStep, setCurrentStep] = useState(0);
@@ -385,9 +386,9 @@ const SignInScreen: React.FC<BaseScreenProps> = ({
                 { transform: [{ scale: inputScaleAnim }] }
             ]}>
                 <View style={[styles.inputWrapper, { borderColor: isInputFocused ? colors.primary : colors.border }]}>
-                    <Ionicons 
-                        name="lock-closed-outline" 
-                        size={20} 
+                    <Ionicons
+                        name="lock-closed-outline"
+                        size={20}
                         color={isInputFocused ? colors.primary : colors.secondaryText}
                         style={styles.inputIcon}
                     />
@@ -399,9 +400,16 @@ const SignInScreen: React.FC<BaseScreenProps> = ({
                         onChangeText={setPassword}
                         onFocus={handleInputFocus}
                         onBlur={handleInputBlur}
-                        secureTextEntry
+                        secureTextEntry={!showPassword}
                         testID="password-input"
                     />
+                    <TouchableOpacity onPress={() => setShowPassword(prev => !prev)} style={styles.passwordToggle}>
+                        <Ionicons
+                            name={showPassword ? 'eye-off' : 'eye'}
+                            size={20}
+                            color={isInputFocused ? colors.primary : colors.secondaryText}
+                        />
+                    </TouchableOpacity>
                 </View>
             </Animated.View>
 
@@ -664,6 +672,10 @@ const styles = StyleSheet.create({
     },
     inputIcon: {
         marginRight: 12,
+    },
+    passwordToggle: {
+        paddingHorizontal: 4,
+        paddingVertical: 4,
     },
     modernInput: {
         flex: 1,

--- a/packages/services/src/ui/screens/SignUpScreen.tsx
+++ b/packages/services/src/ui/screens/SignUpScreen.tsx
@@ -32,6 +32,8 @@ const SignUpScreen: React.FC<BaseScreenProps> = ({
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
 
     // Multi-step form states
@@ -294,18 +296,30 @@ const SignUpScreen: React.FC<BaseScreenProps> = ({
 
             <View style={styles.inputContainer}>
                 <Text style={[styles.label, { color: textColor }]}>Password</Text>
-                <TextInput
-                    style={[
-                        styles.input,
-                        { backgroundColor: inputBackgroundColor, borderColor, color: textColor }
-                    ]}
-                    placeholder="Create a password"
-                    placeholderTextColor={placeholderColor}
-                    value={password}
-                    onChangeText={setPassword}
-                    secureTextEntry
-                    testID="password-input"
-                />
+                <View style={{ position: 'relative' }}>
+                    <TextInput
+                        style={[
+                            styles.input,
+                            { backgroundColor: inputBackgroundColor, borderColor, color: textColor }
+                        ]}
+                        placeholder="Create a password"
+                        placeholderTextColor={placeholderColor}
+                        value={password}
+                        onChangeText={setPassword}
+                        secureTextEntry={!showPassword}
+                        testID="password-input"
+                    />
+                    <TouchableOpacity
+                        onPress={() => setShowPassword(prev => !prev)}
+                        style={styles.passwordToggle}
+                    >
+                        <Ionicons
+                            name={showPassword ? 'eye-off' : 'eye'}
+                            size={20}
+                            color={placeholderColor}
+                        />
+                    </TouchableOpacity>
+                </View>
                 <Text style={[styles.passwordHint, { color: isDarkTheme ? '#AAAAAA' : '#666666' }]}>
                     Password must be at least 8 characters long
                 </Text>
@@ -313,18 +327,30 @@ const SignUpScreen: React.FC<BaseScreenProps> = ({
 
             <View style={styles.inputContainer}>
                 <Text style={[styles.label, { color: textColor }]}>Confirm Password</Text>
-                <TextInput
-                    style={[
-                        styles.input,
-                        { backgroundColor: inputBackgroundColor, borderColor, color: textColor }
-                    ]}
-                    placeholder="Confirm your password"
-                    placeholderTextColor={placeholderColor}
-                    value={confirmPassword}
-                    onChangeText={setConfirmPassword}
-                    secureTextEntry
-                    testID="confirm-password-input"
-                />
+                <View style={{ position: 'relative' }}>
+                    <TextInput
+                        style={[
+                            styles.input,
+                            { backgroundColor: inputBackgroundColor, borderColor, color: textColor }
+                        ]}
+                        placeholder="Confirm your password"
+                        placeholderTextColor={placeholderColor}
+                        value={confirmPassword}
+                        onChangeText={setConfirmPassword}
+                        secureTextEntry={!showConfirmPassword}
+                        testID="confirm-password-input"
+                    />
+                    <TouchableOpacity
+                        onPress={() => setShowConfirmPassword(prev => !prev)}
+                        style={styles.passwordToggle}
+                    >
+                        <Ionicons
+                            name={showConfirmPassword ? 'eye-off' : 'eye'}
+                            size={20}
+                            color={placeholderColor}
+                        />
+                    </TouchableOpacity>
+                </View>
             </View>
 
             <View style={styles.navigationButtons}>
@@ -618,6 +644,12 @@ const styles = StyleSheet.create({
         fontSize: 12,
         marginTop: 4,
         color: '#888',
+    },
+    passwordToggle: {
+        position: 'absolute',
+        right: 16,
+        top: 14,
+        padding: 4,
     },
     progressContainer: {
         flexDirection: 'row',


### PR DESCRIPTION
## Summary
- improve SignInScreen with password visibility toggle
- add show/hide option for password fields on SignUpScreen

## Testing
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6854a37917c88328a141d69cfc1c9086