### PR TITLE
fix(api): harden federated avatar downloads against SSRF

### DIFF
--- a/packages/api/src/services/__tests__/federation.service.test.ts
+++ b/packages/api/src/services/__tests__/federation.service.test.ts
@@ -24,6 +24,7 @@ const mockCacheInvalidate = jest.fn();
 const mockAssetFileContentExists = jest.fn();
 const mockAssetUploadFileDirect = jest.fn();
 const mockAssetDeleteFile = jest.fn();
+const mockDnsLookup = jest.fn();
 
 process.env.AWS_ACCESS_KEY_ID ||= 'test-access-key';
 process.env.AWS_SECRET_ACCESS_KEY ||= 'test-secret-key';
@@ -89,6 +90,11 @@ jest.mock('../s3Service', () => ({
   __esModule: true,
   createS3Service: jest.fn(() => ({})),
 }));
+jest.mock('dns/promises', () => ({
+  __esModule: true,
+  default: { lookup: mockDnsLookup },
+  lookup: mockDnsLookup,
+}));
 
 import { federationService } from '../federation.service';
 
@@ -153,6 +159,7 @@ function resetAssetMocks(): void {
   mockAssetFileContentExists.mockResolvedValue(true);
   mockAssetUploadFileDirect.mockResolvedValue(mockUploadedFile('uploaded-file-id'));
   mockAssetDeleteFile.mockResolvedValue(undefined);
+  mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
 }
 
 /** Let any scheduled fire-and-forget background refresh settle. */
