### PR TITLE
fix(inbox): require explicit smart reply generation

### DIFF
--- a/packages/inbox/components/SmartReplyChips.tsx
+++ b/packages/inbox/components/SmartReplyChips.tsx
@@ -5,12 +5,13 @@
  * Tapping a chip inserts the text into the reply composer.
  */
 
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   Platform,
+  TouchableOpacity,
 } from 'react-native';
 import { Loading } from '@oxyhq/bloom/loading';
 import { Chip } from '@oxyhq/bloom/chip';
@@ -30,9 +31,47 @@ interface SmartReplyChipsProps {
 
 export function SmartReplyChips({ message, onSelectReply }: SmartReplyChipsProps) {
   const colors = useColors();
-  const { replies, isLoading } = useSmartReplies(message);
+  const [hasRequestedReplies, setHasRequestedReplies] = useState(false);
+  const { replies, isLoading, refetch } = useSmartReplies(message);
 
-  // Don't render anything if no suggestions and not loading
+  const handleGenerateReplies = useCallback(() => {
+    setHasRequestedReplies(true);
+    void refetch();
+  }, [refetch]);
+
+  if (!hasRequestedReplies) {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          onPress={handleGenerateReplies}
+          style={[styles.generateButton, { borderColor: colors.border }]}
+        >
+          {Platform.OS === 'web' ? (
+            <HugeiconsIcon
+              icon={AiMail01Icon as unknown as IconSvgElement}
+              size={14}
+              color={colors.primary}
+            />
+          ) : (
+            <MaterialCommunityIcons
+              name="creation"
+              size={14}
+              color={colors.primary}
+            />
+          )}
+          <Text style={[styles.generateText, { color: colors.primary }]}>
+            Generate quick replies with AI
+          </Text>
+        </TouchableOpacity>
+        <Text style={[styles.privacyText, { color: colors.secondaryText }]}>
+          Sends this email to Alia after a sensitive-content check.
+        </Text>
+      </View>
+    );
+  }
+
+  // Don't render anything if no suggestions and not loading after an explicit request.
   if (!isLoading && replies.length === 0) {
     return null;
   }
@@ -100,6 +139,24 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 12,
     fontWeight: '500',
+  },
+  generateButton: {
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  generateText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  privacyText: {
+    fontSize: 11,
+    lineHeight: 14,
   },
   chips: {
     flexDirection: 'row',

--- a/packages/inbox/hooks/queries/useSmartReplies.ts
+++ b/packages/inbox/hooks/queries/useSmartReplies.ts
@@ -34,10 +34,22 @@ Rules:
 - Skip if email appears to be a no-reply, automated, or marketing email
 - Skip if email is about passwords, banking, or sensitive information`;
 
+function getMessageBody(message: Message): string {
+  const body = message.text || message.html || '';
+  return body
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 function buildPrompt(message: Message): string {
   const from = message.from.name || message.from.address;
   const subject = message.subject || '(no subject)';
-  const body = message.text?.slice(0, 1500) || message.html?.slice(0, 1500) || '';
+  const body = getMessageBody(message).slice(0, 1500);
 
   return `From: ${from}
 Subject: ${subject}
@@ -48,6 +60,7 @@ ${body}`;
 function shouldSkipSmartReplies(message: Message): boolean {
   const from = message.from.address.toLowerCase();
   const subject = (message.subject || '').toLowerCase();
+  const body = getMessageBody(message).toLowerCase();
 
   // Skip no-reply addresses
   if (from.includes('noreply') || from.includes('no-reply') || from.includes('donotreply')) {
@@ -59,13 +72,41 @@ function shouldSkipSmartReplies(message: Message): boolean {
     return true;
   }
 
-  // Skip sensitive topics
-  const sensitiveKeywords = ['password', 'reset', 'verify your', 'confirm your account', 'banking', 'transaction'];
-  if (sensitiveKeywords.some((kw) => subject.includes(kw))) {
+  // Skip sensitive topics before any body content can be sent to the AI service.
+  const sensitiveText = `${subject} ${body}`;
+  const sensitiveKeywords = [
+    'password',
+    'passcode',
+    'one-time code',
+    'one time code',
+    'otp',
+    '2fa',
+    'mfa',
+    'verification code',
+    'security code',
+    'reset',
+    'verify your',
+    'confirm your account',
+    'banking',
+    'transaction',
+    'invoice',
+    'payment',
+    'credit card',
+    'ssn',
+    'social security',
+  ];
+  if (sensitiveKeywords.some((kw) => sensitiveText.includes(kw))) {
     return true;
   }
 
-  return false;
+  const sensitivePatterns = [
+    /\b\d{3}-\d{2}-\d{4}\b/, // US SSN
+    /\b(?:\d[ -]*?){13,19}\b/, // payment-card-like numbers
+    /\b(?:code|pin|otp)\s*[:#-]?\s*\d{4,8}\b/i,
+    /\b\d{6}\b.*\b(?:code|pin|otp|verify|verification)\b/i,
+  ];
+
+  return sensitivePatterns.some((pattern) => pattern.test(sensitiveText));
 }
 
 async function fetchSmartReplies(message: Message, token: string): Promise<string[]> {
@@ -117,7 +158,7 @@ export function useSmartReplies(message: Message | null | undefined): SmartRepli
   const query = useQuery({
     queryKey: ['smartReplies', message?._id],
     queryFn: () => fetchSmartReplies(message!, token),
-    enabled: !!message && !!token,
+    enabled: false,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
     gcTime: 10 * 60 * 1000,
     retry: false, // Don't retry on failure
@@ -125,7 +166,7 @@ export function useSmartReplies(message: Message | null | undefined): SmartRepli
 
   return {
     replies: query.data ?? [],
-    isLoading: query.isLoading,
+    isLoading: query.isFetching,
     error: query.error as Error | null,
     refetch: query.refetch,
   };


### PR DESCRIPTION
### Motivation

- Prevent automatic client-side transmission of private email bodies to the external Alia AI service by removing on-mount smart-reply generation. 
- Require explicit user consent before sending any message content to the AI and add stronger body-level sensitive-content checks to avoid exfiltrating OTPs, SSNs, card numbers, or other PII. 

### Description

- Gate smart-reply generation behind an explicit UI action by adding a `Generate quick replies with AI` button and `hasRequestedReplies` state in `packages/inbox/components/SmartReplyChips.tsx`, and only call `refetch()` after the user triggers it. 
- Disable the React Query for smart replies by default (`enabled: false`) in `packages/inbox/hooks/queries/useSmartReplies.ts` so mounting the component does not start the AI request. 
- Add `getMessageBody()` to normalize and strip HTML, then include body-aware sensitive filtering (keyword list + regex checks for SSNs, card-like numbers, OTP/code patterns) and use the sanitized body when building the prompt in `useSmartReplies.ts`. 
- Keep existing UX for showing/loading chips and inserting selected replies; add a short privacy disclosure next to the generate button and a few styling helpers in `SmartReplyChips.tsx`. 

### Testing

- Ran repository checks via `git diff --check` which produced no whitespace/format errors. 
- Ran the package lint script `bun run lint` in this environment but it failed because the `expo` CLI and other runtime dev deps are not installed here, so full lint/tests could not be executed. 
- No automated unit tests were run in this sandbox due to missing node modules and dev tooling; changes are limited, at-call sites `SmartReplyChips` now requires an explicit action before any network call and `useSmartReplies` never issues requests on mount.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc0bf88323a7002650f99e2bfe)