### PR TITLE
Protect inbound email webhook from unauthenticated rate-limit DoS

### DIFF
--- a/packages/api/src/routes/emailInbound.ts
+++ b/packages/api/src/routes/emailInbound.ts
@@ -14,7 +14,8 @@
  */
 
 import { Router } from 'express';
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
+import { timingSafeEqual } from 'node:crypto';
 import { simpleParser } from 'mailparser';
 import type { ParsedMail } from 'mailparser';
 import { rateLimit } from '../middleware/rateLimiter';
@@ -160,8 +161,10 @@ const router = Router();
 
 const INBOUND_WEBHOOK_SECRET = getEnvVar('EMAIL_INBOUND_WEBHOOK_SECRET', '');
 
-// Rate limit: 60 emails per minute (generous for inbound webhook)
-const inboundRateLimit = rateLimit({
+// Rate limit: 60 authenticated emails per minute (generous for inbound webhook).
+// Mounted in server.ts after shared-secret verification so unauthenticated
+// traffic cannot consume Cloudflare Email Routing's delivery quota.
+export const inboundRateLimit = rateLimit({
   prefix: 'rl:email:inbound:',
   windowMs: 60 * 1000,
   max: 60,
@@ -172,20 +175,31 @@ const inboundRateLimit = rateLimit({
 /**
  * Verify the webhook secret from the Authorization header.
  */
-function verifyWebhookSecret(req: Request, res: Response): boolean {
+function constantTimeEquals(provided: string, expected: string): boolean {
+  if (!provided || !expected) return false;
+
+  const providedBuffer = Buffer.from(provided, 'utf8');
+  const expectedBuffer = Buffer.from(expected, 'utf8');
+  if (providedBuffer.length !== expectedBuffer.length) return false;
+
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+export function verifyEmailInboundWebhookSecret(req: Request, res: Response, next: NextFunction): void {
   if (!INBOUND_WEBHOOK_SECRET) {
     logger.error('EMAIL_INBOUND_WEBHOOK_SECRET is not configured');
     res.status(500).json({ error: 'Webhook not configured' });
-    return false;
+    return;
   }
 
-  const authHeader = req.headers.authorization;
-  if (!authHeader || authHeader !== `Bearer ${INBOUND_WEBHOOK_SECRET}`) {
+  const authHeader = req.headers.authorization ?? '';
+  const providedSecret = authHeader.startsWith('Bearer ') ? authHeader.slice('Bearer '.length) : '';
+  if (!constantTimeEquals(providedSecret, INBOUND_WEBHOOK_SECRET)) {
     res.status(401).json({ error: 'Invalid webhook secret' });
-    return false;
+    return;
   }
 
-  return true;
+  next();
 }
 
 /**
@@ -201,10 +215,7 @@ function verifyWebhookSecret(req: Request, res: Response): boolean {
  */
 router.post(
   '/',
-  inboundRateLimit,
   asyncHandler(async (req: Request, res: Response) => {
-    if (!verifyWebhookSecret(req, res)) return;
-
     const rawMessage = req.body as Buffer;
     if (!rawMessage || rawMessage.length === 0) {
       return res.status(400).json({ error: 'Empty message body' });

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -33,7 +33,10 @@ import fedcmService from './services/fedcm.service';
 import reputationService from './services/reputation.service';
 import emailRoutes from './routes/email';
 import emailProxyRoutes from './routes/emailProxy';
-import emailInboundRoutes from './routes/emailInbound';
+import emailInboundRoutes, {
+  inboundRateLimit,
+  verifyEmailInboundWebhookSecret,
+} from './routes/emailInbound';
 import aliaRoutes from './routes/alia';
 import creditsRoutes from './routes/credits';
 import billingRoutes from './routes/billing';
@@ -122,8 +125,15 @@ function isCacheUploadRequest(req: express.Request): boolean {
 // Body parsing middleware - IMPORTANT: Add this before any routes
 // Stripe webhook needs raw body for signature verification (must be before express.json)
 app.use('/billing/webhook', express.raw({ type: 'application/json' }));
-// Email inbound webhook needs raw body for MIME parsing (must be before express.json)
-app.use('/email/inbound', express.raw({ type: '*/*', limit: '25mb' }));
+// Email inbound webhook needs raw body for MIME parsing (must be before express.json).
+// Authenticate and rate-limit before raw parsing so unauthenticated clients
+// cannot force 25 MiB body buffering or consume the Cloudflare Worker quota.
+app.use(
+  '/email/inbound',
+  verifyEmailInboundWebhookSecret,
+  inboundRateLimit,
+  express.raw({ type: '*/*', limit: '25mb' })
+);
 // Skip the global body parsers for the cache stream-upload so the raw request
 // reaches the route as an untouched readable stream.
 const jsonParser = express.json({ limit: '1mb' });

--- a/workers/email-inbound/src/index.ts
+++ b/workers/email-inbound/src/index.ts
@@ -45,8 +45,14 @@ export default {
       if (!response.ok) {
         const text = await response.text();
         // If the API rejects the message (e.g. unknown recipient, spam),
-        // we don't retry — just log it
-        if (response.status >= 400 && response.status < 500) {
+        // we don't retry — just log it. Rate limiting and request timeouts are
+        // retryable delivery failures, not permanent message rejections.
+        if (
+          response.status >= 400 &&
+          response.status < 500 &&
+          response.status !== 408 &&
+          response.status !== 429
+        ) {
           console.log(`API rejected message: ${response.status} ${text}`);
           // Reject the message back to the sender so they get a bounce
           message.setReject(`Message rejected: ${text}`);


### PR DESCRIPTION
### Motivation
- The public `/email/inbound` webhook applied a global rate limiter before authenticating requests and mounted a 25 MiB raw body parser ahead of authentication, allowing unauthenticated clients to exhaust the delivery quota and force large body buffering. 
- The Cloudflare Email Worker treated any 4xx response as a permanent rejection, which caused legitimate deliveries to bounce when the API returned `429` from an exhausted quota.

### Description
- Exported an authenticated-only verifier `verifyEmailInboundWebhookSecret` and the `inboundRateLimit` from `packages/api/src/routes/emailInbound.ts` and implemented a constant-time secret comparison for the bearer secret. 
- Moved the inbound-route middleware mount in `packages/api/src/server.ts` to `verifyEmailInboundWebhookSecret -> inboundRateLimit -> express.raw({ type: '*/*', limit: '25mb' })` so authentication and rate-limiting run before raw body buffering. 
- Removed the pre-auth route-level limiter from the handler so only authenticated, rate-limited requests hit the handler. 
- Updated `workers/email-inbound/src/index.ts` to treat `408` and `429` (timeouts and rate-limit) as retryable failures rather than permanent 4xx rejections so Cloudflare will retry deliveries instead of bouncing immediately.

### Testing
- Ran targeted source assertions via a Node script that validated the exported verifier/limiter, verified the middleware mount order is `auth -> rate-limit -> raw parser`, ensured the route-level limiter was removed, and confirmed the worker now excludes `429` from permanent rejections; these assertions passed. 
- Ran `git diff --check` to ensure no whitespace or obvious diff errors; this succeeded. 
- Attempted `bun run --cwd packages/api build` which is blocked by existing TypeScript config issues unrelated to this patch (contracts `tsconfig` deprecation/rootDir errors), so a full type-checked build could not be completed in this environment. 
- Attempted package tests (`jest`) but the environment lacks `jest` installation, so unit test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db91088323ba478b7da31edb3a)