### PR TITLE
Harden email HTML rendering in Inbox (sanitize + secure WebView)

### DIFF
--- a/packages/inbox/components/HtmlBody.tsx
+++ b/packages/inbox/components/HtmlBody.tsx
@@ -1,6 +1,6 @@
 /**
  * Cross-platform HTML email body renderer.
- * Web: sandboxed iframe with auto-height. Native: react-native-webview with auto-height.
+ * Web: sandboxed iframe with auto-height. Native: locked-down react-native-webview.
  *
  * External images and fonts are routed through our proxy to:
  * - Bypass CORS/CORP restrictions
@@ -11,7 +11,7 @@
 import React, { useCallback, useRef, useState, useEffect, useMemo } from 'react';
 import { Platform, StyleSheet, Linking } from 'react-native';
 import { useTheme } from '@oxyhq/bloom/theme';
-import { proxyExternalImages, getProxyBaseUrl } from '../utils/htmlTransform';
+import { proxyExternalImages, getProxyBaseUrl, sanitizeEmailHtml } from '../utils/htmlTransform';
 
 interface HtmlBodyProps {
   html: string;
@@ -48,7 +48,8 @@ function wrapHtml(html: string, isDark: boolean): string {
 
   // Transform external image/font URLs to go through our proxy
   const proxyBaseUrl = getProxyBaseUrl();
-  const proxiedHtml = proxyExternalImages(html, proxyBaseUrl);
+  const sanitizedHtml = sanitizeEmailHtml(html);
+  const proxiedHtml = proxyExternalImages(sanitizedHtml, proxyBaseUrl);
 
   return `
     <!DOCTYPE html>
@@ -170,27 +171,6 @@ function HtmlBodyWeb({ html }: HtmlBodyProps) {
   );
 }
 
-const HEIGHT_SCRIPT = `
-  <script>
-    (function() {
-      function postHeight() {
-        var h = document.body.scrollHeight;
-        if (h > 0) window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'height', value: h }));
-      }
-      // Post height immediately and on load
-      postHeight();
-      document.addEventListener('DOMContentLoaded', postHeight);
-      window.addEventListener('load', postHeight);
-      // Watch for images loading
-      document.querySelectorAll('img').forEach(function(img) {
-        img.addEventListener('load', postHeight);
-      });
-      // Observe mutations
-      new MutationObserver(postHeight).observe(document.body, { childList: true, subtree: true, attributes: true });
-    })();
-  </script>
-`;
-
 let HtmlBodyNative: React.ComponentType<HtmlBodyProps> | null = null;
 
 if (Platform.OS !== 'web') {
@@ -198,28 +178,16 @@ if (Platform.OS !== 'web') {
   const { WebView } = require('react-native-webview');
 
   HtmlBodyNative = function HtmlBodyNativeComponent({ html }: HtmlBodyProps) {
-    const [height, setHeight] = useState<number | null>(null);
     const { mode } = useTheme();
     const isDark = mode === 'dark';
 
-    const wrappedHtml = useMemo(() => wrapHtml(html, isDark) + HEIGHT_SCRIPT, [html, isDark]);
-
-    const handleMessage = useCallback((event: { nativeEvent: { data: string } }) => {
-      try {
-        const msg = JSON.parse(event.nativeEvent.data);
-        if (msg.type === 'height' && msg.value > 0) {
-          setHeight(msg.value);
-        }
-      } catch {
-        // ignore
-      }
-    }, []);
+    const wrappedHtml = useMemo(() => wrapHtml(html, isDark), [html, isDark]);
 
     // Open links in the system browser instead of navigating the WebView
     const handleNavigation = useCallback((request: { url: string }) => {
       const { url } = request;
-      // Allow the initial HTML load (about:blank or data: URLs)
-      if (url === 'about:blank' || url.startsWith('data:') || url.startsWith('about:')) {
+      // Allow the initial HTML load only. All user-clicked navigations leave the WebView.
+      if (url === 'about:blank' || url.startsWith('about:')) {
         return true;
       }
       // Open external links in system browser
@@ -231,19 +199,20 @@ if (Platform.OS !== 'web') {
 
     return (
       <WebView
-        originWhitelist={['*']}
+        originWhitelist={['about:blank']}
         source={{ html: wrappedHtml }}
-        style={[styles.webView, height ? { height } : { minHeight: 100 }]}
+        style={styles.webView}
         scalesPageToFit={false}
-        scrollEnabled={false}
+        scrollEnabled
         showsVerticalScrollIndicator={false}
         showsHorizontalScrollIndicator={false}
-        onMessage={handleMessage}
         onShouldStartLoadWithRequest={handleNavigation}
-        javaScriptEnabled
+        javaScriptEnabled={false}
         domStorageEnabled={false}
         startInLoadingState={false}
-        cacheEnabled
+        cacheEnabled={false}
+        mixedContentMode="never"
+        setSupportMultipleWindows={false}
       />
     );
   };
@@ -262,5 +231,6 @@ export function HtmlBody({ html }: HtmlBodyProps) {
 const styles = StyleSheet.create({
   webView: {
     backgroundColor: 'transparent',
+    minHeight: 400,
   },
 });

--- a/packages/inbox/utils/htmlTransform.ts
+++ b/packages/inbox/utils/htmlTransform.ts
@@ -5,6 +5,73 @@
  * providing CORS bypass and tracking protection.
  */
 
