### PR TITLE
fix(api): sanitize federated profile text to prevent stored XSS

### DIFF
--- a/packages/api/src/services/__tests__/federation.service.test.ts
+++ b/packages/api/src/services/__tests__/federation.service.test.ts
@@ -24,6 +24,8 @@ const mockCacheInvalidate = jest.fn();
 const mockAssetFileContentExists = jest.fn();
 const mockAssetUploadFileDirect = jest.fn();
 const mockAssetDeleteFile = jest.fn();
+const mockKeyPairFindOne = jest.fn();
+const mockKeyPairCreate = jest.fn();
 
 process.env.AWS_ACCESS_KEY_ID ||= 'test-access-key';
 process.env.AWS_SECRET_ACCESS_KEY ||= 'test-secret-key';
@@ -34,16 +36,21 @@ process.env.AWS_S3_BUCKET ||= 'test-bucket';
 // exists — we never touch the key-pair collection in these tests.
 jest.mock('mongoose', () => {
   class Schema {}
+  const federationKeyPairModel = {
+    findOne: mockKeyPairFindOne,
+    create: mockKeyPairCreate,
+  };
+  const model = jest.fn(() => federationKeyPairModel);
   return {
     __esModule: true,
     default: {
       Schema,
       models: {},
-      model: jest.fn(() => ({})),
+      model,
     },
     Schema,
     models: {},
-    model: jest.fn(() => ({})),
+    model,
   };
 });
 
@@ -174,12 +181,42 @@ describe('FederationService.resolveAndUpsert (fast + eventually-fresh)', () => {
     avatarSpy = jest.spyOn(federationService, 'downloadAndStoreAvatar')
       .mockResolvedValue({ fileId: 'new-file-id', notModified: false });
     mockUserUpdateOne.mockResolvedValue({ acknowledged: true });
+    mockKeyPairFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+    mockKeyPairCreate.mockImplementation(async (doc) => doc);
   });
 
   afterEach(() => {
     webfingerSpy.mockRestore();
     actorSpy.mockRestore();
     avatarSpy.mockRestore();
+  });
+
+
+  it('sanitizes decoded federated display names and bios before returning actor profile fields', async () => {
+    actorSpy.mockRestore();
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'https://evil.example/users/alice',
+        inbox: 'https://evil.example/inbox',
+        preferredUsername: 'alice',
+        name: '&lt;svg onload=alert(document.domain)&gt; Alice &amp; Bob',
+        summary: '<p>&lt;img src=x onerror=alert(document.domain)&gt; Safe &amp; sound</p>',
+      }),
+    } as unknown as Response);
+
+    try {
+      const profile = await federationService.fetchActorProfile(
+        'https://evil.example/users/alice',
+        'alice@evil.example',
+      );
+
+      expect(profile?.displayName).toBe('&lt;svg onload=alert(document.domain)&gt; Alice &amp; Bob');
+      expect(profile?.bio).toBe(' Safe &amp; sound');
+    } finally {
+      global.fetch = originalFetch;
+    }
   });
 
   it('returns a fresh cached user immediately without any remote I/O', async () => {

--- a/packages/api/src/services/federation.service.ts
+++ b/packages/api/src/services/federation.service.ts
@@ -14,6 +14,7 @@ import { createS3Service } from './s3Service';
 import { logger } from '../utils/logger';
 import userCache from '../utils/userCache';
 import { composeDisplayName } from '../utils/displayName';
+import { sanitizeHtml } from '../utils/sanitize';
 
 /** Decode common HTML entities (&#39; &amp; &lt; &gt; &quot; and numeric). */
 function decodeHtmlEntities(text: string): string {
@@ -26,6 +27,20 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;|&apos;/g, "'");
+}
+
+/**
+ * Normalize untrusted ActivityPub profile text for storage in Oxy profile fields.
+ *
+ * Remote servers commonly entity-encode apostrophes and ampersands in plain text,
+ * so decode first for readability. Then strip any markup that was literal or was
+ * revealed by decoding, and finally HTML-escape the remaining text to preserve
+ * the profile-field storage invariant used by local profile updates.
+ */
+function sanitizeFederatedProfileText(text: string, options: { stripTags?: boolean } = {}): string {
+  const decoded = decodeHtmlEntities(text);
+  const withoutTags = options.stripTags ? decoded.replace(/<[^>]*>/g, '') : decoded;
+  return sanitizeHtml(withoutTags);
 }
 
 const AP_ACCEPT_TYPES = [
@@ -648,9 +663,9 @@ class FederationService {
         actorUri: actor.id as string,
         domain,
         username: acct,
-        displayName: decodeHtmlEntities((actor.name as string) || username),
+        displayName: sanitizeFederatedProfileText((actor.name as string) || username),
         avatarUrl: (actor.icon as Record<string, unknown>)?.url as string | undefined,
-        bio: decodeHtmlEntities((actor.summary as string)?.replace(/<[^>]*>/g, '') || ''),
+        bio: sanitizeFederatedProfileText((actor.summary as string) || '', { stripTags: true }),
       };
     } catch (err) {
       logger.warn(`Failed to fetch actor profile ${actorUri}: ${err}`);


### PR DESCRIPTION
### Motivation
- Prevent stored XSS introduced by decoding HTML entities from untrusted ActivityPub actor `name`/`summary` and then persisting the resulting raw markup into profile fields.
- Restore the repository invariant that profile text fields are HTML-escaped before storage so clients never receive unescaped markup from federation resolution.

### Description
- Import the existing HTML escaper `sanitizeHtml` and add `sanitizeFederatedProfileText` which decodes entities, strips revealed or literal tags when requested, and then re-escapes the result with `sanitizeHtml`.
- Replace direct `decodeHtmlEntities(...)` usages in the ActivityPub actor extraction so `displayName` and `bio` become `sanitizeFederatedProfileText(...)` (bios use `stripTags: true`).
- Federated profiles returned by `fetchActorProfile` and later persisted by the upsert paths now carry sanitized values, preserving the prior storage/return invariant.
- Add a regression unit test that mocks a malicious actor payload (encoded tags and entities) and asserts the service returns sanitized `displayName` and `bio`, and add test mocks for the federation key-pair model used during service import.

### Testing
- Ran `git diff --check` which passed with no whitespace/format errors.
- Added/updated `packages/api/src/services/__tests__/federation.service.test.ts` to cover the regression case but test execution was blocked because dependency installation failed; `bun install` could not download npm tarballs (registry `403`), so `jest` was not available and `bun run test` could not run the suite.
- The change is minimal and focused only on sanitization of federated profile text to avoid behavioral regressions outside federation resolution paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db326883239a93c9cc2e975aec)