### PR TITLE
Use Public Suffix List (tldts) for auth URL auto-detection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -319,6 +319,7 @@
         "invariant": "^2.2.4",
         "jwt-decode": "^4.0.0",
         "socket.io-client": "^4.8.1",
+        "tldts": "^7.0.22",
         "zod": "^3.25.64",
       },
       "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,6 +104,7 @@
     "invariant": "^2.2.4",
     "jwt-decode": "^4.0.0",
     "socket.io-client": "^4.8.1",
+    "tldts": "^7.0.22",
     "zod": "^3.25.64"
   },
   "peerDependencies": {

--- a/packages/core/src/utils/__tests__/fapiAutoDetect.test.ts
+++ b/packages/core/src/utils/__tests__/fapiAutoDetect.test.ts
@@ -6,8 +6,8 @@
  * one subdomain over.
  *
  * Ported verbatim from packages/auth-sdk/__tests__/utils/fapiAutoDetect.test.ts
- * plus multi-part-TLD bail-out cases that are unique to the core copy's
- * MULTIPART_TLDS guard.
+ * plus Public Suffix List regression cases that are unique to the core
+ * implementation's registrable-apex guard.
  */
 
 import { autoDetectAuthWebUrl, registrableApex } from '../fapiAutoDetect';
@@ -81,13 +81,28 @@ describe('autoDetectAuthWebUrl', () => {
     });
   });
 