+const DANGEROUS_TAGS = [
+  'script',
+  'iframe',
+  'object',
+  'embed',
+  'applet',
+  'meta',
+  'base',
+  'form',
+  'input',
+  'button',
+  'textarea',
+  'select',
+];
+const DANGEROUS_URL_SCHEMES = /^(?:javascript|data|vbscript|file):/i;
+
+function escapeAttributeValue(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+function isSafeEmailUrl(value: string): boolean {
+  const trimmed = value.trim().replace(/[\u0000-\u001f\u007f\s]+/g, '');
+  if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('/')) return true;
+  if (DANGEROUS_URL_SCHEMES.test(trimmed)) return false;
+
+  try {
+    const parsed = new URL(trimmed);
+    return ['http:', 'https:', 'mailto:', 'tel:', 'cid:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove active content and dangerous URLs from untrusted email HTML before it is
+ * rendered in an iframe or native WebView. This is intentionally conservative:
+ * email markup should be display-only, with no scripts, forms, event handlers,
+ * or javascript/data/file navigations.
+ */
+export function sanitizeEmailHtml(html: string): string {
+  if (!html) return '';
+
+  let sanitized = html;
+
+  for (const tag of DANGEROUS_TAGS) {
+    sanitized = sanitized.replace(new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?<\\/${tag}\\s*>`, 'gi'), '');
+    sanitized = sanitized.replace(new RegExp(`<${tag}\\b[^>]*\\/?>`, 'gi'), '');
+  }
+
+  sanitized = sanitized.replace(/\s+on[a-z0-9_-]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+
+  sanitized = sanitized.replace(
+    /\s+(href|src|xlink:href|action|formaction|poster)\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/gi,
+    (_match, attr: string, _raw: string, doubleQuoted?: string, singleQuoted?: string, unquoted?: string) => {
+      const value = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
+      return isSafeEmailUrl(value) ? ` ${attr}="${escapeAttributeValue(value)}"` : '';
+    },
+  );
+
+  sanitized = sanitized.replace(
+    /url\(\s*(['"]?)([^)'"]+)\1\s*\)/gi,
+    (match, _quote, url: string) => (isSafeEmailUrl(url) ? match : 'url(about:blank)'),
+  );
+
+  return sanitized;
+}
+
 const INTERNAL_DOMAINS = ['oxy.so', 'localhost', '127.0.0.1'];
 
 function isExternalUrl(url: string): boolean {


### PR DESCRIPTION
### Motivation
- Untrusted inbound email HTML was being rendered raw in the native WebView, leaving a path for script-based exfiltration and UI/phishing attacks. 
- The change introduces a conservative sanitization step and safer WebView defaults to reduce attack surface while preserving rich HTML rendering for benign emails. 

### Description
- Added `sanitizeEmailHtml(html: string)` in `packages/inbox/utils/htmlTransform.ts` that strips active tags, event handlers, and disallowed URL schemes and normalizes dangerous attributes. 
- Apply sanitization before proxying external resources and embedding HTML by updating `wrapHtml(...)` to proxy `sanitizeEmailHtml(html)` instead of the raw HTML in `packages/inbox/components/HtmlBody.tsx`. 
- Hardened the native WebView renderer by removing the injected height script, disabling JavaScript/DOM storage, restricting `originWhitelist` to `about:blank`, blocking in-WebView navigations, disabling cache/mixed content and multiple windows, and adding a conservative `minHeight` fallback. 

### Testing
- Ran a sanitizer smoke test that confirmed `<script>`, inline event handlers, `javascript:`/`data:` URLs and `<iframe>` elements are removed while safe `https://` image URLs are preserved. 
- Verified the code patterns (`javaScriptEnabled={false}`, `originWhitelist={['about:blank']}`, and `sanitizeEmailHtml`) are present with `rg` and checked there are no diff-check issues via `git diff --check`. 
- Attempted local lint/type checks, but `expo`/workspace dependencies and tsconfig resolution are not available in this environment so full `bunx tsc --noEmit` and `expo lint` could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8daf908832393831d606a7969ec)