### PR TITLE
fix(core): SSO callback never strands on /__oxy/sso-callback — hard-redirect to dest-or-root on non-ok outcomes

### DIFF
--- a/packages/core/src/utils/__tests__/consumeSsoReturn.test.ts
+++ b/packages/core/src/utils/__tests__/consumeSsoReturn.test.ts
@@ -319,8 +319,8 @@ describe('consumeSsoReturn', () => {
     expect(storage.map.get(ssoAttemptedKey(ORIGIN))).toBe('1');
   });
 
-  describe('dest restore', () => {
-    it('restores a same-origin destination when on the callback path, removes the dest key, and dispatches popstate', async () => {
+  describe('ok dest restore (soft replaceState + popstate)', () => {
+    it('restores a same-origin destination when on the callback path, removes the dest key, dispatches popstate, and does NOT hard-redirect', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 's',
@@ -328,6 +328,7 @@ describe('consumeSsoReturn', () => {
       });
       const history = makeHistory();
       const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
 
       const result = await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -338,6 +339,7 @@ describe('consumeSsoReturn', () => {
         }),
         history,
         dispatchPopState,
+        hardRedirect,
       });
 
       expect(result).toEqual(SESSION);
@@ -347,6 +349,8 @@ describe('consumeSsoReturn', () => {
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
       // URL-driven routers must be told the location changed.
       expect(dispatchPopState).toHaveBeenCalledTimes(1);
+      // ok preserves the in-memory session — NEVER a hard navigation.
+      expect(hardRedirect).not.toHaveBeenCalled();
     });
 
     it('restores a relative same-origin destination (new URL(dest, origin))', async () => {
@@ -356,6 +360,7 @@ describe('consumeSsoReturn', () => {
         [ssoDestKey(ORIGIN)]: '/settings?tab=privacy',
       });
       const history = makeHistory();
+      const hardRedirect = jest.fn();
 
       await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -365,20 +370,50 @@ describe('consumeSsoReturn', () => {
           pathname: SSO_CALLBACK_PATH,
         }),
         history,
+        hardRedirect,
       });
 
       const last = history.calls[history.calls.length - 1];
       expect(last?.[2]).toBe('/settings?tab=privacy');
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
+      expect(hardRedirect).not.toHaveBeenCalled();
     });
 
-    it('rejects a cross-origin (attacker-planted) destination but still removes the dest key', async () => {
+    it('falls back to the app root on ok when NO dest is stored (soft replaceState to "/")', async () => {
+      const oxy = okExchange();
+      const storage = makeStorage({ [ssoStateKey(ORIGIN)]: 's' });
+      const history = makeHistory();
+      const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
+
+      const result = await consumeSsoReturn(oxy, {
+        isWeb: () => true,
+        storage,
+        location: makeLocation({
+          hash: '#oxy_sso=ok&code=c&state=s',
+          pathname: SSO_CALLBACK_PATH,
+        }),
+        history,
+        dispatchPopState,
+        hardRedirect,
+      });
+
+      expect(result).toEqual(SESSION);
+      // First replaceState = fragment strip; last = root fallback.
+      const last = history.calls[history.calls.length - 1];
+      expect(last?.[2]).toBe('/');
+      expect(dispatchPopState).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the app root on ok when the stored dest is cross-origin', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 's',
         [ssoDestKey(ORIGIN)]: 'https://evil.example/phish',
       });
       const history = makeHistory();
+      const hardRedirect = jest.fn();
 
       await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -388,14 +423,16 @@ describe('consumeSsoReturn', () => {
           pathname: SSO_CALLBACK_PATH,
         }),
         history,
+        hardRedirect,
       });
 
-      // Only the fragment-strip replaceState should have run — no dest restore.
-      expect(history.calls).toHaveLength(1);
+      const last = history.calls[history.calls.length - 1];
+      expect(last?.[2]).toBe('/');
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
+      expect(hardRedirect).not.toHaveBeenCalled();
     });
 
-    it('rejects a protocol-relative cross-origin destination', async () => {
+    it('falls back to the app root on ok when the stored dest is protocol-relative cross-origin', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 's',
@@ -413,7 +450,8 @@ describe('consumeSsoReturn', () => {
         history,
       });
 
-      expect(history.calls).toHaveLength(1);
+      const last = history.calls[history.calls.length - 1];
+      expect(last?.[2]).toBe('/');
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
     });
 
@@ -424,6 +462,7 @@ describe('consumeSsoReturn', () => {
         [ssoDestKey(ORIGIN)]: `${ORIGIN}/should-not-apply`,
       });
       const history = makeHistory();
+      const hardRedirect = jest.fn();
 
       await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -434,22 +473,24 @@ describe('consumeSsoReturn', () => {
           search: '?a=1',
         }),
         history,
+        hardRedirect,
       });
 
       // Only the fragment strip ran.
       expect(history.calls).toHaveLength(1);
       expect(history.calls[0]?.[2]).toBe('/already-here?a=1');
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
+      expect(hardRedirect).not.toHaveBeenCalled();
     });
