### PR TITLE
fix(api): verify WebFinger canonical subjects

### DIFF
--- a/packages/api/src/services/__tests__/federation.service.test.ts
+++ b/packages/api/src/services/__tests__/federation.service.test.ts
@@ -395,6 +395,53 @@ describe('FederationService.resolveAndUpsert (fast + eventually-fresh)', () => {
     expect(result).toBe(created);
   });
 
+  it('ignores a WebFinger subject that does not resolve back to the same actor', async () => {
+    const requestedHandle = 'attacker@evil.example';
+    const spoofedHandle = 'victim@trusted.example';
+    const actorUri = 'https://evil.example/users/attacker';
+    const userId = 'evil-user-spoof';
+
+    webfingerSpy.mockImplementation(async (acct: string) => {
+      if (acct === requestedHandle) {
+        return { actorUri, subjectAcct: spoofedHandle };
+      }
+      if (acct === spoofedHandle) {
+        return { actorUri: 'https://trusted.example/users/victim', subjectAcct: spoofedHandle };
+      }
+      return null;
+    });
+    actorSpy.mockResolvedValue({
+      actorUri,
+      domain: 'evil.example',
+      username: requestedHandle,
+      displayName: 'Evil Attacker',
+      avatarUrl: undefined,
+      bio: 'not a trusted.example user',
+    });
+
+    mockFindOneReturning(null);
+    const created = { _id: { toString: () => userId }, username: requestedHandle, type: 'federated' };
+    const select = jest.fn().mockResolvedValue(created);
+    mockUserFindOneAndUpdate.mockReturnValueOnce({ select });
+
+    const result = await federationService.resolveAndUpsert(requestedHandle);
+
+    expect(webfingerSpy).toHaveBeenCalledWith(requestedHandle);
+    expect(webfingerSpy).toHaveBeenCalledWith(spoofedHandle);
+    expect(actorSpy).toHaveBeenCalledWith(actorUri, requestedHandle);
+    expect(mockUserFindOneAndUpdate).toHaveBeenCalledWith(
+      { 'federation.actorUri': actorUri },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          username: requestedHandle,
+          'federation.domain': 'evil.example',
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(result).toBe(created);
+  });
+
   it('uses the WebFinger subject when the requested handle is a www alias', async () => {
     const requestedHandle = 'mosseri@www.threads.net';
     const canonicalHandle = 'mosseri@threads.net';

--- a/packages/api/src/services/federation.service.ts
+++ b/packages/api/src/services/federation.service.ts
@@ -608,6 +608,43 @@ class FederationService {
   }
 
   /**
+   * Returns the acct that can be safely used as the canonical username for a
+   * WebFinger result. A remote WebFinger endpoint may advertise `subject` as a
+   * canonical alias (for example `user@www.example` -> `user@example`), but that
+   * claimed account is controlled by a different domain. Before storing it,
+   * resolve the claimed account through its own domain and require it to point
+   * back to the same actor URI.
+   */
+  private async verifiedAccountForResolution(
+    requestedAcct: string,
+    resolution: WebFingerResolution,
+  ): Promise<string> {
+    const requested = normalizeFediverseHandle(requestedAcct);
+    const subject = resolution.subjectAcct ? normalizeFediverseHandle(resolution.subjectAcct) : null;
+    if (!requested || !subject || subject === requested) {
+      return requested || requestedAcct.toLowerCase();
+    }
+
+    try {
+      const subjectResolution = await this.resolveWebFingerResource(subject);
+      if (subjectResolution?.actorUri === resolution.actorUri) {
+        return subject;
+      }
+
+      logger.warn(
+        `Ignoring unverified WebFinger subject ${subject} for ${requested}: `
+          + `expected actor ${resolution.actorUri}, got ${subjectResolution?.actorUri || 'none'}`,
+      );
+    } catch (err) {
+      logger.warn(
+        `Failed verifying WebFinger subject ${subject} for ${requested}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    return requested;
+  }
+
+  /**
    * Resolve a WebFinger acct to an ActivityPub actor URI.
    * @param acct - e.g. "alice@mastodon.social" or "@alice@mastodon.social"
    */
@@ -641,7 +678,11 @@ class FederationService {
         ? normalizeFediverseHandle(actor.webfinger)
         : null;
       const hintedAcct = acctHint ? normalizeFediverseHandle(acctHint) : null;
-      const acct = actorWebfinger || hintedAcct || `${username.toLowerCase()}@${actorHost}`;
+      // The handle used for storage must come from the WebFinger resource we
+      // resolved and verified before fetching this actor. Actor documents are
+      // attacker-controlled by the actor host, so their optional `webfinger`
+      // field is only a fallback when no trusted hint is available.
+      const acct = hintedAcct || actorWebfinger || `${username.toLowerCase()}@${actorHost}`;
       const domain = domainFromHandle(acct) || actorHost;
 
       return {
@@ -857,7 +898,8 @@ class FederationService {
     const webfinger = await this.resolveWebFingerResource(cleaned);
     if (!webfinger) return null;
 
-    const profile = await this.fetchActorProfile(webfinger.actorUri, webfinger.subjectAcct || cleaned);
+    const verifiedAcct = await this.verifiedAccountForResolution(cleaned, webfinger);
+    const profile = await this.fetchActorProfile(webfinger.actorUri, verifiedAcct);
     if (!profile) return null;
 
     const setFields: Record<string, unknown> = {


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled WebFinger `subject` or actor `webfinger` metadata from creating or renaming cached federated users to another domain's handle and enabling persistent spoofing/squatting.

### Description
- Added a new private method `verifiedAccountForResolution` that resolves a claimed WebFinger `subject` through its own domain and only accepts it if it resolves back to the same `actorUri` as the original WebFinger response.
- Changed `fetchActorProfile` to prefer the verified WebFinger hint (`acctHint`) over the untrusted actor-supplied `webfinger` field when deriving the canonical account for storage.
- Updated `resolveAndUpsert` to call `verifiedAccountForResolution(cleaned, webfinger)` and pass the verified account into `fetchActorProfile` before persisting identity fields and upserting by `federation.actorUri`.
- Added a Jest regression test `ignores a WebFinger subject that does not resolve back to the same actor` to `packages/api/src/services/__tests__/federation.service.test.ts` that simulates a malicious WebFinger subject and verifies the service ignores it.

### Testing
- Ran `git diff --check` successfully to validate formatting and changes.
- Added a unit test covering the malicious-WebFinger subject case in `packages/api/src/services/__tests__/federation.service.test.ts` but running the test suite was blocked because `jest` and other dependencies are not installed in this environment (`bun install` failed due to npm registry 403), so automated test execution could not be completed here.
- Local logic verified by updating the test file and committing the changes; CI should run `bun run test` / `npm test` in the `packages/api` job to validate behavior in a fully provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb608e0508323b30ee85efb1b02c0)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/227" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->