### PR TITLE
fix(core): require delegated service scope intersection

### DIFF
--- a/packages/core/src/mixins/OxyServices.utility.ts
+++ b/packages/core/src/mixins/OxyServices.utility.ts
@@ -953,9 +953,9 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
      * Express.js middleware that enforces a specific service-token scope.
      *
      * Mount AFTER `auth()` / `serviceAuth()` — relies on `req.serviceApp` and
-     * (when delegation is in effect) `req.serviceActingAs.scopes`. The scope
-     * is granted if EITHER list contains it, mirroring the OAuth2 model where
-     * the app's app-level scopes and the per-user delegated scopes both count.
+     * (when delegation is in effect) `req.serviceActingAs.scopes`. App-only
+     * service requests require the app scope. Delegated user requests require
+     * BOTH the app scope and the per-user delegation scope.
      *
      * Requests authenticated as a regular user (no service token) are rejected
      * with 403 — scope-protected endpoints are service-to-service by design.
@@ -988,7 +988,13 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
           return;
         }
 
-        if (appScopes.includes(scope) || delegatedScopes.includes(scope)) {
+        const appHasScope = appScopes.includes(scope);
+        const delegationHasScope = delegatedScopes.includes(scope);
+        const hasRequiredScope = req.serviceActingAs
+          ? appHasScope && delegationHasScope
+          : appHasScope;
+
+        if (hasRequiredScope) {
           next();
           return;
         }

--- a/packages/core/src/mixins/__tests__/serviceAuth.test.ts
+++ b/packages/core/src/mixins/__tests__/serviceAuth.test.ts
@@ -672,9 +672,9 @@ describe('requireScope() middleware', () => {
     expect(res.headersSent).toBe(false);
   });
 
-  it('allows requests where the delegation grant carries the required scope', () => {
+  it('allows delegated requests only when both app and delegation carry the required scope', () => {
     const req = makeReq();
-    req.serviceApp = { appId: 'a', appName: 'svc', credentialId: 'cred-1', scopes: [] };
+    req.serviceApp = { appId: 'a', appName: 'svc', credentialId: 'cred-1', scopes: ['user:read'] };
     req.serviceActingAs = { userId: 'u-1', scopes: ['user:read'] };
     const res = makeRes();
     const next = jest.fn();
@@ -682,6 +682,34 @@ describe('requireScope() middleware', () => {
     oxy.requireScope('user:read')(req as unknown as never, res as unknown as never, next as unknown as never);
 
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects delegated requests when only the app carries the required scope', () => {
+    const req = makeReq();
+    req.serviceApp = { appId: 'a', appName: 'svc', credentialId: 'cred-1', scopes: ['files:write'] };
+    req.serviceActingAs = { userId: 'u-1', scopes: ['profile:read'] };
+    const res = makeRes();
+    const next = jest.fn();
+
+    oxy.requireScope('files:write')(req as unknown as never, res as unknown as never, next as unknown as never);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatchObject({ code: 'INSUFFICIENT_SCOPE' });
+  });
+
+  it('rejects delegated requests when only the delegation carries the required scope', () => {
+    const req = makeReq();
+    req.serviceApp = { appId: 'a', appName: 'svc', credentialId: 'cred-1', scopes: ['profile:read'] };
+    req.serviceActingAs = { userId: 'u-1', scopes: ['files:write'] };
+    const res = makeRes();
+    const next = jest.fn();
+
+    oxy.requireScope('files:write')(req as unknown as never, res as unknown as never, next as unknown as never);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatchObject({ code: 'INSUFFICIENT_SCOPE' });
   });
 
   it('rejects requests missing the required scope with 403', () => {


### PR DESCRIPTION
### Motivation
- Prevent delegated service requests from gaining scopes that were not explicitly granted by both the app and the per-user delegation, closing an authorization bypass where union semantics allowed escalation.

### Description
- Change `requireScope()` to require the requested scope to be present in both `req.serviceApp.scopes` and `req.serviceActingAs.scopes` when `req.serviceActingAs` is present, otherwise require the app scope for app-only requests (`packages/core/src/mixins/OxyServices.utility.ts`).
- Update the `requireScope()` documentation comment to describe the intersection semantics for delegated requests (`packages/core/src/mixins/OxyServices.utility.ts`).
- Add regression tests that assert delegated requests succeed only when both the app and the delegation carry the required scope and fail when only one side has it (`packages/core/src/mixins/__tests__/serviceAuth.test.ts`).

### Testing
- Ran `git diff --check` which reported no problems.
- Added unit tests for the `requireScope()` behavior but running `bun run test` locally was blocked because `jest` is not available in this environment and `bun install` failed due to the registry returning `403`, so tests could not be executed here.
- The new tests are included in `packages/core/src/mixins/__tests__/serviceAuth.test.ts` and should be run in CI or a developer environment with dependencies installed using `bun install` followed by the package test runner (`bun run test` / `jest` as appropriate).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3be13e2ad483239ef00edb327e805d)