### PR TITLE
fix(api): bound public profile recommendation aggregation

### DIFF
--- a/packages/api/src/models/Follow.ts
+++ b/packages/api/src/models/Follow.ts
@@ -43,5 +43,8 @@ FollowSchema.index(
   { followerUserId: 1, followType: 1, followedId: 1 },
   { unique: true }
 );
+// Supports bounded public recommendations by scanning only a recent,
+// followType-filtered prefix before grouping popular followed users.
+FollowSchema.index({ followType: 1, createdAt: -1, _id: 1 });
 
 export default mongoose.model<IFollow>("Follow", FollowSchema);

--- a/packages/api/src/routes/__tests__/profilesRecommendations.test.ts
+++ b/packages/api/src/routes/__tests__/profilesRecommendations.test.ts
@@ -346,10 +346,11 @@ describe('GET /profiles/recommendations exclusion set', () => {
     expect(excludedIds).toEqual([userA.toString(), userB.toString(), userC.toString()].sort());
   });
 
-  it('returns 200 with public profiles for an unauthenticated caller', async () => {
+  it('returns 200 with public profiles for an unauthenticated caller from a bounded follow window', async () => {
     currentUserId = undefined;
 
-    // Public path: follower-ranked aggregation over the Follow collection.
+    // Public path: follower-ranked aggregation over a capped recent Follow
+    // window so unauthenticated callers cannot force whole-graph grouping.
     mockFollowAggregate.mockResolvedValue([
       { _id: userD, username: 'd', name: 'D', followersCount: 5, followingCount: 2, mutualCount: 0 },
     ]);
@@ -365,6 +366,16 @@ describe('GET /profiles/recommendations exclusion set', () => {
     expect(returnedIds).toContain(userD.toString());
     // The personalized following-set query is never issued without a caller.
     expect(mockFollowFind).not.toHaveBeenCalled();
+
+    const pipeline = mockFollowAggregate.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(pipeline).toEqual(
+      expect.arrayContaining([
+        { $match: expect.objectContaining({ followType: 'user' }) },
+        { $sort: { createdAt: -1, _id: 1 } },
+        { $limit: 5000 },
+        { $group: { _id: '$followedId', followersCount: { $sum: 1 } } },
+      ])
+    );
   });
 
   it('requires recently resolved federated users in recommendation pipelines', async () => {

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -86,6 +86,11 @@ const MAX_USERNAME_LENGTH = 30;
 // filter on the public recommendations path, so post-lookup filtering can't
 // shrink the page below the requested limit.
 const PUBLIC_FILTER_HEADROOM = 20;
+// Bound the unauthenticated popularity fallback so a public request cannot
+// aggregate the entire social graph. The sorted prefix is supported by
+// Follow's { followType, createdAt, _id } index and keeps work independent of the
+// total follows collection size.
+const PUBLIC_POPULAR_FOLLOW_WINDOW = 5000;
 
 /**
  * Shared aggregation stages that look up follower and following counts
@@ -672,6 +677,8 @@ async function buildPopularFallback(
 
   const followerRanked = await Follow.aggregate<RecommendationRow>([
     { $match: { followType: FollowType.USER, followedId: { $nin: excludeIds } } },
+    { $sort: { createdAt: -1, _id: 1 } },
+    { $limit: PUBLIC_POPULAR_FOLLOW_WINDOW },
     { $group: { _id: '$followedId', followersCount: { $sum: 1 } } },
     { $sort: { followersCount: -1, _id: 1 } },
     { $skip: parsedOffset },


### PR DESCRIPTION
### Motivation
- The unauthenticated public recommendations path performed an unbounded `Follow.aggregate` grouped by `followedId`, which can scan/group/sort most or all of the `follows` collection and allows remote resource exhaustion as the graph grows.
- The change confines public recommendations to a recent prefix of follows so work is bounded and independent of total collection size.

### Description
- Added a capped popularity window constant `PUBLIC_POPULAR_FOLLOW_WINDOW` and limited the public fallback pipeline to a recent prefix by inserting `{$sort: { createdAt: -1, _id: 1 }}` and `{$limit: PUBLIC_POPULAR_FOLLOW_WINDOW}` before the `$group` in `packages/api/src/routes/profiles.ts`.
- Created a supporting index `FollowSchema.index({ followType: 1, createdAt: -1, _id: 1 })` in `packages/api/src/models/Follow.ts` to make the bounded scan efficient and index-backed.
- Updated the route test `packages/api/src/routes/__tests__/profilesRecommendations.test.ts` to assert the public pipeline includes the bounded `sort`/`limit` prefix and renamed the test accordingly.

### Testing
- Ran `git diff --check` to validate no obvious diff errors and committed the fix as `fix(api): bound public profile recommendation aggregation`.
- Attempted to run package tests with `bun run test -- profilesRecommendations.test.ts` but `jest` was not available in the environment because `bun install` failed due to external npm registry `403` errors, so unit tests could not be executed here.
- The modified unit test was updated to assert the new bounded pipeline and should pass in CI once dependencies are installable and the test suite is run there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db5af08323a18a724f0c6bb447)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->