### PR TITLE
fix(api): authorize app recommendation signals

### DIFF
--- a/packages/api/src/routes/__tests__/profilesRecommendations.test.ts
+++ b/packages/api/src/routes/__tests__/profilesRecommendations.test.ts
@@ -28,6 +28,8 @@ import { Types } from 'mongoose';
 const mockFollowFind = jest.fn();
 const mockFollowAggregate = jest.fn();
 const mockUserAggregate = jest.fn();
+const mockAppUserSignalFind = jest.fn();
+const mockApplicationMemberFindOne = jest.fn();
 
 // The dual-auth middleware is swappable per-test so we can run authenticated and
 // logged-out paths against the same mounted router. The mocked
@@ -107,6 +109,18 @@ jest.mock('../../models/User', () => ({
   __esModule: true,
   default: {
     aggregate: (...args: unknown[]) => mockUserAggregate(...args),
+  },
+}));
+
+jest.mock('../../models/AppUserSignal', () => ({
+  AppUserSignal: {
+    find: (...args: unknown[]) => mockAppUserSignalFind(...args),
+  },
+}));
+
+jest.mock('../../models/ApplicationMember', () => ({
+  ApplicationMember: {
+    findOne: (...args: unknown[]) => mockApplicationMemberFindOne(...args),
   },
 }));
 
