### PR TITLE
Add global follow state sync

### DIFF
--- a/packages/services/docs/follow-button-redux.md
+++ b/packages/services/docs/follow-button-redux.md
@@ -7,6 +7,7 @@ The `FollowButton` component now uses Redux for state management, ensuring that 
 - **Synchronized State**: All follow buttons for the same user ID update simultaneously
 - **Global State Management**: Follow status is managed in Redux store
 - **Backend Synchronization**: Uses core services to sync with backend API
+- **Automatic Initial Sync**: When authenticated, each button fetches follow status from the backend on mount
 - **Loading States**: Individual loading states per user
 - **Error Handling**: Proper error handling with toast notifications
 - **Unified Hook**: Single `useFollow` hook handles both single and multiple users
@@ -222,6 +223,10 @@ await oxyServices.unfollowUser(userId);  // Unfollow - returns { success: boolea
 const { fetchStatus } = useFollow(userId);
 await fetchStatus(); // Syncs with backend state
 ```
+
+## Automatic Initial Fetch
+
+Each `FollowButton` dispatches `fetchFollowStatus` on mount when the user is authenticated and the follow state for that ID isn't already in the Redux store. This keeps the button in sync with the backend even when the page first loads.
 
 ## State Structure
 

--- a/packages/services/src/ui/components/FollowButton.tsx
+++ b/packages/services/src/ui/components/FollowButton.tsx
@@ -21,7 +21,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useOxy } from '../context/OxyContext';
 import { fontFamilies } from '../styles/fonts';
 import { toast } from '../../lib/sonner';
-import { toggleFollowUser, setFollowingStatus, clearFollowError } from '../store';
+import {
+  toggleFollowUser,
+  setFollowingStatus,
+  clearFollowError,
+  fetchFollowStatus
+} from '../store';
 import type { RootState, AppDispatch } from '../store';
 
 export interface FollowButtonProps {
@@ -144,6 +149,11 @@ const FollowButton: React.FC<FollowButtonProps> = ({
     error: state.follow.errors[userId]
   }));
 
+  // Whether the follow status has been loaded from the store
+  const isStatusKnown = useSelector((state: RootState) =>
+    Object.prototype.hasOwnProperty.call(state.follow.followingUsers, userId)
+  );
+
   const { isFollowing, isLoading, error } = followState;
 
   // Animation values
@@ -157,6 +167,13 @@ const FollowButton: React.FC<FollowButtonProps> = ({
       dispatch(setFollowingStatus({ userId, isFollowing: initiallyFollowing }));
     }
   }, [userId, initiallyFollowing]); // Removed dispatch and isFollowing to prevent unnecessary runs
+
+  // Fetch latest follow status from backend on mount if authenticated and not already known
+  useEffect(() => {
+    if (userId && !isStatusKnown && isAuthenticated) {
+      dispatch(fetchFollowStatus({ userId, oxyServices }));
+    }
+  }, [userId, oxyServices, isStatusKnown, isAuthenticated]);
 
   // Update the animation value when isFollowing changes
   useEffect(() => {

--- a/packages/services/src/ui/store/index.ts
+++ b/packages/services/src/ui/store/index.ts
@@ -39,7 +39,11 @@ export const fetchFollowStatus = createAsyncThunk(
       const response = await oxyServices.getFollowStatus(userId);
       return { userId, isFollowing: response.isFollowing };
     } catch (error: any) {
-      // If API call fails, return false as default
+      // Ignore authentication errors when user isn't signed in
+      if (error?.status === 401 || error?.message?.includes('Authentication')) {
+        return { userId, isFollowing: false };
+      }
+      // Log other failures and default to not following
       console.warn(`Failed to fetch follow status for user ${userId}:`, error);
       return { userId, isFollowing: false };
     }


### PR DESCRIPTION
## Summary
- fetch follow status on mount in `FollowButton`
- document automatic initial sync in follow-button docs
- avoid API calls when not authenticated

## Testing
- `npm run services:test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68601e6dbdbc83289a529784a5c3e59d