### PR TITLE
fix(auth): bind FedCM assertion client to request origin

### DIFF
--- a/packages/auth/server/__tests__/fedcm.idp.test.ts
+++ b/packages/auth/server/__tests__/fedcm.idp.test.ts
@@ -371,6 +371,49 @@ describe('POST /fedcm/assertion', () => {
     expect(payload.iss).toBe('https://auth.oxy.so');
   });
 
+  it('rejects when client_id is not the actual requesting Origin', async () => {
+    const approvedButDifferentOrigin = 'https://console.oxy.so';
+    stubbedApprovedClients = [RP_ORIGIN, approvedButDifferentOrigin];
+
+    const res = await app.request('/fedcm/assertion', {
+      method: 'POST',
+      headers: {
+        ...WEBIDENTITY,
+        'content-type': 'application/x-www-form-urlencoded',
+        origin: RP_ORIGIN,
+        cookie: SESSION_COOKIE,
+      },
+      body: new URLSearchParams({
+        account_id: TEST_USER_ID,
+        client_id: approvedButDifferentOrigin,
+        nonce: 'rp-nonce-mismatch',
+      }).toString(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_client' });
+  });
+
+  it('rejects unapproved client_id values before minting a token', async () => {
+    const res = await app.request('/fedcm/assertion', {
+      method: 'POST',
+      headers: {
+        ...WEBIDENTITY,
+        'content-type': 'application/x-www-form-urlencoded',
+        origin: 'https://evil.example.com',
+        cookie: SESSION_COOKIE,
+      },
+      body: new URLSearchParams({
+        account_id: TEST_USER_ID,
+        client_id: 'https://evil.example.com',
+        nonce: 'rp-nonce-unapproved',
+      }).toString(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_client' });
+  });
+
   it('returns 401 with WWW-Authenticate when not logged in at the IdP', async () => {
     const res = await app.request('/fedcm/assertion', {
       method: 'POST',
@@ -569,6 +612,7 @@ describe('Multi-domain FAPI (Clerk-style CNAME)', () => {
   });
 
   it('mints an id_token whose iss matches the request host (per FedCM spec)', async () => {
+    stubbedApprovedClients = ['https://alia.onl'];
     const nonce = 'nonce-multi-domain';
     const res = await app.request('https://auth.alia.onl/fedcm/assertion', {
       method: 'POST',

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -1425,6 +1425,13 @@ app.post('/fedcm/assertion', async (c) => {
     return c.json({ error: 'invalid_request' }, 400);
   }
 
+  const requestOrigin = normaliseOrigin(c.req.header('origin') || '');
+  const approvedClientOrigin = await resolveApprovedClientOrigin(apiBaseUrl, clientId);
+  if (!requestOrigin || !approvedClientOrigin || requestOrigin !== approvedClientOrigin) {
+    return c.json({ error: 'invalid_client' }, 400);
+  }
+  clientId = approvedClientOrigin;
+
   // Verify the session is still valid and the account matches
   const user = await fetchUserFromAPI(apiBaseUrl, sessionId);
   if (!user || user.id !== accountId) {


### PR DESCRIPTION
### Motivation
- Prevent FedCM client_id/origin spoofing by ensuring the IdP mints tokens only when the caller-supplied `client_id` is both approved and matches the actual browser `Origin`, closing an origin/nonce binding bypass.

### Description
- Require `/fedcm/assertion` to normalize and resolve `client_id` via the authoritative approved-client list and verify the normalized value equals the request `Origin`, rejecting the request when they differ and normalizing the signed `aud` to the approved origin (change in `packages/auth/server/index.ts`).
- Add regression coverage that rejects an approved-but-different `client_id` when it does not match the real request Origin and rejects unapproved `client_id` values before token minting (tests added/updated in `packages/auth/server/__tests__/fedcm.idp.test.ts`).
- Adjust the multi-domain assertion test to explicitly seed the expected approved origin in the test stub so the assertion path remains valid in that scenario.

### Testing
- Ran `git diff --check` which passed.
- Attempted `bun test packages/auth/server/__tests__/fedcm.idp.test.ts` but execution was blocked by unresolved workspace dependencies (`Cannot find module '@oxyhq/core'`), so the new tests could not be executed here.
- Attempted `bun install --frozen-lockfile` to install deps for full test runs but it failed due to registry access errors (multiple `403` responses), preventing local test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3be07f2288832390814ba5aeb389f4)