### PR TITLE
fix(services): redact avatar crop error logs

### DIFF
--- a/packages/services/src/ui/screens/AvatarCropScreen.tsx
+++ b/packages/services/src/ui/screens/AvatarCropScreen.tsx
@@ -168,13 +168,22 @@ function isCanvasLoadFailure(err: unknown): boolean {
     );
 }
 
+const SENSITIVE_URI_PATTERN =
+    /\b(?:file|content|ph|assets-library):\/\/\S+|\/(?:data|var|private|storage|sdcard|tmp)\/\S+/gi;
+
+function sanitizeImageErrorMessage(message: string): string {
+    return message.replace(SENSITIVE_URI_PATTERN, '[redacted-uri]');
+}
+
 function normalizeCropError(err: unknown): Error {
-    if (err instanceof Error) return err;
     if (isCanvasLoadFailure(err)) {
         return new Error('Image could not be loaded for cropping');
     }
+    if (err instanceof Error) {
+        return new Error(sanitizeImageErrorMessage(err.message || 'Failed to crop image'));
+    }
     if (typeof err === 'string' && err.trim()) {
-        return new Error(err.trim());
+        return new Error(sanitizeImageErrorMessage(err.trim()));
     }
     return new Error('Failed to crop image');
 }
@@ -382,8 +391,12 @@ const AvatarCropScreen: React.FC<AvatarCropScreenProps> = ({
                     setMeasureError(null);
                     setNaturalSize({ width: w, height: h });
                 },
-                (err) => {
-                    logger.error('Image.getSize failed', err, { component: LOG_COMPONENT });
+                () => {
+                    logger.error(
+                        'Image.getSize failed',
+                        new Error('Image measurement failed'),
+                        { component: LOG_COMPONENT },
+                    );
                     const message = t('editProfile.toasts.cropMeasureFailed') ||
                         'Could not measure the image';
                     setMeasureError(message);


### PR DESCRIPTION
### Motivation
- Prevent production leakage of on-device/local image URIs that can appear inside Error objects from image measurement/manipulation APIs by avoiding logging raw errors to the global `logger`.
- Maintain existing user-facing behavior (toasts / error UI) while removing PII-adjacent file paths from production logs and telemetry.

### Description
- Added a `SENSITIVE_URI_PATTERN` and `sanitizeImageErrorMessage` to redact common local URI/path patterns from error messages in the avatar crop flow in `packages/services/src/ui/screens/AvatarCropScreen.tsx`.
- Updated `normalizeCropError` to return sanitized `Error.message` content for Error/string inputs instead of propagating the raw message.
- Replaced the `Image.getSize` error handler that passed the raw failure object into `logger.error` with a generic `Error('Image measurement failed')` when logging, preserving the existing user-facing toast and `measureError` state.
- Kept crop failure logging but now log the normalized/sanitized error so production logs do not contain local file paths.

### Testing
- Ran `git diff --check` to validate no whitespace or trivial diff issues and it passed.
- Attempted `bun run --filter @oxyhq/services lint` but the lint step could not run in this environment because the `biome` tool / workspace dependencies are not installed (command failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db134483239b5a07df736bd55c)