### PR TITLE
fix(api): require internal apps for service credentials

### DIFF
--- a/packages/api/src/routes/__tests__/applications.test.ts
+++ b/packages/api/src/routes/__tests__/applications.test.ts
@@ -1124,19 +1124,32 @@ describe('credentials lifecycle', () => {
     expect(stored.secretHash).not.toBe(res.body.secret);
   });
 
-  it('400 when a credential requests a scope the application does not hold', async () => {
-    // Seeded app has scopes []. A credential cannot exceed the app's authority,
-    // so requesting federation:write (or any ungranted scope) is rejected.
+  it('403 when creating a service credential for a non-internal application', async () => {
+    apps[0].isInternal = false;
+    apps[0].scopes = ['federation:write'];
     const res = await requestJson(server, 'POST', `/applications/${APP_ID}/credentials`, {
-      name: 'Over-scoped',
+      name: 'External service key',
       type: 'service',
       environment: 'production',
       scopes: ['federation:write'],
     });
+    expect(res.status).toBe(403);
+  });
+
+  it('400 when a credential requests a scope the application does not hold', async () => {
+    // Seeded app has scopes []. A credential cannot exceed the app's authority,
+    // so requesting user:read (or any ungranted scope) is rejected.
+    const res = await requestJson(server, 'POST', `/applications/${APP_ID}/credentials`, {
+      name: 'Over-scoped',
+      type: 'confidential',
+      environment: 'production',
+      scopes: ['user:read'],
+    });
     expect(res.status).toBe(400);
   });
 
-  it('creates a credential whose scopes are a subset of the app scopes', async () => {
+  it('creates a service credential whose scopes are a subset of an internal app scopes', async () => {
+    apps[0].isInternal = true;
     apps[0].scopes = ['user:read', 'files:write', 'federation:write'];
     const res = await requestJson(server, 'POST', `/applications/${APP_ID}/credentials`, {
       name: 'Federation key',

--- a/packages/api/src/routes/__tests__/serviceTokenCredentials.test.ts
+++ b/packages/api/src/routes/__tests__/serviceTokenCredentials.test.ts
@@ -236,12 +236,20 @@ function stubCredential(overrides: Partial<StubCredential> = {}): StubCredential
   };
 }
 
-function stubApp(): { _id: { toString: () => string }; name: string; scopes: string[]; save: jest.Mock } {
+function stubApp(overrides: Partial<{ isInternal: boolean; scopes: string[] }> = {}): {
+  _id: { toString: () => string };
+  name: string;
+  isInternal: boolean;
+  scopes: string[];
+  save: jest.Mock;
+} {
   return {
     _id: { toString: () => APP_ID },
     name: 'Service App',
+    isInternal: true,
     scopes: ['user:read'],
     save: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
   };
 }
 
@@ -396,6 +404,19 @@ describe('POST /auth/service-token — credential resolution + JWT claims (#215)
     expect(res.status).toBe(403);
   });
 
+
+  it('rejects service-token minting for a non-internal application', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValue(stubCredential());
+    mockApplicationFindOne.mockResolvedValue(stubApp({ isInternal: false }));
+
+    const res = await requestJson(server, 'POST', '/auth/service-token', {
+      apiKey: API_KEY,
+      apiSecret: PLAINTEXT_SECRET,
+    });
+
+    expect(res.status).toBe(403);
+  });
+
   it('rejects when the owning application is inactive', async () => {
     mockApplicationCredentialFindOne.mockResolvedValue(stubCredential());
     mockApplicationFindOne.mockResolvedValue(null);
@@ -418,6 +439,7 @@ describe('POST /auth/service-token — credential resolution + JWT claims (#215)
     mockApplicationFindOne.mockResolvedValue({
       _id: { toString: () => APP_ID },
       name: 'Service App',
+      isInternal: true,
       scopes: ['user:read'],
       save: jest.fn().mockResolvedValue(undefined),
     });
@@ -442,6 +464,7 @@ describe('POST /auth/service-token — credential resolution + JWT claims (#215)
     mockApplicationFindOne.mockResolvedValue({
       _id: { toString: () => APP_ID },
       name: 'Mention',
+      isInternal: true,
       scopes: ['user:read', 'files:write', 'federation:write'],
       save: jest.fn().mockResolvedValue(undefined),
     });
@@ -461,6 +484,7 @@ describe('POST /auth/service-token — credential resolution + JWT claims (#215)
     mockApplicationFindOne.mockResolvedValue({
       _id: { toString: () => APP_ID },
       name: 'Service App',
+      isInternal: true,
       scopes: ['user:read', 'files:write'],
       save: jest.fn().mockResolvedValue(undefined),
     });

--- a/packages/api/src/routes/applications.ts
+++ b/packages/api/src/routes/applications.ts
@@ -1137,6 +1137,10 @@ router.post(
     // an explicit request for any scope the app does not hold (rather than
     // silently dropping it) so the developer learns the credential won't carry
     // it; they must first have the scope granted on the application.
+    if (body.type === 'service' && !application.isInternal) {
+      throw new ForbiddenError('Service credentials are only available to internal applications');
+    }
+
     const requestedScopes = body.scopes ?? [];
     const grantableScopes = new Set(application.scopes);
     const ungrantable = requestedScopes.filter((scope) => !grantableScopes.has(scope));

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2549,7 +2549,10 @@ router.post('/service-token', serviceTokenLimiter, validate({ body: serviceToken
     throw new UnauthorizedError('Invalid credentials');
   }
 
-  // The owning application must be active.
+  // The owning application must be active and explicitly marked internal.
+  // Service credentials are bearer credentials for Oxy-to-Oxy/internal routes;
+  // self-service third-party applications must not be able to mint them even if
+  // they somehow hold a historical `service` credential row.
   const app = await Application.findOne({ _id: credential.applicationId, status: 'active' });
   if (!app) {
     logger.warn('[ServiceToken] Application inactive for service credential', {
@@ -2557,6 +2560,14 @@ router.post('/service-token', serviceTokenLimiter, validate({ body: serviceToken
       applicationId: credential.applicationId.toString(),
     });
     throw new UnauthorizedError('Invalid credentials');
+  }
+
+  if (!app.isInternal) {
+    logger.warn('[ServiceToken] Non-internal application attempted service token', {
+      credentialId: credential._id.toString(),
+      applicationId: credential.applicationId.toString(),
+    });
+    throw new ForbiddenError('Service tokens are only available to internal applications');
   }
 
   // Generate stateless service JWT — embed granted scopes so downstream


### PR DESCRIPTION
### Motivation
- Prevent self-service application owners from creating `service` credentials that can mint internal service JWTs and access sensitive internal endpoints. 
- Restore the previous authorization gate that limited service-token issuance to platform-internal applications.

### Description
- Block creating `service` credentials for non-internal apps by rejecting requests in `POST /applications/:appId/credentials` when `body.type === 'service'` and `application.isInternal` is false (change in `packages/api/src/routes/applications.ts`).
- Require the owning `Application` to be `isInternal === true` before issuing a service JWT in `POST /auth/service-token`, returning `403` for non-internal apps (change in `packages/api/src/routes/auth.ts`).
- Add regression tests to cover the new behaviour and ensure credential-scopes remain intersected with app scopes: updates in `packages/api/src/routes/__tests__/applications.test.ts` and `packages/api/src/routes/__tests__/serviceTokenCredentials.test.ts`.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors.
- Attempted to run the affected test suites with `bun run test --runInBand packages/api/src/routes/__tests__/serviceTokenCredentials.test.ts packages/api/src/routes/__tests__/applications.test.ts`, but execution was blocked because `jest` is not available in the environment (test runner unavailable). 
- `bun install` was attempted to restore dependencies but failed due to upstream registry `403` responses, preventing full automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc4689f4083239fe9b1f6cc997177)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->