### PR TITLE
fix(api): fail closed on SMTP TLS load errors

### DIFF
--- a/packages/api/src/services/smtp.inbound.ts
+++ b/packages/api/src/services/smtp.inbound.ts
@@ -55,11 +55,13 @@ export function startSmtpInbound(): SMTPServer {
         ].join(':'),
       };
     } catch (err) {
-      logger.warn('SMTP TLS certs not found, starting without STARTTLS', {
+      const error = err instanceof Error ? err : new Error(String(err));
+      logger.error('SMTP TLS certs configured but could not be loaded; refusing to start without STARTTLS', {
         keyPath: SMTP_INBOUND_CONFIG.tls.key,
         certPath: SMTP_INBOUND_CONFIG.tls.cert,
-        error: err instanceof Error ? err.message : String(err),
+        error: error.message,
       });
+      throw error;
     }
   }
 


### PR DESCRIPTION
### Motivation

- The SMTP inbound startup previously swallowed TLS certificate read errors and continued running without STARTTLS when `SMTP_TLS_KEY`/`SMTP_TLS_CERT` were configured, creating a fail‑open privacy risk. 
- The change enforces a fail‑closed behavior so operators must fix unreadable/missing TLS material instead of silently accepting plaintext inbound mail.

### Description

- In `packages/api/src/services/smtp.inbound.ts` the TLS cert/key load `catch` now logs the failure at error level and rethrows the error instead of only warning and continuing. 
- The code still preserves the existing plaintext-only path when no TLS paths are configured (STARTTLS remains disabled only when TLS is intentionally unset).

### Testing

- Ran `git diff --check` which passed with no whitespace errors. 
- Attempted `bun run --cwd packages/api build`, which could not complete due to unrelated TypeScript `tsconfig` deprecation/rootDir errors in `packages/contracts` (build failed before the API build step). 
- Attempted `bun run --cwd packages/api lint -- src/services/smtp.inbound.ts`, which could not complete because `eslint` could not be resolved from the package config; this is an environment/package resolution issue and unrelated to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db5c3c8323b92b688b29d91e9f)