### PR TITLE
fix(auth): only skip FedCM on auth.oxy.so (the IdP)

### DIFF
--- a/packages/services/src/ui/hooks/useAuth.ts
+++ b/packages/services/src/ui/hooks/useAuth.ts
@@ -101,15 +101,13 @@ export function useAuth(): UseAuthReturn {
   } = useOxy();
 
   const signIn = useCallback(async (publicKey?: string): Promise<User> => {
-    // Check if we're on the auth domain itself (accounts.oxy.so, auth.oxy.so)
-    // In this case, skip FedCM/popup and use local auth flow
-    const isAuthDomain = isWebBrowser() &&
-      (window.location.hostname === 'accounts.oxy.so' ||
-       window.location.hostname === 'auth.oxy.so' ||
-       window.location.hostname === 'localhost');
+    // Check if we're on the identity provider itself (auth.oxy.so)
+    // Only auth.oxy.so has local login forms - accounts.oxy.so is a client app
+    const isIdentityProvider = isWebBrowser() &&
+      window.location.hostname === 'auth.oxy.so';
 
-    // Web (not on auth domain): Use FedCM or popup-based authentication
-    if (isWebBrowser() && !publicKey && !isAuthDomain) {
+    // Web (not on IdP): Use FedCM or popup-based authentication
+    if (isWebBrowser() && !publicKey && !isIdentityProvider) {
       try {
         // Try FedCM first (instant if user already signed in)
         if ((oxyServices as any).isFedCMSupported?.()) {

--- a/packages/services/src/ui/hooks/useWebSSO.ts
+++ b/packages/services/src/ui/hooks/useWebSSO.ts
@@ -46,13 +46,13 @@ function isWebBrowser(): boolean {
 }
 
 /**
- * Check if we're on the auth domain (where FedCM would authenticate against itself)
+ * Check if we're on the identity provider domain (where FedCM would authenticate against itself)
+ * Only auth.oxy.so is the IdP - accounts.oxy.so is a client app like any other
  */
-function isAuthDomain(): boolean {
+function isIdentityProvider(): boolean {
   if (!isWebBrowser()) return false;
   const hostname = window.location.hostname;
-  return hostname === 'accounts.oxy.so' ||
-         hostname === 'auth.oxy.so';
+  return hostname === 'auth.oxy.so';
 }
 
 /**
@@ -90,7 +90,7 @@ export function useWebSSO({
     }
 
     // Don't use FedCM on the auth domain itself - it would authenticate against itself
-    if (isAuthDomain()) {
+    if (isIdentityProvider()) {
       onSSOUnavailable?.();
       return null;
     }
@@ -129,8 +129,8 @@ export function useWebSSO({
 
   // Auto-check SSO on mount (web only, FedCM only, not on auth domain)
   useEffect(() => {
-    if (!enabled || !isWebBrowser() || hasCheckedRef.current || isAuthDomain()) {
-      if (isAuthDomain()) {
+    if (!enabled || !isWebBrowser() || hasCheckedRef.current || isIdentityProvider()) {
+      if (isIdentityProvider()) {
         onSSOUnavailable?.();
       }
       return;


### PR DESCRIPTION
accounts.oxy.so is a client app like homiio.com - it should use FedCM. Only auth.oxy.so is the identity provider with local login forms.

- auth.oxy.so → Skip FedCM (has login/signup forms)
- accounts.oxy.so → Use FedCM (client app)
- homiio.com, alia.onl, etc. → Use FedCM (client apps)

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
