### PR TITLE
fix(auth): require RP grants for silent SSO

### DIFF
--- a/packages/auth/server/__tests__/fedcm.idp.test.ts
+++ b/packages/auth/server/__tests__/fedcm.idp.test.ts
@@ -927,6 +927,29 @@ describe('GET /sso (central top-level-redirect cross-domain SSO)', () => {
         state: 'st-4b',
         prompt: 'none',
       }),
+  it('303-redirects with oxy_sso=none and no code for a first-time RP without a user grant', async () => {
+    stubbedApprovedClients = [RP_ORIGIN];
+    stubbedGrantedOrigins = [];
+    installApiStub();
+
+    const res = await app.request(
+      ssoUrl({
+        client_id: RP_ORIGIN,
+        return_to: VALID_RETURN_TO,
+        state: 'st-no-grant',
+        prompt: 'none',
+      }),
+      { headers: { cookie: SESSION_COOKIE } }
+    );
+
+    expect(res.status).toBe(303);
+    const { frag } = parseSsoRedirect(res);
+    expect(frag.get('oxy_sso')).toBe('none');
+    expect(frag.get('code')).toBeNull();
+    expect(capturedExchange).toBeUndefined();
+    expect(capturedSsoCode).toBeUndefined();
+  });
+
       { headers: { cookie: SESSION_COOKIE } }
     );
     expect(res.status).toBe(400);
@@ -1237,6 +1260,25 @@ describe('GET /sso -> /sso/establish second hop (cross-domain durable session)',
         prompt: 'none',
       }),
       { headers: { cookie: SESSION_COOKIE } }
+  it('does not create a cross-apex establish token for a first-time RP without a user grant', async () => {
+    stubbedApprovedClients = [RP_ORIGIN, CROSS_RP];
+    stubbedGrantedOrigins = [RP_ORIGIN];
+    installApiStub();
+
+    const res = await app.request(
+      ssoUrl({ client_id: CROSS_RP, return_to: CROSS_RETURN_TO, state: 'xd-no-grant', prompt: 'none' }),
+      { headers: { cookie: SESSION_COOKIE } }
+    );
+
+    expect(res.status).toBe(303);
+    const { location, frag } = parseSsoRedirect(res);
+    expect(location.startsWith(`${CROSS_RETURN_TO}#`)).toBe(true);
+    expect(location).not.toContain('/sso/establish');
+    expect(frag.get('oxy_sso')).toBe('none');
+    expect(frag.get('code')).toBeNull();
+    expect(capturedSsoCode).toBeUndefined();
+  });
+
     );
     expect(res.status).toBe(303);
     const { url } = parseEstablishRedirect(res);
@@ -1337,6 +1379,25 @@ describe('GET /sso -> /sso/establish second hop (cross-domain durable session)',
         `https://${CROSS_APEX_HOST}/sso/establish?et=${encodeURIComponent(et)}&return_to=${encodeURIComponent(
           CROSS_RETURN_TO
         )}&state=xd-iss`
+  it('GET /auth/silent posts a null session for an approved RP without a user grant', async () => {
+    stubbedApprovedClients = [RP_ORIGIN, CROSS_RP];
+    stubbedGrantedOrigins = [RP_ORIGIN];
+    installApiStub();
+
+    const res = await app.request(
+      `https://${CROSS_APEX_HOST}/auth/silent?client_id=${encodeURIComponent(CROSS_RP)}&nonce=rp-no-grant`,
+      { headers: { cookie: SESSION_COOKIE } }
+    );
+    expect(res.status).toBe(200);
+
+    const { message, targetOrigin } = extractPostedMessage(await res.text());
+    const msg = message as SilentMessage;
+    expect(msg.type).toBe('oxy_silent_auth');
+    expect(msg.session).toBeNull();
+    expect(targetOrigin).toBe(CROSS_RP);
+    expect(capturedExchange).toBeUndefined();
+  });
+
       );
       expect(res.status).toBe(303);
 

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -423,6 +423,15 @@ async function fetchApprovedClients(apiBaseUrl: string, userId: string): Promise
   }
 }
 
