### PR TITLE
fix(api): bound BIMI DNS avatar lookup

### DIFF
--- a/packages/api/src/services/__tests__/senderAvatar.service.test.ts
+++ b/packages/api/src/services/__tests__/senderAvatar.service.test.ts
@@ -1,0 +1,55 @@
+const mockResolveTxt = jest.fn();
+const mockSenderAvatarFindOne = jest.fn();
+const mockSenderAvatarUpdateOne = jest.fn();
+const mockUserFindOne = jest.fn();
+
+jest.mock('dns/promises', () => ({
+  __esModule: true,
+  default: { resolveTxt: (...args: unknown[]) => mockResolveTxt(...args) },
+}));
+
+jest.mock('../../models/SenderAvatar', () => ({
+  SenderAvatar: {
+    findOne: (...args: unknown[]) => mockSenderAvatarFindOne(...args),
+    updateOne: (...args: unknown[]) => mockSenderAvatarUpdateOne(...args),
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: { findOne: (...args: unknown[]) => mockUserFindOne(...args) },
+}));
+
+import { getAvatarPath } from '../senderAvatar.service';
+
+describe('senderAvatar.service', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+    mockSenderAvatarFindOne.mockReturnValue({ lean: () => Promise.resolve(null) });
+    mockSenderAvatarUpdateOne.mockResolvedValue({ acknowledged: true });
+    mockUserFindOne.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(null) }) });
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, headers: { get: jest.fn() } }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('bounds BIMI DNS lookups so unresolved domains do not stall avatar resolution', async () => {
+    jest.useFakeTimers();
+    mockResolveTxt.mockReturnValue(new Promise(() => undefined));
+
+    const avatarPromise = getAvatarPath('attacker@slow.example');
+
+    await jest.advanceTimersByTimeAsync(1500);
+    await expect(avatarPromise).resolves.toBeNull();
+
+    expect(mockResolveTxt).toHaveBeenCalledWith('default._bimi.slow.example');
+    expect(mockSenderAvatarUpdateOne).toHaveBeenCalledWith(
+      { email: 'attacker@slow.example' },
+      expect.objectContaining({ $set: expect.objectContaining({ avatarPath: null, source: 'none' }) }),
+      { upsert: true },
+    );
+  });
+});

--- a/packages/api/src/services/senderAvatar.service.ts
+++ b/packages/api/src/services/senderAvatar.service.ts
@@ -5,6 +5,7 @@ import User from '../models/User';
 import { extractUsername } from '../config/email.config';
 
 const CACHE_TTL_DAYS = 7;
+const BIMI_DNS_TIMEOUT_MS = 1500;
 
 /** Build a base64-encoded proxy path for an external URL. */
 function proxyPath(url: string): string {
@@ -19,9 +20,20 @@ function proxyPath(url: string): string {
  * BIMI record format: "v=BIMI1; l=https://example.com/logo.svg; a=..."
  * Published at: default._bimi.<domain>
  */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error('BIMI DNS lookup timed out')), timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
+}
+
 async function lookupBimi(domain: string): Promise<string | null> {
   try {
-    const records = await dns.resolveTxt(`default._bimi.${domain}`);
+    const records = await withTimeout(dns.resolveTxt(`default._bimi.${domain}`), BIMI_DNS_TIMEOUT_MS);
     for (const parts of records) {
       const record = parts.join('');
       if (!record.toLowerCase().startsWith('v=bimi1')) continue;


### PR DESCRIPTION
### Motivation
- The BIMI TXT lookup path used `dns.resolveTxt()` without an application-level timeout, which allowed attacker-controlled sender domains with slow/unresponsive nameservers to stall avatar enrichment and delay mailbox API responses.

### Description
- Add a `BIMI_DNS_TIMEOUT_MS` constant and a `withTimeout` helper, and apply it to the BIMI lookup so `dns.resolveTxt()` is bounded in `packages/api/src/services/senderAvatar.service.ts`.
- Preserve existing fallback behavior so a timed-out or missing BIMI record falls through to the Gravatar and favicon checks unchanged.
- Add a Jest regression test at `packages/api/src/services/__tests__/senderAvatar.service.test.ts` that simulates a never-resolving BIMI TXT promise and verifies `getAvatarPath()` completes, returns `null`, and caches the `source: 'none'` result.
- Keep batch concurrency logic as-is; the bounded BIMI lookup prevents a single slow DNS response from blocking a batch indefinitely.

### Testing
- A new unit test was added at `packages/api/src/services/__tests__/senderAvatar.service.test.ts` to validate the timeout behavior, but automated test execution could not be performed in this environment because the `jest` test runner is not available here; CI is expected to run `bun run --cwd packages/api test` which will execute the new test.
- Build/typecheck attempts in this environment were blocked by missing local dev dependencies and existing TypeScript config issues unrelated to this change, so no further automated test runs were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc15648323ab10e457b35580e9)