### PR TITLE
Gate AI thread summarization behind explicit user action to prevent automatic data disclosure

### DIFF
--- a/packages/inbox/components/MessageDetail.tsx
+++ b/packages/inbox/components/MessageDetail.tsx
@@ -144,6 +144,7 @@ function MessageDetailInner({ mode, messageId }: MessageDetailProps) {
   const [replyTargetId, setReplyTargetId] = useState<string | null>(null);
   const [expandedMessages, setExpandedMessages] = useState<Set<string>>(new Set([messageId]));
   const [messageMenuId, setMessageMenuId] = useState<string | null>(null);
+  const [threadSummaryRequested, setThreadSummaryRequested] = useState(false);
 
   const moreMenuControl = useDialogControl();
   const labelPickerControl = useDialogControl();
@@ -758,9 +759,30 @@ function MessageDetailInner({ mode, messageId }: MessageDetailProps) {
             </View>
           )}
 
-          {/* AI Thread Summary - shows for 4+ messages */}
+          {/* AI Thread Summary - requires explicit user action before sending thread content to Alia */}
           {sortedThread.length >= 4 && (
-            <ThreadSummary messages={sortedThread} minMessages={4} />
+            threadSummaryRequested ? (
+              <ThreadSummary messages={sortedThread} minMessages={4} />
+            ) : (
+              <TouchableOpacity
+                style={[
+                  styles.threadSummaryPrompt,
+                  { backgroundColor: colors.surfaceVariant, borderColor: colors.border },
+                ]}
+                onPress={() => setThreadSummaryRequested(true)}
+                activeOpacity={0.75}
+              >
+                <MaterialCommunityIcons name="robot-outline" size={18} color={colors.primary} />
+                <View style={styles.threadSummaryPromptText}>
+                  <Text style={[styles.threadSummaryPromptTitle, { color: colors.text }]}>
+                    Generate AI thread summary
+                  </Text>
+                  <Text style={[styles.threadSummaryPromptDescription, { color: colors.secondaryText }]}>
+                    Sends this conversation to Alia for summarization.
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            )
           )}
         </View>
 
@@ -1291,6 +1313,27 @@ const styles = StyleSheet.create({
   threadCountText: {
     fontSize: 12,
     fontWeight: '500',
+  },
+  threadSummaryPrompt: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginBottom: 16,
+  },
+  threadSummaryPromptText: {
+    flex: 1,
+    gap: 2,
+  },
+  threadSummaryPromptTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  threadSummaryPromptDescription: {
+    fontSize: 12,
   },
   collapsedMessage: {
     flexDirection: 'row',


### PR DESCRIPTION
### Motivation
- Prevent automatic disclosure of private email content to an external AI service when opening long threads by removing the unconditional render of the summarization component. 
- Provide an explicit opt-in affordance and a short disclosure so users know their conversation will be sent to the external summarization API.

### Description
- Stop automatically mounting `ThreadSummary` for threads of 4+ messages and instead require the user to tap a new "Generate AI thread summary" affordance before the component is mounted. (modified: `packages/inbox/components/MessageDetail.tsx`).
- Add `threadSummaryRequested` state to track user consent and conditionally mount `ThreadSummary` only after the user requests it. (modified: `packages/inbox/components/MessageDetail.tsx`).
- Add inline disclosure copy that explains the conversation will be sent to Alia and new styles for the prompt UI. (modified: `packages/inbox/components/MessageDetail.tsx`).

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues and returned success. 
- Ran `bun run lint` in the inbox package which failed because the environment lacks `expo` (error: `expo: command not found`), so linter could not be fully validated in this environment.
- No unit/integration tests were executed in this environment as part of this change; recommend running the package's normal test/lint pipeline (`bun run lint`, `bun run test`) in CI or a development environment that has `expo` available to fully validate behavior and styling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db55148323b741ba2836d99112)