+async function userHasGrantedClient(
+  apiBaseUrl: string,
+  userId: string,
+  clientOrigin: string
+): Promise<boolean> {
+  const grantedOrigins = await fetchApprovedClients(apiBaseUrl, userId);
+  return grantedOrigins.some((origin) => normaliseOrigin(origin) === clientOrigin);
+}
+
 /** Validate that a session is still active via the API. */
 async function validateSession(apiBaseUrl: string, sessionId: string): Promise<boolean> {
   try {
@@ -1664,8 +1673,16 @@ app.get('/auth/silent', async (c) => {
     return c.html(renderSilentHtml(approvedOrigin, null, nonce));
   }
 
-  // Mint a real Oxy access token for the validated, approved origin by reusing
-  // the existing FedCM nonce + exchange pipeline (api.oxy.so is the authority).
+  // Silent restore is only valid for returning RPs. A globally approved
+  // client_id may embed this endpoint, but it must not receive a token unless
+  // this user has an existing FedCM grant for the exact RP origin.
+  if (!(await userHasGrantedClient(config.apiBaseUrl, user.id, approvedOrigin))) {
+    return c.html(renderSilentHtml(approvedOrigin, null, nonce));
+  }
+
+  // Mint a real Oxy access token for the validated, approved, previously
+  // granted origin by reusing the existing FedCM nonce + exchange pipeline
+  // (api.oxy.so is the authority).
   const session = await mintSessionForClient(config, user, approvedOrigin);
   return c.html(renderSilentHtml(approvedOrigin, session, nonce));
 });
@@ -1783,7 +1800,16 @@ app.get('/sso', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('none', state));
   }
 
-  // 8. DURABLE-SESSION SECOND HOP. This bounce runs on the CENTRAL IdP host
+  // 8. Silent SSO is only for returning RPs. A globally approved RP is
+  //    allowed to start the protocol, but it must NOT receive a session unless
+  //    this user has previously granted that exact origin via FedCM consent.
+  //    First-time RPs get the same no-session outcome as a logged-out user so
+  //    the RP can fall back to an interactive sign-in/consent flow.
+  if (!(await userHasGrantedClient(config.apiBaseUrl, user.id, approvedOrigin))) {
+    return redirectToCallback(c, returnTo, buildSsoFragment('none', state));
+  }
+
+  // 9. DURABLE-SESSION SECOND HOP. This bounce runs on the CENTRAL IdP host
   //    (auth.oxy.so), which is THIRD-PARTY to a cross-registrable-domain RP
   //    (e.g. mention.earth) under Safari ITP / Firefox TCP. Minting the code
   //    here would work for THIS load, but the RP could never restore the
@@ -1798,7 +1824,7 @@ app.get('/sso', async (c) => {
   //    For *.oxy.so clients (apex == oxy.so) `apexAuthHostForClient` returns
   //    null — auth.oxy.so is ALREADY first-party to the client, so the central
   //    bounce already carries the durable credential. Skip the hop and mint the
-  //    code directly (steps 9–10 below), exactly as before.
+  //    code directly (steps 10–11 below), exactly as before.
   const apexAuthHost = apexAuthHostForClient(approvedOrigin);
   if (apexAuthHost) {
     const establishToken = await createEstablishToken(
@@ -1820,7 +1846,7 @@ app.get('/sso', async (c) => {
     return c.redirect(establishUrl.toString(), 303);
   }
 
-  // 9. (*.oxy.so path) Mint a real Oxy session for the approved origin via the
+  // 10. (*.oxy.so path) Mint a real Oxy session for the approved origin via the
   //    full, already-audited FedCM nonce + exchange pipeline (server nonce born
   //    + burned inside this call). On any failure → error bounce (no leaks).
   const session = await mintSessionForClient(config, user, approvedOrigin);
@@ -1828,7 +1854,7 @@ app.get('/sso', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('error', state));
   }
 
-  // 10. Wrap the session in an opaque, single-use, origin-bound code via the
+  // 11. Wrap the session in an opaque, single-use, origin-bound code via the
   //     internal `POST /sso/code` (X-Oxy-Internal secret). On failure → error
   //     bounce. The code — never the session — travels in the fragment.
   const code = await createSsoCode(config, approvedOrigin, session);
@@ -1836,7 +1862,7 @@ app.get('/sso', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('error', state));
   }
 
-  // 11. Success: bounce back with `oxy_sso=ok`, the opaque `code`, and `state`
+  // 12. Success: bounce back with `oxy_sso=ok`, the opaque `code`, and `state`
   //     in the FRAGMENT. The RP callback redeems the code at /sso/exchange.
   return redirectToCallback(c, returnTo, buildSsoFragment('ok', state, code));
 });
@@ -1924,7 +1950,15 @@ app.get('/sso/establish', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('error', state));
   }
 
