### PR TITLE
fix(api): require service auth for auth session creation

### DIFF
--- a/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
@@ -3,13 +3,13 @@
  *
  * Every cross-app/device auth session is ALWAYS bound to a REAL registered
  * `Application` record. There is NO free-form `appId` label — the caller must
- * identify the app via `clientId` or `applicationId`. The API exposes sanitized
+ * authenticate with a service token for the app. The API exposes sanitized
  * public application metadata for the consent UI:
  *
- *  - POST /auth/session/create resolves `clientId` (→ ApplicationCredential →
- *    Application) OR `applicationId` (→ Application) and stores the canonical
- *    `applicationId` on the AuthSession. No app reference → 400; unknown refs →
- *    400; non-active apps (suspended/deleted/pending_review) → 403.
+ *  - POST /auth/session/create resolves the canonical `applicationId` from
+ *    the verified service token. Optional `clientId` is only a consistency
+ *    check and must belong to the authenticated app; raw body `applicationId`
+ *    is rejected by validation.
  *  - GET /auth/session/status/:sessionToken ALWAYS embeds a sanitized
  *    `application` object (null only if the app was hard-deleted) and NEVER an
  *    `appId`, without leaking secrets/owner internals.
@@ -34,7 +34,10 @@ const mockUserFindById = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
-  serviceAuthMiddleware: jest.fn(),
+  serviceAuthMiddleware: (req: { serviceApp?: { type: string; appId: string; appName: string; credentialId: string; scopes: string[] } }, _res: unknown, next: () => void) => {
+    req.serviceApp = { type: 'service', appId: '64f7c2a1b8e9d3f4a1c2b3ab', appName: 'Third Party App', credentialId: 'cred-1', scopes: ['auth:session:create'] };
+    next();
+  },
   rejectQueryToken: (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
@@ -42,8 +45,7 @@ jest.mock('../../middleware/rateLimiter', () => ({
   rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
-// Use the REAL validate middleware so the schema (one of clientId/applicationId
-// required) is actually exercised.
+// Use the REAL validate middleware so the strict create schema is exercised.
 jest.unmock('../../middleware/validate');
 
 jest.mock('../../models/AuthSession', () => ({
@@ -327,32 +329,32 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
     expect(created.appId).toBeUndefined();
   });
 
-  it('(b) resolves a valid applicationId directly', async () => {
-    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
-
+  it('(b) rejects a caller-supplied raw applicationId', async () => {
     const res = await requestJson(server, 'POST', '/auth/session/create', {
       sessionToken: 'tok-create-2',
       applicationId: THIRD_PARTY_APP_ID,
     });
 
-    expect(res.status).toBe(200);
-    expect(mockApplicationFindById).toHaveBeenCalledWith(THIRD_PARTY_APP_ID);
-    const created = mockAuthSessionCreate.mock.calls[0][0] as { applicationId: { toString: () => string } };
-    expect(created.applicationId.toString()).toBe(THIRD_PARTY_APP_ID);
-  });
-
-  it('(c0) returns 400 when NEITHER clientId nor applicationId is supplied', async () => {
-    const res = await requestJson(server, 'POST', '/auth/session/create', {
-      sessionToken: 'tok-create-none',
-    });
-
     expect(res.status).toBe(400);
-    expect(mockApplicationCredentialFindOne).not.toHaveBeenCalled();
     expect(mockApplicationFindById).not.toHaveBeenCalled();
     expect(mockAuthSessionCreate).not.toHaveBeenCalled();
   });
 
-  it('(c1) returns 400 for an unknown clientId', async () => {
+  it('(c0) creates when no public app identifier is supplied because service auth is authoritative', async () => {
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+
+    const res = await requestJson(server, 'POST', '/auth/session/create', {
+      sessionToken: 'tok-create-none',
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockApplicationCredentialFindOne).not.toHaveBeenCalled();
+    expect(mockApplicationFindById).toHaveBeenCalledWith(THIRD_PARTY_APP_ID);
+    expect(mockAuthSessionCreate).toHaveBeenCalled();
+  });
+
+  it('(c1) returns 403 for an unknown clientId', async () => {
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
     mockApplicationCredentialFindOne.mockResolvedValueOnce(null);
 
     const res = await requestJson(server, 'POST', '/auth/session/create', {
@@ -360,11 +362,11 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
       clientId: 'oxy_dk_missing',
     });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(403);
     expect(mockAuthSessionCreate).not.toHaveBeenCalled();
   });
 
-  it('(c2) returns 400 for an unknown applicationId', async () => {
+  it('(c2) rejects unknown applicationId as an unknown strict body key', async () => {
     mockApplicationFindById.mockResolvedValueOnce(null);
 
     const res = await requestJson(server, 'POST', '/auth/session/create', {
@@ -376,7 +378,7 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
     expect(mockAuthSessionCreate).not.toHaveBeenCalled();
   });
 
-  it('(c3) returns 400 for a malformed applicationId (invalid ObjectId, never queried)', async () => {
+  it('(c3) rejects malformed applicationId as an unknown strict body key', async () => {
     const res = await requestJson(server, 'POST', '/auth/session/create', {
       sessionToken: 'tok-create-5',
       applicationId: 'not-an-objectid',
@@ -405,7 +407,6 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
 
     const res = await requestJson(server, 'POST', '/auth/session/create', {
       sessionToken: 'tok-create-7',
-      applicationId: THIRD_PARTY_APP_ID,
     });
 
     expect(res.status).toBe(403);
@@ -417,7 +418,6 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
 
     const res = await requestJson(server, 'POST', '/auth/session/create', {
       sessionToken: 'tok-create-8',
-      applicationId: THIRD_PARTY_APP_ID,
     });
 
     expect(res.status).toBe(403);

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -17,7 +17,7 @@ import { intersectScopes } from '../utils/applicationScopes';
 import { ApplicationCredential } from '../models/ApplicationCredential';
 import type { IApplicationCredential } from '../models/ApplicationCredential';
 import { isCredentialUsable } from '../utils/credentialUsability';
-import { authMiddleware, rejectQueryToken, type AuthRequest } from '../middleware/auth';
+import { authMiddleware, rejectQueryToken, serviceAuthMiddleware, type AuthRequest, type ServiceAuthRequest } from '../middleware/auth';
 import { requireSameSiteOrigin } from '../middleware/originGuard';
 import { rateLimit } from '../middleware/rateLimiter';
 import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
@@ -1415,19 +1415,20 @@ import AuthSession from '../models/AuthSession';
  *       403:
  *         description: Application is not available (suspended/deleted/pending review).
  */
-router.post('/session/create', validate({ body: authSessionCreateSchema }), asyncHandler(async (req, res) => {
-  const { sessionToken, expiresAt, clientId, applicationId } = req.body as {
+router.post('/session/create', serviceAuthMiddleware, validate({ body: authSessionCreateSchema }), asyncHandler(async (req: ServiceAuthRequest, res) => {
+  const { sessionToken, expiresAt, clientId } = req.body as {
     sessionToken: string;
     clientId?: string;
-    applicationId?: string;
     expiresAt?: string | number;
   };
 
   if (!sessionToken) {
     throw new BadRequestError('sessionToken is required');
   }
-  if (!clientId && !applicationId) {
-    throw new BadRequestError('Either clientId or applicationId is required');
+
+  const serviceAppId = req.serviceApp?.appId;
+  if (!serviceAppId || !isValidObjectId(serviceAppId)) {
+    throw new UnauthorizedError('Valid service application authentication is required');
   }
 
   const now = Date.now();
@@ -1438,22 +1439,21 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
     expiresAtDate = defaultExpiresAt;
   }
 
-  // Resolve the canonical Application. Every session is bound to a real,
-  // active registered Application — there is no free-form app label.
-  let resolvedApp: IApplication | null = null;
-  if (clientId) {
-    const credential = await resolveUsableCredential(clientId);
-    if (credential) {
-      resolvedApp = await Application.findById(credential.applicationId);
-    }
-  } else if (applicationId) {
-    if (isValidObjectId(applicationId)) {
-      resolvedApp = await Application.findById(applicationId);
-    }
-  }
+  // Resolve the canonical Application from the verified service principal, not
+  // from caller-supplied public identifiers. A public OAuth client_id or raw
+  // Mongo applicationId does not prove the requester controls that app.
+  const resolvedApp = await Application.findById(serviceAppId) as IApplication | null;
 
   if (!resolvedApp) {
     throw new BadRequestError('Invalid application');
+  }
+
+  if (clientId) {
+    const credential = await resolveUsableCredential(clientId);
+    const credentialAppId = credential?.applicationId?.toString();
+    if (!credential || credentialAppId !== resolvedApp._id.toString()) {
+      throw new ForbiddenError('Client does not belong to authenticated application');
+    }
   }
 
   if (resolvedApp.status !== 'active') {

--- a/packages/api/src/schemas/auth.schemas.ts
+++ b/packages/api/src/schemas/auth.schemas.ts
@@ -90,20 +90,16 @@ export const getUserByPublicKeyParams = z.object({
 
 // POST /auth/session/create
 //
-// A cross-app auth session is ALWAYS bound to a registered Application. The
-// caller must identify it with exactly one of:
-//   - `clientId`      an ApplicationCredential.publicKey / OAuth client_id, or
-//   - `applicationId` an Application _id.
-// There is no free-form app label.
+// A cross-app auth session is bound to the registered Application proven by
+// the caller's service bearer token. `clientId` is accepted only as an optional
+// consistency check and must belong to that same Application; raw
+// `applicationId` is deliberately not accepted from the unauthenticated/public
+// request body because it is not proof of app control.
 export const authSessionCreateSchema = z.object({
   sessionToken: z.string().trim().min(1),
   clientId: z.string().trim().min(1).optional(),
-  applicationId: z.string().trim().min(1).optional(),
   expiresAt: z.union([z.string(), z.number()]).optional(),
-}).refine(
-  (data) => Boolean(data.clientId) || Boolean(data.applicationId),
-  { message: 'Either clientId or applicationId is required' }
-);
+}).strict();
 
 // GET /auth/session/status/:sessionToken
 export const authSessionTokenParams = z.object({


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated callers from binding a device/auth session to an arbitrary registered `Application` by supplying public `clientId` or raw `applicationId`. This previously allowed an attacker to impersonate a trusted app and steal tokens via the device-flow. 

### Description
- Update the create-schema to remove public `applicationId` and make the body strict by changing `authSessionCreateSchema` to accept only `sessionToken` and optional `clientId` (`packages/api/src/schemas/auth.schemas.ts`).
- Protect `POST /auth/session/create` with `serviceAuthMiddleware` and resolve the canonical `Application` from the verified service principal `req.serviceApp.appId` rather than caller-supplied identifiers (`packages/api/src/routes/auth.ts`).
- Treat `clientId` only as an optional consistency check and reject it unless it belongs to the authenticated service application to prevent client-id spoofing. 
- Update tests to reflect the new trust boundary and to mock a verified service principal for session creation (`packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts`).

### Testing
- Ran `git diff --check` with no whitespace/patch errors reported. 
- Updated/ran targeted unit-test file changes locally but the environment could not execute Jest: `bun run --cwd packages/api test -- --runTestsByPath src/routes/__tests__/authSessionAppIdentity.test.ts --runInBand` failed because `jest` is not installed in this checkout, so full automated test execution was not possible here. 
- The change updates tests to assert that raw `applicationId` is rejected and that service-authenticated requests create sessions (tests adjusted accordingly).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc48408a8832386e7bd8bfb608068)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->