### PR TITLE
fix(core): bind SSO code exchange to state

### DIFF
--- a/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
@@ -49,7 +49,7 @@ interface CoreStubs {
   handleRedirectCallback: jest.Mock<SessionLoginResponse | null, []>;
   isFedCMSupported: jest.Mock<boolean, []>;
   silentSignInWithFedCM: jest.Mock<Promise<SessionLoginResponse | null>, []>;
-  exchangeSsoCode: jest.Mock<Promise<SessionLoginResponse>, [string]>;
+  exchangeSsoCode: jest.Mock<Promise<SessionLoginResponse>, [string, string?]>;
   generateSsoState: jest.Mock<string, []>;
   managerInitialize: jest.Mock<Promise<User | null>, []>;
   getActiveAccount: jest.Mock<{ sessionId: string } | null, []>;
@@ -117,8 +117,8 @@ jest.mock('@oxyhq/core', () => {
       silentSignInWithFedCM(): Promise<SessionLoginResponse | null> {
         return stubs.silentSignInWithFedCM();
       }
-      exchangeSsoCode(code: string): Promise<SessionLoginResponse> {
-        return stubs.exchangeSsoCode(code);
+      exchangeSsoCode(code: string, state?: string): Promise<SessionLoginResponse> {
+        return stubs.exchangeSsoCode(code, state);
       }
       generateSsoState(): string {
         return stubs.generateSsoState();
@@ -266,7 +266,7 @@ describe('WebOxyProvider cold boot (central SSO)', () => {
     renderProvider(stubs.baseURL, (s) => { latest = s; });
 
     await waitFor(() => expect(latest.isAuthenticated).toBe(true));
-    expect(stubs.exchangeSsoCode).toHaveBeenCalledWith('opaque-2');
+    expect(stubs.exchangeSsoCode).toHaveBeenCalledWith('opaque-2', 'st-2');
     expect(latest.userId).toBe('u1');
     // The fragment is stripped and the real destination restored.
     expect(window.location.hash).toBe('');

--- a/packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx
@@ -32,7 +32,7 @@ interface CoreStubs {
   handleRedirectCallback: jest.Mock<SessionLoginResponse | null, []>;
   isFedCMSupported: jest.Mock<boolean, []>;
   silentSignInWithFedCM: jest.Mock<Promise<SessionLoginResponse | null>, []>;
-  exchangeSsoCode: jest.Mock<Promise<SessionLoginResponse>, [string]>;
+  exchangeSsoCode: jest.Mock<Promise<SessionLoginResponse>, [string, string?]>;
   generateSsoState: jest.Mock<string, []>;
   managerInitialize: jest.Mock<Promise<User | null>, []>;
   getActiveAccount: jest.Mock<{ sessionId: string } | null, []>;
@@ -95,8 +95,8 @@ jest.mock('@oxyhq/core', () => {
       silentSignInWithFedCM(): Promise<SessionLoginResponse | null> {
         return stubs.silentSignInWithFedCM();
       }
-      exchangeSsoCode(code: string): Promise<SessionLoginResponse> {
-        return stubs.exchangeSsoCode(code);
+      exchangeSsoCode(code: string, state?: string): Promise<SessionLoginResponse> {
+        return stubs.exchangeSsoCode(code, state);
       }
       generateSsoState(): string {
         return stubs.generateSsoState();

--- a/packages/core/src/OxyServices.ts
+++ b/packages/core/src/OxyServices.ts
@@ -153,7 +153,7 @@ export interface OxyServices extends InstanceType<ReturnType<typeof composeOxySe
   signUpWithRedirect(options?: RedirectAuthOptions): void;
 
   // Central cross-domain SSO (opaque single-use code exchange)
-  exchangeSsoCode(code: string): Promise<SessionLoginResponse>;
+  exchangeSsoCode(code: string, state?: string): Promise<SessionLoginResponse>;
   generateSsoState(): string;
 
   // Express.js middleware

--- a/packages/core/src/mixins/OxyServices.sso.ts
+++ b/packages/core/src/mixins/OxyServices.sso.ts
@@ -27,6 +27,7 @@ import type { OxyServicesBase } from '../OxyServices.base';
 import type { SessionLoginResponse, MinimalUserData } from '../models/session';
 import type { UserNameResponse } from '@oxyhq/contracts';
 import { createDebugLogger } from '../shared/utils/debugUtils';
+import { ssoStateKey } from '../utils/ssoBounce';
 
 const debug = createDebugLogger('SSO');
 
@@ -67,6 +68,19 @@ export function generateSsoState(): string {
   throw new Error('No secure random source available for SSO state generation');
 }
 
+
+function getStoredSsoStateForCurrentOrigin(): string | null {
+  if (typeof window === 'undefined' || !window.location || !window.sessionStorage) {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage.getItem(ssoStateKey(window.location.origin));
+  } catch {
+    return null;
+  }
+}
+
 export function OxyServicesSsoMixin<T extends typeof OxyServicesBase>(Base: T) {
   return class extends Base {
     constructor(...args: any[]) {
@@ -95,11 +109,19 @@ export function OxyServicesSsoMixin<T extends typeof OxyServicesBase>(Base: T) {
      * @param code - The opaque single-use code delivered in the SSO return
      *   fragment (see {@link parseSsoReturnFragment}). The central store burns
      *   it atomically on exchange.
+     * @param state - The state value returned alongside the code. In browsers,
+     *   when an SSO bounce state is still stored for the current origin, this
+     *   must match before any token-committing exchange is attempted.
      * @returns The resolved {@link SessionLoginResponse}.
      */
-    public async exchangeSsoCode(code: string): Promise<SessionLoginResponse> {
+    public async exchangeSsoCode(code: string, state?: string): Promise<SessionLoginResponse> {
       if (typeof code !== 'string' || code.length === 0) {
         throw this.handleError(new Error('exchangeSsoCode requires a non-empty code'));
+      }
+
+      const expectedState = getStoredSsoStateForCurrentOrigin();
+      if (expectedState !== null && (typeof state !== 'string' || state.length === 0 || state !== expectedState)) {
+        throw this.handleError(new Error('SSO exchange state mismatch'));
       }
 
       const url = `${this.getSessionBaseUrl().replace(/\/$/, '')}/sso/exchange`;

--- a/packages/core/src/mixins/__tests__/sso.test.ts
+++ b/packages/core/src/mixins/__tests__/sso.test.ts
@@ -11,6 +11,7 @@
 
 import { OxyServices } from '../../OxyServices';
 import { generateSsoState } from '../OxyServices.sso';
+import { ssoStateKey } from '../../utils/ssoBounce';
 
 interface FetchCall {
   url: string;
@@ -116,6 +117,37 @@ describe('OxyServices.exchangeSsoCode', () => {
 
     await expect(oxy.exchangeSsoCode('')).rejects.toThrow();
     expect(calls).toHaveLength(0);
+  });
+
+
+  it('rejects a browser SSO exchange when stored state is not echoed', async () => {
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    const { calls } = mockFetchOnce(VALID_BODY);
+    const storage = new Map([[ssoStateKey('https://rp.example'), 'expected-state']]);
+    const previousWindow = (globalThis as unknown as { window?: unknown }).window;
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location: { origin: 'https://rp.example' },
+        sessionStorage: {
+          getItem: (key: string) => storage.get(key) ?? null,
+        },
+      },
+    });
+
+    try {
+      await expect(oxy.exchangeSsoCode('opaque-code-123', 'attacker-state')).rejects.toThrow(
+        'SSO exchange state mismatch',
+      );
+      expect(calls).toHaveLength(0);
+      expect(oxy.hasValidToken()).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: previousWindow,
+      });
+    }
   });
 
   it('throws and does not plant a token on a non-2xx response', async () => {

--- a/packages/core/src/utils/__tests__/consumeSsoReturn.test.ts
+++ b/packages/core/src/utils/__tests__/consumeSsoReturn.test.ts
@@ -218,7 +218,7 @@ describe('consumeSsoReturn', () => {
     });
 
     expect(result).toEqual(SESSION);
-    expect(oxy.exchangeSsoCode).toHaveBeenCalledWith('opaque-code');
+    expect(oxy.exchangeSsoCode).toHaveBeenCalledWith('opaque-code', 's');
     expect(storage.map.has(ssoStateKey(ORIGIN))).toBe(false);
     expect(storage.map.has(ssoGuardKey(ORIGIN))).toBe(false);
     expect(storage.map.has(ssoNoSessionKey(ORIGIN))).toBe(false);

--- a/packages/core/src/utils/__tests__/ssoReturn.test.ts
+++ b/packages/core/src/utils/__tests__/ssoReturn.test.ts
@@ -188,7 +188,7 @@ describe('consumeSsoReturn pre-hydration callback bootstrap', () => {
     );
 
     expect(session).toBe(exchangedSession);
-    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code');
+    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code', 'state-ok');
     expect(replaceStateCalls).toEqual(['/', '/explore?tab=home#top']);
     expect(dispatchPopState).toHaveBeenCalledTimes(1);
     expect(hardRedirect).not.toHaveBeenCalled();

--- a/packages/core/src/utils/ssoReturn.ts
+++ b/packages/core/src/utils/ssoReturn.ts
@@ -202,7 +202,7 @@ export interface ConsumeSsoReturnDeps {
  * @returns The exchanged session on success, otherwise `null`.
  */
 export async function consumeSsoReturn(
-  oxy: { exchangeSsoCode: (code: string) => Promise<SessionLoginResponse> },
+  oxy: { exchangeSsoCode: (code: string, state?: string) => Promise<SessionLoginResponse> },
   deps: ConsumeSsoReturnDeps = {},
 ): Promise<SessionLoginResponse | null> {
   const isWeb =
@@ -344,7 +344,7 @@ export async function consumeSsoReturn(
 
   let session: SessionLoginResponse | undefined;
   try {
-    session = await oxy.exchangeSsoCode(ret.code);
+    session = await oxy.exchangeSsoCode(ret.code, ret.state);
   } catch (error) {
     onExchangeError?.(error);
     markNoSession();

--- a/packages/services/__tests__/context/ssoCallbackIntercept.test.tsx
+++ b/packages/services/__tests__/context/ssoCallbackIntercept.test.tsx
@@ -179,7 +179,7 @@ describe('Eager SSO callback interception (services OxyContext)', () => {
     // The exchanged session is committed by the eager interception.
     await waitFor(() => expect(captured.isAuthenticated).toBe(true));
     expect(captured.userId).toBe(EXCHANGED_USER_ID);
-    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code-123');
+    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code-123', 'expected-state');
 
     // Destination restored off the callback path; fragment stripped; no bounce.
     expect(window.location.pathname).toBe(DEST_PATH);

--- a/packages/services/__tests__/context/ssoCentralBounce.test.tsx
+++ b/packages/services/__tests__/context/ssoCentralBounce.test.tsx
@@ -135,7 +135,7 @@ describe('Central SSO return (sso-return step)', () => {
 
     await waitFor(() => expect(captured.isAuthenticated).toBe(true));
     expect(captured.userId).toBe(EXCHANGED_USER_ID);
-    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code-123');
+    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code-123', 'expected-state');
 
     // Fragment stripped; CSRF state + dest consumed; no NO_SESSION; no bounce.
     expect(window.location.hash).toBe('');
@@ -215,7 +215,7 @@ describe('Central SSO return (sso-return step)', () => {
 
     await waitFor(() => expect(window.sessionStorage.getItem(NO_SESSION_KEY)).toBe('1'));
 
-    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code-123');
+    expect(exchangeSsoCode).toHaveBeenCalledWith('opaque-code-123', 'expected-state');
     expect(captured.isAuthenticated).toBe(false);
     expect(assignSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
### Motivation
- The central SSO helpers exposed a flow where an opaque SSO `code` could be exchanged and installed without verifying the returned `state`, enabling login-CSRF / session-fixation attacks. 
- The change ensures the client-side exchange path enforces the same per-origin CSRF `state` check that other SSO flows already performed, preventing attacker-supplied codes from replacing a victim's session.

### Description
- Threaded the SSO `state` through the return-consumption path so the token-committing call receives both the `code` and `state` (updated `consumeSsoReturn` to call `exchangeSsoCode(code, state)`).
- Added a browser-side guard in the client `exchangeSsoCode` that checks any stored per-origin SSO state (via `sessionStorage`) and rejects the exchange when the returned state does not match, preventing POST/fetch and token installation on mismatch.
- Updated public interface/type to accept an optional `state` parameter on `exchangeSsoCode`, added a small helper `getStoredSsoStateForCurrentOrigin`, and planted the state-check before the `/sso/exchange` request.
- Adjusted and added unit-test assertions across `@oxyhq/core`, `@oxyhq/services`, and `@oxyhq/auth-sdk` tests to assert the state-bound exchange call and to add an explicit test that a mismatched stored state blocks the exchange.

### Testing
- Ran `git diff --check` which reported no whitespace/errors and the commit was created successfully. 
- Attempted to run the core SSO unit tests with `bun run --cwd packages/core test -- ssoReturn.test.ts sso.test.ts` but automated execution in this environment failed because test dependencies / `jest` are not installed (`jest: command not found`), so tests could not be executed here; unit tests were updated in the change-set to cover the new behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8b7bc8323b682580537b60a3e)