### PR TITLE
fix(api): bind analytics access to authenticated user

### DIFF
--- a/packages/api/src/controllers/__tests__/analytics.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/analytics.controller.test.ts
@@ -1,0 +1,119 @@
+const mockAnalyticsFind = jest.fn();
+const mockAnalyticsAggregate = jest.fn();
+const mockAnalyticsFindOneAndUpdate = jest.fn();
+const mockUserFindById = jest.fn();
+const mockUserAggregate = jest.fn();
+
+jest.mock('../../models/Analytics', () => ({
+  __esModule: true,
+  default: {
+    find: mockAnalyticsFind,
+    aggregate: mockAnalyticsAggregate,
+    findOneAndUpdate: mockAnalyticsFindOneAndUpdate,
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    findById: mockUserFindById,
+    aggregate: mockUserAggregate,
+  },
+}));
+
+jest.mock('../utils/dateUtils', () => ({
+  getDateRange: jest.fn(() => ({
+    startDate: new Date('2026-01-01T00:00:00.000Z'),
+    endDate: new Date('2026-01-31T00:00:00.000Z'),
+  })),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), debug: jest.fn(), warn: jest.fn() },
+}));
+
+import type { Response } from 'express';
+import {
+  getAnalytics,
+  getContentViewers,
+  getFollowerDetails,
+  updateAnalytics,
+} from '../analytics.controller';
+import type { AuthRequest } from '../../middleware/auth';
+
+describe('analytics.controller', () => {
+  const authenticatedUserId = 'authenticated-user-id';
+  const attackerSuppliedUserId = 'victim-user-id';
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  const makeRequest = (overrides: Partial<AuthRequest> = {}): AuthRequest => ({
+    user: { _id: authenticatedUserId } as AuthRequest['user'],
+    query: { userID: attackerSuppliedUserId, period: 'weekly' },
+    body: { userID: attackerSuppliedUserId, type: 'profileViews', data: { 'stats.reach.impressions': 1 } },
+    ...overrides,
+  } as AuthRequest);
+
+  it('reads analytics for the authenticated user, ignoring query userID', async () => {
+    const sort = jest.fn().mockResolvedValue([]);
+    mockAnalyticsFind.mockReturnValue({ sort });
+    mockUserFindById.mockReturnValue({ select: jest.fn().mockResolvedValue({ _count: { followers: 1 } }) });
+
+    await getAnalytics(makeRequest(), res as Response);
+
+    expect(mockAnalyticsFind).toHaveBeenCalledWith(expect.objectContaining({
+      userID: authenticatedUserId,
+      period: 'weekly',
+    }));
+    expect(mockUserFindById).toHaveBeenCalledWith(authenticatedUserId);
+    expect(mockAnalyticsFind).not.toHaveBeenCalledWith(expect.objectContaining({ userID: attackerSuppliedUserId }));
+  });
+
+  it('updates analytics for the authenticated user, ignoring body userID', async () => {
+    mockAnalyticsFindOneAndUpdate.mockResolvedValue({});
+
+    await updateAnalytics(makeRequest(), res as Response);
+
+    expect(mockAnalyticsFindOneAndUpdate).toHaveBeenCalledTimes(4);
+    for (const call of mockAnalyticsFindOneAndUpdate.mock.calls) {
+      expect(call[0]).toEqual(expect.objectContaining({ userID: authenticatedUserId }));
+      expect(call[0]).not.toEqual(expect.objectContaining({ userID: attackerSuppliedUserId }));
+    }
+  });
+
+  it('reads content viewers for the authenticated user, ignoring query userID', async () => {
+    mockAnalyticsAggregate.mockResolvedValue([]);
+
+    await getContentViewers(makeRequest(), res as Response);
+
+    expect(mockAnalyticsAggregate).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({
+        $match: expect.objectContaining({ userID: authenticatedUserId }),
+      }),
+    ]));
+  });
+
+  it('reads follower details for the authenticated user, ignoring query userID', async () => {
+    mockUserAggregate.mockResolvedValue([]);
+
+    await getFollowerDetails(makeRequest(), res as Response);
+
+    expect(mockUserAggregate).toHaveBeenCalledWith(expect.arrayContaining([
+      { $match: { _id: authenticatedUserId } },
+    ]));
+  });
+
+  it('rejects analytics access without an authenticated user id', async () => {
+    await getAnalytics(makeRequest({ user: undefined }), res as Response);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(mockAnalyticsFind).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/controllers/analytics.controller.ts
+++ b/packages/api/src/controllers/analytics.controller.ts
@@ -1,12 +1,20 @@
-import { Request, Response } from "express";
+import type { Request, Response } from "express";
+import type { AuthRequest } from "../middleware/auth";
 import Analytics from "../models/Analytics";
 import User from "../models/User";
 import { getDateRange } from "./utils/dateUtils";
 import { logger } from '../utils/logger';
 
+const getAuthenticatedAnalyticsUserId = (req: Request) => (req as AuthRequest).user?._id;
+
 export const getAnalytics = async (req: Request, res: Response) => {
   try {
-    const { userID, period = "weekly" } = req.query;
+    const userID = getAuthenticatedAnalyticsUserId(req);
+    if (!userID) {
+      return res.status(401).json({ message: "Authentication required" });
+    }
+
+    const { period = "weekly" } = req.query;
     const { startDate, endDate } = getDateRange(period as string);
 
     const analytics = await Analytics.find({
@@ -33,7 +41,12 @@ export const getAnalytics = async (req: Request, res: Response) => {
 
 export const updateAnalytics = async (req: Request, res: Response) => {
   try {
-    const { userID, type, data } = req.body;
+    const userID = getAuthenticatedAnalyticsUserId(req);
+    if (!userID) {
+      return res.status(401).json({ message: "Authentication required" });
+    }
+
+    const { type, data } = req.body;
     const date = new Date();
     
     // Update or create analytics record for each period
@@ -66,7 +79,12 @@ export const updateAnalytics = async (req: Request, res: Response) => {
 
 export const getContentViewers = async (req: Request, res: Response) => {
   try {
-    const { userID, period = "weekly" } = req.query;
+    const userID = getAuthenticatedAnalyticsUserId(req);
+    if (!userID) {
+      return res.status(401).json({ message: "Authentication required" });
+    }
+
+    const { period = "weekly" } = req.query;
     const { startDate, endDate } = getDateRange(period as string);
     
     const viewers = await Analytics.aggregate([
@@ -98,7 +116,12 @@ export const getContentViewers = async (req: Request, res: Response) => {
 
 export const getFollowerDetails = async (req: Request, res: Response) => {
   try {
-    const { userID, period = "weekly" } = req.query;
+    const userID = getAuthenticatedAnalyticsUserId(req);
+    if (!userID) {
+      return res.status(401).json({ message: "Authentication required" });
+    }
+
+    const { period = "weekly" } = req.query;
     const { startDate } = getDateRange(period as string);
 
     const followerStats = await User.aggregate([


### PR DESCRIPTION
### Motivation
- Close an authorization gap that allowed authenticated users to read or modify another user's analytics by passing a target `userID` in query/body while the premium check validated only the requester.
- Ensure analytics operations are always scoped to the authenticated principal so privacySettings and premium gating are enforced correctly.

### Description
- Changed analytics controllers to derive the target `userID` from the authenticated request (`req.user._id`) and to return `401` when no authenticated user id is present, removing trust in client-supplied `userID` values in queries and bodies (`packages/api/src/controllers/analytics.controller.ts`).
- Added a small helper `getAuthenticatedAnalyticsUserId` and adjusted controller handlers to use it for all reads/updates/aggregations so DB queries use the authenticated id only.
- Added unit tests that assert attacker-supplied `userID` values are ignored for `getAnalytics`, `updateAnalytics`, `getContentViewers`, and `getFollowerDetails`, and that access is rejected when `req.user` is missing (`packages/api/src/controllers/__tests__/analytics.controller.test.ts`).
- Kept behavior and response shapes unchanged for valid authenticated requests while hardening ownership checks server-side.

### Testing
- Ran `git diff --check` which reported no whitespace/error issues and the diffs were applied cleanly.
- Added controller unit tests under `packages/api/src/controllers/__tests__/analytics.controller.test.ts`, but running the test suite in this environment was blocked because `jest` was not present and `bun install` failed due to npm registry 403 responses, so the new tests were not executed here.
- Static verification performed by repository inspection and targeted mocks confirms the controllers now build queries against the authenticated user's id rather than client-supplied ids.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc66688323bcc1e4f508ee7215)