### PR TITLE
fix(api): prevent federated dedupe from publishing private files

### DIFF
--- a/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
+++ b/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
@@ -381,6 +381,126 @@ describe('uploadCachedMediaStream — abort cleanup', () => {
 
     source.destroy();
   });
+  it('rejects durable federated dedupe against an ordinary private user file without mutating it', async () => {
+    let resolveUpload: ((info: FileInfo) => void) | undefined;
+    let capturedTempKey: string | undefined;
+
+    const uploadStream = jest.fn(
+      (key: string, _body: Readable): Promise<FileInfo> => {
+        capturedTempKey = key;
+        return new Promise<FileInfo>((resolve) => { resolveUpload = resolve; });
+      }
+    );
+    const deleteFile = jest.fn((): Promise<void> => Promise.resolve());
+    const { service } = buildAssetService({ uploadStream, deleteFile });
+
+    const existingFile = {
+      _id: { toString: () => '64c000000000000000000bad' },
+      sha256: 'private-sha',
+      storageKey: 'content/2026/06/pr/private-sha.png',
+      status: 'active',
+      ownerUserId: 'victim-user-id',
+      purpose: 'user',
+      visibility: 'private',
+      metadata: { ownerOnly: true },
+      save: jest.fn((): Promise<void> => Promise.resolve()),
+    };
+    mockFileFindOne.mockResolvedValueOnce(existingFile);
+
+    const source = new Readable({
+      read() {
+        this.push(Buffer.from('PNG!'));
+        this.push(null);
+      },
+    });
+
+    const promise = service.uploadFederatedMediaStream(
+      source,
+      'image/png',
+      'federated-post.png',
+      CACHE_MAX_BYTES,
+      'federated-owner-id',
+      { sourceUri: 'https://remote.example/media/1' }
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    resolveUpload?.({ key: capturedTempKey || 'federation/incoming/x', size: 4, contentType: 'image/png' } as FileInfo);
+
+    await expect(promise).rejects.toMatchObject({ statusCode: 409 });
+
+    expect(existingFile.ownerUserId).toBe('victim-user-id');
+    expect(existingFile.purpose).toBe('user');
+    expect(existingFile.visibility).toBe('private');
+    expect(existingFile.metadata).toEqual({ ownerOnly: true });
+    expect(existingFile.save).not.toHaveBeenCalled();
+    expect(deleteFile).toHaveBeenCalledWith(capturedTempKey);
+
+    source.destroy();
+  });
+
+  it('promotes a deduped federation cache record for durable federated media', async () => {
+    let resolveUpload: ((info: FileInfo) => void) | undefined;
+    let capturedTempKey: string | undefined;
+
+    const uploadStream = jest.fn(
+      (key: string, _body: Readable): Promise<FileInfo> => {
+        capturedTempKey = key;
+        return new Promise<FileInfo>((resolve) => { resolveUpload = resolve; });
+      }
+    );
+    const deleteFile = jest.fn((): Promise<void> => Promise.resolve());
+    const fileExists = jest.fn((): Promise<boolean> => Promise.resolve(true));
+    const { service } = buildAssetService({ uploadStream, deleteFile, fileExists });
+
+    const existingFile = {
+      _id: { toString: () => '64c000000000000000000ace' },
+      sha256: 'cache-sha',
+      storageKey: 'public/content/2026/06/ca/cache-sha.png',
+      status: 'active',
+      ownerUserId: '__federation_media_cache__',
+      purpose: 'federation-media-cache',
+      visibility: 'public',
+      metadata: { cached: true },
+      save: jest.fn((): Promise<void> => Promise.resolve()),
+    };
+    mockFileFindOne.mockResolvedValueOnce(existingFile);
+
+    const source = new Readable({
+      read() {
+        this.push(Buffer.from('PNG!'));
+        this.push(null);
+      },
+    });
+
+    const promise = service.uploadFederatedMediaStream(
+      source,
+      'image/png',
+      'federated-post.png',
+      CACHE_MAX_BYTES,
+      'federated-owner-id',
+      { sourceUri: 'https://remote.example/media/1' }
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    resolveUpload?.({ key: capturedTempKey || 'federation/incoming/x', size: 4, contentType: 'image/png' } as FileInfo);
+
+    await expect(promise).resolves.toBe(existingFile);
+
+    expect(existingFile.ownerUserId).toBe('federated-owner-id');
+    expect(existingFile.purpose).toBe('user');
+    expect(existingFile.visibility).toBe('public');
+    expect(existingFile.metadata).toEqual({
+      cached: true,
+      source: 'federation',
+      sourceUri: 'https://remote.example/media/1',
+      promotedFromFederationCache: true,
+    });
+    expect(existingFile.save).toHaveBeenCalledTimes(1);
+    expect(deleteFile).toHaveBeenCalledWith(capturedTempKey);
+
+    source.destroy();
+  });
+
 });
 
 describe('AssetService.uploadFileDirect — empty-file guard', () => {

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -20,6 +20,7 @@ import {
   storageKeyForVisibility,
 } from '../config/cdn';
 import { logger } from '../utils/logger';
+import { ConflictError } from '../utils/error';
 import path from 'path';
 import {
   AssetInitResponse,
@@ -52,6 +53,7 @@ interface StreamedMediaOptions {
   metadata: Record<string, any>;
   tempPrefix: string;
   logLabel: string;
+  dedupeScope?: 'any' | 'federation-cache';
 }
 
 const FEDERATION_AVATAR_OWNER_ID = '__federation__';
@@ -328,32 +330,36 @@ export class AssetService {
     return file;
   }
 
+  private assertStreamedDedupeAllowed(file: IFile, options: StreamedMediaOptions): void {
+    if (options.dedupeScope !== 'federation-cache') {
+      return;
+    }
+
+    if (file.purpose === FEDERATION_MEDIA_CACHE_PURPOSE) {
+      return;
+    }
+
+    throw new ConflictError('Federated media content already exists outside the federation cache');
+  }
+
   private async prepareExistingStreamedMediaFile(file: IFile, options: StreamedMediaOptions): Promise<IFile> {
     if (options.purpose === FEDERATION_MEDIA_CACHE_PURPOSE) {
       return file;
     }
 
-    let changed = false;
     const wasCacheFile = file.purpose === FEDERATION_MEDIA_CACHE_PURPOSE;
-    if (wasCacheFile) {
-      file.ownerUserId = options.ownerUserId;
-      file.purpose = options.purpose;
-      changed = true;
+    if (!wasCacheFile) {
+      return file;
     }
-    if (file.visibility !== options.visibility) {
-      file.visibility = options.visibility;
-      changed = true;
-    }
+
+    file.ownerUserId = options.ownerUserId;
+    file.purpose = options.purpose;
+    file.visibility = options.visibility;
     file.metadata = {
       ...(file.metadata || {}),
       ...options.metadata,
-      ...(wasCacheFile ? { promotedFromFederationCache: true } : {}),
+      promotedFromFederationCache: true,
     };
-    changed = true;
-
-    if (!changed) {
-      return file;
-    }
 
     await file.save();
     fileCache.invalidate(file._id.toString());
@@ -708,6 +714,7 @@ export class AssetService {
       },
       tempPrefix: 'federation/incoming',
       logLabel: 'Federated media',
+      dedupeScope: 'federation-cache',
     });
   }
 
@@ -798,6 +805,12 @@ export class AssetService {
     // never revived.
     const existingFile = await this.findActiveFileBySha(sha256);
     if (existingFile) {
+      try {
+        this.assertStreamedDedupeAllowed(existingFile, options);
+      } catch (error) {
+        await deleteTempKey(`Failed to clean up rejected ${options.logLabel.toLowerCase()} upload`);
+        throw error;
+      }
       let restored = false;
       try {
         restored = await this.restoreMissingStreamedMediaContent(
@@ -857,6 +870,21 @@ export class AssetService {
       if (this.isDuplicateKeyError(error)) {
         const racedFile = await this.findActiveFileBySha(sha256);
         if (racedFile) {
+          try {
+            this.assertStreamedDedupeAllowed(racedFile, options);
+          } catch (dedupeError) {
+            if (racedFile.storageKey !== storageKey) {
+              try {
+                await this.s3Service.deleteFile(storageKey);
+              } catch (cleanupError) {
+                logger.warn(`Failed to clean up rejected duplicate ${options.logLabel.toLowerCase()} storage object`, {
+                  storageKey,
+                  error: cleanupError,
+                });
+              }
+            }
+            throw dedupeError;
+          }
           let restored = false;
           try {
             restored = await this.restoreMissingStreamedMediaContent(


### PR DESCRIPTION
### Motivation

- A durable federation upload path was reusing any active file that matched an uploaded SHA-256 and unconditionally mutating its visibility/metadata, allowing a `files:write` service token to expose or alter unrelated private user files. The change prevents cross-tenant exposure while preserving federation cache promotion.

### Description

- Introduce a `dedupeScope` option on `StreamedMediaOptions` and a guard `assertStreamedDedupeAllowed` that rejects dedupe when the upload is scoped to the federation cache but the matched file is not a cache record, returning a `409 Conflict` instead of mutating tenant files (`packages/api/src/services/assetService.ts`).
- Restrict `prepareExistingStreamedMediaFile` so only records with purpose `federation-media-cache` are promoted; ordinary user-owned files are returned unchanged and not repurposed for federation uploads (`packages/api/src/services/assetService.ts`).
- Mark `uploadFederatedMediaStream` to use `dedupeScope: 'federation-cache'` so durable federation uploads only dedupe/promote against explicit cache records (`packages/api/src/services/assetService.ts`).
- Add safe cleanup around rejected dedupe and duplicate-save race paths so temporary/duplicate S3 keys are removed when a federated dedupe is rejected (`packages/api/src/services/assetService.ts`).
- Add regression tests that verify a matching private user file is not mutated and that a `federation-media-cache` record can still be promoted (`packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts`).

### Testing

- Ran `git diff --check` to validate patch formatting (no failures). 
- Added unit tests covering the two regression cases in `uploadCachedMediaStream.abort.test.ts`, but running them locally was blocked: `bun install` failed due to package download `403` errors from the npm registry, and `jest` was not available in the environment, so `bun run test --runTestsByPath ...` could not be executed. 
- No automated test failures were observed in this environment because the test runner could not be executed; the new tests are included for CI / local runs where dependencies can be installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db3494832388ba59b4935fe364)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/285" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->