### PR TITLE
fix(services): scope current user cache by session

### DIFF
--- a/packages/services/__tests__/hooks/queryKeys.test.ts
+++ b/packages/services/__tests__/hooks/queryKeys.test.ts
@@ -29,8 +29,9 @@ describe('queryKeys.accounts', () => {
     expect(queryKeys.accounts.detail('s1')).toEqual(['accounts', 'detail', 's1']);
   });
 
-  it('current() is a stable singleton key', () => {
+  it('current() is a stable singleton prefix and scopes by sessionId when supplied', () => {
     expect(queryKeys.accounts.current()).toEqual(['accounts', 'current']);
+    expect(queryKeys.accounts.current('s1')).toEqual(['accounts', 'current', 's1']);
   });
 });
 

--- a/packages/services/src/ui/hooks/mutations/mutationFactory.ts
+++ b/packages/services/src/ui/hooks/mutations/mutationFactory.ts
@@ -81,20 +81,20 @@ export function createProfileMutation<TVariables>(
 
     onMutate: async (variables) => {
       // Cancel queries that might conflict
-      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current() });
+      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current(activeSessionId) });
       for (const key of cancelQueryKeys) {
         await queryClient.cancelQueries({ queryKey: key });
       }
 
       // Snapshot previous user data
-      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
 
       // Apply optimistic update if provided
       if (previousUser && optimisticUpdate) {
         const updates = optimisticUpdate(previousUser, variables);
         const optimisticUser = { ...previousUser, ...updates };
 
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), optimisticUser);
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), optimisticUser);
 
         if (activeSessionId) {
           queryClient.setQueryData<User>(queryKeys.users.profile(activeSessionId), optimisticUser);
@@ -107,7 +107,7 @@ export function createProfileMutation<TVariables>(
     onError: (error, _variables, context) => {
       // Rollback optimistic update
       if (context?.previousUser) {
-        queryClient.setQueryData(queryKeys.accounts.current(), context.previousUser);
+        queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), context.previousUser);
         if (activeSessionId) {
           queryClient.setQueryData(queryKeys.users.profile(activeSessionId), context.previousUser);
         }
@@ -122,7 +122,7 @@ export function createProfileMutation<TVariables>(
 
     onSuccess: (data, variables) => {
       // Update cache with server response
-      queryClient.setQueryData(queryKeys.accounts.current(), data);
+      queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), data);
       if (activeSessionId) {
         queryClient.setQueryData(queryKeys.users.profile(activeSessionId), data);
       }

--- a/packages/services/src/ui/hooks/mutations/useAccountMutations.ts
+++ b/packages/services/src/ui/hooks/mutations/useAccountMutations.ts
@@ -40,10 +40,10 @@ export const useUpdateProfile = () => {
     // Optimistic update
     onMutate: async (updates) => {
       // Cancel outgoing refetches
-      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current() });
+      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current(activeSessionId) });
 
       // Snapshot previous value
-      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
 
       // Optimistically update
       if (previousUser) {
@@ -54,7 +54,7 @@ export const useUpdateProfile = () => {
             ? { ...previousUser.name, ...updates.name }
             : previousUser.name,
         };
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), optimisticUser);
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), optimisticUser);
 
         // Also update profile query if sessionId is available
         if (activeSessionId) {
@@ -74,9 +74,9 @@ export const useUpdateProfile = () => {
           return acc;
         }, {});
 
-        const current = queryClient.getQueryData<User>(queryKeys.accounts.current());
+        const current = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
         if (current) {
-          queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+          queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
             ...current,
             ...partialRollback,
           });
@@ -96,7 +96,7 @@ export const useUpdateProfile = () => {
     // On success, invalidate and refetch
     onSuccess: (data, updates) => {
       // Update cache with server response
-      queryClient.setQueryData(queryKeys.accounts.current(), data);
+      queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), data);
       if (activeSessionId) {
         queryClient.setQueryData(queryKeys.users.profile(activeSessionId), data);
       }
