### PR TITLE
fix(fedcm): backward compatible nonce handling for all browser versions

### DIFF
--- a/packages/auth/app/api/fedcm/assertion/route.ts
+++ b/packages/auth/app/api/fedcm/assertion/route.ts
@@ -82,8 +82,8 @@ export async function POST(request: NextRequest) {
     // Parse request body
     const body = await request.json();
     const { account_id, client_id, disclosure_text_shown } = body;
-    // nonce can be at top level or in params object (Chrome 145+)
-    const nonce = body.nonce || body.params?.nonce;
+    // Prefer params.nonce (Chrome 145+), fallback to top-level nonce (older browsers)
+    const nonce = body.params?.nonce || body.nonce;
 
     if (!account_id || !client_id) {
       return NextResponse.json(

--- a/packages/services/src/core/mixins/OxyServices.fedcm.ts
+++ b/packages/services/src/core/mixins/OxyServices.fedcm.ts
@@ -284,9 +284,10 @@ export function OxyServicesFedCMMixin<T extends typeof OxyServicesBase>(Base: T)
               {
                 configURL: options.configURL,
                 clientId: options.clientId,
-                // nonce must be in params object (Chrome 145+)
+                // Send nonce at both levels for backward compatibility
+                nonce: options.nonce, // For older browsers
                 params: {
-                  nonce: options.nonce,
+                  nonce: options.nonce, // For Chrome 145+
                 },
                 ...(options.context && { loginHint: options.context }),
               },


### PR DESCRIPTION
- Client: Send nonce at both top-level (older browsers) and params (Chrome 145+)
- Server: Prioritize params.nonce over body.nonce for future-proofing

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
