### PR TITLE
fix(auth-sdk): clear persisted query cache on sign-out

### DIFF
--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -45,7 +45,11 @@ import type {
   ColdBootOutcome,
 } from '@oxyhq/core';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { attachQueryPersistence, createQueryClient } from './hooks/queryClient';
+import {
+  attachQueryPersistence,
+  clearBrowserQueryCache,
+  createQueryClient,
+} from './hooks/queryClient';
 import { isWebBrowser } from './hooks/useWebSSO';
 
 export interface WebAuthState {
@@ -911,6 +915,7 @@ export function WebOxyProvider({
       setUser(null);
       setActiveSessionId(null);
       syncAccountsFromManager();
+      await clearBrowserQueryCache(queryClient);
       // EXPLICIT user sign-out: clear the per-origin SSO bounce state so a fresh
       // deliberate sign-in can re-probe the central IdP. Never done on a
       // cold-boot failure path (that would reintroduce the redirect loop).
@@ -920,7 +925,7 @@ export function WebOxyProvider({
       setError(errorMessage);
       onError?.(err instanceof Error ? err : new Error(errorMessage));
     }
-  }, [authManager, onError, syncAccountsFromManager]);
+  }, [authManager, onError, queryClient, syncAccountsFromManager]);
 
   const switchAccount = useCallback(async (authuser: number) => {
     setError(null);
@@ -977,13 +982,20 @@ export function WebOxyProvider({
         // No slots left — fully signed out.
         setUser(null);
         setActiveSessionId(null);
+        await clearBrowserQueryCache(queryClient);
       }
       syncAccountsFromManager();
     } catch (err) {
       syncAccountsFromManager();
       handleAuthError(err);
     }
-  }, [authManager, oxyServices, syncAccountsFromManager, handleAuthError]);
+  }, [
+    authManager,
+    oxyServices,
+    queryClient,
+    syncAccountsFromManager,
+    handleAuthError,
+  ]);
 
   const signOutAll = useCallback(async () => {
     await signOut();
@@ -994,11 +1006,12 @@ export function WebOxyProvider({
     setUser(null);
     setActiveSessionId(null);
     syncAccountsFromManager();
+    await clearBrowserQueryCache(queryClient);
     // EXPLICIT user sign-out (this provider has no cold-boot path that calls
     // this): clear the per-origin SSO bounce state so a fresh deliberate
     // sign-in can re-probe the central IdP.
     clearSsoBounceStateWeb();
-  }, [authManager, syncAccountsFromManager]);
+  }, [authManager, queryClient, syncAccountsFromManager]);
 
   useEffect(() => {
     return () => { authManager.destroy(); };

--- a/packages/auth-sdk/src/hooks/queryClient.ts
+++ b/packages/auth-sdk/src/hooks/queryClient.ts
@@ -166,4 +166,21 @@ export const clearQueryCache = async (
   }
 };
 
+export const clearBrowserQueryCache = async (
+  queryClient: QueryClient,
+): Promise<void> => {
+  queryClient.clear();
+
+  const localStorage = getBrowserLocalStorage();
+  if (!localStorage) return;
+
+  try {
+    localStorage.removeItem(QUERY_CACHE_KEY);
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('[QueryClient] Failed to remove cache', error);
+    }
+  }
+};
+
 export type { PersistedClient };


### PR DESCRIPTION
### Motivation
- Close an auth persistence gap where `sessions` query data (which contains raw `sessionId`) was being persisted to `localStorage` under `oxy_auth_query_cache_v2` and remained after user sign-out, allowing leaked session IDs to be recovered and exchanged for access tokens. 
- Ensure that web sign-out paths remove both the in-memory TanStack Query cache and the persisted cache so no bearer-equivalent session identifiers survive logout.

### Description
- Added `clearBrowserQueryCache(queryClient)` to `packages/auth-sdk/src/hooks/queryClient.ts` which calls `queryClient.clear()` and removes the `oxy_auth_query_cache_v2` entry from browser `localStorage` when available. 
- Wired the new helper into the web provider by importing it in `packages/auth-sdk/src/WebOxyProvider.tsx` and invoking it on full `signOut`, when the final account slot is signed out in `signOutAccount`, and inside `clearSessionState` so persisted query data is removed during all full-session teardown flows. 
- Updated related effect/memo dependency lists to include `queryClient` where the helper is used, preserving existing persistence/restore behavior otherwise.

### Testing
- Ran `git diff --check`, which reported no whitespace or merge conflict issues. 
- Attempted `bun install --frozen-lockfile`, but the job was blocked by npm registry 403 responses so dependency installation could not complete. 
- Attempted `bun run --cwd packages/auth-sdk lint` and `bun run --cwd packages/auth-sdk test`, but both could not run due to missing dev tool binaries (`biome`, `jest`) caused by the unavailable dependencies. 
- Attempted `bun run --cwd packages/auth-sdk build`, which failed due to TypeScript configuration issues unrelated to this change (deprecated `moduleResolution=node10` and missing explicit `rootDir`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3be7adba2483239598515882477fa7)