### PR TITLE
fix(core): prevent linked clients leaking Oxy tokens

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -76,9 +76,9 @@ getNormalizedUserHandle({ username: 'alice', isFederated: true, instance: 'examp
 
 ## Linked App API Clients
 
-Apps that call their own backend should derive API clients from the active SDK
-instance instead of re-implementing auth headers, session restore, CSRF fetches,
-or user forwarding.
+Apps that call their own backend can derive API clients from the active SDK
+instance to reuse base URL handling, caching, request queues, retry behavior, and
+CSRF handling without re-implementing HTTP plumbing.
 
 ```ts
 import { OxyServices } from '@oxyhq/core';
@@ -86,11 +86,12 @@ import { OxyServices } from '@oxyhq/core';
 const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
 const mentionApi = oxy.createLinkedClient({ baseURL: 'https://api.mention.earth' });
 
-await mentionApi.post('/posts', { content: 'Hello from Oxy' });
+await mentionApi.client.post('/posts', { content: 'Hello from Oxy' });
 ```
 
-Linked clients send the current Oxy bearer token for authenticated requests.
-State-changing bearer requests do not fetch app-local CSRF tokens; cookie-only
+Linked clients only share the current Oxy bearer token with same-origin Oxy API
+clients. Different app/backend origins are left unauthenticated so first-party
+Oxy session tokens are not disclosed to relying-party backends. Cookie-only
 writes still use CSRF.
 
 ## Backend Auth Middleware

--- a/packages/core/src/OxyServices.base.ts
+++ b/packages/core/src/OxyServices.base.ts
@@ -122,16 +122,25 @@ export class OxyServicesBase {
   }
 
   /**
-   * Create an app/backend HTTP client linked to this Oxy session.
+   * Create an HTTP client with an independent base URL/cache/queue.
    *
-   * Use this when an app has its own API origin (for example
-   * `https://api.syra.fm`) but authentication is owned by the canonical
-   * OxyServices instance mounted in OxyProvider. The returned client has its own
-   * base URL, cache and request queue, but its bearer token is kept in lockstep
-   * with this session and its 401 refresh path delegates back to this session.
+   * Oxy session bearer tokens are only linked when the new client targets the
+   * same origin as this Oxy API client. For any other origin, the client remains
+   * unauthenticated so first-party Oxy session tokens are never disclosed to an
+   * app/backend origin.
    */
   public createLinkedClient(config: OxyConfig): LinkedHttpClient {
     const client = new HttpService(config);
+    const shouldShareOxySessionToken = this.isSameOrigin(config.baseURL, this.getBaseURL());
+
+    if (!shouldShareOxySessionToken) {
+      return {
+        client,
+        dispose: () => {
+          client.clearTokens();
+        },
+      };
+    }
 
     const syncToken = (accessToken: string | null): void => {
       const currentAccessToken = client.getAccessToken();
@@ -169,6 +178,14 @@ export class OxyServicesBase {
         client.clearTokens();
       },
     };
+  }
+
+  private isSameOrigin(candidateUrl: string, trustedUrl: string): boolean {
+    try {
+      return new URL(candidateUrl).origin === new URL(trustedUrl).origin;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/core/src/__tests__/linkedClient.test.ts
+++ b/packages/core/src/__tests__/linkedClient.test.ts
@@ -45,7 +45,7 @@ describe('OxyServices.createLinkedClient', () => {
 
   it('mirrors token changes from the session owner', () => {
     const oxy = createServices();
-    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.oxy.so' });
 
     expect(linked.client.getAccessToken()).toBeNull();
 
@@ -65,7 +65,7 @@ describe('OxyServices.createLinkedClient', () => {
     const oxy = createServices();
     oxy.setTokens('existing_access');
 
-    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.oxy.so' });
 
     expect(linked.client.getAccessToken()).toBe('existing_access');
 
@@ -74,7 +74,7 @@ describe('OxyServices.createLinkedClient', () => {
 
   it('delegates token refresh to the session owner', async () => {
     const oxy = createServices();
-    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.oxy.so' });
 
     oxy.getClient().setAuthRefreshHandler(async () => 'refreshed_access');
 
@@ -90,7 +90,7 @@ describe('OxyServices.createLinkedClient', () => {
   it('keeps the session owner intact when a linked response 401 cannot refresh', async () => {
     const oxy = createServices();
     oxy.setTokens('stale_access');
-    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.oxy.so' });
 
     const refreshed = await linked.client.refreshAccessToken('response-401');
 
@@ -136,7 +136,7 @@ describe('OxyServices.createLinkedClient', () => {
     });
     oxy.setTokens(accessToken);
     oxy.getClient().setAuthRefreshHandler(async () => null);
-    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.oxy.so' });
 
     await expect(linked.client.put('/api/queue/current', { trackId: 'track_1' }, { retry: false })).rejects.toMatchObject({
       message: 'MISSING_TOKEN',
@@ -149,8 +149,8 @@ describe('OxyServices.createLinkedClient', () => {
     await linked.client.put('/api/queue/current', { trackId: 'track_2' });
 
     expect(calls.map((call) => call.url)).toEqual([
-      'https://api.syra.fm/api/queue/current',
-      'https://api.syra.fm/api/queue/current',
+      'https://api.oxy.so/api/queue/current',
+      'https://api.oxy.so/api/queue/current',
     ]);
     expect(linked.client.getAccessToken()).toBe(accessToken);
 
@@ -168,7 +168,7 @@ describe('OxyServices.createLinkedClient', () => {
   it('keeps the session owner intact when linked preflight refresh cannot refresh', async () => {
     const oxy = createServices();
     oxy.setTokens('existing_access');
-    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.oxy.so' });
 
     const refreshed = await linked.client.refreshAccessToken('preflight');
 
@@ -181,7 +181,7 @@ describe('OxyServices.createLinkedClient', () => {
 
   it('stops mirroring after dispose', () => {
     const oxy = createServices();
-    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.oxy.so' });
 
     oxy.setTokens('before_dispose');
     expect(linked.client.getAccessToken()).toBe('before_dispose');
@@ -190,6 +190,31 @@ describe('OxyServices.createLinkedClient', () => {
     oxy.setTokens('after_dispose');
 
     expect(linked.client.getAccessToken()).toBeNull();
+  });
+
+  it('does not send Oxy bearer tokens to a different linked origin', async () => {
+    const fetchMock = jest.fn(async () => jsonResponse({ ok: true }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const oxy = createServices();
+    oxy.setTokens(createJwt({
+      userId: 'user_1',
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }));
+
+    const linked = oxy.createLinkedClient({ baseURL: 'https://api.syra.fm' });
+
+    expect(linked.client.getAccessToken()).toBeNull();
+
+    await linked.client.get('/private');
+
+    const headers = readHeaders(fetchMock.mock.calls[0]?.[1]);
+    expect(headers.Authorization).toBeUndefined();
+
+    oxy.setTokens('later_access');
+    expect(linked.client.getAccessToken()).toBeNull();
+
+    linked.dispose();
   });
 
   it('joins linked base URLs with relative paths that omit the leading slash', async () => {


### PR DESCRIPTION
### Motivation
- Prevent a high-severity token-leak where `createLinkedClient` mirrored first-party Oxy bearer tokens into an HttpService targeting any caller-supplied `baseURL`, allowing RP backends to receive and replay full session tokens. 
- Ensure linked clients reuse SDK HTTP plumbing without disclosing first-party session tokens to cross-origin relying-party backends.

### Description
- Restrict token sharing in `createLinkedClient` so the owner access token is only mirrored when the linked client's `baseURL` is same-origin with the configured Oxy API; cross-origin linked clients are returned unauthenticated. (changed `packages/core/src/OxyServices.base.ts`, added `isSameOrigin` check).
- Keep the existing same-origin behavior intact: when origins match the linked client still mirrors tokens, subscribes to token changes, and delegates refreshes to the session owner.
- Add a regression test `does not send Oxy bearer tokens to a different linked origin` to `packages/core/src/__tests__/linkedClient.test.ts` asserting cross-origin clients do not store or send Oxy tokens and do not mirror token changes.
- Update documentation/example in `packages/core/README.md` to clarify that linked clients only share bearer tokens with same-origin Oxy API clients and to adjust example usage (`mentionApi.client.post(...)`).

### Testing
- Updated unit tests in `packages/core/src/__tests__/linkedClient.test.ts` to cover the new cross-origin no-token behavior (test added). 
- Ran `git diff --check` with no issues reported.
- Attempted to run package tests (`bun run test -- linkedClient.test.ts`) but the environment lacked test tooling (`jest`) and dependency restore failed (`bun install` returned registry 403 errors), so Jest test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb9f7488c83239a96724e3bfb9831)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->