### PR TITLE
Refactor FedCM endpoints to use proxy pattern and improve CORS handling

### DIFF
--- a/packages/auth/app/api/auth/fedcm/exchange/route.ts
+++ b/packages/auth/app/api/auth/fedcm/exchange/route.ts
@@ -3,10 +3,13 @@
  *
  * Exchanges a FedCM ID token for an Oxy session with access token.
  * This is called by the client app after receiving the ID token from FedCM.
+ *
+ * Note: The main exchange endpoint is at api.oxy.so/api/fedcm/exchange
+ * This endpoint serves as a proxy for auth.oxy.so domain calls.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiGet, apiPost } from '@/lib/oxy-api';
+import { apiPost, getForwardHeaders } from '@/lib/oxy-api';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -25,29 +28,23 @@ interface SessionLoginResponse {
 }
 
 /**
- * Decode ID token (simple base64url decode)
- * In production, verify signature using public key
+ * Get CORS headers for FedCM responses
+ * IMPORTANT: When Access-Control-Allow-Credentials is true,
+ * Access-Control-Allow-Origin CANNOT be '*' - must be specific origin
  */
-function decodeIdToken(token: string): any {
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) {
-      throw new Error('Invalid token format');
-    }
+function getCorsHeaders(request: NextRequest): Record<string, string> {
+  const origin = request.headers.get('origin');
+  const allowOrigin = origin || 'https://oxy.so';
 
-    const payload = parts[1];
-    const decoded = Buffer.from(
-      payload.replace(/-/g, '+').replace(/_/g, '/'),
-      'base64'
-    ).toString('utf-8');
-
-    return JSON.parse(decoded);
-  } catch (error) {
-    throw new Error('Failed to decode ID token');
-  }
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Credentials': 'true',
+  };
 }
 
 export async function POST(request: NextRequest) {
+  const corsHeaders = getCorsHeaders(request);
+
   try {
     const body = await request.json();
     const { id_token } = body;
@@ -55,105 +52,45 @@ export async function POST(request: NextRequest) {
     if (!id_token) {
       return NextResponse.json(
         { error: 'id_token is required' },
-        { status: 400 }
+        { status: 400, headers: corsHeaders }
       );
     }
 
-    // Decode and validate ID token
-    let tokenPayload: any;
-    try {
-      tokenPayload = decodeIdToken(id_token);
-    } catch (error) {
-      return NextResponse.json(
-        { error: 'Invalid ID token' },
-        { status: 401 }
-      );
-    }
-
-    // Validate token
-    if (!tokenPayload.sub || !tokenPayload.aud) {
-      return NextResponse.json(
-        { error: 'Invalid token payload' },
-        { status: 401 }
-      );
-    }
-
-    // Check expiration
-    if (tokenPayload.exp && tokenPayload.exp < Math.floor(Date.now() / 1000)) {
-      return NextResponse.json(
-        { error: 'Token expired' },
-        { status: 401 }
-      );
-    }
-
-    // Verify issuer
-    if (tokenPayload.iss !== 'https://auth.oxy.so') {
-      return NextResponse.json(
-        { error: 'Invalid token issuer' },
-        { status: 401 }
-      );
-    }
-
-    const userId = tokenPayload.sub;
-
-    // Fetch user data
-    const user = await apiGet<any>(`/api/users/${userId}`);
-
-    if (!user) {
-      return NextResponse.json(
-        { error: 'User not found' },
-        { status: 404 }
-      );
-    }
-
-    // Create a new session for this user
-    // Note: In a real implementation, you might want to check for existing sessions
-    // or create a session with the backend directly
-
-    // For now, we'll construct a response with the user data
-    // The client should already have or will create a session via the normal flow
-
-    // Get or create session via the backend
-    // This is a simplified version - you may need to call your actual session creation endpoint
-    const sessionResponse: SessionLoginResponse = {
-      sessionId: '', // Will be filled by backend
-      deviceId: '',
-      expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      user,
-    };
-
-    // Note: In production, you should create an actual session here
-    // For now, return user data and let the client handle session creation
-    // Or integrate with your existing session creation flow
+    // Forward to the main API exchange endpoint which handles signature verification
+    // and session creation properly
+    const sessionResponse = await apiPost<SessionLoginResponse>(
+      '/api/fedcm/exchange',
+      { id_token },
+      { headers: getForwardHeaders(request) }
+    );
 
     return NextResponse.json(sessionResponse, {
       headers: {
         'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': request.headers.get('origin') || '*',
-        'Access-Control-Allow-Credentials': 'true',
+        ...corsHeaders,
       },
     });
   } catch (error) {
     console.error('[FedCM Exchange] Error:', error);
+    const message = error instanceof Error ? error.message : 'Internal server error';
     return NextResponse.json(
-      { error: 'Internal server error' },
+      { error: message },
       {
         status: 500,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': request.headers.get('origin') || '*',
-          'Access-Control-Allow-Credentials': 'true',
-        },
+        headers: corsHeaders,
       }
     );
   }
 }
 
 export async function OPTIONS(request: NextRequest) {
+  const origin = request.headers.get('origin');
+  const allowOrigin = origin || 'https://oxy.so';
+
   return new NextResponse(null, {
     status: 204,
     headers: {
-      'Access-Control-Allow-Origin': request.headers.get('origin') || '*',
+      'Access-Control-Allow-Origin': allowOrigin,
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
       'Access-Control-Allow-Credentials': 'true',

--- a/packages/auth/next.config.ts
+++ b/packages/auth/next.config.ts
@@ -1,7 +1,28 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      {
+        // FedCM manifest - must be accessible cross-origin
+        source: '/fedcm.json',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET, OPTIONS' },
+          { key: 'Content-Type', value: 'application/json' },
+        ],
+      },
+      {
+        // Well-known web-identity file for FedCM discovery
+        source: '/.well-known/web-identity',
+        headers: [
+          { key: 'Access-Control-Allow-Origin', value: '*' },
+          { key: 'Access-Control-Allow-Methods', value: 'GET, OPTIONS' },
+          { key: 'Content-Type', value: 'application/json' },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
This PR refactors the FedCM (Federated Credential Management) endpoints to improve security, maintainability, and CORS compliance. The main changes include:

1. **Exchange endpoint refactoring**: Converts the exchange endpoint from handling token validation locally to acting as a proxy that forwards requests to the main API endpoint (`api.oxy.so/api/fedcm/exchange`), which properly handles signature verification and session creation.

2. **CORS header standardization**: Replaces wildcard CORS origins (`*`) with specific origin handling across all FedCM endpoints. This is critical because FedCM requires `Access-Control-Allow-Credentials: true`, which is incompatible with wildcard origins.

3. **Security improvements**: Adds FedCM request validation using `sec-fetch-dest: webidentity` header checks to prevent CSRF attacks and ensure requests are legitimate FedCM calls.

## Key Changes

- **`exchange/route.ts`**: 
  - Removes local token decoding and validation logic
  - Forwards requests to the main API endpoint via `apiPost`
  - Removes unused `apiGet` import
  - Implements proper CORS header handling with `getCorsHeaders()` helper

- **`accounts/route.ts`**:
  - Adds `getCorsHeaders()` and `createFedCMResponse()` helper functions
  - Adds FedCM request validation via `sec-fetch-dest` header
  - Returns 200 with empty accounts on errors instead of 500 (FedCM interprets 500 as network error)
  - Improves logging and error handling

- **`assertion/route.ts`**:
  - Adds `getCorsHeaders()` helper function
  - Adds FedCM request validation via `sec-fetch-dest` header
  - Standardizes CORS headers across all responses

- **`client_metadata/route.ts`**:
  - Adds `getCorsHeaders()` helper function
  - Adds support for `https://oxy.so` client metadata
  - Standardizes CORS headers

- **`next.config.ts`**:
  - Adds headers configuration for FedCM manifest (`/fedcm.json`)
  - Adds headers configuration for well-known web-identity file (`/.well-known/web-identity`)
  - Both use wildcard CORS origin (appropriate for discovery files)

## Implementation Details

- All FedCM endpoints now use a consistent pattern for CORS header generation
- Origin is extracted from request headers with fallback to `https://oxy.so`
- The exchange endpoint now delegates to the main API, reducing code duplication and ensuring consistent token handling
- FedCM request validation helps prevent misuse of these endpoints
- Error responses maintain proper CORS headers to avoid browser blocking