### PR TITLE
feat(auth): add Google-style account switcher for OAuth popup flow

### DIFF
--- a/packages/auth/app/auth/callback/page.tsx
+++ b/packages/auth/app/auth/callback/page.tsx
@@ -61,6 +61,9 @@ function AuthCallbackContent() {
         state,
       };
 
+      // Debug logging
+      console.log('[AuthCallback] Params:', { sessionId, accessToken: accessToken ? '[present]' : '[missing]', state, redirectUri, targetOrigin });
+
       if (error) {
         response.error = errorDescription || error;
       } else if (sessionId && accessToken) {
@@ -70,6 +73,7 @@ function AuthCallbackContent() {
           expiresAt: expiresAt || new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
         };
       } else {
+        console.error('[AuthCallback] Missing session data:', { sessionId: !!sessionId, accessToken: !!accessToken });
         response.error = 'No session data received';
       }
 

--- a/packages/auth/components/account-switcher.tsx
+++ b/packages/auth/components/account-switcher.tsx
@@ -2,7 +2,14 @@
 
 import { GalleryVerticalEnd, ChevronRight, UserPlus } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { FieldDescription, FieldGroup } from "@/components/ui/field"
+import { Button } from "@/components/ui/button"
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card"
 
 type Account = {
     id: string
@@ -29,86 +36,76 @@ export function AccountSwitcher({
     isLoading,
     ...props
 }: AccountSwitcherProps) {
-    const avatarUrl =
-        account.avatar ||
-        `https://api.dicebear.com/7.x/avataaars/svg?seed=${account.username || account.id}`
+    const avatarUrl = account.avatar
+        ? `https://api.oxy.so/api/files/${account.avatar}`
+        : `https://api.dicebear.com/7.x/avataaars/svg?seed=${account.username || account.id}`
 
     return (
         <div className={cn("flex flex-col gap-6", className)} {...props}>
-            <FieldGroup>
-                <div className="flex flex-col items-center gap-2 text-center">
-                    <a
-                        href="#"
-                        className="flex flex-col items-center gap-2 font-medium"
-                    >
-                        <div className="flex size-8 items-center justify-center rounded-md">
+            <Card>
+                <CardHeader className="text-center pb-2">
+                    <div className="flex justify-center mb-2">
+                        <div className="flex size-10 items-center justify-center rounded-md bg-primary text-primary-foreground">
                             <GalleryVerticalEnd className="size-6" />
                         </div>
-                        <span className="sr-only">Acme Inc.</span>
-                    </a>
-                    <h1 className="text-xl font-bold">Choose an account</h1>
-                    <FieldDescription>
-                        to continue to the app
-                    </FieldDescription>
-                </div>
-
-                <div className="mt-4 space-y-2">
+                    </div>
+                    <CardTitle className="text-xl">Choose an account</CardTitle>
+                    <CardDescription>to continue to the app</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-2">
                     {/* Current account */}
-                    <button
-                        type="button"
+                    <Button
+                        variant="outline"
+                        className="w-full h-auto p-4 justify-start"
                         onClick={onContinue}
                         disabled={isLoading}
-                        className={cn(
-                            "w-full flex items-center gap-4 p-4 rounded-lg border border-border",
-                            "hover:bg-accent hover:border-accent-foreground/20 transition-colors",
-                            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-                            "disabled:opacity-50 disabled:cursor-not-allowed"
-                        )}
                     >
                         <img
                             src={avatarUrl}
                             alt={account.displayName || "User avatar"}
-                            className="size-10 rounded-full bg-muted"
+                            className="size-10 rounded-full bg-muted shrink-0"
                         />
-                        <div className="flex-1 text-left">
-                            <div className="font-medium">
+                        <div className="flex-1 text-left ml-3 min-w-0">
+                            <div className="font-medium truncate">
                                 {account.displayName || account.username}
                             </div>
                             {account.email && (
-                                <div className="text-sm text-muted-foreground">
+                                <div className="text-sm text-muted-foreground truncate">
                                     {account.email}
                                 </div>
                             )}
                         </div>
-                        <ChevronRight className="size-5 text-muted-foreground" />
-                    </button>
+                        <ChevronRight className="size-5 text-muted-foreground shrink-0" />
+                    </Button>
 
                     {/* Use another account */}
-                    <button
-                        type="button"
+                    <Button
+                        variant="outline"
+                        className="w-full h-auto p-4 justify-start"
                         onClick={onUseAnother}
                         disabled={isLoading}
-                        className={cn(
-                            "w-full flex items-center gap-4 p-4 rounded-lg border border-border",
-                            "hover:bg-accent hover:border-accent-foreground/20 transition-colors",
-                            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
-                            "disabled:opacity-50 disabled:cursor-not-allowed"
-                        )}
                     >
-                        <div className="size-10 rounded-full bg-muted flex items-center justify-center">
+                        <div className="size-10 rounded-full bg-muted flex items-center justify-center shrink-0">
                             <UserPlus className="size-5 text-muted-foreground" />
                         </div>
-                        <div className="flex-1 text-left">
+                        <div className="flex-1 text-left ml-3">
                             <div className="font-medium">Use another account</div>
                         </div>
-                        <ChevronRight className="size-5 text-muted-foreground" />
-                    </button>
-                </div>
-            </FieldGroup>
-            <FieldDescription className="px-6 text-center">
-                By continuing, you agree to our <a href="#">Terms of Service</a>{" "}
-                and <a href="#">Privacy Policy</a>.
-            </FieldDescription>
+                        <ChevronRight className="size-5 text-muted-foreground shrink-0" />
+                    </Button>
+                </CardContent>
+            </Card>
+            <p className="px-6 text-center text-sm text-muted-foreground">
+                By continuing, you agree to our{" "}
+                <a href="#" className="underline underline-offset-4 hover:text-primary">
+                    Terms of Service
+                </a>{" "}
+                and{" "}
+                <a href="#" className="underline underline-offset-4 hover:text-primary">
+                    Privacy Policy
+                </a>
+                .
+            </p>
         </div>
     )
 }

--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -206,6 +206,7 @@ export function LoginForm({
                 setExistingSessionId(null)
                 setShowLoginForm(true)
                 toast.error("Session expired", { description: "Please sign in again" })
+                setIsSubmitting(false)
                 return
             }
 
@@ -218,7 +219,15 @@ export function LoginForm({
                 if (state) {
                     callbackUrl.searchParams.set("state", state)
                 }
-                callbackUrl.searchParams.set("redirect_uri", clientId || window.location.origin)
+                // Use clientId for postMessage origin - this is the client app's origin
+                // If clientId is not set, we can't send postMessage to the right origin
+                if (!clientId) {
+                    console.error("[LoginForm] clientId is not set - cannot determine postMessage target")
+                    toast.error("Configuration error", { description: "Missing client ID" })
+                    setIsSubmitting(false)
+                    return
+                }
+                callbackUrl.searchParams.set("redirect_uri", clientId)
                 window.location.href = callbackUrl.toString()
                 return
             }


### PR DESCRIPTION
Updates the account switcher to use shadcn UI components (Card, Button) for a cleaner, more consistent look. Also adds:

- Better error handling for missing clientId in OAuth flow
- Debug logging in callback page to trace session issues
- Proper avatar URL handling via API files endpoint

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
