### PR TITLE
fix(auth): fetch user data after popup authentication

### DIFF
--- a/packages/services/src/core/mixins/OxyServices.popup.ts
+++ b/packages/services/src/core/mixins/OxyServices.popup.ts
@@ -111,6 +111,25 @@ export function OxyServicesPopupAuthMixin<T extends typeof OxyServicesBase>(Base
         this.httpService.setTokens((session as any).accessToken);
       }
 
+      // Fetch user data using the session ID
+      // The callback page only sends sessionId/accessToken, not user data
+      if (session && session.sessionId && !session.user) {
+        try {
+          const userData = await this.makeRequest<any>(
+            'GET',
+            `/api/session/user/${session.sessionId}`,
+            undefined,
+            { cache: false }
+          );
+          if (userData) {
+            (session as any).user = userData;
+          }
+        } catch (userError) {
+          console.warn('[PopupAuth] Failed to fetch user data:', userError);
+          // Continue without user data - caller can fetch separately
+        }
+      }
+
       return session;
     } catch (error) {
       throw error;


### PR DESCRIPTION
The popup callback only sends sessionId/accessToken, not user data. This fix fetches the user data from the API after receiving the session so that the SessionLoginResponse has the complete user object.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
