### PR TITLE
fix(api): prevent bulk unfollow counter races

### DIFF
--- a/packages/api/src/services/__tests__/user.service.bulkUnfollow.test.ts
+++ b/packages/api/src/services/__tests__/user.service.bulkUnfollow.test.ts
@@ -1,0 +1,117 @@
+import { Types } from 'mongoose';
+
+const mockFollowFindLean = jest.fn();
+const mockFollowFindSelect = jest.fn(() => ({ lean: mockFollowFindLean }));
+const mockFollowFind = jest.fn(() => ({ select: mockFollowFindSelect }));
+const mockFollowFindOneAndDeleteLean = jest.fn();
+const mockFollowFindOneAndDeleteSelect = jest.fn(() => ({ lean: mockFollowFindOneAndDeleteLean }));
+const mockFollowFindOneAndDelete = jest.fn(() => ({ select: mockFollowFindOneAndDeleteSelect }));
+
+const mockUserUpdateMany = jest.fn();
+const mockUserFindByIdAndUpdate = jest.fn();
+
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  default: {
+    find: mockFollowFind,
+    findOneAndDelete: mockFollowFindOneAndDelete,
+  },
+  FollowType: {
+    USER: 'user',
+    HASHTAG: 'hashtag',
+    TOPIC: 'topic',
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    updateMany: mockUserUpdateMany,
+    findByIdAndUpdate: mockUserFindByIdAndUpdate,
+  },
+}));
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../securityActivityService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { UserService } from '../user.service';
+
+describe('UserService.bulkUnfollow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUserUpdateMany.mockResolvedValue({ modifiedCount: 1 });
+    mockUserFindByIdAndUpdate.mockResolvedValue(null);
+  });
+
+  it('decrements counters only for follow documents actually deleted', async () => {
+    const currentUserId = new Types.ObjectId().toHexString();
+    const targetDeleted = new Types.ObjectId();
+    const targetRaced = new Types.ObjectId();
+
+    mockFollowFindLean.mockResolvedValue([
+      { followedId: targetDeleted },
+      { followedId: targetRaced },
+    ]);
+    mockFollowFindOneAndDeleteLean
+      .mockResolvedValueOnce({ followedId: targetDeleted })
+      .mockResolvedValueOnce(null);
+
+    const result = await new UserService().bulkUnfollow(currentUserId, [
+      targetDeleted.toHexString(),
+      targetRaced.toHexString(),
+    ]);
+
+    expect(mockFollowFindOneAndDelete).toHaveBeenCalledTimes(2);
+    expect(mockUserUpdateMany).toHaveBeenCalledTimes(1);
+    expect(mockUserUpdateMany).toHaveBeenCalledWith(
+      { _id: { $in: [targetDeleted.toHexString()] } },
+      { $inc: { '_count.followers': -1 } }
+    );
+    expect(mockUserFindByIdAndUpdate).toHaveBeenCalledWith(currentUserId, {
+      $inc: { '_count.following': -1 },
+    });
+    expect(result.unfollowedCount).toBe(1);
+    expect(result.results).toEqual([
+      { userId: targetDeleted.toHexString(), success: true, wasFollowing: true },
+      { userId: targetRaced.toHexString(), success: true, wasFollowing: false },
+    ]);
+  });
+
+  it('does not decrement counters when all observed follows were already removed by a race', async () => {
+    const currentUserId = new Types.ObjectId().toHexString();
+    const targetId = new Types.ObjectId();
+
+    mockFollowFindLean.mockResolvedValue([{ followedId: targetId }]);
+    mockFollowFindOneAndDeleteLean.mockResolvedValueOnce(null);
+
+    const result = await new UserService().bulkUnfollow(currentUserId, [targetId.toHexString()]);
+
+    expect(mockUserUpdateMany).not.toHaveBeenCalled();
+    expect(mockUserFindByIdAndUpdate).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      results: [{ userId: targetId.toHexString(), success: true, wasFollowing: false }],
+      unfollowedCount: 0,
+    });
+  });
+});

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -773,27 +773,47 @@ export class UserService {
     // ordered (filter candidateIds) so result ordering stays stable.
     const toRemoveIds = candidateIds.filter((id) => existingFollowedIds.has(id));
 
+    let actuallyRemovedIds: string[] = [];
+
     if (toRemoveIds.length > 0) {
-      await Follow.deleteMany({
-        followerUserId: currentUserId,
-        followType: FollowType.USER,
-        followedId: { $in: toRemoveIds },
-      });
+      // Delete each follow with an atomic find-and-delete so concurrent bulk
+      // unfollow requests only decrement counters for documents this call
+      // actually removed. A plain deleteMany() only reports an aggregate
+      // deletedCount, which is not enough to safely update each target's
+      // follower counter under races.
+      const deletedFollows = await Promise.all(
+        toRemoveIds.map((followedId) =>
+          Follow.findOneAndDelete({
+            followerUserId: currentUserId,
+            followType: FollowType.USER,
+            followedId,
+          })
+            .select('followedId')
+            .lean()
+        )
+      );
+
+      actuallyRemovedIds = deletedFollows
+        .map((follow) => follow?.followedId)
+        .filter((id): id is Types.ObjectId | string => id != null)
+        .map((id) => id.toString());
 
       // Decrement counts based ONLY on follows actually removed — the exact
       // symmetric inverse of bulkFollow's increment.
-      await Promise.all([
-        User.updateMany(
-          { _id: { $in: toRemoveIds } },
-          { $inc: { '_count.followers': -1 } }
-        ),
-        User.findByIdAndUpdate(currentUserId, {
-          $inc: { '_count.following': -toRemoveIds.length },
-        }),
-      ]);
+      if (actuallyRemovedIds.length > 0) {
+        await Promise.all([
+          User.updateMany(
+            { _id: { $in: actuallyRemovedIds } },
+            { $inc: { '_count.followers': -1 } }
+          ),
+          User.findByIdAndUpdate(currentUserId, {
+            $inc: { '_count.following': -actuallyRemovedIds.length },
+          }),
+        ]);
+      }
     }
 
-    const removedSet = new Set<string>(toRemoveIds);
+    const removedSet = new Set<string>(actuallyRemovedIds);
     const candidateSet = new Set<string>(candidateIds);
 
     // Build a result entry for EVERY deduped candidate id (including invalid
@@ -812,7 +832,7 @@ export class UserService {
 
     return {
       results,
-      unfollowedCount: toRemoveIds.length,
+      unfollowedCount: actuallyRemovedIds.length,
     };
   }
 


### PR DESCRIPTION
### Motivation
- Prevent an integrity race where concurrent `bulkUnfollow` calls could over-decrement `_count.followers` and `_count.following` by basing counter updates on a pre-delete read instead of actual deletions.
- Ensure follower/following counters remain consistent with the true follow graph under concurrent requests.
- Maintain idempotent, unfollow-only semantics while preserving per-target result accuracy returned to callers.

### Description
- Replace the single `deleteMany(...)` with per-target atomic `findOneAndDelete(...)` calls and derive the subsequent counter decrements from the set of documents actually deleted in `packages/api/src/services/user.service.ts`.
- Update the returned per-target `wasFollowing` entries and the `unfollowedCount` to reflect only those targets that were actually removed instead of the pre-read candidate set.
- Add unit tests exercising a partial-race deletion and an all-raced-away case to validate that counters are decremented only for documents this request removed at `packages/api/src/services/__tests__/user.service.bulkUnfollow.test.ts`.

### Testing
- Added unit tests covering raced deletions and no-op counter updates when another request already removed the follow, but test execution was not possible in this environment due to missing `jest` and unavailable package installs.
- Performed a basic diff/consistency check (`git diff --check`) which reported no whitespace or diff issues.
- Attempted dependency installation (`bun install`) and running the test (`bun run test -- user.service.bulkUnfollow.test.ts`) but both were blocked in CI-like environment because the npm registry downloads returned `403` errors, so automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db2f7c83239fb31dcf5a285513)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->