### PR TITLE
fix(api): reject ambiguous username invite resolution

### DIFF
--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -27,6 +27,7 @@ import {
   clearAllRefreshCookies,
 } from '../services/refreshToken.service';
 import type { AuthRequest } from '../middleware/auth';
+import { exactCaseInsensitiveUsernameRegex } from '../utils/resolveUserIdentifier';
 
 /**
  * Constant-time dummy Argon2 hash used to keep login response timing
@@ -229,7 +230,7 @@ export class SessionController {
       }
 
       if (normalizedUsername) {
-        const existingUsername = await User.findOne({ username: normalizedUsername }).select('_id').lean();
+        const existingUsername = await User.findOne({ username: exactCaseInsensitiveUsernameRegex(normalizedUsername) }).select('_id').lean();
         if (existingUsername) {
           return res.status(409).json({ message: 'Username already taken' });
         }
@@ -345,7 +346,7 @@ export class SessionController {
         return res.status(409).json({ message: 'Email already registered' });
       }
 
-      const existingUsername = await User.findOne({ username: normalizedUsername }).select('_id').lean();
+      const existingUsername = await User.findOne({ username: exactCaseInsensitiveUsernameRegex(normalizedUsername) }).select('_id').lean();
       if (existingUsername) {
         return res.status(409).json({ message: 'Username already taken' });
       }

--- a/packages/api/src/utils/resolveUserIdentifier.test.ts
+++ b/packages/api/src/utils/resolveUserIdentifier.test.ts
@@ -1,0 +1,44 @@
+import { exactCaseInsensitiveUsernameRegex, resolveUserByIdentifier } from './resolveUserIdentifier';
+import { User } from '../models/User';
+
+jest.mock('../models/User', () => ({
+  User: {
+    findOne: jest.fn(),
+    find: jest.fn(),
+  },
+}));
+
+const mockedUser = User as jest.Mocked<typeof User>;
+
+describe('resolveUserByIdentifier', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('builds an escaped, anchored, case-insensitive username regex', () => {
+    const regex = exactCaseInsensitiveUsernameRegex('a.b+');
+
+    expect(regex.test('A.B+')).toBe(true);
+    expect(regex.test('xa.b+')).toBe(false);
+    expect(regex.test('aZb+')).toBe(false);
+  });
+
+  it('resolves a username only when the case-insensitive match is unambiguous', async () => {
+    const user = { _id: 'user-id', username: 'alice' };
+    mockedUser.find.mockReturnValue({ limit: jest.fn().mockResolvedValue([user]) } as any);
+
+    await expect(resolveUserByIdentifier('Alice')).resolves.toBe(user);
+    expect(mockedUser.find).toHaveBeenCalledWith({ username: /^Alice$/i });
+  });
+
+  it('does not resolve ambiguous case-colliding usernames to an arbitrary account', async () => {
+    mockedUser.find.mockReturnValue({
+      limit: jest.fn().mockResolvedValue([
+        { _id: 'victim-id', username: 'alice' },
+        { _id: 'attacker-id', username: 'Alice' },
+      ]),
+    } as any);
+
+    await expect(resolveUserByIdentifier('alice')).resolves.toBeNull();
+  });
+});

--- a/packages/api/src/utils/resolveUserIdentifier.ts
+++ b/packages/api/src/utils/resolveUserIdentifier.ts
@@ -16,7 +16,9 @@
  *    case-insensitively against the `username` field. Usernames are stored
  *    trimmed but NOT lowercased, so an anchored case-insensitive regex is used
  *    for an exact (non-substring) match. The identifier is regex-escaped to
- *    avoid metacharacter injection.
+ *    avoid metacharacter injection. Because historical data may contain
+ *    case-colliding usernames, more than one match is treated as ambiguous and
+ *    not resolved to an arbitrary account.
  *
  * Returns the matching user, or `null` when none is found or the (trimmed)
  * identifier is empty.
@@ -25,8 +27,12 @@
 import { User, IUser } from '../models/User';
 
 /** Escape regex metacharacters so the identifier matches literally. */
-function escapeRegExp(value: string): string {
+export function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function exactCaseInsensitiveUsernameRegex(username: string): RegExp {
+  return new RegExp(`^${escapeRegExp(username)}$`, 'i');
 }
 
 /**
@@ -48,7 +54,15 @@ export async function resolveUserByIdentifier(identifier: string): Promise<IUser
   }
 
   // Username — stored trimmed but not lowercased; match exactly but
-  // case-insensitively via an anchored, escaped regex.
-  const exactCaseInsensitive = new RegExp(`^${escapeRegExp(trimmed)}$`, 'i');
-  return User.findOne({ username: exactCaseInsensitive });
+  // case-insensitively via an anchored, escaped regex. Limit to two matches so
+  // existing case-colliding usernames fail closed instead of selecting an
+  // arbitrary account for membership grants.
+  const exactCaseInsensitive = exactCaseInsensitiveUsernameRegex(trimmed);
+  const matches = await User.find({ username: exactCaseInsensitive }).limit(2);
+
+  if (matches.length !== 1) {
+    return null;
+  }
+
+  return matches[0];
 }


### PR DESCRIPTION
### Motivation
- Inviting by username used a case-insensitive regex lookup that could match multiple case-variant accounts (e.g. `Alice` vs `alice`) and return an arbitrary document, allowing an attacker who registers a case-variant to be selected as the invite target.
- Usernames are stored trimmed but not lowercased and the signup uniqueness check was case-sensitive, so case-colliding usernames can coexist and make resolution ambiguous.

### Description
- Update `resolveUserByIdentifier` to treat case-insensitive username matches as ambiguous when more than one document is found and return `null` instead of selecting an arbitrary account, by using `User.find(...).limit(2)` and requiring exactly one match.
- Add `exactCaseInsensitiveUsernameRegex` (and export `escapeRegExp`) in `packages/api/src/utils/resolveUserIdentifier.ts` and reuse it to build the anchored, escaped, case-insensitive regex for username lookups.
- Use the shared `exactCaseInsensitiveUsernameRegex` in `packages/api/src/controllers/session.controller.ts` when checking username uniqueness during registration so new accounts that only differ by case are rejected.
- Add unit tests `packages/api/src/utils/resolveUserIdentifier.test.ts` that validate the regex escaping, unambiguous resolution, and rejection of ambiguous case-colliding matches.

### Testing
- Added unit tests for `resolveUserByIdentifier` (`resolveUserIdentifier.test.ts`) covering escaping, single-match resolution, and ambiguous two-match rejection; the tests are present but were not executed in this environment due to missing test runtime dependencies.
- Attempted to run package tests but `bun install` failed (npm registry returned `403`), and `jest` was not available, so automated tests could not be executed here and therefore their pass/fail status is unknown.
- Local static checks performed (`git diff --check`) showed no whitespace/patch errors prior to preparing the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bbfd21fbc83238d5f86ad286e98da)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->