### PR TITLE
fix(services): gate refresh-cookie restore on durable session

### DIFF
--- a/packages/services/__tests__/context/refreshCookieRestore.test.tsx
+++ b/packages/services/__tests__/context/refreshCookieRestore.test.tsx
@@ -144,6 +144,8 @@ describe('Cold-boot restore via secure refresh cookies (multi-account)', () => {
 
   it('CASE single account: signs the user in from the refresh-all snapshot, plants the token, and persists session id + authuser', async () => {
     const stub = baseStub();
+    window.localStorage.setItem(ACTIVE_SESSION_KEY, COOKIE_SESSION_ID);
+
     stub.refreshAllSessions = jest.fn(async () => ({
       accounts: [
         {
@@ -179,7 +181,31 @@ describe('Cold-boot restore via secure refresh cookies (multi-account)', () => {
     expect(ssoNavigateSpy).not.toHaveBeenCalled();
   });
 
+  it('CASE no durable local session: skips the ambient-cookie exchange and bounces to central SSO', async () => {
+    const stub = baseStub();
+    stub.refreshAllSessions = jest.fn(async () => ({
+      accounts: [
+        {
+          authuser: 0,
+          accessToken: COOKIE_ACCESS_TOKEN,
+          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          sessionId: COOKIE_SESSION_ID,
+          user: { id: COOKIE_USER_ID, username: 'tester', avatar: null, color: null },
+        },
+      ],
+    }));
+
+    renderProvider(stub);
+
+    await waitFor(() => expect(ssoNavigateSpy).toHaveBeenCalledTimes(1));
+
+    expect(stub.refreshAllSessions).not.toHaveBeenCalled();
+    expect(captured.isAuthenticated).toBe(false);
+    expect(setTokensSpy).not.toHaveBeenCalled();
+  });
+
   it('CASE empty: a `{accounts:[]}` snapshot leaves the user logged out, plants nothing, and bounces to central SSO', async () => {
+    window.localStorage.setItem(ACTIVE_SESSION_KEY, COOKIE_SESSION_ID);
     const stub = baseStub();
     // `refreshAllSessions` already defaults to `{accounts: []}` via baseStub.
 
@@ -205,6 +231,7 @@ describe('Cold-boot restore via secure refresh cookies (multi-account)', () => {
   });
 
   it('CASE network error: a refreshAllSessions rejection falls through unauthenticated, then bounces to central SSO', async () => {
+    window.localStorage.setItem(ACTIVE_SESSION_KEY, COOKIE_SESSION_ID);
     const stub = baseStub();
     stub.refreshAllSessions = jest.fn(async () => {
       throw new TypeError('Failed to fetch');

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -838,6 +838,27 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       return false;
     }
 
+    // Security boundary: never exchange an ambient, parent-domain refresh
+    // cookie for JavaScript-visible bearer tokens unless THIS origin already
+    // has durable proof that the SDK previously owned an Oxy session. This
+    // preserves normal reload restore for legitimate RP apps while preventing
+    // unrelated same-site origins (or cookie-tossing attackers) from turning a
+    // bare `oxy_rt_*` cookie into a full access token on first load.
+    let storedActiveSessionId: string | null = null;
+    try {
+      const readyStorage = await getReadyStorage();
+      storedActiveSessionId = await readyStorage.getItem(storageKeys.activeSessionId);
+    } catch (storageError) {
+      if (__DEV__) {
+        loggerUtil.debug('Refresh-all cookie restore skipped: durable session proof unavailable', { component: 'OxyContext', method: 'restoreViaRefreshCookie' }, storageError as unknown);
+      }
+      return false;
+    }
+
+    if (!storedActiveSessionId) {
+      return false;
+    }
+
     let snapshot;
     try {
       // Bound the refresh so a cross-domain/stalled call cannot hang the cold
@@ -859,10 +880,15 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     // account, otherwise the lowest authuser (deterministic). The server has
     // already sorted ascending so [0] is the lowest.
     const persistedAuthuser = readActiveAuthuser();
+    const durableSessionAccount = snapshot.accounts.find((a) => a.sessionId === storedActiveSessionId);
+    if (!durableSessionAccount) {
+      return false;
+    }
+
     const matched = persistedAuthuser !== null
-      ? snapshot.accounts.find((a) => a.authuser === persistedAuthuser)
+      ? snapshot.accounts.find((a) => a.authuser === persistedAuthuser && a.sessionId === storedActiveSessionId)
       : undefined;
-    const activeAccount = matched ?? snapshot.accounts[0];
+    const activeAccount = matched ?? durableSessionAccount;
 
     // Plant the active access token. Sibling accounts' access tokens stay in
     // the snapshot (the chooser can drive a per-account refresh via
@@ -911,7 +937,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     markAuthResolvedRef.current();
     onAuthStateChangeRef.current?.(fullUser);
     return true;
-  }, [oxyServices, persistSessionDurably]);
+  }, [getReadyStorage, oxyServices, persistSessionDurably, storageKeys.activeSessionId]);
 
   // Native (and offline) stored-session restore — the ONLY restore path that
   // runs on React Native, and the web fallback when no cross-domain step won.


### PR DESCRIPTION
### Motivation
- Prevent an attacker-controlled same-site origin or a cookie-tossing attack from exchanging a parent-domain `oxy_rt_*` refresh cookie for a JavaScript-visible bearer token during web cold boot.
- Harden the web cold-boot path so only origins with prior durable session proof can automatically restore full access tokens from the refresh-cookie exchange.

### Description
- Require origin-local durable session proof by reading the persisted `activeSessionId` from ready storage before calling the refresh-cookie fast-path in `restoreViaRefreshCookie` in `packages/services/src/ui/context/OxyContext.tsx`.
- Only accept a `refreshAllSessions` account whose returned `sessionId` matches the persisted active session id before planting the returned access token into the JS-visible HTTP client state.
- Update the dependency array of the `restoreViaRefreshCookie` callback to include the storage helpers used for the durable check.
- Add a regression test in `packages/services/__tests__/context/refreshCookieRestore.test.tsx` asserting that when no durable local session exists the code does not call `refreshAllSessions`, does not plant a token, and instead proceeds to the central SSO bounce; also update existing cookie-restore tests to seed the durable active-session id where appropriate.

### Testing
- `git diff --check` ran locally and reported no whitespace errors.
- Unit test run: attempted `bun run test -- refreshCookieRestore.test.tsx` but `jest` is not available in this ephemeral environment so the test could not be executed here.
- Type check: attempted `bun run typescript` but workspace compilation failed in this environment due to missing dev/runtime dependencies (e.g. `react`, `@oxyhq/core`, `react-native`) so a local `tsc` verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd820f0788323b255b0d0240b9419)