### PR TITLE
fix: enforce blocks before public media access

### DIFF
--- a/packages/api/src/services/__tests__/mediaPrivacyService.test.ts
+++ b/packages/api/src/services/__tests__/mediaPrivacyService.test.ts
@@ -1,0 +1,96 @@
+const mockBlockFindOne = jest.fn();
+
+jest.mock('../../models/Block', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: unknown[]) => mockBlockFindOne(...args),
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  User: {
+    findById: jest.fn(),
+  },
+}));
+
+jest.mock('../../models/Restricted', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/blockCache', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(() => null),
+    set: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(() => null),
+    set: jest.fn(),
+  },
+}));
+
+const { MediaPrivacyService } = jest.requireActual('../mediaPrivacyService') as typeof import(
+  '../mediaPrivacyService'
+);
+
+const createFile = (
+  ownerUserId: string,
+  visibility: 'public' | 'private' | 'unlisted' = 'public'
+) => ({
+  ownerUserId: { toString: () => ownerUserId },
+  visibility,
+});
+
+describe('MediaPrivacyService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockBlockFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+  });
+
+  it('denies authenticated blocked viewers before allowing public files without context', async () => {
+    const ownerId = '0123456789abcdef01234567';
+    const viewerId = 'fedcba987654321001234567';
+    mockBlockFindOne.mockReturnValueOnce({
+      lean: jest.fn().mockResolvedValue({ userId: ownerId, blockedId: viewerId }),
+    });
+    mockBlockFindOne.mockReturnValueOnce({ lean: jest.fn().mockResolvedValue(null) });
+
+    const result = await new MediaPrivacyService().checkMediaAccess(
+      createFile(ownerId),
+      viewerId
+    );
+
+    expect(result).toEqual({ allowed: false, reason: 'blocked' });
+    expect(mockBlockFindOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('still allows unauthenticated public files without context without querying blocks', async () => {
+    const result = await new MediaPrivacyService().checkMediaAccess(
+      createFile('0123456789abcdef01234567')
+    );
+
+    expect(result).toEqual({ allowed: true, isPublic: true });
+    expect(mockBlockFindOne).not.toHaveBeenCalled();
+  });
+
+  it('allows synthetic public owners after the ObjectId block guard skips invalid IDs', async () => {
+    const result = await new MediaPrivacyService().checkMediaAccess(
+      createFile('__federation__'),
+      'fedcba987654321001234567'
+    );
+
+    expect(result).toEqual({ allowed: true, isPublic: true });
+    expect(mockBlockFindOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/mediaPrivacyService.ts
+++ b/packages/api/src/services/mediaPrivacyService.ts
@@ -25,8 +25,10 @@ export class MediaPrivacyService {
         return { allowed: true, reason: 'owner' };
       }
 
-      // Public files without a specific entity context are always accessible
-      if (file.visibility === 'public' && !context) {
+      // Public files without a specific entity context are accessible without authentication.
+      // Authenticated viewers still pass through the block check below so social
+      // privacy controls apply before public media is served.
+      if (file.visibility === 'public' && !context && !viewerUserId) {
         return { allowed: true, isPublic: true };
       }
 
@@ -71,6 +73,10 @@ export class MediaPrivacyService {
         if (!entityAccess.allowed) {
           return { allowed: false, reason: 'entity_access_denied' };
         }
+      }
+
+      if (file.visibility === 'public' && !context) {
+        return { allowed: true, isPublic: true };
       }
 
       return { allowed: true };


### PR DESCRIPTION
### Motivation
- Prevent authenticated viewers who have been blocked from fetching another user's public media via the `/:id/stream` and `/:id/download` paths by ensuring social block checks run for authenticated requests before the public-file fast-path returns allowed.

### Description
- Change `checkMediaAccess` in `packages/api/src/services/mediaPrivacyService.ts` so the public-file shortcut only short-circuits for unauthenticated requests (`file.visibility === 'public' && !context && !viewerUserId`), and ensure authenticated viewers run the bidirectional block check before public media is allowed.
- Preserve existing behavior for unauthenticated public access and for synthetic/system owners that do not look like ObjectIds (the `isUserBlocked` ObjectId guard remains in place).
- Add regression tests `packages/api/src/services/__tests__/mediaPrivacyService.test.ts` that cover: blocked authenticated viewers being denied, anonymous public access skipping block queries, and synthetic owner (`__federation__`) behavior.

### Testing
- Added unit tests `mediaPrivacyService.test.ts` to cover the regressed scenarios; test file added to the repo and validated syntactically.
- Attempted to run `bun run test -- mediaPrivacyService.test.ts`, but `jest` was not available in the environment so the test run could not be executed (`jest: command not found`).
- Attempted `bun install` to install dependencies, but the environment returned HTTP 403 for registry tarballs so dependencies could not be installed and CI-style test runs could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db19f48323a347022ac1e7ea80)