### PR TITLE
fix(inbox): clear email state on account changes

### DIFF
--- a/packages/inbox/components/MailboxDrawer.tsx
+++ b/packages/inbox/components/MailboxDrawer.tsx
@@ -6,7 +6,8 @@
  * pill, Create folder) are hidden until the user is authenticated.
  */
 
-import React, { useMemo, useCallback, useState, useRef } from 'react';
+import React, { useMemo, useCallback, useState, useRef, useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   View,
   Text,
@@ -166,6 +167,7 @@ export function MailboxDrawer({ onClose, onToggle, collapsed }: { onClose?: () =
   const colors = useColors();
   const { user, isAuthenticated } = useOxy();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const insets = useSafeAreaInsets();
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
   const [accountMenuAnchor, setAccountMenuAnchor] = useState<AccountMenuAnchor | null>(null);
@@ -206,6 +208,14 @@ export function MailboxDrawer({ onClose, onToggle, collapsed }: { onClose?: () =
     [],
   );
 
+  const resetInboxForAccountChange = useCallback(() => {
+    useEmailStore.getState().resetAccountScopedState();
+    queryClient.removeQueries({ queryKey: ['mailboxes'] });
+    queryClient.removeQueries({ queryKey: ['labels'] });
+    queryClient.removeQueries({ queryKey: ['messages'] });
+    queryClient.removeQueries({ queryKey: ['message'] });
+  }, [queryClient]);
+
   const handleCloseMenu = useCallback(() => {
     setAccountMenuOpen(false);
   }, []);
@@ -214,8 +224,9 @@ export function MailboxDrawer({ onClose, onToggle, collapsed }: { onClose?: () =
     setAccountMenuOpen(false);
     // Open the sign-in modal to authenticate a new account.
     // OxyContext picks up the new session and AccountMenu reflects it.
+    resetInboxForAccountChange();
     showSignInModal();
-  }, []);
+  }, [resetInboxForAccountChange]);
 
   const handleNavigateManage = useCallback(() => {
     setAccountMenuOpen(false);
@@ -228,6 +239,17 @@ export function MailboxDrawer({ onClose, onToggle, collapsed }: { onClose?: () =
   const toggleMore = useEmailStore((s) => s.toggleMore);
   const { data: mailboxes = [] } = useMailboxes();
   const { data: labels = [] } = useLabels();
+
+  const activeUserId = user?.id ?? user?._id ?? null;
+  const previousUserIdRef = useRef<string | null>(activeUserId);
+
+  useEffect(() => {
+    if (previousUserIdRef.current === activeUserId) {
+      return;
+    }
+    previousUserIdRef.current = activeUserId;
+    resetInboxForAccountChange();
+  }, [activeUserId, resetInboxForAccountChange]);
 
   // Determine active state from URL pathname.
   // Path shapes we care about here:
@@ -689,6 +711,7 @@ export function MailboxDrawer({ onClose, onToggle, collapsed }: { onClose?: () =
           onNavigateManage={handleNavigateManage}
           onAddAccount={handleAddAccount}
           anchor={accountMenuAnchor}
+          onBeforeSessionChange={resetInboxForAccountChange}
         />
       )}
     </View>

--- a/packages/inbox/hooks/useEmail.ts
+++ b/packages/inbox/hooks/useEmail.ts
@@ -28,6 +28,7 @@ interface EmailState {
   isSelectionMode: boolean;
   _api: EmailApiInstance | null;
   _initApi: (http: HttpService) => EmailApiInstance;
+  resetAccountScopedState: () => void;
   selectMailbox: (mailbox: Mailbox) => void;
   selectStarred: () => void;
   selectLabel: (labelId: string, labelName: string) => void;
@@ -61,6 +62,18 @@ export const useEmailStore = create<EmailState>((set, get) => ({
     const api = createEmailApi(http);
     set({ _api: api });
     return api;
+  },
+
+  resetAccountScopedState: () => {
+    set({
+      currentMailbox: null,
+      viewMode: null,
+      selectedMessageId: null,
+      expandedBundles: new Set<string>(),
+      selectedMessageIds: new Set<string>(),
+      isSelectionMode: false,
+      _api: null,
+    });
   },
 
   selectMailbox: (mailbox) => {

--- a/packages/services/src/ui/components/AccountMenu.tsx
+++ b/packages/services/src/ui/components/AccountMenu.tsx
@@ -53,6 +53,8 @@ export interface AccountMenuProps {
     onAddAccount: () => void;
     /** Optional anchor (web only). Native ignores this and uses bottom-sheet style. */
     anchor?: AccountMenuAnchor | null;
+    /** Called before the active identity changes so apps can clear tenant-scoped state. */
+    onBeforeSessionChange?: () => void | Promise<void>;
 }
 
 const isWeb = Platform.OS === 'web';
@@ -76,6 +78,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
     onNavigateManage,
     onAddAccount,
     anchor,
+    onBeforeSessionChange,
 }) => {
     const {
         activeSessionId,
@@ -131,6 +134,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
         }
         setBusySessionId(sessionId);
         try {
+            await onBeforeSessionChange?.();
             await switchSession(sessionId);
             toast.success(t('accountSwitcher.toasts.switchSuccess') || 'Switched account');
             onClose();
@@ -142,7 +146,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
         } finally {
             setBusySessionId(null);
         }
-    }, [activeSessionId, busySessionId, switchSession, t, onClose]);
+    }, [activeSessionId, busySessionId, switchSession, t, onClose, onBeforeSessionChange]);
 
     // Sign out a SPECIFIC inactive account from its per-row icon. `removeSession`
     // is the SDK's canonical per-session sign-out: it targets the given session
@@ -171,6 +175,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
         }
         setSigningOut(true);
         try {
+            await onBeforeSessionChange?.();
             await logout();
             toast.success(t('common.actions.signedOut') || 'Signed out');
             onClose();
@@ -180,7 +185,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
         } finally {
             setSigningOut(false);
         }
-    }, [signingOut, logout, t, onClose]);
+    }, [signingOut, logout, t, onClose, onBeforeSessionChange]);
 
     const performSignOutAll = useCallback(async () => {
         if (signingOutAll) {
@@ -188,6 +193,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
         }
         setSigningOutAll(true);
         try {
+            await onBeforeSessionChange?.();
             await logoutAll();
             toast.success(t('accountSwitcher.toasts.signOutAllSuccess') || 'Signed out of all accounts');
             onClose();
@@ -197,7 +203,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
         } finally {
             setSigningOutAll(false);
         }
-    }, [signingOutAll, logoutAll, t, onClose]);
+    }, [signingOutAll, logoutAll, t, onClose, onBeforeSessionChange]);
 
     // Escape-to-close + focus management (web only).
     useEffect(() => {


### PR DESCRIPTION
### Motivation
- Replacing the Inbox-specific switcher with the shared `AccountMenu` removed the Inbox reset path, allowing React Query caches and Inbox Zustand state to persist across session switches and sign-outs and potentially expose another account's private email data in the same page lifetime.
- The change restores a minimal, app-scoped invalidation/reset path so tenant-scoped caches and the Email API instance are dropped before the active identity changes.

### Description
- Added an optional `onBeforeSessionChange?: () => void | Promise<void>` prop to the shared `AccountMenu` and invoke it before calling `switchSession`, `logout`, and `logoutAll` so consuming apps can clear tenant-scoped state first (`packages/services/src/ui/components/AccountMenu.tsx`).
- Added `resetAccountScopedState()` to the Inbox Zustand store to clear `currentMailbox`, `viewMode`, `selectedMessageId`, `expandedBundles`, `selectedMessageIds`, `isSelectionMode`, and set `_api` to `null` so the Email API is rebuilt for the new identity (`packages/inbox/hooks/useEmail.ts`).
- Wired the Inbox `MailboxDrawer` to provide a `resetInboxForAccountChange` callback that calls the new store reset and removes React Query caches for the `['mailboxes']`, `['labels']`, `['messages']`, and `['message']` namespaces, and passed it to `AccountMenu` as `onBeforeSessionChange`; also call the reset when adding an account and when `user.id` changes (`packages/inbox/components/MailboxDrawer.tsx`).
- Only minimal imports and hooks were added: `useQueryClient` and a `useEffect` to observe the active user id; no behavioral changes to SDK switch/logout logic were made.

### Testing
- `git diff --check` was run and reported no whitespace/patch issues (success).
- `bun run --filter @oxyhq/services lint` was attempted but blocked in this environment because `biome` is not installed (not executed here).
- `bun run --filter @oxyhq/services test --runInBand` was attempted but blocked because `jest` is not available in this environment (not executed here).
- `bun run --filter @oxyhq/services typescript` and `bun run --filter inbox build` were attempted but blocked by missing workspace dependencies/types and a `403` resolving `expo` from the registry respectively (typecheck/build not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db7b088323b3c08026d7309750)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->