### PR TITLE
fix(api): prevent sender avatar favicon SSRF

### DIFF
--- a/packages/api/src/services/__tests__/senderAvatar.service.test.ts
+++ b/packages/api/src/services/__tests__/senderAvatar.service.test.ts
@@ -1,0 +1,50 @@
+jest.mock('../../models/SenderAvatar', () => ({
+  SenderAvatar: {
+    findOne: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(null) })),
+    find: jest.fn(() => ({ lean: jest.fn().mockResolvedValue([]) })),
+    updateOne: jest.fn().mockResolvedValue({}),
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    findOne: jest.fn(() => ({ select: jest.fn(() => ({ lean: jest.fn().mockResolvedValue(null) })) })),
+  },
+}));
+
+jest.mock('dns/promises', () => ({
+  resolveTxt: jest.fn().mockRejectedValue(new Error('no bimi')),
+}));
+
+import { getAvatarPath } from '../senderAvatar.service';
+
+describe('senderAvatar.service', () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockResolvedValue({ ok: false, headers: { get: jest.fn() } });
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not fetch sender-controlled favicon hosts from the API server', async () => {
+    const avatarPath = await getAvatarPath('sender@example.com');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain('https://www.gravatar.com/avatar/');
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('example.com/favicon.ico'))).toBe(false);
+    expect(avatarPath).toBe(`/email/proxy?url=${Buffer.from('https://example.com/favicon.ico').toString('base64')}`);
+  });
+
+  it('rejects localhost and private IP domains for favicon fallback', async () => {
+    await expect(getAvatarPath('attacker@localhost')).resolves.toBeNull();
+    await expect(getAvatarPath('attacker@127.0.0.1')).resolves.toBeNull();
+    await expect(getAvatarPath('attacker@10.0.0.5')).resolves.toBeNull();
+
+    expect(fetchMock.mock.calls.every(([url]) => String(url).includes('www.gravatar.com'))).toBe(true);
+  });
+});

--- a/packages/api/src/services/senderAvatar.service.ts
+++ b/packages/api/src/services/senderAvatar.service.ts
@@ -1,15 +1,71 @@
 import crypto from 'crypto';
 import dns from 'dns/promises';
+import net from 'net';
 import { SenderAvatar } from '../models/SenderAvatar';
 import User from '../models/User';
 import { extractUsername } from '../config/email.config';
 
 const CACHE_TTL_DAYS = 7;
 
