### PR TITLE
fix(api): restrict realtime notification creation

### DIFF
--- a/packages/api/src/routes/notifications.routes.ts
+++ b/packages/api/src/routes/notifications.routes.ts
@@ -14,17 +14,45 @@ import {
   deleteNotification,
   getUnreadCount
 } from '../controllers/notification.controller';
-import { authMiddleware, type AuthRequest } from '../middleware/auth';
+import {
+  authMiddleware,
+  serviceAuthMiddleware,
+  type AuthRequest,
+  type ServiceAuthRequest,
+} from '../middleware/auth';
 import { asyncHandler } from '../utils/asyncHandler';
 import { validate } from '../middleware/validate';
 import { createNotificationSchema, notificationIdParams } from '../schemas/notifications.schemas';
 import { PushToken } from '../models/PushToken';
 import { logger } from '../utils/logger';
-import type { Response } from 'express';
+import type { NextFunction, Response } from 'express';
 
 const router = express.Router();
 
-// Apply authentication middleware to all routes
+const NOTIFICATIONS_WRITE_SCOPE = 'notifications:write';
+
+const requireNotificationsWriteScope = (req: ServiceAuthRequest, res: Response, next: NextFunction) => {
+  const scopes = req.serviceApp?.scopes ?? [];
+  if (!scopes.includes(NOTIFICATIONS_WRITE_SCOPE)) {
+    return res.status(403).json({
+      error: 'Forbidden',
+      message: `Missing required scope: ${NOTIFICATIONS_WRITE_SCOPE}`,
+    });
+  }
+
+  return next();
+};
+
+// Create a new notification
+router.post(
+  '/',
+  serviceAuthMiddleware,
+  requireNotificationsWriteScope,
+  validate({ body: createNotificationSchema }),
+  asyncHandler(createNotification)
+);
+
+// Apply authentication middleware to all user routes
 router.use(authMiddleware);
 
 // Get all notifications for the authenticated user
@@ -32,9 +60,6 @@ router.get('/', asyncHandler(getNotifications));
 
 // Get unread notification count
 router.get('/unread-count', asyncHandler(getUnreadCount));
-
-// Create a new notification
-router.post('/', validate({ body: createNotificationSchema }), asyncHandler(createNotification));
 
 // ─── Push Token Management ──────────────────────────────────────────
 

--- a/packages/api/src/utils/applicationScopes.ts
+++ b/packages/api/src/utils/applicationScopes.ts
@@ -14,6 +14,8 @@
  *   resolve/mutate, federated users (`routes/federation.ts`, `PUT /users/resolve`)
  *   for federation/agent/automation flows. PRIVILEGED — see
  *   {@link PRIVILEGED_APPLICATION_SCOPES}; only Oxy platform staff may grant it.
+ * - `notifications:write` permits trusted services to create realtime
+ *   notifications for arbitrary recipients. PRIVILEGED — staff grant only.
  */
 export const APPLICATION_SCOPES = [
   'files:read',
@@ -25,6 +27,7 @@ export const APPLICATION_SCOPES = [
   'models:read',
   'federation:write',
   'signals:write',
+  'notifications:write',
 ] as const;
 
 export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
@@ -41,13 +44,19 @@ export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
  *   otherwise register an app with a victim domain's redirectUri and impersonate
  *   that domain's users.
  *
- * All other scopes in {@link APPLICATION_SCOPES} authorise an app only over its
- * OWN resources (files, models, webhooks, public user reads) and remain freely
+ * - `notifications:write` lets a service credential deliver realtime
+ *   notifications to arbitrary users and choose actor/entity metadata. A
+ *   self-granting owner could otherwise spoof system or user activity to
+ *   victims' connected clients.
+ *
+ * All non-privileged scopes in {@link APPLICATION_SCOPES} authorise an app only
+ * over its OWN resources (files, models, webhooks, public user reads) and remain freely
  * self-grantable. Keep this set CONSERVATIVE — add a scope here only when it
  * grants authority beyond the app's own tenant.
  */
 export const PRIVILEGED_APPLICATION_SCOPES = [
   'federation:write',
+  'notifications:write',
 ] as const satisfies readonly ApplicationScope[];
 
 const PRIVILEGED_APPLICATION_SCOPE_SET: ReadonlySet<ApplicationScope> = new Set<ApplicationScope>(


### PR DESCRIPTION
### Motivation
- The notifications creation path accepted arbitrary `recipientId`/`actorId`/type/entity metadata from any authenticated user and began emitting those payloads over Socket.IO, enabling realtime spoofing and targeted notification delivery.
- The realtime emission increases impact because attacker-controlled notification bodies are delivered immediately to victims' connected clients.

### Description
- Restrict `POST /notifications` to service tokens by applying `serviceAuthMiddleware` and a scope check before the public/authenticated routes in `packages/api/src/routes/notifications.routes.ts` so only trusted services may create notifications. 
- Add a new privileged application scope `notifications:write` and mark it staff-grant-only in `packages/api/src/utils/applicationScopes.ts` so credentials must explicitly hold `notifications:write` to create realtime notifications. 
- Introduce `requireNotificationsWriteScope` helper to validate `req.serviceApp.scopes` and return `403` when the required scope is missing, and keep all per-user notification routes (list, unread-count, push-token, read/delete) under regular `authMiddleware`. 

### Testing
- Ran `git diff --check` to validate the patch formatting and no whitespace errors, which succeeded. 
- Attempted to run package tests for notifications, but `jest`/test runner was not available in the execution environment so unit tests were not executed (`jest: command not found`). 
- Attempted to build the package, but overall build was blocked by pre-existing TypeScript configuration errors in `packages/contracts` unrelated to this change, so a full compile verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db349c8323b725dd916cc55a88)