@@ -294,6 +308,16 @@ beforeEach(() => {
   jest.clearAllMocks();
   currentUserId = undefined;
   currentServiceApp = undefined;
+  mockAppUserSignalFind.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    sort: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue([]),
+  });
+  mockApplicationMemberFindOne.mockReturnValue({
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue(null),
+  });
 });
 
 describe('GET /profiles/recommendations exclusion set', () => {
@@ -444,10 +468,11 @@ describe('GET /profiles/recommendations exclusion set', () => {
 describe('POST /profiles/recommendations dual-auth viewer resolution', () => {
   function postJson(
     server: http.Server,
-    headers: Record<string, string> = {}
+    headers: Record<string, string> = {},
+    body: Record<string, unknown> = { limit: 10 }
   ): Promise<JsonResponse> {
     const address = server.address() as AddressInfo;
-    const payload = JSON.stringify({ limit: 10 });
+    const payload = JSON.stringify(body);
     return new Promise((resolve, reject) => {
       const req = http.request(
         {
@@ -481,6 +506,70 @@ describe('POST /profiles/recommendations dual-auth viewer resolution', () => {
     const select = jest.fn().mockReturnValue({ limit, lean });
     mockFollowFind.mockReturnValue({ select });
   }
+
+
+  it('ignores an unauthenticated clientId and does not read app-scoped signals', async () => {
+    const victimAppId = new Types.ObjectId().toHexString();
+    currentServiceApp = undefined;
+    currentUserId = undefined;
+    mockFollowAggregate.mockResolvedValue([]);
+    mockUserAggregate.mockResolvedValue([]);
+
+    const res = await postJson(server, {}, { limit: 10, clientId: victimAppId });
+
+    expect(res.status).toBe(200);
+    expect(mockApplicationMemberFindOne).not.toHaveBeenCalled();
+    expect(mockAppUserSignalFind).not.toHaveBeenCalled();
+  });
+
+  it('only reads app-scoped signals when the service token belongs to the requested app', async () => {
+    const appId = new Types.ObjectId().toHexString();
+    currentServiceApp = { appId, scopes: ['user:read'] };
+    const signalLean = jest.fn().mockResolvedValue([
+      { userId: userD, endorsementScore: 10, interestScore: 1 },
+    ]);
+    const signalLimit = jest.fn().mockReturnValue({ lean: signalLean });
+    const signalSort = jest.fn().mockReturnValue({ limit: signalLimit });
+    const signalSelect = jest.fn().mockReturnValue({ sort: signalSort });
+    mockAppUserSignalFind.mockReturnValue({ select: signalSelect });
+    mockFollowAggregate.mockResolvedValue([]);
+    mockUserAggregate.mockImplementation((pipeline: unknown) => {
+      const stages = pipeline as Array<Record<string, unknown>>;
+      const isCountPass = stages.some(
+        (stage) => stage.$project && (stage.$project as Record<string, unknown>).followersCount
+      );
+      if (isCountPass) {
+        return Promise.resolve([{ _id: userD, followersCount: 1, followingCount: 0 }]);
+      }
+      return Promise.resolve([
+        {
+          _id: userD, username: 'd', name: { first: 'D' }, avatar: 'x', verified: false,
+          completenessScore: 1, verifiedScore: 0, repCandScore: 0.5,
+        },
+      ]);
+    });
+
+    const res = await postJson(server, {}, { limit: 10, clientId: appId });
+
+    expect(res.status).toBe(200);
+    const signalQuery = mockAppUserSignalFind.mock.calls[0][0] as { applicationId: Types.ObjectId };
+    expect(signalQuery.applicationId.toHexString()).toBe(appId);
+    const returnedIds = (res.body.data ?? []).map((profile) => String(profile.id));
+    expect(returnedIds).toEqual([userD.toString()]);
+  });
+
+  it('ignores a clientId that does not match the service-token application', async () => {
+    const ownAppId = new Types.ObjectId().toHexString();
+    const victimAppId = new Types.ObjectId().toHexString();
+    currentServiceApp = { appId: ownAppId, scopes: ['user:read'] };
+    mockFollowAggregate.mockResolvedValue([]);
+    mockUserAggregate.mockResolvedValue([]);
+
+    const res = await postJson(server, {}, { limit: 10, clientId: victimAppId });
+
+    expect(res.status).toBe(200);
+    expect(mockAppUserSignalFind).not.toHaveBeenCalled();
+  });
 
   it('service token + valid X-Oxy-User-Id (with user:read) personalizes for that viewer', async () => {
     currentServiceApp = { appId: 'app1', scopes: ['user:read', 'files:write'] };

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -29,6 +29,7 @@ import { usernameParams, profileSearchQuerySchema } from '../schemas/profiles.sc
 import { formatUserNameResponse, type NameParts } from '../utils/displayName';
 import { eligibleUserMatch, FEDERATED_RECOMMENDATION_MAX_AGE_MS } from '../utils/profileQuery';
 import { AppUserSignal } from '../models/AppUserSignal';
+import { ApplicationMember } from '../models/ApplicationMember';
 import { getRedisClient } from '../config/redis';
 import {
   resolveWeightProfile,
@@ -642,6 +643,43 @@ function followedIdToObjectId(value: unknown): Types.ObjectId | null {
 }
 
 /**
+ * Resolve whether a POST /profiles/recommendations caller may use app-scoped
+ * recommendation signals for the requested Application id. AppUserSignal rows
+ * are tenant-scoped; unauthenticated callers and unrelated apps/users must not
+ * be able to select an arbitrary `clientId` and infer curation/interest data.
+ */
+async function resolveAuthorizedRecommendationClientId(
+  req: OptionalUserOrServiceRequest,
+  requestedClientId?: string
+): Promise<string | undefined> {
+  if (!requestedClientId || !Types.ObjectId.isValid(requestedClientId)) {
+    return undefined;
+  }
+
+  const requestedAppId = new Types.ObjectId(requestedClientId).toHexString();
+  if (req.serviceApp?.appId && Types.ObjectId.isValid(req.serviceApp.appId)) {
+    return new Types.ObjectId(req.serviceApp.appId).toHexString() === requestedAppId
+      ? requestedAppId
+      : undefined;
+  }
+
+  const userId = req.user?._id;
+  if (!userId || !Types.ObjectId.isValid(userId)) {
+    return undefined;
+  }
+
+  const membership = await ApplicationMember.findOne({
+    applicationId: new Types.ObjectId(requestedAppId),
+    userId: new Types.ObjectId(userId),
+    status: 'active',
+  })
+    .select('_id')
+    .lean();
+
+  return membership ? requestedAppId : undefined;
+}
+
+/**
  * Popularity-ranked fallback used by the scored builder whenever the personalized
  * candidate union is empty — anonymous callers (no viewer → no graph/app/boost
  * candidates) and cold-start viewers (a viewer who follows accounts with no
@@ -1182,12 +1220,21 @@ router.post(
       clientId: body.clientId ?? null,
     });
 
+    const authorizedClientId = await resolveAuthorizedRecommendationClientId(req, body.clientId);
+
+    if (body.clientId && !authorizedClientId) {
+      logger.debug('POST /profiles/recommendations: ignoring unauthorized clientId', {
+        currentUserId: currentUserId ?? null,
+        serviceAppId: req.serviceApp?.appId ?? null,
+      });
+    }
+
     const recommendations = await buildRecommendations(currentUserId, {
       limit: parsedLimit,
       offset: parsedOffset,
       excludeTypes: body.excludeTypes ?? [],
       excludeIds: body.excludeIds ?? [],
-      clientId: body.clientId,
+      clientId: authorizedClientId,
       boosts: body.boosts,
       signalWeights: body.signalWeights,
     });


### PR DESCRIPTION
### Motivation
- Prevent leakage of tenant-scoped `AppUserSignal` data via the public `POST /profiles/recommendations` endpoint when callers supply an arbitrary `clientId`.
- Ensure only an owning service token or an active `ApplicationMember` may cause app-scoped signals to be used in recommendation scoring or cache keys.

### Description
- Added `resolveAuthorizedRecommendationClientId(req, requestedClientId)` which returns the requested app id only when the bearer `req.serviceApp.appId` matches or the authenticated `req.user` is an active `ApplicationMember` for that application, otherwise returns `undefined`.
- Updated `POST /profiles/recommendations` to call the resolver, log and ignore unauthorized `clientId` values, and pass the authorized id (or `undefined`) into `buildRecommendations` so unauthorized `clientId`s are not used for `AppUserSignal` lookups or cache keys.
- Imported `ApplicationMember` into `packages/api/src/routes/profiles.ts` and added the authorization helper in that file.
- Extended `packages/api/src/routes/__tests__/profilesRecommendations.test.ts` with mocks for `AppUserSignal` and `ApplicationMember`, and added regression tests that assert: unauthenticated callers cannot trigger app-signal reads, a service token for the same app may read its signals, and a service token for a different app cannot read another app’s signals; also adjusted the test POST helper to accept request bodies.

### Testing
- Static/diff check: ran a repository diff/check (`git diff --check`) and verified no whitespace/merge errors (succeeded).
- Unit tests: added targeted route tests in `packages/api/src/routes/__tests__/profilesRecommendations.test.ts` that cover the new authorization behavior (tests are included in the PR), but running them locally was blocked because project dependencies could not be installed in the environment (`bun install` failed due to npm registry `403` responses) so `jest` could not be executed (blocked).
- Notes: no automated test failures were observed in the change itself; the new tests are present and will run in CI once dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc5cac83239351dc43212e63ef)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->