### PR TITLE
fix(auth): require FedCM grant for silent SSO

### DIFF
--- a/packages/auth/server/__tests__/fedcm.idp.test.ts
+++ b/packages/auth/server/__tests__/fedcm.idp.test.ts
@@ -968,6 +968,36 @@ describe('GET /sso (central top-level-redirect cross-domain SSO)', () => {
     const { location, frag } = parseSsoRedirect(res);
     expect(location.startsWith(`${VALID_RETURN_TO}#`)).toBe(true);
     expect(frag.get('oxy_sso')).toBe('ok');
+  it('303-redirects with oxy_sso=none and mints no code when the user has not granted the RP', async () => {
+    stubbedGrantedOrigins = [];
+    installApiStub();
+
+    const res = await app.request(
+      ssoUrl({
+        client_id: RP_ORIGIN,
+        return_to: VALID_RETURN_TO,
+        state: 'st-no-grant',
+        prompt: 'none',
+      }),
+      { headers: { cookie: SESSION_COOKIE } }
+    );
+
+    expect(res.status).toBe(303);
+    const { location, frag } = parseSsoRedirect(res);
+    expect(location.startsWith(`${VALID_RETURN_TO}#`)).toBe(true);
+    expect(frag.get('oxy_sso')).toBe('none');
+    expect(frag.get('state')).toBe('st-no-grant');
+    expect(frag.get('code')).toBeNull();
+    expect(capturedExchange).toBeUndefined();
+    expect(capturedSsoCode).toBeUndefined();
+  });
+
+      if (url.includes('/fedcm/grants/')) {
+        return new Response(JSON.stringify({ origins: [RP_ORIGIN] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
     expect(frag.get('code')).toBe(STUB_SSO_CODE);
     expect(frag.get('state')).toBe('st-6');
 

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -423,6 +423,16 @@ async function fetchApprovedClients(apiBaseUrl: string, userId: string): Promise
   }
 }
 
+/**
+ * Check whether a user has previously granted this RP origin via an explicit
+ * FedCM sign-in. Silent prompt=none SSO may only mint for returning RPs; a
+ * brand-new RP must fall back to an interactive FedCM chooser/consent flow.
+ */
+async function hasApprovedClientGrant(apiBaseUrl: string, userId: string, clientOrigin: string): Promise<boolean> {
+  const approvedClients = await fetchApprovedClients(apiBaseUrl, userId);
+  return approvedClients.includes(clientOrigin);
+}
+
 /** Validate that a session is still active via the API. */
 async function validateSession(apiBaseUrl: string, sessionId: string): Promise<boolean> {
   try {
@@ -1664,6 +1674,13 @@ app.get('/auth/silent', async (c) => {
     return c.html(renderSilentHtml(approvedOrigin, null, nonce));
   }
 
+  // Silent restore may only mint for an RP the user already consented to via
+  // FedCM. If the grant was revoked (or never existed), return no session so
+  // the RP can fall back to its interactive sign-in path.
+  if (!(await hasApprovedClientGrant(config.apiBaseUrl, user.id, approvedOrigin))) {
+    return c.html(renderSilentHtml(approvedOrigin, null, nonce));
+  }
+
   // Mint a real Oxy access token for the validated, approved origin by reusing
   // the existing FedCM nonce + exchange pipeline (api.oxy.so is the authority).
   const session = await mintSessionForClient(config, user, approvedOrigin);
@@ -1783,7 +1800,15 @@ app.get('/sso', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('none', state));
   }
 
-  // 8. DURABLE-SESSION SECOND HOP. This bounce runs on the CENTRAL IdP host
+  // 8. Silent prompt=none SSO is only valid for returning RPs: the user must
+  //    have an existing per-origin FedCM grant. Without that grant, bounce a
+  //    token-less "none" result so the RP falls back to an interactive chooser
+  //    instead of receiving a bearer token without consent.
+  if (!(await hasApprovedClientGrant(config.apiBaseUrl, user.id, approvedOrigin))) {
+    return redirectToCallback(c, returnTo, buildSsoFragment('none', state));
+  }
+
+  // 9. DURABLE-SESSION SECOND HOP. This bounce runs on the CENTRAL IdP host
   //    (auth.oxy.so), which is THIRD-PARTY to a cross-registrable-domain RP
   //    (e.g. mention.earth) under Safari ITP / Firefox TCP. Minting the code
   //    here would work for THIS load, but the RP could never restore the
@@ -1820,7 +1845,7 @@ app.get('/sso', async (c) => {
     return c.redirect(establishUrl.toString(), 303);
   }
 
-  // 9. (*.oxy.so path) Mint a real Oxy session for the approved origin via the
+  // 10. (*.oxy.so path) Mint a real Oxy session for the approved origin via the
   //    full, already-audited FedCM nonce + exchange pipeline (server nonce born
   //    + burned inside this call). On any failure → error bounce (no leaks).
   const session = await mintSessionForClient(config, user, approvedOrigin);
@@ -1828,7 +1853,7 @@ app.get('/sso', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('error', state));
   }
 
-  // 10. Wrap the session in an opaque, single-use, origin-bound code via the
+  // 11. Wrap the session in an opaque, single-use, origin-bound code via the
   //     internal `POST /sso/code` (X-Oxy-Internal secret). On failure → error
   //     bounce. The code — never the session — travels in the fragment.
   const code = await createSsoCode(config, approvedOrigin, session);
@@ -1836,7 +1861,7 @@ app.get('/sso', async (c) => {
     return redirectToCallback(c, returnTo, buildSsoFragment('error', state));
   }
 
-  // 11. Success: bounce back with `oxy_sso=ok`, the opaque `code`, and `state`
+  // 12. Success: bounce back with `oxy_sso=ok`, the opaque `code`, and `state`
   //     in the FRAGMENT. The RP callback redeems the code at /sso/exchange.
   return redirectToCallback(c, returnTo, buildSsoFragment('ok', state, code));
 });
@@ -1922,6 +1947,10 @@ app.get('/sso/establish', async (c) => {
   const user = await fetchUserFromAPI(config.apiBaseUrl, claims.sessionId);
   if (!user) {
     return redirectToCallback(c, returnTo, buildSsoFragment('error', state));
+  }
+
+  if (!(await hasApprovedClientGrant(config.apiBaseUrl, user.id, approvedOrigin))) {
+    return redirectToCallback(c, returnTo, buildSsoFragment('none', state));
   }
 
   // 6. PLANT THE DURABLE FIRST-PARTY CREDENTIAL. Set the host-only


### PR DESCRIPTION
### Motivation
- Prevent silent `prompt=none` central SSO from issuing bearer sessions/codes to RP origins the user has not explicitly granted. 
- Ensure first-party silent restore (`/auth/silent`) and the durable cross-domain hop (`/sso` / `/sso/establish`) honour per-user FedCM grants. 

### Description
- Added helper `hasApprovedClientGrant(apiBaseUrl, userId, clientOrigin)` which checks the user’s per-origin FedCM grants via `GET /fedcm/grants/:userId` and returns a boolean. 
- Require that check in the first-party silent restore handler (`GET /auth/silent`) so it returns a null session when the user has not granted the RP. 
- Require that check in the central silent bounce (`GET /sso`) so ungranted but globally approved client origins receive `oxy_sso=none` instead of a session/code, and avoid proceeding to the durable hop or minting. 
- Require that check in the per-apex second hop (`GET /sso/establish`) before planting the host-only cookie or minting the final code. 
- Added a regression test in `packages/auth/server/__tests__/fedcm.idp.test.ts` asserting that an approved-but-ungranted RP receives `oxy_sso=none` and no code/session mint occurs. 

### Testing
- Ran `bun test server/__tests__/fedcm.idp.test.ts` locally but it failed due to missing test-runner dependencies (`react` in the test preload); the new test is present but full run was blocked. 
- Attempted `bun install` to resolve deps but was blocked by registry access (HTTP 403), preventing a complete test run. 
- Verified `git diff --check` and updated test stubs to return grants in the API mock to exercise the new branch logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bcb204e288323ab283d96ac3d67e4)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->