### PR TITLE
security: disable IdP auto-detection for shared-hosting suffixes

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -462,7 +462,7 @@ export type { QuickAccount, DisplayNameUserShape } from './utils/accountUtils';
 // ---------------------------------------------------------------------------
 // Cross-domain SSO infrastructure
 // ---------------------------------------------------------------------------
-export { autoDetectAuthWebUrl, registrableApex, MULTIPART_TLDS } from './utils/fapiAutoDetect';
+export { autoDetectAuthWebUrl, registrableApex, MULTIPART_TLDS, SHARED_HOSTING_SUFFIXES } from './utils/fapiAutoDetect';
 
 // Central cross-domain SSO (opaque single-use code bounce via auth.oxy.so)
 export { CENTRAL_AUTH_URL, CENTRAL_IDP_APEX, resolveCentralAuthUrl } from './utils/authWebUrl';

--- a/packages/core/src/utils/__tests__/fapiAutoDetect.test.ts
+++ b/packages/core/src/utils/__tests__/fapiAutoDetect.test.ts
@@ -89,6 +89,13 @@ describe('autoDetectAuthWebUrl', () => {
     it('does not derive auth.com.au from a two-label com.au host', () => {
       expect(autoDetectAuthWebUrl(loc('shop.com.au'))).toBeUndefined();
     });
+
+    it.each(['pages.dev', 'github.io', 'appspot.com', 'vercel.app', 'netlify.app'])(
+      'does not derive an attacker-controllable auth.%s from a shared-hosting tenant',
+      (suffix) => {
+        expect(autoDetectAuthWebUrl(loc(`victim.${suffix}`))).toBeUndefined();
+      }
+    );
   });
 
   // Regression guard: the refactor to delegate host handling to `registrableApex`
@@ -106,6 +113,10 @@ describe('autoDetectAuthWebUrl', () => {
       ['intranet', undefined],
       ['', undefined],
       ['foo.co.uk', undefined],
+      ['victim.pages.dev', undefined],
+      ['victim.github.io', undefined],
+      ['victim.appspot.com', undefined],
+      ['victim.vercel.app', undefined],
     ];
     it.each(cases)('autoDetectAuthWebUrl(%s) === %s', (hostname, expected) => {
       const protocol = hostname === 'localhost' || hostname === '[::1]' ? 'http:' : 'https:';
@@ -131,6 +142,13 @@ describe('registrableApex', () => {
   it('returns null for a multi-part public suffix (foo.co.uk -> null)', () => {
     expect(registrableApex('foo.co.uk')).toBeNull();
     expect(registrableApex('shop.com.au')).toBeNull();
+  });
+
+  it('returns null for shared-hosting suffix tenants', () => {
+    expect(registrableApex('victim.pages.dev')).toBeNull();
+    expect(registrableApex('victim.github.io')).toBeNull();
+    expect(registrableApex('victim.appspot.com')).toBeNull();
+    expect(registrableApex('victim.vercel.app')).toBeNull();
   });
 
   it('returns null for IPv4 literals', () => {

--- a/packages/core/src/utils/fapiAutoDetect.ts
+++ b/packages/core/src/utils/fapiAutoDetect.ts
@@ -61,6 +61,26 @@ export const MULTIPART_TLDS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Shared / multi-tenant hosting suffixes where arbitrary tenants can register
+ * sibling subdomains. Auto-detecting `auth.<suffix>` for an app hosted at
+ * `<tenant>.<suffix>` would trust a host that the RP does not control (for
+ * example `victim.pages.dev` -> `auth.pages.dev`), so these suffixes are
+ * treated like public suffixes and require an explicit `authWebUrl`.
+ */
+export const SHARED_HOSTING_SUFFIXES: ReadonlySet<string> = new Set([
+  'pages.dev',
+  'github.io',
+  'appspot.com',
+  'vercel.app',
+  'netlify.app',
+  'herokuapp.com',
+  'firebaseapp.com',
+  'web.app',
+  'surge.sh',
+  'glitch.me',
+]);
+
+/**
  * Compute the bare registrable apex (eTLD+1) of a hostname, guarding against
  * multi-part public suffixes.
  *
@@ -92,7 +112,7 @@ export function registrableApex(hostname: string): string | null {
   const labels = host.split('.');
   if (labels.length < 2) return null;
   const lastTwo = labels.slice(-2).join('.');
-  if (MULTIPART_TLDS.has(lastTwo)) return null;
+  if (MULTIPART_TLDS.has(lastTwo) || SHARED_HOSTING_SUFFIXES.has(lastTwo)) return null;
   return lastTwo;
 }
 

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -19,6 +19,7 @@ import {
   runColdBoot,
   resolveCentralAuthUrl,
   autoDetectAuthWebUrl,
+  registrableApex,
   SSO_CALLBACK_PATH,
   ssoStateKey,
   ssoGuardKey,
@@ -357,12 +358,11 @@ function isSameSiteIdP(idpOrigin: string): boolean {
   const pageHostname = window.location.hostname;
   if (!idpHostname || !pageHostname) return false;
   if (idpHostname === pageHostname) return true;
-  const apexOf = (hostname: string): string => hostname.split('.').slice(-2).join('.');
-  const pageApex = apexOf(pageHostname);
-  // Require a real registrable apex (≥2 labels) AND an exact apex match AND that
-  // the IdP host is the page apex itself or a subdomain of it.
-  if (pageHostname.split('.').length < 2) return false;
-  if (apexOf(idpHostname) !== pageApex) return false;
+  const pageApex = registrableApex(pageHostname);
+  const idpApex = registrableApex(idpHostname);
+  // Require a real registrable apex (not a shared/public suffix) AND an exact
+  // apex match AND that the IdP host is the page apex itself or a subdomain of it.
+  if (!pageApex || idpApex !== pageApex) return false;
   return idpHostname === pageApex || idpHostname.endsWith(`.${pageApex}`);
 }
 


### PR DESCRIPTION
### Motivation
- Close a session-fixation trust boundary where `autoDetectAuthWebUrl()` could map tenant hosts like `victim.pages.dev` → `https://auth.pages.dev`, allowing an attacker-controlled sibling IdP to silently plant sessions. 
- Ensure the SDK fails closed for multi-tenant/shared hosting suffixes and requires an explicit `authWebUrl` when auto-detection would be unsafe.

### Description
- Added a `SHARED_HOSTING_SUFFIXES` denylist to `packages/core/src/utils/fapiAutoDetect.ts` and made `registrableApex()` return `null` for those suffixes so `autoDetectAuthWebUrl()` will not derive `auth.<suffix>` for shared-hosting domains.
- Updated `packages/services/src/ui/context/OxyContext.tsx` to reuse the hardened `registrableApex()` in the same-site IdP check so visibility-driven `/auth/session-check` logout decisions also fail closed on shared/public suffixes.
- Exported the new `SHARED_HOSTING_SUFFIXES` from `@oxyhq/core` and added regression tests in `packages/core/src/utils/__tests__/fapiAutoDetect.test.ts` covering representative shared-hosting suffixes (e.g. `pages.dev`, `github.io`, `appspot.com`, `vercel.app`).
- Modified the code-paths that previously used a naive "last two labels" apex heuristic to use the strengthened logic.

### Testing
- Ran `bun test packages/core/src/utils/__tests__/fapiAutoDetect.test.ts` and all tests in that file passed.
- Ran `git diff --check` to confirm no whitespace/format errors and observed no issues.
- Could not run the full workspace test suite because dependency installation failed in this environment (`bun install` returned registry 403 and `jest` was unavailable), so broader package-level Jest runs were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbf1b48323a0c086761047791d)