### PR TITLE
fix(auth): include CSRF tokens on protected fetches

### DIFF
--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, ShieldAlert } from "lucide-react"
 import { OxyServices } from "@oxyhq/core"
 import { Avatar } from "@oxyhq/bloom/avatar"
 import { buildAuthUrl, buildApiUrl, getApiBaseUrl, getAvatarUrl } from "@/lib/oxy-api-client"
+import { withCsrfHeader } from "@/lib/csrf"
 import { setFedCMLoginStatus, registerFedCMSession, buildPostLoginRedirect, completeFedCMLogin } from "@/lib/auth-utils"
 import { setBasePreset } from "@/lib/bloom-css"
 import { useLayoutContext } from "@/lib/layout-context"
@@ -295,7 +296,7 @@ export function LoginForm({
             }
             const response = await fetch(buildAuthUrl("/login"), {
                 method: "POST",
-                headers: { "content-type": "application/json" },
+                headers: await withCsrfHeader({ "content-type": "application/json" }),
                 credentials: "include",
                 body: JSON.stringify(body),
             })
@@ -349,7 +350,7 @@ export function LoginForm({
             // Correct endpoint: /security/2fa/verify-login (creates session)
             const response = await fetch(buildApiUrl("/security/2fa/verify-login"), {
                 method: "POST",
-                headers: { "content-type": "application/json" },
+                headers: await withCsrfHeader({ "content-type": "application/json" }),
                 credentials: "include",
                 body: JSON.stringify(body),
             })

--- a/packages/auth/lib/csrf.ts
+++ b/packages/auth/lib/csrf.ts
@@ -1,0 +1,46 @@
+import { buildApiUrl } from "@/lib/oxy-api-client"
+
+let cachedCsrfToken: string | null = null
+let csrfTokenPromise: Promise<string | null> | null = null
+
+async function fetchCsrfToken(): Promise<string | null> {
+    if (cachedCsrfToken) return cachedCsrfToken
+    if (csrfTokenPromise) return csrfTokenPromise
+
+    csrfTokenPromise = (async () => {
+        const response = await fetch(buildApiUrl("/csrf-token"), {
+            method: "GET",
+            credentials: "include",
+            headers: { Accept: "application/json" },
+        })
+
+        if (!response.ok) return null
+
+        const payload = await response.json().catch(() => ({}))
+        const token = typeof payload?.csrfToken === "string"
+            ? payload.csrfToken
+            : response.headers.get("X-CSRF-Token")
+
+        cachedCsrfToken = token || null
+        return cachedCsrfToken
+    })().finally(() => {
+        csrfTokenPromise = null
+    })
+
+    return csrfTokenPromise
+}
+
+export async function withCsrfHeader(headers: HeadersInit = {}): Promise<Headers> {
+    const nextHeaders = new Headers(headers)
+    const csrfToken = await fetchCsrfToken()
+
+    if (csrfToken) {
+        nextHeaders.set("X-CSRF-Token", csrfToken)
+    }
+
+    return nextHeaders
+}
+
+export function clearCachedCsrfToken(): void {
+    cachedCsrfToken = null
+}

--- a/packages/auth/src/pages/settings/linked-accounts.tsx
+++ b/packages/auth/src/pages/settings/linked-accounts.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner"
 import { KeyRound, Loader2, Trash2 } from "lucide-react"
 import { buildApiUrl } from "@/lib/oxy-api-client"
 import { mintAccessTokenFromRefreshCookie } from "@/lib/session-auth"
+import { withCsrfHeader } from "@/lib/csrf"
 import { Button } from "@oxyhq/bloom/button"
 import { AuthFormHeader } from "@/components/auth-form-layout"
 
@@ -68,10 +69,10 @@ export function LinkedAccountsPage() {
 
             const res = await fetch(buildApiUrl(`/auth/link/${type}`), {
                 method: "DELETE",
-                headers: {
+                headers: await withCsrfHeader({
                     "content-type": "application/json",
                     Authorization: `Bearer ${auth.accessToken}`,
-                },
+                }),
                 credentials: "include",
             })
             if (res.ok) {

--- a/packages/auth/src/pages/settings/password.tsx
+++ b/packages/auth/src/pages/settings/password.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react"
 import { toast } from "sonner"
 import { buildApiUrl } from "@/lib/oxy-api-client"
 import { mintAccessTokenFromRefreshCookie } from "@/lib/session-auth"
+import { withCsrfHeader } from "@/lib/csrf"
 import { Button } from "@oxyhq/bloom/button"
 import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { PasswordInput } from "@/components/password-input"
@@ -39,8 +40,10 @@ export function ChangePasswordPage() {
                 setIsSubmitting(false)
                 return
             }
-            const headers: Record<string, string> = { "content-type": "application/json" }
-            headers["Authorization"] = `Bearer ${auth.accessToken}`
+            const headers = await withCsrfHeader({
+                "content-type": "application/json",
+                Authorization: `Bearer ${auth.accessToken}`,
+            })
 
             const response = await fetch(buildApiUrl("/auth/change-password"), {
                 method: "POST",

--- a/packages/auth/src/pages/settings/sessions.tsx
+++ b/packages/auth/src/pages/settings/sessions.tsx
@@ -3,6 +3,7 @@ import { toast } from "sonner"
 import { Monitor, LogOut, Loader2 } from "lucide-react"
 import { buildApiUrl } from "@/lib/oxy-api-client"
 import { mintAccessTokenFromRefreshCookie } from "@/lib/session-auth"
+import { withCsrfHeader } from "@/lib/csrf"
 import { Button } from "@oxyhq/bloom/button"
 import { AuthFormHeader } from "@/components/auth-form-layout"
 
@@ -58,10 +59,10 @@ export function SessionsPage() {
 
             const res = await fetch(buildApiUrl(`/session/logout/${auth.sessionId}/${targetSessionId}`), {
                 method: "POST",
-                headers: {
+                headers: await withCsrfHeader({
                     "content-type": "application/json",
                     Authorization: `Bearer ${auth.accessToken}`,
-                },
+                }),
                 credentials: "include",
             })
             if (res.ok) {
@@ -86,10 +87,10 @@ export function SessionsPage() {
 
             const res = await fetch(buildApiUrl(`/session/logout-all/${auth.sessionId}`), {
                 method: "POST",
-                headers: {
+                headers: await withCsrfHeader({
                     "content-type": "application/json",
                     Authorization: `Bearer ${auth.accessToken}`,
-                },
+                }),
                 credentials: "include",
             })
             if (res.ok) {


### PR DESCRIPTION
### Motivation
- State-changing browser fetches (2FA verify-login, session revoke, unlink, change-password) were calling CSRF-protected API routes without the required `X-CSRF-Token` header, causing 403 `CSRF_TOKEN_MISSING` and blocking 2FA completion and security-management flows.
- The SDK/Core `HttpService` already implements correct CSRF prefetch semantics, but the new auth UI code bypassed it by calling `fetch()` directly, so a small app-side fix was required to restore availability without changing server behavior.

### Description
- Add a small CSRF helper `packages/auth/lib/csrf.ts` that fetches `/csrf-token` with `credentials: include`, caches/deduplicates the request, and exposes `withCsrfHeader(headers)` to return a `Headers` instance with `X-CSRF-Token` applied when available.
- Update login flow to use the helper for state-changing requests: `POST /auth/login` and `POST /security/2fa/verify-login` in `packages/auth/components/login-form.tsx` now call `withCsrfHeader(...)` so the CSRF header is sent alongside cookies.
- Update settings actions to include the CSRF header while preserving existing `Authorization` and cookies: `change-password` in `packages/auth/src/pages/settings/password.tsx`, `revoke session` and `revoke-all` in `packages/auth/src/pages/settings/sessions.tsx`, and `unlink auth method` in `packages/auth/src/pages/settings/linked-accounts.tsx` now use `withCsrfHeader(...)`.
- Preserves original semantics: requests continue to send `Authorization: Bearer <token>` where used and `credentials: 'include'` for cookie flows.

### Testing
- Searched for affected endpoints and validated updated call sites with `rg` and `git diff` to confirm the CSRF helper is used for `verify-login`, `logout`, `logout-all`, `auth/link`, and `change-password` (search patterns: `verify-login|logout/|logout-all|auth/link|change-password|X-CSRF-Token|withCsrfHeader|csrf-token`).
- Attempted to build the auth package with `bun run auth:build` and `bun run build` from `packages/auth`, but the environment lacked some toolchain prerequisites (`vite` missing) and the repo's TypeScript config raised preexisting warnings/errors (`TS5107`, `TS5011`); these failures are unrelated to the changes and prevented running the package build/test suite here.
- Commit created with the fixes applied and verified via `git diff` that the helper and call-site changes are present; no automated test run was completed in this environment due to the build/tooling limitations described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db69f483239fd8e546f5cdf1f8)