### PR TITLE
Prevent bearer token leakage in persisted image/logo URLs

### DIFF
--- a/packages/api/src/routes/applications.ts
+++ b/packages/api/src/routes/applications.ts
@@ -27,6 +27,7 @@ import {
 import { logger } from '../utils/logger';
 import { ensurePersonalWorkspace } from '../utils/workspaceProvisioning';
 import credentialDomainCache from '../utils/credentialDomainCache';
+import { stripSensitiveUrlQueryParams } from '../utils/sanitizeUrl';
 import { resolveUserByIdentifier } from '../utils/resolveUserIdentifier';
 import {
   permissionsForRole,
@@ -664,7 +665,7 @@ router.post(
       name: body.name,
       description: body.description,
       websiteUrl: body.websiteUrl || undefined,
-      icon: body.icon,
+      icon: body.icon ? stripSensitiveUrlQueryParams(body.icon) : body.icon,
       redirectUris: resolveRedirectUris(body) ?? [],
       scopes,
       workspaceId: workspaceObjectId,
@@ -744,7 +745,7 @@ router.patch(
     if (body.name !== undefined) application.name = body.name;
     if (body.description !== undefined) application.description = body.description;
     if (body.websiteUrl !== undefined) application.websiteUrl = body.websiteUrl || undefined;
-    if (body.icon !== undefined) application.icon = body.icon;
+    if (body.icon !== undefined) application.icon = stripSensitiveUrlQueryParams(body.icon);
     if (body.scopes !== undefined) {
       // Privileged scopes (e.g. federation:write) are staff-only. A non-staff
       // caller may keep an already-granted privileged scope but may not add one.

--- a/packages/api/src/routes/workspaces.ts
+++ b/packages/api/src/routes/workspaces.ts
@@ -24,6 +24,7 @@ import {
   generateUniqueWorkspaceSlug,
 } from '../utils/workspaceProvisioning';
 import { resolveUserByIdentifier } from '../utils/resolveUserIdentifier';
+import { stripSensitiveUrlQueryParams } from '../utils/sanitizeUrl';
 import {
   workspaceIdRouteParams,
   workspaceMemberParams,
@@ -217,7 +218,7 @@ router.post(
       slug,
       type: 'team',
       description: body.description,
-      icon: body.icon,
+      icon: body.icon ? stripSensitiveUrlQueryParams(body.icon) : body.icon,
       ownerId: new mongoose.Types.ObjectId(userId),
       status: 'active',
     });
@@ -293,7 +294,7 @@ router.patch(
       workspace.description = body.description ?? undefined;
     }
     if (body.icon !== undefined) {
-      workspace.icon = body.icon ?? undefined;
+      workspace.icon = body.icon ? stripSensitiveUrlQueryParams(body.icon) : undefined;
     }
 
     await workspace.save();

--- a/packages/api/src/utils/sanitizeUrl.ts
+++ b/packages/api/src/utils/sanitizeUrl.ts
@@ -1,0 +1,19 @@
+const SENSITIVE_URL_QUERY_PARAMS = new Set(['token', 'access_token', 'authorization']);
+
+/**
+ * Remove credential-bearing query parameters before persisting user-supplied URLs.
+ */
+export function stripSensitiveUrlQueryParams(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+
+  try {
+    const url = new URL(trimmed);
+    for (const param of SENSITIVE_URL_QUERY_PARAMS) {
+      url.searchParams.delete(param);
+    }
+    return url.toString();
+  } catch {
+    return trimmed;
+  }
+}

--- a/packages/console/src/components/apps/general-section.tsx
+++ b/packages/console/src/components/apps/general-section.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/alert-dialog';
 import { toast } from 'sonner';
 import { getErrorMessage } from '@/lib/api-error';
+import { stripSensitiveImageUrlQueryParams } from '@/lib/image-upload';
 import {
   useUpdateApplication,
   useDeleteApplication,
@@ -93,9 +94,9 @@ export function GeneralSection({ application, access }: GeneralSectionProps) {
           name: name.trim(),
           description: description.trim() || undefined,
           websiteUrl: websiteUrl.trim() || undefined,
-          // Sent verbatim (empty string clears the logo) since the value comes
-          // from the upload widget, never free-text.
-          icon: icon.trim(),
+          // Empty string clears the logo. Strip credentials defensively before
+          // saving because application metadata can be exposed publicly.
+          icon: stripSensitiveImageUrlQueryParams(icon),
           redirectUris,
         },
       });

--- a/packages/console/src/lib/image-upload.ts
+++ b/packages/console/src/lib/image-upload.ts
@@ -9,9 +9,9 @@ import type { OxyServices } from '@oxyhq/core';
  *     `response.file.id`. The response does NOT contain a ready URL.
  *  3. We derive a public, directly-renderable URL with the synchronous helper
  *     `oxyServices.getFileDownloadUrl(id)`, which returns the
- *     `/assets/:id/stream` endpoint. For `public`-visibility assets that endpoint
- *     serves without a session token, so the URL renders in a plain `<img>` and
- *     on the public consent screen.
+ *     `/assets/:id/stream` endpoint. For `public`-visibility assets, we request
+ *     a token-free URL so persisted logo/avatar metadata cannot disclose a
+ *     user's bearer token.
  */
 
 /** Allowed image MIME types for logo / avatar uploads. */
@@ -30,6 +30,29 @@ export const MAX_IMAGE_UPLOAD_LABEL = '2 MB';
 
 /** Visibility used for uploaded logos/avatars — public so they render unauthenticated. */
 const PUBLIC_VISIBILITY = 'public' as const;
+
+const SENSITIVE_URL_QUERY_PARAMS = new Set(['token', 'access_token', 'authorization']);
+
+/**
+ * Strip credentials from URLs before persisting image metadata.
+ *
+ * Returns non-URL strings unchanged so callers can still clear fields with an
+ * empty string or preserve future asset-id based formats.
+ */
+export function stripSensitiveImageUrlQueryParams(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return trimmed;
+
+  try {
+    const url = new URL(trimmed);
+    for (const param of SENSITIVE_URL_QUERY_PARAMS) {
+      url.searchParams.delete(param);
+    }
+    return url.toString();
+  } catch {
+    return trimmed;
+  }
+}
 
 /** Shape of the `uploadRawFile` response that we depend on. */
 interface RawFileUploadResponse {
@@ -84,5 +107,9 @@ export async function uploadPublicImage(
   if (!isRawFileUploadResponse(response)) {
     throw new Error('Upload did not return a file id');
   }
-  return oxyServices.getFileDownloadUrl(response.file.id);
+  return stripSensitiveImageUrlQueryParams(
+    oxyServices.getFileDownloadUrl(response.file.id, undefined, undefined, {
+      omitToken: true,
+    })
+  );
 }

--- a/packages/console/src/routes/_layout/settings/workspace.tsx
+++ b/packages/console/src/routes/_layout/settings/workspace.tsx
@@ -62,6 +62,7 @@ import {
   isUserNotFoundError,
   USER_NOT_FOUND_MESSAGE,
 } from '@/lib/api-error';
+import { stripSensitiveImageUrlQueryParams } from '@/lib/image-upload';
 
 export const Route = createFileRoute('/_layout/settings/workspace')({
   component: WorkspaceSettingsPage,
@@ -186,10 +187,11 @@ function WorkspaceSettingsPage() {
   // for team workspaces — personal workspaces inherit the user's account avatar
   // and expose no uploader.
   const handleAvatarChange = async (url: string) => {
-    setIcon(url);
+    const safeUrl = stripSensitiveImageUrlQueryParams(url);
+    setIcon(safeUrl);
     try {
-      await updateWorkspace(workspaceId, { icon: url || null });
-      toast.success(url ? 'Workspace avatar updated' : 'Workspace avatar removed');
+      await updateWorkspace(workspaceId, { icon: safeUrl || null });
+      toast.success(safeUrl ? 'Workspace avatar updated' : 'Workspace avatar removed');
     } catch (error) {
       // Revert the local preview to the persisted value on failure.
       setIcon(currentWorkspace.icon ?? '');

--- a/packages/core/src/mixins/OxyServices.assets.ts
+++ b/packages/core/src/mixins/OxyServices.assets.ts
@@ -1,6 +1,11 @@
 import type { AccountStorageUsageResponse, AssetUploadInput, AssetUrlResponse, AssetVariant, RNFileDescriptor } from '../models/interfaces';
 import type { OxyServicesBase } from '../OxyServices.base';
 
+interface FileDownloadUrlOptions {
+  /** Omit bearer access tokens from generated URLs, even when authenticated. */
+  omitToken?: boolean;
+}
+
 export function OxyServicesAssetsMixin<T extends typeof OxyServicesBase>(Base: T) {
   return class extends Base {
     constructor(...args: any[]) {
@@ -44,8 +49,13 @@ export function OxyServicesAssetsMixin<T extends typeof OxyServicesBase>(Base: T
      *
      * For a CDN-signed URL fetched from the API, use {@link getFileDownloadUrlAsync}.
      */
-    getFileDownloadUrl(fileId: string, variant?: string, expiresIn?: number): string {
-      const token = this.getClient().getAccessToken();
+    getFileDownloadUrl(
+      fileId: string,
+      variant?: string,
+      expiresIn?: number,
+      options: FileDownloadUrlOptions = {}
+    ): string {
+      const token = options.omitToken ? undefined : this.getClient().getAccessToken();
 
       // Public case: no auth token and no expiry requested → clean CDN URL.
       // CloudFront serves the public media origin under `${cloudURL}/<id>`.

--- a/packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts
+++ b/packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts
@@ -49,6 +49,19 @@ describe('OxyServices.getFileDownloadUrl', () => {
         'https://cloud.oxy.so/a%2Fb%20c?variant=large%20size',
       );
     });
+
+    it('can omit the token for persisted public image URLs while authenticated', () => {
+      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+      oxy.setTokens('access-token-abc');
+
+      const url = oxy.getFileDownloadUrl('file123', 'thumb', undefined, {
+        omitToken: true,
+      });
+
+      expect(url).toBe('https://cloud.oxy.so/file123?variant=thumb');
+      expect(url).not.toContain('access-token-abc');
+      expect(url).not.toContain('token=');
+    });
   });
 
   describe('signed / private assets → authenticated API origin', () => {


### PR DESCRIPTION
### Motivation
- Public image upload flow returned token-bearing download URLs when the SDK had an in-memory access token, and these URLs were persisted as application/workspace icon fields that can be read via public endpoints.  This allowed bearer tokens to be leaked through stored metadata.

### Description
- Added an `omitToken` option to `OxyServices.getFileDownloadUrl()` so callers can explicitly request token-free URLs even when authenticated (core change in `packages/core/src/mixins/OxyServices.assets.ts`).
- Console upload helper now requests a token-free URL and strips sensitive query parameters before returning the URL (`packages/console/src/lib/image-upload.ts`).
- Console UI components that persist icons/avatars were updated to defensively strip credential-bearing query params before sending to the API (`packages/console/src/components/apps/general-section.tsx`, `packages/console/src/routes/_layout/settings/workspace.tsx`).
- Added API-side defense by stripping credential-bearing query params server-side before persisting application and workspace `icon` fields (`packages/api/src/utils/sanitizeUrl.ts`, `packages/api/src/routes/applications.ts`, `packages/api/src/routes/workspaces.ts`).
- Added a regression unit test asserting the `omitToken` behavior for authenticated public URLs (`packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts`).

### Testing
- Attempted to run the focused core test `bun run test -- getFileDownloadUrl.test.ts`, but `jest` was not available in the execution environment so the test could not be executed (dependency install failed in this environment).
- Added the unit test to cover token omission semantics; it is included in the commit and should pass when run in CI or a developer environment with dependencies installed.
- Could not complete `bun install` in this environment due to npm registry/permission errors, so full test suite execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bbe6e59f48323ae543e9799836096)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->