### PR TITLE
fix(auth): disclose broad OAuth account access

### DIFF
--- a/packages/auth/components/__tests__/app-identity-card.test.tsx
+++ b/packages/auth/components/__tests__/app-identity-card.test.tsx
@@ -10,6 +10,8 @@
  *     developer name + website link; NO official trust line.
  *   - requested scopes render human-readable labels from `scope-labels`; an
  *     explicit `requestedScopes` prop OVERRIDES the application's own `scopes`.
+ *   - the broad account-access baseline remains visible even when OAuth scopes
+ *     are requested because issued OAuth sessions are not scope-limited.
  *
  * `Avatar` is stubbed to a web-safe surrogate by `setup-mocks.ts` (it otherwise
  * pulls `react-native`, which bun cannot parse in this node test environment).
@@ -156,6 +158,17 @@ describe("AppIdentityCard", () => {
         const text = container.textContent ?? ""
 
         expect(text).toContain(SCOPE_LABELS["user:read"])
+
+        unmount()
+    })
+
+    test("always discloses broad account access when requested scopes are present", () => {
+        const { container, unmount } = renderCard(thirdPartyApp, ["user:read"])
+        const text = container.textContent ?? ""
+
+        expect(text).toContain(SCOPE_LABELS["user:read"])
+        expect(text).toContain("Sign in with Oxy")
+        expect(text).toContain("Access your account on your behalf")
 
         unmount()
     })

--- a/packages/auth/components/app-identity-card.tsx
+++ b/packages/auth/components/app-identity-card.tsx
@@ -6,10 +6,10 @@ import { AuthFormHeader } from "@/components/auth-form-layout";
 import { labelForScope } from "@/lib/scope-labels";
 
 /**
- * Permissions every consent grant carries even when the requesting application
- * declares no explicit OAuth scopes (e.g. the QR-code device flow). These are
- * intentionally generic — the granular `scopes` list, when present, supersedes
- * this baseline in {@link resolveScopeLabels}.
+ * Permissions every consent grant carries. OAuth code exchange currently issues
+ * a normal Oxy user session rather than a token constrained to the requested
+ * OAuth scopes, so the consent screen must always disclose this broad baseline
+ * in addition to any friendly scope labels.
  */
 const BASE_PERMISSION_LABELS: readonly string[] = [
   "Sign in with Oxy",
@@ -30,16 +30,19 @@ function isTrustedApplication(app: PublicApplication): boolean {
 /**
  * Resolve the final, human-readable permission lines to display.
  *
- * - When explicit scopes are provided (the OAuth `scope` URL param for the code
- *   flow, otherwise the application's configured scope list) each scope is
- *   mapped to its friendly label.
- * - When there are none (device/QR flow) we fall back to the base permissions.
+ * Explicit scopes (the OAuth `scope` URL param for the code flow, otherwise the
+ * application's configured scope list) add friendly context, but they do not
+ * narrow the session credentials issued by the backend today. Keep the broad
+ * baseline visible for every grant so consent cannot imply a scope-limited
+ * token.
  */
 function resolveScopeLabels(scopes: readonly string[]): string[] {
-  if (scopes.length === 0) {
-    return [...BASE_PERMISSION_LABELS];
-  }
-  return scopes.map(labelForScope);
+  return [
+    ...BASE_PERMISSION_LABELS,
+    ...scopes.map(labelForScope).filter(
+      (label) => !BASE_PERMISSION_LABELS.includes(label)
+    ),
+  ];
 }
 
 /**
@@ -62,7 +65,8 @@ type AppIdentityCardProps = {
   /**
    * Explicit scopes to display, when known (e.g. the OAuth `scope` URL param,
    * space-separated and split by the caller). When empty, the card falls back
-   * to the application's own configured `scopes`, then to base permissions.
+   * to the application's own configured `scopes`. The broad account-access
+   * baseline is always shown because issued OAuth sessions are not scoped.
    */
   requestedScopes?: readonly string[];
 };
@@ -77,8 +81,9 @@ type AppIdentityCardProps = {
  */
 export function AppIdentityCard({ app, requestedScopes }: AppIdentityCardProps) {
   const trusted = isTrustedApplication(app);
-  // Prefer the explicitly-requested scopes (OAuth flow) over the application's
-  // full configured scope list (device flow / no `scope` param).
+  // Prefer explicitly-requested scopes (OAuth flow) for the friendly scope
+  // details, but always include the broad baseline in resolveScopeLabels because
+  // the issued OAuth session credentials are not scope-limited.
   const effectiveScopes =
     requestedScopes && requestedScopes.length > 0
       ? requestedScopes


### PR DESCRIPTION
### Motivation
- The consent UI was showing only the attacker-controllable `scope` labels when an OAuth `scope` param was present, which could mislead users because the backend still issues a normal unscoped user session.

### Description
- Always include the broad baseline consent lines (`"Sign in with Oxy"` and `"Access your account on your behalf"`) on the consent card in `packages/auth/components/app-identity-card.tsx` so the UI cannot imply a scope-limited token.
- Change `resolveScopeLabels` to prepend the baseline labels to any friendly scope labels instead of replacing the baseline when requested scopes exist.
- Add an integration-level regression test in `packages/auth/components/__tests__/app-identity-card.test.tsx` asserting that narrow requested scopes render their friendly label while the broad account-access baseline remains visible.
- Update inline comments and docs in the component to document the current backend behavior (unscoped OAuth session issuance) to help future maintainers.

### Testing
- Ran `git diff --check` to validate the diff formatting and found no issues (success).
- Attempted to run the auth package test suite with `bun run test` in `packages/auth`, but test execution failed due to missing project dependencies in this environment (dependency installation via `bun install` was blocked by registry errors), so the new test could not be executed here (failure due to environment, not code).
- No further automated test runs were possible because `bun install` could not complete (npm registry 403s) in the current sandbox.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc4ec58fc83239d82a132cfe8d4d1)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->