### PR TITLE
fix(api): validate recommendation excludeTypes query

### DIFF
--- a/packages/api/src/routes/__tests__/profilesRecommendations.test.ts
+++ b/packages/api/src/routes/__tests__/profilesRecommendations.test.ts
@@ -367,6 +367,19 @@ describe('GET /profiles/recommendations exclusion set', () => {
     expect(mockFollowFind).not.toHaveBeenCalled();
   });
 
+  it('rejects repeated excludeTypes query params instead of throwing a 500', async () => {
+    const res = await requestJson(
+      server,
+      '/profiles/recommendations?excludeTypes=federated&excludeTypes=agent'
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('BAD_REQUEST');
+    expect(res.body.message).toBe('Invalid excludeTypes parameter. Must be a comma-separated string');
+    expect(mockFollowAggregate).not.toHaveBeenCalled();
+    expect(mockUserAggregate).not.toHaveBeenCalled();
+  });
+
   it('requires recently resolved federated users in recommendation pipelines', async () => {
     currentUserId = undefined;
     mockFollowAggregate.mockResolvedValue([]);

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -253,6 +253,21 @@ const validatePagination = (req: Request, res: Response, next: () => void): void
   next();
 };
 
+const parseExcludeTypesQuery = (excludeTypesRaw: unknown): string[] => {
+  if (excludeTypesRaw === undefined) {
+    return [];
+  }
+
+  if (typeof excludeTypesRaw !== 'string') {
+    throw new BadRequestError('Invalid excludeTypes parameter. Must be a comma-separated string');
+  }
+
+  return excludeTypesRaw
+    .split(',')
+    .map((type) => type.trim())
+    .filter((type) => VALID_EXCLUDE_TYPES.has(type));
+};
+
 /**
  * @openapi
  * /profiles/username/{username}:
@@ -1127,9 +1142,7 @@ router.get(
     const { limit, offset, excludeTypes: excludeTypesRaw } = req.query as PaginationQuery & { excludeTypes?: string };
     const currentUserId = resolveViewerId(req);
 
-    const excludeTypes = excludeTypesRaw
-      ? excludeTypesRaw.split(',').filter(t => VALID_EXCLUDE_TYPES.has(t.trim())).map(t => t.trim())
-      : [];
+    const excludeTypes = parseExcludeTypesQuery(excludeTypesRaw);
 
     const parsedLimit = limit
       ? Math.min(parseInt(limit, 10), PAGINATION.MAX_LIMIT)


### PR DESCRIPTION
### Motivation
- The `GET /profiles/recommendations` handler called `.split(',')` on `req.query.excludeTypes` after a TypeScript cast, which throws a `TypeError` when Express parses repeated or structured query parameters as a non-string and results in a 500 instead of a controlled 400.
- Improve robustness and input validation for an authenticated recommendations endpoint to avoid low-availability crashes from malformed query input.

### Description
- Add `parseExcludeTypesQuery(excludeTypesRaw: unknown): string[]` to validate runtime type and normalize a comma-separated string into a filtered array of allowed types, returning an empty array when absent and throwing a `BadRequestError` for non-string inputs.
- Replace the inline `.split(',')` usage in the `GET /profiles/recommendations` route with `parseExcludeTypesQuery` to prevent unhandled exceptions for repeated/structured query params.
- Add a regression test in `packages/api/src/routes/__tests__/profilesRecommendations.test.ts` which asserts a `400 BAD_REQUEST` for a repeated `excludeTypes` query (`?excludeTypes=federated&excludeTypes=agent`) and verifies no recommendation aggregation is executed.

### Testing
- Attempted to run the route test via `bun run test -- profilesRecommendations.test.ts`, but `jest` was not available in the execution environment so the test could not be executed (command failed with `jest: command not found`).
- Attempted to install dependencies with `bun install --frozen-lockfile`, but the install failed due to npm registry tarball `403` errors, preventing full local test execution.
- Performed static and local verification of the change by running `git diff --check` and by executing the test harness setup that mounts the router; the added test asserts the expected `400` behaviour (test added, execution blocked by dependency resolution as noted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8ccb48323ae3351f25e83a915)