### PR TITLE
fix(api): protect platform stats stream

### DIFF
--- a/packages/api/src/routes/platform-stats.ts
+++ b/packages/api/src/routes/platform-stats.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import { authMiddleware } from '../middleware/auth';
+import { requireStaff } from '../middleware/requireStaff';
 import { User } from '../models/User';
 import Session from '../models/Session';
 import { Message } from '../models/Message';
@@ -14,7 +16,10 @@ const router = Router();
 // Shared cache for both REST and SSE
 let cachedStats: any = null;
 let cacheTime = 0;
+let inFlightStatsRefresh: Promise<any> | null = null;
+let activeStatsStreams = 0;
 const CACHE_TTL = 2_000; // 2s cache for real-time feel
+const MAX_ACTIVE_STATS_STREAMS = 25;
 
 async function fetchStats() {
   const now = Date.now();
@@ -22,6 +27,18 @@ async function fetchStats() {
     return cachedStats;
   }
 
+  if (inFlightStatsRefresh) {
+    return inFlightStatsRefresh;
+  }
+
+  inFlightStatsRefresh = refreshStats(now).finally(() => {
+    inFlightStatsRefresh = null;
+  });
+
+  return inFlightStatsRefresh;
+}
+
+async function refreshStats(now: number) {
   const [
     totalUsers,
     activeSessions,
@@ -77,6 +94,8 @@ async function fetchStats() {
   return stats;
 }
 
+router.use(authMiddleware, requireStaff);
+
 // REST endpoint (fallback)
 router.get('/', async (_req: Request, res: Response) => {
   try {
@@ -90,6 +109,15 @@ router.get('/', async (_req: Request, res: Response) => {
 
 // SSE endpoint — true real-time push
 router.get('/stream', (req: Request, res: Response) => {
+  if (activeStatsStreams >= MAX_ACTIVE_STATS_STREAMS) {
+    res.status(429).json({ error: 'Too many active platform stats streams' });
+    return;
+  }
+
+  activeStatsStreams += 1;
+  let closed = false;
+  let sendInProgress = false;
+
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
@@ -99,11 +127,20 @@ router.get('/stream', (req: Request, res: Response) => {
 
   // Send initial data immediately
   const sendStats = async () => {
+    if (closed || sendInProgress) {
+      return;
+    }
+
+    sendInProgress = true;
     try {
       const stats = await fetchStats();
-      res.write(`data: ${JSON.stringify(stats)}\n\n`);
+      if (!closed) {
+        res.write(`data: ${JSON.stringify(stats)}\n\n`);
+      }
     } catch (error) {
       logger.error('SSE stats error:', error);
+    } finally {
+      sendInProgress = false;
     }
   };
 
@@ -117,6 +154,12 @@ router.get('/stream', (req: Request, res: Response) => {
   }, 15_000);
 
   req.on('close', () => {
+    if (closed) {
+      return;
+    }
+
+    closed = true;
+    activeStatsStreams = Math.max(0, activeStatsStreams - 1);
     clearInterval(interval);
     clearInterval(keepAlive);
   });


### PR DESCRIPTION
### Motivation
- The unauthenticated `/platform-stats` REST and `/platform-stats/stream` SSE endpoints could disclose aggregate metrics and cause DB load amplification because each SSE connection started its own 2s refresh and `fetchStats` did not deduplicate in-flight refreshes.
- The goal is to restrict access to staff-only, prevent cache-stampede DB queries, and limit the number of concurrent long-lived streams to protect availability.

### Description
- Require staff-only access for both REST and SSE by applying `router.use(authMiddleware, requireStaff)` to the `platform-stats` router.  
- Add in-flight refresh deduplication via a shared `inFlightStatsRefresh: Promise<any> | null` and factor the heavy queries into `refreshStats(now)` so concurrent callers share the same refresh Promise.  
- Add a per-process concurrent stream cap with `MAX_ACTIVE_STATS_STREAMS` and `activeStatsStreams` to return `429` when the cap is exceeded.  
- Prevent overlapping sends per connection with `sendInProgress` and a `closed` flag, and ensure the active stream counter and timers are cleaned up on `req.on('close')`.

### Testing
- Attempted build with `bun run --cwd packages/api build`, but it failed due to upstream TypeScript configuration issues in `@oxyhq/contracts` (tsconfig deprecation/rootDir errors), so the package build didn't complete.  
- Attempted type-check with `bunx tsc -p packages/api/tsconfig.json --noEmit`, but this was blocked by the repo TypeScript deprecation warnings/error conditions.  
- Attempted to run `bunx --bun -p typescript@5.9.2 tsc -p packages/api/tsconfig.json --noEmit` to use a specific TypeScript version, but fetching that package failed with registry `403`, so automated type checks and builds could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db91788323839adbc49827563c)