### PR TITLE
fix(api): require origin proof for official auth sessions

### DIFF
--- a/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
@@ -278,6 +278,7 @@ function officialApp() {
     isInternal: false,
     scopes: ['user:read'],
     createdByUserId: { toString: () => 'staff-1' },
+    redirectUris: ['https://accounts.oxy.so/__oxy/sso-callback'],
   };
 }
 
@@ -339,6 +340,46 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
     expect(mockApplicationFindById).toHaveBeenCalledWith(THIRD_PARTY_APP_ID);
     const created = mockAuthSessionCreate.mock.calls[0][0] as { applicationId: { toString: () => string } };
     expect(created.applicationId.toString()).toBe(THIRD_PARTY_APP_ID);
+  });
+
+  it('(b1) permits an official app only from a registered redirect origin', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
+    mockApplicationFindById.mockResolvedValueOnce(officialApp());
+
+    const res = await requestJson(server, 'POST', '/auth/session/create', {
+      sessionToken: 'tok-create-official-ok',
+      clientId: 'oxy_dk_client',
+    }, { origin: 'https://accounts.oxy.so' });
+
+    expect(res.status).toBe(200);
+    const created = mockAuthSessionCreate.mock.calls[0][0] as { applicationId: { toString: () => string } };
+    expect(created.applicationId.toString()).toBe(OFFICIAL_APP_ID);
+  });
+
+  it('(b2) rejects an official app from an unregistered origin', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
+    mockApplicationFindById.mockResolvedValueOnce(officialApp());
+
+    const res = await requestJson(server, 'POST', '/auth/session/create', {
+      sessionToken: 'tok-create-official-bad-origin',
+      clientId: 'oxy_dk_client',
+    }, { origin: 'https://evil.example' });
+
+    expect(res.status).toBe(403);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('(b3) rejects an official app when origin proof is absent', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
+    mockApplicationFindById.mockResolvedValueOnce(officialApp());
+
+    const res = await requestJson(server, 'POST', '/auth/session/create', {
+      sessionToken: 'tok-create-official-no-origin',
+      clientId: 'oxy_dk_client',
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
   });
 
   it('(c0) returns 400 when NEITHER clientId nor applicationId is supplied', async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1461,6 +1461,17 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
     throw new ForbiddenError('Application is not available');
   }
 
+  // Public OAuth client IDs are routing identifiers, not authenticators. For
+  // trusted first-party/internal app identities, require a browser Origin that
+  // proves the caller is running on one of the app's registered redirect
+  // origins before showing official branding in the device consent UI.
+  if (appRequiresProvenOrigin(resolvedApp)) {
+    const origin = requestOrigin(req);
+    if (!origin || !applicationAllowsOrigin(resolvedApp, origin)) {
+      throw new ForbiddenError('Application origin is not allowed');
+    }
+  }
+
   // Check if session token already exists (generic error to prevent enumeration)
   const existing = await AuthSession.findOne({ sessionToken });
   if (existing) {
@@ -2003,6 +2014,37 @@ function isAllowedRedirectUri(app: { redirectUris?: string[] }, redirectUri: str
  * no usable credential exists. Mirrors the resolution in `/oauth/authorize`
  * and `/oauth/token`.
  */
+
+function originFromRedirectUri(redirectUri: string): string | null {
+  try {
+    return new URL(redirectUri).origin;
+  } catch {
+    return null;
+  }
+}
+
+function requestOrigin(req: express.Request): string | null {
+  const origin = req.headers.origin;
+  if (Array.isArray(origin)) {
+    return origin[0] ?? null;
+  }
+  return origin ?? null;
+}
+
+function applicationAllowsOrigin(app: Pick<IApplication, 'redirectUris'>, origin: string): boolean {
+  return (app.redirectUris ?? []).some((redirectUri) => originFromRedirectUri(redirectUri) === origin);
+}
+
+function appRequiresProvenOrigin(app: Pick<IApplication, 'isOfficial' | 'isInternal' | 'type'>): boolean {
+  return (
+    app.isOfficial ||
+    app.isInternal ||
+    app.type === 'first_party' ||
+    app.type === 'internal' ||
+    app.type === 'system'
+  );
+}
+
 async function resolveUsableCredential(clientId: string): Promise<IApplicationCredential | null> {
   const credential = await ApplicationCredential.findOne({
     publicKey: clientId,


### PR DESCRIPTION
### Motivation
- Close a device-flow impersonation vulnerability where published public `clientId` values could be used by unauthenticated callers to create auth sessions that show official app branding without proving origin control.
- Ensure that trusted first-party / internal / system applications are only attributed when the requesting browser origin matches a registered redirect origin.

### Description
- Require origin proof in `POST /auth/session/create` by rejecting requests that supply a public `clientId` for trusted apps unless the `Origin` header matches one of the app's registered `redirectUris` origins, using exact origin comparison derived from the redirect URIs.
- Add helper functions: `originFromRedirectUri`, `requestOrigin`, `applicationAllowsOrigin`, and `appRequiresProvenOrigin` in `packages/api/src/routes/auth.ts` to centralize origin extraction and policy checks.
- Add three regression tests in `packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts` that verify: a valid registered origin is accepted for an official app, an unregistered origin is rejected, and a missing `Origin` is rejected.
- Files changed: `packages/api/src/routes/auth.ts` and `packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts`.

### Testing
- `git diff --check` succeeded locally against the change set.
- Added unit tests that exercise the new origin checks (`authSessionAppIdentity.test.ts`) but running them was blocked because `jest` is not available in the execution environment; attempts to run `bun install` failed due to registry access (HTTP 403) so test execution could not complete.
- No runtime regressions were observed in static inspection and unit test additions; CI should run the new tests (Jest) and validate the behavior in a full install environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc13d2d3c8323a8205a91d0a075a9)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->