### PR TITLE
fix(api): preserve client device fingerprints

### DIFF
--- a/packages/api/src/types/session.types.ts
+++ b/packages/api/src/types/session.types.ts
@@ -4,8 +4,8 @@
  * Centralized type definitions for session-related operations.
  */
 
-import { ISession } from '../models/Session';
-import { DeviceFingerprint } from '../utils/deviceUtils';
+import type { ISession } from '../models/Session';
+import type { DeviceFingerprintInput } from '../utils/deviceUtils';
 
 export interface SessionValidationResult {
   session: ISession;
@@ -15,7 +15,7 @@ export interface SessionValidationResult {
 
 export interface SessionCreateOptions {
   deviceName?: string;
-  deviceFingerprint?: DeviceFingerprint;
+  deviceFingerprint?: DeviceFingerprintInput;
   /**
    * When set, the session's deviceId is derived deterministically from
    * (userId, stableDeviceKey) via `deriveServiceDeviceId` — used for

--- a/packages/api/src/utils/__tests__/deviceUtils.test.ts
+++ b/packages/api/src/utils/__tests__/deviceUtils.test.ts
@@ -18,7 +18,12 @@ jest.mock('../../models/Session', () => ({ __esModule: true, default: {} }));
 jest.mock('../sessionCache', () => ({ __esModule: true, default: { invalidate: jest.fn() } }));
 jest.mock('../userTransform', () => ({ formatUserResponse: jest.fn() }));
 
-import { deriveStableDeviceId, deriveServiceDeviceId } from '../deviceUtils';
+import crypto from 'crypto';
+import {
+  deriveStableDeviceId,
+  deriveServiceDeviceId,
+  generateDeviceFingerprint,
+} from '../deviceUtils';
 
 const STRONG_SALT_A = 'a'.repeat(48);
 const STRONG_SALT_B = 'b'.repeat(48);
@@ -186,5 +191,43 @@ describe('deriveServiceDeviceId', () => {
   it('THROWS (fail-closed) when DEVICE_ID_SALT is empty', () => {
     process.env.DEVICE_ID_SALT = '';
     expect(() => deriveServiceDeviceId('user-1', RP_A)).toThrow(/DEVICE_ID_SALT/);
+  });
+});
+
+describe('generateDeviceFingerprint', () => {
+  it('preserves 64-character client fingerprint strings instead of hashing them as empty structured objects', () => {
+    const firstClientFingerprint = 'a'.repeat(64);
+    const secondClientFingerprint = 'b'.repeat(64);
+
+    expect(generateDeviceFingerprint(firstClientFingerprint)).toBe(
+      firstClientFingerprint
+    );
+    expect(generateDeviceFingerprint(secondClientFingerprint)).toBe(
+      secondClientFingerprint
+    );
+    expect(generateDeviceFingerprint(firstClientFingerprint)).not.toBe(
+      generateDeviceFingerprint(secondClientFingerprint)
+    );
+    expect(generateDeviceFingerprint(firstClientFingerprint)).not.toBe(
+      crypto.createHash('sha256').update('').digest('hex')
+    );
+  });
+
+  it('continues to hash structured device fingerprints', () => {
+    expect(
+      generateDeviceFingerprint({
+        userAgent: 'Mozilla/5.0',
+        platform: 'macOS',
+        language: 'en-US',
+        timezone: 'America/Los_Angeles',
+        screen: { width: 1440, height: 900, colorDepth: 24 },
+        ipAddress: '203.0.113.10',
+      })
+    ).toBe(
+      crypto
+        .createHash('sha256')
+        .update('Mozilla/5.0|macOS|en-US|America/Los_Angeles|1440x900x24')
+        .digest('hex')
+    );
   });
 });

--- a/packages/api/src/utils/deviceUtils.ts
+++ b/packages/api/src/utils/deviceUtils.ts
@@ -18,6 +18,10 @@ export interface DeviceFingerprint {
   ipAddress: string;
 }
 
+export type DeviceFingerprintInput = DeviceFingerprint | string;
+
+const CLIENT_FINGERPRINT_HEX_RE = /^[a-f0-9]{64}$/i;
+
 export interface DeviceInfo {
   deviceId: string;
   deviceName?: string;
@@ -162,7 +166,16 @@ export function deriveServiceDeviceId(userId: string, key: string): string {
  * Generate a device fingerprint for device identification
  * This helps identify if it's the same physical device
  */
-export const generateDeviceFingerprint = (fingerprint: DeviceFingerprint): string => {
+export const generateDeviceFingerprint = (fingerprint: DeviceFingerprintInput): string => {
+  if (typeof fingerprint === 'string') {
+    const clientFingerprint = fingerprint.trim();
+    if (CLIENT_FINGERPRINT_HEX_RE.test(clientFingerprint)) {
+      return clientFingerprint.toLowerCase();
+    }
+
+    return crypto.createHash('sha256').update(clientFingerprint).digest('hex');
+  }
+
   const fingerprintString = [
     fingerprint.userAgent,
     fingerprint.platform,


### PR DESCRIPTION
### Motivation
- A client-side change started sending a 64-char SHA-256 hex string as `deviceFingerprint`, but the server fingerprint pipeline expected a structured object which produced the same empty-hash for all string inputs and collapsed distinct device logins into one device/session for the same user.
- The goal is to accept and preserve legitimate client-submitted fingerprint strings while keeping existing structured-object fingerprint behavior intact so device/session separation and security monitoring remain correct.

### Description
- Add a union input type `DeviceFingerprintInput = DeviceFingerprint | string` and a `CLIENT_FINGERPRINT_HEX_RE` check so server helpers accept either a structured object or a client-provided string and normalize 64-char hex fingerprints to lowercase.
- Modify `generateDeviceFingerprint` to return the client-provided 64-char hex as-is (normalized), otherwise hash the provided string input or continue hashing the structured object as before so behavior is backwards-compatible.
- Update session types so `SessionCreateOptions.deviceFingerprint` reflects the new `DeviceFingerprintInput` union type to match runtime behavior.
- Add regression unit tests that assert two different client fingerprint strings remain distinct and are not equal to the SHA-256 of an empty structured fingerprint while also asserting structured-object hashing still works.

### Testing
- Added unit test coverage in `packages/api/src/utils/__tests__/deviceUtils.test.ts` that validates preserved client fingerprint strings and structured hashing, but running Jest in this environment failed because `jest` is not available here (test run blocked).
- Attempted `bun run build` which failed in this environment due to unrelated TypeScript config errors in the `contracts` build (the build system in this environment raised `tsconfig` deprecation/rootDir errors), so full CI-style verification was not possible here.
- Local static checks (`git diff --check`) and the repository patch applied cleanly and the new tests were committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db0e148323a1e4fe63930be570)