@@ -143,8 +143,8 @@ export const useUploadAvatar = () => {
       });
     },
     onMutate: async (file) => {
-      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current() });
-      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current(activeSessionId) });
+      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
 
       // Optimistically set a temporary avatar (using file URI as placeholder)
       if (previousUser) {
@@ -152,7 +152,7 @@ export const useUploadAvatar = () => {
           ...previousUser,
           avatar: file.uri, // Temporary, will be replaced with fileId
         };
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), optimisticUser);
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), optimisticUser);
         if (activeSessionId) {
           queryClient.setQueryData<User>(queryKeys.users.profile(activeSessionId), optimisticUser);
         }
@@ -164,9 +164,9 @@ export const useUploadAvatar = () => {
       // Avatar upload only mutates the `avatar` field — restore only that key
       if (context?.previousUser) {
         const previousAvatar = context.previousUser.avatar;
-        const current = queryClient.getQueryData<User>(queryKeys.accounts.current());
+        const current = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
         if (current) {
-          queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+          queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
             ...current,
             avatar: previousAvatar,
           });
@@ -184,7 +184,7 @@ export const useUploadAvatar = () => {
       toast.error(error instanceof Error ? error.message : 'Failed to upload avatar');
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(queryKeys.accounts.current(), data);
+      queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), data);
       if (activeSessionId) {
         queryClient.setQueryData(queryKeys.users.profile(activeSessionId), data);
       }
@@ -270,10 +270,10 @@ export const useUpdateAccountSettings = () => {
     },
     onMutate: async ({ updates }) => {
       await queryClient.cancelQueries({ queryKey: queryKeys.accounts.settings() });
-      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
 
       if (previousUser) {
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
           ...previousUser,
           privacySettings: {
             ...previousUser.privacySettings,
@@ -294,9 +294,9 @@ export const useUpdateAccountSettings = () => {
           return acc;
         }, {});
 
-        const current = queryClient.getQueryData<User>(queryKeys.accounts.current());
+        const current = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
         if (current) {
-          queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+          queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
             ...current,
             privacySettings: {
               ...(current.privacySettings ?? {}),
@@ -308,7 +308,7 @@ export const useUpdateAccountSettings = () => {
       toast.error(error instanceof Error ? error.message : 'Failed to update settings');
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(queryKeys.accounts.current(), data);
+      queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), data);
 
       // Update authStore so frontend components see the changes immediately
       useAuthStore.getState().setUser(data);
@@ -328,7 +328,7 @@ export const useUpdateAccountSettings = () => {
   return {
     ...mutation,
     mutate: (updates: Partial<PrivacySettings>): void => {
-      const currentUser = user ?? queryClient.getQueryData<User>(queryKeys.accounts.current());
+      const currentUser = user ?? queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
       if (!currentUser) {
         toast.error('Cannot update account settings: no current user');
         return;
@@ -336,7 +336,7 @@ export const useUpdateAccountSettings = () => {
       mutation.mutate({ updates, currentUser });
     },
     mutateAsync: async (updates: Partial<PrivacySettings>): Promise<User> => {
-      const currentUser = user ?? queryClient.getQueryData<User>(queryKeys.accounts.current());
+      const currentUser = user ?? queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
       if (!currentUser) {
         throw new Error('Cannot update account settings: no current user');
       }
@@ -373,11 +373,11 @@ export const useUpdatePrivacySettings = () => {
 
       // Cancel outgoing refetches
       await queryClient.cancelQueries({ queryKey: queryKeys.privacy.settings(targetUserId) });
-      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current() });
+      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current(activeSessionId) });
 
       // Snapshot previous values
       const previousPrivacySettings = queryClient.getQueryData(queryKeys.privacy.settings(targetUserId));
-      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
 
       // Optimistically update privacy settings
       if (previousPrivacySettings) {
@@ -389,7 +389,7 @@ export const useUpdatePrivacySettings = () => {
 
       // Also update user query if available
       if (previousUser) {
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
           ...previousUser,
           privacySettings: {
             ...previousUser.privacySettings,
@@ -431,9 +431,9 @@ export const useUpdatePrivacySettings = () => {
           (acc as Record<string, unknown>)[key as string] = previousPrivacy[key as string];
           return acc;
         }, {});
-        const current = queryClient.getQueryData<User>(queryKeys.accounts.current());
+        const current = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
         if (current) {
-          queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+          queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
             ...current,
             privacySettings: {
               ...(current.privacySettings ?? {}),
@@ -479,7 +479,7 @@ export const useUpdatePrivacySettings = () => {
         }),
       );
 
-      const currentUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      const currentUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
       if (currentUser) {
         const updatedUser: User = {
           ...currentUser,
@@ -489,7 +489,7 @@ export const useUpdatePrivacySettings = () => {
             ...incoming,
           },
         };
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), updatedUser);
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), updatedUser);
         useAuthStore.getState().setUser(updatedUser);
       }
       // Deliberately NOT invalidating any queries here. invalidateAccountQueries
@@ -538,11 +538,11 @@ export const useUpdateNotificationPreferences = () => {
       );
     },
     onMutate: async (preferences) => {
-      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current() });
-      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current(activeSessionId) });
+      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
 
       if (previousUser) {
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
           ...previousUser,
           notificationPreferences: {
             ...previousUser.notificationPreferences,
@@ -555,9 +555,9 @@ export const useUpdateNotificationPreferences = () => {
     },
     onError: (error, _preferences, context) => {
       if (context?.previousUser) {
-        const current = queryClient.getQueryData<User>(queryKeys.accounts.current());
+        const current = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
         if (current) {
-          queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+          queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
             ...current,
             notificationPreferences: context.previousUser.notificationPreferences,
           });
@@ -570,7 +570,7 @@ export const useUpdateNotificationPreferences = () => {
       );
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(queryKeys.accounts.current(), data);
+      queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), data);
       useAuthStore.getState().setUser(data);
       invalidateAccountQueries(queryClient);
     },
