### PR TITLE
fix(fedcm): move nonce to params object for Chrome 145+

### DIFF
--- a/packages/auth/app/api/fedcm/assertion/route.ts
+++ b/packages/auth/app/api/fedcm/assertion/route.ts
@@ -81,7 +81,9 @@ export async function POST(request: NextRequest) {
   try {
     // Parse request body
     const body = await request.json();
-    const { account_id, client_id, nonce, disclosure_text_shown } = body;
+    const { account_id, client_id, disclosure_text_shown } = body;
+    // nonce can be at top level or in params object (Chrome 145+)
+    const nonce = body.nonce || body.params?.nonce;
 
     if (!account_id || !client_id) {
       return NextResponse.json(

--- a/packages/services/src/core/mixins/OxyServices.fedcm.ts
+++ b/packages/services/src/core/mixins/OxyServices.fedcm.ts
@@ -284,7 +284,10 @@ export function OxyServicesFedCMMixin<T extends typeof OxyServicesBase>(Base: T)
               {
                 configURL: options.configURL,
                 clientId: options.clientId,
-                nonce: options.nonce,
+                // nonce must be in params object (Chrome 145+)
+                params: {
+                  nonce: options.nonce,
+                },
                 ...(options.context && { loginHint: options.context }),
               },
             ],


### PR DESCRIPTION
Chrome 145 requires nonce to be passed within the params object instead of as a top-level parameter. Updated both client-side (requestIdentityCredential) and server-side (assertion endpoint) to handle the new format.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
