### PR TITLE
fix(api): migrate renamed Mercaria seed app

### DIFF
--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -29,7 +29,7 @@
 
 import crypto from 'crypto';
 import mongoose from 'mongoose';
-import { Application } from '../src/models/Application';
+import { Application, type IApplication } from '../src/models/Application';
 import { ApplicationCredential } from '../src/models/ApplicationCredential';
 import { ApplicationMember } from '../src/models/ApplicationMember';
 import { Workspace } from '../src/models/Workspace';
@@ -53,6 +53,16 @@ type AppType = 'first_party' | 'internal';
 
 interface SeedAppSpec {
   name: string;
+  /**
+   * Previous official seed names that should be migrated in-place when present.
+   *
+   * The seed remains keyed by name for ordinary idempotency, but official app
+   * renames must not leave the old active app/credential trusted forever. If a
+   * legacy row exists and the new row does not, it is renamed/reconciled in
+   * place so the existing client id is preserved. If both rows already exist,
+   * the legacy row is suspended and its credentials are revoked.
+   */
+  legacyNames?: string[];
   description: string;
   websiteUrl?: string;
   type: AppType;
@@ -180,6 +190,7 @@ const SEED_APPS: SeedAppSpec[] = [
   },
   {
     name: 'Mercaria',
+    legacyNames: ['Marketplace'],
     description: 'Official Oxy marketplace app — buy and sell new and secondhand items.',
     websiteUrl: 'https://mercaria.co',
     type: 'first_party',
@@ -220,6 +231,29 @@ interface MappingRow {
   createdApplication: boolean;
   createdMember: boolean;
   createdCredential: boolean;
+}
+
+async function retireLegacyApplication(
+  application: mongoose.Document<unknown, object, IApplication> & IApplication,
+  dryRun: boolean,
+): Promise<number> {
+  if (dryRun) {
+    return 0;
+  }
+
+  application.status = 'suspended';
+  application.redirectUris = [];
+  await application.save();
+
+  const result = await ApplicationCredential.updateMany(
+    {
+      applicationId: application._id,
+      status: { $ne: 'revoked' },
+    },
+    { $set: { status: 'revoked' } },
+  );
+
+  return result.modifiedCount ?? 0;
 }
 
 async function seed(): Promise<void> {
@@ -289,8 +323,10 @@ async function seed(): Promise<void> {
 
   let appsCreated = 0;
   let appsUpdated = 0;
+  let legacyAppsRetired = 0;
   let membersCreated = 0;
   let credentialsCreated = 0;
+  let legacyCredentialsRevoked = 0;
   let credentialsReused = 0;
 
   for (const spec of SEED_APPS) {
@@ -299,7 +335,21 @@ async function seed(): Promise<void> {
     let createdCredential = false;
 
     // ── Application: upsert keyed by (name, createdByUserId) ──
+    // Official app renames include legacyNames so a pre-existing row is
+    // reconciled in-place instead of leaving stale redirect origins trusted.
     let application = await Application.findOne({ name: spec.name, createdByUserId: oxyId });
+    const legacyApplications =
+      spec.legacyNames && spec.legacyNames.length > 0
+        ? await Application.find({
+            name: { $in: spec.legacyNames },
+            createdByUserId: oxyId,
+          })
+        : [];
+
+    if (!application && legacyApplications.length > 0) {
+      application = legacyApplications[0];
+      application.name = spec.name;
+    }
 
     const desiredAppFields = {
       description: spec.description,
@@ -341,6 +391,15 @@ async function seed(): Promise<void> {
         await application.save();
         appsUpdated += 1;
       }
+    }
+
+    for (const legacyApplication of legacyApplications) {
+      if (application && legacyApplication._id.equals(application._id)) {
+        continue;
+      }
+
+      legacyCredentialsRevoked += await retireLegacyApplication(legacyApplication, dryRun);
+      legacyAppsRetired += 1;
     }
 
     // In dry-run with a not-yet-existing app, synthesize a placeholder id.
@@ -415,6 +474,8 @@ async function seed(): Promise<void> {
     appsUpdated,
     membersCreated,
     credentialsCreated,
+    legacyAppsRetired,
+    legacyCredentialsRevoked,
     credentialsReused,
   });
 


### PR DESCRIPTION
### Motivation
- Prevent renamed official seed entries from creating duplicate active OAuth/FedCM clients that leave stale redirect origins and public credentials trusted.
- Ensure the seeder migrates or retires legacy rows when a seed entry is renamed so FedCM/OAuth approved origins reflect the current canonical applications.

### Description
- Add an optional `legacyNames?: string[]` to the seed spec so a renamed official app can identify prior seed names at runtime and be migrated in-place when present.
- Mark `Mercaria` as the successor to the legacy `Marketplace` seed entry by setting `legacyNames: ['Marketplace']` in the `SEED_APPS` list.
- Implement `retireLegacyApplication(...)` which suspends a legacy application, clears its `redirectUris`, and revokes any non-revoked credentials.
- Update the seeding flow to prefer reconciling a legacy row into the new name when the new row is absent, and to retire remaining legacy duplicates when both exist; also add summary counters for retired apps/credentials and tighten the `Application` import typing.

### Testing
- Ran `git diff --check` to validate patch formatting and whitespace, which completed successfully.
- Attempted `bun --check packages/api/scripts/seed-oxy-applications.ts` but it was blocked by missing workspace dependencies (`Cannot find package 'mongoose'`).
- Attempted `bun run --filter @oxyhq/api build` but it was blocked by existing TypeScript configuration errors in `packages/contracts/tsconfig.cjs.json` before this script could be compiled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbd9b08323839e056349c12618)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->