### PR TITLE
fix(api): harden email proxy SSRF checks

### DIFF
--- a/packages/api/src/controllers/emailProxy.controller.ts
+++ b/packages/api/src/controllers/emailProxy.controller.ts
@@ -6,6 +6,10 @@
  */
 
 import { Request, Response } from 'express';
+import dns from 'dns';
+import http from 'http';
+import https from 'https';
+import net from 'net';
 import { BadRequestError } from '../utils/error';
 import { logger } from '../utils/logger';
 import crypto from 'crypto';
@@ -14,6 +18,7 @@ import crypto from 'crypto';
 
 const MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10 MB
 const FETCH_TIMEOUT = 10000; // 10 seconds
+const MAX_REDIRECTS = 5;
 const TRACKING_PIXEL_THRESHOLD = 100; // bytes
 const FONT_EXTENSIONS = /\.(ttf|otf|woff2?|eot)(\?|$)/i;
 const FONT_MIME: Record<string, string> = {
@@ -39,11 +44,59 @@ const PRIVATE_IP_PATTERNS = [
   /^172\.(1[6-9]|2[0-9]|3[01])\./,   // Private Class B
   /^192\.168\./,                     // Private Class C
   /^169\.254\./,                     // Link-local
+  /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./, // Carrier-grade NAT
+  /^192\.0\.0\./,                   // IETF protocol assignments
+  /^192\.0\.2\./,                   // TEST-NET-1
+  /^198\.(1[89])\./,                 // Benchmarking
+  /^198\.51\.100\./,                // TEST-NET-2
+  /^203\.0\.113\./,                 // TEST-NET-3
+  /^22[4-9]\./,                       // Multicast/reserved
+  /^23[0-9]\./,                       // Multicast/reserved
+  /^24[0-9]\./,                       // Multicast/reserved
+  /^25[0-5]\./,                       // Multicast/reserved
   /^fc00:/i,                         // IPv6 private
+  /^fd[0-9a-f]{2}:/i,                // IPv6 unique local
   /^fe80:/i,                         // IPv6 link-local
   /^::1$/,                           // IPv6 loopback
+  /^::$/,                            // IPv6 unspecified
   /^localhost$/i,
 ];
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[(.*)]$/, '$1').toLowerCase();
+}
+
+function isPrivateHost(hostname: string): boolean {
+  return PRIVATE_IP_PATTERNS.some((p) => p.test(normalizeHostname(hostname)));
+}
+
+function isPublicIp(address: string): boolean {
+  const normalized = normalizeHostname(address);
+  if (normalized.startsWith('::ffff:')) {
+    return isPublicIp(normalized.slice('::ffff:'.length));
+  }
+  if (net.isIP(normalized) === 0) return false;
+  return !isPrivateHost(normalized);
+}
+
+async function assertPublicDnsTarget(url: URL): Promise<void> {
+  const hostname = normalizeHostname(url.hostname);
+  if (net.isIP(hostname)) {
+    if (!isPublicIp(hostname)) throw new BadRequestError('Private network URLs are not allowed');
+    return;
+  }
+
+  let addresses: dns.LookupAddress[];
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true });
+  } catch {
+    throw new BadRequestError('Unable to resolve proxy URL hostname');
+  }
+
+  if (addresses.length === 0 || addresses.some(({ address }) => !isPublicIp(address))) {
+    throw new BadRequestError('Private network URLs are not allowed');
+  }
+}
 
 function validateProxyUrl(urlString: string): URL {
   let url: URL;
@@ -57,7 +110,7 @@ function validateProxyUrl(urlString: string): URL {
     throw new BadRequestError('Only HTTP(S) URLs are allowed');
   }
 
-  if (PRIVATE_IP_PATTERNS.some((p) => p.test(url.hostname))) {
+  if (isPrivateHost(url.hostname)) {
     throw new BadRequestError('Private network URLs are not allowed');
   }
 
@@ -167,6 +220,86 @@ function sendProxiedResponse(
   res.send(buffer);
 }
 
+interface ProxyFetchResponse {
+  ok: boolean;
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  buffer: Buffer;
+  finalUrl: URL;
+}
+
+async function fetchPublicResource(url: URL, signal: AbortSignal, redirectsRemaining = MAX_REDIRECTS): Promise<ProxyFetchResponse> {
+  await assertPublicDnsTarget(url);
+
+  const transport = url.protocol === 'https:' ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const req = transport.request(
+      url,
+      {
+        signal,
+        headers: {
+          'User-Agent': 'OxyMail/1.0 (Image Proxy)',
+          Accept: 'image/*,font/*,*/*',
+        },
+        lookup: (hostname, options, callback) => {
+          const lookupOptions = typeof options === 'number'
+            ? { family: options }
+            : { family: options.family, hints: options.hints };
+          dns.lookup(hostname, lookupOptions, (error, address, family) => {
+            if (error) return callback(error, address, family);
+            const addresses = Array.isArray(address) ? address.map((entry) => entry.address) : [address];
+            if (addresses.some((entry) => !isPublicIp(entry))) {
+              return callback(new Error('Private network URLs are not allowed'), address, family);
+            }
+            callback(null, address, family);
+          });
+        },
+      },
+      (response) => {
+        const statusCode = response.statusCode || 0;
+        const location = response.headers.location;
+
+        if (statusCode >= 300 && statusCode < 400 && location) {
+          response.resume();
+          if (redirectsRemaining <= 0) {
+            reject(new BadRequestError('Too many redirects'));
+            return;
+          }
+
+          const redirectUrl = validateProxyUrl(new URL(location, url).href);
+          fetchPublicResource(redirectUrl, signal, redirectsRemaining - 1).then(resolve, reject);
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        let totalLength = 0;
+
+        response.on('data', (chunk: Buffer) => {
+          totalLength += chunk.length;
+          if (totalLength > MAX_IMAGE_SIZE) {
+            req.destroy(new BadRequestError('Resource too large'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        response.on('end', () => {
+          resolve({
+            ok: statusCode >= 200 && statusCode < 300,
+            statusCode,
+            headers: response.headers,
+            buffer: Buffer.concat(chunks),
+            finalUrl: url,
+          });
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 // ─── Controller ───────────────────────────────────────────────────
 
 export async function proxyResource(req: Request, res: Response): Promise<void> {
@@ -205,38 +338,29 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
 
   try {
-    const response = await fetch(url.href, {
-      signal: controller.signal,
-      headers: {
-        'User-Agent': 'OxyMail/1.0 (Image Proxy)',
-        Accept: 'image/*,font/*,*/*',
-      },
-      redirect: 'follow',
-    });
+    const response = await fetchPublicResource(url, controller.signal);
 
     if (!response.ok) {
       clearTimeout(timeoutId);
       return sendTransparentGif(res, 3600);
     }
 
-    const contentType = response.headers.get('content-type') || 'application/octet-stream';
+    const contentTypeHeader = response.headers['content-type'];
+    const contentType = Array.isArray(contentTypeHeader)
+      ? contentTypeHeader[0]
+      : contentTypeHeader || 'application/octet-stream';
 
     // Validate content type — allow octet-stream for font files (many servers
     // serve .ttf/.woff as application/octet-stream instead of font/*)
     const isAllowedType = /^(image\/|font\/|application\/(font|x-font))/i.test(contentType);
-    const isFontByExtension = contentType === 'application/octet-stream' && FONT_EXTENSIONS.test(url.pathname);
+    const isFontByExtension = contentType === 'application/octet-stream' && FONT_EXTENSIONS.test(response.finalUrl.pathname);
     if (!isAllowedType && !isFontByExtension) {
       clearTimeout(timeoutId);
       throw new BadRequestError('Only images and fonts allowed');
     }
 
-    const arrayBuffer = await response.arrayBuffer();
     clearTimeout(timeoutId);
-    const buffer = Buffer.from(arrayBuffer);
-
-    if (buffer.length > MAX_IMAGE_SIZE) {
-      throw new BadRequestError('Resource too large');
-    }
+    const { buffer } = response;
 
     // Block tracking pixels (very small images)
     if (buffer.length < TRACKING_PIXEL_THRESHOLD) {
@@ -247,7 +371,7 @@ export async function proxyResource(req: Request, res: Response): Promise<void> 
     // Use correct MIME when upstream sends generic octet-stream for fonts
     let resolvedType = contentType;
     if (isFontByExtension) {
-      const ext = url.pathname.match(/\.\w+/)?.[0]?.toLowerCase();
+      const ext = response.finalUrl.pathname.match(/\.\w+/)?.[0]?.toLowerCase();
       if (ext && FONT_MIME[ext]) resolvedType = FONT_MIME[ext];
     }
 


### PR DESCRIPTION
### Motivation
- The email proxy previously validated only the literal hostname with regexes and used `fetch(..., redirect: 'follow')`, which allowed authenticated users to trigger server-side requests that could follow redirects or resolve to private/internal IPs (SSRF). 
- The content-type check occurred after the fetch completed, so blind SSRF and internal probing remained possible even when responses were later rejected. 
- The goal is to prevent requests from reaching non-public/internal addresses and to validate every redirect target while preserving existing proxy features (caching, tracking protection, size limits). 

### Description
- Added DNS and socket-level validation helpers (`normalizeHostname`, `isPrivateHost`, `isPublicIp`, `assertPublicDnsTarget`) and expanded the private/reserved IP pattern list to cover CGNAT, TEST-NET, multicast/reserved and IPv6 cases. 
- Replaced automatic redirect-following `fetch` usage with a manual `fetchPublicResource` helper that performs a DNS resolution check before connecting, enforces the same public-IP check in the `lookup` used by the outbound socket, and revalidates each redirect target with a `MAX_REDIRECTS` limit. 
- Updated `proxyResource` to call `fetchPublicResource`, use the fetch helper's `finalUrl` for extension/mime heuristics, and preserve existing behavior for content-type validation, tracking-pixel blocking, size limits, caching, and transparent-gif fallbacks. 
- Minimal API surface change: only `packages/api/src/controllers/emailProxy.controller.ts` was modified and the route/behavior callers remain unchanged. 

### Testing
- Ran `git diff --check` to validate formatting and found no whitespace issues. 
- Attempted to run package tests via `bun run --cwd packages/api test -- emailProxy`, but the test runner could not be executed because dependencies could not be installed in this environment (`bun install` failed with npm registry 403), so automated tests did not run. 
- Attempted TypeScript type-check with `npx tsc -p packages/api/tsconfig.json --noEmit --ignoreDeprecations 6.0`, but type-check failed due to missing runtime/dev dependencies and type packages in the isolated environment, so CI-style validation could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c1d409d7c8323854763079ff14a5a)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->