### PR TITLE
fix(core): restrict implicit Oxy CORS origins

### DIFF
--- a/packages/core/src/server/__tests__/cors.test.ts
+++ b/packages/core/src/server/__tests__/cors.test.ts
@@ -34,7 +34,7 @@ function makeNext(): NextFunction & jest.Mock {
 }
 
 describe('@oxyhq/core/server createOxyCors', () => {
-  it('allows the Oxy apex family (apex + any subdomain) and echoes the exact origin', () => {
+  it('allows the HTTPS Oxy apex family (apex + one-level subdomains) and echoes the exact origin', () => {
     const mw = createOxyCors();
     for (const origin of [
       'https://oxy.so',
@@ -74,6 +74,10 @@ describe('@oxyhq/core/server createOxyCors', () => {
       'https://oxy.so.evil.com', // suffix attack
       'https://notoxy.so', // different apex
       'https://example.com',
+      'http://oxy.so',
+      'http://auth.oxy.so',
+      'https://deep.attacker-controlled.oxy.so',
+      'https://api.oxy.so:8443',
     ]) {
       const req = makeRequest('GET', origin);
       const res = makeResponse();

--- a/packages/core/src/server/cors.ts
+++ b/packages/core/src/server/cors.ts
@@ -11,10 +11,9 @@
  *
  * `createOxyCors` returns a self-contained Express middleware (no `cors`
  * package dependency) that:
- *   - allows the Oxy apex origin family (anything under `*.${CENTRAL_IDP_APEX}`,
- *     i.e. `oxy.so` — covering `auth.oxy.so`, `api.oxy.so`, `accounts.oxy.so`,
- *     `console.oxy.so`, `inbox.oxy.so`, the marketing site, …) reusing the
- *     central-origin constants already in core, NOT a fresh hardcoded list,
+ *   - allows the Oxy apex origin family over HTTPS only: the apex plus
+ *     one-label subdomains such as `auth.oxy.so`, `api.oxy.so`,
+ *     `accounts.oxy.so`, `console.oxy.so`, and `inbox.oxy.so`,
  *   - allows the caller's explicit `appOrigins`,
  *   - DENIES everything else (no reflection, never a wildcard with credentials),
  *   - echoes back the EXACT matched origin (so credentialed requests work) and
@@ -26,7 +25,6 @@
 
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import { CENTRAL_IDP_APEX } from '../utils/authWebUrl';
-import { registrableApex } from '../utils/fapiAutoDetect';
 
 /** Default HTTP methods allowed across origins. */
 const DEFAULT_ALLOWED_METHODS = ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'];
@@ -44,11 +42,16 @@ const DEFAULT_ALLOWED_HEADERS = [
 /** How long (seconds) a browser may cache a successful preflight. */
 const DEFAULT_MAX_AGE_SECONDS = 86_400;
 
+const OXY_ONE_LABEL_SUBDOMAIN_PATTERN = new RegExp(
+  `^[a-z0-9-]+\\.${CENTRAL_IDP_APEX.replace('.', '\\.')}$`,
+);
+
 export interface OxyCorsOptions {
   /**
    * Explicit additional allowed origins (exact-origin match, e.g.
    * `https://app.example.com`, `http://localhost:3000`). These are allowed IN
-   * ADDITION TO the Oxy apex origin family. Each is normalized via `new URL().origin`.
+   * ADDITION TO the built-in HTTPS Oxy apex origin family. Each is normalized
+   * via `new URL().origin`.
    */
   appOrigins?: string[];
   /**
@@ -68,25 +71,27 @@ export interface OxyCorsOptions {
 }
 
 /**
- * Whether `candidate` belongs to the Oxy apex origin family — i.e. its
- * registrable apex equals {@link CENTRAL_IDP_APEX} (`oxy.so`). This matches the
- * apex itself (`https://oxy.so`) and any subdomain (`https://auth.oxy.so`,
- * `https://api.oxy.so`, …) over http or https, ports allowed. Returns false on
- * any parse failure (fail closed).
+ * Whether `candidate` belongs to the built-in Oxy apex origin family. This
+ * intentionally mirrors the API allowlist shape: HTTPS only, no custom port,
+ * the apex itself (`https://oxy.so`), or exactly one lowercase subdomain label
+ * (`https://auth.oxy.so`, `https://api.oxy.so`, …).
+ *
+ * Arbitrary/multi-level subdomains and `http://*.oxy.so` are not implicitly
+ * trusted for credentialed CORS. If a service needs a non-standard development
+ * or tenant origin, it must opt in explicitly via `appOrigins`.
  */
 function isOxyFamilyOrigin(candidate: string): boolean {
-  let hostname: string;
-  let protocol: string;
   try {
     const url = new URL(candidate);
-    hostname = url.hostname.toLowerCase();
-    protocol = url.protocol;
+    if (url.protocol !== 'https:' || url.port !== '') return false;
+
+    const hostname = url.hostname;
+    if (hostname === CENTRAL_IDP_APEX) return true;
+
+    return OXY_ONE_LABEL_SUBDOMAIN_PATTERN.test(hostname);
   } catch {
     return false;
   }
-  if (protocol !== 'https:' && protocol !== 'http:') return false;
-  if (hostname === CENTRAL_IDP_APEX) return true;
-  return registrableApex(hostname) === CENTRAL_IDP_APEX;
 }
 
 /** Normalize a raw origin string to its canonical `scheme://host[:port]` form. */
@@ -99,8 +104,8 @@ function normalizeOrigin(raw: string): string | null {
 }
 
 /**
- * Build the origin-matching predicate: true iff `origin` is in the Oxy apex
- * family OR exactly matches one of the configured app origins.
+ * Build the origin-matching predicate: true iff `origin` is in the built-in
+ * HTTPS Oxy apex family OR exactly matches one of the configured app origins.
  */
 function buildOriginAllowed(appOrigins: string[]): (origin: string) => boolean {
   const explicit = new Set<string>();


### PR DESCRIPTION
### Motivation

- Close a credentialed CORS policy gap where the implicit Oxy-family matcher trusted `http:` origins and arbitrary/multi-level `*.oxy.so` hostnames, which could allow attacker-controlled oxy subdomains to perform credentialed cross-origin reads. 

### Description

- Restrict the built-in Oxy-family matcher in `packages/core/src/server/cors.ts` to HTTPS-only, no custom port, and the apex plus exactly one lowercase subdomain label (e.g. `https://auth.oxy.so`), replacing the previous registrable-apex logic.  
- Remove the broad `registrableApex`-based acceptance and add a one-label subdomain regex (`OXY_ONE_LABEL_SUBDOMAIN_PATTERN`) and updated explanatory comments.  
- Update the CORS unit test `packages/core/src/server/__tests__/cors.test.ts` to document and assert that HTTP oxy origins, multi-level oxy subdomains, and custom-port oxy origins are denied unless explicitly opt‑in via `appOrigins`.

### Testing

- Verified header behavior with a small local check script (`bun /tmp/oxy-cors-check.ts`) which confirmed HTTPS one-label oxy subdomains are allowed and `http://` oxy, multi-level subdomains, and custom-port oxy origins are denied.  
- Ran `git diff --check` to validate no whitespace/patch issues.  
- Attempted to run unit tests (`bun run test` / Jest) and install deps (`bun install`), but those actions were blocked by the environment (missing `jest` binary and npm registry `403` responses), so the updated tests are present but could not be executed in this CI-less environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb76d091c832390bc67712309ab1e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->