### PR TITLE
fix(api): harden public email proxy redirects

### DIFF
--- a/packages/api/src/controllers/__tests__/emailProxy.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/emailProxy.controller.test.ts
@@ -1,0 +1,125 @@
+import { lookup } from 'dns/promises';
+import { proxyResource } from '../emailProxy.controller';
+
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn(),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+type MockResponse = {
+  setHeader: jest.Mock;
+  send: jest.Mock;
+};
+
+const mockLookup = lookup as jest.MockedFunction<typeof lookup>;
+const originalFetch = global.fetch;
+
+function makeReq(url: string) {
+  return { query: { url } } as any;
+}
+
+function makeRes(): MockResponse {
+  return {
+    setHeader: jest.fn(),
+    send: jest.fn(),
+  };
+}
+
+function imageResponse(body = 'x'.repeat(128), init: ResponseInit = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'image/png' },
+    ...init,
+  });
+}
+
+describe('email proxy SSRF protections', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('rejects direct private network URLs before fetching', async () => {
+    const res = makeRes();
+
+    await expect(proxyResource(makeReq('http://127.0.0.1/internal.png'), res as any)).rejects.toThrow(
+      'Private network URLs are not allowed'
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects hostnames that resolve to private network addresses before fetching', async () => {
+    mockLookup.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
+    const res = makeRes();
+
+    await expect(proxyResource(makeReq('http://metadata.example/internal.png'), res as any)).rejects.toThrow(
+      'Private network URLs are not allowed'
+    );
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not follow redirects to private network URLs', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock.mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://127.0.0.1/internal.png' },
+      })
+    );
+    const res = makeRes();
+
+    await expect(proxyResource(makeReq('http://public.example/redirect'), res as any)).rejects.toThrow(
+      'Private network URLs are not allowed'
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://public.example/redirect',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
+
+  it('revalidates safe redirect targets and proxies allowed images', async () => {
+    const fetchMock = global.fetch as jest.Mock;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://cdn.example/image.png' },
+        })
+      )
+      .mockResolvedValueOnce(imageResponse());
+    const res = makeRes();
+
+    await proxyResource(makeReq('https://public.example/redirect'), res as any);
+
+    expect(mockLookup).toHaveBeenCalledWith('public.example', { all: true, verbatim: false });
+    expect(mockLookup).toHaveBeenCalledWith('cdn.example', { all: true, verbatim: false });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://public.example/redirect',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://cdn.example/image.png',
+      expect.objectContaining({ redirect: 'manual' })
+    );
+    expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
+    expect(res.send).toHaveBeenCalledWith(expect.any(Buffer));
+  });
+});

--- a/packages/api/src/controllers/emailProxy.controller.ts
+++ b/packages/api/src/controllers/emailProxy.controller.ts
@@ -5,7 +5,9 @@
  * and provide tracking protection for users.
  */
 
-import { Request, Response } from 'express';
+import { Request, Response as ExpressResponse } from 'express';
+import { lookup } from 'dns/promises';
+import net from 'net';
 import { BadRequestError } from '../utils/error';
 import { logger } from '../utils/logger';
 import crypto from 'crypto';
@@ -14,6 +16,7 @@ import crypto from 'crypto';
 
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
 const FETCH_TIMEOUT = 10000; // 10 seconds
