### PR TITLE
fix(api): prevent revival/claiming of deleted assets by SHA

### DIFF
--- a/packages/api/src/models/File.ts
+++ b/packages/api/src/models/File.ts
@@ -89,7 +89,6 @@ const FileSchema = new Schema<IFile>({
   sha256: { 
     type: String, 
     required: true, 
-    unique: true,
     index: true 
   },
   size: { type: Number, required: true },
@@ -139,6 +138,10 @@ FileSchema.index({ ownerUserId: 1, status: 1 });
 FileSchema.index({ ownerUserId: 1, visibility: 1, status: 1 });
 FileSchema.index({ visibility: 1, status: 1 }); // For public file queries
 FileSchema.index({ 'links.app': 1, 'links.entityType': 1, 'links.entityId': 1 });
+FileSchema.index(
+  { sha256: 1 },
+  { unique: true, partialFilterExpression: { status: { $in: ['active', 'trash'] } } }
+);
 FileSchema.index({ sha256: 1, status: 1 });
 FileSchema.index({ purpose: 1, ownerUserId: 1, status: 1 }); // For cache-namespace lookups
 FileSchema.index({ createdAt: -1 });

--- a/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
+++ b/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
@@ -259,122 +259,34 @@ describe('uploadCachedMediaStream — abort cleanup', () => {
     source.destroy();
   });
 
-  it('revives a deleted direct-upload record and restores its missing storage', async () => {
+  it('scopes SHA de-duplication to non-deleted file records', async () => {
     const deleteFile = jest.fn((): Promise<void> => Promise.resolve());
-    const fileExists = jest.fn((): Promise<boolean> => Promise.resolve(false));
-    const uploadBuffer = jest.fn((key: string, buffer: Buffer, options?: UploadOptions): Promise<FileInfo> => Promise.resolve({
-      key,
-      size: buffer.length,
-      contentType: options?.contentType || 'application/octet-stream',
-    } as FileInfo));
-    const { service } = buildAssetService({ deleteFile, fileExists, uploadBuffer });
+    const { service } = buildAssetService({ deleteFile });
 
     const existingFile = {
-      _id: { toString: () => '64c000000000000000000fed' },
+      _id: { toString: () => '64c000000000000000000aaa' },
       sha256: 'deduped-sha',
       storageKey: 'content/2026/06/de/deduped-sha.jpg',
-      status: 'deleted',
-      ownerUserId: '__federation__',
+      status: 'active',
+      ownerUserId: 'owner',
       purpose: 'user',
       size: 4,
       mime: 'image/jpeg',
-      ext: '.jpg',
-      originalName: 'old-avatar.jpg',
-      visibility: 'public',
-      metadata: { old: true },
-      links: [{ app: 'old', entityType: 'profile', entityId: 'old', createdBy: 'old', createdAt: new Date() }],
-      variants: [{ type: 'thumb', key: 'variants/old/thumb.webp', readyAt: new Date() }],
-      save: jest.fn((): Promise<void> => Promise.resolve()),
+      visibility: 'private',
     };
     mockFileFindOne.mockResolvedValueOnce(existingFile);
 
-    const result = await service.uploadFileDirect(
+    await expect(service.uploadFileDirect(
       'fresh-owner',
       Buffer.from('JPEG'),
       'image/jpeg',
-      'fresh-avatar.jpg',
-      'public',
-      { source: 'federation-avatar' }
-    );
+      'fresh-avatar.jpg'
+    )).resolves.toBe(existingFile);
 
-    expect(result).toBe(existingFile);
-    expect(fileExists).toHaveBeenCalledWith(existingFile.storageKey);
-    expect(uploadBuffer).toHaveBeenCalledWith(existingFile.storageKey, Buffer.from('JPEG'), { contentType: 'image/jpeg' });
-    expect(existingFile.status).toBe('active');
-    expect(existingFile.ownerUserId).toBe('fresh-owner');
-    expect(existingFile.originalName).toBe('fresh-avatar.jpg');
-    expect(existingFile.metadata).toEqual({ source: 'federation-avatar' });
-    expect(existingFile.links).toEqual([]);
-    expect(existingFile.variants).toEqual([]);
-    expect(existingFile.save).toHaveBeenCalledTimes(1);
-    expect(mockGenerateVariants).toHaveBeenCalledWith(existingFile._id.toString());
-  });
-
-  it('revives a deleted cached-media record after deduplicating streamed media', async () => {
-    let resolveUpload: ((info: FileInfo) => void) | undefined;
-    let capturedTempKey: string | undefined;
-
-    const uploadStream = jest.fn(
-      (key: string, _body: Readable): Promise<FileInfo> => {
-        capturedTempKey = key;
-        return new Promise<FileInfo>((resolve) => { resolveUpload = resolve; });
-      }
-    );
-    const deleteFile = jest.fn((): Promise<void> => Promise.resolve());
-    const fileExists = jest.fn((): Promise<boolean> => Promise.resolve(false));
-    const copyFile = jest.fn((): Promise<void> => Promise.resolve());
-    const { service } = buildAssetService({ uploadStream, deleteFile, fileExists, copyFile });
-
-    const existingFile = {
-      _id: { toString: () => '64c000000000000000000cab' },
-      sha256: 'deleted-cache-sha',
-      storageKey: 'content/2026/06/de/deleted-cache-sha.png',
-      status: 'deleted',
-      ownerUserId: '__federation__',
-      purpose: 'federation-media-cache',
-      size: 4,
-      mime: 'image/png',
-      ext: '.png',
-      originalName: 'old-cache.png',
-      visibility: 'public',
-      metadata: { old: true },
-      links: [{ app: 'mention', entityType: 'post', entityId: 'old', createdBy: 'old', createdAt: new Date() }],
-      variants: [{ type: 'thumb', key: 'variants/old/thumb.webp', readyAt: new Date() }],
-      save: jest.fn((): Promise<void> => Promise.resolve()),
-    };
-    mockFileFindOne.mockResolvedValueOnce(existingFile);
-
-    const source = new Readable({
-      read() {
-        this.push(Buffer.from('PNG!'));
-        this.push(null);
-      },
+    expect(mockFileFindOne).toHaveBeenCalledWith({
+      sha256: 'f4dc1c96a30fbdeb2a15cb6d4229469fff36c0266dc0c346599093c24d4c0a01',
+      status: { $ne: 'deleted' },
     });
-
-    const promise = service.uploadCachedMediaStream(
-      source,
-      'image/png',
-      'federation-cache-media',
-      CACHE_MAX_BYTES
-    );
-
-    await new Promise((resolve) => setImmediate(resolve));
-    resolveUpload?.({ key: capturedTempKey || 'cache/incoming/x', size: 4, contentType: 'image/png' } as FileInfo);
-
-    await expect(promise).resolves.toBe(existingFile);
-
-    expect(fileExists).toHaveBeenCalledWith(existingFile.storageKey);
-    expect(copyFile).toHaveBeenCalledWith(capturedTempKey, existingFile.storageKey);
-    expect(deleteFile).toHaveBeenCalledWith(capturedTempKey);
-    expect(existingFile.status).toBe('active');
-    expect(existingFile.ownerUserId).toBe('__federation_media_cache__');
-    expect(existingFile.purpose).toBe('federation-media-cache');
-    expect(existingFile.metadata).toEqual({});
-    expect(existingFile.links).toEqual([]);
-    expect(existingFile.variants).toEqual([]);
-    expect(existingFile.save).toHaveBeenCalledTimes(1);
-    expect(mockGenerateVariants).toHaveBeenCalledWith(existingFile._id.toString());
-
-    source.destroy();
   });
+
 });

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -69,60 +69,8 @@ export class AssetService {
     return err?.code === 11000 || Boolean(err?.message?.includes('E11000'));
   }
 
-  private async findFileBySha(sha256: string): Promise<IFile | null> {
-    return File.findOne({ sha256 });
-  }
-
-  private async reviveDeletedDirectUploadFile(
-    file: IFile,
-    userId: string,
-    size: number,
-    mimeType: string,
-    originalName: string,
-    visibility?: FileVisibility,
-    metadata?: Record<string, any>
-  ): Promise<IFile> {
-    file.status = 'active';
-    file.ownerUserId = userId;
-    file.purpose = 'user';
-    file.size = size;
-    file.mime = mimeType;
-    file.ext = this.getExtensionFromMime(mimeType);
-    file.originalName = originalName;
-    file.visibility = visibility || 'private';
-    file.metadata = metadata || {};
-    file.links = [];
-    file.variants = [];
-
-    await file.save();
-    fileCache.invalidate(file._id.toString());
-    fileCache.set(file._id.toString(), file);
-    return file;
-  }
-
-  private async reviveDeletedStreamedMediaFile(
-    file: IFile,
-    size: number,
-    mimeType: string,
-    originalName: string,
-    options: StreamedMediaOptions
-  ): Promise<IFile> {
-    file.status = 'active';
-    file.ownerUserId = options.ownerUserId;
-    file.purpose = options.purpose;
-    file.size = size;
-    file.mime = mimeType;
-    file.ext = this.getExtensionFromMime(mimeType);
-    file.originalName = originalName;
-    file.visibility = options.visibility;
-    file.metadata = options.metadata;
-    file.links = [];
-    file.variants = [];
-
-    await file.save();
-    fileCache.invalidate(file._id.toString());
-    fileCache.set(file._id.toString(), file);
-    return file;
+  private async findActiveFileBySha(sha256: string): Promise<IFile | null> {
+    return File.findOne({ sha256, status: { $ne: 'deleted' } });
   }
 
   private isPrivateIpAddress(address: string): boolean {
@@ -461,24 +409,10 @@ export class AssetService {
   ): Promise<AssetInitResponse> {
     try {
       // Check if file already exists by SHA256
-      const existingFile = await this.findFileBySha(expectedSha256);
+      const existingFile = await this.findActiveFileBySha(expectedSha256);
 
       if (existingFile) {
         const storageKey = existingFile.storageKey || this.generateStorageKey(expectedSha256, expectedMime);
-        if (existingFile.status === 'deleted') {
-          existingFile.status = 'active';
-          existingFile.ownerUserId = userId;
-          existingFile.purpose = 'user';
-          existingFile.size = expectedSize;
-          existingFile.mime = expectedMime;
-          existingFile.ext = this.getExtensionFromMime(expectedMime);
-          existingFile.visibility = 'private';
-          existingFile.links = [];
-          existingFile.variants = [];
-          await existingFile.save();
-          fileCache.invalidate(existingFile._id.toString());
-          fileCache.set(existingFile._id.toString(), existingFile);
-        }
         if (!(await this.s3Service.fileExists(storageKey))) {
           logger.warn('Existing asset record has no storage object; returning upload URL for the existing key', {
             fileId: existingFile._id.toString(),
@@ -566,7 +500,7 @@ export class AssetService {
       const size = fileBuffer.length;
 
       // Check if file already exists by SHA256
-      const existingFile = await this.findFileBySha(sha256);
+      const existingFile = await this.findActiveFileBySha(sha256);
 
       if (existingFile) {
         const restored = await this.restoreMissingDirectUploadContent(
@@ -575,24 +509,13 @@ export class AssetService {
           mimeType,
           'direct upload',
         );
-        const wasDeleted = existingFile.status === 'deleted';
-        const preparedFile = wasDeleted
-          ? await this.reviveDeletedDirectUploadFile(
-            existingFile,
-            userId,
-            size,
-            mimeType,
-            originalName,
-            visibility,
-            metadata,
-          )
-          : await this.prepareExistingDirectUploadFile(
-            existingFile,
-            userId,
-            visibility,
-            metadata,
-          );
-        if (restored || wasDeleted) {
+        const preparedFile = await this.prepareExistingDirectUploadFile(
+          existingFile,
+          userId,
+          visibility,
+          metadata,
+        );
+        if (restored) {
           this.queueVariantGeneration(preparedFile);
         }
         logger.info('File already exists, returning existing', { 
@@ -628,7 +551,7 @@ export class AssetService {
         await file.save();
       } catch (error) {
         if (this.isDuplicateKeyError(error)) {
-          const racedFile = await this.findFileBySha(sha256);
+          const racedFile = await this.findActiveFileBySha(sha256);
           if (racedFile) {
             const restored = await this.restoreMissingDirectUploadContent(
               racedFile,
@@ -636,24 +559,13 @@ export class AssetService {
               mimeType,
               'direct upload duplicate race',
             );
-            const wasDeleted = racedFile.status === 'deleted';
-            const preparedFile = wasDeleted
-              ? await this.reviveDeletedDirectUploadFile(
-                racedFile,
-                userId,
-                size,
-                mimeType,
-                originalName,
-                visibility,
-                metadata,
-              )
-              : await this.prepareExistingDirectUploadFile(
-                racedFile,
-                userId,
-                visibility,
-                metadata,
-              );
-            if (restored || wasDeleted) {
+            const preparedFile = await this.prepareExistingDirectUploadFile(
+              racedFile,
+              userId,
+              visibility,
+              metadata,
+            );
+            if (restored) {
               this.queueVariantGeneration(preparedFile);
             }
             logger.info('File already exists after concurrent upload, returning existing', {
@@ -835,7 +747,7 @@ export class AssetService {
 
     // Dedup: if this exact content already exists (cache or otherwise), reuse
     // it and drop the temp object.
-    const existingFile = await this.findFileBySha(sha256);
+    const existingFile = await this.findActiveFileBySha(sha256);
     if (existingFile) {
       let restored = false;
       try {
@@ -847,17 +759,8 @@ export class AssetService {
       } finally {
         await deleteTempKey(`Failed to clean up deduplicated ${options.logLabel.toLowerCase()} upload`);
       }
-      const wasDeleted = existingFile.status === 'deleted';
-      const preparedFile = wasDeleted
-        ? await this.reviveDeletedStreamedMediaFile(
-          existingFile,
-          size,
-          mimeType,
-          originalName,
-          options,
-        )
-        : await this.prepareExistingStreamedMediaFile(existingFile, options);
-      if (restored || wasDeleted) {
+      const preparedFile = await this.prepareExistingStreamedMediaFile(existingFile, options);
+      if (restored) {
         this.queueVariantGeneration(preparedFile);
       }
       logger.info(`${options.logLabel} already exists, returning existing`, {
@@ -903,7 +806,7 @@ export class AssetService {
       await file.save();
     } catch (error) {
       if (this.isDuplicateKeyError(error)) {
-        const racedFile = await this.findFileBySha(sha256);
+        const racedFile = await this.findActiveFileBySha(sha256);
         if (racedFile) {
           let restored = false;
           try {
@@ -924,17 +827,8 @@ export class AssetService {
               }
             }
           }
-          const wasDeleted = racedFile.status === 'deleted';
-          const preparedFile = wasDeleted
-            ? await this.reviveDeletedStreamedMediaFile(
-              racedFile,
-              size,
-              mimeType,
-              originalName,
-              options,
-            )
-            : await this.prepareExistingStreamedMediaFile(racedFile, options);
-          if (restored || wasDeleted) {
+          const preparedFile = await this.prepareExistingStreamedMediaFile(racedFile, options);
+          if (restored) {
             this.queueVariantGeneration(preparedFile);
           }
           logger.info(`${options.logLabel} already exists after concurrent upload, returning existing`, {


### PR DESCRIPTION
### Motivation
- Prevent an authorization/ownership bug where a caller-supplied SHA could match a deleted `File` record and cause that deleted record to be reactivated and transferred to the caller.
- Restore the original ownership/deletion boundary so tombstoned records remain isolated from client-supplied hash-based deduplication.

### Description
- Scope SHA de-duplication lookups to non-deleted records by introducing `findActiveFileBySha(sha256)` and replacing all `findFileBySha` usages in `packages/api/src/services/assetService.ts` with the active-only lookup so `status: 'deleted'` records are excluded from reuse.
- Remove deleted-record revival logic from `initUpload`, direct upload, streamed upload, and duplicate-race handling so deleted files are no longer reactivated or reassigned to callers.
- Change the `File` schema (`packages/api/src/models/File.ts`) so `sha256` uniqueness is enforced only for non-deleted records via a partial unique index (`partialFilterExpression: { status: { $in: ['active','trash'] } }`), and remove the unconditional `unique: true` on the field.
- Update the unit test `packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts` to assert that SHA de-duplication queries include `status: { $ne: 'deleted' }` instead of expecting deleted-record revival behavior.

### Testing
- Ran `git diff --check` to validate patch formatting and simple diffs, which passed.
- Attempted dependency install with `bun install --frozen-lockfile` but it was blocked by external npm registry 403 responses so full test execution could not run in this environment.
- Attempted to run the package test subset (`cd packages/api && bun run test -- <test-file>`), but `jest` was not available because dependencies failed to install, so unit tests could not be executed here; tests were updated to reflect the new non-revival behavior and are expected to pass once dependencies are installed and `jest` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db87508323ac3a6e3b1192107e)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->