### PR TITLE
Restrict manual Cloudflare deploys to main and pin checkout to main

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -37,10 +37,12 @@ jobs:
 
   deploy-auth:
     needs: detect-changes
-    if: needs.detect-changes.outputs.auth == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.auth == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -92,10 +94,12 @@ jobs:
 
   deploy-accounts:
     needs: detect-changes
-    if: needs.detect-changes.outputs.accounts == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.accounts == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -112,10 +116,12 @@ jobs:
 
   deploy-inbox:
     needs: detect-changes
-    if: needs.detect-changes.outputs.inbox == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.inbox == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -132,10 +138,12 @@ jobs:
 
   deploy-console:
     needs: detect-changes
-    if: needs.detect-changes.outputs.console == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.detect-changes.outputs.console == 'true' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14


### PR DESCRIPTION
### Motivation
- Manual `workflow_dispatch` could build and deploy an attacker-selected branch/tag to production Cloudflare Pages because deploy jobs ran unconditionally for `workflow_dispatch` and `actions/checkout` did not pin the ref. This change closes that vector by ensuring manual deploys only act on `refs/heads/main` and always check out `main` for production deploy jobs.

### Description
- Updated `.github/workflows/deploy-cloudflare.yml` deploy job conditions to require `(github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')` in addition to existing path-filter outputs so `push` behavior is unchanged and manual dispatches are restricted to main.
- Pinned each production deploy job's `actions/checkout@v4` step to `main` by adding `with: ref: main` so a manual run cannot build an arbitrary branch or tag.
- Changes touch the `deploy-auth`, `deploy-accounts`, `deploy-inbox`, and `deploy-console` jobs in `.github/workflows/deploy-cloudflare.yml`.

### Testing
- Ran a `python3` assertion that verifies the new `workflow_dispatch` conditional includes `github.ref == 'refs/heads/main'` and that `ref: main` is present, which succeeded.
- Parsed the updated workflow YAML with Ruby (`YAML.load_file`) to validate syntax, which succeeded.
- Confirmed the modified workflow file diff includes the intended `if` condition and pinned checkout entries; automated checks passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c05f7f22483239f75c18f7edcf77a)