### PR TITLE
fix(api): count attachment bytes toward email storage quota

### DIFF
--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -38,6 +38,12 @@ import { assetService } from './assetServiceSingleton';
 import { simpleParser } from 'mailparser';
 
 class EmailService {
+  calculateMessageStorageSize(message: { text?: string; html?: string; attachments?: Array<{ size: number }> }): number {
+    const bodySize = Buffer.byteLength((message.text || '') + (message.html || ''), 'utf8');
+    const attachmentSize = (message.attachments ?? []).reduce((sum, attachment) => sum + attachment.size, 0);
+    return bodySize + attachmentSize;
+  }
+
   // ─── Mailbox Management ───────────────────────────────────────────
 
   /**
@@ -971,6 +977,9 @@ class EmailService {
     const sentMailbox = await this.getMailboxBySpecialUse(userId, '\\Sent');
     if (!sentMailbox) throw new NotFoundError('Sent mailbox not found');
 
+    const size = this.calculateMessageStorageSize(messageData);
+    await this.enforceQuota(userId, size);
+
     const message = await Message.create({
       userId: new mongoose.Types.ObjectId(userId),
       mailboxId: sentMailbox._id,
@@ -985,7 +994,7 @@ class EmailService {
       headers: {},
       attachments: messageData.attachments ?? [],
       flags: { seen: true, starred: false, answered: false, forwarded: false, draft: false },
-      size: messageData.size,
+      size,
       inReplyTo: messageData.inReplyTo,
       references: messageData.references ?? [],
       date: new Date(),
@@ -993,7 +1002,7 @@ class EmailService {
     });
 
     await Mailbox.findByIdAndUpdate(sentMailbox._id, {
-      $inc: { totalMessages: 1, size: messageData.size },
+      $inc: { totalMessages: 1, size },
     });
 
     return message.toJSON();
@@ -1122,10 +1131,8 @@ class EmailService {
     const sentMailbox = await this.getMailboxBySpecialUse(userId, '\\Sent');
     if (!sentMailbox) throw new NotFoundError('Sent mailbox not found');
 
-    const size = Buffer.byteLength(
-      (params.text || '') + (params.html || ''),
-      'utf8'
-    );
+    const size = this.calculateMessageStorageSize(params);
+    await this.enforceQuota(userId, size);
 
     const message = await Message.create({
       userId: new mongoose.Types.ObjectId(userId),

--- a/packages/api/src/services/smtp.outbound.ts
+++ b/packages/api/src/services/smtp.outbound.ts
@@ -90,6 +90,8 @@ class SmtpOutboundService {
 
   async send(message: OutboundMessage): Promise<{ messageId: string; queued: boolean }> {
     const messageId = `<${uuidv4()}@${EMAIL_DOMAIN}>`;
+    const size = emailService.calculateMessageStorageSize(message);
+    await emailService.enforceQuota(message.userId, size);
     const nmAttachments = await this.resolveAttachments(message.attachments || []);
 
     const mailOptions = {
@@ -113,7 +115,6 @@ class SmtpOutboundService {
     try {
       await this.transporter.sendMail(mailOptions);
 
-      const size = Buffer.byteLength((message.text || '') + (message.html || ''), 'utf8');
       await emailService.storeSentMessage(message.userId, {
         messageId,
         from: message.from,
@@ -358,6 +359,8 @@ class SmtpOutboundService {
     msg.attempts++;
 
     try {
+      const size = emailService.calculateMessageStorageSize(msg);
+      await emailService.enforceQuota(msg.userId, size);
       const nmAttachments = await this.resolveAttachments(msg.attachments || []);
       await this.transporter.sendMail({
         messageId: msg.messageId,
@@ -374,7 +377,6 @@ class SmtpOutboundService {
         ...SECURE_MAIL_CONTENT_OPTIONS,
       });
 
-      const size = Buffer.byteLength((msg.text || '') + (msg.html || ''), 'utf8');
       await emailService.storeSentMessage(msg.userId, {
         messageId: msg.messageId,
         from: msg.from,


### PR DESCRIPTION
### Motivation
- Attachment uploads and sent messages previously omitted attachment bytes from quota accounting, allowing authenticated users to upload large files to S3 or send attachments without increasing mailbox usage and enabling unbounded storage growth. 

### Description
- Add a shared helper `calculateMessageStorageSize(...)` in `packages/api/src/services/email.service.ts` that sums body bytes and attachment bytes. 
- Use the new helper to enforce quota via `enforceQuota(userId, size)` before persisting scheduled or Sent messages in `scheduleMessage` and `storeSentMessage`. 
- Update outbound send and retry paths in `packages/api/src/services/smtp.outbound.ts` to compute the attachment-inclusive size, call `enforceQuota` before dispatch, and pass the computed size into `storeSentMessage` so mailbox counters account for attachments. 

### Testing
- Ran `git diff --check` to validate no whitespace or simple diff issues and inspected the resulting diffs. 
- Attempted to run unit tests (`bun run test -- email.send.attachments.test.ts`) and workspace install (`bun install`), but test execution was blocked because dependency installation failed in this environment (registry returned 403), so Jest was not available. 
- Ran TypeScript compilation attempt (`tsc -p packages/api/tsconfig.json --noEmit --ignoreDeprecations 6.0`) which surfaced many type errors originating from missing dependency/type packages caused by the failed `bun install`, so full type-checking could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbe8fc832383262e50cb26b101)