-  describe('bails out on multi-part public suffixes (would derive an attacker-registrable apex)', () => {
-    it('does not derive auth.co.uk from a two-label co.uk host', () => {
-      expect(autoDetectAuthWebUrl(loc('foo.co.uk'))).toBeUndefined();
+  describe('uses the Public Suffix List for registrable apex detection', () => {
+    it('derives from the registrable domain under multi-part public suffixes', () => {
+      expect(autoDetectAuthWebUrl(loc('foo.co.uk'))).toBe('https://auth.foo.co.uk');
+      expect(autoDetectAuthWebUrl(loc('shop.com.au'))).toBe('https://auth.shop.com.au');
+      expect(autoDetectAuthWebUrl(loc('shop.victim.com.tr'))).toBe('https://auth.victim.com.tr');
     });
 
-    it('does not derive auth.com.au from a two-label com.au host', () => {
-      expect(autoDetectAuthWebUrl(loc('shop.com.au'))).toBeUndefined();
+    it('derives from the registrable domain under private hosted suffixes', () => {
+      expect(autoDetectAuthWebUrl(loc('honest.github.io'))).toBe('https://auth.honest.github.io');
+      expect(autoDetectAuthWebUrl(loc('app.victim.pages.dev'))).toBe(
+        'https://auth.victim.pages.dev'
+      );
+      expect(autoDetectAuthWebUrl(loc('site.victim.netlify.app'))).toBe(
+        'https://auth.victim.netlify.app'
+      );
+    });
+
+    it('returns undefined for bare public and private suffixes', () => {
+      expect(autoDetectAuthWebUrl(loc('co.uk'))).toBeUndefined();
+      expect(autoDetectAuthWebUrl(loc('github.io'))).toBeUndefined();
+      expect(autoDetectAuthWebUrl(loc('pages.dev'))).toBeUndefined();
+      expect(autoDetectAuthWebUrl(loc('netlify.app'))).toBeUndefined();
     });
   });
 
@@ -105,7 +120,7 @@ describe('autoDetectAuthWebUrl', () => {
       ['[::1]', undefined],
       ['intranet', undefined],
       ['', undefined],
-      ['foo.co.uk', undefined],
+      ['foo.co.uk', 'https://auth.foo.co.uk'],
     ];
     it.each(cases)('autoDetectAuthWebUrl(%s) === %s', (hostname, expected) => {
       const protocol = hostname === 'localhost' || hostname === '[::1]' ? 'http:' : 'https:';
@@ -128,9 +143,23 @@ describe('registrableApex', () => {
     expect(registrableApex('WWW.Mention.EARTH')).toBe('mention.earth');
   });
 
-  it('returns null for a multi-part public suffix (foo.co.uk -> null)', () => {
-    expect(registrableApex('foo.co.uk')).toBeNull();
-    expect(registrableApex('shop.com.au')).toBeNull();
+  it('returns the eTLD+1 for hosts under multi-part public suffixes', () => {
+    expect(registrableApex('foo.co.uk')).toBe('foo.co.uk');
+    expect(registrableApex('www.foo.co.uk')).toBe('foo.co.uk');
+    expect(registrableApex('shop.victim.com.tr')).toBe('victim.com.tr');
+  });
+
+  it('returns the eTLD+1 for hosts under private hosted suffixes', () => {
+    expect(registrableApex('honest.github.io')).toBe('honest.github.io');
+    expect(registrableApex('app.victim.pages.dev')).toBe('victim.pages.dev');
+    expect(registrableApex('site.victim.netlify.app')).toBe('victim.netlify.app');
+  });
+
+  it('returns null for bare public and private suffixes', () => {
+    expect(registrableApex('co.uk')).toBeNull();
+    expect(registrableApex('github.io')).toBeNull();
+    expect(registrableApex('pages.dev')).toBeNull();
+    expect(registrableApex('netlify.app')).toBeNull();
   });
 
   it('returns null for IPv4 literals', () => {

--- a/packages/core/src/utils/fapiAutoDetect.ts
+++ b/packages/core/src/utils/fapiAutoDetect.ts
@@ -20,10 +20,9 @@
  *   - SSR / non-browser (no `window`).
  *   - `localhost`, `127.0.0.1`, IPv4/IPv6 literals.
  *   - Hostnames with fewer than two labels.
- *   - Hostnames whose trailing two labels form a known multi-part public
- *     suffix (e.g. `co.uk`), where the naive `labels.slice(-2)` apex would be
- *     an attacker-registrable suffix like `auth.co.uk` rather than the real
- *     registrable domain.
+ *   - Hostnames where a registrable domain cannot be determined from the
+ *     Public Suffix List, including private hosted suffixes such as
+ *     `github.io`, `pages.dev`, and `netlify.app`.
  *
  * When the page is already loaded ON the IdP itself (`auth.<anything>`),
  * the helper returns the current origin so the SDK keeps everything
@@ -35,34 +34,11 @@
  * is required for end-to-end FedCM correctness — no per-RP config.
  */
 
-/**
- * Known multi-part public suffixes where the registrable domain is the LAST
- * THREE labels, not two. Deriving an apex from `labels.slice(-2)` against any
- * of these would yield an attacker-registrable suffix (e.g. `auth.co.uk`),
- * so we bail out instead.
- *
- * This is intentionally a small, explicit allow-list rather than the full
- * Public Suffix List — it covers the suffixes the Oxy ecosystem's RPs use.
- * Any multi-part-TLD RP MUST extend this set (or wire in a proper PSL check)
- * before relying on this helper, otherwise auto-detection silently bails to
- * `undefined` and the consumer must pass `authWebUrl` explicitly.
- */
-export const MULTIPART_TLDS: ReadonlySet<string> = new Set([
-  'co.uk',
-  'com.au',
-  'co.jp',
-  'co.nz',
-  'com.br',
-  'co.za',
-  'com.mx',
-  'co.in',
-  'co.kr',
-  'com.sg',
-]);
+import { getDomain } from 'tldts';
 
 /**
- * Compute the bare registrable apex (eTLD+1) of a hostname, guarding against
- * multi-part public suffixes.
+ * Compute the bare registrable apex (eTLD+1) of a hostname using the Public
+ * Suffix List, including private hosted suffixes.
  *
  * This is the pure host-handling kernel shared by {@link autoDetectAuthWebUrl}
  * and the IdP worker — it performs NO protocol handling, NO `auth.` prefixing,
@@ -74,10 +50,7 @@ export const MULTIPART_TLDS: ReadonlySet<string> = new Set([
  *   - IPv4 literals (`192.168.1.10`);
  *   - IPv6 literals or any host carrying a port (`[::1]`, anything with `:`);
  *   - single-label hosts (`intranet`, `localhost`);
- *   - hosts whose trailing two labels form a known multi-part public suffix
- *     (e.g. `foo.co.uk`), where `labels.slice(-2)` would yield an
- *     attacker-registrable suffix (`co.uk`) rather than a real registrable
- *     domain. Such hosts MUST configure `authWebUrl` explicitly.
+ *   - public suffixes without a registrable label (e.g. `co.uk`, `github.io`).
  *
  * @param hostname - A bare hostname (no scheme), e.g. `www.mention.earth`.
  * @returns The eTLD+1 (`mention.earth`), or `null` when undefinable.
@@ -89,11 +62,7 @@ export function registrableApex(hostname: string): string | null {
   // IPv6 literals are bracketed; any remaining ':' implies a port — neither
   // yields a registrable apex.
   if (host.startsWith('[') || host.includes(':')) return null;
-  const labels = host.split('.');
-  if (labels.length < 2) return null;
-  const lastTwo = labels.slice(-2).join('.');
-  if (MULTIPART_TLDS.has(lastTwo)) return null;
-  return lastTwo;
+  return getDomain(host, { allowPrivateDomains: true });
 }
 
 export function autoDetectAuthWebUrl(


### PR DESCRIPTION
### Motivation
- Prevent derivation of attacker-controllable IdP hosts by replacing a small hard-coded multi-part suffix list with a proper eTLD+1 computation using the Public Suffix List.

### Description
- Replace the ad-hoc `MULTIPART_TLDS` heuristic with `tldts.getDomain` in `registrableApex` so the registrable eTLD+1 (including private hosted suffixes) is computed correctly. 
- Keep `autoDetectAuthWebUrl` behavior (same-origin for `auth.*`, dev checks) but bail to `undefined` when a registrable apex cannot be determined. 
- Add `tldts` to `packages/core/package.json` and update `bun.lock` workspace metadata. 
- Update and extend `packages/core/src/utils/__tests__/fapiAutoDetect.test.ts` to add PSL/private-hosted suffix regression cases and adjust expectations accordingly. 
- Commit message: `fix(core): use PSL for auth URL detection`.

### Testing
- Ran `git diff --check` which succeeded without whitespace errors. 
- Attempted to run the core unit test file via `bun run test --runTestsByPath src/utils/__tests__/fapiAutoDetect.test.ts`, but the test run failed because `jest` is not available in this environment (`command not found`).
- Attempted to install `tldts` with `bun add tldts@^7.0.22 --cwd packages/core`, but the package registry fetch was blocked (HTTP 403), so dependency installation could not be completed here; `package.json` and `bun.lock` were updated to declare the dependency.
- Changes were committed locally (`fix(core): use PSL for auth URL detection`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bcec2d8b48323b8c2b3b974fddc45)