### PR TITLE
fix(services): scope payment queries by session

### DIFF
--- a/packages/services/__tests__/hooks/queryKeys.test.ts
+++ b/packages/services/__tests__/hooks/queryKeys.test.ts
@@ -90,17 +90,19 @@ describe('queryKeys.payments', () => {
     expect(queryKeys.payments.all).toEqual(['payments']);
   });
 
-  it("subscription() resolves to 'current' when no userId is provided", () => {
+  it("subscription() resolves to 'current' when no session scope is provided", () => {
     expect(queryKeys.payments.subscription()).toEqual(['payments', 'subscription', 'current']);
-    expect(queryKeys.payments.subscription('u1')).toEqual(['payments', 'subscription', 'u1']);
+    expect(queryKeys.payments.subscription('sess-1')).toEqual(['payments', 'subscription', 'sess-1']);
   });
 
-  it('history() builds [payments, history, current]', () => {
+  it('history() includes the session scope when provided', () => {
     expect(queryKeys.payments.history()).toEqual(['payments', 'history', 'current']);
+    expect(queryKeys.payments.history('sess-1')).toEqual(['payments', 'history', 'sess-1']);
   });
 
-  it('wallet() builds [payments, wallet, current]', () => {
+  it('wallet() includes the session scope when provided', () => {
     expect(queryKeys.payments.wallet()).toEqual(['payments', 'wallet', 'current']);
+    expect(queryKeys.payments.wallet('sess-1')).toEqual(['payments', 'wallet', 'sess-1']);
   });
 
   it('walletTransactions() includes pagination in the leaf so pages cache independently', () => {
@@ -112,10 +114,10 @@ describe('queryKeys.payments', () => {
       5,
       0,
     ]);
-    expect(queryKeys.payments.walletTransactions(5, 5)).toEqual([
+    expect(queryKeys.payments.walletTransactions(5, 5, 'sess-2')).toEqual([
       'payments',
       'wallet',
-      'current',
+      'sess-2',
       'transactions',
       5,
       5,

--- a/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
+++ b/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
@@ -221,6 +221,32 @@ describe('payment query hooks', () => {
       expect(result.current.data?.balance).toBe(42.5);
       expect(result.current.data?.address).toBeNull();
     });
+
+    it('scopes wallet cache by active session so account switches refetch', async () => {
+      const { rerender, result } = renderHook(() => useUserWallet(), {
+        wrapper: makeWrapper(queryClient),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockState.oxyServices.getCurrentUserWallet).toHaveBeenCalledTimes(1);
+
+      mockState = {
+        ...mockState,
+        activeSessionId: 'sess-2',
+        user: { id: 'u2' },
+      };
+      rerender();
+
+      await waitFor(() =>
+        expect(mockState.oxyServices.getCurrentUserWallet).toHaveBeenCalledTimes(2),
+      );
+      expect(queryClient.getQueryData(['payments', 'wallet', 'sess-1'])).toEqual(
+        WALLET_FIXTURE,
+      );
+      expect(queryClient.getQueryData(['payments', 'wallet', 'sess-2'])).toEqual(
+        WALLET_FIXTURE,
+      );
+    });
   });
 
   describe('useUserWalletTransactions', () => {

--- a/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
+++ b/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
@@ -37,7 +37,7 @@ export const useUserSubscription = (options?: { enabled?: boolean }) => {
   const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.subscription(),
+    queryKey: queryKeys.payments.subscription(activeSessionId ?? undefined),
     queryFn: async () => {
       return authenticatedApiCall<Subscription>(
         oxyServices,
@@ -62,7 +62,7 @@ export const useUserPayments = (options?: { enabled?: boolean }) => {
   const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.history(),
+    queryKey: queryKeys.payments.history(activeSessionId ?? undefined),
     queryFn: async () => {
       return authenticatedApiCall<Payment[]>(
         oxyServices,
@@ -87,7 +87,7 @@ export const useUserWallet = (options?: { enabled?: boolean }) => {
   const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.wallet(),
+    queryKey: queryKeys.payments.wallet(activeSessionId ?? undefined),
     queryFn: async () => {
       return authenticatedApiCall<Wallet>(
         oxyServices,
@@ -121,7 +121,11 @@ export const useUserWalletTransactions = (
   const offset = params?.offset;
 
   return useQuery({
-    queryKey: queryKeys.payments.walletTransactions(limit, offset),
+    queryKey: queryKeys.payments.walletTransactions(
+      limit,
+      offset,
+      activeSessionId ?? undefined,
+    ),
     queryFn: async () => {
       return authenticatedApiCall<WalletTransactionsResponse>(
         oxyServices,

--- a/packages/services/src/ui/hooks/queryClient.ts
+++ b/packages/services/src/ui/hooks/queryClient.ts
@@ -50,7 +50,6 @@ const PERSISTED_QUERY_PREFIXES: ReadonlyArray<string> = [
   'sessions',
   'devices',
   'privacy',
-  'payments',
 ];
 
 /**

--- a/packages/services/src/ui/hooks/useSessionManagement.ts
+++ b/packages/services/src/ui/hooks/useSessionManagement.ts
@@ -8,6 +8,7 @@ import { handleAuthError, isInvalidSessionError } from '../utils/errorHandlers';
 import type { OxyServices } from '@oxyhq/core';
 import type { QueryClient } from '@tanstack/react-query';
 import { clearQueryCache } from './queryClient';
+import { queryKeys } from './queries/queryKeys';
 import { isWebBrowser } from './useWebSSO';
 import { writeActiveAuthuser } from '../utils/activeAuthuser';
 
@@ -300,6 +301,7 @@ export const useSessionManagement = ({
         }
 
         const user = validation.user as User;
+        queryClient?.removeQueries({ queryKey: queryKeys.payments.all });
         await activateSession(sessionId, user);
 
         try {
@@ -353,6 +355,7 @@ export const useSessionManagement = ({
       logger,
       onError,
       oxyServices,
+      queryClient,
       setAuthError,
       updateSessions,
     ],


### PR DESCRIPTION
### Motivation
- Payment and wallet React Query hooks used a stable singleton cache key (e.g. `['payments','wallet','current']`) and the query persistence whitelist included `payments`, allowing cached billing/wallet data to be reused across account/session switches and across restarts.\
- This could leak sensitive financial data to a different active account in the same browser/profile until the cache expired or a refetch occurred.\

### Description
- Scope all current-user payment-related query keys to the active session by passing `activeSessionId` into `queryKeys.payments.*` usage (`packages/services/src/ui/hooks/queries/usePaymentQueries.ts`).\
- Remove `payments` from the persistence whitelist so successful payment reads are not dehydrated and persisted across cold restarts (`packages/services/src/ui/hooks/queryClient.ts`).\
- Clear in-memory payments queries during a session switch so cached entries are removed before activating the new session (`packages/services/src/ui/hooks/useSessionManagement.ts`).\
- Update unit tests to assert session-scoped payment keys and that wallet queries refetch after an active session change (`packages/services/__tests__/hooks/queryKeys.test.ts` and `packages/services/__tests__/hooks/usePaymentQueries.test.tsx`).\

### Testing
- Ran `git diff --check` to validate there are no whitespace/merge artifacts and it passed.\
- Updated and added unit tests (`queryKeys.test.ts` and `usePaymentQueries.test.tsx`) that exercise the new session-scoped keys and a wallet refetch-on-session-switch behavior, but running them locally was blocked because the test runner (`jest`) is not available in this environment.\
- Attempted `bun install` to run the full package tests but dependency fetches failed (registry returned `403`), preventing end-to-end automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db8f508323abcb8c61581c332f)