### PR TITLE
Require per-user FedCM grant for /auth/silent to prevent token leakage

### DIFF
--- a/packages/auth/server/__tests__/fedcm.idp.test.ts
+++ b/packages/auth/server/__tests__/fedcm.idp.test.ts
@@ -687,6 +687,26 @@ describe('GET /auth/silent (Safari/Firefox first-party restore)', () => {
     // The worker must drive the api `/fedcm/nonce` + `/fedcm/exchange` calls
     // with Origin == the approved client origin, or the API rejects them
     // (origin_aud_mismatch / nonce_origin_mismatch).
+  it('REFUSES to mint a token for an approved client_id without a per-user grant', async () => {
+    // The RP is globally approved, but this user has not previously granted it.
+    // Silent restore must preserve the FedCM consent boundary and return null.
+    stubbedApprovedClients = [RP_ORIGIN];
+    stubbedGrantedOrigins = [];
+    installApiStub();
+
+    const res = await app.request(
+      `/auth/silent?client_id=${encodeURIComponent(RP_ORIGIN)}&nonce=rp-nonce-grant`,
+      { headers: { cookie: SESSION_COOKIE } }
+    );
+
+    expect(res.status).toBe(200);
+    const { message, targetOrigin } = extractPostedMessage(await res.text());
+    expect((message as SilentMessage).session).toBeNull();
+    expect(targetOrigin).toBe(RP_ORIGIN);
+    expect(capturedNonceOrigin).toBeUndefined();
+    expect(capturedExchange).toBeUndefined();
+  });
+
     expect(capturedNonceOrigin).toBe(RP_ORIGIN);
     expect(capturedExchange?.origin).toBe(RP_ORIGIN);
     expect(typeof capturedExchange?.idToken).toBe('string');

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -423,6 +423,10 @@ async function fetchApprovedClients(apiBaseUrl: string, userId: string): Promise
   }
 }
 
+function hasGrantedClientOrigin(grantedOrigins: string[], clientOrigin: string): boolean {
+  return grantedOrigins.some((origin) => normaliseOrigin(origin) === clientOrigin);
+}
+
 /** Validate that a session is still active via the API. */
 async function validateSession(apiBaseUrl: string, sessionId: string): Promise<boolean> {
   try {
@@ -1664,8 +1668,18 @@ app.get('/auth/silent', async (c) => {
     return c.html(renderSilentHtml(approvedOrigin, null, nonce));
   }
 
-  // Mint a real Oxy access token for the validated, approved origin by reusing
-  // the existing FedCM nonce + exchange pipeline (api.oxy.so is the authority).
+  // Silent token issuance is allowed only for RPs this user has already
+  // authorized. The global approved-client list says an origin may use FedCM at
+  // all; the per-user grant list is the consent boundary that prevents any
+  // approved/compromised RP from minting tokens for every visiting IdP user.
+  const grantedOrigins = await fetchApprovedClients(config.apiBaseUrl, user.id);
+  if (!hasGrantedClientOrigin(grantedOrigins, approvedOrigin)) {
+    return c.html(renderSilentHtml(approvedOrigin, null, nonce));
+  }
+
+  // Mint a real Oxy access token for the validated, approved AND user-granted
+  // origin by reusing the existing FedCM nonce + exchange pipeline
+  // (api.oxy.so is the authority).
   const session = await mintSessionForClient(config, user, approvedOrigin);
   return c.html(renderSilentHtml(approvedOrigin, session, nonce));
 });


### PR DESCRIPTION
### Motivation
- `/auth/silent` could mint and post a real Oxy session to any globally-approved FedCM client origin without verifying the specific user had previously granted that origin, allowing a compromised/attacker-approved RP to obtain tokens for visiting users.
- The intent is to preserve the FedCM consent boundary: global approval enables the flow, but a per-user grant is required before issuing tokens to that user's session.

### Description
- Added a small helper `hasGrantedClientOrigin(grantedOrigins, clientOrigin)` and callsite logic that fetches the user's granted RP origins via `fetchApprovedClients(config.apiBaseUrl, user.id)` and refuses to mint a token unless the requested `approvedOrigin` appears in that per-user grants list. 
- Kept the existing global approved-clients check in `resolveApprovedClientOrigin` but now require both global approval and a per-user grant before invoking the nonce/exchange pipeline (`mintSessionForClient`).
- Added a regression test in `packages/auth/server/__tests__/fedcm.idp.test.ts` that verifies a globally-approved client without a per-user grant receives a null session and that no `/fedcm/nonce` or `/fedcm/exchange` calls are attempted.

### Testing
- Ran `git diff --check` and confirmed the diff is clean. 
- Added a targeted unit test (`server/__tests__/fedcm.idp.test.ts`) that asserts the new per-user grant requirement; the test is present but not executed end-to-end in this environment. 
- Attempted to run `bun test` and `bun install` but execution was blocked by the environment (package resolution returned HTTP 403), so automated tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bcd25009c8323b21e0b28d4ee3f63)