### PR TITLE
Require service-token scopes for media-cache upload and delete

### DIFF
--- a/packages/api/src/routes/__tests__/assetsServiceCache.test.ts
+++ b/packages/api/src/routes/__tests__/assetsServiceCache.test.ts
@@ -182,7 +182,7 @@ beforeEach(() => {
         type: 'service',
         appId: 'mention-app',
         appName: 'mention',
-        scopes: ['files:write'],
+        scopes: ['files:write', 'federation:write'],
       };
       next();
     }
@@ -223,6 +223,31 @@ describe('POST /assets/service/cache', () => {
     expect(mockUploadCachedMediaStream).toHaveBeenCalledTimes(1);
     // authMiddleware must NOT have run for this service route.
     expect(mockAuthMiddleware).not.toHaveBeenCalled();
+  });
+
+  it('requires the files:write service scope', async () => {
+    mockServiceAuthMiddleware.mockImplementationOnce(
+      (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
+        req.serviceApp = {
+          type: 'service',
+          appId: 'mention-app',
+          appName: 'mention',
+          scopes: ['federation:write'],
+        };
+        next();
+      }
+    );
+
+    const res = await requestRaw(
+      server,
+      'POST',
+      '/assets/service/cache',
+      { 'content-type': 'image/png', 'content-length': '4' },
+      Buffer.from('PNG!')
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockUploadCachedMediaStream).not.toHaveBeenCalled();
   });
 
   it('rejects an unsupported content-type with 415 and never touches S3', async () => {
@@ -379,6 +404,30 @@ describe('DELETE /assets/service/cache/:id', () => {
     expect(res.status).toBe(200);
     expect(mockDeleteCachedMedia).toHaveBeenCalledWith(CACHE_FILE_ID);
     expect(mockAuthMiddleware).not.toHaveBeenCalled();
+  });
+
+  it('requires the federation:write service scope', async () => {
+    mockServiceAuthMiddleware.mockImplementationOnce(
+      (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
+        req.serviceApp = {
+          type: 'service',
+          appId: 'mention-app',
+          appName: 'mention',
+          scopes: ['files:write'],
+        };
+        next();
+      }
+    );
+
+    const res = await requestRaw(
+      server,
+      'DELETE',
+      `/assets/service/cache/${CACHE_FILE_ID}`,
+      {}
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteCachedMedia).not.toHaveBeenCalled();
   });
 
   it('refuses to delete a normal user-owned asset (out of scope) with 403', async () => {

--- a/packages/api/src/routes/assets.ts
+++ b/packages/api/src/routes/assets.ts
@@ -560,13 +560,15 @@ const cacheDeleteLimiter = rateLimit({
  *       namespace. The raw bytes are sent as the request body (NOT multipart)
  *       so large video streams straight to S3 without buffering in RAM.
  *       Content-Type must be image/*, video/*, or audio/*.
- * @access Service token only (serviceAuthMiddleware)
+ * @access Service token only (requires files:write)
  */
 router.post(
   '/service/cache',
   serviceAuthMiddleware,
   cacheUploadLimiter,
   asyncHandler(async (req: ServiceAuthRequest, res: express.Response) => {
+    requireServiceScope(req, 'files:write');
+
     const mime = (req.headers['content-type'] || '').split(';')[0].trim().toLowerCase();
     if (!mime) {
       throw new BadRequestError('Content-Type header is required');
@@ -718,7 +720,7 @@ router.post(
  * @desc Evict a cached media asset by id. Rejects (403) anything that is not
  *       in the reserved cache namespace, so a service token can never delete
  *       user-owned media.
- * @access Service token only (serviceAuthMiddleware)
+ * @access Service token only (requires federation:write)
  */
 router.delete(
   '/service/cache/:id',
@@ -726,6 +728,8 @@ router.delete(
   cacheDeleteLimiter,
   validate({ params: assetIdParams }),
   asyncHandler(async (req: ServiceAuthRequest, res: express.Response) => {
+    requireServiceScope(req, 'federation:write');
+
     const { id: fileId } = req.params;
 
     const result = await assetService.deleteCachedMedia(fileId);


### PR DESCRIPTION
### Motivation
- Close an authorization gap where `POST /assets/service/cache` and `DELETE /assets/service/cache/:id` accepted any valid service token without checking the token's scopes, allowing lower-scoped service credentials to write or evict federation cache objects.
- Enforce least-privilege: uploads should require `files:write` and evictions should require `federation:write` so compromised low-scope tokens cannot abuse the shared cache namespace.

### Description
- Added a scope gate using `requireServiceScope(req, 'files:write')` at the start of the `POST /assets/service/cache` handler to require the `files:write` scope before accepting uploads.
- Added a scope gate using `requireServiceScope(req, 'federation:write')` at the start of the `DELETE /assets/service/cache/:id` handler to require the `federation:write` scope before evicting cached objects.
- Updated the route JSDoc `@access` comments to reflect the required scopes for each service route.
- Updated `packages/api/src/routes/__tests__/assetsServiceCache.test.ts` to set the test service principal's default scopes to include both `files:write` and `federation:write`, and added regression tests that assert upload without `files:write` and delete without `federation:write` return `403` and do not call the asset service.

### Testing
- Ran a pre-commit diff/style check (`git diff --check`) which passed without issues.
- Updated and exercised the unit test file `packages/api/src/routes/__tests__/assetsServiceCache.test.ts` locally, but executing the test runner failed because `jest` was not available in the environment (`jest: command not found`).
- Attempted dependency install with `bun install --frozen-lockfile --ignore-scripts`, but the run was blocked by external registry HTTP 403 errors so full test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db69cc83239425200fec2012c7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->