### PR TITLE
Disable public SMTP in API container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,9 @@ AWS_ACCESS_KEY_ID=your-key
 AWS_SECRET_ACCESS_KEY=your-secret
 
 # ─── Email ────────────────────────────────────────────────────────
-SMTP_ENABLED=true
+# SMTP is disabled by default so public mail handling does not share the API process.
+# For self-hosted SMTP deployments, run a dedicated mail worker/container instead.
+SMTP_ENABLED=false
 EMAIL_DOMAIN=oxy.so
 
 # Cloudflare Email Routing inbound webhook secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 ##
-## Dockerfile for the Oxy API Server (with built-in email worker)
+## Dockerfile for the Oxy API Server
 ##
-## Runs the full Express API + SMTP inbound/outbound on a single process.
-## Set SMTP_ENABLED=true to activate the email server.
+## Runs the Express API. Inbound email is handled by Cloudflare Email
+## Routing -> Worker -> /email/inbound in production. Do not expose public
+## SMTP ports from this API container.
 ##
 ## Build:  docker build -t oxy-api .
-## Run:    docker run --env-file .env -p 8080:8080 -p 25:25 -p 587:587 oxy-api
+## Run:    docker run --env-file .env -p 8080:8080 oxy-api
 ##
 
 FROM node:20-alpine AS builder
@@ -72,8 +73,8 @@ COPY --from=builder /app/packages/api/scripts packages/api/scripts
 COPY --from=builder /app/packages/api/src packages/api/src
 COPY --from=builder /app/packages/core/src packages/core/src
 
-# Main API entry point (includes SMTP when SMTP_ENABLED=true)
+# Main API entry point
 CMD ["node", "packages/api/dist/server.js"]
 
-# HTTP API + SMTP ports
-EXPOSE 8080 25 587
+# HTTP API port
+EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 ##
-## Docker Compose — Oxy API + Email Server
+## Docker Compose — Oxy API
 ##
-## Runs everything on a single DigitalOcean Droplet:
-## - Oxy API (Express, port 8080 behind Caddy reverse proxy)
-## - SMTP inbound (port 25) + outbound
-## - Rspamd spam filtering
-## - Caddy reverse proxy (auto HTTPS with Let's Encrypt)
+## Runs the Express API behind Caddy. Production inbound mail should use
+## Cloudflare Email Routing -> Worker -> /email/inbound; public SMTP is not
+## exposed from this API container.
 ##
 ## Usage:
 ##   cp .env.example .env       # fill in your values
@@ -14,7 +12,7 @@
 ##
 
 services:
-  # ─── Oxy API + SMTP Server ──────────────────────────────────────
+  # ─── Oxy API ────────────────────────────────────────────────────
   api:
     build:
       context: .
@@ -27,23 +25,13 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
-    ports:
-      - "25:25"        # SMTP inbound (must be exposed directly, not through Caddy)
-      - "587:587"      # SMTP submission
     expose:
       - "8080"         # HTTP API (Caddy proxies to this)
     env_file:
       - .env
     environment:
       - PORT=8080
-      - SMTP_ENABLED=true
-      - RSPAMD_URL=http://rspamd:11333
-    volumes:
-      # Mount TLS certs for SMTP STARTTLS
-      - certs:/certs:ro
-    depends_on:
-      rspamd:
-        condition: service_started
+      - SMTP_ENABLED=false
     networks:
       - oxy-net
 


### PR DESCRIPTION
### Motivation
- The unified deployment exposed public SMTP (`25`/`587`) from the same container that runs the HTTP API and forced `SMTP_ENABLED=true`, which co-locates unauthenticated SMTP processing with the API and creates a network-accessible resource-exhaustion/DoS risk. 
- Production inbound mail is intended to be Cloudflare Email Routing → Worker → `POST /email/inbound`, so the default sample config should not enable on-box SMTP that can impact API availability.

### Description
- Set `SMTP_ENABLED=false` in `.env.example` and added guidance that self-hosted SMTP should run in a dedicated mail worker/container. 
- Updated `Dockerfile` docs and removed public SMTP port exposure so the image documents/`EXPOSE`s only `8080` (the API), leaving the API entrypoint unchanged. 
- Updated `docker-compose.yml` to remove `ports` mappings for `25:25` and `587:587`, set `SMTP_ENABLED=false` in the `api` service environment, and removed the on-container SMTP cert mount / direct `rspamd` dependency for the API service. 
- Retained the SMTP implementation gated by `SMTP_ENABLED` in code so operators can opt into a separate mail worker, but the sample API container no longer enables or exposes SMTP by default.

### Testing
- Ran `git diff --check` which completed without whitespace errors. 
- Ran pattern searches (`rg`) to verify that `SMTP_ENABLED=true` and public SMTP port mappings are no longer present in `.env.example`, `Dockerfile`, and `docker-compose.yml`, which succeeded. 
- Attempted `docker compose config` to validate the compose file, but Docker is not available in this environment so compose validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c3009c4c88323a78e1b507bfba6b8)