### PR TITLE
fix: make subscription credit grants idempotent

### DIFF
--- a/packages/api/src/models/BillingTransaction.ts
+++ b/packages/api/src/models/BillingTransaction.ts
@@ -4,6 +4,7 @@ export interface IBillingTransaction extends Document {
   userId: string;
   stripeCustomerId?: string;
   stripePaymentIntentId?: string;
+  stripeCreditGrantKey?: string;
   type: 'credit_purchase' | 'subscription_payment' | 'refund';
   amount: number;
   currency: string;
@@ -24,6 +25,10 @@ const BillingTransactionSchema = new Schema<IBillingTransaction>({
     type: String,
   },
   stripePaymentIntentId: {
+    type: String,
+    sparse: true,
+  },
+  stripeCreditGrantKey: {
     type: String,
     sparse: true,
   },
@@ -57,6 +62,7 @@ const BillingTransactionSchema = new Schema<IBillingTransaction>({
 });
 
 BillingTransactionSchema.index({ userId: 1, createdAt: -1 });
+BillingTransactionSchema.index({ stripeCreditGrantKey: 1 }, { unique: true, sparse: true });
 
 const BillingTransaction = mongoose.model<IBillingTransaction>('BillingTransaction', BillingTransactionSchema);
 

--- a/packages/api/src/models/UserCredits.ts
+++ b/packages/api/src/models/UserCredits.ts
@@ -10,6 +10,7 @@ export interface IUserCredits extends Document<string> {
     paid: number;
   };
   stripeCustomerId?: string;
+  subscriptionCreditGrantKeys?: string[];
   createdAt: Date;
   updatedAt: Date;
   refreshCreditsIfNeeded(): Promise<void>;
@@ -27,6 +28,7 @@ const UserCreditsSchema = new Schema<IUserCredits>({
     paid: { type: Number, default: 0 },
   },
   stripeCustomerId: { type: String },
+  subscriptionCreditGrantKeys: { type: [String], default: [] },
 }, {
   timestamps: true,
 });

--- a/packages/api/src/routes/billing.ts
+++ b/packages/api/src/routes/billing.ts
@@ -426,21 +426,50 @@ async function handleSubscriptionUpdate(stripeSubscription: Stripe.Subscription)
     { upsert: true, new: true }
   );
 
-  // Add credits on subscription renewal
+  // Add credits once per paid subscription period. Stripe may deliver the
+  // same subscription event more than once, and normal subscription.updated
+  // events can arrive immediately after signup while the period start is
+  // still recent. Keep the credit grant idempotency marker on UserCredits so
+  // the marker and credit increment happen in one atomic update.
   if (stripeSubscription.status === 'active') {
     const now = Date.now() / 1000;
     if (Math.abs(now - subscriptionItem.current_period_start) < 300) {
-      await userCredits.addCredits(plan.creditsPerMonth, 'paid');
-      await BillingTransaction.create({
-        userId: userCredits._id,
-        stripeCustomerId: customerId,
-        type: 'subscription_payment',
-        amount: plan.price,
-        currency: plan.currency,
-        credits: plan.creditsPerMonth,
-        status: 'completed',
-        description: `${plan.name} subscription credits`,
-      });
+      const creditGrantKey = `${stripeSubscription.id}:${subscriptionItem.current_period_start}`;
+      const creditedUser = await UserCredits.findOneAndUpdate(
+        { _id: userCredits._id, subscriptionCreditGrantKeys: { $ne: creditGrantKey } },
+        {
+          $inc: { 'credits.paid': plan.creditsPerMonth },
+          $addToSet: { subscriptionCreditGrantKeys: creditGrantKey },
+        },
+        { new: true }
+      );
+
+      if (!creditedUser) {
+        logger.info('Skipping duplicate subscription credit grant', {
+          creditGrantKey,
+          subscriptionId: stripeSubscription.id,
+          customerId,
+        });
+        return;
+      }
+
+      await BillingTransaction.updateOne(
+        { stripeCreditGrantKey: creditGrantKey },
+        {
+          $setOnInsert: {
+            userId: userCredits._id,
+            stripeCustomerId: customerId,
+            stripeCreditGrantKey: creditGrantKey,
+            type: 'subscription_payment',
+            amount: plan.price,
+            currency: plan.currency,
+            credits: plan.creditsPerMonth,
+            status: 'completed',
+            description: `${plan.name} subscription credits`,
+          },
+        },
+        { upsert: true }
+      );
     }
   }
 }


### PR DESCRIPTION
### Motivation
- Close a high-impact billing integrity bug where Stripe `customer.subscription.*` webhook deliveries (or immediate `subscription.updated` events such as from `cancel_at_period_end` updates) could grant the same monthly paid credits multiple times for a single billing period. 
- Ensure subscription credit grants are idempotent and auditable to prevent inflation of user paid credits.

### Description
- Add a per-period idempotency marker on the user credits document by introducing `subscriptionCreditGrantKeys` on `UserCredits` and storing the key as an array on the document, applied atomically during grant. (`packages/api/src/models/UserCredits.ts`)
- Add `stripeCreditGrantKey` to `BillingTransaction` and create a unique sparse index on it so a single billing transaction record can be tied to a single subscription-period grant key. (`packages/api/src/models/BillingTransaction.ts`)
- Update the subscription webhook handler to derive a grant key from `stripeSubscription.id` and the subscription `current_period_start`, perform an atomic `findOneAndUpdate` that both increments `credits.paid` and adds the grant key only when the key is not already present, and then upsert a single billing transaction with `$setOnInsert` keyed by the same grant key. This prevents duplicate grants on repeated webhook deliveries. (`packages/api/src/routes/billing.ts`)
- Keep the original five-minute period-start window check but make the grant operation idempotent and auditable by writing the grant key into both the `UserCredits` document and the `BillingTransaction` record.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch errors and it succeeded. 
- Attempted to run package tests (`bun run test --runInBand billing`) but the test runner (`jest`) was not available in the execution environment, so automated tests could not be executed here. 
- Attempted to run the repository build (`bun run build`) but the build step failed earlier in the toolchain due to upstream TypeScript configuration errors in the `@oxyhq/contracts` build (TypeScript deprecation/rootDir errors), blocking a full compile in this environment. 
- Performed code-level verification locally in the repository that the DB-updates are atomic: credit increment and grant-key set are performed in a single `findOneAndUpdate`, and the billing transaction write uses an idempotent `updateOne` with `upsert` + `$setOnInsert` keyed by the grant key. Automated test execution and a full CI run are recommended before deploying.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db89c4832390269274614238fa)