### PR TITLE
fix(api): sanitize Alia streaming errors

### DIFF
--- a/packages/api/src/routes/__tests__/alia.test.ts
+++ b/packages/api/src/routes/__tests__/alia.test.ts
@@ -1,0 +1,104 @@
+import express from 'express';
+import http, { IncomingMessage } from 'http';
+import { AddressInfo } from 'net';
+import axios from 'axios';
+
+jest.mock('axios');
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+interface RawResponse {
+  status: number;
+  body: string;
+}
+
+const request = async (app: express.Express, body: unknown): Promise<RawResponse> => {
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    return await new Promise<RawResponse>((resolve, reject) => {
+      const payload = JSON.stringify(body);
+      const req = http.request(
+        {
+          hostname: '127.0.0.1',
+          port,
+          path: '/api/alia/chat/completions',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+          },
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+          res.on('end', () => {
+            resolve({
+              status: res.statusCode ?? 0,
+              body: Buffer.concat(chunks).toString('utf8'),
+            });
+          });
+        },
+      );
+
+      req.on('error', reject);
+      req.end(payload);
+    });
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+};
+
+describe('Alia proxy route', () => {
+  const originalAliaApiKey = process.env.ALIA_API_KEY;
+
+  beforeEach(() => {
+    mockedAxios.post.mockReset();
+    process.env.ALIA_API_KEY = 'test-alia-key';
+  });
+
+  afterAll(() => {
+    if (originalAliaApiKey === undefined) {
+      delete process.env.ALIA_API_KEY;
+    } else {
+      process.env.ALIA_API_KEY = originalAliaApiKey;
+    }
+  });
+
+  it('returns a safe JSON error when an upstream streaming request fails with a stream body', async () => {
+    const streamBody = new IncomingMessage(null as never);
+
+    mockedAxios.post.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: streamBody,
+      },
+    });
+
+    const { default: aliaRouter } = await import('../alia');
+    const app = express();
+    app.use(express.json());
+    app.use('/api/alia', aliaRouter);
+
+    const response = await request(app, { stream: true, model: 'invalid' });
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'https://api.alia.onl/v1/chat/completions',
+      { stream: true, model: 'invalid' },
+      expect.objectContaining({ responseType: 'stream' }),
+    );
+    expect(response.status).toBe(400);
+    expect(JSON.parse(response.body)).toEqual({
+      error: 'ALIA_PROXY_ERROR',
+      message: 'Failed to reach Alia API',
+    });
+  });
+});

--- a/packages/api/src/routes/alia.ts
+++ b/packages/api/src/routes/alia.ts
@@ -6,6 +6,33 @@ const router = Router();
 
 const ALIA_BASE_URL = 'https://api.alia.onl/v1';
 const ALIA_API_KEY = process.env.ALIA_API_KEY;
+const ALIA_PROXY_ERROR_MESSAGE = 'Failed to reach Alia API';
+
+const isReadableStream = (value: unknown): value is NodeJS.ReadableStream => {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as NodeJS.ReadableStream).pipe === 'function' &&
+    typeof (value as NodeJS.ReadableStream).on === 'function'
+  );
+};
+
+const toSafeErrorMessage = (data: unknown): unknown => {
+  if (data === undefined || data === null || isReadableStream(data)) {
+    return ALIA_PROXY_ERROR_MESSAGE;
+  }
+
+  if (typeof data !== 'object') {
+    return data;
+  }
+
+  try {
+    JSON.stringify(data);
+    return data;
+  } catch {
+    return ALIA_PROXY_ERROR_MESSAGE;
+  }
+};
 
 /**
  * POST /api/alia/chat/completions
@@ -40,7 +67,7 @@ router.post('/chat/completions', authMiddleware, async (req: Request, res: Respo
     }
   } catch (err: any) {
     const status = err.response?.status ?? 502;
-    const message = err.response?.data ?? 'Failed to reach Alia API';
+    const message = toSafeErrorMessage(err.response?.data);
     res.status(status).json({ error: 'ALIA_PROXY_ERROR', message });
   }
 });


### PR DESCRIPTION
### Motivation
- The Alia proxy route allowed clients to request streaming (`req.body.stream === true`) and on upstream non-2xx responses would embed `err.response.data` (which can be a Node `IncomingMessage` stream) directly into `res.json()`, causing `TypeError: Converting circular structure to JSON` and an unhandled rejection that can crash the process.

### Description
- Add a `toSafeErrorMessage` helper and `isReadableStream` predicate to detect stream or otherwise non-serializable upstream error payloads and replace them with a safe fallback string instead of attempting to JSON-serialize them.
- Preserve existing streaming behavior (`responseType: 'stream'` and `response.data.pipe(res)`) for valid streaming responses while sanitizing error branches.
- Replace the previous direct use of `err.response?.data` in the catch block with the sanitized `toSafeErrorMessage(err.response?.data)` value.
- Add a regression test `packages/api/src/routes/__tests__/alia.test.ts` that mocks an Axios rejection containing an `IncomingMessage` body and asserts the route returns a safe JSON error.

### Testing
- Added a Jest regression test `packages/api/src/routes/__tests__/alia.test.ts` that verifies a streaming upstream error with a stream body returns `{ error: 'ALIA_PROXY_ERROR', message: 'Failed to reach Alia API' }` (test file committed).
- Attempted to run the test via `bun run test -- alia.test.ts` but `jest` is not available in the current environment so the test run could not execute (command failed).
- Attempted `bun install` to provision test deps but it failed due to npm registry `403` responses, so automated tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc006c8323a677f2f6c68dfe88)