### PR TITLE
fix(auth): keep recovery token in HttpOnly cookie

### DIFF
--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -61,6 +61,33 @@ const RECOVERY_CODE_LENGTH = 10;
 const RECOVERY_CODE_TTL_MS = 10 * 60 * 1000;
 const RECOVERY_TOKEN_TTL_MS = 15 * 60 * 1000;
 const MAX_RECOVERY_ATTEMPTS = 3;
+const RECOVERY_COOKIE_NAME = 'oxy_recovery_token';
+const RECOVERY_COOKIE_PATH = '/auth/recover';
+
+function recoveryCookieOptions(maxAge: number) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax' as const,
+    domain: process.env.REFRESH_COOKIE_DOMAIN || 'oxy.so',
+    path: RECOVERY_COOKIE_PATH,
+    maxAge,
+  };
+}
+
+function setRecoveryCookie(res: Response, recoveryToken: string): void {
+  res.cookie(RECOVERY_COOKIE_NAME, recoveryToken, recoveryCookieOptions(RECOVERY_TOKEN_TTL_MS));
+}
+
+function clearRecoveryCookie(res: Response): void {
+  res.clearCookie(RECOVERY_COOKIE_NAME, recoveryCookieOptions(0));
+}
+
+function getRecoveryTokenFromRequest(req: Request): string | undefined {
+  const cookies = (req as Request & { cookies?: Record<string, unknown> }).cookies;
+  const token = cookies?.[RECOVERY_COOKIE_NAME];
+  return typeof token === 'string' && token.length > 0 ? token : undefined;
+}
 
 // More robust email validation regex (RFC 5322 compliant)
 // Validates: local-part@domain with proper character restrictions
@@ -907,8 +934,10 @@ export class SessionController {
         { expiresIn: Math.floor(RECOVERY_TOKEN_TTL_MS / 1000) }
       );
 
+      setRecoveryCookie(res, recoveryToken);
+
       return res.json({
-        recoveryToken,
+        success: true,
         expiresAt: new Date(Date.now() + RECOVERY_TOKEN_TTL_MS).toISOString(),
       });
     } catch (error) {
@@ -922,10 +951,11 @@ export class SessionController {
    */
   static async resetPassword(req: Request, res: Response) {
     try {
-      const { recoveryToken, password } = req.body;
+      const { password } = req.body;
+      const recoveryToken = getRecoveryTokenFromRequest(req);
 
       if (!recoveryToken || !password) {
-        return res.status(400).json({ message: 'Recovery token and password are required' });
+        return res.status(400).json({ message: 'Recovery session and password are required' });
       }
 
       // Validate password strength
@@ -965,6 +995,7 @@ export class SessionController {
 
       recovery.used = true;
       await recovery.save();
+      clearRecoveryCookie(res);
 
       try {
         await securityActivityService.logAccountRecovery(

--- a/packages/api/src/schemas/auth.schemas.ts
+++ b/packages/api/src/schemas/auth.schemas.ts
@@ -64,7 +64,6 @@ export const recoverVerifySchema = z.object({
 
 // POST /auth/recover/reset
 export const recoverResetSchema = z.object({
-  recoveryToken: z.string().trim().min(1),
   password: z.string().min(8),
 });
 

--- a/packages/auth/components/recover-form.tsx
+++ b/packages/auth/components/recover-form.tsx
@@ -35,7 +35,6 @@ export function RecoverForm({
     devCode,
     ...props
 }: RecoverFormProps) {
-    const recoveryStorageKey = "oxy_recovery_token"
     const navigate = useNavigate()
     const currentStep = step === "verify" || step === "reset" || step === "success" ? step : "request"
     const [localError, setLocalError] = useState<string | undefined>()
@@ -121,13 +120,6 @@ export function RecoverForm({
                     return
                 }
 
-                if (!payload?.recoveryToken) {
-                    setLocalError("Unable to continue recovery")
-                    return
-                }
-
-                sessionStorage.setItem(recoveryStorageKey, payload.recoveryToken)
-
                 const nextUrl = new URL("/recover", window.location.origin)
                 nextUrl.searchParams.set("step", "reset")
                 if (formIdentifier) {
@@ -148,21 +140,13 @@ export function RecoverForm({
                     return
                 }
 
-                const recoveryToken = sessionStorage.getItem(recoveryStorageKey)
-                if (!recoveryToken) {
-                    setLocalError(
-                        "Recovery session expired. Please request a new code."
-                    )
-                    return
-                }
-
                 const response = await fetch(buildAuthUrl("/recover/reset"), {
                     method: "POST",
                     headers: {
                         "content-type": "application/json",
                     },
                     credentials: "include",
-                    body: JSON.stringify({ recoveryToken, password }),
+                    body: JSON.stringify({ password }),
                 })
 
                 const payload = await response.json().catch(() => ({}))
@@ -174,8 +158,6 @@ export function RecoverForm({
                     setLocalError(message)
                     return
                 }
-
-                sessionStorage.removeItem(recoveryStorageKey)
 
                 const nextUrl = new URL("/recover", window.location.origin)
                 nextUrl.searchParams.set("step", "success")


### PR DESCRIPTION
### Motivation
- The recovery verification flow previously returned a raw `recoveryToken` in JSON and the client stored it in `sessionStorage`, exposing a bearer-equivalent token to same-origin JavaScript; this change closes that token exposure for the recovery path.
- This PR implements the safer cookie-based pattern already used elsewhere (HttpOnly, Secure, SameSite) so recovery flows do not leak bearer tokens to JS.

### Description
- Set an HttpOnly, SameSite=Lax, `Path=/auth/recover` cookie named `oxy_recovery_token` when a recovery code is verified instead of returning the raw token in JSON by adding `setRecoveryCookie(...)` and related helpers in `packages/api/src/controllers/session.controller.ts`.
- Make the reset endpoint read the recovery token from the server-side cookie and clear it after successful use by adding `getRecoveryTokenFromRequest(...)` and `clearRecoveryCookie(...)` in `packages/api/src/controllers/session.controller.ts`.
- Remove the `recoveryToken` field from the reset request schema so the server-side cookie is the authoritative bearer for reset (`packages/api/src/schemas/auth.schemas.ts`).
- Remove client-side `sessionStorage` handling and stop sending `recoveryToken` in the reset JSON body from the auth UI (`packages/auth/components/recover-form.tsx`).

### Testing
- Ran `git diff --check` which passed with the committed changes. 
- Verified no remaining client-side sessionStorage usage or JSON recovery-token echoes with `rg -n "sessionStorage\.(setItem|getItem|removeItem).*recovery|recoveryStorageKey|body: JSON.stringify(\{ recoveryToken|return res.json(\{\s*recoveryToken"` across the repo.
- Attempted to run package tests but they were blocked by the environment: `bun run --filter @oxyhq/api test` failed due to missing `jest` and `bun run --filter auth test` failed due to missing `jsdom`/`react` dependencies, so full automated test run could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7f9048323a8dfbfd9c6fee5a9)