+const BLOCKED_HOSTNAMES = new Set(['localhost', 'localhost.localdomain']);
+const PRIVATE_IPV4_RANGES: Array<[number, number]> = [
+  [0x00000000, 0xff000000], // 0.0.0.0/8
+  [0x0a000000, 0xff000000], // 10.0.0.0/8
+  [0x7f000000, 0xff000000], // 127.0.0.0/8
+  [0xa9fe0000, 0xffff0000], // 169.254.0.0/16
+  [0xac100000, 0xfff00000], // 172.16.0.0/12
+  [0xc0000000, 0xffffff00], // 192.0.0.0/24
+  [0xc0000200, 0xffffff00], // 192.0.2.0/24
+  [0xc0a80000, 0xffff0000], // 192.168.0.0/16
+  [0xc6336400, 0xffffff00], // 198.51.100.0/24
+  [0xcb007100, 0xffffff00], // 203.0.113.0/24
+  [0xe0000000, 0xf0000000], // 224.0.0.0/4
+  [0xf0000000, 0xf0000000], // 240.0.0.0/4
+];
+
 /** Build a base64-encoded proxy path for an external URL. */
 function proxyPath(url: string): string {
   const encoded = Buffer.from(url, 'utf-8').toString('base64');
   return `/email/proxy?url=${encoded}`;
+}
+
+function ipv4ToInt(ip: string): number {
+  return ip.split('.').reduce((acc, part) => (acc << 8) + Number(part), 0) >>> 0;
+}
+
+function isPrivateOrReservedIp(host: string): boolean {
+  if (net.isIPv4(host)) {
+    const value = ipv4ToInt(host);
+    return PRIVATE_IPV4_RANGES.some(([range, mask]) => (value & mask) === range);
+  }
+
+  if (!net.isIPv6(host)) return false;
+
+  const normalized = host.toLowerCase();
+  return (
+    normalized === '::' ||
+    normalized === '::1' ||
+    normalized.startsWith('fc') ||
+    normalized.startsWith('fd') ||
+    normalized.startsWith('fe80:') ||
+    normalized.startsWith('::ffff:127.') ||
+    normalized.startsWith('::ffff:10.') ||
+    normalized.startsWith('::ffff:192.168.') ||
+    /^::ffff:172\.(1[6-9]|2[0-9]|3[01])\./.test(normalized)
+  );
+}
+
+function isSafePublicHostname(hostname: string): boolean {
+  const host = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, '$1')
+    .replace(/\.$/, '');
+  if (!host || BLOCKED_HOSTNAMES.has(host) || isPrivateOrReservedIp(host)) return false;
+  if (host.includes(':')) return false;
+  return /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/.test(
+    host,
+  );
 }
 
 /**
@@ -20,6 +76,8 @@ function proxyPath(url: string): string {
  * Published at: default._bimi.<domain>
  */
 async function lookupBimi(domain: string): Promise<string | null> {
+  if (!isSafePublicHostname(domain)) return null;
+
   try {
     const records = await dns.resolveTxt(`default._bimi.${domain}`);
     for (const parts of records) {
@@ -66,11 +124,15 @@ async function resolveAvatar(email: string): Promise<{ avatarPath: string | null
     }
   }
 
-  // 3. Gravatar — HEAD check
+  // 3. Gravatar — HEAD check against the fixed Gravatar host only
   const md5Hash = crypto.createHash('md5').update(normalized).digest('hex');
   const gravatarUrl = `https://www.gravatar.com/avatar/${md5Hash}?d=404&s=80`;
   try {
-    const res = await fetch(gravatarUrl, { method: 'HEAD', signal: AbortSignal.timeout(5000) });
+    const res = await fetch(gravatarUrl, {
+      method: 'HEAD',
+      signal: AbortSignal.timeout(5000),
+      redirect: 'error',
+    });
     if (res.ok) {
       return { avatarPath: proxyPath(gravatarUrl), source: 'gravatar' };
     }
@@ -78,24 +140,11 @@ async function resolveAvatar(email: string): Promise<{ avatarPath: string | null
     // Gravatar check failed — continue
   }
 
-  // 4. Domain favicon — HEAD check
-  if (domain) {
+  // 4. Domain favicon — do not probe sender-controlled hosts from the API.
+  // The email proxy validates and fetches the URL only when the client requests it.
+  if (domain && isSafePublicHostname(domain)) {
     const faviconUrl = `https://${domain}/favicon.ico`;
-    try {
-      const res = await fetch(faviconUrl, {
-        method: 'HEAD',
-        signal: AbortSignal.timeout(5000),
-        redirect: 'follow',
-      });
-      if (res.ok) {
-        const ct = res.headers.get('content-type') || '';
-        if (ct.startsWith('image/') || ct.includes('icon')) {
-          return { avatarPath: proxyPath(faviconUrl), source: 'favicon' };
-        }
-      }
-    } catch {
-      // Favicon check failed
-    }
+    return { avatarPath: proxyPath(faviconUrl), source: 'favicon' };
   }
 
   return { avatarPath: null, source: 'none' };


### PR DESCRIPTION
### Motivation

- Prevent a blind SSRF introduced by server-side favicon HEAD probes derived from untrusted sender email domains. 
- Ensure avatar enrichment does not allow attacker-controlled sender domains to cause the API server to fetch localhost/private IPs or follow redirects into internal services.

### Description

- Add hostname/IP safety checks (`isSafePublicHostname`, private/IP ranges, blocked hostnames) and restrict BIMI TXT lookups to safe public hostnames only. 
- Stop issuing server-side `fetch()` probes to sender-controlled favicon URLs; the service now returns a `/email/proxy` path for syntactically safe public hostnames instead of probing them directly. 
- Constrain Gravatar probing to the fixed `gravatar.com` host and disable redirects (`redirect: 'error'`) to reduce SSRF/redirect risk. 
- Add a Jest regression test `packages/api/src/services/__tests__/senderAvatar.service.test.ts` that asserts the API does not fetch sender-controlled favicon hosts and rejects localhost/private IP favicon fallbacks.

### Testing

- Attempted unit test run: `bun run --cwd packages/api test -- senderAvatar.service.test.ts`, but the environment lacks `jest` so the test could not be executed (blocked). 
- Type-check: `tsc --noEmit -p packages/api/tsconfig.json` was attempted but blocked by an existing TypeScript deprecation error related to `baseUrl` (TypeScript/tsconfig configuration issue). 
- Dependency install: `bun install` was attempted but failed due to the npm registry returning 403 for package downloads, preventing running the test/build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c105f995c832389d1743cec3bf5cd)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->