### PR TITLE
Prevent presigned PUT URL issuance for deduped live assets

### DIFF
--- a/packages/api/src/services/__tests__/assetService.initUpload.test.ts
+++ b/packages/api/src/services/__tests__/assetService.initUpload.test.ts
@@ -1,0 +1,92 @@
+import { AssetService } from '../assetService';
+import { S3Service } from '../s3Service';
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockFileFindOne = jest.fn();
+jest.mock('../../models/File', () => ({
+  File: { findOne: (...args: unknown[]) => mockFileFindOne(...args), findById: jest.fn() },
+  FileVisibility: {},
+}));
+
+jest.mock('../variantService', () => ({
+  VariantService: class {
+    constructor(_s3: unknown) { /* no-op */ }
+  },
+}));
+
+jest.mock('../mediaPrivacyService', () => ({
+  mediaPrivacyService: {},
+}));
+
+interface FakeS3 {
+  fileExists: jest.Mock<Promise<boolean>, [string]>;
+  getPresignedUploadUrl: jest.Mock<Promise<string>, [string, { contentType: string; expiresIn: number }]>;
+}
+
+function buildAssetService(fake: FakeS3): AssetService {
+  return new AssetService(fake as unknown as S3Service);
+}
+
+function existingFile(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    _id: { toString: () => 'victim-file-id' },
+    sha256: 'a'.repeat(64),
+    storageKey: 'users/victim/private/secret.png',
+    ownerUserId: 'victim-user-id',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('AssetService.initUpload dedupe signing', () => {
+  beforeEach(() => {
+    mockFileFindOne.mockReset();
+  });
+
+  it('does not return a PUT URL for a live existing object owned by another user', async () => {
+    const fakeS3: FakeS3 = {
+      fileExists: jest.fn(() => Promise.resolve(true)),
+      getPresignedUploadUrl: jest.fn(() => Promise.resolve('signed-put-url')),
+    };
+    mockFileFindOne.mockResolvedValue(existingFile());
+
+    const result = await buildAssetService(fakeS3).initUpload(
+      'attacker-user-id',
+      'a'.repeat(64),
+      123,
+      'image/png',
+    );
+
+    expect(fakeS3.fileExists).toHaveBeenCalledWith('users/victim/private/secret.png');
+    expect(fakeS3.getPresignedUploadUrl).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      uploadUrl: '',
+      fileId: 'victim-file-id',
+      sha256: 'a'.repeat(64),
+    });
+  });
+
+  it('only returns a repair PUT URL for a missing existing object when requested by its owner', async () => {
+    const fakeS3: FakeS3 = {
+      fileExists: jest.fn(() => Promise.resolve(false)),
+      getPresignedUploadUrl: jest.fn(() => Promise.resolve('owner-repair-url')),
+    };
+    mockFileFindOne.mockResolvedValue(existingFile({ ownerUserId: 'owner-user-id' }));
+
+    const result = await buildAssetService(fakeS3).initUpload(
+      'owner-user-id',
+      'a'.repeat(64),
+      123,
+      'image/png',
+    );
+
+    expect(fakeS3.getPresignedUploadUrl).toHaveBeenCalledWith('users/victim/private/secret.png', {
+      contentType: 'image/png',
+      expiresIn: 3600,
+    });
+    expect(result.uploadUrl).toBe('owner-repair-url');
+  });
+});

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -465,6 +465,7 @@ export class AssetService {
 
       if (existingFile) {
         const storageKey = existingFile.storageKey || this.generateStorageKey(expectedSha256, expectedMime);
+        let uploadUrl = '';
         if (existingFile.status === 'deleted') {
           existingFile.status = 'active';
           existingFile.ownerUserId = userId;
@@ -479,11 +480,28 @@ export class AssetService {
           fileCache.invalidate(existingFile._id.toString());
           fileCache.set(existingFile._id.toString(), existingFile);
         }
-        if (!(await this.s3Service.fileExists(storageKey))) {
+        const objectExists = await this.s3Service.fileExists(storageKey);
+        if (!objectExists && existingFile.ownerUserId === userId) {
           logger.warn('Existing asset record has no storage object; returning upload URL for the existing key', {
             fileId: existingFile._id.toString(),
             sha256: expectedSha256,
             storageKey,
+          });
+          // Only the file owner may receive a repair PUT URL for an existing
+          // record, and only when the object is missing. Signing a live
+          // deduplicated object's key would allow any authenticated user who
+          // knows the SHA-256 to overwrite another user's asset bytes.
+          uploadUrl = await this.s3Service.getPresignedUploadUrl(storageKey, {
+            contentType: expectedMime,
+            expiresIn: 3600
+          });
+        } else if (!objectExists) {
+          logger.warn('Existing asset record has no storage object; not returning repair URL to non-owner', {
+            fileId: existingFile._id.toString(),
+            sha256: expectedSha256,
+            storageKey,
+            requesterUserId: userId,
+            ownerUserId: existingFile.ownerUserId,
           });
         }
 
@@ -492,14 +510,6 @@ export class AssetService {
           fileId: existingFile._id 
         });
         
-        // File already exists, return existing info
-        // We still need to provide an upload URL in case the client wants to verify or repair storage.
-        // Do not include metadata in the presigned URL signature; clients aren't required to send it
-        const uploadUrl = await this.s3Service.getPresignedUploadUrl(storageKey, {
-          contentType: expectedMime,
-          expiresIn: 3600
-        });
-
         return {
           uploadUrl,
           fileId: existingFile._id.toString(),


### PR DESCRIPTION
### Motivation

- The previous `initUpload` path returned a presigned S3 PUT URL for an existing deduplicated file record unconditionally, which allowed any authenticated user who knew a file's SHA-256 to obtain a write URL for the actual stored object and overwrite another user's asset.
- The goal is to preserve repair behavior for missing objects while removing the ability for non-owners to sign live deduplicated object keys.

### Description

- Change `AssetService.initUpload` to check the actual S3 object existence and only produce a repair presigned PUT URL when the object is missing and the requester is the file owner; otherwise return an empty `uploadUrl` for existing objects. (`packages/api/src/services/assetService.ts`)
- Keep the revive/repair logic for `deleted` records intact, but gate signing to owner-only missing-object repairs.
- Add regression tests that assert (1) a live existing object owned by another user does not get a PUT URL, and (2) the owner still receives a repair PUT URL when the object is missing. (`packages/api/src/services/__tests__/assetService.initUpload.test.ts`)

### Testing

- Added Jest unit tests in `packages/api/src/services/__tests__/assetService.initUpload.test.ts` to cover the regressed dedupe signing behavior; the tests are present in the branch but were not executed to completion in this environment.
- Attempted to run `bun run --filter @oxyhq/api test -- assetService.initUpload.test.ts`, which failed in this environment with `jest: command not found` so the tests could not be executed here.
- Attempted to run `bun run --filter @oxyhq/api build`, which failed before the API build due to TypeScript/tsconfig issues in `@oxyhq/contracts` in this runtime; CI should run with the proper toolchain where the new tests will execute as part of the package test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb6f7c148832385036f81ad7df6b6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->