### PR TITLE
fix(api): cap similar profile co-follower fanout

### DIFF
--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -86,6 +86,10 @@ const MAX_USERNAME_LENGTH = 30;
 // filter on the public recommendations path, so post-lookup filtering can't
 // shrink the page below the requested limit.
 const PUBLIC_FILTER_HEADROOM = 20;
+// Bound attacker-selected co-follower fan-out before materializing IDs or
+// building the follow aggregation's $in clause. This keeps /similar stable for
+// high-follower targets while still sampling enough overlap for useful results.
+const SIMILAR_PROFILE_MAX_TARGET_FOLLOWERS = 5000;
 
 /**
  * Shared aggregation stages that look up follower and following counts
@@ -542,7 +546,11 @@ router.get(
       Follow.find({
         followedId: targetUserId,
         followType: FollowType.USER,
-      }).select('followerUserId').lean(),
+      })
+        .select('followerUserId')
+        .sort({ _id: 1 })
+        .limit(SIMILAR_PROFILE_MAX_TARGET_FOLLOWERS)
+        .lean(),
       Follow.find({
         followerUserId: currentUserId,
         followType: FollowType.USER,
@@ -611,6 +619,7 @@ router.get(
       currentUserId,
       targetUserId,
       similarCount: formattedSimilar.length,
+      sampledTargetFollowers: targetFollowerIds.length,
     });
 
     sendSuccess(res, formattedSimilar);


### PR DESCRIPTION
### Motivation
- The authenticated `GET /profiles/:userId/similar` endpoint previously materialized all followers of an arbitrary target user and used that full set in a `$in` match, enabling high-memory allocations and very large aggregation inputs for attacker-selected high-follower accounts.
- Limit the attacker-controlled fan-out while preserving relevance by sampling a bounded, deterministic subset of the target's followers before building the aggregation input.

### Description
- Add a sample cap constant `SIMILAR_PROFILE_MAX_TARGET_FOLLOWERS` to bound the number of target followers used for co-follower overlap computations. (`packages/api/src/routes/profiles.ts`).
- Apply a deterministic `.sort({ _id: 1 }).limit(SIMILAR_PROFILE_MAX_TARGET_FOLLOWERS)` to the initial `Follow.find(...).select('followerUserId').lean()` query so IDs are capped before materialization or use in the aggregation `$in` clause. (`packages/api/src/routes/profiles.ts`).
- Surface the sampled follower count in debug logging as `sampledTargetFollowers` to make the bounded behavior observable in logs. (`packages/api/src/routes/profiles.ts`).

### Testing
- Ran `git diff --check` and verified no whitespace/patch issues (succeeded).
- Attempted to run the package build with `bun run --cwd packages/api build`, but the build is blocked by unrelated TypeScript configuration errors in `@oxyhq/contracts` (TS config deprecation and `rootDir` settings), so a full compiled test run could not be completed (blocked).
- Attempted to run package tests with `bun run --cwd packages/api test`, but the test runner invocation failed in this environment because `jest` is not available in the checkout, so automated tests did not run here (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dd461c8323a7bd8f94890aaf52)