### PR TITLE
fix(api): tighten workspace-derived application permissions

### DIFF
--- a/packages/api/src/routes/__tests__/applications.test.ts
+++ b/packages/api/src/routes/__tests__/applications.test.ts
@@ -888,25 +888,53 @@ describe('workspace-membership grants application access', () => {
     expect(callerMembership?.role).toBe('owner');
   });
 
-  it('workspace owner/admin can update the app (full app permissions)', async () => {
+  it('workspace admin can update and delete the app without full app-owner permissions', async () => {
     seedApp();
     seedWorkspaceMember(WS_OWNER_ID, 'admin');
     actAs(WS_OWNER_ID);
 
-    const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, { name: 'WS Rename' });
-    expect(res.status).toBe(200);
-    expect(res.body.application?.name).toBe('WS Rename');
+    const updateRes = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
+      name: 'WS Rename',
+    });
+    expect(updateRes.status).toBe(200);
+    expect(updateRes.body.application?.name).toBe('WS Rename');
+
+    const deleteRes = await requestJson(server, 'DELETE', `/applications/${APP_ID}`);
+    expect(deleteRes.status).toBe(200);
   });
 
-  it('workspace member gets app:read + app:update but NOT app:delete', async () => {
+  it('workspace admin cannot manage credentials or transfer app ownership implicitly', async () => {
+    seedApp();
+    seedMember(DEVELOPER_ID, 'developer');
+    seedWorkspaceMember(WS_OWNER_ID, 'admin');
+    actAs(WS_OWNER_ID);
+
+    const credentialsRes = await requestJson(server, 'GET', `/applications/${APP_ID}/credentials`);
+    expect(credentialsRes.status).toBe(403);
+
+    const transferRes = await requestJson(
+      server,
+      'POST',
+      `/applications/${APP_ID}/transfer-ownership`,
+      {
+        userId: DEVELOPER_ID,
+      }
+    );
+    expect(transferRes.status).toBe(403);
+  });
+
+  it('workspace member gets app:read but NOT app:update or app:delete', async () => {
     seedApp();
     seedWorkspaceMember(WS_MEMBER_ID, 'member');
     actAs(WS_MEMBER_ID);
 
+    const readRes = await requestJson(server, 'GET', `/applications/${APP_ID}`);
+    expect(readRes.status).toBe(200);
+
     const updateRes = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
       name: 'Member Rename',
     });
-    expect(updateRes.status).toBe(200);
+    expect(updateRes.status).toBe(403);
 
     const deleteRes = await requestJson(server, 'DELETE', `/applications/${APP_ID}`);
     expect(deleteRes.status).toBe(403);

--- a/packages/api/src/utils/applicationRoles.ts
+++ b/packages/api/src/utils/applicationRoles.ts
@@ -116,23 +116,28 @@ export function isApplicationRole(value: string): value is ApplicationRole {
  * applications owned by that workspace.
  *
  * A workspace member gets implicit app access (no per-app ApplicationMember row
- * required) according to their workspace role:
- *  - owner / admin → full application permissions (manage everything);
- *  - member        → read + update the application;
- *  - viewer        → read-only.
+ * required) according to the app-management permissions carried by their
+ * workspace role:
+ *  - owner  → full application permissions (workspace owner authority);
+ *  - admin  → read, update, and delete workspace-owned applications;
+ *  - member → read-only access to workspace-owned applications;
+ *  - viewer → read-only access to workspace-owned applications.
  *
- * These are UNIONed with any explicit ApplicationMember permissions at the
- * route's RBAC site so the caller always receives the broader of the two.
+ * Workspace membership must not synthesize credential, application-member, or
+ * ownership-transfer permissions unless those operations are explicitly modeled
+ * by the workspace role. These permissions are UNIONed with any explicit
+ * ApplicationMember permissions at the route's RBAC site so per-app grants can
+ * still broaden access intentionally.
  */
 export function appPermissionsForWorkspaceRole(
   workspaceRole: 'owner' | 'admin' | 'member' | 'viewer'
 ): ApplicationPermission[] {
   switch (workspaceRole) {
     case 'owner':
-    case 'admin':
       return [...APPLICATION_PERMISSIONS];
+    case 'admin':
+      return ['app:read', 'app:update', 'app:delete'];
     case 'member':
-      return ['app:read', 'app:update'];
     case 'viewer':
       return ['app:read'];
   }


### PR DESCRIPTION
### Motivation
- Close an authorization gap that allowed workspace members to implicitly obtain `app:update` (and admins to obtain full application permissions), which could let low-privileged users modify sensitive application configuration (redirect URIs, scopes, webhooks, status) and enable privilege escalation or OAuth hijacking.

### Description
- Tighten the workspace→application permission mapper in `packages/api/src/utils/applicationRoles.ts` so `owner` still receives all `APPLICATION_PERMISSIONS`, `admin` receives only `['app:read','app:update','app:delete']`, and both `member` and `viewer` receive only `['app:read']` (no implicit credential, membership, billing, or ownership-transfer grants).
- Update `packages/api/src/routes/__tests__/applications.test.ts` to reflect the tightened policy by asserting that workspace admins may update/delete apps but cannot implicitly manage credentials or transfer ownership, and that workspace members may only read (cannot patch/delete).
- Commit created with message: `fix(api): tighten workspace-derived app permissions`.

### Testing
- Ran `git diff --check` to validate no whitespace/git-diff issues; it passed.
- Executed a quick runtime sanity check with `bun -e "import { appPermissionsForWorkspaceRole } from './packages/api/src/utils/applicationRoles.ts'; console.log(JSON.stringify({member: appPermissionsForWorkspaceRole('member'), admin: appPermissionsForWorkspaceRole('admin')}));"` which returned the tightened mappings (`member: ['app:read']`, `admin: ['app:read','app:update','app:delete']`).
- Attempted to run the package test target `bun run test --runTestsByPath src/routes/__tests__/applications.test.ts` but it could not be executed in this environment because `jest` is not installed; running `bun install` to fetch dependencies is blocked by registry access errors (npm registry returned 403), so full test execution was not possible here.
- The updated tests are included in the commit and should run in CI or a developer environment with dependencies available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc09d79dc8323b4c70bd2fee3716a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->