### PR TITLE
fix: pin Docker installs to committed bun.lock to prevent live dependency resolution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,16 +49,24 @@ dkim-private.pem
 **/.eslintcache
 
 # Other apps in the monorepo that the API image does not build.
-# The Dockerfile only copies packages/core and packages/api, but
-# excluding the rest keeps the build context lean.
-packages/accounts
-packages/auth
-packages/auth-sdk
-packages/console
-packages/inbox
-packages/services
-packages/test-app-expo
-packages/test-app-vite
+# Keep their sources out of the image context, but allow package manifests so
+# Docker can run a full-workspace frozen Bun install against the committed lock.
+packages/accounts/*
+!packages/accounts/package.json
+packages/auth/*
+!packages/auth/package.json
+packages/auth-sdk/*
+!packages/auth-sdk/package.json
+packages/console/*
+!packages/console/package.json
+packages/inbox/*
+!packages/inbox/package.json
+packages/services/*
+!packages/services/package.json
+packages/test-app-expo/*
+!packages/test-app-expo/package.json
+packages/test-app-vite/*
+!packages/test-app-vite/package.json
 
 # Local Docker artifacts
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,21 +14,24 @@ RUN npm install -g bun
 
 WORKDIR /app
 
-# Copy workspace root and override workspaces to only include api + core + contracts.
-# `@oxyhq/api` depends on `@oxyhq/contracts` (workspace:*); core is retained for the
-# admin scripts that import packages/core/src/* at runtime.
-# Remove bun.lock since the workspace change invalidates it — bun will
-# resolve fresh dependencies (still deterministic from package.json versions).
-COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/core','packages/contracts','packages/api']; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
-
-# Copy package.json files for dependency resolution
+# Copy the full workspace manifest set and committed lockfile before installing.
+# Keeping the root workspaces unchanged lets `bun install --frozen-lockfile` use
+# the reviewed, integrity-pinned versions from bun.lock instead of resolving
+# mutable semver ranges during production Docker builds.
+COPY package.json bun.lock ./
 COPY packages/api/package.json packages/api/
-COPY packages/core/package.json packages/core/
+COPY packages/auth/package.json packages/auth/
+COPY packages/auth-sdk/package.json packages/auth-sdk/
+COPY packages/accounts/package.json packages/accounts/
+COPY packages/console/package.json packages/console/
 COPY packages/contracts/package.json packages/contracts/
+COPY packages/core/package.json packages/core/
+COPY packages/inbox/package.json packages/inbox/
+COPY packages/services/package.json packages/services/
+COPY packages/test-app-expo/package.json packages/test-app-expo/
 
-# Install dependencies (no lockfile — workspace subset doesn't match the full monorepo lock)
-RUN bun install
+# Install dependencies from the committed lockfile.
+RUN bun install --frozen-lockfile
 
 # Copy source code
 COPY packages/core/ packages/core/
@@ -49,15 +52,21 @@ RUN npm install -g bun
 
 WORKDIR /app
 
-# Copy workspace root and override workspaces
-COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/core','packages/contracts','packages/api']; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
+# Copy the full workspace manifest set and committed lockfile before installing.
+COPY package.json bun.lock ./
 COPY packages/api/package.json packages/api/
-COPY packages/core/package.json packages/core/
+COPY packages/auth/package.json packages/auth/
+COPY packages/auth-sdk/package.json packages/auth-sdk/
+COPY packages/accounts/package.json packages/accounts/
+COPY packages/console/package.json packages/console/
 COPY packages/contracts/package.json packages/contracts/
+COPY packages/core/package.json packages/core/
+COPY packages/inbox/package.json packages/inbox/
+COPY packages/services/package.json packages/services/
+COPY packages/test-app-expo/package.json packages/test-app-expo/
 
-# Install production dependencies
-RUN bun install --production
+# Install production dependencies from the committed lockfile.
+RUN bun install --production --frozen-lockfile
 
 # Copy built artifacts
 COPY --from=builder /app/packages/api/dist packages/api/dist


### PR DESCRIPTION
### Motivation
- Prevent production Docker builds from resolving mutable semver ranges by restoring use of the committed `bun.lock`, closing a supply-chain window where rebuilt images could pull unreviewed package versions.

### Description
- Updated `Dockerfile` builder stage to `COPY package.json bun.lock ./` and run `bun install --frozen-lockfile` so build deps are installed from the reviewed lockfile. 
- Updated `Dockerfile` production stage to `COPY package.json bun.lock ./` and run `bun install --production --frozen-lockfile` so runtime deps are also pinned.
- Added `COPY` entries for each workspace `package.json` in the Dockerfile so the full workspace lockfile is valid for a frozen install.
- Updated `.dockerignore` to exclude workspace source trees while allowing their `package.json` manifests into the build context so Docker can perform a full-workspace frozen Bun install.

### Testing
- Ran `git diff --check` and a local Node verification script that asserts every workspace `package.json` is copied and that `bun install --frozen-lockfile` is present; these checks passed.
- Attempted a temporary `bun install --frozen-lockfile --production` in a simulated context which reached dependency fetches but failed with registry `403` in this environment (network restrictions), indicating no lockfile mutation error but preventing a full install verification here.
- Attempted `docker build` in the environment but Docker is not available, so an image build could not be executed; CI/build should validate the frozen install on the runner where Docker and registry access are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bff34175883238a1cbe2195b3ca21)