### PR TITLE
fix(inbox): harden native HTML email rendering to avoid WebView JS abuse

### DIFF
--- a/packages/inbox/components/HtmlBody.tsx
+++ b/packages/inbox/components/HtmlBody.tsx
@@ -17,6 +17,31 @@ interface HtmlBodyProps {
   html: string;
 }
 
+const MIN_WEBVIEW_HEIGHT = 100;
+const MAX_WEBVIEW_HEIGHT = 10_000;
+
+function sanitizeEmailHtml(html: string): string {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<\/?(?:iframe|object|embed|applet|form|input|button|textarea|select|meta|link)\b[^>]*>/gi, '')
+    .replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '')
+    .replace(/\s+(?:href|src|xlink:href|formaction)\s*=\s*(["'])\s*javascript:[^"']*\1/gi, '')
+    .replace(/\s+(?:href|src|xlink:href|formaction)\s*=\s*javascript:[^\s>]*/gi, '');
+}
+
+function clampWebViewHeight(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const roundedHeight = Math.ceil(value);
+  if (roundedHeight <= 0) {
+    return null;
+  }
+
+  return Math.min(Math.max(roundedHeight, MIN_WEBVIEW_HEIGHT), MAX_WEBVIEW_HEIGHT);
+}
+
 /**
  * Wrap email HTML with styling and proxy external resources.
  *
@@ -48,7 +73,7 @@ function wrapHtml(html: string, isDark: boolean): string {
 
   // Transform external image/font URLs to go through our proxy
   const proxyBaseUrl = getProxyBaseUrl();
-  const proxiedHtml = proxyExternalImages(html, proxyBaseUrl);
+  const proxiedHtml = proxyExternalImages(sanitizeEmailHtml(html), proxyBaseUrl);
 
   return `
     <!DOCTYPE html>
@@ -207,8 +232,11 @@ if (Platform.OS !== 'web') {
     const handleMessage = useCallback((event: { nativeEvent: { data: string } }) => {
       try {
         const msg = JSON.parse(event.nativeEvent.data);
-        if (msg.type === 'height' && msg.value > 0) {
-          setHeight(msg.value);
+        if (msg.type === 'height') {
+          const nextHeight = clampWebViewHeight(msg.value);
+          if (nextHeight !== null) {
+            setHeight(nextHeight);
+          }
         }
       } catch {
         // ignore
@@ -231,9 +259,9 @@ if (Platform.OS !== 'web') {
 
     return (
       <WebView
-        originWhitelist={['*']}
+        originWhitelist={['about:blank']}
         source={{ html: wrappedHtml }}
-        style={[styles.webView, height ? { height } : { minHeight: 100 }]}
+        style={[styles.webView, height ? { height } : { minHeight: MIN_WEBVIEW_HEIGHT }]}
         scalesPageToFit={false}
         scrollEnabled={false}
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
### Motivation
- The native inbox renderer became reachable after adding `react-native-webview`, which allowed attacker-controlled email HTML to run JavaScript inside a native `WebView` and abuse the `postMessage` channel or active content. 
- The existing message handler accepted unbounded `height` values and the native `WebView` used a wildcard `originWhitelist`, enabling UI/availability attacks from malicious emails.

### Description
- Add `sanitizeEmailHtml` to strip `<script>` tags, active-content elements (iframes/objects/embeds/etc.), inline event handlers, and `javascript:` URL attributes before proxying external resources. 
- Add `MIN_WEBVIEW_HEIGHT` and `MAX_WEBVIEW_HEIGHT` constants and implement `clampWebViewHeight` to bound page-reported heights; the `onMessage` handler now applies the clamped height. 
- Replace the native `WebView` `originWhitelist` `['*']` with `['about:blank']` for static email HTML to reduce allowed navigation origins. 
- Use a min-height constant for native fallback rendering and keep existing navigation handling that opens external links in the system browser.

### Testing
- Ran `git diff --check` which succeeded with no whitespace errors. 
- Attempted `bun run --cwd packages/inbox lint` which could not complete in this environment because the `expo` CLI is not installed, so lint could not be fully validated. 
- Attempted `tsc` via `bunx --bun tsc -p packages/inbox/tsconfig.json --noEmit` which could not complete in this environment due to missing workspace/Expo TypeScript base configs and dependencies, so type-checking could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db46988323bd934c6b070ceed2)