### PR TITLE
fix(inbox): scope react-query cache by authenticated user & clear on account switch

### DIFF
--- a/packages/inbox/app/_layout.tsx
+++ b/packages/inbox/app/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack, ThemeProvider } from 'expo-router';
 import Head from 'expo-router/head';
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { Platform } from 'react-native';
 import 'react-native-reanimated';
@@ -23,6 +23,7 @@ import { LocaleProvider, useTranslation } from '@/lib/i18n';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AuthGate } from '@/components/AuthGate';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
+import { useEmailStore } from '@/hooks/useEmail';
 import { registerServiceWorker } from '@/utils/registerServiceWorker';
 import { onConnectivityChange, flushQueue } from '@/utils/offlineQueue';
 import { OXY_CLIENT_ID } from '@/constants/oxy';
@@ -137,10 +138,25 @@ function BloomImageResolver({ children }: { children: ReactNode }) {
  */
 function RootEffects() {
   const { t } = useTranslation();
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
+  const previousUserIdRef = useRef<string | null>(null);
+
+  // Private email query data is scoped by user id, and cache/UI state is also
+  // cleared whenever the authenticated Oxy identity changes so a shared app
+  // instance cannot show the prior user's cached mail during account switches.
+  useEffect(() => {
+    const previousUserId = previousUserIdRef.current;
+    if (previousUserId !== userId) {
+      queryClient.clear();
+      useEmailStore.getState().resetUserState();
+      previousUserIdRef.current = userId;
+    }
+  }, [userId]);
 
   // Real-time inbox updates. The hook is a no-op until a user is signed in
-  // and tears the socket down on sign-out — react-query caches survive,
-  // so reconciling fetches happen the moment a new session is restored.
+  // and tears the socket down on sign-out or user switch; cache/state
+  // invalidation above prevents cross-user inbox data reuse.
   useInboxSocket({ baseURL: API_URL });
 
   // Register service worker on web

--- a/packages/inbox/components/MessageRow.tsx
+++ b/packages/inbox/components/MessageRow.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useState, useRef } from 'react';
 import { View, Pressable, TouchableOpacity, StyleSheet, Platform } from 'react-native';
 import { useQueryClient } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react';
 import { Text } from '@oxyhq/bloom/typography';
@@ -145,6 +146,8 @@ function MessageRowInner({
   const isUnread = !message.flags.seen;
   const [avatarHovered, setAvatarHovered] = useState(false);
   const queryClient = useQueryClient();
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
   const prefetchedRef = useRef(false);
 
   const showCheckbox = isSelectionMode || (Platform.OS === 'web' && avatarHovered);
@@ -180,14 +183,14 @@ function MessageRowInner({
 
   // Prefetch message data on hover (web only, once per mount)
   const handleMouseEnter = useCallback(() => {
-    if (!prefetchedRef.current) {
+    if (!prefetchedRef.current && userId) {
       prefetchedRef.current = true;
       queryClient.prefetchQuery({
-        queryKey: ['message', message._id],
+        queryKey: ['message', message._id, userId],
         staleTime: 60_000,
       });
     }
-  }, [queryClient, message._id]);
+  }, [queryClient, message._id, userId]);
 
   const senderName = getSenderName(message);
   const preview = getPreview(message);

--- a/packages/inbox/hooks/mutations/useMessageMutations.ts
+++ b/packages/inbox/hooks/mutations/useMessageMutations.ts
@@ -203,7 +203,11 @@ export function useArchiveMessage() {
       // Auto-advance selected message
       const { selectedMessageId } = useEmailStore.getState();
       if (selectedMessageId === messageId) {
-        const data = queryClient.getQueryData<MessagesInfinite>(['messages', useEmailStore.getState().currentMailbox?._id]);
+        const data = queryClient
+          .getQueriesData<MessagesInfinite>({
+            queryKey: ['messages', useEmailStore.getState().currentMailbox?._id],
+          })
+          .find(([, cached]) => !!cached)?.[1];
         const messages = flatMessages(data);
         const idx = messages.findIndex((m) => m._id === messageId);
         const nextId = idx < messages.length - 1 ? messages[idx + 1]._id : idx > 0 ? messages[idx - 1]._id : null;
@@ -257,7 +261,11 @@ export function useDeleteMessage() {
       // Auto-advance selected message
       const { selectedMessageId } = useEmailStore.getState();
       if (selectedMessageId === messageId) {
-        const data = queryClient.getQueryData<MessagesInfinite>(['messages', useEmailStore.getState().currentMailbox?._id]);
+        const data = queryClient
+          .getQueriesData<MessagesInfinite>({
+            queryKey: ['messages', useEmailStore.getState().currentMailbox?._id],
+          })
+          .find(([, cached]) => !!cached)?.[1];
         const messages = flatMessages(data);
         const idx = messages.findIndex((m) => m._id === messageId);
         const nextId = idx < messages.length - 1 ? messages[idx + 1]._id : idx > 0 ? messages[idx - 1]._id : null;

--- a/packages/inbox/hooks/queries/useMailboxes.ts
+++ b/packages/inbox/hooks/queries/useMailboxes.ts
@@ -1,16 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 import { useEmailStore } from '@/hooks/useEmail';
 import type { Mailbox } from '@/services/emailApi';
 
 export function useMailboxes() {
   const api = useEmailStore((s) => s._api);
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
 
   return useQuery<Mailbox[]>({
-    queryKey: ['mailboxes'],
+    queryKey: ['mailboxes', userId],
     queryFn: async () => {
       if (!api) throw new Error('Email API not initialized');
       return await api.listMailboxes();
     },
-    enabled: !!api,
+    enabled: !!api && !!userId,
   });
 }

--- a/packages/inbox/hooks/queries/useMessage.ts
+++ b/packages/inbox/hooks/queries/useMessage.ts
@@ -1,16 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 import { useEmailStore } from '@/hooks/useEmail';
 import type { Message } from '@/services/emailApi';
 
 export function useMessage(messageId: string | undefined) {
   const api = useEmailStore((s) => s._api);
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
 
   return useQuery<Message | null>({
-    queryKey: ['message', messageId],
+    queryKey: ['message', messageId, userId],
     queryFn: async () => {
       if (!api) throw new Error('Email API not initialized');
       return api.getMessage(messageId!);
     },
-    enabled: !!messageId && !!api,
+    enabled: !!messageId && !!api && !!userId,
   });
 }

--- a/packages/inbox/hooks/queries/useMessages.ts
+++ b/packages/inbox/hooks/queries/useMessages.ts
@@ -1,4 +1,5 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 import { useEmailStore } from '@/hooks/useEmail';
 import type { Message, Pagination } from '@/services/emailApi';
 
@@ -18,11 +19,13 @@ interface UseMessagesOptions {
 export function useMessages(options: UseMessagesOptions = {}) {
   const { mailboxId, starred, label } = options;
   const api = useEmailStore((s) => s._api);
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
 
   const hasFilter = !!mailboxId || !!starred || !!label;
 
   return useInfiniteQuery<MessagesPage>({
-    queryKey: ['messages', mailboxId ?? null, starred ?? false, label ?? null],
+    queryKey: ['messages', mailboxId ?? null, starred ?? false, label ?? null, userId],
     queryFn: async ({ pageParam = 0 }) => {
       if (!api) throw new Error('Email API not initialized');
       return await api.listMessages({
@@ -36,7 +39,7 @@ export function useMessages(options: UseMessagesOptions = {}) {
     initialPageParam: 0,
     getNextPageParam: (lastPage) =>
       lastPage.pagination.hasMore ? lastPage.pagination.offset + lastPage.pagination.limit : undefined,
-    enabled: hasFilter && !!api,
+    enabled: hasFilter && !!api && !!userId,
     refetchInterval: 60_000, // Poll for new messages every 60 seconds
   });
 }

--- a/packages/inbox/hooks/queries/useQuota.ts
+++ b/packages/inbox/hooks/queries/useQuota.ts
@@ -1,17 +1,20 @@
 import { useQuery } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 import { useEmailStore } from '@/hooks/useEmail';
 import type { QuotaUsage } from '@/services/emailApi';
 
 export function useQuota() {
   const api = useEmailStore((s) => s._api);
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
 
   return useQuery<QuotaUsage>({
-    queryKey: ['quota'],
+    queryKey: ['quota', userId],
     queryFn: async () => {
       if (!api) throw new Error('Email API not initialized');
       return api.getQuota();
     },
-    enabled: !!api,
+    enabled: !!api && !!userId,
     staleTime: 60_000,
   });
 }

--- a/packages/inbox/hooks/queries/useSearchMessages.ts
+++ b/packages/inbox/hooks/queries/useSearchMessages.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 import { useEmailStore } from '@/hooks/useEmail';
 import type { Message, Pagination } from '@/services/emailApi';
 
@@ -20,6 +21,8 @@ interface SearchResult {
 
 export function useSearchMessages(options: SearchOptions) {
   const api = useEmailStore((s) => s._api);
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
 
   const hasFilter = !!(
     options.q?.trim() ||
@@ -33,11 +36,11 @@ export function useSearchMessages(options: SearchOptions) {
   );
 
   return useQuery<SearchResult>({
-    queryKey: ['search', options],
+    queryKey: ['search', options, userId],
     queryFn: async () => {
       if (!api) throw new Error('Email API not initialized');
       return await api.search(options);
     },
-    enabled: hasFilter && !!api,
+    enabled: hasFilter && !!api && !!userId,
   });
 }

--- a/packages/inbox/hooks/queries/useSettings.ts
+++ b/packages/inbox/hooks/queries/useSettings.ts
@@ -1,22 +1,27 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useOxy } from '@oxyhq/services';
 import { useEmailStore } from '@/hooks/useEmail';
 import type { EmailSettings } from '@/services/emailApi';
 
 export function useSettings() {
   const api = useEmailStore((s) => s._api);
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
 
   return useQuery<EmailSettings>({
-    queryKey: ['settings'],
+    queryKey: ['settings', userId],
     queryFn: async () => {
       if (!api) throw new Error('Email API not initialized');
       return api.getSettings();
     },
-    enabled: !!api,
+    enabled: !!api && !!userId,
   });
 }
 
 export function useUpdateSettings() {
   const api = useEmailStore((s) => s._api);
+  const { user } = useOxy();
+  const userId = user?.id ?? null;
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -25,7 +30,7 @@ export function useUpdateSettings() {
       await api.updateSettings(settings);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      queryClient.invalidateQueries({ queryKey: ['settings', userId] });
     },
   });
 }

--- a/packages/inbox/hooks/useEmail.ts
+++ b/packages/inbox/hooks/useEmail.ts
@@ -28,6 +28,7 @@ interface EmailState {
   isSelectionMode: boolean;
   _api: EmailApiInstance | null;
   _initApi: (http: HttpService) => EmailApiInstance;
+  resetUserState: () => void;
   selectMailbox: (mailbox: Mailbox) => void;
   selectStarred: () => void;
   selectLabel: (labelId: string, labelName: string) => void;
@@ -122,5 +123,17 @@ export const useEmailStore = create<EmailState>((set, get) => ({
 
   selectAll: (ids) => {
     set({ selectedMessageIds: new Set(ids), isSelectionMode: ids.length > 0 });
+  },
+
+  resetUserState: () => {
+    set({
+      currentMailbox: null,
+      viewMode: null,
+      selectedMessageId: null,
+      expandedBundles: new Set<string>(),
+      selectedMessageIds: new Set<string>(),
+      isSelectionMode: false,
+      _api: null,
+    });
   },
 }));

--- a/packages/inbox/hooks/useInboxSocket.ts
+++ b/packages/inbox/hooks/useInboxSocket.ts
@@ -99,7 +99,7 @@ function prependToMessageCache(
 ) {
   queryClient.setQueriesData<MessagesInfinite>(
     {
-      // The query key shape is ['messages', mailboxId, starred, label]. We
+      // The query key shape is ['messages', mailboxId, starred, label, userId]. We
       // match by predicate so the prepend lands in every active variant
       // (including starred + label views the message also belongs to,
       // though `email:new` only carries the mailbox id, so we match on
@@ -107,7 +107,12 @@ function prependToMessageCache(
       // reconciliation invalidate below).
       predicate: (q) => {
         const key = q.queryKey;
-        return Array.isArray(key) && key[0] === 'messages' && key[1] === mailboxId;
+        return (
+          Array.isArray(key) &&
+          key[0] === 'messages' &&
+          key[1] === mailboxId &&
+          key[4] === optimistic.userId
+        );
       },
     },
     (old) => {
@@ -129,15 +134,16 @@ function prependToMessageCache(
 }
 
 /**
- * Update the mailbox unread count in the `['mailboxes']` cache so the sidebar
+ * Update the mailbox unread count in the `['mailboxes', userId]` cache so the sidebar
  * badge re-renders without a network round-trip.
  */
 function updateMailboxUnread(
   queryClient: ReturnType<typeof useQueryClient>,
+  userId: string,
   mailboxId: string,
   unread: number,
 ) {
-  queryClient.setQueryData<Mailbox[] | undefined>(['mailboxes'], (old) => {
+  queryClient.setQueryData<Mailbox[] | undefined>(['mailboxes', userId], (old) => {
     if (!old) return old;
     let mutated = false;
     const next = old.map((mb) => {
@@ -244,7 +250,7 @@ export function useInboxSocket({ baseURL }: UseInboxSocketOptions) {
           // 2. Bump the unread badge optimistically by 1; the authoritative
           //    `email:unread_count` event (emitted alongside by the server)
           //    will reconcile the exact number.
-          queryClientRef.current.setQueryData<Mailbox[] | undefined>(['mailboxes'], (old) => {
+          queryClientRef.current.setQueryData<Mailbox[] | undefined>(['mailboxes', userId], (old) => {
             if (!old) return old;
             let mutated = false;
             const next = old.map((mb) => {
@@ -261,7 +267,12 @@ export function useInboxSocket({ baseURL }: UseInboxSocketOptions) {
           queryClientRef.current.invalidateQueries({
             predicate: (q) => {
               const key = q.queryKey;
-              return Array.isArray(key) && key[0] === 'messages' && key[1] === event.mailboxId;
+              return (
+                Array.isArray(key) &&
+                key[0] === 'messages' &&
+                key[1] === event.mailboxId &&
+                key[4] === userId
+              );
             },
           });
 
@@ -285,7 +296,7 @@ export function useInboxSocket({ baseURL }: UseInboxSocketOptions) {
             }
             return;
           }
-          updateMailboxUnread(queryClientRef.current, payload.mailboxId, payload.unread);
+          updateMailboxUnread(queryClientRef.current, userId, payload.mailboxId, payload.unread);
           break;
         }
       }


### PR DESCRIPTION
### Motivation
- Prevent cross-user leakage of private inbox data cached by TanStack Query when multiple accounts reuse the same app/browser instance.
- Ensure realtime socket writes, hover-prefetches, and mutations do not populate global keys that can be read by a different signed-in user. 
- Keep UI state (Zustand) and the QueryClient cache aligned with the authenticated identity so account switch / logout yields a fresh inbox view.

### Description
- Scoped every sensitive inbox query key to the authenticated Oxy user id by adding `userId` to keys in hooks: `useMailboxes`, `useMessages`, `useMessage`, `useSearchMessages`, `useQuota`, and `useSettings` and guarded `enabled` with `userId` so cached data is per-user. (files: `packages/inbox/hooks/queries/*`)
- Added an auth-change effect at the inbox root (`packages/inbox/app/_layout.tsx`) that clears the global `queryClient` and resets the inbox UI/API Zustand store when the signed-in `user.id` changes, preventing reuse of prior-user cache during account switches. (file: `packages/inbox/app/_layout.tsx`)
- Added `resetUserState` to the email Zustand store and invoked it from the root effect to clear UI selection / API instance state on user change. (file: `packages/inbox/hooks/useEmail.ts`)
- Updated realtime socket handlers and optimistic cache updates to write into the user-scoped cache keys (mailboxes/messages predicate now requires the matching `userId`), and changed prefetch/prefetchQuery callers to include `userId` so hover and socket paths cannot leak another user's data. (files: `packages/inbox/hooks/useInboxSocket.ts`, `packages/inbox/components/MessageRow.tsx`)
- Adjusted mutation helpers (message archive/delete auto-advance path) to find the matching per-user query entry with `getQueriesData` rather than assume a single global key so auto-advance behavior is preserved after adding user-scoped keys. (file: `packages/inbox/hooks/mutations/useMessageMutations.ts`)

### Testing
- Ran `git diff --check` to ensure no obvious whitespace/check failures; result: clean.
- Searched for remaining unscoped keys with `rg "queryKey: \['(search|messages|message|settings|mailboxes|quota)'"` and verified updated matches now include `userId`.
- Type-check attempt: `bunx tsc --noEmit -p packages/inbox/tsconfig.json` produced unrelated module/JSX type errors in this environment due to missing Expo/type-deps (environment warning), not the changes here.
- Formatter attempt: `biome format` could not run in this environment (registry/installation unavailable), so formatting could not be validated here.

Files touched (high-level): `packages/inbox/app/_layout.tsx`, `packages/inbox/hooks/useEmail.ts`, `packages/inbox/hooks/queries/useMailboxes.ts`, `useMessages.ts`, `useMessage.ts`, `useSearchMessages.ts`, `useQuota.ts`, `useSettings.ts`, `packages/inbox/hooks/useInboxSocket.ts`, `packages/inbox/components/MessageRow.tsx`, and `packages/inbox/hooks/mutations/useMessageMutations.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dafd6083239bb50be46ecb0bda)