### PR TITLE
fix(api): gate `signals:write` behind staff to prevent reputation farming

### DIFF
--- a/packages/api/src/routes/__tests__/applications.test.ts
+++ b/packages/api/src/routes/__tests__/applications.test.ts
@@ -748,15 +748,18 @@ describe('POST /applications — create', () => {
     expect(res.status).toBe(403);
   });
 
-  it('403 when a non-staff creator tries to self-grant a privileged scope (federation:write)', async () => {
-    const res = await requestJson(server, 'POST', '/applications', {
-      workspaceId: WORKSPACE_ID,
-      name: 'Escalation App',
-      redirectUris: ['https://mention.earth/__oxy/sso-callback'],
-      scopes: ['user:read', 'federation:write'],
-    });
-    expect(res.status).toBe(403);
-  });
+  it.each(['federation:write', 'signals:write'])(
+    '403 when a non-staff creator tries to self-grant a privileged scope (%s)',
+    async (scope) => {
+      const res = await requestJson(server, 'POST', '/applications', {
+        workspaceId: WORKSPACE_ID,
+        name: 'Escalation App',
+        redirectUris: ['https://mention.earth/__oxy/sso-callback'],
+        scopes: ['user:read', scope],
+      });
+      expect(res.status).toBe(403);
+    }
+  );
 
   it('allows a non-staff creator to grant ordinary (non-privileged) scopes', async () => {
     const res = await requestJson(server, 'POST', '/applications', {
@@ -768,15 +771,19 @@ describe('POST /applications — create', () => {
     expect(res.body.application?.scopes).toEqual(['user:read', 'files:write']);
   });
 
-  it('allows a STAFF creator to grant a privileged scope', async () => {
+  it('allows a STAFF creator to grant privileged scopes', async () => {
     actAs(OWNER_ID, true);
     const res = await requestJson(server, 'POST', '/applications', {
       workspaceId: WORKSPACE_ID,
       name: 'Federated App',
-      scopes: ['user:read', 'federation:write'],
+      scopes: ['user:read', 'federation:write', 'signals:write'],
     });
     expect(res.status).toBe(201);
-    expect(res.body.application?.scopes).toEqual(['user:read', 'federation:write']);
+    expect(res.body.application?.scopes).toEqual([
+      'user:read',
+      'federation:write',
+      'signals:write',
+    ]);
   });
 });
 
@@ -1065,12 +1072,15 @@ describe('PATCH /applications/:appId', () => {
     expect(res.body.application?.type).toBe('internal');
   });
 
-  it('403 when a non-staff owner tries to ADD a privileged scope via update', async () => {
-    const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
-      scopes: ['user:read', 'federation:write'],
-    });
-    expect(res.status).toBe(403);
-  });
+  it.each(['federation:write', 'signals:write'])(
+    '403 when a non-staff owner tries to ADD a privileged scope via update (%s)',
+    async (scope) => {
+      const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
+        scopes: ['user:read', scope],
+      });
+      expect(res.status).toBe(403);
+    }
+  );
 
   it('lets a non-staff owner keep an already-granted privileged scope (no re-grant)', async () => {
     // Staff previously elevated this app; a routine non-staff edit that re-sends
@@ -1086,13 +1096,17 @@ describe('PATCH /applications/:appId', () => {
     expect(res.body.application?.scopes).toEqual(['user:read', 'federation:write']);
   });
 
-  it('lets a STAFF owner add a privileged scope via update', async () => {
+  it('lets a STAFF owner add privileged scopes via update', async () => {
     actAs(OWNER_ID, true);
     const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
-      scopes: ['user:read', 'federation:write'],
+      scopes: ['user:read', 'federation:write', 'signals:write'],
     });
     expect(res.status).toBe(200);
-    expect(res.body.application?.scopes).toEqual(['user:read', 'federation:write']);
+    expect(res.body.application?.scopes).toEqual([
+      'user:read',
+      'federation:write',
+      'signals:write',
+    ]);
   });
 });
 

--- a/packages/api/src/utils/applicationScopes.ts
+++ b/packages/api/src/utils/applicationScopes.ts
@@ -40,6 +40,10 @@ export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
  *   resolve/mutate, ARBITRARY federated users. A self-granting owner could
  *   otherwise register an app with a victim domain's redirectUri and impersonate
  *   that domain's users.
+ * - `signals:write` lets a service credential write cross-app ranking signals
+ *   and can trigger reputation awards for arbitrary Oxy users. A self-granting
+ *   owner could otherwise submit forged endorsement edges to inflate reputation
+ *   and recommendation rankings.
  *
  * All other scopes in {@link APPLICATION_SCOPES} authorise an app only over its
  * OWN resources (files, models, webhooks, public user reads) and remain freely
@@ -48,6 +52,7 @@ export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
  */
 export const PRIVILEGED_APPLICATION_SCOPES = [
   'federation:write',
+  'signals:write',
 ] as const satisfies readonly ApplicationScope[];
 
 const PRIVILEGED_APPLICATION_SCOPE_SET: ReadonlySet<ApplicationScope> = new Set<ApplicationScope>(


### PR DESCRIPTION
### Motivation
- A new `signals:write` application scope allowed ordinary app owners to self-grant cross-app signal write authority and submit forged endorsement edges that trigger reputation awards, enabling reputation inflation and manipulation.
- The change's intent is to prevent low-privileged applications from obtaining cross-tenant authority that can affect user reputation and recommendation signals.

### Description
- Add `signals:write` to the staff-only `PRIVILEGED_APPLICATION_SCOPES` set so the scope may only be granted by platform staff, in `packages/api/src/utils/applicationScopes.ts` via `PRIVILEGED_APPLICATION_SCOPES`.
- Expand application route tests in `packages/api/src/routes/__tests__/applications.test.ts` to assert that non-staff creators and non-staff owners are rejected when attempting to add `signals:write` on create and update, while staff callers may grant it.
- Preserve existing behavior for other privileged scopes (`federation:write`) and keep the ingest endpoint requiring the `signals:write` scope on service tokens (no endpoint logic changes were made beyond gating the scope at grant-time).

### Testing
- Ran `git diff --check` which reported a clean diff with the intended file changes and no whitespace errors.
- Attempted to run the focused test command `bun run test -- applications.test.ts` but it failed because `jest` is not available in the environment (`command not found`).
- Attempted `bun install --frozen-lockfile` to run the full test suite but it was blocked by npm registry `403` errors for multiple packages, so automated test execution in this environment was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc0cc0832395dafb713b36db2e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/281" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->