### PR TITLE
fix(api): require ownership for email attachments

### DIFF
--- a/packages/api/src/controllers/email.controller.ts
+++ b/packages/api/src/controllers/email.controller.ts
@@ -26,7 +26,7 @@ import type { RecipientInput, AttachmentInput } from '../schemas/email.schemas';
  * canonical IAttachment shape persisted on Message. Each fileId MUST:
  *   - exist
  *   - be in status 'active' (not trash/deleted)
- *   - be accessible to the requesting user (assetService.canUserAccessFile)
+ *   - be owned by the requesting user
  *
  * The IAttachment is built from the IFile so the Message subdocument carries
  * a stable snapshot of name/contentType/size at send time, regardless of any
@@ -53,8 +53,7 @@ async function resolveAttachmentInputs(
     if (!file) {
       throw new BadRequestError(`Attachment file not found or not active: ${input.fileId}`);
     }
-    const allowed = await assetService.canUserAccessFile(file, userId);
-    if (!allowed) {
+    if (file.ownerUserId.toString() !== userId) {
       throw new ForbiddenError(`Not authorized to attach file ${file._id}`);
     }
     resolved.push({

--- a/packages/api/src/routes/__tests__/email.send.attachments.test.ts
+++ b/packages/api/src/routes/__tests__/email.send.attachments.test.ts
@@ -3,15 +3,15 @@
  *
  * Exercises the canonical `{ fileId, contentId?, isInline? }` attachment
  * contract introduced by the Oxy File Manager migration. The route handler
- * resolves each fileId via assetService, enforces ownership via
- * canUserAccessFile, snapshots `{name, contentType, size}` from the File
+ * resolves each fileId via assetService, enforces ownerUserId ownership,
+ * snapshots `{name, contentType, size}` from the File
  * record into the IAttachment subdocument, and links each file to the
  * stored Message under `app: 'oxy-mail'`.
  *
  * Failure modes covered:
  *   1. Happy path — valid {fileId} array sends; resolved IAttachment[]
  *      reaches smtpOutbound.send AND linkFile is called for each file.
- *   2. Foreign file (canUserAccessFile → false) → 403 ForbiddenError.
+ *   2. Foreign file (ownerUserId !== sender) → 403 ForbiddenError.
  *   3. Missing file (assetService returns no record) → 400 BadRequestError.
  *   4. Trashed file (status !== 'active') → 400 BadRequestError.
  *   5. Legacy shape (bare `s3Key`/`filename`) → 400 from Zod validation
@@ -153,13 +153,15 @@ const FILE_OWN = '64f0000000000000000000a1';
 const FILE_FOREIGN = '64f0000000000000000000a2';
 const FILE_TRASHED = '64f0000000000000000000a3';
 const FILE_MISSING = '64f0000000000000000000a4';
+const OTHER_USER_ID = '64b0000000000000000000bb';
 
-function makeFile(id: string, status: 'active' | 'trash' | 'deleted'): {
+function makeFile(id: string, status: 'active' | 'trash' | 'deleted', ownerUserId = TEST_USER_ID): {
   _id: { toString: () => string };
   status: 'active' | 'trash' | 'deleted';
   originalName: string;
   mime: string;
   size: number;
+  ownerUserId: { toString: () => string };
 } {
   return {
     _id: { toString: () => id },
@@ -167,6 +169,7 @@ function makeFile(id: string, status: 'active' | 'trash' | 'deleted'): {
     originalName: `${id}.pdf`,
     mime: 'application/pdf',
     size: 1234,
+    ownerUserId: { toString: () => ownerUserId },
   };
 }
 
@@ -202,7 +205,7 @@ describe('POST /email/messages — attachment resolution', () => {
     );
 
     expect(mockGetFilesByIds).toHaveBeenCalledWith([FILE_OWN]);
-    expect(mockCanUserAccessFile).toHaveBeenCalledWith(ownedFile, TEST_USER_ID);
+    expect(mockCanUserAccessFile).not.toHaveBeenCalled();
 
     expect(mockSmtpSend).toHaveBeenCalledTimes(1);
     const sendArg = mockSmtpSend.mock.calls[0][0] as {
@@ -226,10 +229,10 @@ describe('POST /email/messages — attachment resolution', () => {
     });
   });
 
-  it('returns 403 when the requesting user cannot access the referenced file', async () => {
-    const foreignFile = makeFile(FILE_FOREIGN, 'active');
+  it('returns 403 when the requesting user does not own the referenced file', async () => {
+    const foreignFile = makeFile(FILE_FOREIGN, 'active', OTHER_USER_ID);
     mockGetFilesByIds.mockResolvedValueOnce([foreignFile]);
-    mockCanUserAccessFile.mockResolvedValueOnce(false);
+    mockCanUserAccessFile.mockResolvedValueOnce(true);
 
     const res = await postJson(server, '/email/messages', {
       to: [{ address: 'bob@example.com' }],
@@ -241,6 +244,7 @@ describe('POST /email/messages — attachment resolution', () => {
     expect(res.body).toEqual(
       expect.objectContaining({ error: expect.stringMatching(/forbidden/i) }),
     );
+    expect(mockCanUserAccessFile).not.toHaveBeenCalled();
     expect(mockSmtpSend).not.toHaveBeenCalled();
     expect(mockLinkFile).not.toHaveBeenCalled();
   });

--- a/packages/api/src/schemas/email.schemas.ts
+++ b/packages/api/src/schemas/email.schemas.ts
@@ -101,7 +101,7 @@ export type RecipientInput = z.infer<typeof recipientSchema>;
 // the Oxy File Manager. The server resolves the File record, mirrors its
 // originalName/mime/size into the Message subdocument, and creates a link
 // (app: 'oxy-mail') so the file isn't orphaned. Only the file owner may
-// reference their own files (enforced via assetService.canUserAccessFile).
+// reference their own files (enforced by the controller).
 const attachmentInputSchema = z.object({
   fileId: z.string().trim().min(1),
   contentId: z.string().trim().optional(),


### PR DESCRIPTION
### Motivation
- Prevent a privilege escalation where callers could attach and send File Manager files they do not own by passing accessible `fileId`s; view/access checks are insufficient for attachment/attachment-linking flows. 
- The outbound path downloads raw bytes by `fileId` with no caller context and `linkFile` mutates file metadata, so ownership must be enforced earlier to avoid cross-tenant data exposure or metadata tampering.

### Description
- Enforce ownership in the email controller: `resolveAttachmentInputs` now requires `file.ownerUserId.toString() === userId` before building the attachment snapshot or sending the message. (packages/api/src/controllers/email.controller.ts)
- Update the attachment schema comment to reflect that ownership is enforced by the controller rather than via a general access predicate. (packages/api/src/schemas/email.schemas.ts)
- Update tests to model ownership semantics, include `ownerUserId` in test fixtures, and assert non-owned active files are rejected before SMTP send or File Manager linking; also assert the old `canUserAccessFile` predicate is not relied upon in this path. (packages/api/src/routes/__tests__/email.send.attachments.test.ts)

### Testing
- Updated unit tests in `packages/api/src/routes/__tests__/email.send.attachments.test.ts` to cover the ownership rejection case; tests were adjusted to assert the new behavior.
- Attempted to run the package test (`bun run test -- packages/api/src/routes/__tests__/email.send.attachments.test.ts --runInBand`) but automated execution was blocked because `jest` is not installed in this environment, so the test suite was not executed here (command failed with `jest: command not found`).
- Changes were compiled into a commit for review and should be verified by CI which has project dependencies available; the intended unit tests should pass once run in the normal CI/workspace environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd25a14988323a5919e1cc8b8649e)