### PR TITLE
fix(core): make identity backup refresh atomic

### DIFF
--- a/packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts
+++ b/packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts
@@ -21,7 +21,7 @@ import { setPlatformOS } from '../../utils/platform';
 // Fault-injectable in-memory secure store. `failPlan` lets a test make a
 // specific (op, key) pair throw to simulate a keychain that fails mid-write or
 // is transiently locked.
-const failPlan: { failKey?: string; failOp?: 'set' | 'get' } = {};
+const failPlan: { failKey?: string; failOp?: 'set' | 'get'; failTimes?: number } = {};
 
 jest.mock(
   'expo-secure-store',
@@ -29,6 +29,14 @@ jest.mock(
     const store = new Map<string, string>();
     const maybeFail = (op: 'set' | 'get', key: string) => {
       if (failPlan.failOp === op && failPlan.failKey === key) {
+        if (failPlan.failTimes !== undefined) {
+          failPlan.failTimes -= 1;
+          if (failPlan.failTimes <= 0) {
+            failPlan.failKey = undefined;
+            failPlan.failOp = undefined;
+            failPlan.failTimes = undefined;
+          }
+        }
         throw new Error(`Simulated ${op} failure for ${key}`);
       }
     };
@@ -51,6 +59,7 @@ jest.mock(
         store.clear();
         failPlan.failKey = undefined;
         failPlan.failOp = undefined;
+        failPlan.failTimes = undefined;
       },
       __getStore__: () => store,
       __failPlan__: failPlan,
@@ -92,7 +101,7 @@ jest.mock('../../utils/platformCrypto', () => ({
 interface SecureStoreTestHandle {
   __resetStore__: () => void;
   __getStore__: () => Map<string, string>;
-  __failPlan__: { failKey?: string; failOp?: 'set' | 'get' };
+  __failPlan__: { failKey?: string; failOp?: 'set' | 'get'; failTimes?: number };
 }
 
 describe('KeyManager atomicity & recoverability under flaky storage', () => {
@@ -145,6 +154,36 @@ describe('KeyManager atomicity & recoverability under flaky storage', () => {
     expect(m.get('oxy_identity_backup_private_key')).toBe(originalPriv);
     expect(m.get('oxy_identity_backup_public_key')).toBe(originalPublic);
   });
+
+  it('a failed final backup refresh rejects and rolls back instead of succeeding with a stale backup', async () => {
+    const originalPublic = await KeyManager.createIdentity();
+    const ss = (await import('expo-secure-store' as string)) as unknown as SecureStoreTestHandle;
+    const originalPriv = ss.__getStore__().get('oxy_identity_private_key');
+    resetCaches();
+
+    // Let the new primary write and verify, then fail exactly once while
+    // refreshing the backup to the new identity. This used to return success
+    // with primary=B and backup=A, enabling a later absent-primary restore to
+    // silently switch back to A.
+    ss.__failPlan__.failOp = 'set';
+    ss.__failPlan__.failKey = 'oxy_identity_backup_public_key';
+    ss.__failPlan__.failTimes = 1;
+    await expect(KeyManager.createIdentity({ overwrite: true })).rejects.toBeDefined();
+
+    resetCaches();
+
+    // The operation failed atomically: primary and backup both still identify
+    // the original account, so callers cannot observe success with a stale
+    // cross-account backup.
+    expect(await KeyManager.hasIdentity()).toBe(true);
+    expect(await KeyManager.getPublicKey()).toBe(originalPublic);
+    const m = ss.__getStore__();
+    expect(m.get('oxy_identity_private_key')).toBe(originalPriv);
+    expect(m.get('oxy_identity_public_key')).toBe(originalPublic);
+    expect(m.get('oxy_identity_backup_private_key')).toBe(originalPriv);
+    expect(m.get('oxy_identity_backup_public_key')).toBe(originalPublic);
+  });
+
 
   it('restoreIdentityFromBackup does NOT clobber a healthy primary that is only transiently unreadable', async () => {
     const original = await KeyManager.createIdentity();

--- a/packages/core/src/crypto/keyManager.ts
+++ b/packages/core/src/crypto/keyManager.ts
@@ -795,11 +795,25 @@ export class KeyManager {
     }
 
     // Step 3: The new primary is durable and functional. NOW it is safe to
-    // refresh the backup to the new key. If this final backup write fails the
-    // user still has a fully working primary, and the backup still holds the
-    // PREVIOUS good identity — so we log and continue rather than failing the
-    // whole operation (failing here would be strictly worse: a working
-    // primary would be reported as an error to the caller).
+    // refresh the backup to the new key. This is part of the successful write
+    // contract: returning success while the backup still belongs to the
+    // previous identity would allow a later restore with an absent primary to
+    // silently switch the device back to the previous account. Snapshot the
+    // backup first so a partial backup refresh can be rolled back along with
+    // the primary before surfacing the failure.
+    let priorBackupPrivate: string | null;
+    let priorBackupPublic: string | null;
+    let priorBackupTimestamp: string | null;
+    try {
+      priorBackupPrivate = await store.getItemAsync(STORAGE_KEYS.BACKUP_PRIVATE_KEY);
+      priorBackupPublic = await store.getItemAsync(STORAGE_KEYS.BACKUP_PUBLIC_KEY);
+      priorBackupTimestamp = await store.getItemAsync(STORAGE_KEYS.BACKUP_TIMESTAMP);
+    } catch (error) {
+      logger.error('Failed to snapshot identity backup before refresh', error, { component: 'KeyManager' });
+      await KeyManager._rollbackPrimary(store, priorPrivate, priorPublic);
+      throw new IdentityPersistError('Failed to snapshot identity backup before refresh', error);
+    }
+
     try {
       await store.setItemAsync(STORAGE_KEYS.BACKUP_PRIVATE_KEY, canonicalPrivate, {
         keychainAccessible: store.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
@@ -807,16 +821,52 @@ export class KeyManager {
       await store.setItemAsync(STORAGE_KEYS.BACKUP_PUBLIC_KEY, canonicalPublic);
       await store.setItemAsync(STORAGE_KEYS.BACKUP_TIMESTAMP, Date.now().toString());
     } catch (error) {
-      logger.warn(
-        'Primary identity persisted successfully but refreshing the backup failed; primary is usable, backup may be stale',
-        { component: 'KeyManager' },
-        error,
-      );
+      logger.error('Failed to refresh identity backup after primary write', error, { component: 'KeyManager' });
+      await KeyManager._rollbackBackup(store, priorBackupPrivate, priorBackupPublic, priorBackupTimestamp);
+      await KeyManager._rollbackPrimary(store, priorPrivate, priorPublic);
+      throw new IdentityPersistError('Failed to refresh identity backup after primary write', error);
     }
 
     // Update cache only after we are certain the identity is durable.
     KeyManager.cachedPublicKey = canonicalPublic;
     KeyManager.cachedHasIdentity = true;
+  }
+
+  /**
+   * Restore the backup slot to a previously-snapshotted state. Best-effort so
+   * the original persistence error remains the one surfaced to the caller.
+   *
+   * @internal
+   */
+  private static async _rollbackBackup(
+    store: Awaited<ReturnType<typeof initSecureStore>>,
+    priorBackupPrivate: string | null,
+    priorBackupPublic: string | null,
+    priorBackupTimestamp: string | null,
+  ): Promise<void> {
+    try {
+      if (priorBackupPrivate) {
+        await store.setItemAsync(STORAGE_KEYS.BACKUP_PRIVATE_KEY, priorBackupPrivate, {
+          keychainAccessible: store.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+        });
+      } else {
+        try { await store.deleteItemAsync(STORAGE_KEYS.BACKUP_PRIVATE_KEY); } catch { /* best effort */ }
+      }
+
+      if (priorBackupPublic) {
+        await store.setItemAsync(STORAGE_KEYS.BACKUP_PUBLIC_KEY, priorBackupPublic);
+      } else {
+        try { await store.deleteItemAsync(STORAGE_KEYS.BACKUP_PUBLIC_KEY); } catch { /* best effort */ }
+      }
+
+      if (priorBackupTimestamp) {
+        await store.setItemAsync(STORAGE_KEYS.BACKUP_TIMESTAMP, priorBackupTimestamp);
+      } else {
+        try { await store.deleteItemAsync(STORAGE_KEYS.BACKUP_TIMESTAMP); } catch { /* best effort */ }
+      }
+    } catch (rollbackError) {
+      logger.error('Failed to roll back identity backup after a failed refresh', rollbackError, { component: 'KeyManager' });
+    }
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Prevent a stale-previous-account backup from remaining after a successful overwrite and later being restored to silently switch the device back to the prior account.
- Ensure the final backup refresh is part of the atomic success contract so callers never observe success while a cross-account backup remains.

### Description
- Make the final backup refresh in `_persistIdentityAtomic` a required step by snapshotting the existing backup, attempting the refresh, and rolling back both backup and primary on failure in `packages/core/src/crypto/keyManager.ts`.
- Add a `_rollbackBackup` helper to restore the backup slot to its prior state when a partial refresh fails.
- Update the SecureStore fault-injection test harness to support one-shot failures and add a regression test that verifies an overwrite rejects and rolls back if the final backup refresh fails in `packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts`.

### Testing
- Ran `git diff --check`, which passed with no whitespace or diff errors.
- Attempted to run the new atomicity test via `bun run test` / Jest, but `jest` was not available in the environment so unit tests could not be executed.
- Attempted `bun install` to enable running tests, but dependency installation failed due to npm registry tarball HTTP 403 responses in this environment, preventing local test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dd05388323a19c4b350c67bc87)