### PR TITLE
fix(services): preserve global logout on web

### DIFF
--- a/packages/services/__tests__/context/useAuthOperations.test.tsx
+++ b/packages/services/__tests__/context/useAuthOperations.test.tsx
@@ -446,27 +446,22 @@ describe('useAuthOperations.logoutAll', () => {
   });
 
   // Under jest's jsdom env `isWebBrowser()` returns true, so `logoutAll`
-  // takes the web cookie-cleared branch. The bearer-protected
-  // `logoutAllSessions` is reserved for native and is NOT called on web —
-  // see the "Semantics intentionally diverge by platform" comment in
-  // `useAuthOperations.logoutAll` for why this is correct UX.
-  it('clears every device-local cookie + every session state on success (web)', async () => {
+  // must revoke the active user's sessions across devices first, then clear
+  // every device-local cookie slot from this browser.
+  it('revokes global sessions and clears every device-local cookie on success (web)', async () => {
     const helpers = setup({ activeSessionId: 'session-1' });
     await act(async () => {
       await helpers.result.current.logoutAll();
     });
+    expect(helpers.oxyServices.logoutAllSessions).toHaveBeenCalledWith('session-1');
     expect(helpers.oxyServices.logoutAllSessionsViaCookie).toHaveBeenCalledTimes(1);
-    // The bearer "revoke every session of this user across devices" endpoint
-    // is intentionally NOT called on web — the cookie endpoint covers the
-    // chooser's "Sign out of all accounts" semantics.
-    expect(helpers.oxyServices.logoutAllSessions).not.toHaveBeenCalled();
     expect(helpers.clearSessionState).toHaveBeenCalledTimes(1);
     // The persisted active-authuser slot is cleared so the next cold boot
     // starts from a clean slate.
     expect(window.localStorage.getItem('oxy_active_authuser')).toBeNull();
   });
 
-  it('re-throws and reports when the server fails (web cookie endpoint)', async () => {
+  it('re-throws and reports when the cookie cleanup fails after global revocation', async () => {
     const helpers = setup({
       activeSessionId: 'session-1',
       oxyServices: {
@@ -482,6 +477,7 @@ describe('useAuthOperations.logoutAll', () => {
       }),
     ).rejects.toThrow('server down');
 
+    expect(helpers.oxyServices.logoutAllSessions).toHaveBeenCalledWith('session-1');
     expect(helpers.onError).toHaveBeenCalledWith(expect.objectContaining({
       code: 'LOGOUT_ALL_ERROR',
     }));

--- a/packages/services/src/ui/context/hooks/useAuthOperations.ts
+++ b/packages/services/src/ui/context/hooks/useAuthOperations.ts
@@ -275,26 +275,15 @@ export const useAuthOperations = ({
     }
 
     try {
-      // Semantics intentionally diverge by platform to match user expectation:
-      //   - Web: "Sign out of all accounts" = sign out every device-local
-      //     account on THIS device. The cookie endpoint is the only path
-      //     that can `Set-Cookie` an immediate expiry on every
-      //     `oxy_rt_${n}` slots AND revoke every presented family server-side.
-      //     The bearer-protected
-      //     `logoutAllSessions(activeSessionId)` would only revoke the
-      //     active user's sessions across devices and leave sibling
-      //     accounts' cookies sitting on this device — wrong UX for the
-      //     chooser's "Sign out of all accounts".
-      //   - Native: there are no per-account cookies; "Sign out of all"
-      //     keeps its long-standing "revoke every session of THIS user"
-      //     meaning via the bearer endpoint.
-      // After clearing on web, also drop the persisted active-authuser so
-      // the next cold boot starts from a clean slate.
+      // Always invoke the bearer-protected global endpoint first: the public
+      // `logoutAll`/`signOutAll` contract means revoking this user's sessions
+      // across devices, not just clearing refresh cookies presented by the
+      // current browser. On web, follow up with the cookie endpoint so every
+      // device-local account slot is expired in the browser as well.
+      await oxyServices.logoutAllSessions(activeSessionId);
       if (isWebBrowser()) {
         await oxyServices.logoutAllSessionsViaCookie();
         clearActiveAuthuser();
-      } else {
-        await oxyServices.logoutAllSessions(activeSessionId);
       }
       // logoutAll is ALWAYS a full sign-out: clear the per-origin SSO bounce
       // state (web-guarded internally) so a fresh sign-in can re-probe.


### PR DESCRIPTION
### Motivation
- Restore the intended "Sign out all sessions across all devices" behavior after a regression made the web `logoutAll` branch only clear local refresh cookies instead of revoking the user's sessions server-side.
- Ensure the Session Management UI and public `signOutAll` contract truly revoke remote sessions during an emergency global logout.

### Description
- Always call the bearer-backed global endpoint via `oxyServices.logoutAllSessions(activeSessionId)` before any web cookie cleanup in `useAuthOperations.logoutAll` (`packages/services/src/ui/context/hooks/useAuthOperations.ts`).
- On web, follow the global revocation with `oxyServices.logoutAllSessionsViaCookie()` and `clearActiveAuthuser()` so browser-local multi-account refresh-cookie slots are expired as well.
- Update the `useAuthOperations.logoutAll` unit tests to assert that the web path invokes both the global revocation and the cookie cleanup, and adjust the error test to reflect the new call order (`packages/services/__tests__/context/useAuthOperations.test.tsx`).
- Changes are limited to the services layer orchestration and tests; server-side endpoints (`/session/logout-all/:sessionId` and `/auth/logout`) remain unchanged and are used together to achieve correct semantics.

### Testing
- Ran `git diff --check` locally to validate whitespace/patch sanity and updated tests compile-wise in repository.
- Attempted to run the updated unit test (`useAuthOperations`), but `bun install` failed due to upstream registry `403` errors so Jest could not be executed in this environment; therefore the updated tests were not executed here.
- The change is covered by the modified unit test in `packages/services/__tests__/context/useAuthOperations.test.tsx` which asserts both the global revocation and cookie cleanup on web.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd5acae5883239f4aad20211575b5)