### PR TITLE
fix(auth): update React state after popup authentication

### DIFF
--- a/packages/services/src/ui/hooks/useAuth.ts
+++ b/packages/services/src/ui/hooks/useAuth.ts
@@ -91,6 +91,7 @@ export function useAuth(): UseAuthReturn {
     isTokenReady,
     error,
     signIn: oxySignIn,
+    handlePopupSession,
     logout,
     logoutAll,
     refreshSessions,
@@ -115,6 +116,8 @@ export function useAuth(): UseAuthReturn {
       try {
         const popupSession = await (oxyServices as any).signInWithPopup?.();
         if (popupSession?.user) {
+          // Update context state with the session (this updates user, sessions, storage)
+          await handlePopupSession(popupSession);
           return popupSession.user;
         }
         throw new Error('Sign-in failed. Please try again.');
@@ -161,7 +164,7 @@ export function useAuth(): UseAuthReturn {
     }
 
     throw new Error('No authentication method available');
-  }, [oxySignIn, hasIdentity, getPublicKey, showBottomSheet, oxyServices]);
+  }, [oxySignIn, hasIdentity, getPublicKey, showBottomSheet, oxyServices, handlePopupSession]);
 
   const signOut = useCallback(async (): Promise<void> => {
     await logout();


### PR DESCRIPTION
After signInWithPopup returns, the useAuth hook now calls handlePopupSession to update the OxyContext state (user, sessions, storage). This fixes the issue where popup auth completed successfully but the app state didn't update.

The handlePopupSession method:
- Updates the sessions state with the new session
- Sets the active session ID
- Calls loginSuccess to update the auth store
- Persists the session to storage

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
