### PR TITLE
fix(api): authorize managed account reads

### DIFF
--- a/packages/api/src/routes/managedAccounts.ts
+++ b/packages/api/src/routes/managedAccounts.ts
@@ -86,10 +86,15 @@ router.get('/', async (req: AuthenticatedRequest, res: express.Response) => {
 
 // ============================================
 // GET /verify — Lightweight verification for the acting-as middleware
-// Query params: accountId, userId
+// Query params: accountId, userId (userId must match the authenticated user)
 // ============================================
 router.get('/verify', async (req: AuthenticatedRequest, res: express.Response) => {
   try {
+    const authenticatedUserId = getUserId(req);
+    if (!authenticatedUserId) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
     const { accountId, userId } = req.query;
 
     if (
@@ -105,7 +110,11 @@ router.get('/verify', async (req: AuthenticatedRequest, res: express.Response) =
       return res.status(400).json({ error: 'Invalid accountId or userId format' });
     }
 
-    const role = await managedAccountService.verifyActingAs(userId, accountId);
+    if (userId !== authenticatedUserId) {
+      return res.status(403).json({ error: 'Forbidden: cannot verify another user' });
+    }
+
+    const role = await managedAccountService.verifyActingAs(authenticatedUserId, accountId);
 
     if (!role) {
       return res.json({ authorized: false, role: null });
@@ -133,7 +142,7 @@ router.get('/:accountId', async (req: AuthenticatedRequest, res: express.Respons
       return res.status(400).json({ error: 'Invalid accountId format' });
     }
 
-    const result = await managedAccountService.getManagedAccountDetails(accountId);
+    const result = await managedAccountService.getManagedAccountDetails(accountId, userId);
     if (!result) {
       return res.status(404).json({ error: 'Managed account not found' });
     }

--- a/packages/api/src/services/managedAccount.service.ts
+++ b/packages/api/src/services/managedAccount.service.ts
@@ -167,12 +167,15 @@ export class ManagedAccountService {
 
   /**
    * Get details for a specific managed account.
+   * Requester must be one of the account's managers.
    */
   async getManagedAccountDetails(
-    accountId: string
+    accountId: string,
+    requesterId: string
   ): Promise<ManagedAccountResponse | null> {
     const managedAccount = await ManagedAccount.findOne({
       accountId: new mongoose.Types.ObjectId(accountId),
+      'managers.userId': new mongoose.Types.ObjectId(requesterId),
     }).lean();
 
     if (!managedAccount) return null;


### PR DESCRIPTION
### Motivation
- Prevent an authorization bypass in the managed-accounts endpoints that allowed any authenticated user to read or verify arbitrary managed-account relationships and user profile metadata.
- Ensure all read paths bind the inspected `accountId` to the authenticated requester so managed-account data is only visible to owners/managers.

### Description
- Require an authenticated requester in `GET /managed-accounts/verify` and reject attempts where the `userId` query parameter does not match the authenticated user's id, then call `managedAccountService.verifyActingAs` for the authenticated user only.
- Pass the authenticated requester id into `managedAccountService.getManagedAccountDetails(...)` from `GET /managed-accounts/:accountId` so the service can enforce requester membership.
- Update `getManagedAccountDetails` to require the requester be present in `managers.userId` (querying `ManagedAccount` with `'managers.userId'`), preventing cross-tenant reads while preserving existing write authorization checks.

### Testing
- Attempted to run the project build via `bun run build`, but the build failed due to existing TypeScript configuration issues in `@oxyhq/contracts` (deprecated `moduleResolution=node10` and missing `rootDir`) so a full compile could not be completed.
- Attempted to run the managed-account unit tests via `bun run test -- --runInBand packages/api/src/services/__tests__/managedAccount.service.test.ts`, but the test run could not complete in this environment because `jest` was not available, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc5d008323a843f14ddfce0f26)