### PR TITLE
fix: restrict credentialed SDK fetches

### DIFF
--- a/packages/core/src/HttpService.ts
+++ b/packages/core/src/HttpService.ts
@@ -496,13 +496,21 @@ export class HttpService {
         const useXhrForUpload = isFormData && isReactNative() && typeof XMLHttpRequest !== 'undefined';
 
         const response = useXhrForUpload
-          ? await this.uploadViaXHR(fullUrl, method, headers, bodyValue as FormData, controller.signal, timeout)
+          ? await this.uploadViaXHR(
+              fullUrl,
+              method,
+              headers,
+              bodyValue as FormData,
+              controller.signal,
+              timeout,
+              this.shouldSendCredentials(fullUrl),
+            )
           : await fetch(fullUrl, {
               method,
               headers,
               body: bodyValue as BodyInit | null | undefined,
               signal: controller.signal,
-              credentials: 'include', // Include cookies for cross-origin requests (CSRF, session)
+              credentials: this.getCredentialsMode(fullUrl),
             });
 
         if (timeoutId) clearTimeout(timeoutId);
@@ -694,13 +702,15 @@ export class HttpService {
     body: FormData,
     abortSignal: AbortSignal,
     timeout: number,
+    withCredentials: boolean,
   ): Promise<Response> {
     return new Promise<Response>((resolve, reject) => {
       const xhr = new XMLHttpRequest();
       xhr.open(method, url, true);
-      // withCredentials mirrors fetch's `credentials: 'include'` so the
-      // session cookie and CSRF cookie continue to flow.
-      xhr.withCredentials = true;
+      // Only send ambient cookies to the configured API origin. Absolute
+      // caller-supplied URLs can target arbitrary origins, so they must not
+      // receive credential-bearing requests by default.
+      xhr.withCredentials = withCredentials;
 
       // Forward headers but skip Content-Type — XHR sets the multipart
       // boundary automatically and overriding it breaks the upload.
@@ -872,6 +882,18 @@ export class HttpService {
 
     const queryString = searchParams.toString();
     return queryString ? `${base}${base.includes('?') ? '&' : '?'}${queryString}` : base;
+  }
+
+  private getCredentialsMode(url: string): RequestCredentials {
+    return this.shouldSendCredentials(url) ? 'include' : 'omit';
+  }
+
+  private shouldSendCredentials(url: string): boolean {
+    try {
+      return new URL(url).origin === new URL(this.baseURL).origin;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/core/src/__tests__/httpServiceCsrf.test.ts
+++ b/packages/core/src/__tests__/httpServiceCsrf.test.ts
@@ -157,4 +157,36 @@ describe('HttpService CSRF behavior', () => {
     expect(headers.Authorization).toBeUndefined();
     expect(headers['X-CSRF-Token']).toBe('csrf_1');
   });
+
+  it('includes credentials for configured API origin requests', async () => {
+    const calls: FetchCall[] = [];
+    globalThis.fetch = async (input, init) => {
+      calls.push({ url: String(input), init });
+      return jsonResponse({ ok: true });
+    };
+
+    const http = new HttpService({ baseURL: 'https://api.oxy.so', enableRetry: false });
+
+    await http.get('/users/me');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://api.oxy.so/users/me');
+    expect(calls[0].init?.credentials).toBe('include');
+  });
+
+  it('omits credentials for caller-supplied absolute URLs outside the configured API origin', async () => {
+    const calls: FetchCall[] = [];
+    globalThis.fetch = async (input, init) => {
+      calls.push({ url: String(input), init });
+      return jsonResponse({ ok: true });
+    };
+
+    const http = new HttpService({ baseURL: 'https://api.oxy.so', enableRetry: false });
+
+    await http.get('https://attacker.oxy.so/collect');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://attacker.oxy.so/collect');
+    expect(calls[0].init?.credentials).toBe('omit');
+  });
 });

--- a/packages/core/src/mixins/OxyServices.assets.ts
+++ b/packages/core/src/mixins/OxyServices.assets.ts
@@ -452,11 +452,21 @@ export function OxyServicesAssetsMixin<T extends typeof OxyServicesBase>(Base: T
     public async fetchAssetContent(url: string, type: 'text'): Promise<string>;
     public async fetchAssetContent(url: string, type: 'blob'): Promise<Blob>;
     public async fetchAssetContent(url: string, type: 'text' | 'blob') {
-      const response = await fetch(url, { credentials: 'include' });
+      const response = await fetch(url, {
+        credentials: this.shouldSendAssetCredentials(url) ? 'include' : 'omit',
+      });
       if (!response?.ok) {
         throw new Error(`Failed to fetch asset content (status ${response?.status})`);
       }
       return type === 'text' ? response.text() : response.blob();
+    }
+
+    private shouldSendAssetCredentials(url: string): boolean {
+      try {
+        return new URL(url).origin === new URL(this.getBaseURL()).origin;
+      } catch {
+        return false;
+      }
     }
   };
 }

--- a/packages/core/src/mixins/__tests__/assetCredentials.test.ts
+++ b/packages/core/src/mixins/__tests__/assetCredentials.test.ts
@@ -1,0 +1,47 @@
+import { OxyServices } from '../../OxyServices';
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+describe('asset fetch credentials', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('omits credentials for arbitrary asset content URLs', async () => {
+    const calls: FetchCall[] = [];
+    globalThis.fetch = async (input, init) => {
+      calls.push({ url: String(input), init });
+      return new Response('asset-body', { status: 200 });
+    };
+
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+
+    await oxy.fetchAssetContent('https://attacker.oxy.so/cdn/object.txt', 'text');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://attacker.oxy.so/cdn/object.txt');
+    expect(calls[0].init?.credentials).toBe('omit');
+  });
+
+  it('includes credentials for asset content fetched from the configured API origin', async () => {
+    const calls: FetchCall[] = [];
+    globalThis.fetch = async (input, init) => {
+      calls.push({ url: String(input), init });
+      return new Response('asset-body', { status: 200 });
+    };
+
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+
+    await oxy.fetchAssetContent('https://api.oxy.so/assets/private-file/stream', 'text');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://api.oxy.so/assets/private-file/stream');
+    expect(calls[0].init?.credentials).toBe('include');
+  });
+});


### PR DESCRIPTION
### Motivation

- A prior change made broad SDK fetch helpers use `credentials: 'include'` for all requests, which can cause browsers to send HttpOnly cookies (e.g. `oxy_session_id` scoped to `.oxy.so`) to caller-supplied absolute URLs and leak bearer-equivalent session identifiers.

### Description

- Make `HttpService` only send ambient credentials when the request target origin matches the configured API `baseURL`; otherwise use `credentials: 'omit'` for fetch and `xhr.withCredentials = false` for RN XHR uploads.
- Add `getCredentialsMode(url)` and `shouldSendCredentials(url)` helpers to centralize origin checks for credentialed requests.
- Update `fetchAssetContent` to omit credentials for arbitrary asset URLs and only include them when the asset URL is on the configured API origin.
- Add unit tests that assert credentials are included for requests to the configured API origin and omitted for caller-supplied absolute URLs on other origins.

### Testing

- Ran `git diff --check` to validate no trailing whitespace or lefover diff issues, which passed. 
- Added unit tests under `packages/core/src/__tests__/httpServiceCsrf.test.ts` and `packages/core/src/mixins/__tests__/assetCredentials.test.ts` but executing the test runner was blocked because `jest` is not installed in this environment (`jest: command not found`).
- Attempted `bun run typescript` to typecheck, but it failed due to missing repository dependencies/types in the environment (errors from unresolved packages). 
- Attempted `bun install` but the environment could not fetch registry tarballs (npm registry returned 403), so dependency installation and full test/compile runs are blocked in this CI/development environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db66988323b36af1be8a5686ab)