### PR TITLE
fix(inbox): remount inline reply on target change

### DIFF
--- a/packages/inbox/components/MessageDetail.tsx
+++ b/packages/inbox/components/MessageDetail.tsx
@@ -939,6 +939,7 @@ function MessageDetailInner({ mode, messageId }: MessageDetailProps) {
         {replyMode && (
           <View style={[styles.inlineReplyWrapper, { marginTop: 16 }]}>
             <InlineReply
+              key={`${replyMode}:${replyTargetId ?? currentMessage._id}`}
               message={replyTargetId ? (sortedThread.find(m => m._id === replyTargetId) || currentMessage) : currentMessage}
               mode={replyMode}
               onClose={handleCloseReply}


### PR DESCRIPTION
### Motivation
- Per-message Reply/Reply all/Forward actions could retarget an already-open inline composer without remounting it, causing stale `to/cc/bcc/body/quotedText` state to be sent with a different `inReplyTo`/references and potentially leaking quoted content to the wrong recipient.

### Description
- Add a React `key` to the `InlineReply` instance so it is recreated whenever the active `replyMode` or `replyTargetId` changes by rendering `key={`${replyMode}:${replyTargetId ?? currentMessage._id}`}` in `packages/inbox/components/MessageDetail.tsx` to force remount and reset of local composer state.

### Testing
- Ran `git diff --check`, which produced no whitespace/patch errors and succeeded.
- Attempted `bun run lint` in `packages/inbox`, which failed in this environment because `expo`/`node_modules` are not installed, so full linting could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc72ec8323913d34f3402810db)