### PR TITLE
fix: keep Alia chat behind Oxy API proxy

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -492,6 +492,10 @@ app.use('/email/proxy', emailProxyRoutes); // public, no auth — must be before
 app.use('/email/inbound', emailInboundRoutes); // Cloudflare Email Routing webhook — must be before /email
 app.use('/email', userRateLimiter, csrfProtection, emailRoutes);
 app.use('/alia', userRateLimiter, aliaRoutes);
+// Compatibility route for Alia SDK clients that append /v1/chat/completions
+// to their configured API origin. Keep authenticated browser traffic on the
+// Oxy-owned API; aliaRoutes forwards server-side with ALIA_API_KEY.
+app.use('/v1', userRateLimiter, aliaRoutes);
 app.use('/credits', userRateLimiter, csrfProtection, creditsRoutes);
 app.use('/billing', billingRoutes);
 app.use('/models', modelsStatsRoutes);

--- a/packages/inbox/components/InboxList.tsx
+++ b/packages/inbox/components/InboxList.tsx
@@ -92,6 +92,7 @@ interface DrawerNavigation {
  *   Compose bottom = insets.bottom + 16, Compose height ≈ 52, plus 24 gap.
  */
 const ALIA_FAB_BOTTOM_OFFSET = 16 + 52 + 24;
+const ALIA_PROXY_API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://api.oxy.so';
 
 export function InboxList({ replaceNavigation }: InboxListProps) {
   const router = useRouter();
@@ -705,7 +706,7 @@ export function InboxList({ replaceNavigation }: InboxListProps) {
           </View>
           <AliaChatSheet
             ref={aliaChatRef}
-            apiUrl="https://api.alia.onl"
+            apiUrl={ALIA_PROXY_API_URL}
             clientContext="User is in the Inbox app viewing their email. Use oxy_inbox tools to access their emails."
             suggestions={[
               { label: 'Unread emails', icon: 'mail', prompt: 'What emails need my attention?' },


### PR DESCRIPTION
### Motivation
- Prevent client-side leakage of authenticated Oxy bearer tokens and private inbox context to the external Alia origin by restoring the in-app Alia SDK to call the Oxy-owned proxy endpoint. 
- Preserve the intended server-side design where the Oxy backend forwards requests to `api.alia.onl` using a server-side `ALIA_API_KEY` instead of letting the client contact the third-party origin directly.

### Description
- Updated the Inbox Alia chat sheet to use the Oxy API origin from `EXPO_PUBLIC_API_URL` (fallback `https://api.oxy.so`) instead of the hardcoded `https://api.alia.onl` by changing `packages/inbox/components/InboxList.tsx` to pass `apiUrl={ALIA_PROXY_API_URL}`. 
- Added a compatibility mount so SDK clients that append `/v1/chat/completions` remain on the Oxy-owned API by mounting the existing `aliaRoutes` at `/v1` in `packages/api/src/server.ts`, which keeps authenticated browser traffic on the backend proxy that forwards with `ALIA_API_KEY`.

### Testing
- Verified the code edits with targeted searches using `rg` for the old `apiUrl="https://api.alia.onl"` and the new `app.use('/v1', ...)` patterns and confirmed matches in the modified files. (success)
- Ran `git diff --check` to ensure no whitespace/patch issues were introduced. (success)
- Attempted `bun run api:build` in the current environment and observed the build is blocked by unrelated TypeScript/`packages/contracts/tsconfig.cjs.json` issues (`moduleResolution=node10` deprecation and `rootDir`), so a full build could not be completed here. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0cbfbb0083238e31072994fcffbe)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->