### PR TITLE
fix(services): scope payment query cache by user

### DIFF
--- a/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
+++ b/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
@@ -132,6 +132,7 @@ import {
   useUserWallet,
   useUserWalletTransactions,
 } from '../../src/ui/hooks/queries/usePaymentQueries';
+import { queryKeys } from '../../src/ui/hooks/queries/queryKeys';
 
 const makeWrapper = (queryClient: QueryClient) =>
   function Wrapper({ children }: { children: ReactNode }) {
@@ -186,6 +187,17 @@ describe('payment query hooks', () => {
 
     it('honours an explicit enabled: false override even when authenticated', () => {
       const { result } = renderHook(() => useUserSubscription({ enabled: false }), {
+        wrapper: makeWrapper(queryClient),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(mockState.oxyServices.getCurrentUserSubscription).not.toHaveBeenCalled();
+    });
+
+    it('does not call the SDK without a scoped current user id', () => {
+      mockState.user = null;
+
+      const { result } = renderHook(() => useUserSubscription(), {
         wrapper: makeWrapper(queryClient),
       });
 
@@ -257,5 +269,37 @@ describe('payment query hooks', () => {
       // Two distinct offsets => two independent fetches.
       expect(mockState.oxyServices.getCurrentUserWalletTransactions).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('scopes payment query keys by the authenticated user id', async () => {
+    const { result: firstResult } = renderHook(() => useUserWallet(), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(firstResult.current.isSuccess).toBe(true));
+
+    const firstServices = mockState.oxyServices;
+    const secondWallet: Wallet = { userId: 'u2', balance: 7, address: null };
+    mockState = {
+      oxyServices: {
+        ...makeServices(),
+        getCurrentUserWallet: jest.fn(async () => secondWallet),
+      },
+      isAuthenticated: true,
+      activeSessionId: 'sess-2',
+      user: { id: 'u2' },
+    };
+
+    const { result: secondResult } = renderHook(() => useUserWallet(), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(secondResult.current.isSuccess).toBe(true));
+
+    expect(firstServices.getCurrentUserWallet).toHaveBeenCalledTimes(1);
+    expect(mockState.oxyServices.getCurrentUserWallet).toHaveBeenCalledTimes(1);
+    expect(secondResult.current.data?.userId).toBe('u2');
+    expect(queryClient.getQueryData(queryKeys.payments.wallet('u1'))).toEqual(WALLET_FIXTURE);
+    expect(queryClient.getQueryData(queryKeys.payments.wallet('u2'))).toEqual(secondWallet);
   });
 });

--- a/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
+++ b/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
@@ -34,10 +34,10 @@ import type {
  * API's `{ plan: 'basic' }` fallback when the user has never subscribed.
  */
 export const useUserSubscription = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.subscription(),
+    queryKey: queryKeys.payments.subscription(user?.id),
     queryFn: async () => {
       return authenticatedApiCall<Subscription>(
         oxyServices,
@@ -45,7 +45,7 @@ export const useUserSubscription = (options?: { enabled?: boolean }) => {
         () => oxyServices.getCurrentUserSubscription(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
     // Subscription state changes rarely; tolerate a longer fresh window.
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
@@ -59,10 +59,10 @@ export const useUserSubscription = (options?: { enabled?: boolean }) => {
  * returns the user's `deposit` and `purchase` transactions newest-first.
  */
 export const useUserPayments = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.history(),
+    queryKey: queryKeys.payments.history(user?.id),
     queryFn: async () => {
       return authenticatedApiCall<Payment[]>(
         oxyServices,
@@ -70,7 +70,7 @@ export const useUserPayments = (options?: { enabled?: boolean }) => {
         () => oxyServices.getUserPayments(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
     // Billing history is append-mostly; a short fresh window is fine.
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
@@ -84,10 +84,10 @@ export const useUserPayments = (options?: { enabled?: boolean }) => {
  * Balance changes frequently, so the fresh window is intentionally short.
  */
 export const useUserWallet = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.wallet(),
+    queryKey: queryKeys.payments.wallet(user?.id),
     queryFn: async () => {
       return authenticatedApiCall<Wallet>(
         oxyServices,
@@ -95,7 +95,7 @@ export const useUserWallet = (options?: { enabled?: boolean }) => {
         () => oxyServices.getCurrentUserWallet(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
     staleTime: 60 * 1000, // 1 minute (balance moves often)
     gcTime: 10 * 60 * 1000, // 10 minutes
   });
@@ -116,12 +116,12 @@ export const useUserWalletTransactions = (
   params?: { limit?: number; offset?: number },
   options?: { enabled?: boolean },
 ) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
   const limit = params?.limit;
   const offset = params?.offset;
 
   return useQuery({
-    queryKey: queryKeys.payments.walletTransactions(limit, offset),
+    queryKey: queryKeys.payments.walletTransactions(limit, offset, user?.id),
     queryFn: async () => {
       return authenticatedApiCall<WalletTransactionsResponse>(
         oxyServices,
@@ -129,7 +129,7 @@ export const useUserWalletTransactions = (
         () => oxyServices.getCurrentUserWalletTransactions({ limit, offset }),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
     staleTime: 60 * 1000, // 1 minute (ledger updates frequently)
     gcTime: 10 * 60 * 1000, // 10 minutes
   });

--- a/packages/services/src/ui/hooks/queryClient.ts
+++ b/packages/services/src/ui/hooks/queryClient.ts
@@ -33,7 +33,7 @@ import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persi
 import { isDev } from '@oxyhq/core';
 import type { StorageInterface } from '../utils/storageHelpers';
 
-const QUERY_CACHE_KEY = 'oxy_query_cache_v2';
+const QUERY_CACHE_KEY = 'oxy_query_cache_v3';
 const QUERY_CACHE_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days
 const QUERY_PERSIST_THROTTLE_MS = 1_000;
 
@@ -50,7 +50,6 @@ const PERSISTED_QUERY_PREFIXES: ReadonlyArray<string> = [
   'sessions',
   'devices',
   'privacy',
-  'payments',
 ];
 
 /**
@@ -209,9 +208,10 @@ export const attachQueryPersistence = (
   return { unsubscribe, restored };
 };
 
-// Legacy v1 cache key — kept so we can opportunistically purge stale blobs
-// written by older builds. Safe to drop after a few releases.
-const LEGACY_QUERY_CACHE_KEYS: ReadonlyArray<string> = ['oxy_query_cache'];
+// Legacy cache keys — kept so we can opportunistically purge stale blobs
+// written by older builds. v2 may contain persisted payments data, so the
+// active key is bumped to v3 and old blobs are only removed during explicit clears.
+const LEGACY_QUERY_CACHE_KEYS: ReadonlyArray<string> = ['oxy_query_cache_v2', 'oxy_query_cache'];
 
 /**
  * Remove the persisted query+mutation cache (used on full sign-out / data


### PR DESCRIPTION
### Motivation
- Fix a client-side confidentiality leak where payment/wallet/subscription queries used shared `current` query keys and the `payments` namespace was persisted, allowing one account's financial data to be visible after session switching or hydration. 
- Ensure financial data is either not persisted across sessions or is isolated per authenticated principal.

### Description
- Scope payment-related query keys to the authenticated user id by passing `user?.id` into `queryKeys.payments.*` and require a resolved `user?.id` before enabling the hooks in `packages/services/src/ui/hooks/queries/usePaymentQueries.ts`.
- Remove the `'payments'` namespace from the persisted query whitelist and bump the persisted cache key to `oxy_query_cache_v3` while retaining legacy keys for explicit clears in `packages/services/src/ui/hooks/queryClient.ts`.
- Add regression tests that assert the hooks do not run without a scoped user id and that wallet cache entries are stored per-user in `packages/services/__tests__/hooks/usePaymentQueries.test.tsx`.
- Files changed: `usePaymentQueries.ts`, `queryClient.ts`, and `__tests__/hooks/usePaymentQueries.test.tsx` (plus small test/import adjustments).

### Testing
- Ran `git diff --check` which reported no whitespace or merge issues (success).
- Attempted to run the package tests with `bun run test -- usePaymentQueries queryKeys --runInBand`, but the runner failed in this environment because `jest` is not available (`jest: command not found`), so the new tests were added but not executed here.
- Attempted a TypeScript compile with `bun run typescript` which failed due to missing workspace dependencies/type declarations in this execution environment (e.g. `react`, `@oxyhq/core`, `react-native`, `@tanstack/react-query`), so local/CI compilation should be validated in an environment with workspace deps installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db5b988323b1a533b160639dfb)