### PR TITLE
fix(api): harden inbound SMTP STARTTLS policy

### DIFF
--- a/packages/api/src/services/smtp.inbound.ts
+++ b/packages/api/src/services/smtp.inbound.ts
@@ -38,10 +38,8 @@ export function startSmtpInbound(): SMTPServer {
           'ECDHE-RSA-AES128-GCM-SHA256',
           'DHE-RSA-AES256-GCM-SHA384',
           'DHE-RSA-AES128-GCM-SHA256',
-          'AES256-GCM-SHA384',
-          'AES128-GCM-SHA256',
         ].join(':'),
-        // Include rsa_pkcs1_sha1 for older MTAs still using TLSv1.2
+        // Keep STARTTLS on forward-secret TLS 1.2+ suites and SHA-256+ signatures.
         sigalgs: [
           'ecdsa_secp256r1_sha256',
           'ecdsa_secp384r1_sha384',
@@ -51,7 +49,6 @@ export function startSmtpInbound(): SMTPServer {
           'rsa_pkcs1_sha256',
           'rsa_pkcs1_sha384',
           'rsa_pkcs1_sha512',
-          'rsa_pkcs1_sha1',
         ].join(':'),
       };
     } catch (err) {


### PR DESCRIPTION
### Motivation
- The previous change began spreading a custom `tlsOptions` into the inbound `SMTPServer` which made explicit weak TLS options (static RSA TLS 1.2 ciphers and `rsa_pkcs1_sha1`) effective; this patch tightens the STARTTLS policy to avoid enabling non-forward-secret suites or SHA-1 signatures.

### Description
- Removed static RSA TLS 1.2 cipher entries (`AES256-GCM-SHA384`, `AES128-GCM-SHA256`) and dropped the deprecated `rsa_pkcs1_sha1` from the `sigalgs` list in `packages/api/src/services/smtp.inbound.ts`, preserving ECDHE/DHE forward-secret suites and SHA-256+ signature algorithms.

### Testing
- `git diff --check` ran successfully and the file changes are clean; `bun run --cwd packages/api build` was attempted but blocked by unrelated TypeScript config errors in `@oxyhq/contracts`; `bun run --cwd packages/api test -- --runInBand packages/api/src/services/smtp.inbound.ts` could not run in this environment because `jest` is not installed, so runtime tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7fe4c83238e48957c03158dc6)