### PR TITLE
fix(api): require reputation:write for service awards

### DIFF
--- a/packages/api/src/routes/__tests__/reputationAwardAuthz.test.ts
+++ b/packages/api/src/routes/__tests__/reputationAwardAuthz.test.ts
@@ -1,0 +1,189 @@
+/**
+ * /reputation/award authorization tests.
+ *
+ * Ensures service-token callers must carry the privileged reputation:write
+ * scope before they can mutate the global reputation ledger.
+ */
+
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+
+const mockJwtVerify = jest.fn();
+const mockServiceAuthMiddleware = jest.fn();
+const mockAuthMiddleware = jest.fn();
+const mockAward = jest.fn();
+const mockResolveUserIdToObjectId = jest.fn();
+
+jest.mock('jsonwebtoken', () => ({
+  __esModule: true,
+  default: { verify: (...args: unknown[]) => mockJwtVerify(...args) },
+  verify: (...args: unknown[]) => mockJwtVerify(...args),
+}));
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
+  serviceAuthMiddleware: (...args: unknown[]) => mockServiceAuthMiddleware(...args),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../utils/validation', () => ({
+  resolveUserIdToObjectId: (...args: unknown[]) => mockResolveUserIdToObjectId(...args),
+  validatePagination: (_limit: unknown, _offset: unknown, _max: number, defaultLimit: number) => ({
+    limit: defaultLimit,
+    offset: 0,
+  }),
+}));
+
+jest.mock('../../services/reputation.service', () => ({
+  __esModule: true,
+  default: {
+    award: (...args: unknown[]) => mockAward(...args),
+    listTransactions: jest.fn(),
+    getBalance: jest.fn(),
+    createDispute: jest.fn(),
+    upsertRule: jest.fn(),
+    listEnabledRules: jest.fn(),
+    getLeaderboard: jest.fn(),
+    getInfluence: jest.fn(),
+    listDisputesForUser: jest.fn(),
+    listOpenDisputes: jest.fn(),
+    reverseTransaction: jest.fn(),
+    voidTransaction: jest.fn(),
+    recalculateBalance: jest.fn(),
+    resolveDispute: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import reputationRouter from '../reputation.routes';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: { error?: string; message?: string; data?: Record<string, unknown> };
+}
+
+async function requestJson(server: http.Server, payload: unknown): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload ?? {});
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: 'POST',
+        host: '127.0.0.1',
+        port: address.port,
+        path: '/reputation/award',
+        headers: {
+          authorization: 'Bearer service-token',
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: raw.length > 0 ? JSON.parse(raw) : {} });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  process.env.ACCESS_TOKEN_SECRET = 'test-secret';
+  const app = express();
+  app.use(express.json());
+  app.use('/reputation', reputationRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => server.close(done));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockJwtVerify.mockReturnValue({ type: 'service' });
+  mockResolveUserIdToObjectId.mockResolvedValue('64cccccccccccccccccccccc');
+  mockAward.mockResolvedValue({
+    _id: { toString: () => 'txn1' },
+    userId: { toString: () => '64cccccccccccccccccccccc' },
+    points: 1,
+    actionType: 'post_created',
+    category: 'content',
+    status: 'active',
+    createdAt: new Date('2026-06-24T00:00:00.000Z'),
+    updatedAt: new Date('2026-06-24T00:00:00.000Z'),
+  });
+});
+
+describe('POST /reputation/award service-token scope gate', () => {
+  it('rejects a service token that lacks reputation:write', async () => {
+    mockServiceAuthMiddleware.mockImplementation((req, _res, next) => {
+      req.serviceApp = {
+        type: 'service',
+        appId: 'app1',
+        appName: 'Third Party',
+        credentialId: 'cred1',
+        scopes: [],
+      };
+      next();
+    });
+
+    const res = await requestJson(server, {
+      userId: 'victim',
+      actionType: 'post_created',
+      sourceActionId: 'attacker-controlled-action',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/reputation:write/i);
+    expect(mockAward).not.toHaveBeenCalled();
+  });
+
+  it('allows a service token that carries reputation:write', async () => {
+    mockServiceAuthMiddleware.mockImplementation((req, _res, next) => {
+      req.serviceApp = {
+        type: 'service',
+        appId: 'app1',
+        appName: 'Privileged App',
+        credentialId: 'cred1',
+        scopes: ['reputation:write'],
+      };
+      next();
+    });
+
+    const res = await requestJson(server, {
+      userId: 'member',
+      actionType: 'post_created',
+      applicationId: 'spoofed-app',
+      credentialId: 'spoofed-credential',
+      sourceActionId: 'real-action',
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockAward).toHaveBeenCalledWith(expect.objectContaining({
+      userId: '64cccccccccccccccccccccc',
+      actionType: 'post_created',
+      applicationId: 'app1',
+      credentialId: 'cred1',
+      sourceActionId: 'real-action',
+    }));
+  });
+});

--- a/packages/api/src/routes/reputation.routes.ts
+++ b/packages/api/src/routes/reputation.routes.ts
@@ -40,6 +40,7 @@ const router = express.Router();
 
 const WINDOW_15_MIN = 15 * 60 * 1000;
 const WINDOW_1_MIN = 60 * 1000;
+const REQUIRED_AWARD_SCOPE = 'reputation:write';
 
 /** Read limiter for public/auth read endpoints. */
 const readLimiter = rateLimit({
@@ -81,6 +82,13 @@ interface UserOrServiceRequest extends AuthRequest, ServiceAuthRequest {}
  * token resolves `req.serviceApp`; anything else falls through to the regular
  * user `authMiddleware`.
  */
+function requireReputationWriteScope(req: ServiceAuthRequest): void {
+  const scopes = req.serviceApp?.scopes ?? [];
+  if (!scopes.includes(REQUIRED_AWARD_SCOPE)) {
+    throw new ForbiddenError(`Missing required scope: ${REQUIRED_AWARD_SCOPE}`);
+  }
+}
+
 function authUserOrService(
   req: UserOrServiceRequest,
   res: Response,
@@ -268,8 +276,9 @@ router.post(
 /**
  * POST /reputation/award.
  *
- * Awarding is restricted to service tokens (the canonical path — a source app
- * reports an action) and platform staff. Regular users may NOT award reputation
+ * Awarding is restricted to service tokens with the privileged
+ * `reputation:write` scope (the canonical path — a source app reports an
+ * action) and platform staff. Regular users may NOT award reputation
  * (no self-award). When called with a service token the `applicationId` /
  * `credentialId` are resolved from `req.serviceApp` and any client-supplied
  * values for those fields are ignored.
@@ -288,6 +297,8 @@ router.post(
     let createdByUserId: string | undefined;
 
     if (serviceApp) {
+      requireReputationWriteScope(req);
+
       // Canonical service path — source app identity is the token's, not the
       // client body's.
       applicationId = serviceApp.appId;

--- a/packages/api/src/utils/applicationScopes.ts
+++ b/packages/api/src/utils/applicationScopes.ts
@@ -14,6 +14,9 @@
  *   resolve/mutate, federated users (`routes/federation.ts`, `PUT /users/resolve`)
  *   for federation/agent/automation flows. PRIVILEGED — see
  *   {@link PRIVILEGED_APPLICATION_SCOPES}; only Oxy platform staff may grant it.
+ * - `reputation:write` permits service credentials to create reputation ledger
+ *   awards/penalties for arbitrary users. PRIVILEGED — only Oxy platform staff
+ *   may grant it.
  */
 export const APPLICATION_SCOPES = [
   'files:read',
@@ -25,6 +28,7 @@ export const APPLICATION_SCOPES = [
   'models:read',
   'federation:write',
   'signals:write',
+  'reputation:write',
 ] as const;
 
 export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
@@ -40,6 +44,9 @@ export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
  *   resolve/mutate, ARBITRARY federated users. A self-granting owner could
  *   otherwise register an app with a victim domain's redirectUri and impersonate
  *   that domain's users.
+ * - `reputation:write` lets a service credential mutate the global reputation
+ *   ledger for arbitrary users. A self-granting owner could otherwise inflate or
+ *   penalise trust tiers outside its own tenant.
  *
  * All other scopes in {@link APPLICATION_SCOPES} authorise an app only over its
  * OWN resources (files, models, webhooks, public user reads) and remain freely
@@ -48,6 +55,7 @@ export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
  */
 export const PRIVILEGED_APPLICATION_SCOPES = [
   'federation:write',
+  'reputation:write',
 ] as const satisfies readonly ApplicationScope[];
 
 const PRIVILEGED_APPLICATION_SCOPE_SET: ReadonlySet<ApplicationScope> = new Set<ApplicationScope>(


### PR DESCRIPTION
### Motivation
- Prevent unscoped service tokens from mutating the global reputation ledger and altering users' trust/influence without explicit authorization.

### Description
- Added a new privileged application scope `reputation:write` and included it in `PRIVILEGED_APPLICATION_SCOPES` so it cannot be self-granted by ordinary app owners (`packages/api/src/utils/applicationScopes.ts`).
- Gate `POST /reputation/award` so service-token callers must carry the `reputation:write` scope before a transaction is created, preserving the staff path and canonical token-derived `applicationId`/`credentialId` behavior (`packages/api/src/routes/reputation.routes.ts`).
- Added a scoped Jest regression test that verifies an unscoped service token is rejected (403) and a token with `reputation:write` is accepted and still uses the canonical token identity (`packages/api/src/routes/__tests__/reputationAwardAuthz.test.ts`).

### Testing
- Added a Jest test file `packages/api/src/routes/__tests__/reputationAwardAuthz.test.ts` covering both reject/allow cases; execution was attempted but could not complete because the test runner (`jest`) was not available in the container (exit: `jest: command not found`).
- Attempted to install dependencies with `bun install --frozen-lockfile` to run tests, but the install failed due to the npm registry returning 403, so the new test was not executed in this environment.
- Static checks (`git diff --check`) and code edits were validated locally; the new unit test is present and expected to pass in CI where dependencies are available and `jest` is installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bbcd30fdc832391bba3323e3652eb)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->