### PR TITLE
fix(api): require TLS certs for inbound SMTP STARTTLS

### DIFF
--- a/packages/api/src/services/smtp.inbound.ts
+++ b/packages/api/src/services/smtp.inbound.ts
@@ -55,7 +55,7 @@ export function startSmtpInbound(): SMTPServer {
         ].join(':'),
       };
     } catch (err) {
-      logger.warn('SMTP TLS certs not found, starting without STARTTLS', {
+      logger.error('SMTP TLS certs could not be loaded; refusing to start plaintext SMTP inbound', {
         keyPath: SMTP_INBOUND_CONFIG.tls.key,
         certPath: SMTP_INBOUND_CONFIG.tls.cert,
         error: err instanceof Error ? err.message : String(err),
@@ -63,21 +63,18 @@ export function startSmtpInbound(): SMTPServer {
     }
   }
 
-  // Disable STARTTLS when no certs are configured to prevent broken TLS
-  // handshakes that cause MTAs to reject delivery
-  const disabledCommands = ['AUTH'];
   if (!tlsOptions) {
-    disabledCommands.push('STARTTLS');
-    logger.info('No TLS certs configured, STARTTLS disabled — accepting plaintext only');
+    throw new Error('SMTP inbound requires readable SMTP_TLS_KEY and SMTP_TLS_CERT to advertise STARTTLS');
   }
 
   smtpServer = new SMTPServer({
     name: EMAIL_DOMAIN,
     banner: SMTP_INBOUND_CONFIG.banner,
     size: SMTP_INBOUND_CONFIG.maxMessageSize,
-    disabledCommands,
+    disabledCommands: ['AUTH'],
     authOptional: true,
-    ...(tlsOptions ? { secure: false, ...tlsOptions } : {}),
+    secure: false,
+    ...tlsOptions,
 
     /**
      * Validate RCPT TO addresses — reject if the user doesn't exist.


### PR DESCRIPTION
### Motivation
- Prevent a confidentiality regression where the SMTP inbound service disabled `STARTTLS` and accepted plaintext mail when TLS cert files were missing or unreadable.
- Ensure the server only advertises opportunistic TLS when valid certificate/key are provided to avoid exposing inbound messages on the wire.

### Description
- Change `packages/api/src/services/smtp.inbound.ts` to refuse to start the SMTP inbound server when `SMTP_TLS_KEY`/`SMTP_TLS_CERT` cannot be read instead of disabling `STARTTLS` and accepting plaintext mail.
- Replace the previous `disabledCommands` branch with a hard requirement that `tlsOptions` be present, logging an error when certs cannot be loaded and throwing to avoid plaintext operation.
- Always pass `secure: false` and the loaded `tlsOptions` into `new SMTPServer(...)` for the valid-TLS path and keep `disabledCommands` set to `['AUTH']` only.
- Raise the log severity when certs fail to load to make the condition more prominent in service logs.

### Testing
- Ran `git diff --check` to validate the working-tree changes and it completed without issues.
- Attempted `bun run build` but the workspace build was blocked by unrelated TypeScript configuration/deprecation errors in `@oxyhq/contracts`, so a full package build could not be completed in this environment.
- Attempted `tsc --noEmit` (`bunx tsc --noEmit -p tsconfig.json`) from `packages/api` but it failed due to existing TypeScript deprecation configuration warnings, preventing a compile-time verification in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db2cbc832389bde144aae0bc68)