### PR TITLE
fix(fedcm): gate user grants lookup

### DIFF
--- a/packages/api/src/config/swagger.ts
+++ b/packages/api/src/config/swagger.ts
@@ -27,6 +27,12 @@ const options: swaggerJsdoc.Options = {
           bearerFormat: 'JWT',
           description: 'JWT access token obtained from /auth/login or /auth/verify',
         },
+        internalSecretAuth: {
+          type: 'apiKey',
+          in: 'header',
+          name: 'X-Oxy-Internal',
+          description: 'Internal shared secret for IdP/API server-to-server calls.',
+        },
       },
       schemas: {
         Error: {

--- a/packages/api/src/controllers/__tests__/fedcm.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/fedcm.controller.test.ts
@@ -86,9 +86,11 @@ function createReq(overrides: Partial<Request> = {}): Request {
 }
 
 const VALID_USER_ID = '64f7c2a1b8e9d3f4a1c2b3d4';
+const TEST_INTERNAL_SECRET = 'test-sso-internal-secret-32-chars-long!!';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  process.env.SSO_INTERNAL_SECRET = TEST_INTERNAL_SECRET;
 });
 
 describe('mintNonce', () => {
@@ -177,9 +179,29 @@ describe('exchangeIdToken', () => {
 });
 
 describe('getUserGrants', () => {
+  it('returns 404 when the internal shared secret header is absent', async () => {
+    const res = createRes();
+    await getUserGrants(createReq({ params: { userId: VALID_USER_ID } }), res as unknown as Response);
+    expect(res.statusCode).toBe(404);
+    expect(mockGetUserGrantedOrigins).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the internal shared secret is invalid', async () => {
+    const res = createRes();
+    await getUserGrants(
+      createReq({ params: { userId: VALID_USER_ID }, headers: { 'x-oxy-internal': 'wrong-secret' } }),
+      res as unknown as Response
+    );
+    expect(res.statusCode).toBe(404);
+    expect(mockGetUserGrantedOrigins).not.toHaveBeenCalled();
+  });
+
   it('returns 400 for a malformed userId', async () => {
     const res = createRes();
-    await getUserGrants(createReq({ params: { userId: 'not-an-objectid' } }), res as unknown as Response);
+    await getUserGrants(
+      createReq({ params: { userId: 'not-an-objectid' }, headers: { 'x-oxy-internal': TEST_INTERNAL_SECRET } }),
+      res as unknown as Response
+    );
     expect(res.statusCode).toBe(400);
     expect(mockGetUserGrantedOrigins).not.toHaveBeenCalled();
   });
@@ -187,7 +209,10 @@ describe('getUserGrants', () => {
   it('returns the granted origins on success', async () => {
     mockGetUserGrantedOrigins.mockResolvedValueOnce(['https://mention.earth']);
     const res = createRes();
-    await getUserGrants(createReq({ params: { userId: VALID_USER_ID } }), res as unknown as Response);
+    await getUserGrants(
+      createReq({ params: { userId: VALID_USER_ID }, headers: { 'x-oxy-internal': TEST_INTERNAL_SECRET } }),
+      res as unknown as Response
+    );
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({ origins: ['https://mention.earth'] });
   });
@@ -195,7 +220,10 @@ describe('getUserGrants', () => {
   it('returns 500 when the service throws', async () => {
     mockGetUserGrantedOrigins.mockRejectedValueOnce(new Error('db down'));
     const res = createRes();
-    await getUserGrants(createReq({ params: { userId: VALID_USER_ID } }), res as unknown as Response);
+    await getUserGrants(
+      createReq({ params: { userId: VALID_USER_ID }, headers: { 'x-oxy-internal': TEST_INTERNAL_SECRET } }),
+      res as unknown as Response
+    );
     expect(res.statusCode).toBe(500);
   });
 });

--- a/packages/api/src/controllers/fedcm.controller.ts
+++ b/packages/api/src/controllers/fedcm.controller.ts
@@ -1,8 +1,40 @@
+import * as crypto from 'crypto';
 import { Request, Response } from 'express';
 import fedcmService from '../services/fedcm.service';
 import { logger } from '../utils/logger';
 import { AuthRequest } from '../middleware/auth';
 import { issueAndSetRefreshCookie } from '../services/refreshToken.service';
+
+/** Constant-time string equality (length-tolerant; no early-exit leak). */
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) {
+    crypto.timingSafeEqual(aBuf, aBuf);
+    return false;
+  }
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * Validate the internal shared-secret header for IdP server-to-server FedCM
+ * grant lookups. Fails closed when SSO_INTERNAL_SECRET is missing so the
+ * per-user grant relationship is never exposed by an accidentally public route.
+ */
+function hasValidInternalSecret(req: Request): boolean {
+  const expected = process.env.SSO_INTERNAL_SECRET;
+  if (typeof expected !== 'string' || expected.length === 0) {
+    logger.error('GET /fedcm/grants/:userId called but SSO_INTERNAL_SECRET is not configured');
+    return false;
+  }
+
+  const provided = req.headers['x-oxy-internal'];
+  if (typeof provided !== 'string' || provided.length === 0) {
+    return false;
+  }
+
+  return timingSafeStringEqual(provided, expected);
+}
 
 /**
  * Mint a single-use server-side nonce for the FedCM handoff. The auth UI
@@ -92,15 +124,17 @@ export async function exchangeIdToken(req: Request, res: Response) {
  * `approved_clients` array, which lets Chrome treat the account as a returning
  * account for those RPs (skips disclosure UI, enables silent mediation).
  *
- * Returns only public app origins the user themselves authorized — the same
- * data surface as the public `GET /fedcm/clients/approved`, filtered to this
- * user — so it carries no token material or PII and is safe to expose to the
- * IdP server-to-server fetch without a bearer token. The result is also
- * intersected with the currently-approved client list, so a removed origin can
- * never leak back.
+ * This is per-user relationship/activity metadata, so it is gated to the IdP
+ * server-to-server caller with the same `X-Oxy-Internal` shared secret used by
+ * `/sso/code`. The result is also intersected with the currently-approved
+ * client list, so a removed origin can never leak back.
  */
 export async function getUserGrants(req: Request, res: Response) {
   try {
+    if (!hasValidInternalSecret(req)) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+
     const { userId } = req.params;
 
     if (!userId || !/^[a-f0-9]{24}$/i.test(userId)) {

--- a/packages/api/src/routes/fedcm.ts
+++ b/packages/api/src/routes/fedcm.ts
@@ -133,15 +133,17 @@ router.get('/clients/approved', getApprovedClients);
  *   get:
  *     tags:
  *       - Federation
- *     security: []
+ *     security:
+ *       - internalSecretAuth: []
  *     summary: List RP origins a user has granted via FedCM
  *     description: >
  *       Returns the relying-party origins the user has previously authorized
  *       through FedCM, intersected with the currently-approved client list.
  *       The IdP accounts endpoint (auth.oxy.so) calls this server-to-server to
  *       populate the FedCM `approved_clients` array, which lets Chrome treat
- *       the account as a returning account for those RPs (skips the disclosure
- *       UI and enables silent mediation). Carries no token material or PII.
+ *       the account as a returning account for those RPs. Requires the
+ *       X-Oxy-Internal shared secret because this per-user RP grant set is
+ *       private relationship/activity metadata.
  *     parameters:
  *       - name: userId
  *         in: path
@@ -149,6 +151,12 @@ router.get('/clients/approved', getApprovedClients);
  *         schema:
  *           type: string
  *         description: The user's id (24-char hex ObjectId).
+ *       - in: header
+ *         name: X-Oxy-Internal
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Shared secret equal to SSO_INTERNAL_SECRET.
  *     responses:
  *       200:
  *         description: Granted origins (possibly empty).
@@ -163,6 +171,8 @@ router.get('/clients/approved', getApprovedClients);
  *                     type: string
  *       400:
  *         description: Missing or malformed userId.
+ *       404:
+ *         description: Internal shared secret missing or invalid.
  */
 router.get('/grants/:userId', getUserGrants);
 

--- a/packages/auth/server/__tests__/fedcm.idp.test.ts
+++ b/packages/auth/server/__tests__/fedcm.idp.test.ts
@@ -68,6 +68,7 @@ interface CapturedExchange {
 }
 let capturedNonceOrigin: string | undefined;
 let capturedExchange: CapturedExchange | undefined;
+let capturedGrantsSecret: string | undefined;
 
 // Captures the internal `POST /sso/code` call GET /sso makes so tests can
 // assert the X-Oxy-Internal secret + clientOrigin + session payload shape.
@@ -90,6 +91,7 @@ function installApiStub(): void {
   capturedNonceOrigin = undefined;
   capturedExchange = undefined;
   capturedSsoCode = undefined;
+  capturedGrantsSecret = undefined;
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = typeof input === 'string' ? input : input.toString();
     const headers = new Headers(init?.headers);
@@ -106,6 +108,7 @@ function installApiStub(): void {
     // The accounts endpoint resolves the user's granted RP origins to populate
     // the FedCM `approved_clients` array.
     if (url.includes('/fedcm/grants/')) {
+      capturedGrantsSecret = headers.get('x-oxy-internal') ?? undefined;
       return new Response(
         JSON.stringify({ origins: stubbedGrantedOrigins }),
         { status: 200, headers: { 'content-type': 'application/json' } }
@@ -266,6 +269,7 @@ describe('GET /fedcm/accounts', () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { accounts: Array<{ approved_clients?: string[] }> };
     expect(body.accounts[0].approved_clients).toEqual([RP_ORIGIN, 'https://homiio.com']);
+    expect(capturedGrantsSecret).toBe(process.env.SSO_INTERNAL_SECRET);
   });
 
   it('omits approved_clients for a brand-new user with no grants (first-visit needs the chooser)', async () => {

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -402,15 +402,18 @@ async function fetchUserFromAPI(apiBaseUrl: string, sessionId: string): Promise<
  *
  * Best-effort: any failure yields an empty list (the account is still returned,
  * just without the returning-account optimization). The API endpoint is
- * cookie-less and harmless (it only returns public app origins the user
- * themselves authorized), so no auth token is needed for this server-to-server
- * call.
+ * cookie-less but returns private per-user RP grant metadata, so the IdP must
+ * present the internal shared secret on this server-to-server call.
  */
-async function fetchApprovedClients(apiBaseUrl: string, userId: string): Promise<string[]> {
+async function fetchApprovedClients(config: ResolvedConfig, userId: string): Promise<string[]> {
+  if (!config.ssoInternalSecret) return [];
   try {
-    const url = `${apiBaseUrl}/fedcm/grants/${encodeURIComponent(userId)}`;
+    const url = `${config.apiBaseUrl}/fedcm/grants/${encodeURIComponent(userId)}`;
     const res = await fetch(url, {
-      headers: { 'Accept': 'application/json' },
+      headers: {
+        Accept: 'application/json',
+        'X-Oxy-Internal': config.ssoInternalSecret,
+      },
       signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) return [];
@@ -1279,7 +1282,8 @@ app.get('/fedcm/accounts', async (c) => {
     return c.json({ error: 'invalid_request' }, 400);
   }
 
-  const { apiBaseUrl } = resolveConfig(c);
+  const config = resolveConfig(c);
+  const { apiBaseUrl } = config;
   const sessionId = getCookie(c, COOKIE_NAME);
 
   if (!sessionId) {
@@ -1353,7 +1357,7 @@ app.get('/fedcm/accounts', async (c) => {
   // skips the disclosure UI and lets `mediation: 'silent'` resolve — this is
   // what makes cross-app SSO work for returning users. A brand-new user has an
   // empty list (first visit always needs one chooser interaction, by spec).
-  const approvedClients = await fetchApprovedClients(apiBaseUrl, user.id);
+  const approvedClients = await fetchApprovedClients(config, user.id);
   if (approvedClients.length > 0) {
     account.approved_clients = approvedClients;
   }


### PR DESCRIPTION
### Motivation
- The unauthenticated `GET /fedcm/grants/:userId` endpoint exposed per-user FedCM grant metadata (which RP origins a user had previously granted) and could be queried by anyone knowing a user's ObjectId.
- This per-user relationship is private activity metadata and must be restricted to internal IdP→API server-to-server calls only.

### Description
- Require the internal shared secret header `X-Oxy-Internal` (validated in constant time) before returning per-user FedCM grants in `packages/api/src/controllers/fedcm.controller.ts`, and fail closed with `404` when the secret is missing/invalid.
- Update the FedCM OpenAPI docs and swagger components to document an `internalSecretAuth` scheme and remove the previous `security: []` (public) declaration for the grants endpoint in `packages/api/src/routes/fedcm.ts` and `packages/api/src/config/swagger.ts`.
- Change the IdP worker to present the internal secret when requesting user grants (send `X-Oxy-Internal`) and to skip the lookup when the secret is not configured, in `packages/auth/server/index.ts`.
- Add/adjust regression tests to assert missing/invalid secret cases and to verify the IdP sends the `X-Oxy-Internal` header, in `packages/api/src/controllers/__tests__/fedcm.controller.test.ts` and `packages/auth/server/__tests__/fedcm.idp.test.ts`.

### Testing
- Ran a static verification that the OpenAPI block for `/fedcm/grants/{userId}` no longer declares `security: []` and documents `X-Oxy-Internal` via a small Python check (`python3`), which succeeded.
- Attempted to run package tests with `bun run test` / `bun test` and `jest` for the modified controller, but automated test runs were blocked in this environment because `node_modules` and test runner deps (e.g. `jest`, `react`) are not installed; therefore the updated tests could not be executed here.
- Confirmed unit-test-level changes were applied (new assertions and env setup) and committed as `fix(fedcm): gate user grants lookup`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc60a88323b4a5a71e51355347)