### PR TITLE
Fix FedCM client approval cache staleness

### DIFF
--- a/packages/api/src/services/__tests__/fedcm.service.test.ts
+++ b/packages/api/src/services/__tests__/fedcm.service.test.ts
@@ -64,15 +64,12 @@ jest.mock('../../models/Application', () => ({
   default: { find: mockAppFind },
 }));
 
-// Pass-through cache: read methods delegate straight to the loader (the
-// uncached Mongo read driven by the FedCMClient mocks above) so approval
-// lookups behave exactly as before; only `invalidate` is asserted on.
+// Pass-through cache for non-authoritative list reads; approval decisions
+// bypass this cache and read the canonical registry directly.
 jest.mock('../../utils/approvedClientsCache', () => ({
   __esModule: true,
   default: {
     getApprovedOrigins: (loader: () => Promise<string[]>) => loader(),
-    isApproved: async (origin: string, loader: () => Promise<string[]>) =>
-      (await loader()).includes(origin),
     invalidate: mockCacheInvalidate,
   },
 }));
@@ -358,6 +355,23 @@ describe('FedCM exchangeIdToken (H9)', () => {
     expect('error' in result).toBe(false);
     if ('error' in result) return;
     expect(result.sessionId).toBe('sess-123');
+  });
+});
+
+describe('FedCM isClientApproved authorization', () => {
+  it('bypasses the list cache and rereads the registry after revocation', async () => {
+    mockAppFind
+      .mockReturnValueOnce(
+        leanQuery([{ name: 'Relying Party', redirectUris: [`${APPROVED_ORIGIN}/__oxy/sso-callback`] }])
+      )
+      .mockReturnValueOnce(leanQuery([]));
+
+    await expect(fedcmService.isClientApproved(APPROVED_ORIGIN)).resolves.toBe(true);
+    await expect(fedcmService.isClientApproved(APPROVED_ORIGIN)).resolves.toBe(false);
+
+    expect(mockAppFind).toHaveBeenCalledTimes(2);
+    expect(mockAppFind).toHaveBeenNthCalledWith(1, { status: 'active' });
+    expect(mockAppFind).toHaveBeenNthCalledWith(2, { status: 'active' });
   });
 });
 

--- a/packages/api/src/services/fedcm.service.ts
+++ b/packages/api/src/services/fedcm.service.ts
@@ -254,13 +254,22 @@ class FedCMService {
   }
 
   /**
-   * Check if a client origin is approved (short-TTL cached membership test).
-   * Fail-closed: any unexpected throw resolves to `false`, and the cache loader
-   * itself returns `[]` on Mongo error so a DB hiccup denies rather than admits.
+   * Check if a client origin is currently approved.
+   *
+   * Authorization decisions intentionally bypass the in-process allow-list cache:
+   * oxy-api runs multiple ECS tasks, and a revoke handled by one task cannot
+   * synchronously clear another task's local memory. Reading the canonical
+   * registry on every approval check prevents a recently-revoked RP from being
+   * accepted by a stale task during the cache TTL window.
+   *
+   * Fail-closed: any unexpected throw resolves to `false`. The uncached loader
+   * itself returns the dev/native fallback on Mongo error, so unknown origins are
+   * denied while local/native development origins remain usable.
    */
   async isClientApproved(origin: string): Promise<boolean> {
     try {
-      return await approvedClientsCache.isApproved(origin, () => this.fetchApprovedClientOrigins());
+      const origins = await this.fetchApprovedClientOrigins();
+      return origins.includes(origin);
     } catch (error) {
       logger.error('Error checking FedCM client approval:', error);
       return false;

--- a/packages/api/src/utils/approvedClientsCache.ts
+++ b/packages/api/src/utils/approvedClientsCache.ts
@@ -10,22 +10,13 @@ const LOCAL_KEY = 'approved:origins';
 const LOG_COMPONENT = 'ApprovedClientsCache';
 
 /**
- * In-process cache for the FedCM approved-clients allow-list.
+ * In-process cache for non-authoritative FedCM approved-client list reads.
  *
- * Collapses the 3-5 redundant `FedCMClient` reads per SSO/FedCM sign-in
- * (preflight + POST in `ssoExchangeCors`, `issueSsoCode`, `exchangeIdToken`,
- * and `getUserGrantedOrigins` on cold boot) into at most one Mongo read per
- * TTL window. The approved set is tiny and changes rarely (create / delete /
- * seed only), so the whole origin list is cached as a single entry.
- *
- * MULTI-TASK CAVEAT: oxy-api runs as multiple ECS Fargate tasks, so this
- * in-process Map is per-task. A revoke (`removeApprovedClient`) on task A
- * clears only task A's cache; other tasks serve the stale list until their own
- * 60s TTL expires. This is acceptable for a rarely-changing allow-list, and
- * revocation is ALSO enforced fail-closed elsewhere: the FedCM exchange
- * re-checks approval against this same list, and the SSO code exchange is
- * origin-bound + single-use. The TTL caps worst-case cross-task staleness at
- * 60s; the best-effort Redis tier shortens it further when Valkey is reachable.
+ * This cache is safe only for list/catalog-style callers that can tolerate a
+ * short refresh delay. Security-sensitive authorization checks must bypass it
+ * and read the canonical registry directly, because oxy-api runs multiple ECS
+ * tasks and a revoke handled by one task cannot synchronously clear another
+ * task's local memory.
  */
 class ApprovedClientsCache {
   private local: Map<string, { origins: string[]; timestamp: number; ttl: number }> = new Map();
@@ -48,15 +39,6 @@ class ApprovedClientsCache {
     const origins = await loader();
     this.setLocal(origins);
     return origins;
-  }
-
-  /**
-   * Membership test against the cached approved-origins list. One source of
-   * truth — no separate per-origin cache to keep coherent.
-   */
-  async isApproved(origin: string, loader: () => Promise<string[]>): Promise<boolean> {
-    const origins = await this.getApprovedOrigins(loader);
-    return origins.includes(origin);
   }
 
   /**


### PR DESCRIPTION
### Motivation
- The in-process approved-clients allow-list introduced per-task staleness where a recently-revoked relying party could still be accepted by other ECS tasks until their local TTL expired, creating a security window for SSO/FedCM flows. 
- Authorization decisions for FedCM must reflect the canonical registry immediately to avoid issuing sessions/tokens to revoked RPs. 
- The change aims to preserve the lightweight list cache for non-authoritative catalog reads while ensuring security-sensitive checks are authoritative.

### Description
- Changed `FedCMService.isClientApproved` to bypass the in-process list cache and call the canonical `fetchApprovedClientOrigins()` on every authorization decision, returning membership from the fresh registry. 
- Updated `approvedClientsCache` comments to document that it is only for non-authoritative list/catalog reads and removed the `isApproved` helper to discourage its use for security-sensitive checks. 
- Added a unit test that simulates an approval followed by a revocation and asserts `isClientApproved()` rereads the registry (i.e., returns true before revocation and false after), and updated the approved-clients cache mock in tests accordingly.

### Testing
- Ran `git diff --check` and static checks for the modified files which succeeded. 
- Attempted to run the FedCM unit tests with `bun run test -- fedcm.service.test.ts` but the runtime environment lacked `jest` so the test run could not complete. 
- Attempted `bun install` to materialize test dependencies but dependency fetches failed (npm registry returned HTTP 403), preventing end-to-end execution of the test suite in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbd0b48323a7dfcbdf0ecfd41f)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->