### PR TITLE
fix(api): validate octet-stream email proxy fonts

### DIFF
--- a/packages/api/src/controllers/__tests__/emailProxy.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/emailProxy.controller.test.ts
@@ -1,0 +1,61 @@
+import { proxyResource } from '../emailProxy.controller';
+import { BadRequestError } from '../../utils/error';
+
+jest.mock('../../utils/logger', () => ({
+  logger: { debug: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+function createMockResponse() {
+  const res: any = {};
+  res.setHeader = jest.fn();
+  res.send = jest.fn();
+  return res;
+}
+
+function createRequest(url: string) {
+  return {
+    query: {
+      url: encodeURIComponent(url),
+    },
+  } as any;
+}
+
+describe('email proxy controller', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('rejects application/octet-stream font-extension responses without font bytes', async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(Buffer.from('internal service secret'.repeat(10)), {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+    ) as any;
+
+    await expect(proxyResource(createRequest('https://example.com/benign.woff'), createMockResponse()))
+      .rejects
+      .toThrow(BadRequestError);
+  });
+
+  it('still accepts application/octet-stream font-extension responses with a valid font signature', async () => {
+    const font = Buffer.alloc(128);
+    font.write('wOFF', 0, 'ascii');
+
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(font, {
+        status: 200,
+        headers: { 'content-type': 'application/octet-stream' },
+      })
+    ) as any;
+
+    const res = createMockResponse();
+    await proxyResource(createRequest('https://example.com/font.woff'), res);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'font/woff');
+    expect(res.send).toHaveBeenCalledWith(font);
+  });
+});

--- a/packages/api/src/controllers/emailProxy.controller.ts
+++ b/packages/api/src/controllers/emailProxy.controller.ts
@@ -24,6 +24,34 @@ const FONT_MIME: Record<string, string> = {
   '.eot': 'application/vnd.ms-fontobject',
 };
 
+function getFontExtension(pathname: string): string | undefined {
+  return pathname.match(/\.\w+$/)?.[0]?.toLowerCase();
+}
+
+function isFontBuffer(buffer: Buffer, ext: string): boolean {
+  switch (ext) {
+    case '.woff':
+      return buffer.subarray(0, 4).toString('ascii') === 'wOFF';
+    case '.woff2':
+      return buffer.subarray(0, 4).toString('ascii') === 'wOF2';
+    case '.otf':
+      return buffer.subarray(0, 4).toString('ascii') === 'OTTO';
+    case '.ttf': {
+      const signature = buffer.subarray(0, 4);
+      return (
+        signature.equals(Buffer.from([0x00, 0x01, 0x00, 0x00])) ||
+        signature.toString('ascii') === 'true' ||
+        signature.toString('ascii') === 'typ1'
+      );
+    }
+    case '.eot':
+      // Embedded OpenType files contain the ASCII "LP" magic at bytes 34-35.
+      return buffer.length >= 36 && buffer.subarray(34, 36).toString('ascii') === 'LP';
+    default:
+      return false;
+  }
+}
+
 // Transparent 1x1 GIF for blocked tracking pixels
 const TRANSPARENT_GIF = Buffer.from(
   'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
@@ -220,11 +248,14 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
     }
 
     const contentType = response.headers.get('content-type') || 'application/octet-stream';
+    const normalizedContentType = contentType.split(';', 1)[0]?.trim().toLowerCase() || 'application/octet-stream';
+    const fontExtension = getFontExtension(url.pathname);
 
     // Validate content type — allow octet-stream for font files (many servers
-    // serve .ttf/.woff as application/octet-stream instead of font/*)
+    // serve .ttf/.woff as application/octet-stream instead of font/*), but
+    // only after verifying the body has a real font signature.
     const isAllowedType = /^(image\/|font\/|application\/(font|x-font))/i.test(contentType);
-    const isFontByExtension = contentType === 'application/octet-stream' && FONT_EXTENSIONS.test(url.pathname);
+    const isFontByExtension = normalizedContentType === 'application/octet-stream' && FONT_EXTENSIONS.test(url.pathname);
     if (!isAllowedType && !isFontByExtension) {
       clearTimeout(timeoutId);
       throw new BadRequestError('Only images and fonts allowed');
@@ -238,6 +269,10 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
       throw new BadRequestError('Resource too large');
     }
 
+    if (isFontByExtension && (!fontExtension || !isFontBuffer(buffer, fontExtension))) {
+      throw new BadRequestError('Invalid font resource');
+    }
+
     // Block tracking pixels (very small images)
     if (buffer.length < TRACKING_PIXEL_THRESHOLD) {
       logger.debug('Blocked tracking pixel', { url: decodedUrl, size: buffer.length });
@@ -247,8 +282,7 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
     // Use correct MIME when upstream sends generic octet-stream for fonts
     let resolvedType = contentType;
     if (isFontByExtension) {
-      const ext = url.pathname.match(/\.\w+/)?.[0]?.toLowerCase();
-      if (ext && FONT_MIME[ext]) resolvedType = FONT_MIME[ext];
+      if (fontExtension && FONT_MIME[fontExtension]) resolvedType = FONT_MIME[fontExtension];
     }
 
     addToCache(cacheKey, buffer, resolvedType);


### PR DESCRIPTION
### Motivation
- Close an SSRF/exfiltration vector where the public email proxy allowed `application/octet-stream` responses based only on the original URL path looking like a font, enabling attackers to fetch arbitrary internal octet-stream bytes.
- Ensure the email proxy still supports legitimate fonts served with a generic `application/octet-stream` MIME by verifying actual font bytes before retyping and caching.

### Description
- Added `getFontExtension()` and `isFontBuffer()` helpers to detect font file extensions and validate font magic bytes for `.woff`, `.woff2`, `.otf`, `.ttf`, and `.eot` files.
- Normalize `Content-Type` header and require that `application/octet-stream` responses with a font-like pathname also pass `isFontBuffer()` before being accepted as fonts; otherwise reject with `BadRequestError`.
- Keep the existing behavior of remapping validated font responses to a specific `FONT_MIME` and caching/sending them via the same `addToCache()` / `sendProxiedResponse()` path.
- Added targeted unit tests in `packages/api/src/controllers/__tests__/emailProxy.controller.test.ts` to cover rejecting non-font octet-stream bodies and accepting valid WOFF bytes.

### Testing
- Added unit tests for `proxyResource` covering the octet-stream font-extension path; tests were committed to `packages/api/src/controllers/__tests__/emailProxy.controller.test.ts` and are intended to run under the package Jest runner.
- Attempted `bun run test --runInBand src/controllers/__tests__/emailProxy.controller.test.ts`, but test execution was blocked because `jest` is unavailable in this environment (dependencies not installed).
- Attempted `bun install` and `tsc -p packages/api/tsconfig.json --noEmit`; `bun install` failed resolving registry packages (403), and `tsc` failed due to a deprecated `baseUrl` setting under the available TypeScript, so type-check/run verification could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0fa344188323830c9d776eda662c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->