### PR TITLE
fix(api): bound app-data namespace reads

### DIFF
--- a/packages/api/src/routes/__tests__/userData.test.ts
+++ b/packages/api/src/routes/__tests__/userData.test.ts
@@ -1,0 +1,129 @@
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+
+const mockAuthMiddleware = jest.fn();
+const mockExists = jest.fn();
+const mockCountDocuments = jest.fn();
+const mockFindOneAndUpdate = jest.fn();
+const mockFind = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../models/UserAppData', () => ({
+  __esModule: true,
+  APP_DATA_IDENTIFIER_PATTERN: /^[a-z0-9_-]{1,64}$/u,
+  default: {
+    exists: mockExists,
+    countDocuments: mockCountDocuments,
+    findOneAndUpdate: mockFindOneAndUpdate,
+    find: mockFind,
+  },
+}));
+
+import userDataRouter from '../userData';
+import { errorHandler } from '../../middleware/errorHandler';
+import { APP_DATA_MAX_NAMESPACE_KEYS } from '../../schemas/userData.schemas';
+
+interface JsonResponse {
+  status: number;
+  body: { entries?: Record<string, unknown>; error?: string; message?: string; details?: unknown };
+}
+
+function execResult<T>(value: T) {
+  return { exec: jest.fn().mockResolvedValue(value) };
+}
+
+function leanExecResult<T>(value: T) {
+  return { lean: () => execResult(value) };
+}
+
+async function requestJson(server: http.Server, method: string, path: string, payload?: unknown): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? '' : JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: raw.length > 0 ? JSON.parse(raw) : {} });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/users/me/app-data', userDataRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthMiddleware.mockImplementation((req: { user?: { id: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 'user-1' };
+    next();
+  });
+});
+
+test('rejects new app-data keys after the namespace key quota is reached', async () => {
+  mockExists.mockReturnValue(execResult(null));
+  mockCountDocuments
+    .mockReturnValueOnce(execResult(APP_DATA_MAX_NAMESPACE_KEYS))
+    .mockReturnValueOnce(execResult(10));
+
+  const response = await requestJson(server, 'PUT', '/users/me/app-data/academy/new_key', { value: true });
+
+  expect(response.status).toBe(409);
+  expect(response.body.message).toBe('App-data namespace key quota exceeded');
+  expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+});
+
+test('limits namespace list queries and refuses oversized legacy namespaces', async () => {
+  const limit = jest.fn().mockReturnValue(leanExecResult(
+    Array.from({ length: APP_DATA_MAX_NAMESPACE_KEYS + 1 }, (_, index) => ({
+      key: `key_${index}`,
+      value: index,
+    })),
+  ));
+  mockFind.mockReturnValue({ limit });
+
+  const response = await requestJson(server, 'GET', '/users/me/app-data/academy');
+
+  expect(limit).toHaveBeenCalledWith(APP_DATA_MAX_NAMESPACE_KEYS + 1);
+  expect(response.status).toBe(413);
+  expect(response.body.message).toBe('App-data namespace exceeds the maximum list response size');
+});

--- a/packages/api/src/routes/userData.ts
+++ b/packages/api/src/routes/userData.ts
@@ -13,6 +13,7 @@
  *   - 64 KB serialized JSON per value (enforced by the schema).
  *   - 100 writes/minute/user across PUT and DELETE (rate-limit middleware
  *     keyed on the authenticated user ID).
+ *   - At most 128 keys per namespace and 1024 keys per user.
  *   - Namespace and key must match `[a-z0-9_-]{1,64}`.
  */
 
@@ -22,16 +23,43 @@ import { authMiddleware, type AuthRequest } from '../middleware/auth';
 import { rateLimit } from '../middleware/rateLimiter';
 import { validate } from '../middleware/validate';
 import { asyncHandler } from '../utils/asyncHandler';
-import { UnauthorizedError } from '../utils/error';
+import { ApiError, ConflictError, UnauthorizedError } from '../utils/error';
 import { logger } from '../utils/logger';
 import UserAppData from '../models/UserAppData';
 import {
   appDataKeyParamsSchema,
   appDataNamespaceParamsSchema,
   appDataValueBodySchema,
+  APP_DATA_MAX_NAMESPACE_KEYS,
+  APP_DATA_MAX_USER_KEYS,
 } from '../schemas/userData.schemas';
 
 const router = Router();
