### PR TITLE
fix(api): restrict global topic writes to staff

### DIFF
--- a/packages/api/src/routes/__tests__/topics.routes.test.ts
+++ b/packages/api/src/routes/__tests__/topics.routes.test.ts
@@ -1,0 +1,162 @@
+import express from 'express';
+import http from 'http';
+
+const mockAuthMiddleware = jest.fn();
+const mockResolveNames = jest.fn();
+const mockFindOneAndUpdate = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
+}));
+
+jest.mock('../../services/TopicService.js', () => ({
+  topicService: {
+    list: jest.fn(),
+    localizeTopics: jest.fn(),
+    getCategories: jest.fn(),
+    search: jest.fn(),
+    getBySlug: jest.fn(),
+    resolveNames: (...args: unknown[]) => mockResolveNames(...args),
+  },
+}));
+
+jest.mock('../../models/Topic.js', () => ({
+  TopicType: {
+    Category: 'category',
+    Tag: 'tag',
+  },
+  Topic: {
+    findOneAndUpdate: (...args: unknown[]) => mockFindOneAndUpdate(...args),
+  },
+}));
+
+import topicsRouter from '../topics.routes';
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+function requestJson(
+  server: http.Server,
+  method: string,
+  path: string,
+  payload?: unknown
+): Promise<JsonResponse> {
+  const { port } = server.address() as { port: number };
+  const body = payload === undefined ? '' : JSON.stringify(payload);
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        method,
+        path,
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: raw.length > 0 ? JSON.parse(raw) : {} });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+let currentIsStaff = false;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/topics', topicsRouter);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentIsStaff = false;
+  mockAuthMiddleware.mockImplementation(
+    (req: { user?: unknown }, _res: unknown, next: () => void) => {
+      req.user = {
+        _id: { toString: () => 'user-id' },
+        isStaff: currentIsStaff,
+      };
+      next();
+    }
+  );
+});
+
+describe('/topics write authorization', () => {
+  it('rejects topic resolution for authenticated non-staff users', async () => {
+    const res = await requestJson(server, 'POST', '/topics/resolve', {
+      names: [{ name: 'Poisoned topic', type: 'tag' }],
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'Forbidden' });
+    expect(mockResolveNames).not.toHaveBeenCalled();
+  });
+
+  it('allows staff users to resolve topic names', async () => {
+    currentIsStaff = true;
+    mockResolveNames.mockResolvedValue(new Map([['poisoned topic', { slug: 'poisoned-topic' }]]));
+
+    const res = await requestJson(server, 'POST', '/topics/resolve', {
+      names: [{ name: 'Poisoned topic', type: 'tag' }],
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockResolveNames).toHaveBeenCalledWith([{ name: 'Poisoned topic', type: 'tag' }]);
+  });
+
+  it('rejects metadata updates for authenticated non-staff users', async () => {
+    const res = await requestJson(server, 'PATCH', '/topics/technology', {
+      displayName: 'Defaced',
+      description: 'Poisoned global metadata',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ error: 'Forbidden' });
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('allows staff users to update topic metadata', async () => {
+    currentIsStaff = true;
+    const updatedTopic = { slug: 'technology', displayName: 'Technology' };
+    mockFindOneAndUpdate.mockReturnValue({
+      lean: jest.fn().mockResolvedValue(updatedTopic),
+    });
+
+    const res = await requestJson(server, 'PATCH', '/topics/technology', {
+      displayName: 'Technology',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(updatedTopic);
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { slug: 'technology', isActive: true },
+      { $set: { displayName: 'Technology' } },
+      { new: true }
+    );
+  });
+});

--- a/packages/api/src/routes/topics.routes.ts
+++ b/packages/api/src/routes/topics.routes.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from 'express';
 import { authMiddleware } from '../middleware/auth';
+import { requireStaff } from '../middleware/requireStaff';
 import { topicService } from '../services/TopicService.js';
 import { Topic, TopicType } from '../models/Topic.js';
 
@@ -100,7 +101,7 @@ router.use(authMiddleware);
  * Batch resolve names to topics (upsert).
  * Body: { names: Array<{ name: string; type: TopicType }> }
  */
-router.post('/resolve', async (req: Request, res: Response) => {
+router.post('/resolve', requireStaff, async (req: Request, res: Response) => {
   try {
     const { names } = req.body;
     if (!Array.isArray(names) || names.length === 0) {
@@ -120,7 +121,7 @@ router.post('/resolve', async (req: Request, res: Response) => {
  * PATCH /:slug
  * Update topic metadata (description, translations, icon, image, aliases).
  */
-router.patch('/:slug', async (req: Request, res: Response) => {
+router.patch('/:slug', requireStaff, async (req: Request, res: Response) => {
   try {
     const { slug } = req.params;
     const allowedFields = ['description', 'translations', 'icon', 'image', 'aliases', 'displayName'];


### PR DESCRIPTION
### Motivation
- The `/topics` write routes previously required only a normal authenticated session, allowing any logged-in user to create or mutate global Topic records and enabling platform-wide content poisoning or defacement.
- The change closes this authorization gap by ensuring only platform staff can perform global topic upserts/metadata edits.

### Description
- Import and apply the existing `requireStaff` middleware to the sensitive routes `POST /topics/resolve` and `PATCH /topics/:slug` so only staff users can upsert or modify global topic metadata; public read routes remain unchanged.
- Add a route-level regression test file `packages/api/src/routes/__tests__/topics.routes.test.ts` that validates non-staff users receive `403` and staff users can successfully resolve names and update metadata.
- Files modified: `packages/api/src/routes/topics.routes.ts` (added `requireStaff` guard) and `packages/api/src/routes/__tests__/topics.routes.test.ts` (new tests).

### Testing
- Added unit tests in `packages/api/src/routes/__tests__/topics.routes.test.ts` covering both rejection for non-staff and acceptance for staff users (these tests are included in the PR).
- Attempted to run the tests with `bun run test -- topics.routes.test.ts`, but execution was blocked because `jest` is not available in the environment and `bun install` failed due to npm registry 403 errors, so automated tests could not be executed here.
- The change is minimal and uses the existing `requireStaff` guard; the new tests should pass in CI once dependencies are available and `jest` runs in the normal CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0002190483239497ac5bbc2acbd0)