### PR TITLE
fix(auth): dedupe eager SSO session commit

### DIFF
--- a/packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx
@@ -35,6 +35,8 @@ interface CoreStubs {
   exchangeSsoCode: jest.Mock<Promise<SessionLoginResponse>, [string]>;
   generateSsoState: jest.Mock<string, []>;
   managerInitialize: jest.Mock<Promise<User | null>, []>;
+  managerHandleAuthSuccess: jest.Mock<Promise<void>, [SessionLoginResponse, 'fedcm' | 'redirect' | 'credentials']>;
+  managerRestoreFromCookies: jest.Mock<Promise<void>, []>;
   getActiveAccount: jest.Mock<{ sessionId: string } | null, []>;
   baseURL: string;
 }
@@ -47,6 +49,8 @@ const stubs: CoreStubs = {
   exchangeSsoCode: jest.fn(async () => ({}) as SessionLoginResponse),
   generateSsoState: jest.fn(() => 'state-fixed'),
   managerInitialize: jest.fn(async () => null),
+  managerHandleAuthSuccess: jest.fn(async () => undefined),
+  managerRestoreFromCookies: jest.fn(async () => undefined),
   getActiveAccount: jest.fn(() => null),
   baseURL: 'https://api.oxy.so',
 };
@@ -59,6 +63,8 @@ function resetStubs(baseURL: string): void {
   stubs.exchangeSsoCode = jest.fn(async () => ({}) as SessionLoginResponse);
   stubs.generateSsoState = jest.fn(() => 'state-fixed');
   stubs.managerInitialize = jest.fn(async () => null);
+  stubs.managerHandleAuthSuccess = jest.fn(async () => undefined);
+  stubs.managerRestoreFromCookies = jest.fn(async () => undefined);
   stubs.getActiveAccount = jest.fn(() => null);
   stubs.baseURL = baseURL;
 }
@@ -113,12 +119,13 @@ jest.mock('@oxyhq/core', () => {
       getActiveAccount: () => stubs.getActiveAccount(),
       getAccounts: () => [],
       getActiveAuthuser: () => null,
-      handleAuthSuccess: jest.fn(async () => undefined),
-      restoreFromCookies: jest.fn(async () => undefined),
+      handleAuthSuccess: (session: SessionLoginResponse, method: 'fedcm' | 'redirect' | 'credentials') => stubs.managerHandleAuthSuccess(session, method),
+      restoreFromCookies: () => stubs.managerRestoreFromCookies(),
       signOutAllViaCookies: jest.fn(async () => undefined),
       destroy: jest.fn(),
     }),
   };
+
 });
 
 import { WebOxyProvider, useAuth } from '../src/WebOxyProvider';
@@ -206,4 +213,29 @@ describe('WebOxyProvider eager SSO callback interception', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(bounced()).toBe(false);
   });
+
+  it('ok: eagerly shares callback exchange but commits the SSO session only once', async () => {
+    resetStubs('https://api.intercept-ok');
+    window.sessionStorage.setItem(ssoStateKey(ORIGIN), 's');
+    window.sessionStorage.setItem(ssoDestKey(ORIGIN), `${ORIGIN}${DEST_PATH}`);
+    setLocation(`${ORIGIN}${SSO_CALLBACK_PATH}#oxy_sso=ok&code=code-1&state=s`);
+
+    const user = { id: 'user-1', username: 'u1', name: { displayName: 'User One' } } as User;
+    stubs.exchangeSsoCode = jest.fn(async () => ({
+      user,
+      sessionId: 'session-1',
+      token: 'token-1',
+    }) as SessionLoginResponse);
+
+    let latest: ProbeState = { isAuthenticated: false, userId: null, isLoading: true };
+    renderProvider(stubs.baseURL, (state) => { latest = state; });
+
+    await waitFor(() => expect(latest.userId).toBe('user-1'));
+
+    expect(stubs.exchangeSsoCode).toHaveBeenCalledTimes(1);
+    expect(stubs.managerHandleAuthSuccess).toHaveBeenCalledTimes(1);
+    expect(stubs.managerRestoreFromCookies).toHaveBeenCalledTimes(1);
+    expect(latest.isAuthenticated).toBe(true);
+  });
+
 });

