### PR TITLE
chore: bump @oxyhq/bloom to ^0.9.1 across consumer apps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@expo/metro-runtime": "~56.0.11",
         "@fontsource-variable/phudu": "^5.2.10",
-        "@oxyhq/bloom": "^0.8.5",
+        "@oxyhq/bloom": "^0.9.1",
         "expo-contacts": "~56.0.9",
         "expo-splash-screen": "~56.0.10",
         "is-arrayish": "^0.3.2",
@@ -28,7 +28,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@lottiefiles/dotlottie-react": "^0.13.5",
-        "@oxyhq/bloom": "^0.8.5",
+        "@oxyhq/bloom": "^0.9.1",
         "@oxyhq/core": "*",
         "@oxyhq/services": "*",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -178,7 +178,7 @@
         "@hono/node-server": "^1.14.3",
         "@hugeicons/core-free-icons": "^3.1.1",
         "@hugeicons/react": "^1.1.4",
-        "@oxyhq/bloom": "^0.8.5",
+        "@oxyhq/bloom": "^0.9.1",
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "workspace:*",
         "@radix-ui/react-alert-dialog": "1.1.4",
@@ -254,7 +254,7 @@
         "@hugeicons/core-free-icons": "^3.1.1",
         "@hugeicons/react": "^1.1.4",
         "@oxyhq/auth": "*",
-        "@oxyhq/bloom": "^0.8.5",
+        "@oxyhq/bloom": "^0.9.1",
         "@oxyhq/core": "*",
         "@tailwindcss/vite": "^4.0.6",
         "@tanstack/react-query": "^5.100",
@@ -359,7 +359,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@lottiefiles/dotlottie-react": "^0.13.5",
         "@lottiefiles/dotlottie-react-native": "^0.7.1",
-        "@oxyhq/bloom": "^0.8.5",
+        "@oxyhq/bloom": "^0.9.1",
         "@oxyhq/core": "*",
         "@oxyhq/services": "*",
         "@radix-ui/react-dropdown-menu": "^2.1.6",
@@ -544,7 +544,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.1.6",
         "@lottiefiles/dotlottie-react": "^0.13.5",
-        "@oxyhq/bloom": "^0.8.5",
+        "@oxyhq/bloom": "^0.9.1",
         "@oxyhq/services": "*",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native/virtualized-lists": "0.83.2",
@@ -596,7 +596,7 @@
     },
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.8.5",
+    "@oxyhq/bloom": "^0.9.1",
     "@radix-ui/react-slot": "1.2.3",
     "ioredis": "5.11.1",
     "react": "19.2.3",
@@ -1418,7 +1418,7 @@
 
     "@oxyhq/auth": ["@oxyhq/auth@workspace:packages/auth-sdk"],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.8.5", "", { "dependencies": { "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-router", "react-dom", "react-native-gesture-handler", "react-native-reanimated", "react-native-svg", "sonner", "sonner-native"] }, "sha512-2j4Lg7vtc5r7yyTR214iv2lJ35IqwVn313K5RU6RfrJ7oWVSAKbeQNFKFtHdcu1JJJyXGrCpnxZB7Wjn00xWFw=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.9.1", "", { "dependencies": { "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-router": ">=3.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-router", "react-dom", "react-native-gesture-handler", "react-native-reanimated", "react-native-svg", "sonner", "sonner-native"] }, "sha512-RxWZGhqFl6bkv6rQ6J2BYNDH5kf5BN2zetqNCqUiZbfmN1OGM2OBhtFHK6fbODb7xoE0x/8UvxRg8dxYg4ThSg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@workspace:packages/contracts"],
 

