### PR TITLE
ci: restrict auth Pages deploy to main

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -37,7 +37,9 @@ jobs:
 
   deploy-auth:
     needs: detect-changes
-    if: needs.detect-changes.outputs.auth == 'true' || github.event_name == 'workflow_dispatch'
+    # The auth app is the production IdP surface. Only deploy it from the
+    # protected main branch, including manual workflow_dispatch runs.
+    if: github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.auth == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- Fix a CI/CD authorization flaw where a manual `workflow_dispatch` could build a non-main ref but deploy it to the production `oxy-auth` Cloudflare Pages project by forcing `--branch=main`, allowing unreviewed code to be published as production IdP.

### Description
- Update ` .github/workflows/deploy-cloudflare.yml` to require the `deploy-auth` job only run when `github.ref == 'refs/heads/main'` (while preserving `workflow_dispatch`), and add an inline comment documenting that the auth app is the production IdP surface.

### Testing
- Verified the workflow YAML parses successfully with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-cloudflare.yml'); puts 'yaml ok'"`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3beda339b8832380ef0bada8cc4f78)