+  });
 
-    it('restores dest + dispatches popstate on a "none" outcome (no-stranding regression)', async () => {
+  describe('non-ok hard redirect (never strand on the callback path)', () => {
+    it('hard-redirects to the app root on a "none" outcome with NO dest stored', async () => {
       const oxy = okExchange();
-      const storage = makeStorage({
-        [ssoStateKey(ORIGIN)]: 's',
-        [ssoDestKey(ORIGIN)]: `${ORIGIN}/explore?x=1#sec`,
-      });
+      const storage = makeStorage({ [ssoStateKey(ORIGIN)]: 's' });
       const history = makeHistory();
       const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
 
       const result = await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -460,28 +501,60 @@ describe('consumeSsoReturn', () => {
         }),
         history,
         dispatchPopState,
+        hardRedirect,
       });
 
       expect(result).toBeNull();
       expect(oxy.exchangeSsoCode).not.toHaveBeenCalled();
-      // Last replaceState targets the captured dest — the user is returned.
-      const last = history.calls[history.calls.length - 1];
-      expect(last?.[2]).toBe('/explore?x=1#sec');
-      expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
-      expect(dispatchPopState).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledWith(`${ORIGIN}/`);
+      // Soft restore is NOT used on a non-ok outcome.
+      expect(dispatchPopState).not.toHaveBeenCalled();
       // Loop-breaker flags must still be set.
       expect(storage.map.get(ssoNoSessionKey(ORIGIN))).toBe('1');
       expect(storage.map.get(ssoAttemptedKey(ORIGIN))).toBe('1');
     });
 
-    it('restores dest + dispatches popstate on an "error" outcome', async () => {
+    it('hard-redirects to a same-origin dest on a "none" outcome', async () => {
+      const oxy = okExchange();
+      const storage = makeStorage({
+        [ssoStateKey(ORIGIN)]: 's',
+        [ssoDestKey(ORIGIN)]: `${ORIGIN}/explore?x=1#sec`,
+      });
+      const history = makeHistory();
+      const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
+
+      const result = await consumeSsoReturn(oxy, {
+        isWeb: () => true,
+        storage,
+        location: makeLocation({
+          hash: '#oxy_sso=none&state=s',
+          pathname: SSO_CALLBACK_PATH,
+        }),
+        history,
+        dispatchPopState,
+        hardRedirect,
+      });
+
+      expect(result).toBeNull();
+      expect(oxy.exchangeSsoCode).not.toHaveBeenCalled();
+      expect(hardRedirect).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledWith(`${ORIGIN}/explore?x=1#sec`);
+      expect(dispatchPopState).not.toHaveBeenCalled();
+      expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
+      expect(storage.map.get(ssoNoSessionKey(ORIGIN))).toBe('1');
+      expect(storage.map.get(ssoAttemptedKey(ORIGIN))).toBe('1');
+    });
+
+    it('hard-redirects to a same-origin dest on an "error" outcome', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 's',
         [ssoDestKey(ORIGIN)]: `${ORIGIN}/feed`,
       });
       const history = makeHistory();
-      const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
 
       const result = await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -491,26 +564,25 @@ describe('consumeSsoReturn', () => {
           pathname: SSO_CALLBACK_PATH,
         }),
         history,
-        dispatchPopState,
+        hardRedirect,
       });
 
       expect(result).toBeNull();
-      const last = history.calls[history.calls.length - 1];
-      expect(last?.[2]).toBe('/feed');
+      expect(hardRedirect).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledWith(`${ORIGIN}/feed`);
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
-      expect(dispatchPopState).toHaveBeenCalledTimes(1);
       expect(storage.map.get(ssoNoSessionKey(ORIGIN))).toBe('1');
       expect(storage.map.get(ssoAttemptedKey(ORIGIN))).toBe('1');
     });
 
