### PR TITLE
fix: restrict manual AWS deploys to main

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -23,7 +23,11 @@ env:
 
 jobs:
   deploy:
+    # workflow_dispatch can be run against arbitrary refs; only production
+    # deploys from the protected main branch may assume the AWS deploy role.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
+    environment: production
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### Motivation
- The reusable GitHub Actions workflow allowed `workflow_dispatch` manual runs to proceed against arbitrary refs and then assume the production AWS OIDC role, which could deploy unreviewed code to production.
- Prevent manual dispatch from bypassing branch protections and require repository-side production environment approvals before the job assumes the deploy role.

### Description
- Added a job-level branch guard `if: github.ref == 'refs/heads/main'` to the `deploy` job in `.github/workflows/deploy-aws.yml` so the job only proceeds for the `main` branch.
- Attached `environment: production` to the `deploy` job to enable repository-side environment protection and approval workflows for production deploys.
- Preserved the `workflow_dispatch:` trigger so manual runs remain possible but will now be gated by the branch guard and environment.
- Left the AWS OIDC role assumption (`role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy`) and build/push/deploy steps unchanged to preserve existing behavior for legitimate `main` branch deploys.

### Testing
- Ran a small verification script that asserts the workflow contains `if: github.ref == 'refs/heads/main'`, `environment: production`, `workflow_dispatch:`, and the `role-to-assume` line, and it succeeded. 
- Ran `git diff --check` to ensure no whitespace/format issues and it returned no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bd97d70f083238f491703a3c56ca2)