### PR TITLE
fix: enforce frozen Docker dependency installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,21 +14,23 @@ RUN npm install -g bun
 
 WORKDIR /app
 
-# Copy workspace root and override workspaces to only include api + core + contracts.
-# `@oxyhq/api` depends on `@oxyhq/contracts` (workspace:*); core is retained for the
-# admin scripts that import packages/core/src/* at runtime.
-# Remove bun.lock since the workspace change invalidates it — bun will
-# resolve fresh dependencies (still deterministic from package.json versions).
-COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/core','packages/contracts','packages/api']; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
-
-# Copy package.json files for dependency resolution
+# Copy workspace manifests without mutating package.json so the checked-in lockfile
+# remains authoritative for Docker builds. Frozen installs intentionally fail when
+# bun.lock is stale instead of resolving unreviewed semver-compatible versions.
+COPY package.json bun.lock ./
+COPY packages/accounts/package.json packages/accounts/
 COPY packages/api/package.json packages/api/
-COPY packages/core/package.json packages/core/
+COPY packages/auth-sdk/package.json packages/auth-sdk/
+COPY packages/auth/package.json packages/auth/
+COPY packages/console/package.json packages/console/
 COPY packages/contracts/package.json packages/contracts/
+COPY packages/core/package.json packages/core/
+COPY packages/inbox/package.json packages/inbox/
+COPY packages/services/package.json packages/services/
+COPY packages/test-app-expo/package.json packages/test-app-expo/
 
-# Install dependencies (no lockfile — workspace subset doesn't match the full monorepo lock)
-RUN bun install
+# Install dependencies exactly as recorded in bun.lock.
+RUN bun install --frozen-lockfile
 
 # Copy source code
 COPY packages/core/ packages/core/
@@ -49,15 +51,22 @@ RUN npm install -g bun
 
 WORKDIR /app
 
-# Copy workspace root and override workspaces
-COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/core','packages/contracts','packages/api']; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
+# Copy workspace manifests without mutating package.json so the checked-in lockfile
+# remains authoritative for the runtime image as well.
+COPY package.json bun.lock ./
+COPY packages/accounts/package.json packages/accounts/
 COPY packages/api/package.json packages/api/
-COPY packages/core/package.json packages/core/
+COPY packages/auth-sdk/package.json packages/auth-sdk/
+COPY packages/auth/package.json packages/auth/
+COPY packages/console/package.json packages/console/
 COPY packages/contracts/package.json packages/contracts/
+COPY packages/core/package.json packages/core/
+COPY packages/inbox/package.json packages/inbox/
+COPY packages/services/package.json packages/services/
+COPY packages/test-app-expo/package.json packages/test-app-expo/
 
-# Install production dependencies
-RUN bun install --production
+# Install production dependencies exactly as recorded in bun.lock.
+RUN bun install --frozen-lockfile --production
 
 # Copy built artifacts
 COPY --from=builder /app/packages/api/dist packages/api/dist


### PR DESCRIPTION
### Motivation
- Prevent Docker builds from resolving or mutating dependency versions during image creation so the committed `bun.lock` remains authoritative and supply-chain updates are reviewable.
- Restore deterministic, fail-fast behavior when the lockfile is stale to avoid unreviewed semver-compatible upgrades entering production images.

### Description
- Stop mutating the root `package.json.workspaces` inside the Docker build and instead copy the committed `bun.lock` alongside all workspace `package.json` manifests into both builder and runtime stages.
- Run `bun install --frozen-lockfile` in the builder stage to ensure installs match the checked-in lockfile exactly.
- Run `bun install --frozen-lockfile --production` in the production stage so runtime dependencies are installed only as recorded in the lockfile.
- Keep the build steps that compile `@oxyhq/contracts`, `@oxyhq/core`, and `@oxyhq/api` unchanged and continue to copy built artifacts from the builder to the runtime stage.

### Testing
- Ran `git diff --check` to validate Dockerfile formatting and local modifications, which passed without errors.
- Simulated a manifest-only Docker install context and attempted `bun install --frozen-lockfile --lockfile-only`, which reached registry resolution but failed to complete due to network registry `403` responses in this environment (shows the frozen install path exercised but external registry access was blocked). 
- Attempted to run `docker build` but Docker is not available in the execution environment, so full image build verification could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bfebb2ef883238f45c67958744e9f)