+
+async function enforceAppDataKeyQuotas(userId: string, namespace: string, key: string): Promise<void> {
+  const existing = await UserAppData.exists({ userId, namespace, key }).exec();
+  if (existing) {
+    return;
+  }
+
+  const [namespaceKeyCount, userKeyCount] = await Promise.all([
+    UserAppData.countDocuments({ userId, namespace }).exec(),
+    UserAppData.countDocuments({ userId }).exec(),
+  ]);
+
+  if (namespaceKeyCount >= APP_DATA_MAX_NAMESPACE_KEYS) {
+    throw new ConflictError('App-data namespace key quota exceeded', {
+      limit: APP_DATA_MAX_NAMESPACE_KEYS,
+      namespace,
+    });
+  }
+
+  if (userKeyCount >= APP_DATA_MAX_USER_KEYS) {
+    throw new ConflictError('App-data user key quota exceeded', {
+      limit: APP_DATA_MAX_USER_KEYS,
+    });
+  }
+}
 
 /**
  * Per-user write rate limiter: 100 writes (PUT + DELETE) per minute.
@@ -183,6 +211,8 @@ router.put(
     const { namespace, key } = req.params;
     const { value } = req.body as { value: unknown };
 
+    await enforceAppDataKeyQuotas(req.user.id, namespace, key);
+
     const now = new Date();
     const doc = await UserAppData.findOneAndUpdate(
       { userId: req.user.id, namespace, key },
@@ -246,9 +276,9 @@ router.delete(
  *     description: >
  *       Returns `{ entries }` where `entries` is a `key -> value` map of
  *       everything stored under `namespace` for the authenticated user. The
- *       response is bounded by the per-user write rate limit upstream and by
- *       the 64 KB cap per individual value; consumers should still expect to
- *       paginate large namespaces themselves.
+ *       response is bounded by the 128-key namespace quota and by the 64 KB
+ *       cap per individual value. If an older namespace exceeds the current
+ *       quota, the endpoint refuses to materialize it in one response.
  *     parameters:
  *       - in: path
  *         name: namespace
@@ -282,8 +312,18 @@ router.get(
       { userId: req.user.id, namespace },
       { key: 1, value: 1 },
     )
+      .limit(APP_DATA_MAX_NAMESPACE_KEYS + 1)
       .lean()
       .exec();
+
+    if (docs.length > APP_DATA_MAX_NAMESPACE_KEYS) {
+      throw new ApiError(
+        413,
+        'App-data namespace exceeds the maximum list response size',
+        'PAYLOAD_TOO_LARGE',
+        { limit: APP_DATA_MAX_NAMESPACE_KEYS, namespace },
+      );
+    }
 
     const entries: Record<string, unknown> = {};
     for (const doc of docs) {

--- a/packages/api/src/schemas/userData.schemas.ts
+++ b/packages/api/src/schemas/userData.schemas.ts
@@ -18,6 +18,12 @@ import { APP_DATA_IDENTIFIER_PATTERN } from '../models/UserAppData';
 /** Hard cap on the serialized JSON size of a single stored value (64 KB). */
 export const APP_DATA_MAX_VALUE_BYTES = 64 * 1024;
 
+/** Maximum number of app-data keys a user may store in one namespace. */
+export const APP_DATA_MAX_NAMESPACE_KEYS = 128;
+
+/** Maximum number of app-data keys a user may store across all namespaces. */
+export const APP_DATA_MAX_USER_KEYS = 1024;
+
 const identifierSchema = z
   .string()
   .trim()


### PR DESCRIPTION
### Motivation
- The per-user app-data KV feature allowed unlimited keys per namespace and returned an unpaginated full-namespace listing, creating a resource-exhaustion (DoS) risk when an attacker accumulated many values.
- Introduce defensive quotas and bounded listing to prevent large DB reads, excessive memory use, and huge JSON responses while preserving existing per-value size and write-rate limits.

### Description
- Add new constants `APP_DATA_MAX_NAMESPACE_KEYS` and `APP_DATA_MAX_USER_KEYS` to `packages/api/src/schemas/userData.schemas.ts` to define quotas (128 keys per namespace, 1024 keys per user).
- Enforce quotas in the write path by adding `enforceAppDataKeyQuotas(userId, namespace, key)` which checks counts and throws `ConflictError` for new keys; existing keys may still be updated.
- Bound namespace listings with `.limit(APP_DATA_MAX_NAMESPACE_KEYS + 1)` and return a `413 PAYLOAD_TOO_LARGE` `ApiError` when a namespace exceeds the quota instead of materializing an unbounded response.
- Add regression tests in `packages/api/src/routes/__tests__/userData.test.ts` covering quota rejection on PUT and oversized namespace listing behavior.

### Testing
- `git diff --check` was run locally and reported clean diffs (no whitespace/errors).
- New Jest route tests were added (`packages/api/src/routes/__tests__/userData.test.ts`) to validate quota enforcement and bounded-list behavior, but they could not be executed in this environment because test dependencies are not installable here (`jest` not found).
- `bun install --frozen-lockfile` was attempted but failed due to upstream registry `403` errors, so automated test execution was blocked; the added tests are deterministic and mock the DB layer to run under normal CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db6d1c832399e4bdc9671852c2)