### PR TITLE
fix: restrict Cloudflare deploys to main ref

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -37,7 +37,7 @@ jobs:
 
   deploy-auth:
     needs: detect-changes
-    if: needs.detect-changes.outputs.auth == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.auth == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +92,7 @@ jobs:
 
   deploy-accounts:
     needs: detect-changes
-    if: needs.detect-changes.outputs.accounts == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.accounts == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
 
   deploy-inbox:
     needs: detect-changes
-    if: needs.detect-changes.outputs.inbox == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.inbox == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -132,7 +132,7 @@ jobs:
 
   deploy-console:
     needs: detect-changes
-    if: needs.detect-changes.outputs.console == 'true' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (needs.detect-changes.outputs.console == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- Prevent manual `workflow_dispatch` runs from building and deploying production frontend artifacts from arbitrary refs using production Cloudflare credentials, restoring the expected protection for main-branch deployments.

### Description
- Add `github.ref == 'refs/heads/main'` to the `if:` condition of each Cloudflare Pages deploy job (`deploy-auth`, `deploy-accounts`, `deploy-inbox`, `deploy-console`) so deploys only proceed for push-to-main or manual runs that are explicitly targeting `main`, while leaving the Cloudflare `pages deploy` commands and project targets unchanged.

### Testing
- Ran an automated validation script that checks each deploy job includes the `github.ref == 'refs/heads/main'` guard and ran `git diff --check` to verify no whitespace or YAML errors; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c065d97788323951c28531c56f735)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->