### PR TITLE
fix: avoid embedding access tokens in asset URLs

### DIFF
--- a/packages/core/src/mixins/OxyServices.assets.ts
+++ b/packages/core/src/mixins/OxyServices.assets.ts
@@ -2,11 +2,6 @@ import type { AccountStorageUsageResponse, AssetUploadInput, AssetUrlResponse, A
 import type { OxyServicesBase } from '../OxyServices.base';
 import { isReactNative } from '../utils/platform';
 
-interface FileDownloadUrlOptions {
-  /** Omit bearer access tokens from generated URLs, even when authenticated. */
-  omitToken?: boolean;
-}
-
 export function OxyServicesAssetsMixin<T extends typeof OxyServicesBase>(Base: T) {
   return class extends Base {
     constructor(...args: any[]) {
@@ -25,55 +20,30 @@ export function OxyServicesAssetsMixin<T extends typeof OxyServicesBase>(Base: T
     }
 
     /**
-     * Build a synchronous file URL from an Oxy asset id.
+     * Build a synchronous, `<img src>`-ready file URL from an Oxy asset id.
      *
-     * This is the single chokepoint every Oxy app uses to turn a stored file id
-     * (avatars, post media, etc.) into a `<img src>`-ready URL, so it resolves to
-     * one of two forms depending on whether the caller needs a signed/private URL:
-     *
-     * - **Public asset (default)** — no access token planted on the client AND no
-     *   `expiresIn` requested → returns the clean CDN form
-     *   `${cloudURL}/<id>[?variant=...]` (e.g. `https://cloud.oxy.so/<id>?variant=thumb`).
-     *   CloudFront resolves the id against the public media origin. No token,
-     *   `fallback`, or origin query params are emitted — these URLs are cacheable
-     *   and shareable.
-     * - **Signed / private asset** — an access token is present on the client OR
-     *   `expiresIn` was passed (the caller explicitly wants an expiring/authorized
-     *   URL) → keeps the authenticated origin form
-     *   `${baseURL}/assets/<id>/stream?...&token=...`. Private assets are NOT on
-     *   the public CDN, so they must go through the API origin that can authorize
-     *   the request.
-     *
-     * `cloudURL` (default `https://cloud.oxy.so`) is configured once on the
-     * `OxyServices` constructor and read via `getCloudURL()`; the API origin is
-     * `getBaseURL()` (e.g. `https://api.oxy.so`).
-     *
-     * For a CDN-signed URL fetched from the API, use {@link getFileDownloadUrlAsync}.
+     * This method must never embed the caller's general access token in the
+     * returned URL. The URL is commonly rendered into DOM attributes, browser
+     * network panels, caches, and logs. Public asset URLs use the clean CDN
+     * origin; callers that need authorized/private access should use
+     * {@link getFileDownloadUrlAsync}, which asks the API for a scoped download
+     * URL instead of exposing the in-memory bearer token in a query string.
      */
-    getFileDownloadUrl(
-      fileId: string,
-      variant?: string,
-      expiresIn?: number,
-      options: FileDownloadUrlOptions = {}
-    ): string {
-      const token = options.omitToken ? undefined : this.getClient().getAccessToken();
-
-      // Public case: no auth token and no expiry requested → clean CDN URL.
-      // CloudFront serves the public media origin under `${cloudURL}/<id>`.
-      if (!token && !expiresIn) {
+    getFileDownloadUrl(fileId: string, variant?: string, expiresIn?: number): string {
+      // Never embed the in-memory bearer token: this URL is rendered into DOM
+      // attributes, browser network panels, caches, and logs. Public assets get
+      // the clean CDN origin; private/authorized access goes through
+      // `getFileDownloadUrlAsync`.
+      if (!expiresIn) {
         const variantQs = variant ? `?variant=${encodeURIComponent(variant)}` : '';
         return `${this.getCloudURL()}/${encodeURIComponent(fileId)}${variantQs}`;
       }
 
-      // Signed / private case: route through the authenticated API origin's
-      // stream endpoint so the request can be authorized (private assets are not
-      // exposed on the public CDN).
       const base = this.getBaseURL();
       const params = new URLSearchParams();
       if (variant) params.set('variant', variant);
-      if (expiresIn) params.set('expiresIn', String(expiresIn));
+      params.set('expiresIn', String(expiresIn));
       params.set('fallback', 'placeholderVisible');
-      if (token) params.set('token', token);
 
       const qs = params.toString();
       return `${base}/assets/${encodeURIComponent(fileId)}/stream${qs ? `?${qs}` : ''}`;

--- a/packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts
+++ b/packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts
@@ -7,10 +7,9 @@
  *   - PUBLIC (no access token planted, no `expiresIn`) → the clean CDN form
  *     `${cloudURL}/<id>[?variant=...]` (default `https://cloud.oxy.so/<id>`),
  *     which CloudFront resolves against the public media origin.
- *   - SIGNED / PRIVATE (an access token is present OR `expiresIn` is passed) →
- *     the authenticated API origin form
- *     `${baseURL}/assets/<id>/stream?...&token=...` — private assets are not on
- *     the public CDN.
+ *   - EXPIRING ORIGIN FALLBACK (`expiresIn` is passed) → the API origin
+ *     stream form without a bearer token in the query string. Callers that need
+ *     private access should use `getFileDownloadUrlAsync()` for a scoped URL.
  */
 
 import { OxyServices } from '../../OxyServices';
@@ -50,37 +49,23 @@ describe('OxyServices.getFileDownloadUrl', () => {
       );
     });
 
-    it('can omit the token for persisted public image URLs while authenticated', () => {
-      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
-      oxy.setTokens('access-token-abc');
-
-      const url = oxy.getFileDownloadUrl('file123', 'thumb', undefined, {
-        omitToken: true,
-      });
-
-      expect(url).toBe('https://cloud.oxy.so/file123?variant=thumb');
-      expect(url).not.toContain('access-token-abc');
-      expect(url).not.toContain('token=');
-    });
   });
 
-  describe('signed / private assets → authenticated API origin', () => {
-    it('returns the stream endpoint with the token when an access token is present', () => {
+  describe('token-safe URL generation', () => {
+    it('does not include the in-memory access token in synchronous image URLs', () => {
       const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
       oxy.setTokens('access-token-abc');
 
       const url = oxy.getFileDownloadUrl('file123', 'thumb');
 
-      expect(url.startsWith('https://api.oxy.so/assets/file123/stream?')).toBe(true);
-      const params = new URLSearchParams(url.split('?')[1]);
-      expect(params.get('variant')).toBe('thumb');
-      expect(params.get('token')).toBe('access-token-abc');
-      expect(params.get('fallback')).toBe('placeholderVisible');
-      expect(url).not.toContain('cloud.oxy.so');
+      expect(url).toBe('https://cloud.oxy.so/file123?variant=thumb');
+      expect(url).not.toContain('access-token-abc');
+      expect(url).not.toContain('token=');
     });
 
-    it('routes through the stream endpoint when expiresIn is requested even without a token', () => {
+    it('routes through the stream endpoint when expiresIn is requested without embedding a token', () => {
       const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+      oxy.setTokens('access-token-abc');
 
       const url = oxy.getFileDownloadUrl('file123', 'thumb', 3600);
 
@@ -90,6 +75,7 @@ describe('OxyServices.getFileDownloadUrl', () => {
       expect(params.get('variant')).toBe('thumb');
       expect(params.get('fallback')).toBe('placeholderVisible');
       expect(params.get('token')).toBeNull();
+      expect(url).not.toContain('access-token-abc');
       expect(url).not.toContain('cloud.oxy.so');
     });
   });


### PR DESCRIPTION
### Motivation

- A consumer path rendered `oxyServices.getFileDownloadUrl(user.avatar)` into an `<img src>` which exposed the in-memory bearer access token in the returned URL query string, risking token leakage through DOM/network logs and reuse as a bearer credential. 
- Synchronous image URLs (nav avatars, sidebar header) must be safe for public/dom rendering and must not embed the general API access token. 

### Description

- Changed `OxyServices.getFileDownloadUrl()` in `packages/core/src/mixins/OxyServices.assets.ts` so it no longer reads or appends the in-memory access token to returned synchronous image URLs. 
- The method now returns a clean CDN URL for normal image usage and only falls back to the API origin stream endpoint when `expiresIn` is explicitly requested, without adding a `token` query parameter. 
- Updated the unit test `packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts` to assert token-safe behavior (no embedded `token=` or access token present in synchronous URLs and stream fallback does not embed the token). 
- Committed the changes with message `fix: avoid embedding access tokens in asset URLs` and left existing console avatar usage intact so callers benefit from the safe helper update without client changes. 

### Testing

- Ran `git diff --check` and local repository checks which passed and confirmed the diff touching `packages/core/src/mixins/OxyServices.assets.ts` and `packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts`. 
- Attempted to run package tests via `bun run --cwd packages/core test -- getFileDownloadUrl`, but execution was blocked because `jest` was unavailable after `bun install` failed due to external registry `403` errors. 
- Attempted `bun install` to fetch dependencies but it was blocked by npm registry `403` responses, preventing full automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db996883239d577731cc307ce4)