### PR TITLE
fix(api): add per-IP login rate limiter to /auth/login

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -79,6 +79,16 @@ const USERNAME_REGEX = /^[a-zA-Z0-9]{3,30}$/;
 // Password Authentication Routes
 // ============================================
 
+// Dedicated per-IP password login limit. The sign-in controller also enforces
+// per-identifier lockout, but this route-level limiter prevents spraying a few
+// guesses across many accounts from the same network.
+const loginLimiter = rateLimit({
+  prefix: 'rl:auth:login:',
+  windowMs: 15 * 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 200 : 30,
+  message: 'Too many login attempts from this IP, please try again later.',
+});
+
 /**
  * @openapi
  * /auth/signup:
@@ -291,7 +301,7 @@ router.post('/signup', validate({ body: signupSchema }), SessionController.signU
  *       429:
  *         description: Too many failed login attempts. Try again later.
  */
-router.post('/login', validate({ body: loginSchema }), SessionController.signIn);
+router.post('/login', loginLimiter, validate({ body: loginSchema }), SessionController.signIn);
 
 /**
  * @openapi


### PR DESCRIPTION
### Motivation
- Close a security gap introduced by raising the blanket `/auth/*` cap by adding a route-specific per-IP limiter for password logins so cross-account password-spraying from a single IP is mitigated while preserving the existing per-identifier lockout.

### Description
- Add a `loginLimiter` in `packages/api/src/routes/auth.ts` (Redis prefix `rl:auth:login:`) with a 15-minute window and `max: 30` in production (`200` in development).
- Mount `loginLimiter` on the `POST /auth/login` route before validation and `SessionController.signIn` so the endpoint now enforces an endpoint-specific per-IP ceiling without changing the sign-in flow or per-identifier lockout logic.

### Testing
- Ran `git diff --check` (no whitespace errors) which passed. 
- Attempted a package build (`bun run --filter @oxyhq/api build`) which failed due to unrelated TypeScript configuration deprecation/errors in `@oxyhq/contracts` (blocked the local build). 
- Attempted to run the sign-in unit test but the test runner (`jest`) is not available in the execution environment, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db4ad88323ab6108bf9b17b48d)