### PR TITLE
fix(core): require validated sessions for Socket.IO auth

### DIFF
--- a/packages/core/src/__tests__/authSocket.test.ts
+++ b/packages/core/src/__tests__/authSocket.test.ts
@@ -1,0 +1,96 @@
+import { OxyServices } from '../OxyServices';
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function createJwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown): string => Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode(payload)}.forged-signature`;
+}
+
+async function runAuthSocket(oxy: OxyServices, token: string) {
+  const socket: {
+    handshake: { auth: { token: string } };
+    data?: Record<string, unknown>;
+    user?: { id: string; userId: string; sessionId?: string | null };
+  } = { handshake: { auth: { token } } };
+  let nextError: Error | undefined;
+
+  await oxy.authSocket()(socket, (err?: Error) => {
+    nextError = err;
+  });
+
+  return { socket, nextError };
+}
+
+describe('authSocket', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('rejects decoded JWT payloads that do not include a server-validated session', async () => {
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    const fetchMock = jest.fn();
+    globalThis.fetch = fetchMock;
+
+    const { socket, nextError } = await runAuthSocket(oxy, createJwt({
+      userId: 'victimUserId',
+      exp: 4102444800,
+    }));
+
+    expect(nextError?.message).toBe('Session required');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(socket.data?.userId).toBeUndefined();
+    expect(socket.user).toBeUndefined();
+  });
+
+  it('rejects tokens whose decoded user does not match the validated session user', async () => {
+    globalThis.fetch = async () =>
+      jsonResponse({
+        valid: true,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        lastActivity: '2026-06-24T00:00:00.000Z',
+        user: { id: 'realUserId', username: 'real', publicKey: 'pub_1' },
+      });
+
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    const { socket, nextError } = await runAuthSocket(oxy, createJwt({
+      userId: 'victimUserId',
+      sessionId: 'session_1',
+      exp: 4102444800,
+    }));
+
+    expect(nextError?.message).toBe('Session user mismatch');
+    expect(socket.data?.userId).toBeUndefined();
+    expect(socket.user).toBeUndefined();
+  });
+
+  it('attaches the validated session user when the decoded user matches', async () => {
+    globalThis.fetch = async () =>
+      jsonResponse({
+        valid: true,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        lastActivity: '2026-06-24T00:00:00.000Z',
+        user: { id: 'user_1', username: 'nate', publicKey: 'pub_1' },
+      });
+
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    const { socket, nextError } = await runAuthSocket(oxy, createJwt({
+      userId: 'user_1',
+      sessionId: 'session_1',
+      exp: 4102444800,
+    }));
+
+    expect(nextError).toBeUndefined();
+    expect(socket.data?.userId).toBe('user_1');
+    expect(socket.data?.sessionId).toBe('session_1');
+    expect(socket.user).toEqual({ id: 'user_1', userId: 'user_1', sessionId: 'session_1' });
+  });
+});

--- a/packages/core/src/mixins/OxyServices.utility.ts
+++ b/packages/core/src/mixins/OxyServices.utility.ts
@@ -856,8 +856,8 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
             return next(new Error('Invalid token'));
           }
 
-          const userId = decoded.userId || decoded.id;
-          if (!userId) {
+          const claimedUserId = decoded.userId || decoded.id;
+          if (!claimedUserId) {
             return next(new Error('Invalid token payload'));
           }
 
@@ -866,24 +866,33 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
             return next(new Error('Token expired'));
           }
 
-          // Validate session if available
-          if (decoded.sessionId) {
-            try {
-              const result = await oxyInstance.validateSession(decoded.sessionId, {
-                useHeaderValidation: true,
-              });
-              if (!result || !result.valid) {
-                return next(new Error('Session invalid'));
-              }
-            } catch (validateErr) {
-              if (debug) {
-                logger.debug('[oxy.authSocket] Session validation failed', {
-                  component: 'auth',
-                  method: 'authSocket',
-                }, validateErr);
-              }
-              return next(new Error('Session validation failed'));
+          if (!decoded.sessionId) {
+            return next(new Error('Session required'));
+          }
+
+          let userId = claimedUserId;
+          try {
+            const result = await oxyInstance.validateSession(decoded.sessionId, {
+              useHeaderValidation: true,
+            });
+            if (!result || !result.valid || !result.user) {
+              return next(new Error('Session invalid'));
             }
+
+            const validatedUserId = getUserIdentityId(result.user);
+            if (!validatedUserId || validatedUserId !== claimedUserId) {
+              return next(new Error('Session user mismatch'));
+            }
+
+            userId = validatedUserId;
+          } catch (validateErr) {
+            if (debug) {
+              logger.debug('[oxy.authSocket] Session validation failed', {
+                component: 'auth',
+                method: 'authSocket',
+              }, validateErr);
+            }
+            return next(new Error('Session validation failed'));
           }
 
           // Attach user data to socket. We expose BOTH `socket.data.userId`
@@ -1051,6 +1060,12 @@ async function verifyServiceTokenSignature(token: string, secret: string): Promi
  * access token signed by the same shared secret could be replayed as a
  * service token because no claim binding existed.
  */
+
+function getUserIdentityId(user: User): string | null {
+  const candidate = (user as User & { _id?: unknown }).id ?? (user as User & { _id?: unknown })._id;
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
+}
+
 function verifyServiceTokenClaims(
   decoded: JwtPayload,
   expected: { audience: string; issuer: string },


### PR DESCRIPTION
### Motivation
- Close a critical authentication bypass in the Socket.IO middleware that trusted decoded JWT claims without cryptographic or server-side verification, which allowed attacker-supplied tokens to impersonate arbitrary users.

### Description
- Hardened `authSocket()` in `packages/core/src/mixins/OxyServices.utility.ts` to require `sessionId` in the token payload and to call `validateSession()` before authenticating the socket.  
- Compare the server-validated session user to the claimed `userId` from the decoded token and reject the connection on mismatch.  
- Added a helper `getUserIdentityId` to safely extract normalized `id`/`_id` from the session `user` object.  
- Added regression tests at `packages/core/src/__tests__/authSocket.test.ts` covering: missing `sessionId`, decoded-vs-validated user mismatch, and the valid matched-session path.

### Testing
- Added unit tests for `authSocket()` (new test file `packages/core/src/__tests__/authSocket.test.ts`), but executing them in this environment was blocked because dependency resolution failed.  
- Attempted `bun install` (dependency fetch failed with HTTP 403 in this environment) and `bun run test` / typecheck runs therefore did not complete.  
- Ran local static checks (`git diff --check`) and validated the code diff and new test file were created as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c2ddabd888323ade34c26cd0dda4f)