### PR TITLE
fix(api): restrict Application-derived FedCM/SSO approved origins to trusted apps

### DIFF
--- a/packages/api/src/services/__tests__/fedcm.service.test.ts
+++ b/packages/api/src/services/__tests__/fedcm.service.test.ts
@@ -56,8 +56,8 @@ jest.mock('../../models/FedCMClient', () => ({
   },
 }));
 
-// The canonical Application registry — production RP origins are derived from
-// each active application's redirectUris.
+// The canonical Application registry — trusted production RP origins are derived
+// from active Applications whose staff-controlled trust fields approve them.
 jest.mock('../../models/Application', () => ({
   __esModule: true,
   Application: { find: mockAppFind },
@@ -156,11 +156,10 @@ function createReq(originHeader?: string | null): Request {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Default approval source: an ACTIVE Application whose redirectUri lives on
-  // APPROVED_ORIGIN — so the derived approved-origins set contains it. This is
-  // the new single source of truth (replaces the old hardcoded FedCMClient list).
+  // Default approval source: a staff-trusted ACTIVE Application whose redirectUri
+  // lives on APPROVED_ORIGIN — so the derived approved-origins set contains it.
   mockAppFind.mockReturnValue(
-    leanQuery([{ name: 'Relying Party', redirectUris: [`${APPROVED_ORIGIN}/__oxy/sso-callback`] }])
+    leanQuery([{ name: 'Relying Party', type: 'first_party', redirectUris: [`${APPROVED_ORIGIN}/__oxy/sso-callback`] }])
   );
   // Default nonce claim: succeeds for the expected origin.
   mockFindOneAndUpdate.mockResolvedValue({
@@ -397,27 +396,27 @@ describe('FedCM recordGrant', () => {
   });
 });
 
-describe('FedCM approved-origins derivation (Application registry = single source of truth)', () => {
+describe('FedCM approved-origins derivation (trusted Application registry + manual approvals)', () => {
   const DEV_NATIVE = ['http://localhost:3000', 'http://localhost:8081', 'astro://auth'];
 
-  it('derives every active application redirectUri origin (so a new app is auto-approved)', async () => {
-    // 12-app prod shape: registering an app with a /__oxy/sso-callback redirect
-    // auto-approves its SSO origin — the fix for console.oxy.so being rejected.
+  it('derives redirectUri origins only from active staff-trusted applications', async () => {
+    // 12-app prod shape: staff-controlled trust fields approve the official RP
+    // origins without letting arbitrary third-party apps self-approve.
     mockAppFind.mockReturnValueOnce(
       leanQuery([
-        { name: 'Oxy Website', redirectUris: ['https://oxy.so/__oxy/sso-callback', 'https://fairco.in/__oxy/sso-callback'] },
-        { name: 'Oxy Accounts', redirectUris: ['https://accounts.oxy.so/__oxy/sso-callback'] },
-        { name: 'Oxy Console', redirectUris: ['https://console.oxy.so/__oxy/sso-callback'] },
-        { name: 'Oxy Inbox', redirectUris: ['https://inbox.oxy.so/__oxy/sso-callback'] },
-        { name: 'Oxy Pay', redirectUris: ['https://pay.oxy.so/__oxy/sso-callback'] },
-        { name: 'Allo', redirectUris: ['https://allo.oxy.so/__oxy/sso-callback'] },
-        { name: 'Syra', redirectUris: ['https://syra.oxy.so/__oxy/sso-callback'] },
-        { name: 'Homiio', redirectUris: ['https://homiio.com/__oxy/sso-callback'] },
-        { name: 'Mention', redirectUris: ['https://mention.earth/__oxy/sso-callback'] },
-        { name: 'Alia', redirectUris: ['https://alia.onl/__oxy/sso-callback'] },
-        { name: 'TNP', redirectUris: ['https://tnp.network/__oxy/sso-callback'] },
+        { name: 'Oxy Website', isOfficial: true, redirectUris: ['https://oxy.so/__oxy/sso-callback', 'https://fairco.in/__oxy/sso-callback'] },
+        { name: 'Oxy Accounts', type: 'first_party', redirectUris: ['https://accounts.oxy.so/__oxy/sso-callback'] },
+        { name: 'Oxy Console', type: 'first_party', redirectUris: ['https://console.oxy.so/__oxy/sso-callback'] },
+        { name: 'Oxy Inbox', type: 'first_party', redirectUris: ['https://inbox.oxy.so/__oxy/sso-callback'] },
+        { name: 'Oxy Pay', isOfficial: true, redirectUris: ['https://pay.oxy.so/__oxy/sso-callback'] },
+        { name: 'Allo', isOfficial: true, redirectUris: ['https://allo.oxy.so/__oxy/sso-callback'] },
+        { name: 'Syra', isOfficial: true, redirectUris: ['https://syra.oxy.so/__oxy/sso-callback'] },
+        { name: 'Homiio', isOfficial: true, redirectUris: ['https://homiio.com/__oxy/sso-callback'] },
+        { name: 'Mention', isOfficial: true, redirectUris: ['https://mention.earth/__oxy/sso-callback'] },
+        { name: 'Alia', isOfficial: true, redirectUris: ['https://alia.onl/__oxy/sso-callback'] },
+        { name: 'TNP', isOfficial: true, redirectUris: ['https://tnp.network/__oxy/sso-callback'] },
         // An app with no redirectUris contributes no origin (Oxy Auth IdP).
-        { name: 'Oxy Auth', redirectUris: [] },
+        { name: 'Oxy Auth', type: 'system', redirectUris: [] },
       ])
     );
 
@@ -430,8 +429,15 @@ describe('FedCM approved-origins derivation (Application registry = single sourc
     ]) {
       expect(origins).toContain(expected);
     }
-    // The Application registry MUST be the source (not a hardcoded FedCMClient list).
-    expect(mockAppFind).toHaveBeenCalledWith({ status: 'active' });
+    // The trusted Application registry MUST be the source (not a hardcoded FedCMClient list).
+    expect(mockAppFind).toHaveBeenCalledWith({
+      status: 'active',
+      $or: [
+        { isOfficial: true },
+        { isInternal: true },
+        { type: { $in: ['first_party', 'internal', 'system'] } },
+      ],
+    });
   });
 
   it('always includes the dev/native origins (not modelled as Applications)', async () => {
@@ -446,19 +452,42 @@ describe('FedCM approved-origins derivation (Application registry = single sourc
     // The service only queries { status: 'active' }; a suspended app is never
     // returned by that query, so its origin must not appear.
     mockAppFind.mockReturnValueOnce(
-      leanQuery([{ name: 'Active App', redirectUris: ['https://active.example/__oxy/sso-callback'] }])
+      leanQuery([{ name: 'Active App', type: 'first_party', redirectUris: ['https://active.example/__oxy/sso-callback'] }])
     );
     const origins = await fedcmService.getApprovedClientOrigins();
 
     expect(origins).toContain('https://active.example');
     expect(origins).not.toContain('https://suspended.example');
     // Guard: the query filters to active only.
-    expect(mockAppFind).toHaveBeenCalledWith({ status: 'active' });
+    expect(mockAppFind).toHaveBeenCalledWith({
+      status: 'active',
+      $or: [
+        { isOfficial: true },
+        { isInternal: true },
+        { type: { $in: ['first_party', 'internal', 'system'] } },
+      ],
+    });
+  });
+
+  it('does NOT query user-created third_party apps as SSO-approved clients', async () => {
+    mockAppFind.mockReturnValueOnce(leanQuery([]));
+
+    const origins = await fedcmService.getApprovedClientOrigins();
+
+    expect(origins).not.toContain('https://attacker.example');
+    expect(mockAppFind).toHaveBeenCalledWith({
+      status: 'active',
+      $or: [
+        { isOfficial: true },
+        { isInternal: true },
+        { type: { $in: ['first_party', 'internal', 'system'] } },
+      ],
+    });
   });
 
   it('normalises derived origins (lowercases host, strips path/trailing slash)', async () => {
     mockAppFind.mockReturnValueOnce(
-      leanQuery([{ name: 'Mixed Case', redirectUris: ['HTTPS://Console.OXY.so/__oxy/sso-callback'] }])
+      leanQuery([{ name: 'Mixed Case', type: 'first_party', redirectUris: ['HTTPS://Console.OXY.so/__oxy/sso-callback'] }])
     );
     const origins = await fedcmService.getApprovedClientOrigins();
     expect(origins).toContain('https://console.oxy.so');
@@ -484,7 +513,7 @@ describe('FedCM approved-origins derivation (Application registry = single sourc
   });
 });
 
-describe('FedCM seedApprovedClients (dev/native only — prod origins derive from the registry)', () => {
+describe('FedCM seedApprovedClients (dev/native only — trusted prod origins derive from the registry)', () => {
   function seededOrigins(): string[] {
     return mockClientFindOneAndUpdate.mock.calls.map((call) => call[0].origin);
   }
@@ -497,7 +526,7 @@ describe('FedCM seedApprovedClients (dev/native only — prod origins derive fro
       expect.arrayContaining(['http://localhost:3000', 'http://localhost:8081', 'astro://auth'])
     );
     // The hardcoded prod app list is GONE — these must NOT be seeded as FedCMClient
-    // rows; they are derived from the Application registry instead.
+    // rows; they are derived from trusted Application records instead.
     for (const prod of ['https://console.oxy.so', 'https://mention.earth', 'https://oxy.so', 'https://fairco.in']) {
       expect(origins).not.toContain(prod);
     }
@@ -535,11 +564,11 @@ describe('FedCM seedApprovedClients (dev/native only — prod origins derive fro
   });
 });
 
-describe('FedCM getUserAuthorizedApps (display names from the Application registry)', () => {
+describe('FedCM getUserAuthorizedApps (display names from trusted Applications)', () => {
   it('labels a granted origin with its Application name + description', async () => {
     mockAppFind.mockReturnValue(
       leanQuery([
-        { name: 'Oxy Console', description: 'Developer console', redirectUris: ['https://console.oxy.so/__oxy/sso-callback'] },
+        { name: 'Oxy Console', description: 'Developer console', type: 'first_party', redirectUris: ['https://console.oxy.so/__oxy/sso-callback'] },
       ])
     );
     mockGrantFind.mockReturnValueOnce(

--- a/packages/api/src/services/fedcm.service.ts
+++ b/packages/api/src/services/fedcm.service.ts
@@ -16,15 +16,24 @@ import { formatUserNameResponse } from '../utils/displayName';
  * Origins that must be approved as FedCM/SSO clients but are NOT represented by
  * a registered {@link Application} — local dev servers and the native app
  * callback scheme. These are intentionally a small, explicit constant: every
- * PRODUCTION RP origin is derived from the Application registry instead (see
- * `deriveApprovedOrigins`), so a newly-registered app is auto-approved and no
- * production origin is ever "forgotten" in a hand-maintained list.
+ * trusted PRODUCTION RP origin is derived from staff-approved Application
+ * metadata instead (see `fetchApprovedClientOrigins`), so user-created
+ * third-party apps cannot self-approve SSO origins.
  */
 const DEV_NATIVE_APPROVED_ORIGINS = [
   'http://localhost:3000',
   'http://localhost:8081',
   'astro://auth',
 ] as const;
+
+const TRUSTED_APPLICATION_FEDCM_FILTER = {
+  status: 'active',
+  $or: [
+    { isOfficial: true },
+    { isInternal: true },
+    { type: { $in: ['first_party', 'internal', 'system'] } },
+  ],
+};
 
 const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const NONCE_BYTES = 32;
@@ -156,13 +165,11 @@ class FedCMService {
   /**
    * Uncached read of all approved client origins straight from Mongo.
    *
-   * Single source of truth: the production RP origins are DERIVED from the
-   * canonical {@link Application} registry — for every `status: 'active'`
-   * application, each of its `redirectUris` contributes its origin
-   * (`new URL(uri).origin`, normalised). Registering an app with a
-   * `https://<app>/__oxy/sso-callback` redirect therefore auto-approves its SSO
-   * origin; nothing has to be added to a hand-maintained list, so no app is
-   * ever forgotten (the bug that rejected console.oxy.so).
+   * Single source of truth for production first-party RP origins: derive origins
+   * from the canonical {@link Application} registry, but only for active apps
+   * whose staff-controlled trust fields mark them as platform-approved. Normal
+   * user-created third-party apps are active too, so `status: 'active'` alone is
+   * not a trust boundary for FedCM/SSO session minting.
    *
    * Unioned with:
    *  - {@link DEV_NATIVE_APPROVED_ORIGINS} (localhost dev + native scheme — not
@@ -187,7 +194,7 @@ class FedCMService {
 
     try {
       const [apps, manualClients] = await Promise.all([
-        Application.find({ status: 'active' }).select('redirectUris').lean(),
+        Application.find(TRUSTED_APPLICATION_FEDCM_FILTER).select('redirectUris').lean(),
         // Manual/admin-approved escape-hatch entries (not Applications).
         FedCMClient.find({ approved: true }).select('origin').lean(),
       ]);
@@ -225,7 +232,7 @@ class FedCMService {
     const catalog = new Map<string, { name: string; description?: string }>();
     try {
       const [apps, manualClients] = await Promise.all([
-        Application.find({ status: 'active' }).select('name description redirectUris').lean(),
+        Application.find(TRUSTED_APPLICATION_FEDCM_FILTER).select('name description redirectUris').lean(),
         FedCMClient.find({ approved: true }).select('origin name description').lean(),
       ]);
 
@@ -270,8 +277,9 @@ class FedCMService {
   /**
    * Seed the dev/native FedCM clients (idempotent — run on startup).
    *
-   * PRODUCTION RP origins are NOT seeded here: they are derived live from the
-   * {@link Application} registry by {@link fetchApprovedClientOrigins}. This
+   * PRODUCTION RP origins are NOT seeded here: trusted first-party/internal
+   * origins are derived live from the {@link Application} registry by
+   * {@link fetchApprovedClientOrigins}. This
    * function only persists the small {@link DEV_NATIVE_APPROVED_ORIGINS} set
    * (localhost + native scheme) as {@link FedCMClient} rows so they survive in
    * the admin-visible collection and the `getUserAuthorizedApps` catalog.
@@ -318,7 +326,7 @@ class FedCMService {
         );
       }
 
-      logger.info(`Seeded ${devNativeClients.length} dev/native FedCM clients (production origins derive from the Application registry)`);
+      logger.info(`Seeded ${devNativeClients.length} dev/native FedCM clients (trusted production origins derive from the Application registry)`);
       // Drop any list cached before/during seeding so the first read after
       // boot reflects the freshly-seeded allow-list.
       approvedClientsCache.invalidate();


### PR DESCRIPTION
### Motivation
- Close a privilege-escalation where any authenticated user could self-approve an SSO origin by creating an `Application` with arbitrary `redirectUris`, enabling silent SSO/session minting for attacker-controlled origins.
- Preserve the admin/manual approval escape hatch (`FedCMClient`) and the small dev/native allow-list while restoring a clear trust boundary between user-created third-party apps and platform-trusted RPs.

### Description
- Require staff-trust markers when deriving FedCM/SSO approved origins from the `Application` registry by introducing `TRUSTED_APPLICATION_FEDCM_FILTER` and using it in `fetchApprovedClientOrigins()` and `fetchApprovedClientCatalog()` in `packages/api/src/services/fedcm.service.ts`.
- Keep `DEV_NATIVE_APPROVED_ORIGINS` and manually-approved `FedCMClient` rows as explicit allow-list sources and union them with the trusted Application origins.
- Update tests in `packages/api/src/services/__tests__/fedcm.service.test.ts` to assert the new behavior, including a new test that verifies user-created `third_party` apps are not queried as SSO-approved clients.

### Testing
- Updated unit test file: `packages/api/src/services/__tests__/fedcm.service.test.ts` was extended to cover the trusted filter and the negative case for `third_party` apps; these tests were added and committed.
- Attempted to run package tests via `bun run test packages/api/src/services/__tests__/fedcm.service.test.ts --runInBand` but the environment lacks `jest` and dependency installation (`bun install`) failed due to npm registry `403`, so automated tests could not be executed here.
- Local verification: code compiles in-edit (no runtime execution in this environment) and changes were committed (`fix(api): require trusted apps for FedCM origins`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bbe40d9e883238a3d9c103c6c90db)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->