### PR TITLE
fix(core): trust only verified identities for rate limits

### DIFF
--- a/packages/core/src/server/__tests__/rateLimit.test.ts
+++ b/packages/core/src/server/__tests__/rateLimit.test.ts
@@ -1,0 +1,116 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import type { OxyServices } from '../../OxyServices';
+
+const rateLimitMock = jest.fn();
+
+jest.mock('express-rate-limit', () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => rateLimitMock(...args),
+}));
+
+import { createOxyRateLimit } from '../rateLimit';
+
+interface CapturedRateLimitOptions {
+  max: (req: Request) => number;
+  keyGenerator: (req: Request) => string;
+  skip: (req: Request) => boolean;
+}
+
+interface RateLimitTestRequest extends Request {
+  userId?: string | null;
+  user?: { id?: string; _id?: string } | null;
+  sessionId?: string | null;
+  serviceApp?: { appId?: string } | null;
+  serviceActingAs?: { userId?: string } | null;
+  observedMax?: number;
+  observedKey?: string;
+}
+
+function makeOxy(authHandler: RequestHandler): OxyServices {
+  return {
+    auth: jest.fn(() => authHandler),
+  } as unknown as OxyServices;
+}
+
+function makeRequest(overrides: Partial<RateLimitTestRequest> = {}): RateLimitTestRequest {
+  return {
+    method: 'GET',
+    path: '/api/test',
+    ip: '203.0.113.9',
+    socket: { remoteAddress: '203.0.113.9' },
+    ...overrides,
+  } as RateLimitTestRequest;
+}
+
+describe('@oxyhq/core/server rate limiter', () => {
+  beforeEach(() => {
+    rateLimitMock.mockImplementation((options: CapturedRateLimitOptions) => {
+      return (req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+        req.observedMax = options.max(req);
+        req.observedKey = options.keyGenerator(req);
+        next();
+      };
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not trust locally decoded non-session JWT identities for quota or bucket keys', () => {
+    const oxy = makeOxy((req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+      req.userId = 'attacker-controlled-user';
+      req.user = { id: 'attacker-controlled-user' };
+      next();
+    });
+    const req = makeRequest();
+    const next = jest.fn();
+
+    createOxyRateLimit(oxy, { authenticatedMax: 5000, anonymousMax: 600 })(
+      req,
+      {} as Response,
+      next,
+    );
+
+    expect(req.observedMax).toBe(600);
+    expect(req.observedKey).toBe('203.0.113.9');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses authenticated quota and per-user keys for server-validated sessions', () => {
+    const oxy = makeOxy((req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+      req.userId = 'validated-user';
+      req.user = { id: 'validated-user' };
+      req.sessionId = 'validated-session';
+      next();
+    });
+    const req = makeRequest();
+
+    createOxyRateLimit(oxy, { authenticatedMax: 5000, anonymousMax: 600 })(
+      req,
+      {} as Response,
+      jest.fn(),
+    );
+
+    expect(req.observedMax).toBe(5000);
+    expect(req.observedKey).toBe('user:validated-user');
+  });
+
+  it('continues through the anonymous limiter if optional auth returns an error', () => {
+    const oxy = makeOxy((_req: Request, _res: Response, next: NextFunction) => {
+      next(new Error('token rejected'));
+    });
+    const req = makeRequest();
+    const next = jest.fn();
+
+    createOxyRateLimit(oxy, { authenticatedMax: 5000, anonymousMax: 600 })(
+      req,
+      {} as Response,
+      next,
+    );
+
+    expect(req.observedMax).toBe(600);
+    expect(req.observedKey).toBe('203.0.113.9');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/server/rateLimit.ts
+++ b/packages/core/src/server/rateLimit.ts
@@ -41,6 +41,9 @@ import type { OxyServices } from '../OxyServices';
 interface OxyAuthedRequest extends Request {
   userId?: string | null;
   user?: { id?: string; _id?: string } | null;
+  sessionId?: string | null;
+  serviceApp?: { appId?: string } | null;
+  serviceActingAs?: { userId?: string } | null;
 }
 
 export interface OxyRateLimitOptions {
@@ -101,11 +104,39 @@ function ipKeyGenerator(ip: string): string {
   return ip.replace(/:/g, '_');
 }
 
-/** Resolve the rate-limit key: per authenticated user, else per (IPv6-safe) IP. */
-function resolveKey(req: OxyAuthedRequest): string {
+/**
+ * Resolve the trusted authenticated rate-limit key.
+ *
+ * `oxy.auth({ optional: true })` preserves legacy non-session user tokens by
+ * decoding their JWT claims locally. Those claims are not cryptographically
+ * verified and therefore MUST NOT influence abuse-control buckets. Only use
+ * identities that came from a server-validated session or a verified service
+ * token/delegation.
+ */
+function resolveTrustedAuthenticatedKey(req: OxyAuthedRequest): string | null {
   const userId = req.userId ?? req.user?.id ?? req.user?._id;
-  if (userId) {
+  if (userId && req.sessionId) {
     return `user:${userId}`;
+  }
+
+  const delegatedUserId = req.serviceActingAs?.userId;
+  if (delegatedUserId && req.serviceApp?.appId) {
+    return `user:${delegatedUserId}`;
+  }
+
+  const serviceAppId = req.serviceApp?.appId;
+  if (serviceAppId) {
+    return `service:${serviceAppId}`;
+  }
+
+  return null;
+}
+
+/** Resolve the rate-limit key: per trusted authenticated identity, else per (IPv6-safe) IP. */
+function resolveKey(req: OxyAuthedRequest): string {
+  const authenticatedKey = resolveTrustedAuthenticatedKey(req);
+  if (authenticatedKey) {
+    return authenticatedKey;
   }
   const ip = req.ip || req.socket.remoteAddress || 'unknown';
   return ipKeyGenerator(ip);
@@ -139,9 +170,9 @@ export function createOxyRateLimit(
     windowMs,
     ...(store ? { store } : {}),
     max: (req: Request): number => {
-      const authed = req as OxyAuthedRequest;
-      const userId = authed.userId ?? authed.user?.id ?? authed.user?._id;
-      return userId ? authenticatedMax : anonymousMax;
+      return resolveTrustedAuthenticatedKey(req as OxyAuthedRequest)
+        ? authenticatedMax
+        : anonymousMax;
     },
     keyGenerator: (req: Request): string => resolveKey(req as OxyAuthedRequest),
     message,
@@ -160,8 +191,8 @@ export function createOxyRateLimit(
     resolveSession(req, res, (err?: unknown) => {
       if (err) {
         // Optional auth never rejects; a token error just means "anonymous".
-        // Swallow the error and continue to limit as anonymous.
-        next();
+        // Swallow the error and continue through the anonymous limiter.
+        limiter(req, res, next);
         return;
       }
       limiter(req, res, next);


### PR DESCRIPTION
### Motivation
- Prevent forged/unsigned JWT claims (non-session tokens decoded locally) from being treated as authenticated identities for abuse controls. 
- Avoid attacker-controlled user IDs being used as rate-limit keys to shard traffic and bypass anonymous/IP limits. 
- Ensure the new `createOxyRateLimit` middleware only grants the higher authenticated quota to server-validated sessions or verified service/delegation contexts.

### Description
- Restrict trusted keys in `packages/core/src/server/rateLimit.ts` by adding `sessionId`, `serviceApp`, and `serviceActingAs` to the resolved request shape and by introducing `resolveTrustedAuthenticatedKey()` which only returns an authenticated key for server-validated sessions or verified service/delegation; otherwise it returns `null`.
- Update `resolveKey()` to prefer the trusted authenticated key (from `resolveTrustedAuthenticatedKey`) and fall back to an IPv6-safe IP key when no trusted identity exists. 
- Change the limiter `max` selection to use `resolveTrustedAuthenticatedKey()` so locally decoded non-session JWTs no longer receive the authenticated quota. 
- Ensure optional-auth errors do not skip limiting by continuing through the anonymous limiter (call `limiter(req, res, next)` on auth error instead of bypassing). 
- Add focused unit tests at `packages/core/src/server/__tests__/rateLimit.test.ts` covering forged non-session identities, validated sessions, and optional-auth error fallback.

### Testing
- Ran `git diff --check` locally to validate formatting and found no whitespace errors. 
- Added Jest tests at `packages/core/src/server/__tests__/rateLimit.test.ts` that assert non-session JWTs are treated as anonymous, validated sessions get authenticated quota and user keys, and optional-auth errors fall back to anonymous limiting. 
- Attempted to run package tests (`bun run --filter @oxyhq/core test -- src/server/__tests__/rateLimit.test.ts`) but the environment lacked `jest` (test runner not installed), so the test run failed; also ran `bun install` but it failed due to external registry (npm) 403 errors, preventing full test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc5e24832385c50c9856bef206)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->