-  // 6. PLANT THE DURABLE FIRST-PARTY CREDENTIAL. Set the host-only
+  // 6. Silent SSO establish tokens are only valid for returning RPs. The
+  //    central hop checked this before minting `et`; re-check here because a
+  //    grant can be revoked between hops. Do this BEFORE planting the durable
+  //    first-party cookie or minting a session/code.
+  if (!(await userHasGrantedClient(config.apiBaseUrl, user.id, approvedOrigin))) {
+    return redirectToCallback(c, returnTo, buildSsoFragment('none', state));
+  }
+
+  // 7. PLANT THE DURABLE FIRST-PARTY CREDENTIAL. Set the host-only
   //    `fedcm_session` cookie for THIS request host (auth.<rp-apex>) using the
   //    SAME options `/fedcm/set-session` uses (no Domain, Secure, HttpOnly,
   //    SameSite=None, 30d). The value is the validated central sessionId,
@@ -1937,7 +1971,7 @@ app.get('/sso/establish', async (c) => {
   });
   c.header('Set-Login', 'logged-in');
 
-  // 7. Complete the SSO handoff: mint a real Oxy session for the approved
+  // 8. Complete the SSO handoff: mint a real Oxy session for the approved
   //    origin via the full FedCM nonce + exchange pipeline (server nonce born +
   //    burned inside), then wrap it in an opaque, single-use, origin-bound code.
   //    Either failure → error bounce (the durable cookie is already set, so a
@@ -1959,7 +1993,7 @@ app.get('/sso/establish', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('error', state));
   }
 
-  // 8. Success: bounce back to the RP callback with `oxy_sso=ok`, the opaque
+  // 9. Success: bounce back to the RP callback with `oxy_sso=ok`, the opaque
   //    `code`, and `state` in the FRAGMENT. The RP redeems the code at
   //    /sso/exchange; subsequent reloads restore via the cookie we just planted.
   return redirectToCallback(c, returnTo, buildSsoFragment('ok', state, code));


### PR DESCRIPTION
### Motivation
- Prevent silent SSO from issuing a full Oxy session to a globally-approved RP when the user has not previously granted that RP, closing a security bypass that allowed approved RPs to obtain tokens on first visit.
- Ensure the IdP only performs silent token issuance for returning RPs that the user has explicitly granted, preserving interactive consent for first-time RPs.

### Description
- Add `userHasGrantedClient(apiBaseUrl, userId, clientOrigin)` helper that checks the per-user FedCM grants via `GET /fedcm/grants/:userId` and normalises origins.
- Require an existing per-user grant before minting or handing off sessions in the silent flows by gating `GET /auth/silent`, the central `GET /sso` bounce, and the per‑apex `GET /sso/establish` with `userHasGrantedClient` checks.
- Change behaviour for first-time (no-grant) but globally-approved RPs to return the same no-session/null-session outcome (`oxy_sso=none` or posted `null` session) so RPs must perform an interactive consent/sign-in flow instead of receiving tokens silently.
- Add regression tests to `packages/auth/server/__tests__/fedcm.idp.test.ts` that cover: same-apex SSO without a user grant, cross-apex establish without a user grant, and first-party `/auth/silent` without a grant.

### Testing
- Ran `git diff --check` which passed with no whitespace/patch issues.
- Attempted `bun test server/__tests__/fedcm.idp.test.ts` in `packages/auth` to exercise the IdP silent/S SO tests, but the local test run failed due to missing workspace dependency (`Cannot find package 'react'`), so the new tests were added but not executed successfully in this environment.
- Commit containing the fix was created: `fix(auth): require RP grants for silent SSO` (changes include `packages/auth/server/index.ts` and updated `packages/auth/server/__tests__/fedcm.idp.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bcb698ba08323a6d4ff289dcdf4c5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->