### PR TITLE
fix(api): gate contact discovery behind opt-in privacy

### DIFF
--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -152,6 +152,8 @@ export interface IUser extends Document {
     sensitiveContent: boolean;
     autoFilter: boolean;
     muteKeywords: boolean;
+    discoverableByEmail?: boolean;
+    discoverableByPhone?: boolean;
   };
   // Avatar file ID referencing assets collection
   avatar?: string; // file id
@@ -430,6 +432,11 @@ const UserSchema: Schema = new Schema(
       sensitiveContent: { type: Boolean, default: false },
       autoFilter: { type: Boolean, default: true },
       muteKeywords: { type: Boolean, default: false },
+      // Contact discovery is opt-in. These default to false so stored email/phone
+      // hashes cannot be used as an account-enumeration oracle unless the
+      // target user explicitly chooses to be discoverable by that channel.
+      discoverableByEmail: { type: Boolean, default: false },
+      discoverableByPhone: { type: Boolean, default: false },
     },
   avatar: { type: String },
     color: {

--- a/packages/api/src/routes/contacts.ts
+++ b/packages/api/src/routes/contacts.ts
@@ -5,13 +5,17 @@
  * already have Oxy accounts. Clients hash emails/phones locally with SHA-256
  * (see `utils/contactHash.ts` for the canonical algorithm) and upload only
  * those digests. The server intersects them against precomputed indexes on
- * the `User` collection and returns the matched user IDs.
+ * the `User` collection and returns matched user IDs only for users who
+ * explicitly opted in to contact discovery for that identifier type.
  *
  * Privacy invariants:
  *   - Raw email / phone never traverses this route.
- *   - The response contains no PII — only Oxy user IDs and the hash the
- *     caller supplied (so the client can map matches back to the local
- *     contact that produced them).
+ *   - The response contains no PII — only opted-in Oxy user IDs and the
+ *     hash the caller supplied (so the client can map matches back to the
+ *     local contact that produced them).
+ *   - Stored contact hashes are never queryable for users who have not
+ *     explicitly enabled `privacySettings.discoverableByEmail` or
+ *     `privacySettings.discoverableByPhone`.
  *   - No write to the database. Discovery is stateless.
  *
  * Abuse controls:
@@ -111,7 +115,8 @@ interface DiscoverMatch {
  *       to E.164 — see `utils/contactHash.ts` in `@oxyhq/core`) and upload
  *       only the resulting 64-character hex digests. The server intersects
  *       them against precomputed indexes on the `User` collection and returns
- *       matched Oxy user IDs.
+ *       matched Oxy user IDs only when the matched user has opted in to
+ *       contact discovery for that identifier type.
  *
  *       Privacy invariants:
  *         - Raw email / phone never traverses this endpoint.
@@ -234,6 +239,9 @@ router.post(
               // Federated/agent/automated accounts are not meant to surface
               // in a personal contact-sync flow.
               type: { $in: ['local', null] },
+              // Contact discovery is opt-in. Without this gate, deterministic
+              // email/phone hashes can be used as an account-enumeration oracle.
+              'privacySettings.discoverableByEmail': true,
             },
             { _id: 1, hashedEmail: 1 },
           )
@@ -246,6 +254,9 @@ router.post(
               hashedPhone: { $in: uniquePhoneHashes },
               _id: { $ne: req.user.id },
               type: { $in: ['local', null] },
+              // Contact discovery is opt-in. Without this gate, deterministic
+              // phone hashes can be used as an account-enumeration oracle.
+              'privacySettings.discoverableByPhone': true,
             },
             { _id: 1, hashedPhone: 1 },
           )

--- a/packages/api/src/routes/privacy.ts
+++ b/packages/api/src/routes/privacy.ts
@@ -42,6 +42,8 @@ const privacySettingsSchema = z.object({
   sensitiveContent: z.boolean().optional(),
   autoFilter: z.boolean().optional(),
   muteKeywords: z.boolean().optional(),
+  discoverableByEmail: z.boolean().optional(),
+  discoverableByPhone: z.boolean().optional(),
 });
 
 // Get privacy settings (own settings only)


### PR DESCRIPTION
### Motivation

- Close an account-enumeration/privacy vulnerability where authenticated callers could submit attacker-chosen SHA-256 digests to `/contacts/discover` and learn whether arbitrary emails/phones belonged to Oxy accounts.
- Ensure deterministic contact hashes are queryable only when the target user has explicitly opted in, restoring a privacy-by-default posture.

### Description

- Add two opt-in flags to user privacy settings: `privacySettings.discoverableByEmail` and `privacySettings.discoverableByPhone`, both defaulting to `false` in the `User` model (`packages/api/src/models/User.ts`).
- Extend the privacy settings schema to accept the new opt-in fields so users can update them (`packages/api/src/routes/privacy.ts`).
- Gate `/contacts/discover` matching queries so email matches require `'privacySettings.discoverableByEmail': true` and phone matches require `'privacySettings.discoverableByPhone': true`, preventing matches for non-opted-in accounts (`packages/api/src/routes/contacts.ts`).
- Update route comments/documentation to explicitly state the opt-in requirement and the privacy invariant (`packages/api/src/routes/contacts.ts`).

### Testing

- Ran `git diff --check` to validate there are no whitespace/merge conflicts, which succeeded.
- Attempted to run the package test runner (`bun run test --runInBand ...` / Jest) for the API, but automated test execution could not complete in this environment because the local test dependencies/runner are not installed (`jest: command not found`), so no API tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dba6f88323917bdc3adc1dc9ae)