### PR TITLE
fix(fedcm): add comprehensive logging and missing approved clients

### DIFF
--- a/packages/services/src/core/mixins/OxyServices.fedcm.ts
+++ b/packages/services/src/core/mixins/OxyServices.fedcm.ts
@@ -378,12 +378,37 @@ export function OxyServicesFedCMMixin<T extends typeof OxyServicesBase>(Base: T)
    * @private
    */
   public async exchangeIdTokenForSession(idToken: string): Promise<SessionLoginResponse> {
-    return this.makeRequest<SessionLoginResponse>(
-      'POST',
-      '/api/fedcm/exchange',
-      { id_token: idToken },
-      { cache: false }
-    );
+    console.log('[FedCM] exchangeIdTokenForSession: Starting exchange...');
+    console.log('[FedCM] exchangeIdTokenForSession: Token length:', idToken?.length);
+    console.log('[FedCM] exchangeIdTokenForSession: Token preview:', idToken?.substring(0, 50) + '...');
+
+    try {
+      const response = await this.makeRequest<SessionLoginResponse>(
+        'POST',
+        '/api/fedcm/exchange',
+        { id_token: idToken },
+        { cache: false }
+      );
+
+      console.log('[FedCM] exchangeIdTokenForSession: Response received:', {
+        hasResponse: !!response,
+        hasSessionId: !!(response as any)?.sessionId,
+        hasUser: !!(response as any)?.user,
+        hasAccessToken: !!(response as any)?.accessToken,
+        userId: (response as any)?.user?.id,
+        username: (response as any)?.user?.username,
+        responseKeys: response ? Object.keys(response) : [],
+      });
+
+      return response;
+    } catch (error) {
+      console.error('[FedCM] exchangeIdTokenForSession: Error:', {
+        name: error instanceof Error ? error.name : 'Unknown',
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
- Add oxy.so and accounts.oxy.so to approved FedCM clients list
- Add detailed logging to API exchangeIdToken function:
  - Token length and preview
  - Token verification status
  - Client approval status
  - User lookup status
  - Session creation status
  - Response details
- Add logging to client-side exchangeIdTokenForSession:
  - Token details before exchange
  - Full response details after exchange
  - Error details on failure

This will help debug why FedCM sign-in is not creating sessions.

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/160">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