+const MAX_REDIRECTS = 3;
 const TRACKING_PIXEL_THRESHOLD = 100; // bytes
 const FONT_EXTENSIONS = /\.(ttf|otf|woff2?|eot)(\?|$)/i;
 const FONT_MIME: Record<string, string> = {
@@ -32,20 +35,39 @@ const TRANSPARENT_GIF = Buffer.from(
 
 // ─── SSRF Protection ──────────────────────────────────────────────
 
-const PRIVATE_IP_PATTERNS = [
-  /^127\./,                          // Loopback
-  /^0\./,                            // Current network
-  /^10\./,                           // Private Class A
-  /^172\.(1[6-9]|2[0-9]|3[01])\./,   // Private Class B
-  /^192\.168\./,                     // Private Class C
-  /^169\.254\./,                     // Link-local
-  /^fc00:/i,                         // IPv6 private
-  /^fe80:/i,                         // IPv6 link-local
-  /^::1$/,                           // IPv6 loopback
-  /^localhost$/i,
-];
+function isPrivateIpAddress(address: string): boolean {
+  const ipVersion = net.isIP(address);
 
-function validateProxyUrl(urlString: string): URL {
+  if (ipVersion === 4) {
+    const [a, b] = address.split('.').map(Number);
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      a >= 224
+    );
+  }
+
+  if (ipVersion === 6) {
+    const normalized = address.toLowerCase();
+    return (
+      normalized === '::1' ||
+      normalized === '::' ||
+      normalized.startsWith('fc') ||
+      normalized.startsWith('fd') ||
+      normalized.startsWith('fe80:')
+    );
+  }
+
+  return false;
+}
+
+async function validateProxyUrl(urlString: string): Promise<URL> {
   let url: URL;
   try {
     url = new URL(urlString);
@@ -57,7 +79,24 @@ function validateProxyUrl(urlString: string): URL {
     throw new BadRequestError('Only HTTP(S) URLs are allowed');
   }
 
-  if (PRIVATE_IP_PATTERNS.some((p) => p.test(url.hostname))) {
+  const hostname = url.hostname.toLowerCase();
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    isPrivateIpAddress(hostname)
+  ) {
+    throw new BadRequestError('Private network URLs are not allowed');
+  }
+
+  let addresses: Array<{ address: string }>;
+  try {
+    addresses = await lookup(hostname, { all: true, verbatim: false });
+  } catch {
+    throw new BadRequestError('Unable to resolve URL host');
+  }
+
+  if (addresses.length === 0 || addresses.some(({ address }) => isPrivateIpAddress(address))) {
     throw new BadRequestError('Private network URLs are not allowed');
   }
 
@@ -146,7 +185,7 @@ setInterval(() => {
 
 // ─── Response Helpers ─────────────────────────────────────────────
 
-function sendTransparentGif(res: Response, cacheTime = 86400): void {
+function sendTransparentGif(res: ExpressResponse, cacheTime = 86400): void {
   res.setHeader('Content-Type', 'image/gif');
   res.setHeader('Cache-Control', `public, max-age=${cacheTime}`);
   res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
@@ -154,7 +193,7 @@ function sendTransparentGif(res: Response, cacheTime = 86400): void {
 }
 
 function sendProxiedResponse(
-  res: Response,
+  res: ExpressResponse,
   buffer: Buffer,
   contentType: string,
   cacheHit: boolean
@@ -169,7 +208,7 @@ function sendProxiedResponse(
 
 // ─── Controller ───────────────────────────────────────────────────
 
-export async function proxyResource(req: Request, res: Response): Promise<void> {
+export async function proxyResource(req: Request, res: ExpressResponse): Promise<void> {
   const { url: encodedUrl } = req.query;
 
   if (!encodedUrl || typeof encodedUrl !== 'string') {
@@ -185,7 +224,7 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
     decodedUrl = decodeURIComponent(encodedUrl);
   }
 
-  const url = validateProxyUrl(decodedUrl);
+  const url = await validateProxyUrl(decodedUrl);
 
   // Block tracking URLs
   if (isTrackingUrl(url)) {
@@ -205,16 +244,37 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
 
   try {
-    const response = await fetch(url.href, {
-      signal: controller.signal,
-      headers: {
-        'User-Agent': 'OxyMail/1.0 (Image Proxy)',
-        Accept: 'image/*,font/*,*/*',
-      },
-      redirect: 'follow',
-    });
+    let currentUrl = url;
+    let response: globalThis.Response | undefined;
 
-    if (!response.ok) {
+    for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects += 1) {
+      response = await fetch(currentUrl.href, {
+        signal: controller.signal,
+        headers: {
+          'User-Agent': 'OxyMail/1.0 (Image Proxy)',
+          Accept: 'image/*,font/*,*/*',
+        },
+        redirect: 'manual',
+      });
+
+      if (![301, 302, 303, 307, 308].includes(response.status)) {
+        break;
+      }
+
+      const location = response.headers.get('location');
+      if (!location) {
+        break;
+      }
+
+      if (redirects === MAX_REDIRECTS) {
+        clearTimeout(timeoutId);
+        return sendTransparentGif(res, 3600);
+      }
+
+      currentUrl = await validateProxyUrl(new URL(location, currentUrl).href);
+    }
+
+    if (!response || !response.ok) {
       clearTimeout(timeoutId);
       return sendTransparentGif(res, 3600);
     }
@@ -224,7 +284,7 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
     // Validate content type — allow octet-stream for font files (many servers
     // serve .ttf/.woff as application/octet-stream instead of font/*)
     const isAllowedType = /^(image\/|font\/|application\/(font|x-font))/i.test(contentType);
-    const isFontByExtension = contentType === 'application/octet-stream' && FONT_EXTENSIONS.test(url.pathname);
+    const isFontByExtension = contentType === 'application/octet-stream' && FONT_EXTENSIONS.test(currentUrl.pathname);
     if (!isAllowedType && !isFontByExtension) {
       clearTimeout(timeoutId);
       throw new BadRequestError('Only images and fonts allowed');
@@ -247,7 +307,7 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
     // Use correct MIME when upstream sends generic octet-stream for fonts
     let resolvedType = contentType;
     if (isFontByExtension) {
-      const ext = url.pathname.match(/\.\w+/)?.[0]?.toLowerCase();
+      const ext = currentUrl.pathname.match(/\.\w+/)?.[0]?.toLowerCase();
       if (ext && FONT_MIME[ext]) resolvedType = FONT_MIME[ext];
     }
 


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated SSRF via the public `/email/proxy` endpoint by strengthening URL validation and preventing attacker-controlled redirects from reaching internal/private hosts.
- The previous implementation only validated the original hostname with regexes and used `redirect: 'follow'`, allowing a malicious initial URL to redirect the server to localhost/RFC1918/metadata endpoints.

### Description
- Replaced the regex-only validation with `validateProxyUrl` that performs DNS `lookup` and rejects hosts or resolved addresses that map to loopback, link-local, multicast, or private ranges, and disallows `localhost`/`.local` names; this function is now async and uses `net.isIP` for address checks. (`packages/api/src/controllers/emailProxy.controller.ts`)
- Switched fetch behavior from automatic redirect following to manual redirect handling with a `MAX_REDIRECTS` cap and revalidation of each redirect target via `validateProxyUrl` before proceeding to the next hop. (`packages/api/src/controllers/emailProxy.controller.ts`)
- Preserved existing safeguards including content-type checks, font-extension fallback, size limits, tracking-pixel blocking, caching, and response headers, while adapting logic to reference the final validated `currentUrl` after redirects. (`packages/api/src/controllers/emailProxy.controller.ts`)
- Added regression tests that exercise direct private URLs, hostnames resolving to private addresses, blocked private redirects, and safe redirects that are revalidated then proxied. (`packages/api/src/controllers/__tests__/emailProxy.controller.test.ts`)

### Testing
- `git diff --check` and local repository sanity checks were run and passed for the applied changes. (succeeded)
- Added unit tests for `proxyResource` covering private-host rejection and redirect revalidation, but running the test suite was blocked because `bun install` failed due to npm registry access returning HTTP 403 in this environment, so `jest` could not be executed. (blocked)
- `bun install` was attempted to prepare test dependencies but failed due to registry access errors, preventing automated test execution in this environment. (blocked)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0d0074a0832398d7c53a73c35545)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->