### PR TITLE
fix(api): require grace expiry for deprecated credentials

### DIFF
--- a/packages/api/src/routes/__tests__/serviceTokenCredentials.test.ts
+++ b/packages/api/src/routes/__tests__/serviceTokenCredentials.test.ts
@@ -327,6 +327,21 @@ describe('POST /auth/service-token — credential resolution + JWT claims (#215)
     expect(typeof res.body.data?.token).toBe('string');
   });
 
+  it('rejects a deprecated credential without an explicit grace expiry', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValue(
+      stubCredential({
+        status: 'deprecated',
+      })
+    );
+
+    const res = await requestJson(server, 'POST', '/auth/service-token', {
+      apiKey: API_KEY,
+      apiSecret: PLAINTEXT_SECRET,
+    });
+
+    expect(res.status).toBe(401);
+  });
+
   it('rejects a deprecated credential whose grace window has expired', async () => {
     mockApplicationCredentialFindOne.mockResolvedValue(
       stubCredential({

--- a/packages/api/src/utils/credentialUsability.ts
+++ b/packages/api/src/utils/credentialUsability.ts
@@ -7,11 +7,12 @@ import type {
  * Predicate: may this credential currently be used to authenticate?
  *
  * A credential is usable when:
- *  - it is `active`, OR it is `deprecated` (rotated within its grace window); AND
- *  - it has no `expiresAt`, or `expiresAt` is still in the future.
+ *  - it is `active` and has no `expiresAt` or a future `expiresAt`; OR
+ *  - it is `deprecated` and has a future `expiresAt` (rotation grace window).
  *
- * `revoked` credentials are NEVER usable. `deprecated` credentials remain usable
- * only until their grace `expiresAt` elapses (set during rotation). This is the
+ * `revoked` credentials are NEVER usable. `deprecated` credentials MUST have
+ * an explicit future grace `expiresAt` (set during rotation); a deprecated
+ * credential without an expiry is treated as disabled. This is the
  * single source of truth shared by every credential-resolution site (OAuth
  * authorize/token, service-token mint) — do not duplicate the predicate.
  *
@@ -24,13 +25,13 @@ export function isCredentialUsable(
   if (credential.status === 'revoked') {
     return false;
   }
-  if (credential.status !== 'active' && credential.status !== 'deprecated') {
-    return false;
+  if (credential.status === 'active') {
+    return !credential.expiresAt || credential.expiresAt.getTime() > Date.now();
   }
-  if (credential.expiresAt && credential.expiresAt.getTime() <= Date.now()) {
-    return false;
+  if (credential.status === 'deprecated') {
+    return Boolean(credential.expiresAt && credential.expiresAt.getTime() > Date.now());
   }
-  return true;
+  return false;
 }
 
 export type { IApplicationCredential };


### PR DESCRIPTION
### Motivation
- Close a security gap where `deprecated` `ApplicationCredential`s without an explicit `expiresAt` could be treated as usable, potentially re-enabling previously-disabled OAuth/service credentials.

### Description
- Tighten the credential predicate in `packages/api/src/utils/credentialUsability.ts` so that `active` credentials remain usable without an `expiresAt`, but `deprecated` credentials are usable only when they have an explicit future `expiresAt` (rotation grace window).
- Add a regression test in `packages/api/src/routes/__tests__/serviceTokenCredentials.test.ts` that asserts a `deprecated` credential with no `expiresAt` is rejected while preserving the existing acceptance of `deprecated` credentials with a future `expiresAt`.
- Preserve existing behavior for `revoked` and expired `expiresAt` cases and keep the predicate pure/side-effect-free for easy import in routes and tests.

### Testing
- Ran an inline check with `bun -e` that exercised `isCredentialUsable` for `active`, `deprecated` (future/past/none), and `revoked` cases, which succeeded.
- Added the Jest regression test covering the new case, but could not execute it here because `jest` is not available in the execution environment (`bun run test -- serviceTokenCredentials.test.ts` was not runnable). 
- Attempted to build the API (`bun run api:build`) but the local build was blocked by unrelated TypeScript config issues in `packages/contracts` so full CI/build verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bc3dcd0308323867accabada1677f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->