### PR TITLE
fix(api): reject rotated session access tokens

### DIFF
--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -381,6 +381,16 @@ describe('Session Service', () => {
 
       expect(result).toBeNull();
     });
+    it('should reject a rotated-out access token for an active session', async () => {
+      const mockSession = createMockSession({ accessToken: 'new-access-token' });
+      mockFindOneResults.push(mockSession);
+
+      const result = await sessionService.validateSession('old-access-token');
+
+      expect(result).toBeNull();
+      expect(sessionCache.invalidate).toHaveBeenCalledWith('session-123');
+    });
+
   });
 
   describe('revokeSession', () => {

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -28,6 +28,20 @@ const REFRESH_TOKEN_EXPIRES_IN = '7d';
 const OBJECT_ID_LENGTH = 24; // MongoDB ObjectId hex string length
 const TOKEN_ROTATION_GRACE_PERIOD_MS = 30_000; // 30 seconds grace period for concurrent tab refreshes
 
+function timingSafeTokenEqual(provided: string, expected: unknown): boolean {
+  if (typeof expected !== 'string' || !provided || !expected) {
+    return false;
+  }
+
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
 /**
  * Extract userId string from various possible formats (ObjectId, populated object, string)
  * Handles edge cases and corrupted cache entries gracefully
@@ -239,6 +253,11 @@ class SessionService {
       }
 
       const { session } = result;
+
+      if (!timingSafeTokenEqual(accessToken, session.accessToken)) {
+        sessionCache.invalidate(sessionId);
+        return null;
+      }
 
       if (sessionCache.shouldUpdateLastActive(sessionId)) {
         this.updateLastActivity(sessionId).catch(() => {


### PR DESCRIPTION
### Motivation
- Restore intended token-rotation semantics so a previously issued access token that has been rotated out of the session record is not accepted for authentication.
- Prevent attackers who possess an old but unexpired JWT from retaining access after the legitimate client has refreshed or reauthenticated.

### Description
- Add a timing-safe comparison helper `timingSafeTokenEqual` that uses `crypto.timingSafeEqual` to compare the presented access token with the session's stored `accessToken` in `packages/api/src/services/session.service.ts`.
- Update `validateSession` to invalidate the session cache and return `null` when the presented token does not match the active session's stored token, rejecting rotated-out tokens.
- Add a regression unit test `should reject a rotated-out access token for an active session` in `packages/api/src/services/__tests__/session.service.test.ts` to cover this behavior.

### Testing
- Ran `git diff --check` to validate the change formatting and diff sanity which passed locally.
- Attempted to run the focused unit test with `bun run test -- session.service.test.ts`, but execution was blocked because test dependencies (Jest) were not available in the environment.
- Attempted `bun install` to provision test dependencies, but the run failed due to npm registry tarball `403` responses, so automated tests could not be executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dbf7b08323b04632b0add43ac6)