### PR TITLE
fix: restrict AWS SSM secret sync to API allowlist

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -36,16 +36,45 @@ jobs:
           role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Sync GitHub secrets -> SSM (GitHub is the source of truth)
+      - name: Sync API deployment secrets -> SSM (GitHub is the source of truth)
         env:
-          SECRETS_JSON: ${{ toJSON(secrets) }}
+          ACCESS_TOKEN_SECRET: ${{ secrets.ACCESS_TOKEN_SECRET }}
+          REFRESH_TOKEN_SECRET: ${{ secrets.REFRESH_TOKEN_SECRET }}
+          FEDCM_TOKEN_SECRET: ${{ secrets.FEDCM_TOKEN_SECRET }}
+          SSO_INTERNAL_SECRET: ${{ secrets.SSO_INTERNAL_SECRET }}
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+          REDIS_URL: ${{ secrets.REDIS_URL }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          ALIA_API_KEY: ${{ secrets.ALIA_API_KEY }}
+          SMTP_TLS_KEY: ${{ secrets.SMTP_TLS_KEY }}
+          SMTP_TLS_CERT: ${{ secrets.SMTP_TLS_CERT }}
+          SMTP_RELAY_USER: ${{ secrets.SMTP_RELAY_USER }}
+          SMTP_RELAY_PASS: ${{ secrets.SMTP_RELAY_PASS }}
+          EMAIL_INBOUND_WEBHOOK_SECRET: ${{ secrets.EMAIL_INBOUND_WEBHOOK_SECRET }}
+          DKIM_PRIVATE_KEY: ${{ secrets.DKIM_PRIVATE_KEY }}
+          EMAIL_S3_ACCESS_KEY_ID: ${{ secrets.EMAIL_S3_ACCESS_KEY_ID }}
+          EMAIL_S3_SECRET_ACCESS_KEY: ${{ secrets.EMAIL_S3_SECRET_ACCESS_KEY }}
+          DEVICE_ID_SALT: ${{ secrets.DEVICE_ID_SALT }}
+          OXY_PUBLIC_KEY: ${{ secrets.OXY_PUBLIC_KEY }}
+          OXY_PRIVATE_KEY: ${{ secrets.OXY_PRIVATE_KEY }}
+          LIVEKIT_API_KEY: ${{ secrets.LIVEKIT_API_KEY }}
+          LIVEKIT_API_SECRET: ${{ secrets.LIVEKIT_API_SECRET }}
         run: |
-          # Secrets that are shared across all Oxy services live under
-          # /oxy/_shared/; everything else is scoped to this app.
-          SHARED="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY REDIS_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET"
-          echo "$SECRETS_JSON" | jq -r 'to_entries[] | select((.key|ascii_upcase) as $k | ($k=="GITHUB_TOKEN" or ($k|startswith("ACTIONS_")))|not) | [.key,.value]|@tsv' | \
-          while IFS=$'\t' read -r k v; do
-            [ -z "$k" ] && continue
+          # Only sync secrets that the oxy-api ECS task is expected to consume.
+          # Do not iterate over the entire GitHub secrets context: this repository also contains
+          # credentials for other systems (Cloudflare, legacy droplet deploys,
+          # etc.) that must not be copied into the API's SSM namespace.
+          SHARED_SECRETS="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY REDIS_URL LIVEKIT_API_KEY LIVEKIT_API_SECRET"
+          API_SECRETS="ACCESS_TOKEN_SECRET REFRESH_TOKEN_SECRET FEDCM_TOKEN_SECRET SSO_INTERNAL_SECRET MONGODB_URI AWS_S3_BUCKET AWS_ENDPOINT_URL STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET GITHUB_CLIENT_SECRET ALIA_API_KEY SMTP_TLS_KEY SMTP_TLS_CERT SMTP_RELAY_USER SMTP_RELAY_PASS EMAIL_INBOUND_WEBHOOK_SECRET DKIM_PRIVATE_KEY EMAIL_S3_ACCESS_KEY_ID EMAIL_S3_SECRET_ACCESS_KEY DEVICE_ID_SALT OXY_PUBLIC_KEY OXY_PRIVATE_KEY"
+
+          for k in $SHARED_SECRETS $API_SECRETS; do
+            v=$(printenv "$k" || true)
             # Defence in depth: a secret left as an empty string or a single
             # dash placeholder is almost always a mistake (forgot to set a
             # value, or scripted with `gh secret set REDIS_URL --body '-'`).
@@ -60,7 +89,7 @@ jobs:
               echo "::warning::skip REDIS_URL because it does not point at the us-west-2 Valkey endpoint; SSM unchanged"
               continue
             fi
-            case " $SHARED " in *" $k "*) path="/oxy/_shared/$k";; *) path="/oxy/$APP/$k";; esac
+            case " $SHARED_SECRETS " in *" $k "*) path="/oxy/_shared/$k";; *) path="/oxy/$APP/$k";; esac
             aws ssm put-parameter --name "$path" --value "$v" --type SecureString --overwrite >/dev/null && echo "synced -> $path"
           done
 


### PR DESCRIPTION
### Motivation
- Close an overbroad secret-replication vulnerability in the AWS deploy workflow that serialized the entire GitHub Actions secrets context and wrote unrelated repository secrets into the API SSM namespace, expanding blast radius and creating stale copies.
- Limit the SSM sync to only the specific shared and API secrets the `oxy-api` task expects while preserving the existing placeholder-empty guard and the `REDIS_URL` regional endpoint check.

### Description
- Replaced the `toJSON(secrets)`-based loop with an explicit allowlist approach using `SHARED_SECRETS` and `API_SECRETS`, and exposed only expected secrets as step environment variables.
- Shared keys are written under `/oxy/_shared/<KEY>` and API-specific keys under `/oxy/$APP/<KEY>`, and the placeholder-empty value guard plus the `REDIS_URL` us-west-2 endpoint guard were kept intact.
- Modified file: ` .github/workflows/deploy-aws.yml`.

### Testing
- Verified the workflow no longer references `toJSON(secrets)` and does not mention unrelated Cloudflare/DigitalOcean secrets via a Python content assertion, which passed.
- Validated the workflow YAML parses with `YAML.load_file('.github/workflows/deploy-aws.yml')`, which succeeded.
- Ran a whitespace/check style verification (`git diff --check` equivalent) on the modified file, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc1c3c83239958342b441e63c5)