### PR TITLE
fix(api): constrain email import resource usage

### DIFF
--- a/packages/api/src/routes/email.ts
+++ b/packages/api/src/routes/email.ts
@@ -5,11 +5,12 @@
  * All routes require authentication via authMiddleware.
  */
 
-import { Router } from 'express';
+import { Router, type NextFunction, type Request, type Response } from 'express';
 import multer from 'multer';
 import { authMiddleware } from '../middleware/auth';
 import { asyncHandler } from '../utils/asyncHandler';
 import { validate } from '../middleware/validate';
+import { BadRequestError } from '../utils/error';
 import {
   createMailboxSchema,
   mailboxIdParams,
@@ -96,13 +97,42 @@ import {
 
 const router = Router();
 
-// Multer for .eml uploads on POST /import (in-memory, max 50 MB / file).
+const IMPORT_MAX_FILES = 5;
+const IMPORT_MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+
+// Multer for .eml uploads on POST /import (in-memory, max 25 MB / file).
 // Attachment uploads no longer flow through this route — clients upload files
 // to the Oxy file manager (/assets) and reference them by fileId on send.
-const upload = multer({
+const importUpload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 50 * 1024 * 1024 },
+  limits: {
+    fileSize: IMPORT_MAX_FILE_SIZE_BYTES,
+    files: IMPORT_MAX_FILES,
+    fields: 0,
+    parts: IMPORT_MAX_FILES,
+  },
+  fileFilter: (_req, file, cb) => {
+    if (!file.originalname.toLowerCase().endsWith('.eml')) {
+      cb(
+        new BadRequestError(
+          `Invalid file type: ${file.originalname}. Only .eml files are accepted.`,
+        ),
+      );
+      return;
+    }
+    cb(null, true);
+  },
 });
+
+const importUploadMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  importUpload.array('files', IMPORT_MAX_FILES)(req, res, (err) => {
+    if (err instanceof multer.MulterError) {
+      next(new BadRequestError(err.message));
+      return;
+    }
+    next(err);
+  });
+};
 
 // All email routes require authentication
 router.use(authMiddleware);
@@ -165,7 +195,7 @@ router.get('/quota', asyncHandler(getQuota));
 // .eml are extracted server-side and persisted via the Oxy file manager
 // (assetService.uploadFileDirect), exactly like inbound MIME from Cloudflare.
 
-router.post('/import', upload.array('files', 50), asyncHandler(importMessages));
+router.post('/import', importUploadMiddleware, asyncHandler(importMessages));
 
 // ─── Subscriptions ───────────────────────────────────────────
 

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -1752,10 +1752,16 @@ class EmailService {
 
     await this.ensureMailboxes(userId);
     await this.ensureDefaultLabels(userId);
+    await this.enforceQuota(
+      userId,
+      files.reduce((total, file) => total + file.buffer.length, 0),
+    );
 
     const inbox = await this.getMailboxBySpecialUse(userId, '\\Inbox');
     if (!inbox) throw new NotFoundError('Inbox not found');
 
+    const tier = await this.getUserTier(userId);
+    const maxAttachmentSize = EMAIL_QUOTAS[tier].maxAttachmentSize;
     let imported = 0;
 
     for (const file of files) {
@@ -1785,8 +1791,25 @@ class EmailService {
         // Upload attachments to the Oxy file manager
         const storedAttachments: IAttachment[] = [];
         const importedFileIds: string[] = [];
+        const parsedAttachments = parsed.attachments || [];
+        const attachmentBytes = parsedAttachments.reduce(
+          (sum, att) => sum + (att.size || att.content.length),
+          0,
+        );
+        for (const att of parsedAttachments) {
+          const attachmentSize = att.size || att.content.length;
+          if (attachmentSize > maxAttachmentSize) {
+            throw new BadRequestError(
+              `Attachment ${att.filename || 'attachment'} exceeds the ${maxAttachmentSize} byte limit for your plan.`,
+            );
+          }
+        }
+
+        const totalSize = rawSize + attachmentBytes;
+        await this.enforceQuota(userId, totalSize);
+
         if (parsed.attachments?.length) {
-          for (const att of parsed.attachments) {
+          for (const att of parsedAttachments) {
             const uploadedFile = await assetService.uploadFileDirect(
               userId,
               att.content,
@@ -1806,8 +1829,6 @@ class EmailService {
             importedFileIds.push(uploadedFile._id.toString());
           }
         }
-
-        const totalSize = rawSize + storedAttachments.reduce((sum, a) => sum + a.size, 0);
 
         const message = await Message.create({
           userId: new mongoose.Types.ObjectId(userId),
@@ -1868,6 +1889,9 @@ class EmailService {
 
         imported++;
       } catch (err) {
+        if (err instanceof BadRequestError) {
+          throw err;
+        }
         logger.warn('Failed to import .eml file', {
           filename: file.originalname,
           error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
### Motivation
- The `/email/import` endpoint previously accepted up to 50 in-memory `.eml` uploads at 50 MiB each and parsed/uploaded attachments without calling `enforceQuota()`, enabling authenticated users to exhaust heap, CPU, and storage quotas and cause DoS. 

### Description
- Added import-specific multer limits and validation by introducing `IMPORT_MAX_FILES = 5`, `IMPORT_MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024`, `fields: 0`, `parts` caps, and a `fileFilter` to reject non-`.eml` filenames early in `packages/api/src/routes/email.ts`. 
- Replaced the direct `upload.array(...)` usage with `importUploadMiddleware` that converts multer errors into the existing `BadRequestError` shape so early rejections are handled by the global error handler. 
- Enforced quota checks in `emailService.importMessages` by calling `enforceQuota()` on the total incoming buffers and again per-parsed message before uploading attachments, and validated each parsed attachment against the plan `maxAttachmentSize` from `EMAIL_QUOTAS` to prevent oversized attachments. 
- Preserved existing behavior for valid imports (parsing with `simpleParser`, `assetService.uploadFileDirect` uploads, `Message.create`, mailbox size increment, linking assets, and async AI processing) while failing early for invalid/over-quota imports. 

### Testing
- Ran `git diff --check`, which passed with no style/format errors. 
- Attempted `bun run build`, which failed before the API build due to the `@oxyhq/contracts` TypeScript build errors (TS5107/TS5011) in the current environment. 
- Attempted to run the package unit tests with `bun run test` / `jest`, but `bun install` failed due to npm registry 403 responses and `jest` was not available, so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc02088323baee453f359f5452)