### PR TITLE
fix(inbox): pin markdown-it to 12.3.2 to mitigate ReDoS in Alia chat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3441,7 +3441,7 @@
 
     "map-obj": ["map-obj@4.3.0", "", {}, ""],
 
-    "markdown-it": ["markdown-it@10.0.0", "", { "dependencies": { "argparse": "^1.0.7", "entities": "~2.0.0", "linkify-it": "^2.0.0", "mdurl": "^1.0.1", "uc.micro": "^1.0.5" }, "bin": "bin/markdown-it.js" }, ""],
+    "markdown-it": ["markdown-it@12.3.2", "", { "dependencies": { "argparse": "^2.0.1", "entities": "~2.1.0", "linkify-it": "^3.0.1", "mdurl": "^1.0.1", "uc.micro": "^1.0.5" }, "bin": "bin/markdown-it.js" }, ""],
 
     "marky": ["marky@1.3.0", "", {}, ""],
 
@@ -5693,11 +5693,11 @@
 
     "make-dir/semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, ""],
 
-    "markdown-it/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, ""],
+    "markdown-it/argparse": ["argparse@2.0.1", "", {}, ""],
 
-    "markdown-it/entities": ["entities@2.0.3", "", {}, ""],
+    "markdown-it/entities": ["entities@2.1.0", "", {}, ""],
 
-    "markdown-it/linkify-it": ["linkify-it@2.2.0", "", { "dependencies": { "uc.micro": "^1.0.1" } }, ""],
+    "markdown-it/linkify-it": ["linkify-it@3.0.3", "", { "dependencies": { "uc.micro": "^1.0.1" } }, ""],
 
     "markdown-it/uc.micro": ["uc.micro@1.0.6", "", {}, ""],
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "@radix-ui/react-slot": "1.2.3",
-    "@oxyhq/bloom": "^0.20.0"
+    "@oxyhq/bloom": "^0.20.0",
+    "markdown-it": "12.3.2"
   },
   "dependencies": {
     "@expo/metro-runtime": "~56.0.11",


### PR DESCRIPTION
### Motivation
- The Inbox app pulls `@alia.onl/sdk` which brings `react-native-markdown-display` that resolves `markdown-it@10.0.0`, a version with known ReDoS/uncontrolled-resource-consumption vulnerabilities that can crash or hang client apps when parsing attacker-controlled Markdown.
- The change aims to force the markdown renderer onto a patched `markdown-it` to eliminate the vulnerable parser while preserving existing runtime behavior of the Alia chat surface.

### Description
- Added a root `overrides` entry for `markdown-it` pinned to `12.3.2` in `package.json` so all workspace installs prefer the patched parser version.
- Updated `bun.lock` entries to resolve `markdown-it` to `12.3.2` and adjusted its immediate transitive entries (`argparse`, `entities`, `linkify-it`) to compatible versions.
- The change is intentionally minimal and only forces a safe downstream `markdown-it` resolution so `react-native-markdown-display` used by the Alia SDK will use the patched parser.

### Testing
- Verified the lockfile no longer contains `markdown-it@10.0.0` and now contains `markdown-it@12.3.2` using scripted assertions, and the checks succeeded.
- Ran `rg` searches for the vulnerable/resolved versions and `bun pm ls markdown-it` to confirm the override is visible, and those checks succeeded.
- Validated `package.json` JSON syntax with `python3 -m json.tool` and ran `git diff --check`, both succeeded.
- Attempts to run `bun install` / `bun install --frozen-lockfile` to fully validate install-time behavior were blocked by the environment returning `403 Forbidden` from the npm registry, so full install verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db41208323941da978edfbd6e7)