### PR TITLE
fix(api): normalize profile color before premium check

### DIFF
--- a/packages/api/src/services/__tests__/user.service.color.test.ts
+++ b/packages/api/src/services/__tests__/user.service.color.test.ts
@@ -1,0 +1,78 @@
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    findById: jest.fn(),
+    findOne: jest.fn(),
+  },
+}));
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {
+    findOne: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: jest.fn() },
+}));
+
+jest.mock('../securityActivityService', () => ({
+  __esModule: true,
+  default: { logEmailChange: jest.fn(), logProfileUpdate: jest.fn() },
+}));
+
+import User from '../../models/User';
+import Subscription from '../../models/Subscription';
+import { userService } from '../user.service';
+
+const mockUser = User as jest.Mocked<typeof User>;
+const mockSubscription = Subscription as jest.Mocked<typeof Subscription>;
+
+describe('UserService.updateUserProfile color authorization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(['oxy', 'OXY', 'OxY', ' oxy '])(
+    'requires premium access before saving normalized oxy color variant %p',
+    async (color) => {
+      (mockUser.findById as jest.Mock).mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue({ username: 'regular-user' }),
+        }),
+      });
+      (mockSubscription.findOne as jest.Mock).mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await expect(userService.updateUserProfile('user-1', { color })).rejects.toThrow(
+        'The oxy color is exclusive to premium subscribers'
+      );
+
+      expect(mockSubscription.findOne).toHaveBeenCalledWith({
+        userId: 'user-1',
+        status: 'active',
+        plan: { $in: ['pro', 'business'] },
+      });
+      expect(mockUser.findById).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('persists non-premium color using the same normalization as the schema', async () => {
+    const set = jest.fn();
+    const save = jest.fn().mockResolvedValue(undefined);
+    const toObject = jest.fn().mockReturnValue({ _id: 'user-1', color: 'blue' });
+
+    (mockUser.findById as jest.Mock).mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({ email: 'user@example.com', set, save, toObject }),
+    });
+
+    await userService.updateUserProfile('user-1', { color: ' Blue ' });
+
+    expect(set).toHaveBeenCalledWith('color', 'blue');
+    expect(save).toHaveBeenCalled();
+    expect(mockSubscription.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -107,6 +107,10 @@ function isBulkWriteLikeError(error: unknown): error is BulkWriteLikeError {
   return Array.isArray(candidate.writeErrors) || typeof candidate.code === 'number';
 }
 
+function normalizeProfileColor(value: unknown): unknown {
+  return typeof value === 'string' ? value.trim().toLowerCase() : value;
+}
+
 export class UserService {
   /**
    * Get user by ID with proper serialization
@@ -170,8 +174,11 @@ export class UserService {
         continue;
       }
 
-      // Validate premium-exclusive colors
-      if (key === 'color' && value === 'oxy') {
+      const normalizedValue = key === 'color' ? normalizeProfileColor(value) : value;
+
+      // Validate premium-exclusive colors against the same normalized value
+      // that the User schema will persist (trim + lowercase).
+      if (key === 'color' && normalizedValue === 'oxy') {
         const user = await User.findById(userId).select('username').lean();
         const isOxyUser = user?.username?.toLowerCase() === 'oxy';
         if (!isOxyUser) {
@@ -197,7 +204,7 @@ export class UserService {
       }
       
       // Assign other fields
-      (filteredUpdates as Record<string, unknown>)[key] = value;
+      (filteredUpdates as Record<string, unknown>)[key] = normalizedValue;
     }
 
     // Validate uniqueness constraints


### PR DESCRIPTION
### Motivation
- The `oxy` premium color check compared the raw submitted value to the exact string `"oxy"` before the Mongoose schema trimmed and lowercased the value, allowing case/whitespace variants to bypass subscription authorization.

### Description
- Add a `normalizeProfileColor` helper and normalize `color` updates with `trim().toLowerCase()` before running the premium-only check so the authorization uses the same normalization as the `User` schema.
- Persist the normalized color value (`normalizedValue`) into the filtered update set so the service and model behavior remain consistent.
- Add a Jest unit test `packages/api/src/services/__tests__/user.service.color.test.ts` that asserts `oxy`, `OXY`, `OxY`, and ` oxy ` are blocked for non-premium users and that ordinary colors are normalized before saving.

### Testing
- Ran source assertions that verify `normalizeProfileColor` is present and the premium check compares against the normalized value, which passed (`python3` assertion script).
- Added unit tests for the new behavior (`user.service.color.test.ts`) but executing `jest` in this environment failed because test dependencies are not installed; the test file demonstrates the expected coverage.
- Attempted `bun install --frozen-lockfile` and `bun run test` but dependency fetch failed due to registry HTTP 403 responses, so end-to-end test execution could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7ce48832380da75019d2173ce)