@@ -596,11 +596,11 @@ export const useUpdateUserPreferences = () => {
       );
     },
     onMutate: async (preferences) => {
-      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current() });
-      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current());
+      await queryClient.cancelQueries({ queryKey: queryKeys.accounts.current(activeSessionId) });
+      const previousUser = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
 
       if (previousUser) {
-        queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+        queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
           ...previousUser,
           userPreferences: {
             ...previousUser.userPreferences,
@@ -613,9 +613,9 @@ export const useUpdateUserPreferences = () => {
     },
     onError: (error, _preferences, context) => {
       if (context?.previousUser) {
-        const current = queryClient.getQueryData<User>(queryKeys.accounts.current());
+        const current = queryClient.getQueryData<User>(queryKeys.accounts.current(activeSessionId));
         if (current) {
-          queryClient.setQueryData<User>(queryKeys.accounts.current(), {
+          queryClient.setQueryData<User>(queryKeys.accounts.current(activeSessionId), {
             ...current,
             userPreferences: context.previousUser.userPreferences,
           });
@@ -624,7 +624,7 @@ export const useUpdateUserPreferences = () => {
       toast.error(error instanceof Error ? error.message : 'Failed to update preferences');
     },
     onSuccess: (data) => {
-      queryClient.setQueryData(queryKeys.accounts.current(), data);
+      queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), data);
       useAuthStore.getState().setUser(data);
       invalidateAccountQueries(queryClient);
     },

--- a/packages/services/src/ui/hooks/mutations/useServicesMutations.ts
+++ b/packages/services/src/ui/hooks/mutations/useServicesMutations.ts
@@ -17,12 +17,12 @@ export const useSwitchSession = () => {
     mutationFn: async (sessionId: string) => {
       return await switchSession(sessionId);
     },
-    onSuccess: (user) => {
+    onSuccess: (user, sessionId) => {
       // Invalidate all session queries
       invalidateSessionQueries(queryClient);
       
       // Update current user query
-      queryClient.setQueryData(queryKeys.accounts.current(), user);
+      queryClient.setQueryData(queryKeys.accounts.current(sessionId), user);
       
       // Invalidate account queries
       queryClient.invalidateQueries({ queryKey: queryKeys.accounts.all });

--- a/packages/services/src/ui/hooks/queries/queryKeys.ts
+++ b/packages/services/src/ui/hooks/queries/queryKeys.ts
@@ -17,7 +17,10 @@ export const queryKeys = {
     list: (sessionIds: string[]) => [...queryKeys.accounts.lists(), sessionIds] as const,
     details: () => [...queryKeys.accounts.all, 'detail'] as const,
     detail: (sessionId: string) => [...queryKeys.accounts.details(), sessionId] as const,
-    current: () => [...queryKeys.accounts.all, 'current'] as const,
+    current: (sessionId?: string | null) =>
+      sessionId
+        ? ([...queryKeys.accounts.all, 'current', sessionId] as const)
+        : ([...queryKeys.accounts.all, 'current'] as const),
     settings: () => [...queryKeys.accounts.all, 'settings'] as const,
   },
 

--- a/packages/services/src/ui/hooks/queries/useAccountQueries.ts
+++ b/packages/services/src/ui/hooks/queries/useAccountQueries.ts
@@ -65,7 +65,7 @@ export const useCurrentUser = (options?: { enabled?: boolean }) => {
   const queryClient = useQueryClient();
 
   const query = useQuery({
-    queryKey: queryKeys.accounts.current(),
+    queryKey: queryKeys.accounts.current(activeSessionId),
     queryFn: async () => {
       if (!activeSessionId) {
         throw new Error('No active session');

--- a/packages/services/src/ui/utils/avatarUtils.ts
+++ b/packages/services/src/ui/utils/avatarUtils.ts
@@ -52,7 +52,7 @@ export async function updateProfileWithAvatar(
   );
 
   // Update cache with server response
-  queryClient.setQueryData(queryKeys.accounts.current(), data);
+  queryClient.setQueryData(queryKeys.accounts.current(activeSessionId), data);
   if (activeSessionId) {
     queryClient.setQueryData(queryKeys.users.profile(activeSessionId), data);
   }


### PR DESCRIPTION
### Motivation

- Prevent a stale per-session cached `User` from being mirrored into the global auth store after account switches by ensuring current-user query data is keyed by `activeSessionId` when available.

### Description

- Make `queryKeys.accounts.current()` optionally accept a `sessionId` so current-user cache entries can be scoped to a session while preserving the unscoped singleton prefix when no session is provided.
- Switch `useCurrentUser` to use the session-scoped query key (`queryKeys.accounts.current(activeSessionId)`) so TanStack Query cache entries are separated per active session.
- Update all mutations, optimistic updates, rollbacks and helpers that read/write the current-user cache to use the session-scoped key (changes in `useAccountMutations.ts`, `mutationFactory.ts`, `useServicesMutations.ts`, and `avatarUtils.ts`).
- Add/adjust a unit test for `queryKeys.accounts.current()` to assert both the singleton prefix and the session-scoped variant (`packages/services/__tests__/hooks/queryKeys.test.ts`).

### Testing

- Ran `git diff --check` which passed with no whitespace errors.
- Attempted to run the focused test via `bun run test -- queryKeys.test.ts` but it failed because `jest` is not installed in this environment (command error: `jest: command not found`).
- Attempted to install dependencies with `bun install` but the job could not complete because npm registry tarball requests returned HTTP 403, preventing a full test run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc339883239a5b7cec821027eb)