### PR TITLE
Fix unsafe email structured search regex filters

### DIFF
--- a/packages/api/src/controllers/email.controller.ts
+++ b/packages/api/src/controllers/email.controller.ts
@@ -21,6 +21,12 @@ import {
 import { logger } from '../utils/logger';
 import type { RecipientInput, AttachmentInput } from '../schemas/email.schemas';
 
+function getOptionalQueryString(value: unknown, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  throw new BadRequestError(`${name} must be a single string value`);
+}
+
 /**
  * Resolve user-supplied { fileId, contentId?, isInline? } references into the
  * canonical IAttachment shape persisted on Message. Each fileId MUST:
@@ -546,14 +552,14 @@ export async function saveDraft(req: AuthRequest, res: Response): Promise<void> 
 
 export async function searchMessages(req: AuthRequest, res: Response): Promise<void> {
   const userId = req.user!.id;
-  const q = req.query.q as string | undefined;
-  const mailboxId = req.query.mailbox as string | undefined;
-  const from = req.query.from as string | undefined;
-  const to = req.query.to as string | undefined;
-  const subject = req.query.subject as string | undefined;
+  const q = getOptionalQueryString(req.query.q, 'q');
+  const mailboxId = getOptionalQueryString(req.query.mailbox, 'mailbox');
+  const from = getOptionalQueryString(req.query.from, 'from');
+  const to = getOptionalQueryString(req.query.to, 'to');
+  const subject = getOptionalQueryString(req.query.subject, 'subject');
   const hasAttachment = req.query.hasAttachment === 'true';
-  const dateAfter = req.query.dateAfter as string | undefined;
-  const dateBefore = req.query.dateBefore as string | undefined;
+  const dateAfter = getOptionalQueryString(req.query.dateAfter, 'dateAfter');
+  const dateBefore = getOptionalQueryString(req.query.dateBefore, 'dateBefore');
   const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
   const offset = parseInt(req.query.offset as string) || 0;
 

--- a/packages/api/src/services/__tests__/emailService.searchMessages.test.ts
+++ b/packages/api/src/services/__tests__/emailService.searchMessages.test.ts
@@ -1,0 +1,86 @@
+const mockMessageFind = jest.fn();
+const mockCountDocuments = jest.fn();
+
+jest.mock('../../models/Message', () => ({
+  Message: {
+    find: (...args: unknown[]) => mockMessageFind(...args),
+    countDocuments: (...args: unknown[]) => mockCountDocuments(...args),
+  },
+}));
+
+jest.mock('../../models/Mailbox', () => ({ Mailbox: {} }));
+jest.mock('../../models/Label', () => ({ Label: {} }));
+jest.mock('../../models/Bundle', () => ({ Bundle: {} }));
+jest.mock('../../models/User', () => ({ __esModule: true, default: {} }));
+jest.mock('../../models/Reminder', () => ({ Reminder: {} }));
+jest.mock('../../models/Contact', () => ({ Contact: {} }));
+jest.mock('../../models/EmailTemplate', () => ({ EmailTemplate: {} }));
+jest.mock('../../models/EmailFilter', () => ({ EmailFilter: {} }));
+jest.mock('../senderAvatar.service', () => ({ getAvatarPathsBatch: jest.fn() }));
+jest.mock('../aiLabeling.service', () => ({ aiLabelingService: {} }));
+jest.mock('../cardExtraction.service', () => ({ cardExtractionService: {} }));
+jest.mock('../smtp.outbound', () => ({ smtpOutbound: {} }));
+jest.mock('../push.service', () => ({ pushService: {} }));
+jest.mock('../assetServiceSingleton', () => ({ assetService: {} }));
+jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() } }));
+
+import { emailService } from '../email.service';
+
+function mockFindChain() {
+  const chain = {
+    sort: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    maxTimeMS: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockResolvedValue([]),
+  };
+  mockMessageFind.mockReturnValue(chain);
+  return chain;
+}
+
+function mockCountChain() {
+  const chain = {
+    maxTimeMS: jest.fn().mockResolvedValue(0),
+  };
+  mockCountDocuments.mockReturnValue(chain);
+  return chain;
+}
+
+describe('emailService.searchMessages structured filters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('treats from, to, and subject filters as escaped literal regex strings', async () => {
+    const findChain = mockFindChain();
+    const countChain = mockCountChain();
+
+    await emailService.searchMessages('64b000000000000000000001', '', {
+      from: '(a+)+$@example.com',
+      to: 'ops+alerts@example.com',
+      subject: 'Invoice [Q2] (final)?',
+    });
+
+    const filter = mockMessageFind.mock.calls[0][0];
+    expect(filter['from.address']).toEqual({ $regex: '\\(a\\+\\)\\+\\$@example\\.com', $options: 'i' });
+    expect(filter['to.address']).toEqual({ $regex: 'ops\\+alerts@example\\.com', $options: 'i' });
+    expect(filter.subject).toEqual({ $regex: 'Invoice \\[Q2\\] \\(final\\)\\?', $options: 'i' });
+    expect(mockCountDocuments).toHaveBeenCalledWith(filter);
+    expect(findChain.maxTimeMS).toHaveBeenCalledWith(5000);
+    expect(countChain.maxTimeMS).toHaveBeenCalledWith(5000);
+  });
+
+  it('rejects overlong structured filters before querying MongoDB', async () => {
+    mockFindChain();
+    mockCountChain();
+
+    await expect(
+      emailService.searchMessages('64b000000000000000000001', '', {
+        from: 'a'.repeat(129),
+      }),
+    ).rejects.toThrow('Search filters must be 128 characters or fewer');
+
+    expect(mockMessageFind).not.toHaveBeenCalled();
+    expect(mockCountDocuments).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -37,6 +37,23 @@ import { pushService } from './push.service';
 import { assetService } from './assetServiceSingleton';
 import { simpleParser } from 'mailparser';
 
+const MAX_STRUCTURED_SEARCH_FILTER_LENGTH = 128;
+const EMAIL_SEARCH_MAX_TIME_MS = 5_000;
+
+export function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function normalizeStructuredSearchFilter(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  if (value.length > MAX_STRUCTURED_SEARCH_FILTER_LENGTH) {
+    throw new BadRequestError(
+      `Search filters must be ${MAX_STRUCTURED_SEARCH_FILTER_LENGTH} characters or fewer`,
+    );
+  }
+  return escapeRegexLiteral(value);
+}
+
 class EmailService {
   // ─── Mailbox Management ───────────────────────────────────────────
 
@@ -1908,14 +1925,18 @@ class EmailService {
     if (mailboxId) {
       filter.mailboxId = new mongoose.Types.ObjectId(mailboxId);
     }
-    if (from) {
-      filter['from.address'] = { $regex: from, $options: 'i' };
+    const fromFilter = normalizeStructuredSearchFilter(from);
+    const toFilter = normalizeStructuredSearchFilter(to);
+    const subjectFilter = normalizeStructuredSearchFilter(subject);
+
+    if (fromFilter) {
+      filter['from.address'] = { $regex: fromFilter, $options: 'i' };
     }
-    if (to) {
-      filter['to.address'] = { $regex: to, $options: 'i' };
+    if (toFilter) {
+      filter['to.address'] = { $regex: toFilter, $options: 'i' };
     }
-    if (subject) {
-      filter.subject = { $regex: subject, $options: 'i' };
+    if (subjectFilter) {
+      filter.subject = { $regex: subjectFilter, $options: 'i' };
     }
     if (hasAttachment) {
       filter['attachments.0'] = { $exists: true };
@@ -1937,8 +1958,9 @@ class EmailService {
         .sort(sort)
         .skip(offset)
         .limit(limit)
+        .maxTimeMS(EMAIL_SEARCH_MAX_TIME_MS)
         .lean({ virtuals: true }),
-      Message.countDocuments(filter),
+      Message.countDocuments(filter).maxTimeMS(EMAIL_SEARCH_MAX_TIME_MS),
     ]);
 
     return { data, total, limit, offset };


### PR DESCRIPTION
### Motivation
- The email search endpoint accepted `from`, `to`, and `subject` query values and forwarded them directly into MongoDB `$regex` operators, enabling attacker-supplied pathological regexes to consume DB CPU and degrade availability.
- The intent is to keep structured search functionality while preventing executable regex injection and bounding query execution cost.

### Description
- Validate query parameters as single string values in `packages/api/src/controllers/email.controller.ts` by adding `getOptionalQueryString` and using it for `q`, `mailbox`, `from`, `to`, `subject`, `dateAfter`, and `dateBefore`.
- Escape user-supplied structured filters and enforce a length limit by adding `escapeRegexLiteral`, `normalizeStructuredSearchFilter`, and `MAX_STRUCTURED_SEARCH_FILTER_LENGTH = 128` to `packages/api/src/services/email.service.ts`, and use the normalized values for `from`, `to`, and `subject` regexes.
- Bound database execution time by adding `EMAIL_SEARCH_MAX_TIME_MS = 5000` and applying `.maxTimeMS(...)` to both the `find` and `countDocuments` queries in `packages/api/src/services/email.service.ts`.
- Add focused Jest unit tests at `packages/api/src/services/__tests__/emailService.searchMessages.test.ts` that assert filters are escaped, overlong filters are rejected, and `maxTimeMS` is applied.

### Testing
- Created and committed unit tests in `packages/api/src/services/__tests__/emailService.searchMessages.test.ts` (tests added but not executed in this environment).
- Ran `git diff --check` and a small Node snippet to validate `escapeRegexLiteral` behavior, both succeeded and confirmed regex metacharacters are escaped.
- Attempted to run the new Jest test via `bun run test` and `bun install`, but `jest`/dependencies could not be installed in this environment due to registry `403` errors, so Jest tests were not executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db98988323b9c90990e1b085bc)