### PR TITLE
fix(api): remove stale public CDN asset copies on visibility downgrade

### DIFF
--- a/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
+++ b/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
@@ -378,3 +378,35 @@ describe('uploadCachedMediaStream — abort cleanup', () => {
     source.destroy();
   });
 });
+
+describe('AssetService visibility relocation', () => {
+  it('deletes legacy backfilled public CDN copies when a non-public DB key is downgraded', async () => {
+    const existingKeys = new Set([
+      'content/2026/06/legacy-avatar.jpg',
+      'public/content/2026/06/legacy-avatar.jpg',
+    ]);
+    const deleteFile = jest.fn((key: string): Promise<void> => {
+      existingKeys.delete(key);
+      return Promise.resolve();
+    });
+    const fileExists = jest.fn((key: string): Promise<boolean> => Promise.resolve(existingKeys.has(key)));
+    const copyFile = jest.fn((): Promise<void> => Promise.resolve());
+    const { service } = buildAssetService({ deleteFile, fileExists, copyFile });
+
+    type RelocationHarness = {
+      relocateObjectForVisibility(key: string, visibility: 'private' | 'public' | 'unlisted'): Promise<string>;
+    };
+
+    const relocatedKey = await (service as unknown as RelocationHarness).relocateObjectForVisibility(
+      'content/2026/06/legacy-avatar.jpg',
+      'private'
+    );
+
+    expect(relocatedKey).toBe('content/2026/06/legacy-avatar.jpg');
+    expect(copyFile).not.toHaveBeenCalled();
+    expect(deleteFile).toHaveBeenCalledTimes(1);
+    expect(deleteFile).toHaveBeenCalledWith('public/content/2026/06/legacy-avatar.jpg');
+    expect(existingKeys.has('content/2026/06/legacy-avatar.jpg')).toBe(true);
+    expect(existingKeys.has('public/content/2026/06/legacy-avatar.jpg')).toBe(false);
+  });
+});

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -1340,12 +1340,44 @@ export class AssetService {
   }
 
   /**
+   * Delete a legacy backfilled CDN copy for a non-public object key. Older
+   * public files may have DB keys outside `public/` while a backfill-created
+   * `public/<key>` copy exists for CDN serving; visibility downgrades must
+   * remove that deterministic public copy even when the stored key itself does
+   * not need relocation.
+   */
+  private async deleteBackfilledPublicCopy(key: string): Promise<void> {
+    if (isPublicKey(key)) {
+      return;
+    }
+
+    const publicKey = applyPublicPrefix(key);
+    if (!(await this.s3Service.fileExists(publicKey))) {
+      return;
+    }
+
+    try {
+      await this.s3Service.deleteFile(publicKey);
+    } catch (cleanupError) {
+      logger.warn('Failed to delete legacy public CDN copy after visibility downgrade', {
+        sourceKey: key,
+        publicKey,
+        error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+      });
+    }
+  }
+
+  /**
    * Relocate a single S3 object so its key prefix matches `visibility`. Returns
    * the (possibly unchanged) key. Idempotent and best-effort: a missing source
    * object is logged and the original key is returned unchanged.
    */
   private async relocateObjectForVisibility(key: string, visibility: FileVisibility): Promise<string> {
     const targetKey = this.targetKeyForVisibility(key, visibility);
+    if (visibility !== 'public') {
+      await this.deleteBackfilledPublicCopy(key);
+    }
+
     if (targetKey === key) {
       return key;
     }
@@ -1528,13 +1560,16 @@ export class AssetService {
         throw new Error('Cannot delete file with active links. Use force=true to override.');
       }
 
-      // Delete from storage
+      // Delete from storage, including any legacy CDN copy produced by the
+      // public-asset backfill while the DB key stayed non-public.
       await this.s3Service.deleteFile(file.storageKey);
+      await this.deleteBackfilledPublicCopy(file.storageKey);
 
       // Delete variants from storage
       for (const variant of file.variants) {
         try {
           await this.s3Service.deleteFile(variant.key);
+          await this.deleteBackfilledPublicCopy(variant.key);
         } catch (error) {
           logger.warn('Failed to delete variant', { variant: variant.key, error });
         }


### PR DESCRIPTION
### Motivation

- A backfill copied legacy public objects into the `public/` CDN prefix without updating DB keys, allowing deterministic CDN URLs to remain reachable after a file's visibility is changed to `private`/`unlisted`.
- Visibility downgrade paths did not remove these backfilled `public/<key>` objects when the DB `storageKey` remained non-public, resulting in an access-control bypass for previously public media.

### Description

- Add `deleteBackfilledPublicCopy(key: string)` to `packages/api/src/services/assetService.ts` which deletes the `public/<key>` copy when present and logs failures.
- Invoke `deleteBackfilledPublicCopy` from `relocateObjectForVisibility` for non-public targets and from `deleteFile` for originals and variants so legacy CDN copies are removed on downgrade and permanent deletion.
- Add a regression unit test in `packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts` that verifies a legacy non-public DB key with a backfilled `public/<key>` copy is cleaned up when visibility is downgraded.

### Testing

- Added a focused unit test that exercises `relocateObjectForVisibility` for the legacy backfill case and asserts the `public/<key>` copy is deleted; the test file is `packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts`.
- Ran `git diff --check` successfully to validate formatting and diffs.
- Attempted to run package tests with `bun run --cwd packages/api test --runInBand <test>`, but dependency installation failed due to the environment returning HTTP 403 from the registry so the test run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb2864ab88323bdb17d3b56529a93)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->