### PR TITLE
fix(services): scope account query caches by session

### DIFF
--- a/packages/services/src/ui/hooks/queries/queryKeys.ts
+++ b/packages/services/src/ui/hooks/queries/queryKeys.ts
@@ -46,7 +46,7 @@ export const queryKeys = {
   devices: {
     all: ['devices'] as const,
     lists: () => [...queryKeys.devices.all, 'list'] as const,
-    list: (userId?: string) => [...queryKeys.devices.lists(), userId] as const,
+    list: (accountScope?: string) => [...queryKeys.devices.lists(), accountScope] as const,
     details: () => [...queryKeys.devices.all, 'detail'] as const,
     detail: (deviceId: string) => [...queryKeys.devices.details(), deviceId] as const,
   },
@@ -71,7 +71,7 @@ export const queryKeys = {
   // Storage usage queries
   storage: {
     all: ['storage'] as const,
-    usage: () => [...queryKeys.storage.all, 'usage'] as const,
+    usage: (accountScope?: string) => [...queryKeys.storage.all, 'usage', accountScope] as const,
   },
 
   // Connected apps (FedCM grants the user has authorized)

--- a/packages/services/src/ui/hooks/queries/useServicesQueries.ts
+++ b/packages/services/src/ui/hooks/queries/useServicesQueries.ts
@@ -5,6 +5,9 @@ import { queryKeys } from './queryKeys';
 import { useOxy } from '../../context/OxyContext';
 import { fetchSessionsWithFallback, mapSessionsToClient } from '../../utils/sessionHelpers';
 
+const accountQueryScope = (activeSessionId: string | null, actingAs?: string | null): string =>
+  `${activeSessionId ?? 'no-session'}:${actingAs ?? 'self'}`;
+
 /**
  * Get all active sessions for the current user
  */
@@ -90,10 +93,10 @@ export const useDeviceSessions = (options?: { enabled?: boolean }) => {
  * Get user devices
  */
 export const useUserDevices = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, actingAs } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.devices.list(),
+    queryKey: queryKeys.devices.list(accountQueryScope(activeSessionId, actingAs)),
     queryFn: async () => {
       return authenticatedApiCall(
         oxyServices,
@@ -101,7 +104,7 @@ export const useUserDevices = (options?: { enabled?: boolean }) => {
         () => oxyServices.getUserDevices()
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!activeSessionId,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });
@@ -132,10 +135,10 @@ export const useSecurityInfo = (options?: { enabled?: boolean }) => {
  * `useEffect` fetches.
  */
 export const useAccountStorageUsage = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, actingAs } = useOxy();
 
   return useQuery<AccountStorageUsageResponse>({
-    queryKey: queryKeys.storage.usage(),
+    queryKey: queryKeys.storage.usage(accountQueryScope(activeSessionId, actingAs)),
     queryFn: async () => {
       return authenticatedApiCall(
         oxyServices,
@@ -143,7 +146,7 @@ export const useAccountStorageUsage = (options?: { enabled?: boolean }) => {
         () => oxyServices.getAccountStorageUsage()
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!activeSessionId,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   });


### PR DESCRIPTION
### Motivation
- Prevent a client-side confidentiality leak where account-sensitive TanStack Query results (devices, storage usage) were cached under static keys and could be shown after switching sessions/accounts.
- Avoid persisting stale device metadata across restarts by ensuring query keys are scoped to the active session and acting-as account.

### Description
- Extend query key helpers so `devices.list(...)` and `storage.usage(...)` accept an `accountScope` discriminator instead of using static keys.
- Add an `accountQueryScope(activeSessionId, actingAs)` helper and include it in `useUserDevices()` and `useAccountStorageUsage()` query keys so cached results are unique per-active-session/acting-as pair.
- Require an active session for devices and storage queries by tightening their `enabled` guards to also check `!!activeSessionId`.
- Small behavioral change: device list and storage usage caches are now segregated per session/acting-as, preventing cross-account reuse and reducing the risk of persisted stale sensitive data.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors.
- Attempted package tests with `bun run --cwd packages/services test -- --runTestsByPath src/ui/hooks/queries/useServicesQueries.ts` but the test runner could not be executed in this environment because `jest` and other dev dependencies are not installed here.
- Attempted TypeScript build with `bun run --cwd packages/services typescript` but it failed in the current container due to missing workspace dependencies and type declarations (e.g. `react`, `@oxyhq/core`, React Native typings), so full compile/test could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc46108323a041cf126587508a)