### PR TITLE
fix: enforce dependency audit gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '20.x'
+          bun-version: 1.3.14
 
-      - name: Run npm audit
-        run: npm audit --audit-level=high || true
+      - name: Run Bun audit
+        run: bun audit --audit-level=high


### PR DESCRIPTION
### Motivation
- Restore the CI dependency-audit gate which was previously disabled by `npm audit --audit-level=high || true`, so high-or-critical findings or audit execution errors no longer get masked during CI runs.

### Description
- Update `.github/workflows/ci.yml` security-audit job to install Bun (`oven-sh/setup-bun@v2` with `bun-version: 1.3.14`) and run `bun audit --audit-level=high` instead of the non-blocking `npm audit --audit-level=high || true` so the audit runs against `bun.lock` and fails the job on high-or-higher vulnerabilities.

### Testing
- Ran `git diff --check` and it reported no issues, so the YAML change is syntactically safe.
- Inspected the workflow steps via a Ruby YAML loader to confirm the final security-audit step is `run: bun audit --audit-level=high`, which succeeded in this environment.
- `actionlint` and a live Bun install/audit execution were attempted but were blocked by external network/npm registry restrictions in this environment (403), so runtime execution of `bun audit` could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cb8db9db08323ba17ad2dec2a7dd5)