### PR TITLE
Fix service token cache poisoning on failed auth

### DIFF
--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -247,11 +247,24 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
       entry.pending = pending;
       try {
         return await pending;
+      } catch (error) {
+        // Do not retain unauthenticated cache entries. If the initial
+        // /auth/service-token request fails (for example, wrong apiSecret),
+        // leaving the pre-seeded empty entry would cause later calls with the
+        // real secret for the same apiKey to fail locally as a credential
+        // mismatch without ever contacting the server. Keep previously-issued
+        // stale tokens on refresh failures, but remove never-authenticated
+        // entries.
+        const failed = this._serviceTokenCache.get(cacheKey);
+        if (failed?.pending === pending && !failed.token) {
+          this._serviceTokenCache.delete(cacheKey);
+        }
+        throw error;
       } finally {
         // Clear the in-flight slot; the entry itself (with fresh token / expiry)
         // is updated inside _doFetchServiceToken before we land here.
         const settled = this._serviceTokenCache.get(cacheKey);
-        if (settled) {
+        if (settled?.pending === pending) {
           settled.pending = null;
         }
       }

--- a/packages/core/src/mixins/__tests__/serviceAuth.test.ts
+++ b/packages/core/src/mixins/__tests__/serviceAuth.test.ts
@@ -312,6 +312,25 @@ describe('H1: getServiceToken per-credential cache + secret verification', () =>
     );
   });
 
+  it('does not poison the cache when initial token fetch fails for an apiKey', async () => {
+    makeRequestSpy
+      .mockRejectedValueOnce(new Error('invalid service credentials'))
+      .mockResolvedValueOnce({
+        token: 'token-A',
+        expiresIn: 3600,
+        appName: 'tenant-A',
+      });
+
+    await expect(oxy.getServiceToken('key-A', 'attacker-secret')).rejects.toThrow(
+      'invalid service credentials',
+    );
+
+    const token = await oxy.getServiceToken('key-A', 'secret-A');
+
+    expect(token).toBe('token-A');
+    expect(makeRequestSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('refreshes the cached token when it expires (using the correct stored secret)', async () => {
     // First token already past its buffer window.
     makeRequestSpy.mockResolvedValueOnce({


### PR DESCRIPTION
### Motivation

- A previously-introduced per-apiKey token cache could be poisoned when a first `/auth/service-token` request failed because the code seeded a cache entry before the server authenticated the provided secret, causing later valid secrets for the same apiKey to be rejected locally.
- The change aims to prevent that denial-of-service by ensuring unauthenticated/never-issued cache entries are removed when the initial token fetch fails while preserving existing valid/stale entries on refresh failures.

### Description

- Update `getServiceToken()` in `packages/core/src/mixins/OxyServices.auth.ts` to catch failures from the in-flight token fetch and delete the pre-seeded cache entry when the entry has no issued token, avoiding persistent poisoned entries; the finally block now only clears `pending` when it matches the in-flight promise.
- Keep previously-issued stale tokens in the cache on refresh failures so callers do not lose existing tokens when a refresh attempt fails.
- Add a regression test `does not poison the cache when initial token fetch fails for an apiKey` to `packages/core/src/mixins/__tests__/serviceAuth.test.ts` that verifies a failed initial fetch does not block a later valid secret.

### Testing

- `git diff --check` (sanity check) was run and showed no whitespace errors.
- Added a unit test covering the reported scenario (`serviceAuth.test.ts`) but running `jest` was blocked because `jest` is not installed in the execution environment.
- Attempted `bun install` to run the test suite, but registry tarball requests returned `403`, so dependencies could not be installed and automated tests could not be executed end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db50c08323ac1b722cef6e7bc9)