### PR TITLE
fix(auth): FedCM config and auth domain handling

### DIFF
--- a/packages/auth/public/fedcm.json
+++ b/packages/auth/public/fedcm.json
@@ -2,6 +2,7 @@
   "accounts_endpoint": "/api/fedcm/accounts",
   "client_metadata_endpoint": "/api/fedcm/client_metadata",
   "id_assertion_endpoint": "/api/fedcm/assertion",
+  "login_url": "/login",
   "branding": {
     "background_color": "#000000",
     "color": "#ffffff",


### PR DESCRIPTION
1. Add missing login_url to fedcm.json (required by Chrome)

2. Add global lock to prevent concurrent FedCM requests
   - FedCM only allows one navigator.credentials.get at a time
   - Multiple requests cause "Only one request may be outstanding" error

3. Skip FedCM on auth domains (accounts.oxy.so, auth.oxy.so)
   - Can't FedCM authenticate against yourself
   - On auth domain, fall through to local auth flow
   - Web fallback: redirect to /login

4. useAuth improvements for auth domain
   - Detect when on accounts.oxy.so/auth.oxy.so
   - Skip FedCM/popup, use local forms instead
   - Add web fallback redirect to login page

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
