### PR TITLE
Add password visibility component

### DIFF
--- a/packages/services/src/ui/components/PasswordInput.tsx
+++ b/packages/services/src/ui/components/PasswordInput.tsx
@@ -1,0 +1,57 @@
+import React, { useState, useCallback } from 'react';
+import { View, TextInput, TouchableOpacity, StyleSheet, TextInputProps } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+interface PasswordInputProps extends Omit<TextInputProps, 'secureTextEntry'> {
+    iconColor?: string;
+    containerStyle?: any;
+}
+
+const PasswordInput: React.FC<PasswordInputProps> = React.memo(({
+    value,
+    onChangeText,
+    iconColor = '#888',
+    style,
+    containerStyle,
+    ...rest
+}) => {
+    const [visible, setVisible] = useState(false);
+
+    const toggleVisibility = useCallback(() => {
+        setVisible(v => !v);
+    }, []);
+
+    return (
+        <View style={[styles.container, containerStyle]}>
+            <TextInput
+                {...rest}
+                value={value}
+                onChangeText={onChangeText}
+                secureTextEntry={!visible}
+                style={[styles.input, style]}
+            />
+            <TouchableOpacity onPress={toggleVisibility} style={styles.toggle}>
+                <Ionicons name={visible ? 'eye-off' : 'eye'} size={20} color={iconColor} />
+            </TouchableOpacity>
+        </View>
+    );
+});
+
+const styles = StyleSheet.create({
+    container: {
+        position: 'relative',
+        width: '100%',
+    },
+    input: {
+        paddingRight: 32,
+        flex: 1,
+    },
+    toggle: {
+        position: 'absolute',
+        right: 8,
+        top: 12,
+        padding: 4,
+    },
+});
+
+export default PasswordInput;

--- a/packages/services/src/ui/screens/SignInScreen.tsx
+++ b/packages/services/src/ui/screens/SignInScreen.tsx
@@ -21,6 +21,7 @@ import OxyLogo from '../components/OxyLogo';
 import Avatar from '../components/Avatar';
 import { BottomSheetScrollView } from '../components/bottomSheet';
 import { Ionicons } from '@expo/vector-icons';
+import PasswordInput from '../components/PasswordInput';
 import Svg, { Path, Circle, Defs, LinearGradient, Stop } from 'react-native-svg';
 import { toast } from '../../lib/sonner';
 
@@ -385,13 +386,13 @@ const SignInScreen: React.FC<BaseScreenProps> = ({
                 { transform: [{ scale: inputScaleAnim }] }
             ]}>
                 <View style={[styles.inputWrapper, { borderColor: isInputFocused ? colors.primary : colors.border }]}>
-                    <Ionicons 
-                        name="lock-closed-outline" 
-                        size={20} 
+                    <Ionicons
+                        name="lock-closed-outline"
+                        size={20}
                         color={isInputFocused ? colors.primary : colors.secondaryText}
                         style={styles.inputIcon}
                     />
-                    <TextInput
+                    <PasswordInput
                         style={[styles.modernInput, { color: colors.text }]}
                         placeholder="Enter your password"
                         placeholderTextColor={colors.placeholder}
@@ -399,7 +400,7 @@ const SignInScreen: React.FC<BaseScreenProps> = ({
                         onChangeText={setPassword}
                         onFocus={handleInputFocus}
                         onBlur={handleInputBlur}
-                        secureTextEntry
+                        iconColor={isInputFocused ? colors.primary : colors.secondaryText}
                         testID="password-input"
                     />
                 </View>

--- a/packages/services/src/ui/screens/SignUpScreen.tsx
+++ b/packages/services/src/ui/screens/SignUpScreen.tsx
@@ -18,7 +18,7 @@ import { useOxy } from '../context/OxyContext';
 import { fontFamilies } from '../styles/fonts';
 import OxyLogo from '../components/OxyLogo';
 import { BottomSheetScrollView, BottomSheetView } from '../components/bottomSheet';
-import { Ionicons } from '@expo/vector-icons'; // Add icon import
+import PasswordInput from '../components/PasswordInput';
 import Svg, { Path, Circle } from 'react-native-svg';
 import { toast } from '../../lib/sonner';
 
@@ -294,7 +294,7 @@ const SignUpScreen: React.FC<BaseScreenProps> = ({
 
             <View style={styles.inputContainer}>
                 <Text style={[styles.label, { color: textColor }]}>Password</Text>
-                <TextInput
+                <PasswordInput
                     style={[
                         styles.input,
                         { backgroundColor: inputBackgroundColor, borderColor, color: textColor }
@@ -303,7 +303,7 @@ const SignUpScreen: React.FC<BaseScreenProps> = ({
                     placeholderTextColor={placeholderColor}
                     value={password}
                     onChangeText={setPassword}
-                    secureTextEntry
+                    iconColor={placeholderColor}
                     testID="password-input"
                 />
                 <Text style={[styles.passwordHint, { color: isDarkTheme ? '#AAAAAA' : '#666666' }]}>
@@ -313,7 +313,7 @@ const SignUpScreen: React.FC<BaseScreenProps> = ({
 
             <View style={styles.inputContainer}>
                 <Text style={[styles.label, { color: textColor }]}>Confirm Password</Text>
-                <TextInput
+                <PasswordInput
                     style={[
                         styles.input,
                         { backgroundColor: inputBackgroundColor, borderColor, color: textColor }
@@ -322,7 +322,7 @@ const SignUpScreen: React.FC<BaseScreenProps> = ({
                     placeholderTextColor={placeholderColor}
                     value={confirmPassword}
                     onChangeText={setConfirmPassword}
-                    secureTextEntry
+                    iconColor={placeholderColor}
                     testID="confirm-password-input"
                 />
             </View>


### PR DESCRIPTION
## Summary
- extract password field logic into a memoized `PasswordInput` component
- use `PasswordInput` on sign-in and sign-up screens
- remove redundant toggle state and styles

## Testing
- `npm test` *(fails: missing script)*
- `npm run typescript -w @oxyhq/services` *(fails: tsc missing)*

------
https://chatgpt.com/codex/tasks/task_e_6854a37917c88328a141d69cfc1c9086