--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -422,6 +422,22 @@ export function WebOxyProvider({
   const handleAuthSuccessRef = useRef(handleAuthSuccess);
   handleAuthSuccessRef.current = handleAuthSuccess;
 
+  const committedSsoSessionsRef = useRef<WeakSet<SessionLoginResponse>>(new WeakSet());
+  const commitSsoSessionOnce = useCallback(async (session: SessionLoginResponse) => {
+    // The eager callback interceptor and cold-boot SSO step intentionally share
+    // one exchange promise, but both can observe its non-null session. Commit
+    // before awaiting so overlapping callers cannot both run the side-effectful
+    // post-login cookie restore/rotation path for the same SSO return.
+    if (committedSsoSessionsRef.current.has(session)) {
+      return;
+    }
+    committedSsoSessionsRef.current.add(session);
+    await handleAuthSuccessRef.current(session, 'credentials');
+  }, []);
+
+  const commitSsoSessionOnceRef = useRef(commitSsoSessionOnce);
+  commitSsoSessionOnceRef.current = commitSsoSessionOnce;
+
   const handleAuthError = useCallback((err: unknown) => {
     const errorMessage = err instanceof Error ? err.message : 'Authentication failed';
     setError(errorMessage);
@@ -704,7 +720,11 @@ export function WebOxyProvider({
         case 'redirect':
         case 'fedcm':
         case 'sso':
-          await handleAuthSuccess(outcome.session.session, outcome.session.method === 'sso' ? 'credentials' : outcome.session.method);
+          if (outcome.session.method === 'sso') {
+            await commitSsoSessionOnceRef.current(outcome.session.session);
+          } else {
+            await handleAuthSuccess(outcome.session.session, outcome.session.method);
+          }
           return;
         case 'cookie': {
           syncAccountsFromManager();
@@ -763,7 +783,7 @@ export function WebOxyProvider({
       runSsoReturnRef.current()
         .then(async (session) => {
           if (session) {
-            await handleAuthSuccess(session.session, 'credentials');
+            await commitSsoSessionOnceRef.current(session.session);
             return;
           }
           // No SSO return to commit. Re-evaluate the bounce gate: if a session
@@ -819,7 +839,7 @@ export function WebOxyProvider({
     runSsoReturnRef.current()
       .then(async (session) => {
         if (session) {
-          await handleAuthSuccessRef.current(session.session, 'credentials');
+          await commitSsoSessionOnceRef.current(session.session);
         }
       })
       .catch((err) => {


### PR DESCRIPTION
### Motivation
- Prevent duplicate post-login side effects when both the eager callback interceptor and the cold-boot SSO step observe the same shared SSO-return result, which could cause concurrent `restoreFromCookies()` calls and refresh-token reuse revocation. 
- Ensure the SSO exchange remains deduped while also deduping the subsequent session commit so the SDK does not trigger overlapping cookie-rotation network requests for the same login.

### Description
- Add a once-per-session commit guard (`commitSsoSessionOnce`) backed by a `WeakSet` of returned `SessionLoginResponse` objects in `packages/auth-sdk/src/WebOxyProvider.tsx`. 
- Route all SSO commit sites (cold-boot `sso` branch, bfcache `pageshow`, and the eager `/__oxy/sso-callback` interception) through `commitSsoSessionOnce` so `handleAuthSuccess` / `restoreFromCookies` run at most once per exchanged session. 
- Update the `WebOxyProvider` bfcache/eager/cold-boot call sites to use the dedup helper while preserving existing FedCM/redirect commit behavior. 
- Add a regression test to `packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx` that stubs `AuthManager` calls and asserts a single code exchange and a single `handleAuthSuccess`/`restoreFromCookies` commit for an `ok` SSO callback.

### Testing
- Ran `git diff --check` to validate whitespace/patch sanity and found no issues. 
- Added a focused Jest regression test `packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx` that asserts one exchange and one commit for an `ok` callback (test added but not executed in this environment). 
- Attempted to run the test with `bun run test` and to install dependencies with `bun install --frozen-lockfile`, but execution was blocked due to the environment lacking `jest` and external registry `403` errors, so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbcfe8832389a3b441c495a7e6)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/288" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->