### PR TITLE
fix: harden federated asset repair fetch

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,7 @@
         "@aws-sdk/s3-request-presigner": "^3.857.0",
         "@node-rs/argon2": "^2.0.2",
         "@oxyhq/contracts": "workspace:*",
+        "@oxyhq/core": "workspace:*",
         "@socket.io/redis-adapter": "^8.3.0",
         "@types/cheerio": "^0.22.35",
         "@types/compression": "^1.8.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -46,6 +46,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@oxyhq/core": "workspace:*",
     "@aws-sdk/client-s3": "^3.857.0",
     "@aws-sdk/lib-storage": "3.983.0",
     "@aws-sdk/s3-request-presigner": "^3.857.0",

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -1,8 +1,7 @@
 import crypto from 'crypto';
-import { lookup } from 'dns/promises';
-import net from 'net';
 import { Readable, Transform } from 'stream';
 import mongoose from 'mongoose';
+import { safeFetch, SsrfRejection, UpstreamError } from '@oxyhq/core/server';
 import { File, IFile, IFileLink, IFileVariant, FileVisibility } from '../models/File';
 import { S3Service } from './s3Service';
 import {
@@ -125,62 +124,41 @@ export class AssetService {
     return file;
   }
 
-  private isPrivateIpAddress(address: string): boolean {
-    const ipVersion = net.isIP(address);
-    if (ipVersion === 4) {
-      const parts = address.split('.').map(Number);
-      const [a, b] = parts;
-      return (
-        a === 0 ||
-        a === 10 ||
-        a === 127 ||
-        (a === 100 && b >= 64 && b <= 127) ||
-        (a === 169 && b === 254) ||
-        (a === 172 && b >= 16 && b <= 31) ||
-        (a === 192 && b === 168) ||
-        (a === 198 && (b === 18 || b === 19)) ||
-        a >= 224
-      );
+  private async readFederationRepairImageBody(
+    response: AsyncIterable<Buffer | Uint8Array | string>,
+    url: string,
+  ): Promise<Buffer | null> {
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+
+    for await (const chunk of response) {
+      const bufferChunk = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += bufferChunk.length;
+
+      if (totalBytes > FEDERATION_REPAIR_MAX_BYTES) {
+        logger.warn('Federation repair image exceeded byte limit while streaming', {
+          url,
+          size: totalBytes,
+        });
+        return null;
+      }
+
+      chunks.push(bufferChunk);
     }
 
-    if (ipVersion === 6) {
-      const normalized = address.toLowerCase();
-      return (
-        normalized === '::1' ||
-        normalized.startsWith('fc') ||
-        normalized.startsWith('fd') ||
-        normalized.startsWith('fe80:')
-      );
+    if (totalBytes === 0) {
+      logger.warn('Federation repair image is empty', { url });
+      return null;
     }
 
-    return false;
+    return Buffer.concat(chunks, totalBytes);
   }
 
-  private async validateFederationRepairUrl(url: URL): Promise<boolean> {
-    if (url.protocol !== 'https:') {
-      return false;
+  private getHeaderValue(header: string | string[] | undefined): string {
+    if (Array.isArray(header)) {
+      return header[0] || '';
     }
-
-    const hostname = url.hostname.toLowerCase();
-    if (
-      hostname === 'localhost' ||
-      hostname.endsWith('.localhost') ||
-      hostname.endsWith('.local') ||
-      this.isPrivateIpAddress(hostname)
-    ) {
-      return false;
-    }
-
-    try {
-      const addresses = await lookup(hostname, { all: true, verbatim: false });
-      return addresses.length > 0 && addresses.every(({ address }) => !this.isPrivateIpAddress(address));
-    } catch (error) {
-      logger.warn('Failed to resolve federation repair URL host', {
-        host: hostname,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return false;
-    }
+    return header || '';
   }
 
   private getFederationRepairRemoteUrl(file: IFile): string | null {
@@ -203,78 +181,84 @@ export class AssetService {
   }
 
   private async fetchFederationRepairImage(remoteUrl: string): Promise<{ buffer: Buffer; mime: string } | null> {
-    let currentUrl: URL;
+    let parsedUrl: URL;
     try {
-      currentUrl = new URL(remoteUrl);
+      parsedUrl = new URL(remoteUrl);
     } catch {
       return null;
     }
 
-    for (let redirects = 0; redirects <= FEDERATION_REPAIR_MAX_REDIRECTS; redirects += 1) {
-      if (!(await this.validateFederationRepairUrl(currentUrl))) {
-        logger.warn('Blocked unsafe federation repair URL', { url: currentUrl.toString() });
-        return null;
-      }
+    if (parsedUrl.protocol !== 'https:') {
+      logger.warn('Blocked non-HTTPS federation repair URL', { url: remoteUrl });
+      return null;
+    }
 
-      const response = await fetch(currentUrl, {
-        redirect: 'manual',
-        signal: AbortSignal.timeout(15_000),
+    let response: Awaited<ReturnType<typeof safeFetch>>['response'] | null = null;
+    try {
+      const result = await safeFetch(parsedUrl.toString(), {
+        maxRedirects: FEDERATION_REPAIR_MAX_REDIRECTS,
+        headersTimeoutMs: 15_000,
+        allowedProtocols: new Set(['https:']),
         headers: {
           Accept: 'image/avif,image/webp,image/png,image/jpeg,image/gif,image/*;q=0.8',
           'User-Agent': FEDERATION_REPAIR_USER_AGENT,
         },
       });
+      response = result.response;
+      const { status, headers, finalUrl } = result;
 
-      if (response.status >= 300 && response.status < 400) {
-        const location = response.headers.get('location');
-        if (!location) {
-          return null;
-        }
-        currentUrl = new URL(location, currentUrl);
-        continue;
-      }
-
-      if (!response.ok) {
+      if (status < 200 || status >= 300) {
         logger.warn('Federation repair download failed', {
-          url: currentUrl.toString(),
-          status: response.status,
+          url: finalUrl,
+          status,
         });
         return null;
       }
 
-      const rawContentType = response.headers.get('content-type') || '';
+      const rawContentType = this.getHeaderValue(headers['content-type']);
       const mime = rawContentType.split(';')[0].trim().toLowerCase();
       if (!mime.startsWith('image/') || !isAllowedCacheMime(mime)) {
         logger.warn('Federation repair rejected non-image content', {
-          url: currentUrl.toString(),
+          url: finalUrl,
           contentType: rawContentType,
         });
         return null;
       }
 
-      const declaredLength = Number(response.headers.get('content-length'));
+      const declaredLength = Number(this.getHeaderValue(headers['content-length']));
       if (Number.isFinite(declaredLength) && declaredLength > FEDERATION_REPAIR_MAX_BYTES) {
         logger.warn('Federation repair image is too large', {
-          url: currentUrl.toString(),
+          url: finalUrl,
           declaredLength,
         });
         return null;
       }
 
-      const buffer = Buffer.from(await response.arrayBuffer());
-      if (buffer.length === 0 || buffer.length > FEDERATION_REPAIR_MAX_BYTES) {
-        logger.warn('Federation repair image has invalid size', {
-          url: currentUrl.toString(),
-          size: buffer.length,
-        });
+      const buffer = await this.readFederationRepairImageBody(response, finalUrl);
+      if (!buffer) {
         return null;
       }
 
       return { buffer, mime };
+    } catch (error) {
+      if (error instanceof SsrfRejection) {
+        logger.warn('Blocked unsafe federation repair URL', {
+          url: parsedUrl.toString(),
+          reason: error.message,
+        });
+        return null;
+      }
+      if (error instanceof UpstreamError) {
+        logger.warn('Federation repair upstream error', {
+          url: parsedUrl.toString(),
+          error: error.message,
+        });
+        return null;
+      }
+      throw error;
+    } finally {
+      response?.destroy();
     }
-
-    logger.warn('Federation repair exceeded redirect limit', { url: remoteUrl });
-    return null;
   }
 
   private async restoreMissingDirectUploadContent(

--- a/packages/core/src/server/__tests__/safeFetch.test.ts
+++ b/packages/core/src/server/__tests__/safeFetch.test.ts
@@ -105,6 +105,13 @@ describe('@oxyhq/core/server safeFetch — assertSafePublicUrl', () => {
     }
   });
 
+  it('honors per-call protocol restrictions', async () => {
+    const result = await assertSafePublicUrl('http://example.com/', new Set(['https:']));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe('disallowed protocol http:');
+    expect(mockDnsLookup).not.toHaveBeenCalled();
+  });
+
   it('rejects disallowed protocols, ports, credentials, and oversized URLs', async () => {
     expect((await assertSafePublicUrl('ftp://example.com/')).ok).toBe(false);
     expect((await assertSafePublicUrl('file:///etc/passwd')).ok).toBe(false);

--- a/packages/core/src/server/safeFetch.ts
+++ b/packages/core/src/server/safeFetch.ts
@@ -277,7 +277,10 @@ export function isBlockedIp(rawIp: string): boolean {
  * Re-run this on EVERY redirect hop so a public hostname cannot redirect (or
  * DNS-rebind) into an internal address.
  */
-export async function assertSafePublicUrl(rawUrl: string): Promise<SsrfCheckResult> {
+export async function assertSafePublicUrl(
+  rawUrl: string,
+  allowedProtocols: ReadonlySet<string> = ALLOWED_PROTOCOLS,
+): Promise<SsrfCheckResult> {
   if (typeof rawUrl !== 'string' || rawUrl.length === 0) {
     return { ok: false, reason: 'missing url' };
   }
@@ -292,7 +295,7 @@ export async function assertSafePublicUrl(rawUrl: string): Promise<SsrfCheckResu
     return { ok: false, reason: 'malformed url' };
   }
 
-  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+  if (!allowedProtocols.has(parsed.protocol)) {
     return { ok: false, reason: `disallowed protocol ${parsed.protocol}` };
   }
 
@@ -405,6 +408,8 @@ export interface SafeFetchOptions {
    * destroyed.
    */
   signal?: AbortSignal;
+  /** Protocols this call is allowed to contact. Defaults to http and https. */
+  allowedProtocols?: ReadonlySet<string>;
 }
 
 /** The validated, non-redirect response returned by {@link safeFetch}. */
@@ -509,6 +514,7 @@ export async function safeFetch(
     maxRedirects = MAX_REDIRECTS,
     headersTimeoutMs = UPSTREAM_HEADERS_TIMEOUT_MS,
     signal,
+    allowedProtocols = ALLOWED_PROTOCOLS,
   } = options;
 
   // Normalize a case-insensitive header map and ensure a User-Agent default.
@@ -530,7 +536,7 @@ export async function safeFetch(
       throw new UpstreamError('request aborted');
     }
 
-    const guard = await assertSafePublicUrl(currentUrl);
+    const guard = await assertSafePublicUrl(currentUrl, allowedProtocols);
     if (!guard.ok) {
       throw new SsrfRejection(guard.reason);
     }


### PR DESCRIPTION
### Motivation
- The federated asset self-repair path used unpinned DNS validation plus a later `fetch()` to `metadata.remoteUrl`, creating a DNS TOCTOU SSRF risk for public federated assets. 
- The flow buffered the whole response via `arrayBuffer()` before enforcing the 10 MiB cap, opening a resource-exhaustion/DoS surface from chunked or lying Content-Length responses. 
- Stored federation metadata (e.g. actor icon URL) can be attacker-controlled for public assets, so the repair fetch must be pinned and streamed safely.  

### Description
- Route the federation repair download through the shared SSRF-hardened `safeFetch` in `@oxyhq/core/server`, which pins the validated IP to the outbound TCP connection and revalidates every redirect hop, and restrict the repair call to HTTPS-only. 
- Replace `response.arrayBuffer()` with a streaming reader `readFederationRepairImageBody` that enforces `FEDERATION_REPAIR_MAX_BYTES` while streaming and returns early if the limit is exceeded or the body is empty. 
- Add small header helper `getHeaderValue`, ensure redirect/response bodies are destroyed promptly, and surface `SsrfRejection`/`UpstreamError` handling so unsafe or failing upstreams are logged and rejected. 
- Add `@oxyhq/core` as an API dependency and a unit assertion in `safeFetch` tests to exercise per-call protocol restrictions. 

### Testing
- Typecheck: ran `bun --check packages/core/src/server/safeFetch.ts`, which completed successfully. 
- Unit tests: attempted `bun run --filter @oxyhq/core test -- safeFetch.test.ts`, but test execution was blocked because `jest` is not available in this environment. 
- Build: attempted `bun run --filter @oxyhq/api build`, but the CI-like build was blocked by local TypeScript/config deprecation and workspace install issues. 
- Install: `bun install --frozen-lockfile` was attempted but failed due to registry `403` responses in this environment, preventing a full build/test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db25a4832399940adaf88dde00)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->