### PR TITLE
fix(core): avoid logging CSRF token values

### DIFF
--- a/packages/core/src/HttpService.ts
+++ b/packages/core/src/HttpService.ts
@@ -915,8 +915,11 @@ export class HttpService {
 
           if (response.ok) {
             const data = await response.json() as { csrfToken?: string };
-            this.logger.debug('CSRF response data:', data);
             const token = data.csrfToken || null;
+            this.logger.debug('CSRF response data:', {
+              hasCsrfToken: typeof token === 'string' && token.length > 0,
+              csrfTokenLength: token?.length,
+            });
             this.tokenStore.setCsrfToken(token);
             this.logger.debug('CSRF token fetched');
             return token;

--- a/packages/core/src/__tests__/httpServiceCsrf.test.ts
+++ b/packages/core/src/__tests__/httpServiceCsrf.test.ts
@@ -157,4 +157,38 @@ describe('HttpService CSRF behavior', () => {
     expect(headers.Authorization).toBeUndefined();
     expect(headers['X-CSRF-Token']).toBe('csrf_1');
   });
+
+  it('does not log raw csrf-token response values when debug logging is enabled', async () => {
+    const csrfToken = 'csrf_secret_value_that_must_not_be_logged';
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith('/csrf-token')) {
+        return new Response(JSON.stringify({ csrfToken }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return jsonResponse({ ok: true });
+    };
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    const http = new HttpService({
+      baseURL: 'https://api.mention.earth',
+      enableRetry: false,
+      enableLogging: true,
+      logLevel: 'debug',
+    });
+
+    await http.post('/posts', { text: 'hello' });
+
+    const logs = consoleLogSpy.mock.calls
+      .map((call) =>
+        call.map((arg) => (typeof arg === 'object' ? JSON.stringify(arg) : String(arg))).join(' ')
+      )
+      .join('\n');
+    expect(logs).not.toContain(csrfToken);
+    expect(logs).toContain('hasCsrfToken');
+    expect(logs).toContain(String(csrfToken.length));
+  });
+
 });


### PR DESCRIPTION
### Motivation
- The CSRF fetch path previously logged the full JSON response at debug level, which can include the sensitive `csrfToken` value and may be emitted in production log streams when a consumer enables SDK debug logging.  This change reduces sensitive data exposure risk.
- Keep debug observability while avoiding raw secret leakage by logging only non-sensitive metadata about the token (presence/length) instead of the token itself.

### Description
- Replace the raw `this.logger.debug('CSRF response data:', data)` call in `packages/core/src/HttpService.ts` with a debug log that emits only `{ hasCsrfToken, csrfTokenLength }` and continue to set the token in the token store unchanged.
- Add a regression test `packages/core/src/__tests__/httpServiceCsrf.test.ts` that enables debug logging, stubs `/csrf-token` to return a secret value, performs a write, and asserts that captured console output does not contain the raw CSRF token while still including the non-sensitive metadata.

### Testing
- Added an automated test file `packages/core/src/__tests__/httpServiceCsrf.test.ts` covering the new behavior and non-leak assertions.
- Verified repository checks (`git diff --check`) and prepared the test; running `bun run test -- httpServiceCsrf.test.ts` and `bun install` in this environment was blocked due to dependency/registry access (npm registry returned 403 and `jest` was not available), so the new test could not be executed here, but it is designed to run under normal CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8dc3f9c8323bf96e8bf86d9d3cd)