### PR TITLE
fix(inbox): clear cached state before settings sign-out

### DIFF
--- a/packages/inbox/components/settings/sections/AccountSection.tsx
+++ b/packages/inbox/components/settings/sections/AccountSection.tsx
@@ -34,6 +34,7 @@ import { toast } from '@oxyhq/bloom';
 
 import { useColors } from '@/constants/theme';
 import { useSettings, useUpdateSettings } from '@/hooks/queries/useSettings';
+import { resetInboxState } from '@/hooks/useEmail';
 import type { EmailSettings } from '@/services/emailApi';
 import { SectionHeader } from '@/components/settings/SectionHeader';
 
@@ -151,6 +152,7 @@ export function AccountSection() {
 
   const handleSignOut = useCallback(async () => {
     try {
+      resetInboxState();
       await logout();
       toast.success('Signed out.');
     } catch (err) {

--- a/packages/inbox/hooks/useEmail.ts
+++ b/packages/inbox/hooks/useEmail.ts
@@ -8,6 +8,7 @@
 import { create } from 'zustand';
 import { createEmailApi, type EmailApiInstance, type Mailbox } from '@/services/emailApi';
 import type { OxyServices } from '@oxyhq/core';
+import { queryClient } from '@/hooks/queries/queryClient';
 
 type HttpService = OxyServices['httpService'];
 
@@ -124,3 +125,22 @@ export const useEmailStore = create<EmailState>((set, get) => ({
     set({ selectedMessageIds: new Set(ids), isSelectionMode: ids.length > 0 });
   },
 }));
+
+/** Reset all inbox-specific state before switching or signing out accounts. */
+export function resetInboxState() {
+  useEmailStore.setState({
+    currentMailbox: null,
+    viewMode: null,
+    selectedMessageId: null,
+    moreExpanded: false,
+    bundleView: false,
+    expandedBundles: new Set<string>(),
+    selectedMessageIds: new Set<string>(),
+    isSelectionMode: false,
+    _api: null,
+  });
+
+  // Clear all React Query caches so stale data from one account cannot be
+  // rendered for the next active account while query results are still fresh.
+  queryClient.clear();
+}


### PR DESCRIPTION
### Motivation
- Prevent leaked inbox data across local/multi-session account sign-outs when the settings Sign out path triggers a raw `logout()` without clearing inbox-specific caches and API instances.  
- Ensure the settings sign-out reuses the same inbox-reset semantics as the account-switcher flow to avoid showing previous-account messages, labels, or settings after an automatic session switch.

### Description
- Added a shared helper `resetInboxState()` in `packages/inbox/hooks/useEmail.ts` that clears the Zustand email UI state, nulls the cached `_api` instance, and calls `queryClient.clear()` to flush TanStack Query caches.  
- Imported and wired `resetInboxState()` into `packages/inbox/components/settings/sections/AccountSection.tsx` so the handler calls `resetInboxState()` before invoking `logout()`.  
- Kept existing behavior and UX of the settings sign-out dialog while ensuring inbox caches are cleared first.

### Testing
- Ran `git diff --check` to validate no whitespace errors; this completed successfully.  
- Ran a TypeScript check with `bunx tsc --noEmit -p packages/inbox/tsconfig.json`, which could not complete in this environment due to missing local dev dependencies and Expo TypeScript base; the typecheck was blocked by the environment rather than the change.  
- Ran the package lint script `bun run --cwd packages/inbox lint`, which could not run here because `expo` is not installed in the environment; linting should be executed in CI or a dev workstation and is expected to pass.  

If desired, run the following locally or in CI to fully validate: `bunx tsc --noEmit -p packages/inbox/tsconfig.json` and `bun run --cwd packages/inbox lint`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8daef18832386e372ede894673a)