### PR TITLE
fix: dedupe subscription credit grants

### DIFF
--- a/packages/api/src/models/BillingTransaction.ts
+++ b/packages/api/src/models/BillingTransaction.ts
@@ -4,6 +4,8 @@ export interface IBillingTransaction extends Document {
   userId: string;
   stripeCustomerId?: string;
   stripePaymentIntentId?: string;
+  stripeSubscriptionId?: string;
+  stripeSubscriptionPeriodStart?: Date;
   type: 'credit_purchase' | 'subscription_payment' | 'refund';
   amount: number;
   currency: string;
@@ -26,6 +28,13 @@ const BillingTransactionSchema = new Schema<IBillingTransaction>({
   stripePaymentIntentId: {
     type: String,
     sparse: true,
+  },
+  stripeSubscriptionId: {
+    type: String,
+    index: true,
+  },
+  stripeSubscriptionPeriodStart: {
+    type: Date,
   },
   type: {
     type: String,
@@ -57,6 +66,17 @@ const BillingTransactionSchema = new Schema<IBillingTransaction>({
 });
 
 BillingTransactionSchema.index({ userId: 1, createdAt: -1 });
+BillingTransactionSchema.index(
+  { stripeSubscriptionId: 1, stripeSubscriptionPeriodStart: 1, type: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      type: 'subscription_payment',
+      stripeSubscriptionId: { $exists: true },
+      stripeSubscriptionPeriodStart: { $exists: true },
+    },
+  }
+);
 
 const BillingTransaction = mongoose.model<IBillingTransaction>('BillingTransaction', BillingTransactionSchema);
 

--- a/packages/api/src/routes/billing.ts
+++ b/packages/api/src/routes/billing.ts
@@ -1,4 +1,5 @@
 import { Router, Request, Response } from 'express';
+import mongoose from 'mongoose';
 import Stripe from 'stripe';
 import { authMiddleware, AuthRequest } from '../middleware/auth';
 import { UserCredits } from '../models/UserCredits';
@@ -430,17 +431,51 @@ async function handleSubscriptionUpdate(stripeSubscription: Stripe.Subscription)
   if (stripeSubscription.status === 'active') {
     const now = Date.now() / 1000;
     if (Math.abs(now - subscriptionItem.current_period_start) < 300) {
-      await userCredits.addCredits(plan.creditsPerMonth, 'paid');
-      await BillingTransaction.create({
-        userId: userCredits._id,
-        stripeCustomerId: customerId,
-        type: 'subscription_payment',
-        amount: plan.price,
-        currency: plan.currency,
-        credits: plan.creditsPerMonth,
-        status: 'completed',
-        description: `${plan.name} subscription credits`,
-      });
+      const periodStart = new Date(subscriptionItem.current_period_start * 1000);
+      const session = await mongoose.startSession();
+      try {
+        await session.withTransaction(async () => {
+          const transactionResult = await BillingTransaction.updateOne(
+            {
+              type: 'subscription_payment',
+              stripeSubscriptionId: stripeSubscription.id,
+              stripeSubscriptionPeriodStart: periodStart,
+            },
+            {
+              $setOnInsert: {
+                userId: userCredits._id,
+                stripeCustomerId: customerId,
+                stripeSubscriptionId: stripeSubscription.id,
+                stripeSubscriptionPeriodStart: periodStart,
+                type: 'subscription_payment',
+                amount: plan.price,
+                currency: plan.currency,
+                credits: plan.creditsPerMonth,
+                status: 'completed',
+                description: `${plan.name} subscription credits`,
+              },
+            },
+            { upsert: true, session }
+          );
+
+          if (transactionResult.upsertedCount === 0) {
+            logger.info('Skipping duplicate subscription credit grant', {
+              subscriptionId: stripeSubscription.id,
+              periodStart: periodStart.toISOString(),
+              userId: userCredits._id,
+            });
+            return;
+          }
+
+          await UserCredits.updateOne(
+            { _id: userCredits._id },
+            { $inc: { 'credits.paid': plan.creditsPerMonth } },
+            { session }
+          );
+        });
+      } finally {
+        await session.endSession();
+      }
     }
   }
 }


### PR DESCRIPTION
### Motivation

- Prevent duplicate paid-credit grants when Stripe emits both `customer.subscription.created` and `customer.subscription.updated` for the same billing period. This was possible because the handler granted credits based solely on `subscriptionItem.current_period_start` without any invoice/event/period idempotency key.  
- Ensure financial integrity by making subscription renewal credit grants idempotent and atomic across the transaction record and the user's credit balance.

### Description

- Added `stripeSubscriptionId` and `stripeSubscriptionPeriodStart` fields to the `BillingTransaction` model and exported index definitions in `packages/api/src/models/BillingTransaction.ts` so subscription payments can be tied to a subscription+period.  
- Created a unique partial index on `{ stripeSubscriptionId, stripeSubscriptionPeriodStart, type }` that only applies to `type: 'subscription_payment'` to prevent duplicate period-level `subscription_payment` rows.  
- Reworked the subscription webhook handler in `packages/api/src/routes/billing.ts` to perform an atomic upsert within a `mongoose` session: the handler now upserts a `subscription_payment` transaction for the period using `$setOnInsert` and only increments the user's paid credits when the upsert actually inserted a new document; duplicate webhook events for the same subscription-period are skipped with an informational log.  

### Testing

- Ran `git diff --check` which passed with no whitespace errors.  
- Attempted to build the API (`bun run --filter @oxyhq/api build`) and run TypeScript checks, but full build/typecheck is blocked in this environment by existing TypeScript configuration/deprecation and missing type dependencies in `@oxyhq/contracts` and workspace packages; these unrelated infra/type issues prevented a clean local `tsc` end-to-end run.  
- Verified the change surface via repository inspection and local edits: the new model fields, index, and transactional upsert logic are present and will prevent duplicate grants when the code is run in a properly provisioned environment with MongoDB replica set support for transactions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db0b688323935e9a7bbc2324d5)