--- a/package.json
+++ b/package.json
@@ -71,12 +71,12 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "@radix-ui/react-slot": "1.2.3",
-    "@oxyhq/bloom": "^0.8.5"
+    "@oxyhq/bloom": "^0.9.1"
   },
   "dependencies": {
     "@expo/metro-runtime": "~56.0.11",
     "@fontsource-variable/phudu": "^5.2.10",
-    "@oxyhq/bloom": "^0.8.5",
+    "@oxyhq/bloom": "^0.9.1",
     "expo-contacts": "~56.0.9",
     "expo-splash-screen": "~56.0.10",
     "is-arrayish": "^0.3.2",

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@lottiefiles/dotlottie-react": "^0.13.5",
-    "@oxyhq/bloom": "^0.8.5",
+    "@oxyhq/bloom": "^0.9.1",
     "@oxyhq/core": "*",
     "@oxyhq/services": "*",
     "@react-native-async-storage/async-storage": "^2.2.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.14.3",
-    "@oxyhq/bloom": "^0.8.5",
+    "@oxyhq/bloom": "^0.9.1",
     "@oxyhq/contracts": "workspace:*",
     "@oxyhq/core": "workspace:*",
     "@base-ui/react": "^1.1.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -16,7 +16,7 @@
     "@hugeicons/core-free-icons": "^3.1.1",
     "@hugeicons/react": "^1.1.4",
     "@oxyhq/auth": "*",
-    "@oxyhq/bloom": "^0.8.5",
+    "@oxyhq/bloom": "^0.9.1",
     "@oxyhq/core": "*",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-query": "^5.100",

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -16,7 +16,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@lottiefiles/dotlottie-react": "^0.13.5",
     "@lottiefiles/dotlottie-react-native": "^0.7.1",
-    "@oxyhq/bloom": "^0.8.5",
+    "@oxyhq/bloom": "^0.9.1",
     "@oxyhq/core": "*",
     "@oxyhq/services": "*",
     "@radix-ui/react-dropdown-menu": "^2.1.6",

--- a/packages/test-app-expo/package.json
+++ b/packages/test-app-expo/package.json
@@ -15,7 +15,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5.1.6",
     "@lottiefiles/dotlottie-react": "^0.13.5",
-    "@oxyhq/bloom": "^0.8.5",
+    "@oxyhq/bloom": "^0.9.1",
     "@oxyhq/services": "*",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native/virtualized-lists": "0.83.2",


### PR DESCRIPTION
## Summary

Bumps `@oxyhq/bloom` from `^0.8.5` → `^0.9.1` across every consumer that declares it in the OxyHQServices monorepo. `@oxyhq/core` / `@oxyhq/services` remain internal workspace deps (no version change).

### Packages bumped
- `package.json` (root `@oxyhq/sdk`) — both `dependencies` and `overrides`
- `packages/accounts`
- `packages/auth`
- `packages/console`
- `packages/inbox`
- `packages/test-app-expo`

`packages/services` declares a `>=0.5.0` peer range that already satisfies 0.9.1 — left as-is.

### Bloom CSS-var contract (auth, console)
Bloom 0.9.1 emits full CSS colors (`rgb(...)`/`hsl(...)`); consumers must use `var(--x)`, never `hsl(var(--x))`. The Vite + Tailwind v4 + shadcn apps (auth, console) already use `@theme inline { --color-X: var(--X) }` and reference base tokens as `var(--x)`. Scanned all `.css`/`.ts`/`.tsx` in both apps — **no `hsl(var(` usage to fix**. `console/src/components/ui/sidebar.tsx` already uses `var(--sidebar-border)` (prior-incident fix intact).

### inbox NativeWind decision: stayed on NW4
inbox declares `nativewind ^4.1.23` but **never wires NativeWind into its build** — no `nativewind/babel` plugin, no `global.css`, no `tailwind.config`, and zero `nativewind`/`react-native-css` imports in source. It consumes Bloom purely as a pre-built component library themed via `BloomThemeProvider`. Bloom 0.9.1's platform-split (`.native.ts`/`.web.ts`/clean `.ts`) lets inbox's web export + tsc pass with no `react-native-css/native-internal` landmine. **No NW5 migration needed.**

## Verification
- `bun install` regenerated `bun.lock` (committed in this commit); `bun install --frozen-lockfile` → in sync, exit 0.
- `bun run build:all` (turbo, contracts→core→auth→services→rest) → **9 successful, 9 total**. Includes `vite build` for auth + console and `expo export --platform web` for accounts + inbox + test-app-expo.
- `tsc --noEmit` on accounts/inbox/test-app-expo: remaining errors (4 / 14 / 1) are **pre-existing and unrelated to Bloom** (app-local `AvatarUserShape` vs core `User.avatar` strict-null mismatch from May; `@alia.onl/sdk` `absoluteFillObject`; FlashList/expo-router typings). **Zero `@oxyhq/bloom` type regressions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->