### PR TITLE
fix(api): remove allo.you from Allo SSO seed

### DIFF
--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -132,9 +132,9 @@ const SEED_APPS: SeedAppSpec[] = [
   {
     name: 'Allo',
     description: 'Official Oxy encrypted messaging app.',
-    websiteUrl: 'https://allo.you',
+    websiteUrl: 'https://allo.oxy.so',
     type: 'first_party',
-    redirectUris: [cb('https://allo.you'), cb('https://allo.oxy.so')],
+    redirectUris: [cb('https://allo.oxy.so')],
   },
   {
     name: 'Alia',


### PR DESCRIPTION
### Motivation
- A seed change had added `https://allo.you` as an Allo redirect URI which expands the FedCM/SSO trusted-origin set and therefore implicitly authorises the `https://allo.you` origin to receive origin-bound SSO codes. This is a security-sensitive trust-boundary expansion that must be reverted.

### Description
- Reverted the Allo seed metadata so the seeded app `websiteUrl` is `https://allo.oxy.so` and the seeded `redirectUris` list contains only `https://allo.oxy.so`.
- The change was made in `packages/api/scripts/seed-oxy-applications.ts` to stop the seed from auto-approving the `allo.you` origin for FedCM/SSO.

### Testing
- Ran `git diff --check` to validate the working tree has no whitespace/diff errors and it passed.
- Verified no remaining occurrences with `rg -n "allo\.you" packages/api/scripts/seed-oxy-applications.ts` which returned no matches.
- Attempted to run the package test runner (`bun run test` / `jest` / `turbo`) but those commands were unavailable in this environment so full package test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db93fc832380b5a360bdb29fe6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->