### PR TITLE
fix(services): scope payment query cache by account

### DIFF
--- a/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
+++ b/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
@@ -194,6 +194,37 @@ describe('payment query hooks', () => {
     });
   });
 
+  it('scopes payment cache entries by active user to prevent cross-account reuse', async () => {
+    mockState.oxyServices.getUserPayments
+      .mockResolvedValueOnce([{ ...PAYMENTS_FIXTURE[0], id: 'p-u1', userId: 'u1' }])
+      .mockResolvedValueOnce([
+        { ...PAYMENTS_FIXTURE[0], id: 'p-u2', userId: 'u2', amount: 19.99 },
+      ]);
+
+    const first = renderHook(() => useUserPayments(), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(first.result.current.isSuccess).toBe(true));
+    expect(first.result.current.data?.[0]?.id).toBe('p-u1');
+
+    mockState = {
+      ...mockState,
+      activeSessionId: 'sess-2',
+      user: { id: 'u2' },
+    };
+
+    const second = renderHook(() => useUserPayments(), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(second.result.current.isSuccess).toBe(true));
+
+    expect(mockState.oxyServices.getUserPayments).toHaveBeenCalledTimes(2);
+    expect(second.result.current.data?.[0]?.id).toBe('p-u2');
+    expect(second.result.current.data?.[0]?.userId).toBe('u2');
+  });
+
   describe('useUserPayments', () => {
     it('calls getUserPayments and returns the typed payment array', async () => {
       const { result } = renderHook(() => useUserPayments(), {

--- a/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
+++ b/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
@@ -34,10 +34,12 @@ import type {
  * API's `{ plan: 'basic' }` fallback when the user has never subscribed.
  */
 export const useUserSubscription = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const accountScope =
+    activeSessionId && user?.id ? `${activeSessionId}:${user.id}` : undefined;
 
   return useQuery({
-    queryKey: queryKeys.payments.subscription(),
+    queryKey: queryKeys.payments.subscription(accountScope),
     queryFn: async () => {
       return authenticatedApiCall<Subscription>(
         oxyServices,
@@ -45,7 +47,7 @@ export const useUserSubscription = (options?: { enabled?: boolean }) => {
         () => oxyServices.getCurrentUserSubscription(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!accountScope,
     // Subscription state changes rarely; tolerate a longer fresh window.
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
@@ -59,10 +61,12 @@ export const useUserSubscription = (options?: { enabled?: boolean }) => {
  * returns the user's `deposit` and `purchase` transactions newest-first.
  */
 export const useUserPayments = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const accountScope =
+    activeSessionId && user?.id ? `${activeSessionId}:${user.id}` : undefined;
 
   return useQuery({
-    queryKey: queryKeys.payments.history(),
+    queryKey: queryKeys.payments.history(accountScope),
     queryFn: async () => {
       return authenticatedApiCall<Payment[]>(
         oxyServices,
@@ -70,7 +74,7 @@ export const useUserPayments = (options?: { enabled?: boolean }) => {
         () => oxyServices.getUserPayments(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!accountScope,
     // Billing history is append-mostly; a short fresh window is fine.
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
@@ -84,10 +88,12 @@ export const useUserPayments = (options?: { enabled?: boolean }) => {
  * Balance changes frequently, so the fresh window is intentionally short.
  */
 export const useUserWallet = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const accountScope =
+    activeSessionId && user?.id ? `${activeSessionId}:${user.id}` : undefined;
 
   return useQuery({
-    queryKey: queryKeys.payments.wallet(),
+    queryKey: queryKeys.payments.wallet(accountScope),
     queryFn: async () => {
       return authenticatedApiCall<Wallet>(
         oxyServices,
@@ -95,7 +101,7 @@ export const useUserWallet = (options?: { enabled?: boolean }) => {
         () => oxyServices.getCurrentUserWallet(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!accountScope,
     staleTime: 60 * 1000, // 1 minute (balance moves often)
     gcTime: 10 * 60 * 1000, // 10 minutes
   });
@@ -116,12 +122,14 @@ export const useUserWalletTransactions = (
   params?: { limit?: number; offset?: number },
   options?: { enabled?: boolean },
 ) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const accountScope =
+    activeSessionId && user?.id ? `${activeSessionId}:${user.id}` : undefined;
   const limit = params?.limit;
   const offset = params?.offset;
 
   return useQuery({
-    queryKey: queryKeys.payments.walletTransactions(limit, offset),
+    queryKey: queryKeys.payments.walletTransactions(limit, offset, accountScope),
     queryFn: async () => {
       return authenticatedApiCall<WalletTransactionsResponse>(
         oxyServices,
@@ -129,7 +137,7 @@ export const useUserWalletTransactions = (
         () => oxyServices.getCurrentUserWalletTransactions({ limit, offset }),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!accountScope,
     staleTime: 60 * 1000, // 1 minute (ledger updates frequently)
     gcTime: 10 * 60 * 1000, // 10 minutes
   });


### PR DESCRIPTION
### Motivation
- Prevent cross-account leakage of sensitive payment and wallet data caused by payment queries using unscoped static keys (e.g. `['payments','history','current']`) that are shared across local account/session switches.  
- Ensure payment-related React Query entries are account-scoped so switching `activeSessionId` + `user.id` cannot surface cached data from a previously active account.

### Description
- Scope payment query keys by an account identifier derived from `activeSessionId` and `user.id` (named `accountScope`) for subscription, payment history, wallet, and wallet transactions so each account has its own cache entries; updated `useUserSubscription`, `useUserPayments`, `useUserWallet`, and `useUserWalletTransactions` accordingly in `packages/services/src/ui/hooks/queries/usePaymentQueries.ts`.
- Tighten hook enablement so queries remain disabled until a valid `accountScope` exists (`enabled: ... && !!accountScope`) to avoid rendering stale shared cache entries during session transitions.
- Include `accountScope` in the pagination-aware `walletTransactions` query key so pages remain per-account and per-page.
- Add a regression unit test `scopes payment cache entries by active user to prevent cross-account reuse` to `packages/services/__tests__/hooks/usePaymentQueries.test.tsx` that mocks two different accounts/sessions and verifies separate fetches and distinct cached results.

### Testing
- Added a unit test in `packages/services/__tests__/hooks/usePaymentQueries.test.tsx` that asserts a switched account triggers a second fetch and does not reuse the first account's cached payments.  
- Ran `git diff --check` with no whitespace errors.  
- Attempted to run the package tests (`jest`) in this environment, but the `jest` binary is not available here so automated test execution was blocked (test addition is present and designed to pass in CI where `jest` is installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbcc948323b69d8dd7f6846f8e)