### PR TITLE
fix(api): bound public search pagination

### DIFF
--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -7,11 +7,16 @@ import { searchQuerySchema } from '../schemas/search.schemas';
 
 const router = express.Router();
 
+type ValidatedSearchQuery = {
+  query?: string;
+  type?: 'all' | 'users';
+  page: number;
+  limit: number;
+};
+
 router.get("/", validate({ query: searchQuerySchema }), async (req: Request, res: Response) => {
   try {
-    const { query, type = "all" } = req.query;
-    const page = Math.max(1, parseInt(req.query.page as string) || 1);
-    const limit = Math.min(50, Math.max(1, parseInt(req.query.limit as string) || 10));
+    const { query, type = "all", page, limit } = req.query as ValidatedSearchQuery;
     const skip = (page - 1) * limit;
 
     const sanitized = sanitizeSearchQuery((query as string) || '');

--- a/packages/api/src/schemas/search.schemas.ts
+++ b/packages/api/src/schemas/search.schemas.ts
@@ -1,9 +1,27 @@
 import { z } from 'zod';
 
+export const MAX_SEARCH_LIMIT = 50;
+export const DEFAULT_SEARCH_LIMIT = 10;
+export const MAX_SEARCH_SKIP = 1000;
+
+const paginationParam = (name: string, max: number) => z.preprocess(
+  (value) => (typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value),
+  z.number({ invalid_type_error: `${name} must be a positive integer` })
+    .int(`${name} must be a positive integer`)
+    .min(1, `${name} must be at least 1`)
+    .max(max, `${name} is too large`)
+);
+
 // GET /search
 export const searchQuerySchema = z.object({
   query: z.string().trim().optional(),
   type: z.enum(['all', 'users']).optional().default('all'),
-  page: z.string().regex(/^\d+$/).optional(),
-  limit: z.string().regex(/^\d+$/).optional(),
-});
+  page: paginationParam('page', MAX_SEARCH_SKIP + 1).optional().default(1),
+  limit: paginationParam('limit', MAX_SEARCH_LIMIT).optional().default(DEFAULT_SEARCH_LIMIT),
+}).refine(
+  ({ page, limit }) => (page - 1) * limit <= MAX_SEARCH_SKIP,
+  {
+    path: ['page'],
+    message: `page is too large; search results are limited to an offset of ${MAX_SEARCH_SKIP}`,
+  }
+);


### PR DESCRIPTION
### Motivation
- The public `/search` endpoint accepted unbounded `page` values and applied `.skip()` to MongoDB over regex `OR` queries, allowing unauthenticated clients to force expensive large offsets and degrade availability. 
- The intent of this change is to harden pagination input handling by validating numeric parameters and capping the maximum offset to prevent large, attacker-controlled skips while preserving existing per-page limits.

### Description
- Add `MAX_SEARCH_LIMIT`, `DEFAULT_SEARCH_LIMIT`, and `MAX_SEARCH_SKIP` constants and replace string-based `page`/`limit` validators with numeric `zod` preprocessing that enforces integer ranges in `packages/api/src/schemas/search.schemas.ts`.
- Add a `refine` rule that rejects requests whose computed offset `(page - 1) * limit` exceeds `MAX_SEARCH_SKIP` (1,000) to prevent arbitrarily large `.skip()` values. 
- Update the search route to use typed, validated query values (`ValidatedSearchQuery`) instead of reparsing raw strings and to compute `skip` from the validated numbers in `packages/api/src/routes/search.ts`.

### Testing
- Attempted to build the workspace with `bun run build`, but the build was blocked by existing TypeScript configuration/deprecation errors in `@oxyhq/contracts` so the package build could not complete. (failed)
- Attempted to run type checks with `tsc --noEmit` (`bunx tsc -p packages/api/tsconfig.json --noEmit --ignoreDeprecations 6.0`), but type checks failed due to missing workspace dependencies and type packages in the current environment. (failed)
- Attempted to install dependencies with `bun install` to enable runtime/schema validation tests, but the install failed due to `registry.npmjs.org` 403 responses for many packages, preventing execution of `zod`-driven validation tests. (failed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8daf67083238d2218681803a737)