### PR TITLE
fix(api): harden refresh cookie origin scope

### DIFF
--- a/packages/api/src/config/__tests__/env.test.ts
+++ b/packages/api/src/config/__tests__/env.test.ts
@@ -1,10 +1,10 @@
 /**
  * Environment configuration validation tests
  *
- * Focus: REFRESH_COOKIE_DOMAIN strict-hostname validation (MED-2). The value
- * is interpolated into a hand-built `Set-Cookie` header
- * (`appendLegacyRefreshCookieDeletion`), so anything beyond a bare hostname
- * (scheme, port, spaces, `;`, `,`, control chars) must fail fast at startup.
+ * Focus: REFRESH_COOKIE_DOMAIN strict validation (MED-2). Refresh cookies
+ * default to host-only scope. If the emergency Domain override is used, it must
+ * be exactly the API host so bearer-equivalent cookies never leak to sibling
+ * subdomain servers.
  */
 
 import {
@@ -85,15 +85,14 @@ describe('validateRequiredEnvVars — REFRESH_COOKIE_DOMAIN', () => {
     expect(() => validateRequiredEnvVars()).not.toThrow();
   });
 
-  it('passes for a valid bare hostname', () => {
-    process.env.REFRESH_COOKIE_DOMAIN = 'oxy.so';
-    expect(() => validateRequiredEnvVars()).not.toThrow();
-
+  it('passes for the exact API host emergency override', () => {
     process.env.REFRESH_COOKIE_DOMAIN = 'api.oxy.so';
     expect(() => validateRequiredEnvVars()).not.toThrow();
   });
 
   it.each([
+    'oxy.so',
+    'auth.oxy.so',
     'oxy.so; Secure',
     'oxy.so,evil.com',
     'http://oxy.so',

--- a/packages/api/src/config/allowedOrigins.ts
+++ b/packages/api/src/config/allowedOrigins.ts
@@ -5,10 +5,10 @@
  * (middleware/originGuard.ts) so both layers enforce the exact same policy.
  *
  * Policy:
- *  - Exact first-party apex origins (https only).
- *  - One-level https subdomains of the first-party zones (lowercase
- *    RFC 1123-ish labels only — uppercase, unicode/homograph, ports, paths,
- *    and suffix-spoofing like `oxy.so.evil.com` all fail the anchored regex).
+ *  - Exact first-party apex origins and explicitly registered first-party app
+ *    origins (https only).
+ *  - No wildcard subdomain trust: same-site tenant/user subdomains must not be
+ *    able to make credentialed CORS requests to bearer-minting endpoints.
  *  - `http://localhost[:port]` / `http://127.0.0.1[:port]` ONLY outside
  *    production.
  *  - Optional emergency escape hatch via `OXY_EXTRA_ALLOWED_ORIGINS`
@@ -21,23 +21,33 @@ import { logger } from '../utils/logger';
 
 const EXACT_ALLOWED_ORIGINS: ReadonlySet<string> = new Set([
   'https://oxy.so',
+  'https://api.oxy.so',
+  'https://accounts.oxy.so',
+  'https://allo.oxy.so',
+  'https://auth.oxy.so',
+  'https://cloud.oxy.so',
+  'https://console.oxy.so',
+  'https://inbox.oxy.so',
+  'https://noted.oxy.so',
+  'https://pay.oxy.so',
+  'https://syra.oxy.so',
   'https://mention.earth',
+  'https://api.mention.earth',
+  'https://auth.mention.earth',
   'https://homiio.com',
+  'https://app.homiio.com',
+  'https://auth.homiio.com',
   'https://alia.onl',
+  'https://api.alia.onl',
+  'https://auth.alia.onl',
   'https://syra.fm',
   'https://moovo.now',
+  'https://go.moovo.now',
+  'https://hub.moovo.now',
   'https://mercaria.co',
+  'https://dashboard.mercaria.co',
+  'https://pos.mercaria.co',
 ]);
-
-const ALLOWED_ORIGIN_PATTERNS: readonly RegExp[] = [
-  /^https:\/\/[a-z0-9-]+\.oxy\.so$/,
-  /^https:\/\/[a-z0-9-]+\.mention\.earth$/,
-  /^https:\/\/[a-z0-9-]+\.homiio\.com$/,
-  /^https:\/\/[a-z0-9-]+\.alia\.onl$/,
-  /^https:\/\/[a-z0-9-]+\.syra\.fm$/,
-  /^https:\/\/[a-z0-9-]+\.moovo\.now$/,
-  /^https:\/\/[a-z0-9-]+\.mercaria\.co$/,
-];
 
 const DEV_ORIGIN_PATTERN = /^http:\/\/(?:localhost|127\.0\.0\.1)(?::\d{1,5})?$/;
 
@@ -92,10 +102,6 @@ function getExtraAllowedOrigins(): ReadonlySet<string> {
  */
 export function isAllowedOrigin(origin: string): boolean {
   if (EXACT_ALLOWED_ORIGINS.has(origin)) {
-    return true;
-  }
-
-  if (ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin))) {
     return true;
   }
 

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -236,14 +236,19 @@ export function validateRequiredEnvVars(): void {
     );
   }
 
-  // REFRESH_COOKIE_DOMAIN becomes a cookie Domain attribute, so a malformed
-  // value could alter cookie scope. Fail fast on anything that is not a bare
-  // hostname.
+  // REFRESH_COOKIE_DOMAIN becomes a cookie Domain attribute. Refresh cookies
+  // are bearer-equivalent, so the safe default is host-only (unset). If an
+  // operator uses the emergency override, fail fast unless it is the exact API
+  // host; parent-domain scopes such as `oxy.so` leak the cookie to sibling
+  // subdomain servers despite HttpOnly.
   const refreshCookieDomain = process.env.REFRESH_COOKIE_DOMAIN;
-  if (refreshCookieDomain && !isValidHostname(refreshCookieDomain)) {
+  if (
+    refreshCookieDomain &&
+    (!isValidHostname(refreshCookieDomain) || refreshCookieDomain !== 'api.oxy.so')
+  ) {
     missing.push(
-      'REFRESH_COOKIE_DOMAIN (invalid: must be a bare hostname like "oxy.so" — ' +
-      'no scheme, port, path, spaces, or ";"/"," characters)'
+      'REFRESH_COOKIE_DOMAIN (invalid: leave unset for host-only cookies, or set exactly "api.oxy.so"; ' +
+      'parent domains, schemes, ports, paths, spaces, and ";"/"," characters are forbidden)'
     );
   }
 

--- a/packages/api/src/middleware/__tests__/originGuard.test.ts
+++ b/packages/api/src/middleware/__tests__/originGuard.test.ts
@@ -1,8 +1,8 @@
 /**
  * Origin guard tests (MED-1 CSRF hardening, Phase A)
  *
- * `isAllowedOrigin`: strict allowlist — exact first-party origins, one-level
- * https subdomains, dev-only localhost, and validated
+ * `isAllowedOrigin`: strict allowlist — exact first-party app origins,
+ * dev-only localhost, and validated
  * `OXY_EXTRA_ALLOWED_ORIGINS` entries. Suffix-spoofing, case tricks, and
  * homograph hosts must all fail.
  *
@@ -63,7 +63,7 @@ describe('isAllowedOrigin', () => {
     'https://mercaria.co',
   ];
 
-  const SUBDOMAIN_ALLOWED = [
+  const APP_ORIGIN_ALLOWED = [
     'https://api.oxy.so',
     'https://accounts.oxy.so',
     'https://auth.oxy.so',
@@ -84,6 +84,7 @@ describe('isAllowedOrigin', () => {
     'https://oxy-so.example.com',
     'https://EVIL.oxy.so',
     'https://оxy.so',
+    'https://attacker.oxy.so',
     'https://a.b.oxy.so',
     'https://oxy.so:8443',
     'https://oxy.so/path',
@@ -99,7 +100,7 @@ describe('isAllowedOrigin', () => {
     expect(isAllowedOrigin(origin)).toBe(true);
   });
 
-  it.each(SUBDOMAIN_ALLOWED)('allows https subdomain %s', (origin) => {
+  it.each(APP_ORIGIN_ALLOWED)('allows registered app origin %s', (origin) => {
     expect(isAllowedOrigin(origin)).toBe(true);
   });
 
@@ -218,7 +219,7 @@ describe('requireSameSiteOrigin', () => {
     expect(res.body).toEqual({ ok: true });
   });
 
-  it('passes allowlisted subdomain origins', async () => {
+  it('passes registered app origins', async () => {
     const res = await request('POST', { origin: 'https://accounts.oxy.so' });
     expect(res.status).toBe(200);
   });

--- a/packages/api/src/routes/__tests__/refreshToken.test.ts
+++ b/packages/api/src/routes/__tests__/refreshToken.test.ts
@@ -626,7 +626,8 @@ describe('clearRefreshCookie', () => {
 
     clearRefreshCookie(res, { authuser: 0 });
 
-    // The real cookie clear targets Path=/auth with Max-Age=0.
+    // The real cookie clear targets Path=/auth with Max-Age=0 and also
+    // expires the pre-hardening parent-domain cookie.
     const primaryClear = cookies.find(
       (c) =>
         c.startsWith(`${REFRESH_COOKIE_SLOT_0}=`) &&
@@ -634,5 +635,8 @@ describe('clearRefreshCookie', () => {
         /Max-Age=0/.test(c)
     );
     expect(primaryClear).toBeDefined();
+    expect(
+      cookies.some((c) => c.includes('Domain=oxy.so') && /Max-Age=0/.test(c))
+    ).toBe(true);
   });
 });

--- a/packages/api/src/services/refreshToken.service.ts
+++ b/packages/api/src/services/refreshToken.service.ts
@@ -37,7 +37,7 @@ import RefreshToken from '../models/RefreshToken';
 import Session from '../models/Session';
 import sessionService from './session.service';
 import { logger } from '../utils/logger';
-import { getEnvVar, isProduction } from '../config/env';
+import { isProduction } from '../config/env';
 import { sha256Hex, base64UrlEncode } from './oauthCode.service';
 
 /** Number of random bytes in a raw refresh token (256-bit). */
@@ -66,6 +66,7 @@ export const MAX_DEVICE_ACCOUNTS = 10;
  * (revoke it) — while still keeping it off every other route.
  */
 export const REFRESH_COOKIE_PATH = '/auth';
+const LEGACY_PARENT_REFRESH_COOKIE_DOMAIN = 'oxy.so';
 
 export interface IssueRefreshTokenOptions {
   sessionId: string;
@@ -307,7 +308,7 @@ export interface RefreshCookieOptions {
   httpOnly: true;
   secure: boolean;
   sameSite: 'lax';
-  domain: string;
+  domain?: string;
   path: string;
   maxAge: number;
 }
@@ -425,8 +426,9 @@ export async function selectActiveCandidate(
  *   local http dev so the flow is testable without TLS.
  * - `sameSite: 'lax'` — sent on top-level navigations (cold boot) yet not on
  *   cross-site sub-requests, blunting CSRF while preserving cold-boot replay.
- * - `domain` — defaults to `oxy.so` (configurable via REFRESH_COOKIE_DOMAIN) so
- *   the cookie is shared across `*.oxy.so` subdomains.
+ * - Host-only by default — no Domain attribute, so sibling subdomain servers
+ *   cannot receive this bearer-equivalent cookie. `REFRESH_COOKIE_DOMAIN` is
+ *   only an emergency override and is validated at startup.
  * - `path: /auth` — the browser sends it to the first-party session routes
  *   (`/auth/session`, `/auth/refresh`, `/auth/logout`) and nowhere else.
  * - `maxAge` — express `res.cookie` takes maxAge in MILLISECONDS and converts to
@@ -437,7 +439,9 @@ export function buildRefreshCookieOptions(): RefreshCookieOptions {
     httpOnly: true,
     secure: isProduction(),
     sameSite: 'lax',
-    domain: getEnvVar('REFRESH_COOKIE_DOMAIN', 'oxy.so'),
+    ...(process.env.REFRESH_COOKIE_DOMAIN
+      ? { domain: process.env.REFRESH_COOKIE_DOMAIN }
+      : {}),
     path: REFRESH_COOKIE_PATH,
     maxAge: REFRESH_TOKEN_TTL_MS,
   };
@@ -447,11 +451,19 @@ export function buildRefreshCookieOptions(): RefreshCookieOptions {
  * Set a refresh-token cookie on the response.
  *
  * Writes the indexed `oxy_rt_${authuser}` cookie at `Path=/auth` with HttpOnly,
- * Secure, SameSite=Lax, Domain, and Max-Age.
+ * Secure, SameSite=Lax, host-only default scope, and Max-Age.
  *
  * `authuser` is validated by `refreshCookieName`, which throws `RangeError`
  * for anything outside `[0, MAX_DEVICE_ACCOUNTS)`.
  */
+function clearLegacyParentRefreshCookie(res: Response, name: string): void {
+  res.cookie(name, '', {
+    ...buildRefreshCookieOptions(),
+    domain: LEGACY_PARENT_REFRESH_COOKIE_DOMAIN,
+    maxAge: 0,
+  });
+}
+
 export function setRefreshCookie(
   res: Response,
   token: string,
@@ -459,6 +471,9 @@ export function setRefreshCookie(
 ): void {
   const name = refreshCookieName(opts.authuser);
   res.cookie(name, token, buildRefreshCookieOptions());
+  // Delete any pre-hardening parent-domain cookie with the same indexed name so
+  // sibling `*.oxy.so` servers stop receiving the old bearer-equivalent value.
+  clearLegacyParentRefreshCookie(res, name);
 }
 
 /**
@@ -473,6 +488,7 @@ export function clearRefreshCookie(
 ): void {
   const name = refreshCookieName(opts.authuser);
   res.cookie(name, '', { ...buildRefreshCookieOptions(), maxAge: 0 });
+  clearLegacyParentRefreshCookie(res, name);
 }
 
 /**
@@ -498,7 +514,9 @@ export function clearAllRefreshCookies(
   const opts = { ...buildRefreshCookieOptions(), maxAge: 0 };
 
   for (const key of buckets.keys()) {
-    res.cookie(refreshCookieName(key), '', opts);
+    const name = refreshCookieName(key);
+    res.cookie(name, '', opts);
+    clearLegacyParentRefreshCookie(res, name);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Close a high-severity web logic vulnerability where a parent-domain refresh cookie (`oxy.so`) + permissive credentialed CORS allowed same-site subdomains to obtain a bearer `accessToken` via `POST /auth/refresh` without robust Origin/CSRF protections.

### Description
- Replace wildcard one-level subdomain trust with an explicit allowlist of known first-party app origins in `packages/api/src/config/allowedOrigins.ts`, removing the previous `ALLOWED_ORIGIN_PATTERNS` regex that matched any `*.oxy.so` subdomain.
- Make refresh cookies host-only by default by omitting the `Domain` attribute in `buildRefreshCookieOptions()` and only applying an emergency override when `REFRESH_COOKIE_DOMAIN` is explicitly set to the exact API host; update startup validation in `packages/api/src/config/env.ts` to reject unsafe values.
- When setting/clearing refresh cookies, explicitly expire any legacy parent-domain (`oxy.so`) cookie so previously issued parent-domain bearer cookies no longer leak to sibling subdomains; added helpers in `packages/api/src/services/refreshToken.service.ts` to clear legacy cookies.
- Update tests to assert the hardened policies: origin allowlist rejects `https://attacker.oxy.so`, `REFRESH_COOKIE_DOMAIN` validation behavior, and that cookie-clearing emits a `Domain=oxy.so` Max-Age=0 header to clean up legacy cookies.

### Testing
- Ran `git diff --check` successfully to ensure no whitespace/merge errors were introduced.
- Attempted `bun install` but dependency resolution failed due to external npm registry `403` responses, so workspace install could not complete.
- Attempted `bun run test` and `jest`-scoped runs but they were blocked because dependencies/installation did not complete; tests could not be executed locally here.
- Attempted `bun run api:build` but the build was blocked by existing TypeScript configuration deprecation/rootDir errors in the `@oxyhq/contracts` build step, so full compile verification could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd87226008323bebbe29b2a3e8d8a)