### PR TITLE
fix(api): avoid self-revoking stable FedCM sessions

### DIFF
--- a/packages/api/src/services/__tests__/issueAndSetRefreshCookie.test.ts
+++ b/packages/api/src/services/__tests__/issueAndSetRefreshCookie.test.ts
@@ -225,6 +225,26 @@ describe('issueAndSetRefreshCookie — slot allocation', () => {
     expect(mockDeactivateSession).toHaveBeenCalledWith('sess-a');
   });
 
+  it('does not deactivate the current session when same-user slot replacement reuses the sessionId', async () => {
+    const existingRaw = 'SAME-SESSION-TOK';
+    stage(buildStored(existingRaw, {
+      sessionId: 'sess-stable', family: 'fam-stable',
+      userId: { toString: () => 'u-same' },
+    }));
+    const { res, calls } = makeResponseStub();
+    const result = await issueAndSetRefreshCookie(res, 'sess-stable', 'u-same', {
+      cookieHeader: `oxy_rt_0=${existingRaw}`,
+    });
+
+    expect(result.authuser).toBe(0);
+    expect(calls[0].name).toBe('oxy_rt_0');
+    expect(mockTokenUpdateMany).toHaveBeenCalledWith(
+      { family: 'fam-stable', revokedAt: null },
+      { $set: { revokedAt: expect.any(Date) } }
+    );
+    expect(mockDeactivateSession).not.toHaveBeenCalled();
+  });
+
   it('evicts the LRU slot when all MAX_DEVICE_ACCOUNTS are occupied by different users', async () => {
     // Fill slots 0..MAX-1 with distinct users; slot 3 is the LRU.
     const cookieParts: string[] = [];

--- a/packages/api/src/services/refreshToken.service.ts
+++ b/packages/api/src/services/refreshToken.service.ts
@@ -672,7 +672,9 @@ export async function issueAndSetRefreshCookie(
 
   // Same user already has a slot -> reuse it after revoking the old family
   // (a fresh sign-in for the same account must invalidate the prior token so
-  // a replay can't ride the same slot).
+  // a replay can't ride the same slot). FedCM/service sign-ins may intentionally
+  // reuse the same stable sessionId; in that case revoke the old token family
+  // without deactivating the still-current session.
   const existing = userIdToAuthuser.get(userIdStr);
   if (typeof existing === 'number') {
     const buckets = parseAllRefreshCookies(cookieHeader);
@@ -681,7 +683,8 @@ export async function issueAndSetRefreshCookie(
       const tokenHash = sha256Hex(raw);
       const row = await RefreshToken.findOne({ tokenHash });
       if (row) {
-        await revokeFamily(row.family, row.sessionId);
+        const sessionToDeactivate = row.sessionId === sessionId ? undefined : row.sessionId;
+        await revokeFamily(row.family, sessionToDeactivate);
         break;
       }
     }


### PR DESCRIPTION
### Motivation
- Prevent a regression where issuing a refresh cookie for a reused FedCM/stable session deactivates the very session that was just refreshed, breaking repeat FedCM sign-in/silent-auth flows.

### Description
- Update `packages/api/src/services/refreshToken.service.ts` so `revokeFamily` is called with `undefined` for the `sessionId` when the stored row's `sessionId` equals the supplied `sessionId`, avoiding self-deactivation while still revoking the old token family.
- Add a regression test in `packages/api/src/services/__tests__/issueAndSetRefreshCookie.test.ts` that asserts same-user slot replacement that reuses the same `sessionId` revokes the prior family but does not call `deactivateSession`.
- Small clarifying comment added to explain the FedCM/stable-session special-case behavior.

### Testing
- Ran `git diff --check` to validate the working tree and formatting, which passed without errors.
- Attempted to run the package tests with `bun run test -- src/services/__tests__/issueAndSetRefreshCookie.test.ts --runInBand`, but the test runner invocation failed because `jest` is not available in the execution environment (command error: `jest: command not found`).
- Attempted `bun install --frozen-lockfile` to install deps and enable running Jest, but the install failed due to the environment returning HTTP 403 from the npm registry, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db6600832386613813c922d22d)