-    it('restores dest + dispatches popstate on a state mismatch', async () => {
+    it('hard-redirects to the dest on a state mismatch (CSRF)', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 'expected',
         [ssoDestKey(ORIGIN)]: `${ORIGIN}/notifications`,
       });
       const history = makeHistory();
-      const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
 
       const result = await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -520,19 +592,100 @@ describe('consumeSsoReturn', () => {
           pathname: SSO_CALLBACK_PATH,
         }),
         history,
-        dispatchPopState,
+        hardRedirect,
       });
 
       expect(result).toBeNull();
       expect(oxy.exchangeSsoCode).not.toHaveBeenCalled();
-      const last = history.calls[history.calls.length - 1];
-      expect(last?.[2]).toBe('/notifications');
+      expect(hardRedirect).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledWith(`${ORIGIN}/notifications`);
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
-      expect(dispatchPopState).toHaveBeenCalledTimes(1);
       expect(storage.map.get(ssoNoSessionKey(ORIGIN))).toBe('1');
     });
 
-    it('does NOT restore dest on a "none" outcome when not on the callback path', async () => {
+    it('hard-redirects to the app root when ok carries a code but the exchange fails', async () => {
+      const boom = new Error('exchange failed');
+      const oxy = {
+        exchangeSsoCode: jest.fn(async () => {
+          throw boom;
+        }),
+      };
+      const storage = makeStorage({ [ssoStateKey(ORIGIN)]: 's' });
+      const history = makeHistory();
+      const hardRedirect = jest.fn();
+      const onExchangeError = jest.fn();
+
+      const result = await consumeSsoReturn(oxy, {
+        isWeb: () => true,
+        storage,
+        location: makeLocation({
+          hash: '#oxy_sso=ok&code=c&state=s',
+          pathname: SSO_CALLBACK_PATH,
+        }),
+        history,
+        hardRedirect,
+        onExchangeError,
+      });
+
+      expect(result).toBeNull();
+      expect(onExchangeError).toHaveBeenCalledWith(boom);
+      expect(hardRedirect).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledWith(`${ORIGIN}/`);
+      expect(storage.map.get(ssoNoSessionKey(ORIGIN))).toBe('1');
+    });
+
+    it('hard-redirects to the app root when ok carries a code but the exchange returns no sessionId', async () => {
+      const oxy = {
+        exchangeSsoCode: jest.fn(async () => ({ sessionId: '' }) as SessionLoginResponse),
+      };
+      const storage = makeStorage({ [ssoStateKey(ORIGIN)]: 's' });
+      const history = makeHistory();
+      const hardRedirect = jest.fn();
+
+      const result = await consumeSsoReturn(oxy, {
+        isWeb: () => true,
+        storage,
+        location: makeLocation({
+          hash: '#oxy_sso=ok&code=c&state=s',
+          pathname: SSO_CALLBACK_PATH,
+        }),
+        history,
+        hardRedirect,
+      });
+
+      expect(result).toBeNull();
+      expect(hardRedirect).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledWith(`${ORIGIN}/`);
+    });
+
+    it('falls back to the app root on a "none" outcome when the dest is cross-origin', async () => {
+      const oxy = okExchange();
+      const storage = makeStorage({
+        [ssoStateKey(ORIGIN)]: 's',
+        [ssoDestKey(ORIGIN)]: 'https://evil.example/phish',
+      });
+      const history = makeHistory();
+      const hardRedirect = jest.fn();
+
+      const result = await consumeSsoReturn(oxy, {
+        isWeb: () => true,
+        storage,
+        location: makeLocation({
+          hash: '#oxy_sso=none&state=s',
+          pathname: SSO_CALLBACK_PATH,
+        }),
+        history,
+        hardRedirect,
+      });
+
+      expect(result).toBeNull();
+      // Never honour the cross-origin dest — fall back to the same-origin root.
+      expect(hardRedirect).toHaveBeenCalledTimes(1);
+      expect(hardRedirect).toHaveBeenCalledWith(`${ORIGIN}/`);
+      expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
+    });
+
+    it('does NOT hard-redirect on a "none" outcome when NOT on the callback path', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 's',
@@ -540,6 +693,7 @@ describe('consumeSsoReturn', () => {
       });
       const history = makeHistory();
       const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
 
       const result = await consumeSsoReturn(oxy, {
         isWeb: () => true,
@@ -551,46 +705,52 @@ describe('consumeSsoReturn', () => {
         }),
         history,
         dispatchPopState,
+        hardRedirect,
       });
 
       expect(result).toBeNull();
-      // Only the fragment strip ran — no dest restore off the callback path.
+      // Only the fragment strip ran — no navigation off the callback path.
       expect(history.calls).toHaveLength(1);
       expect(history.calls[0]?.[2]).toBe('/explore?a=1');
       expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
+      expect(hardRedirect).not.toHaveBeenCalled();
       expect(dispatchPopState).not.toHaveBeenCalled();
     });
 
-    it('rejects a cross-origin dest on a "none" outcome and does NOT dispatch popstate', async () => {
+    it('does NOT hard-redirect on an "ok" outcome when NOT on the callback path', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 's',
-        [ssoDestKey(ORIGIN)]: 'https://evil.example/phish',
+        [ssoDestKey(ORIGIN)]: `${ORIGIN}/should-not-apply`,
       });
       const history = makeHistory();
       const dispatchPopState = jest.fn();
+      const hardRedirect = jest.fn();
 
       const result = await consumeSsoReturn(oxy, {
         isWeb: () => true,
         storage,
         location: makeLocation({
-          hash: '#oxy_sso=none&state=s',
-          pathname: SSO_CALLBACK_PATH,
+          hash: '#oxy_sso=ok&code=c&state=s',
+          pathname: '/feed',
+          search: '?tab=home',
         }),
         history,
         dispatchPopState,
+        hardRedirect,
       });
 
-      expect(result).toBeNull();
-      // Only the fragment-strip replaceState ran — the cross-origin dest is rejected.
+      expect(result).toEqual(SESSION);
+      // Only the fragment strip ran — no navigation off the callback path.
       expect(history.calls).toHaveLength(1);
-      expect(storage.map.has(ssoDestKey(ORIGIN))).toBe(false);
+      expect(history.calls[0]?.[2]).toBe('/feed?tab=home');
+      expect(hardRedirect).not.toHaveBeenCalled();
       expect(dispatchPopState).not.toHaveBeenCalled();
     });
   });
 
   describe('default dispatchPopState (jsdom)', () => {
-    it('fires a real popstate listener after a "none" dest restore on the callback path', async () => {
+    it('fires a real popstate listener after an "ok" dest restore on the callback path', async () => {
       const oxy = okExchange();
       const storage = makeStorage({
         [ssoStateKey(ORIGIN)]: 's',
@@ -605,20 +765,52 @@ describe('consumeSsoReturn', () => {
           isWeb: () => true,
           storage,
           location: makeLocation({
-            hash: '#oxy_sso=none&state=s',
+            hash: '#oxy_sso=ok&code=c&state=s',
             pathname: SSO_CALLBACK_PATH,
           }),
           history,
           // No injected dispatchPopState — exercise the real default.
         });
 
-        expect(result).toBeNull();
+        expect(result).toEqual(SESSION);
         const last = history.calls[history.calls.length - 1];
         expect(last?.[2]).toBe('/dashboard?tab=home');
         expect(onPopState).toHaveBeenCalledTimes(1);
       } finally {
         window.removeEventListener('popstate', onPopState);
       }
+    });
+  });
+
+  describe('default hardRedirect (feature-detected, never throws)', () => {
+    it('stays total (resolves null, sets loop-breaker flags) on a non-ok outcome with the real default seam', async () => {
+      const oxy = okExchange();
+      const storage = makeStorage({
+        [ssoStateKey(ORIGIN)]: 's',
+        [ssoDestKey(ORIGIN)]: '/dashboard',
+      });
+      const history = makeHistory();
+
+      // No injected `hardRedirect` — exercise the real default, which reads the
+      // jsdom `window.location.replace`. jsdom routes the resulting navigation
+      // to its virtual console (a "Not implemented" notice) and does NOT throw,
+      // so the function must remain total: resolve null and set the loop-breaker
+      // flags. (The injected-`hardRedirect` suite above asserts the precise
+      // target argument deterministically.)
+      await expect(
+        consumeSsoReturn(oxy, {
+          isWeb: () => true,
+          storage,
+          location: makeLocation({
+            hash: '#oxy_sso=none&state=s',
+            pathname: SSO_CALLBACK_PATH,
+          }),
+          history,
+        }),
+      ).resolves.toBeNull();
+
+      expect(storage.map.get(ssoNoSessionKey(ORIGIN))).toBe('1');
+      expect(storage.map.get(ssoAttemptedKey(ORIGIN))).toBe('1');
     });
   });
 });

--- a/packages/core/src/utils/ssoReturn.ts
+++ b/packages/core/src/utils/ssoReturn.ts
@@ -135,9 +135,22 @@ export interface ConsumeSsoReturnDeps {
    * location changed via `history.replaceState`, which does NOT itself emit
    * `popstate`. Default: dispatch a real `PopStateEvent` on `window` when
    * present; no-op off-web. Called ONLY after a successful same-origin
-   * dest restore (never when the dest is rejected/absent). NEVER throws.
+   * dest restore on the `ok` path (never when the dest is rejected/absent).
+   * NEVER throws.
    */
   dispatchPopState?: () => void;
+  /**
+   * Hard, full-document navigation used to leave the internal callback path on
+   * every NON-`ok` outcome (`none`/`error`, state-mismatch, missing code,
+   * failed exchange, missing sessionId). A SOFT `history.replaceState` +
+   * synthetic `popstate` does NOT reliably make Expo Router / TanStack Router
+   * re-resolve away from the 404 they have already rendered for the
+   * unregistered callback route — so for these outcomes (where there is no
+   * in-memory session to preserve) a full navigation is both safe and
+   * guaranteed to clear the 404. Default: `window.location.replace(url)` when
+   * present; feature-detected end to end so it never throws off-web.
+   */
+  hardRedirect?: (url: string) => void;
 }
 
 /**
@@ -164,14 +177,22 @@ export interface ConsumeSsoReturnDeps {
  *     treated exactly like "no session" (never loops, never rethrows).
  *   - On EVERY consumed outcome (ok, none, error, state-mismatch, no-code,
  *     failed-exchange, no-sessionId) — not just ok — if the page landed on
- *     {@link SSO_CALLBACK_PATH}, the real pre-bounce destination is restored
- *     from the DEST key so the user is never stranded on the internal callback
- *     path. Same-origin only (an attacker-planted cross-origin or relative-evil
- *     dest is rejected). The DEST key is removed unconditionally.
- *   - After a same-origin dest restore (which uses `history.replaceState`, that
- *     does NOT itself emit `popstate`), a synthetic `popstate` is dispatched so
- *     URL-driven routers (Expo Router / React Navigation web) re-sync to the
- *     restored route. It is NOT dispatched when the dest is rejected/absent.
+ *     {@link SSO_CALLBACK_PATH}, the user is taken to a same-origin TARGET so
+ *     they are never stranded on the internal callback path (which is an
+ *     unregistered route in every consumer router → a hard 404). The target is
+ *     the stored DEST when it parses as same-origin (an attacker-planted
+ *     cross-origin / protocol-relative dest is rejected), ELSE the app root
+ *     (`origin + '/'`). The DEST key is removed unconditionally.
+ *   - For the `ok` outcome the target is applied via a SOFT
+ *     `history.replaceState` + synthetic `popstate` so the freshly exchanged
+ *     in-memory session the provider is about to commit is preserved (no
+ *     reload). `popstate` is dispatched only on the `ok` same-origin restore.
+ *   - For every NON-`ok` outcome there is no in-memory session to preserve, and
+ *     the consumer router has ALREADY synchronously rendered its 404 for the
+ *     unregistered callback route — a soft replaceState+popstate does not
+ *     reliably make it re-resolve. So these outcomes perform a HARD
+ *     full-document navigation to the target (`hardRedirect`), which is both
+ *     safe (nothing to lose) and guaranteed to clear the 404 in every router.
  *
  * Total: this function NEVER throws. Off-web it is a no-op returning `null`.
  *
@@ -214,6 +235,21 @@ export async function consumeSsoReturn(
       }
     });
 
+  // Default: a hard, full-document navigation used to leave the callback path
+  // on non-`ok` outcomes. Feature-detected end to end so it never throws in any
+  // environment (SSR / native / a stubbed location without `replace`).
+  const hardRedirect =
+    deps.hardRedirect ??
+    ((url: string) => {
+      if (
+        typeof window !== 'undefined' &&
+        window.location &&
+        typeof window.location.replace === 'function'
+      ) {
+        window.location.replace(url);
+      }
+    });
+
   const ret = parseSsoReturnFragment(location.hash);
   if (!ret) {
     // Not an oxy_sso fragment — nothing to do (do NOT touch any flags).
@@ -241,39 +277,56 @@ export async function consumeSsoReturn(
     storage.setItem(ssoAttemptedKey(origin), '1');
   };
 
-  // Restore the user's real pre-bounce destination so they are never stranded
-  // on the internal callback path — invoked on EVERY consumed outcome, not just
-  // success. Same-origin only — never honour a cross-origin/protocol-relative
-  // dest that could have been planted to redirect the user. The DEST key is
-  // removed unconditionally. After a successful same-origin restore a synthetic
-  // `popstate` is dispatched so URL-driven routers re-sync.
-  const restoreDest = (): void => {
-    if (location.pathname === SSO_CALLBACK_PATH) {
-      const dest = storage.getItem(ssoDestKey(origin));
-      if (dest) {
-        try {
-          const destUrl = new URL(dest, origin);
-          if (destUrl.origin === origin) {
-            history.replaceState(
-              null,
-              '',
-              destUrl.pathname + destUrl.search + destUrl.hash,
-            );
-            dispatchPopState();
-          }
-        } catch {
-          // Malformed stored destination — leave the URL on the callback path.
+  // Compute the same-origin TARGET to leave the callback path for. Returns the
+  // stored DEST when present AND it parses as same-origin (never honour a
+  // cross-origin / protocol-relative dest that could have been planted to
+  // redirect the user), ELSE the app root (`origin + '/'`) so the user is never
+  // stranded on the internal callback path even when no dest was stored. The
+  // DEST key is removed unconditionally. Returns the relative path+search+hash
+  // (so it can be fed to either `history.replaceState` or a `hardRedirect`),
+  // or `null` when the page is not on the callback path (nothing to leave).
+  const consumeCallbackTarget = (): string | null => {
+    if (location.pathname !== SSO_CALLBACK_PATH) {
+      // Not on the callback path — still drop the dest key (consumed) but there
+      // is nothing to navigate away from.
+      storage.removeItem(ssoDestKey(origin));
+      return null;
+    }
+    const dest = storage.getItem(ssoDestKey(origin));
+    storage.removeItem(ssoDestKey(origin));
+    if (dest) {
+      try {
+        const destUrl = new URL(dest, origin);
+        if (destUrl.origin === origin) {
+          return destUrl.pathname + destUrl.search + destUrl.hash;
         }
+      } catch {
+        // Malformed stored destination — fall through to the app-root fallback.
       }
     }
-    storage.removeItem(ssoDestKey(origin));
+    // No dest, a cross-origin/protocol-relative dest, or an unparseable dest:
+    // fall back to the app root so the router always leaves the 404.
+    return '/';
+  };
+
+  // Non-`ok` outcomes: there is no in-memory session to preserve, and the
+  // consumer router has already rendered its 404 for the unregistered callback
+  // route — a soft replaceState+popstate does not reliably make it re-resolve.
+  // Perform a HARD full-document navigation to the target (safe: nothing to
+  // lose; guaranteed: every router leaves the 404). Off the callback path this
+  // is a no-op (target is null).
+  const leaveCallbackHard = (): void => {
+    const target = consumeCallbackTarget();
+    if (target !== null) {
+      hardRedirect(origin + target);
+    }
   };
 
   if (ret.kind === 'none' || ret.kind === 'error') {
     // The central IdP had no session (or the bounce failed). Record it so we do
     // not bounce again this tab — the definitive loop breaker.
     markNoSession();
-    restoreDest();
+    leaveCallbackHard();
     return null;
   }
 
@@ -281,7 +334,7 @@ export async function consumeSsoReturn(
     // Forged / replayed / stale fragment, or a malformed ok with no code. Treat
     // exactly like "no session": never exchange, never loop.
     markNoSession();
-    restoreDest();
+    leaveCallbackHard();
     return null;
   }
 
@@ -291,17 +344,25 @@ export async function consumeSsoReturn(
   } catch (error) {
     onExchangeError?.(error);
     markNoSession();
-    restoreDest();
+    leaveCallbackHard();
     return null;
   }
 
   if (!session?.sessionId) {
     markNoSession();
-    restoreDest();
+    leaveCallbackHard();
     return null;
   }
 
-  restoreDest();
+  // `ok`: the provider is about to commit the freshly exchanged in-memory
+  // session — do NOT hard-redirect (a full navigation would discard it). Use a
+  // SOFT `history.replaceState` to the target + a synthetic `popstate` so
+  // URL-driven routers re-sync to the restored route without a reload.
+  const target = consumeCallbackTarget();
+  if (target !== null) {
+    history.replaceState(null, '', target);
+    dispatchPopState();
+  }
 
   return session;
 }


### PR DESCRIPTION
## Problem

Signed-out visitors to any Oxy app (accounts.oxy.so, console.oxy.so, …) landed on `/__oxy/sso-callback#oxy_sso=none&state=…` and saw the app router's "Unmatched Route / Page could not be found" 404.

`consumeSsoReturn`'s `restoreDest()` stranded the user on the callback path:
- It used a SOFT `history.replaceState` + synthetic `popstate` to restore the pre-bounce dest. expo-router (accounts) / TanStack-router (console) have ALREADY synchronously rendered their 404 for the unregistered `/__oxy/sso-callback` route, and the soft replaceState+popstate does NOT reliably make them re-resolve → the 404 persisted.
- When NO dest was stored, it did nothing → the URL stayed on `/__oxy/sso-callback` forever → permanent 404.

## Fix (in `packages/core/src/utils/ssoReturn.ts`)

- New injectable `hardRedirect?: (url: string) => void` on `ConsumeSsoReturnDeps`. Default: feature-detected `window.location.replace(url)`, never throws off-web.
- Whenever `location.pathname === SSO_CALLBACK_PATH`, a same-origin **target** is ALWAYS computed: the stored same-origin dest, ELSE `origin + '/'` (app root). The dest key is removed unconditionally. Cross-origin / protocol-relative / malformed dests are never honoured.
- **Non-`ok` outcomes** (`none`/`error`, state-mismatch, missing code, failed exchange, missing sessionId): perform a HARD redirect to the target. No in-memory session to preserve → a full navigation is safe and guarantees EVERY router leaves the 404.
- **`ok` outcome**: unchanged SOFT restore (`history.replaceState(target)` + `dispatchPopState()`) so the provider commits the freshly exchanged in-memory session without a reload — now also leaves the callback path when no dest was stored (root fallback).
- Off the callback path: no navigation (unchanged).

All existing security/loop invariants preserved: fragment stripped first, CSRF state check, NO_SESSION/attempted flags, exchange try/catch totality, off-web no-op, function stays TOTAL.

## Consumers

No consumer changes needed — `WebOxyProvider` (`@oxyhq/auth`) and `OxyContext` (`@oxyhq/services`) only inject `isWeb`/`onExchangeError` and rely on the new default `hardRedirect`.

## Tests

`packages/core/src/utils/__tests__/consumeSsoReturn.test.ts`: 29 cases (none/error/state-mismatch/missing-code/failed-exchange/no-sessionId hard-redirect to dest-or-root; ok soft-restore + no hard-redirect; not-on-callback-path no-op; cross-origin/malformed → root fallback; default seam totality). Full core suite: **316 passed / 23 suites**.

Builds: core ✓, auth ✓, services ✓.

No version bump / publish (in-repo apps consume via workspace; external republish is a separate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->