### PR TITLE
fix(api): verify social auth linking tokens

### DIFF
--- a/packages/api/src/routes/authLinking.ts
+++ b/packages/api/src/routes/authLinking.ts
@@ -16,11 +16,34 @@ import type { AuthMethodType } from '../models/User.js';
 import { authMiddleware, AuthRequest } from '../middleware/auth.js';
 import SignatureService from '../services/signature.service.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
-import { BadRequestError, ConflictError } from '../utils/error.js';
+import { BadRequestError, ConflictError, UnauthorizedError } from '../utils/error.js';
 import { validate } from '../middleware/validate.js';
 import { linkAuthMethodSchema, unlinkTypeParams } from '../schemas/authLinking.schemas.js';
+import socialAuthService from '../services/socialAuth.service.js';
+import type { SocialProfile } from '../services/socialAuth.service.js';
 
 const router = Router();
+
+type SocialAuthMethodType = 'google' | 'apple' | 'github';
+
+async function verifySocialLinkToken(type: SocialAuthMethodType, providerToken: unknown): Promise<SocialProfile> {
+  if (typeof providerToken !== 'string' || !providerToken.trim()) {
+    throw new BadRequestError('providerToken is required for social auth linking');
+  }
+
+  const safeProviderToken = providerToken.trim();
+  const profile = type === 'google'
+    ? await socialAuthService.verifyGoogleToken(safeProviderToken)
+    : type === 'apple'
+      ? await socialAuthService.verifyAppleToken(safeProviderToken)
+      : await socialAuthService.verifyGitHubCode(safeProviderToken);
+
+  if (!profile) {
+    throw new UnauthorizedError(`Invalid ${type} provider token`);
+  }
+
+  return profile;
+}
 
 // All routes require authentication
 router.use(authMiddleware);
@@ -94,7 +117,7 @@ router.post('/link', validate({ body: linkAuthMethodSchema }), asyncHandler(asyn
     throw new BadRequestError('User not authenticated');
   }
 
-  const { type, publicKey, signature, timestamp, email, password, providerId } = req.body;
+  const { type, publicKey, signature, timestamp, email, password, providerId, providerToken } = req.body;
 
   // Validate type is a non-empty string to prevent NoSQL injection
   if (typeof type !== 'string' || !type.trim()) {
@@ -217,6 +240,11 @@ router.post('/link', validate({ body: linkAuthMethodSchema }), asyncHandler(asyn
         throw new BadRequestError('providerId must be a non-empty string');
       }
       const safeProviderId = providerId.trim();
+      const verifiedProfile = await verifySocialLinkToken(safeType as SocialAuthMethodType, providerToken);
+      if (verifiedProfile.providerId !== safeProviderId) {
+        throw new BadRequestError('providerId does not match verified provider token');
+      }
+      const verifiedEmail = verifiedProfile.email?.trim().toLowerCase();
 
       // Check if this social account is already linked to another user
       // Use literal type values instead of user-controlled type to prevent injection
@@ -238,7 +266,7 @@ router.post('/link', validate({ body: linkAuthMethodSchema }), asyncHandler(asyn
       if (!existingMethod) {
         user.authMethods.push(buildAuthMethod(safeType as AuthMethodType, {
           providerId: safeProviderId,
-          email: typeof email === 'string' ? email.trim() : undefined,
+          email: verifiedEmail,
         }));
       }
 

--- a/packages/api/src/schemas/authLinking.schemas.ts
+++ b/packages/api/src/schemas/authLinking.schemas.ts
@@ -9,6 +9,7 @@ export const linkAuthMethodSchema = z.object({
   email: z.string().trim().email().optional(),
   password: z.string().min(8).optional(),
   providerId: z.string().trim().optional(),
+  providerToken: z.string().trim().optional(),
 });
 
 // DELETE /auth/link/:type


### PR DESCRIPTION
### Motivation
- The social auth linking endpoint accepted caller-supplied `providerId`/email without proving ownership of the external account, allowing an authenticated user to squat or falsely bind social accounts.

### Description
- Require a `providerToken` for `google`/`apple`/`github` links and verify it via the existing `socialAuthService` before persisting any social auth metadata.
- Reject the link if the verified provider profile's `providerId` does not match the caller-supplied `providerId` and persist the verified provider `email` instead of trusting client-supplied email.
- Add a `verifySocialLinkToken` helper in `authLinking` and extend the `link` request schema to accept `providerToken` (`providerToken` added to `linkAuthMethodSchema`).

### Testing
- Ran `git diff --check` which succeeded.
- Attempted `bun run --filter @oxyhq/api build` which could not complete due to unrelated TypeScript deprecation/rootDir errors in `@oxyhq/contracts` (build blocked).
- Attempted `tsc --noEmit` and `bun install` to run full type checks and tests, but these were blocked by missing dev dependencies / npm registry `403` responses in this environment, so full CI/test runs could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db35d0832385651c70f2056c8c)