### PR TITLE
fix(api): bound inbound AI labeling

### DIFF
--- a/packages/api/src/config/email.config.ts
+++ b/packages/api/src/config/email.config.ts
@@ -94,10 +94,14 @@ export const DEFAULT_MAILBOXES = [
 
 /** AI auto-labeling on inbound email */
 export const AI_LABELING_CONFIG = {
-  enabled: process.env.AI_LABELING_ENABLED !== 'false',
+  // Inbound email is unauthenticated, so AI labeling must be explicitly enabled
+  // and bounded to avoid turning public SMTP traffic into unbounded AI calls.
+  enabled: getEnvBoolean('AI_LABELING_ENABLED', false),
   model: getEnvVar('AI_LABELING_MODEL', 'alia-lite'),
   timeout: getEnvNumber('AI_LABELING_TIMEOUT', 10000),
-  maxBodyChars: 1500,
+  maxBodyChars: getEnvNumber('AI_LABELING_MAX_BODY_CHARS', 1500),
+  maxConcurrent: Math.max(1, getEnvNumber('AI_LABELING_MAX_CONCURRENT', 2)),
+  maxQueueSize: Math.max(0, getEnvNumber('AI_LABELING_MAX_QUEUE_SIZE', 100)),
 };
 
 /** Encryption settings */

--- a/packages/api/src/services/__tests__/aiLabeling.service.test.ts
+++ b/packages/api/src/services/__tests__/aiLabeling.service.test.ts
@@ -1,0 +1,101 @@
+describe('aiLabelingService', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('keeps AI labeling disabled unless explicitly enabled', async () => {
+    delete process.env.AI_LABELING_ENABLED;
+
+    const { AI_LABELING_CONFIG } = await import('../../config/email.config');
+
+    expect(AI_LABELING_CONFIG.enabled).toBe(false);
+  });
+
+  it('bounds background classification concurrency and queue size', async () => {
+    process.env.ALIA_API_KEY = 'test-alia-key';
+
+    jest.doMock('../../config/email.config', () => ({
+      AI_LABELING_CONFIG: {
+        enabled: true,
+        model: 'alia-lite',
+        timeout: 10000,
+        maxBodyChars: 1500,
+        maxConcurrent: 2,
+        maxQueueSize: 4,
+      },
+    }));
+
+    jest.doMock('../../utils/logger', () => ({
+      logger: {
+        info: jest.fn(),
+        warn: jest.fn(),
+      },
+    }));
+
+    jest.doMock('../../models/Label', () => ({
+      Label: {
+        find: jest.fn(() => ({
+          select: jest.fn(() => ({
+            lean: jest.fn().mockResolvedValue([{ name: 'Work' }]),
+          })),
+        })),
+      },
+    }));
+
+    jest.doMock('../../models/Message', () => ({
+      Message: {
+        findOne: jest.fn(() => ({
+          select: jest.fn(() => ({
+            lean: jest.fn().mockResolvedValue({
+              subject: 'Hello',
+              from: { name: 'Sender', address: 'sender@example.com' },
+              to: [],
+              text: 'Body',
+            }),
+          })),
+        })),
+        updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+      },
+    }));
+
+    const axiosResolvers: Array<(value: unknown) => void> = [];
+    const axiosPost = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          axiosResolvers.push(resolve);
+        }),
+    );
+    jest.doMock('axios', () => ({
+      __esModule: true,
+      default: { post: axiosPost },
+    }));
+
+    const { aiLabelingService } = await import('../aiLabeling.service');
+
+    expect(aiLabelingService.enqueueClassification('user-1', 'message-1')).toBe(true);
+    expect(aiLabelingService.enqueueClassification('user-1', 'message-2')).toBe(true);
+    expect(aiLabelingService.enqueueClassification('user-1', 'message-3')).toBe(true);
+    expect(aiLabelingService.enqueueClassification('user-1', 'message-4')).toBe(true);
+    expect(aiLabelingService.enqueueClassification('user-1', 'message-5')).toBe(false);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(axiosPost).toHaveBeenCalledTimes(2);
+
+    axiosResolvers[0]?.({ data: { choices: [{ message: { content: '["Work"]' } }] } });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(axiosPost).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/api/src/services/__tests__/emailService.inboundAttachments.test.ts
+++ b/packages/api/src/services/__tests__/emailService.inboundAttachments.test.ts
@@ -67,7 +67,7 @@ jest.mock('../../models/EmailFilter', () => ({ EmailFilter: { find: jest.fn().mo
 
 jest.mock('../senderAvatar.service', () => ({ getAvatarPathsBatch: jest.fn() }));
 jest.mock('../aiLabeling.service', () => ({
-  aiLabelingService: { classifyAndLabel: jest.fn().mockResolvedValue(undefined) },
+  aiLabelingService: { enqueueClassification: jest.fn().mockReturnValue(true) },
 }));
 jest.mock('../cardExtraction.service', () => ({
   cardExtractionService: { extractAndUpdate: jest.fn().mockResolvedValue(undefined) },

--- a/packages/api/src/services/aiLabeling.service.ts
+++ b/packages/api/src/services/aiLabeling.service.ts
@@ -2,7 +2,7 @@
  * AI Email Labeling Service
  *
  * Classifies incoming emails using the Alia AI API and applies matching labels.
- * Runs as fire-and-forget after message storage — never blocks email delivery.
+ * Runs through a bounded background queue after message storage — never blocks email delivery.
  */
 
 import axios from 'axios';
@@ -15,6 +15,69 @@ const ALIA_BASE_URL = 'https://api.alia.onl/v1';
 const ALIA_API_KEY = process.env.ALIA_API_KEY;
 
 class AiLabelingService {
+  private activeJobs = 0;
+  private readonly queue: Array<{ userId: string; messageId: string }> = [];
+  private processingScheduled = false;
+
+  /**
+   * Enqueue background AI labeling with bounded concurrency/backpressure.
+   * Returns false when labeling is disabled or the queue is full.
+   */
+  enqueueClassification(userId: string, messageId: string): boolean {
+    if (!AI_LABELING_CONFIG.enabled || !ALIA_API_KEY) {
+      return false;
+    }
+
+    if (this.queue.length >= AI_LABELING_CONFIG.maxQueueSize) {
+      logger.warn('AI labeling queue full; dropping classification job', {
+        messageId,
+        maxQueueSize: AI_LABELING_CONFIG.maxQueueSize,
+      });
+      return false;
+    }
+
+    this.queue.push({ userId, messageId });
+    this.scheduleProcessing();
+    return true;
+  }
+
+  private scheduleProcessing(): void {
+    if (this.processingScheduled) {
+      return;
+    }
+
+    this.processingScheduled = true;
+    queueMicrotask(() => {
+      this.processingScheduled = false;
+      this.processQueue();
+    });
+  }
+
+  private processQueue(): void {
+    while (
+      this.activeJobs < AI_LABELING_CONFIG.maxConcurrent &&
+      this.queue.length > 0
+    ) {
+      const job = this.queue.shift();
+      if (!job) {
+        return;
+      }
+
+      this.activeJobs += 1;
+      this.classifyAndLabel(job.userId, job.messageId)
+        .catch((error) => {
+          logger.warn('AI labeling failed', {
+            messageId: job.messageId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        })
+        .finally(() => {
+          this.activeJobs -= 1;
+          this.scheduleProcessing();
+        });
+    }
+  }
+
   /**
    * Classify a message and apply labels.
    * Fire-and-forget — failures are logged, never thrown.

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -769,9 +769,7 @@ class EmailService {
     // Fire-and-forget AI processing (non-blocking, only for non-spam)
     if (!isSpam) {
       const msgId = message._id.toString();
-      aiLabelingService.classifyAndLabel(userId, msgId).catch((err) => {
-        logger.warn('AI labeling failed', { msgId, error: String(err) });
-      });
+      aiLabelingService.enqueueClassification(userId, msgId);
       cardExtractionService.extractAndUpdate(userId, msgId).catch((err) => {
         logger.warn('Card extraction failed', { msgId, error: String(err) });
       });
@@ -1859,9 +1857,7 @@ class EmailService {
 
         // Fire-and-forget AI processing
         const msgId = message._id.toString();
-        aiLabelingService.classifyAndLabel(userId, msgId).catch((err) => {
-          logger.warn('AI labeling failed for imported message', { msgId, error: String(err) });
-        });
+        aiLabelingService.enqueueClassification(userId, msgId);
         cardExtractionService.extractAndUpdate(userId, msgId).catch((err) => {
           logger.warn('Card extraction failed for imported message', { msgId, error: String(err) });
         });


### PR DESCRIPTION
### Motivation

- The inbound SMTP path previously scheduled `aiLabelingService.classifyAndLabel()` as a fire-and-forget task for every non-spam message, which can be amplified by unauthenticated mail to exhaust worker resources and third-party AI quota.  
- The change makes AI labeling explicitly opt-in and bounds background work to prevent resource exhaustion and runaway outbound API calls.

### Description

- Require explicit enabling by replacing the default `ALIA_API_KEY`-presence check with `AI_LABELING_ENABLED` and add configurable knobs `AI_LABELING_MAX_BODY_CHARS`, `AI_LABELING_MAX_CONCURRENT`, and `AI_LABELING_MAX_QUEUE_SIZE` in `packages/api/src/config/email.config.ts`.  
- Introduce a bounded in-memory queue with limited concurrency in `packages/api/src/services/aiLabeling.service.ts` via `enqueueClassification`, `processQueue`, and simple backpressure/drop behavior when the queue is full.  
- Update inbound and import flows in `packages/api/src/services/email.service.ts` to call `aiLabelingService.enqueueClassification(...)` instead of spawning unbounded promises.  
- Add unit test coverage and mocks for the new enqueue behavior in `packages/api/src/services/__tests__/aiLabeling.service.test.ts` and update the existing inbound attachments test to mock `enqueueClassification`.

### Testing

- Ran `git diff --check` with no whitespace errors reported.  
- Attempted to run the new unit test via `bun run test -- aiLabeling.service.test.ts` but the test runner install failed because dependency installation was blocked by registry access errors, so Jest could not be executed in this environment.  
- Attempted static type check with `tsc --noEmit -p packages/api/tsconfig.json`, but the run was blocked by an existing TypeScript deprecation error (repo `tsconfig` `baseUrl` deprecation), preventing a clean `tsc` verification here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db9af88323bae1c1a9d2f285d0)