### PR TITLE
fix(api,security): avoid pre-auth login lockout denial

### DIFF
--- a/packages/api/src/controllers/__tests__/signIn.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/signIn.controller.test.ts
@@ -5,10 +5,10 @@
  *  - H5: constant-time username lookup. When the identifier resolves to
  *    no user, we must still execute a password verification call so the
  *    response timing is indistinguishable from the wrong-password branch.
- *  - H7: per-account lockout. After repeated failures we return 429 +
- *    Retry-After, but keep the same generic message body so the
- *    unauthenticated caller cannot tell account-locked from
- *    invalid-credentials.
+ *  - H7: per-account invalid-attempt throttling. After repeated failures we
+ *    return 429 + Retry-After for invalid credentials, but a correct
+ *    password still clears failures and signs in so attackers cannot lock
+ *    victims out of their accounts.
  */
 
 const mockUserFindOne = jest.fn();
@@ -177,16 +177,18 @@ describe('SessionController.signIn (H5)', () => {
     expect(res.json).toHaveBeenCalledWith({ message: 'Invalid credentials' });
   });
 
-  it('blocks the request when the account is already locked (pre-check)', async () => {
+  it('does not pre-check lockout before credential verification', async () => {
     mockIsLockedOut.mockResolvedValueOnce({ locked: true, retryAfterSeconds: 300, attempts: 5 });
+    mockUserFindOne.mockReturnValueOnce(makeQuery(null));
+    mockVerifyPassword.mockResolvedValueOnce(false);
 
     const res = createMockRes();
     await SessionController.signIn(createReq({ identifier: 'alice', password: 'whatever' }), res);
 
-    expect(mockUserFindOne).not.toHaveBeenCalled();
-    expect(mockVerifyPassword).not.toHaveBeenCalled();
-    expect(res.setHeader).toHaveBeenCalledWith('Retry-After', '300');
-    expect(res.status).toHaveBeenCalledWith(429);
+    expect(mockIsLockedOut).not.toHaveBeenCalled();
+    expect(mockUserFindOne).toHaveBeenCalled();
+    expect(mockVerifyPassword).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({ message: 'Invalid credentials' });
   });
 

--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -19,7 +19,7 @@ import { formatUserResponse, type UserLike } from '../utils/userTransform';
 import { generateAlphanumericCode, hashPassword, verifyPassword, validatePasswordStrength } from '../utils/password';
 import securityActivityService from '../services/securityActivityService';
 import anomalyDetectionService from '../services/anomalyDetection.service';
-import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
+import { recordFailure, clearFailures } from '../services/loginLockout.service';
 import {
   issueAndSetRefreshCookie,
   revokeFamilyBySession,
@@ -624,11 +624,11 @@ export class SessionController {
    * milliseconds while a real password check costs tens of milliseconds,
    * leaking account existence.
    *
-   * Lockout (H7): we track per-identifier failed attempts. After the
-   * configured threshold the account returns the same generic
-   * "Invalid credentials" message plus a `Retry-After` header — we never
-   * tell the unauthenticated caller that the account is locked, because
-   * that itself is enumeration.
+   * Login throttling (H7): we track per-identifier failed attempts and add
+   * a `Retry-After` response to repeated invalid credentials. We do not
+   * reject before verifying the supplied password; a legitimate user with
+   * the correct password must be able to clear failures and sign in even if
+   * an attacker has filled the failure bucket for their identifier.
    */
   static async signIn(req: Request, res: Response) {
     try {
@@ -644,17 +644,12 @@ export class SessionController {
         return res.status(400).json({ message: 'Invalid identifier' });
       }
 
-      // Check lockout BEFORE the credential lookup. We always return the
-      // same generic 401-style message; only the Retry-After header differs.
+      // Do not check the lockout bucket before credential verification.
+      // This route is public; a pre-verification per-account lockout lets an
+      // unauthenticated attacker deny login to a known user by filling that
+      // user's failure bucket. Instead, verify credentials first and only use
+      // the bucket to throttle repeated invalid attempts.
       const lockoutKey = parsedIdentifier.value;
-      const lockState = await isLockedOut({
-        scope: LOGIN_LOCKOUT_SCOPE,
-        identifier: lockoutKey,
-      });
-      if (lockState.locked && typeof lockState.retryAfterSeconds === 'number') {
-        res.setHeader('Retry-After', String(lockState.retryAfterSeconds));
-        return res.status(429).json({ message: 'Invalid credentials' });
-      }
 
       const query = parsedIdentifier.field === 'email'
         ? { email: parsedIdentifier.value }


### PR DESCRIPTION
### Motivation
- Prevent a targeted account lockout DoS where an unauthenticated attacker could fill an identifier's failure bucket and cause even a correct password to be rejected before verification.
- Preserve constant-time username/password timing hardening (H5) and retain throttling for repeated invalid credentials while ensuring legitimate users can still authenticate to clear failures (H7).

### Description
- Removed the pre-credential `isLockedOut` check from `SessionController.signIn` so the route always performs user lookup and password verification before applying failure-based throttling (changed `packages/api/src/controllers/session.controller.ts`).
- Stopped importing `isLockedOut` from the lockout service and kept `recordFailure`/`clearFailures` so failed verifications still increment the bucket and successful sign-ins clear it (changed `packages/api/src/controllers/session.controller.ts`).
- Updated sign-in regression tests to assert that the pre-check is not used and that credential verification still runs (changed `packages/api/src/controllers/__tests__/signIn.controller.test.ts`).
- Preserved existing behavior where failed verifications return `401` and once the threshold is reached subsequent invalid attempts return `429` with a `Retry-After` header.

### Testing
- Ran `git diff --check` which reported no whitespace or diff issues.
- Attempted to run the focused unit tests via `bun run test --runInBand src/controllers/__tests__/signIn.controller.test.ts`, but the test runner (`jest`) was not available in this environment so the test invocation could not execute.
- Attempted `bun install` to install deps required for running tests, but dependency fetches failed against the npm registry (multiple `403` responses), preventing full automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbd3848323be76b834fe78ab67)