### PR TITLE
fix(api): enforce refresh-token sibling checks

### DIFF
--- a/packages/api/src/routes/__tests__/refreshToken.test.ts
+++ b/packages/api/src/routes/__tests__/refreshToken.test.ts
@@ -436,10 +436,15 @@ describe('POST /auth/refresh', () => {
     const validCurrent = 'valid-current-token';
     const usedRow = buildStoredToken(usedStale, {
       _id: 'rt-used',
-      family: 'fam-used',
+      family: 'fam-shared',
+      sessionId: 'sess-shared',
       usedAt: new Date(Date.now() - 1000),
     });
-    const validRow = buildStoredToken(validCurrent, { _id: 'rt-valid', family: 'fam-valid' });
+    const validRow = buildStoredToken(validCurrent, {
+      _id: 'rt-valid',
+      family: 'fam-shared',
+      sessionId: 'sess-shared',
+    });
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
 
     stageToken(usedRow);
@@ -460,7 +465,7 @@ describe('POST /auth/refresh', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ accessToken: 'access-jwt', expiresAt: expiresAt.toISOString(), authuser: 0 });
     // Access token minted off the VALID sibling's session.
-    expect(mockGetAccessToken).toHaveBeenCalledWith('sess-123');
+    expect(mockGetAccessToken).toHaveBeenCalledWith('sess-shared');
 
     // Rotated to a brand-new value, distinct from BOTH presented cookies.
     const rotated = extractRefreshCookieValue(res.setCookie);
@@ -476,10 +481,15 @@ describe('POST /auth/refresh', () => {
   it('rotates the VALID sibling when it is presented FIRST (valid FIRST)', async () => {
     const validCurrent = 'valid-current-token';
     const usedStale = 'used-stale-token';
-    const validRow = buildStoredToken(validCurrent, { _id: 'rt-valid', family: 'fam-valid' });
+    const validRow = buildStoredToken(validCurrent, {
+      _id: 'rt-valid',
+      family: 'fam-shared',
+      sessionId: 'sess-shared',
+    });
     const usedRow = buildStoredToken(usedStale, {
       _id: 'rt-used',
-      family: 'fam-used',
+      family: 'fam-shared',
+      sessionId: 'sess-shared',
       usedAt: new Date(Date.now() - 1000),
     });
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
@@ -506,9 +516,47 @@ describe('POST /auth/refresh', () => {
     expect(rotated).not.toBe(usedStale);
     expect(rotated).not.toBe(validCurrent);
 
-    // Still no reuse-detection — the used sibling is the same user's stale cookie.
     expect(mockUpdateMany).not.toHaveBeenCalled();
     expect(mockDeactivateSession).not.toHaveBeenCalled();
+  });
+
+  it('fires reuse-detection when a used duplicate belongs to a different family', async () => {
+    const usedStale = 'victim-used-token';
+    const validCurrent = 'attacker-valid-token';
+    const usedRow = buildStoredToken(usedStale, {
+      _id: 'rt-used',
+      family: 'fam-victim',
+      sessionId: 'sess-victim',
+      usedAt: new Date(Date.now() - 1000),
+    });
+    const validRow = buildStoredToken(validCurrent, {
+      _id: 'rt-valid',
+      family: 'fam-attacker',
+      sessionId: 'sess-attacker',
+    });
+
+    stageToken(usedRow);
+    stageToken(validRow);
+    mockUpdateMany.mockResolvedValueOnce({ modifiedCount: 2 });
+    mockDeactivateSession.mockResolvedValueOnce(true);
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/refresh',
+      {},
+      `${REFRESH_COOKIE_SLOT_0}=${usedStale}; ${REFRESH_COOKIE_SLOT_0}=${validCurrent}`
+    );
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ message: 'Invalid refresh token' });
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      { family: 'fam-victim', revokedAt: null },
+      { $set: { revokedAt: expect.any(Date) } }
+    );
+    expect(mockDeactivateSession).toHaveBeenCalledWith('sess-victim');
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
   });
 
   it('fires reuse-detection for a LONE used token with no valid sibling', async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -773,10 +773,10 @@ router.post('/refresh', refreshLimiter, requireSameSiteOrigin, asyncHandler(asyn
   };
 
   if (classification.kind === 'used') {
-    // REUSE DETECTED. SECURITY: a lone used/revoked token with NO valid sibling
-    // in THIS slot is a theft signal. We revoke the whole family + deactivate
-    // the session for the affected slot ONLY — other indexed slots (other
-      // signed-in accounts on this device) stay untouched.
+    // REUSE DETECTED. SECURITY: a used/revoked token is a theft signal unless
+    // classification found a valid sibling from the SAME family+session in THIS
+    // slot. Revoke the affected family + deactivate that session only — other
+    // indexed slots (other signed-in accounts on this device) stay untouched.
     await revokeFamily(classification.family, classification.sessionId);
     clearThisSlot();
     logger.warn('[RefreshToken] Reuse detected — family revoked', {

--- a/packages/api/src/services/refreshToken.service.ts
+++ b/packages/api/src/services/refreshToken.service.ts
@@ -251,30 +251,31 @@ export type CandidateClassification =
  * Classify a list of presented raw refresh-token candidates WITHOUT consuming
  * any of them (purely a lookup — no `usedAt` mutation, no rotation).
  *
- * SECURITY RATIONALE (load-bearing — do not weaken): a browser only ever sends
- * its OWN httpOnly cookies, so multiple candidates for one indexed slot can
- * only be that device's own duplicate values. Picking the VALID sibling and
- * ignoring a USED sibling is safe — it is the same user's slot, one already
- * rotated.
+ * SECURITY RATIONALE (load-bearing — do not weaken): Cookie headers are
+ * client-controlled, so duplicate values for one indexed slot are only safe to
+ * de-duplicate when every used/revoked candidate is a sibling of the selected
+ * valid token (same rotation family and session).
  *
- * A genuine theft replay is a LONE used token with NO valid sibling among the
- * candidates: that still classifies as `'used'`, so the caller fires
- * reuse-detection (revoke family + deactivate session). We never weaken that —
- * if ANY candidate is valid `'valid'` wins first, but with no valid sibling a
- * used/revoked token is treated exactly as before: theft.
+ * A used/revoked candidate from a DIFFERENT family/session remains a theft
+ * replay signal even if another presented cookie is valid. In that case the
+ * caller must revoke the replayed token's family instead of rotating the
+ * unrelated valid token.
  *
  * Order of resolution:
- *   1. First VALID candidate wins → `{ kind: 'valid' }` (returned immediately).
- *   2. Else, first candidate whose stored row is used OR revoked →
- *      `{ kind: 'used' }` (revoked is bucketed with used because it means the
- *      family was already nuked, and we want reuse-detection to re-assert it).
- *   3. Else → `{ kind: 'none' }` (unknown/expired/garbage only).
+ *   1. Collect the first VALID candidate and the first used/revoked candidate.
+ *   2. If a VALID candidate exists and every used/revoked candidate belongs to
+ *      that same family+session, return `{ kind: 'valid' }`.
+ *   3. Else, first used/revoked candidate → `{ kind: 'used' }` (revoked is
+ *      bucketed with used because it means the family was already nuked, and we
+ *      want reuse-detection to re-assert it).
+ *   4. Else → `{ kind: 'none' }` (unknown/expired/garbage only).
  */
 export async function classifyRefreshCandidates(
   rawCandidates: string[]
 ): Promise<CandidateClassification> {
   const now = new Date();
-  let firstUsed: { family: string; sessionId: string } | null = null;
+  let firstValid: { rawToken: string; family: string; sessionId: string } | null = null;
+  const usedCandidates: Array<{ family: string; sessionId: string }> = [];
 
   for (const rawToken of rawCandidates) {
     const tokenHash = sha256Hex(rawToken);
@@ -286,17 +287,35 @@ export async function classifyRefreshCandidates(
     const isValid =
       stored.usedAt == null && stored.revokedAt == null && stored.expiresAt > now;
     if (isValid) {
-      return { kind: 'valid', rawToken };
+      firstValid ??= { rawToken, family: stored.family, sessionId: stored.sessionId };
+      continue;
     }
 
-    // A used OR revoked row with no valid sibling is the reuse-detection signal.
-    // Remember the FIRST such row so the caller revokes the correct family.
-    if (firstUsed === null && (stored.usedAt != null || stored.revokedAt != null)) {
-      firstUsed = { family: stored.family, sessionId: stored.sessionId };
+    if (stored.usedAt != null || stored.revokedAt != null) {
+      usedCandidates.push({ family: stored.family, sessionId: stored.sessionId });
     }
   }
 
-  if (firstUsed !== null) {
+  if (firstValid !== null) {
+    const { family: validFamily, sessionId: validSessionId } = firstValid;
+    const unrelatedUsed = usedCandidates.find(
+      (candidate) =>
+        candidate.family !== validFamily || candidate.sessionId !== validSessionId
+    );
+
+    // A used/revoked token can only be ignored as a stale migration duplicate
+    // when it belongs to the same rotation family AND session as the valid
+    // candidate. Otherwise it is an unrelated replay attempt and must trigger
+    // reuse-detection containment.
+    if (unrelatedUsed === undefined) {
+      return { kind: 'valid', rawToken: firstValid.rawToken };
+    }
+
+    return { kind: 'used', family: unrelatedUsed.family, sessionId: unrelatedUsed.sessionId };
+  }
+
+  const firstUsed = usedCandidates[0];
+  if (firstUsed !== undefined) {
     return { kind: 'used', family: firstUsed.family, sessionId: firstUsed.sessionId };
   }
 


### PR DESCRIPTION
### Motivation

- Prevent a refresh-token reuse-detection bypass where an attacker can present an unrelated used/revoked token alongside a valid token in the same `Cookie` header and suppress revocation containment. 
- Preserve the intentional migration tolerance for browser-owned duplicate cookies while restoring the security invariant that a presented used/revoked token from a different family/session must trigger reuse-detection.

### Description

- Tighten `classifyRefreshCandidates` in `packages/api/src/services/refreshToken.service.ts` to collect the first valid candidate and all used/revoked candidates and require that any used/revoked candidate be from the same `family`+`session` as the valid one before suppressing reuse-detection. 
- If any used/revoked candidate is from a different family/session the classifier now returns a `used` classification so the caller revokes the replayed family and deactivates the session. 
- Update the `/auth/refresh` route comment in `packages/api/src/routes/auth.ts` to document the same-family/session invariant. 
- Adjust `packages/api/src/routes/__tests__/refreshToken.test.ts` to (a) preserve same-family migration rotation behavior and (b) add a test that proves a used token from a different family presented alongside a valid token triggers reuse-detection and revocation.

### Testing

- Ran `git diff --check` to validate formatting and local diffs, which succeeded. 
- Attempted to run the refresh-token unit tests with `bun run test --runInBand packages/api/src/routes/__tests__/refreshToken.test.ts`, but the environment lacks `jest` so the run failed (command not found). 
- Attempted `bun install --frozen-lockfile` to bootstrap dependencies for local test execution, but it failed due to the CI environment returning HTTP 403 from the npm registry, so full test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db255c8323a3347745821e24f2)