### PR TITLE
fix(api): require CSRF when bearer requests carry cookies

### DIFF
--- a/packages/api/src/middleware/__tests__/csrf.test.ts
+++ b/packages/api/src/middleware/__tests__/csrf.test.ts
@@ -53,18 +53,58 @@ describe('verifyCsrfToken', () => {
     mockWarn.mockClear();
   });
 
-  it('allows state-changing requests with an explicit bearer token and no CSRF header', () => {
+  it('allows bearer-only state-changing requests with no CSRF header', () => {
     const { res, next } = runVerify({
       headers: {
         authorization: 'Bearer user-session-token',
       },
-      cookies: {
-        csrf_token: 'cookie-token',
-      },
+      cookies: {},
     });
 
     expect(next).toHaveBeenCalledTimes(1);
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('rejects bearer requests that also carry ambient cookies without a CSRF header', () => {
+    const { res, next } = runVerify({
+      headers: {
+        authorization: 'Bearer forged-token',
+        cookie: 'csrf_token=cookie-token; session=victim-session',
+      },
+      cookies: {
+        csrf_token: 'cookie-token',
+        session: 'victim-session',
+      },
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.body).toEqual({
+      message: 'CSRF token missing',
+      code: 'CSRF_TOKEN_MISSING',
+    });
+  });
+
+  it('does not allow X-Native-App to bypass CSRF when ambient cookies are present', () => {
+    const { res, next } = runVerify({
+      headers: {
+        authorization: 'Bearer forged-token',
+        cookie: 'csrf_token=cookie-token; session=victim-session',
+        'x-native-app': 'true',
+        'x-csrf-token': 'attacker-controlled-token',
+      },
+      cookies: {
+        csrf_token: 'cookie-token',
+        session: 'victim-session',
+      },
+    });
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.body).toEqual({
+      message: 'Invalid CSRF token',
+      code: 'CSRF_TOKEN_INVALID',
+    });
   });
 
   it('still rejects cookie-authenticated state-changing requests without a CSRF header', () => {

--- a/packages/api/src/middleware/csrf.ts
+++ b/packages/api/src/middleware/csrf.ts
@@ -71,12 +71,15 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
     return next();
   }
 
-  // Skip CSRF for Bearer-authenticated requests. CSRF protects ambient cookie
-  // auth; Authorization is an explicit header that browsers do not attach
-  // cross-site on behalf of an attacker. Auth middleware still validates the
-  // token and rejects invalid or expired user/service tokens.
+  // Skip CSRF only for bearer-only requests. CSRF protects ambient cookie
+  // auth; when cookies are present, require the normal double-submit token even
+  // if an Authorization header is also present. This prevents a cross-origin
+  // browser request from adding an attacker-controlled bearer header to bypass
+  // CSRF while the victim's cookies are still attached. Auth middleware still
+  // validates bearer tokens on routes that require them.
   const authHeader = req.headers.authorization;
-  if (authHeader?.startsWith('Bearer ')) {
+  const hasAmbientCookies = Boolean(req.headers.cookie) || Object.keys(req.cookies ?? {}).length > 0;
+  if (authHeader?.startsWith('Bearer ') && !hasAmbientCookies) {
     return next();
   }
 
@@ -85,7 +88,7 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
 
   // Check if this is a native app request (React Native, mobile apps)
   // Native apps send X-Native-App: true because they can't persist cookies
-  const isNativeApp = req.headers[NATIVE_APP_HEADER] === 'true';
+  const isNativeApp = req.headers[NATIVE_APP_HEADER] === 'true' && !hasAmbientCookies;
 
   if (isNativeApp) {
     // Native app mode: Only require header token (no cookie matching)
@@ -158,7 +161,12 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
   }
 
   // Tokens must match (timing-safe comparison)
-  if (!crypto.timingSafeEqual(Buffer.from(cookieToken), Buffer.from(headerToken))) {
+  const cookieTokenBuffer = Buffer.from(cookieToken);
+  const headerTokenBuffer = Buffer.from(headerToken);
+  if (
+    cookieTokenBuffer.length !== headerTokenBuffer.length ||
+    !crypto.timingSafeEqual(cookieTokenBuffer, headerTokenBuffer)
+  ) {
     logger.warn('CSRF token mismatch', {
       method: req.method,
       path: req.path,


### PR DESCRIPTION
### Motivation
- A recent change added a CSRF exemption for bearer tokens by decoding the JWT payload without verifying the signature, allowing an attacker to craft an unsigned token and bypass CSRF for browser requests that still carry victim cookies.\n- The aim is to ensure the CSRF exemption is safe for true server-to-server calls while preserving protection for any request that may be using ambient cookies or other browser-attached credentials.\n- Also harden token comparison to avoid mismatched-length exceptions during timing-safe comparisons.

### Description
- Restrict bearer-token CSRF exemption in `packages/api/src/middleware/csrf.ts` so it only skips CSRF when the request is a bearer-only call with no ambient cookies (`hasAmbientCookies` guard).\n- Prevent `X-Native-App` header from enabling header-only CSRF mode when ambient cookies are present by requiring no ambient cookies for native-app bypass as well.\n- Harden the double-submit comparison by checking buffer lengths before `crypto.timingSafeEqual` to avoid errors on mismatched token sizes.\n- Add regression tests in `packages/api/src/middleware/__tests__/csrf.test.ts` to cover: bearer-only requests (no cookies), bearer requests that carry ambient cookies (should be rejected without CSRF), and `X-Native-App` header attempts when cookies are attached (should be rejected).

### Testing
- Ran `git diff --check` on the edits and confirmed no whitespace/patch errors.\n- Added unit tests in `packages/api/src/middleware/__tests__/csrf.test.ts` that exercise the new guards (tests included in the change).\n- Attempted to run `bun run test --runInBand src/middleware/__tests__/csrf.test.ts` but could not execute unit tests because `jest` was not available in the environment (`jest: command not found`).\n- `bun install` failed in this environment due to registry/package tarball `403` responses, preventing dependency installation and local test execution.\n- `bun run build` could not complete due to a TypeScript configuration issue surfaced in `@oxyhq/contracts` (deprecated `moduleResolution=node10` / missing explicit `rootDir`), so a full build/test cycle could not be run here; the new tests should pass when run in CI or a developer environment with dependencies available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8f3a883239a289434812ebf2e)