### PR TITLE
fix(auth): set cookie SameSite=None for FedCM cross-origin requests

### DIFF
--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -134,13 +134,26 @@ export function LoginForm({
                 return
             }
 
-            const cookieParts = [`oxy_session_id=${payload.sessionId}`, "path=/", "samesite=lax"]
+            // Set cookie with SameSite=None for FedCM cross-origin requests
+            // Requires Secure flag, and domain for cross-subdomain access
+            const isSecure = window.location.protocol === "https:"
+            const host = window.location.hostname
+            const cookieDomain = host.endsWith(".oxy.so") || host === "oxy.so" ? ".oxy.so" : undefined
+
+            const cookieParts = [
+                `oxy_session_id=${payload.sessionId}`,
+                "path=/",
+                "samesite=none", // Required for FedCM cross-origin requests
+            ]
             if (payload.expiresAt) {
                 const expiresAt = new Date(payload.expiresAt).toUTCString()
                 cookieParts.push(`expires=${expiresAt}`)
             }
-            if (window.location.protocol === "https:") {
-                cookieParts.push("secure")
+            if (isSecure) {
+                cookieParts.push("secure") // Required for SameSite=None
+            }
+            if (cookieDomain) {
+                cookieParts.push(`domain=${cookieDomain}`)
             }
             document.cookie = cookieParts.join("; ")
 

--- a/packages/auth/components/sign-up-form.tsx
+++ b/packages/auth/components/sign-up-form.tsx
@@ -83,13 +83,26 @@ export function SignUpForm({
                 return
             }
 
-            const cookieParts = [`oxy_session_id=${payload.sessionId}`, "path=/", "samesite=lax"]
+            // Set cookie with SameSite=None for FedCM cross-origin requests
+            // Requires Secure flag, and domain for cross-subdomain access
+            const isSecure = window.location.protocol === "https:"
+            const host = window.location.hostname
+            const cookieDomain = host.endsWith(".oxy.so") || host === "oxy.so" ? ".oxy.so" : undefined
+
+            const cookieParts = [
+                `oxy_session_id=${payload.sessionId}`,
+                "path=/",
+                "samesite=none", // Required for FedCM cross-origin requests
+            ]
             if (payload.expiresAt) {
                 const expiresAt = new Date(payload.expiresAt).toUTCString()
                 cookieParts.push(`expires=${expiresAt}`)
             }
-            if (window.location.protocol === "https:") {
-                cookieParts.push("secure")
+            if (isSecure) {
+                cookieParts.push("secure") // Required for SameSite=None
+            }
+            if (cookieDomain) {
+                cookieParts.push(`domain=${cookieDomain}`)
             }
             document.cookie = cookieParts.join("; ")
 


### PR DESCRIPTION
The session cookie was being set with SameSite=Lax in the client-side login and signup forms, which blocked FedCM's cross-origin requests to the accounts endpoint.

Changed to SameSite=None with Secure flag (required) and proper domain (.oxy.so) for cross-subdomain access. This allows FedCM to read the session when fetching accounts from auth.oxy.so.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