@@ -480,6 +487,48 @@ describe('FederationService.scheduleAvatarRefresh (off request path)', () => {
     jest.clearAllMocks();
     resetAssetMocks();
     mockUserUpdateOne.mockResolvedValue({ acknowledged: true });
+  });
+
+  it('blocks unsafe avatar URLs before fetch to prevent SSRF', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: { get: () => 'image/png' },
+      arrayBuffer: () => Promise.resolve(Buffer.from('png-bytes').buffer),
+    } as unknown as Response);
+
+    await expect(federationService.downloadAndStoreAvatar('http://127.0.0.1/avatar.png'))
+      .resolves.toMatchObject({ fileId: null, notModified: false });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    mockDnsLookup.mockResolvedValueOnce([{ address: '10.0.0.5', family: 4 }]);
+    await expect(federationService.downloadAndStoreAvatar('https://metadata.example/avatar.png'))
+      .resolves.toMatchObject({ fileId: null, notModified: false });
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+
+  it('rejects oversized avatars from Content-Length before buffering', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: {
+        get: (name: string) => {
+          if (name.toLowerCase() === 'content-length') return `${5 * 1024 * 1024 + 1}`;
+          if (name.toLowerCase() === 'content-type') return 'image/png';
+          return null;
+        },
+      },
+      arrayBuffer: jest.fn(),
+    } as unknown as Response);
+
+    await expect(federationService.downloadAndStoreAvatar('https://cdn.example/avatar.png'))
+      .resolves.toMatchObject({ fileId: null, notModified: false });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockAssetUploadFileDirect).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
   });
 
   it('skips the forced re-download when lastAvatarFetchedAt is within the throttle window', async () => {

--- a/packages/api/src/services/federation.service.ts
+++ b/packages/api/src/services/federation.service.ts
@@ -7,6 +7,8 @@
  */
 
 import crypto from 'crypto';
+import dns from 'dns/promises';
+import net from 'net';
 import mongoose from 'mongoose';
 import User, { IUser } from '../models/User';
 import { AssetService } from './assetService';
@@ -61,6 +63,8 @@ const REFRESH_MIN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
  * meaningfully change faster than the actor record it belongs to.
  */
 const AVATAR_REFRESH_MIN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_AVATAR_DOWNLOAD_BYTES = 5 * 1024 * 1024;
+const MAX_AVATAR_REDIRECTS = 3;
 
 const FEDIVERSE_HANDLE_REGEX = /^@?[\w.-]+@[\w.-]+\.\w+$/;
 
@@ -77,6 +81,118 @@ function normalizeFediverseHandle(handle: string): string | null {
   if (!localPart || !domain) return null;
 
   return `${localPart}@${domain}`;
+}
+
+function isBlockedIPv4(ip: string): boolean {
+  const parts = ip.split('.').map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return true;
+  }
+
+  const [a, b] = parts;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168) ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    a >= 224
+  );
+}
+
+function isBlockedIPv6(ip: string): boolean {
+  const normalized = ip.toLowerCase();
+  const mappedIpv4 = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mappedIpv4) {
+    return isBlockedIPv4(mappedIpv4[1]);
+  }
+
+  return (
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    normalized.startsWith('fe80:') ||
+    normalized.startsWith('::ffff:0:') ||
+    normalized.startsWith('64:ff9b:') ||
+    normalized.startsWith('2001:db8:') ||
+    normalized.startsWith('2001:2:') ||
+    normalized.startsWith('2001:10:') ||
+    normalized.startsWith('ff')
+  );
+}
+
+function isBlockedIpAddress(ip: string): boolean {
+  const family = net.isIP(ip);
+  if (family === 4) return isBlockedIPv4(ip);
+  if (family === 6) return isBlockedIPv6(ip);
+  return true;
+}
+
+async function assertSafeAvatarUrl(avatarUrl: string): Promise<URL> {
+  let parsed: URL;
+  try {
+    parsed = new URL(avatarUrl);
+  } catch {
+    throw new Error('Invalid avatar URL');
+  }
+
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Avatar URL must use HTTPS');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('Avatar URL credentials are not allowed');
+  }
+  if (parsed.port && parsed.port !== '443') {
+    throw new Error('Avatar URL custom ports are not allowed');
+  }
+
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  if (!hostname || hostname.toLowerCase() === 'localhost') {
+    throw new Error('Avatar URL hostname is not allowed');
+  }
+
+  if (net.isIP(hostname) !== 0) {
+    if (isBlockedIpAddress(hostname)) {
+      throw new Error('Avatar URL IP address is not allowed');
+    }
+    return parsed;
+  }
+
+  const addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+  if (addresses.length === 0 || addresses.some(({ address }) => isBlockedIpAddress(address))) {
+    throw new Error('Avatar URL resolved to a blocked address');
+  }
+
+  return parsed;
+}
+
+async function fetchSafeAvatarUrl(
+  avatarUrl: string,
+  init: RequestInit,
+  redirectsRemaining = MAX_AVATAR_REDIRECTS,
+): Promise<Response> {
+  const parsed = await assertSafeAvatarUrl(avatarUrl);
+  const res = await fetch(parsed.toString(), {
+    ...init,
+    redirect: 'manual',
+  });
+
+  if ([301, 302, 303, 307, 308].includes(res.status)) {
+    if (redirectsRemaining <= 0) {
+      throw new Error('Avatar download exceeded redirect limit');
+    }
+    const location = res.headers.get('location');
+    if (!location) {
+      throw new Error('Avatar redirect missing Location header');
+    }
+    const redirectedUrl = new URL(location, parsed);
+    return fetchSafeAvatarUrl(redirectedUrl.toString(), init, redirectsRemaining - 1);
+  }
+
+  return res;
 }
 
 function domainFromHandle(handle: string): string | null {
@@ -690,7 +806,7 @@ class FederationService {
         requestHeaders['If-Modified-Since'] = conditional.lastModified;
       }
 
-      const res = await fetch(avatarUrl, {
+      const res = await fetchSafeAvatarUrl(avatarUrl, {
         headers: requestHeaders,
         signal: AbortSignal.timeout(15_000),
       });
@@ -729,6 +845,14 @@ class FederationService {
 
       const etag = res.headers.get('etag') || undefined;
       const lastModified = res.headers.get('last-modified') || undefined;
+      const contentLength = res.headers.get('content-length');
+      if (contentLength) {
+        const parsedLength = Number(contentLength);
+        if (!Number.isFinite(parsedLength) || parsedLength <= 0 || parsedLength > MAX_AVATAR_DOWNLOAD_BYTES) {
+          logger.warn(`Avatar download skipped: invalid content-length "${contentLength}" for ${avatarUrl}`);
+          return { fileId: null, etag, lastModified, notModified: false };
+        }
+      }
 
       // Sanitize content-type: strip parameters (e.g. "image/jpeg; charset=utf-8" → "image/jpeg")
       const rawContentType = res.headers.get('content-type') || 'image/png';
@@ -741,7 +865,7 @@ class FederationService {
       }
 
       const buffer = Buffer.from(await res.arrayBuffer());
-      if (buffer.length === 0 || buffer.length > 5 * 1024 * 1024) {
+      if (buffer.length === 0 || buffer.length > MAX_AVATAR_DOWNLOAD_BYTES) {
         return { fileId: null, etag, lastModified, notModified: false }; // max 5MB
       }
 


### PR DESCRIPTION
### Motivation
- Prevent server-side request forgery and data exfiltration caused by downloading attacker-controlled avatar URLs from privileged service-authenticated callers.

### Description
- Add a safe-fetch wrapper (`fetchSafeAvatarUrl`) and URL assertion (`assertSafeAvatarUrl`) that parse and validate `avatar` URLs, enforcing HTTPS-only, no embedded credentials, no custom ports, and rejecting `localhost` and literal/resolved private or reserved IP addresses.
- Follow redirects manually with a limit (`MAX_AVATAR_REDIRECTS`) and validate each redirect target before following to avoid redirect-based bypasses.
- Introduce a pre-buffer `Content-Length` guard and a shared `MAX_AVATAR_DOWNLOAD_BYTES` (5MB) constant to reject oversized responses before reading the full body while keeping the existing post-read size check.
- Replace the direct `fetch(avatarUrl, ...)` call in `downloadAndStoreAvatar` with the safe-fetch path, preserving conditional (`ETag`/`Last-Modified`) handling and existing upload logic, and add unit tests that assert unsafe URLs are blocked and oversized responses are rejected.

### Testing
- Added Jest unit tests in `packages/api/src/services/__tests__/federation.service.test.ts` covering unsafe URL blocking and oversized `Content-Length` handling; these tests mock DNS resolution and `fetch` behavior.
- Attempted to run the package tests with `bun run test -- federation.service.test.ts` but execution was blocked because `jest` is not available in the ephemeral environment (dev dependencies are not installed), so tests were not executed here.
- Attempted `bun install --frozen-lockfile` to install deps but it failed due to npm registry HTTP 403 responses in this environment, preventing local test execution; a static diff/check was performed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bfc020d2483238f88545b458daf87)