### PR TITLE
fix: sanitize Redis example endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,10 @@ ACCESS_TOKEN_SECRET=your-jwt-secret
 REFRESH_TOKEN_SECRET=your-refresh-jwt-secret
 
 # ─── Redis / Valkey (rate limiting + Socket.IO) ──────────────────
-# Private URI via VPC — omit to fall back to in-memory stores
-REDIS_URL=rediss://default:password@private-db-valkey-ams3-04785-do-user-23621266-0.i.db.ondigitalocean.com:25061
+# Optional Redis / Valkey URI for rate limiting and Socket.IO.
+# Leave unset to fall back to in-memory stores. Use a generic placeholder only;
+# never commit provider-specific private endpoints or real credentials.
+# REDIS_URL=rediss://default:password@valkey-host:6379
 
 # ─── S3 / DigitalOcean Spaces (main assets) ──────────────────────
 AWS_REGION=ams3


### PR DESCRIPTION
### Motivation
- Prevent disclosure of a provider-specific private Redis/Valkey hostname in the root environment template and avoid a deployment path where the deploy workflow would skip injecting the real `REDIS_URL` secret when `.env` is created from the template.

### Description
- Commented out the root `REDIS_URL` entry in `.env.example` and replaced the specific DigitalOcean endpoint with a generic commented placeholder and guidance instructing maintainers not to commit provider-specific private endpoints or credentials.

### Testing
- Ran the repository search `rg -n "private-db-valkey|do-user-23621266|REDIS_URL=rediss://default:password@private" .env.example packages/api/.env.example .github/workflows || true` which returned no matches, confirming the sensitive example string was removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce89f8c8323a25c822addb116a3)