### PR TITLE
fix(accounts): scope privacy counts to active user

### DIFF
--- a/packages/accounts/app/(tabs)/sharing.tsx
+++ b/packages/accounts/app/(tabs)/sharing.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback, useState, useEffect } from 'react';
+import React, { useMemo, useCallback, useState, useEffect, useRef } from 'react';
 import { View, StyleSheet, Text, ActivityIndicator, Platform } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useColors } from '@/hooks/useColors';
@@ -48,21 +48,34 @@ export default function PeopleAndSharingScreen() {
   // Blocked and restricted users state
   const [blockedCount, setBlockedCount] = useState(0);
   const [restrictedCount, setRestrictedCount] = useState(0);
-  const [hasFetchedPrivacy, setHasFetchedPrivacy] = useState(false);
+  const [fetchedPrivacyUserId, setFetchedPrivacyUserId] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [pendingPrivacyKey, setPendingPrivacyKey] = useState<string | null>(null);
 
+  const activePrivacyUserIdRef = useRef<string | undefined>(userId);
+
+  useEffect(() => {
+    activePrivacyUserIdRef.current = userId;
+  }, [userId]);
+
   const fetchPrivacyCounts = useCallback(async () => {
     if (!oxyServices || !userId) return;
+
+    const requestedUserId = userId;
     try {
       const [blockedUsers, restrictedUsers] = await Promise.all([
         oxyServices.getBlockedUsers(),
         oxyServices.getRestrictedUsers(),
       ]);
+
+      if (activePrivacyUserIdRef.current !== requestedUserId) return;
+
       setBlockedCount(Array.isArray(blockedUsers) ? blockedUsers.length : 0);
       setRestrictedCount(Array.isArray(restrictedUsers) ? restrictedUsers.length : 0);
     } finally {
-      setHasFetchedPrivacy(true);
+      if (activePrivacyUserIdRef.current === requestedUserId) {
+        setFetchedPrivacyUserId(requestedUserId);
+      }
     }
   }, [oxyServices, userId]);
 
@@ -238,11 +251,20 @@ export default function PeopleAndSharingScreen() {
 
   // Fetch blocked/restricted counts
   useEffect(() => {
-    if (userId && !hasFetchedPrivacy) {
+    if (!userId) {
+      setBlockedCount(0);
+      setRestrictedCount(0);
+      setFetchedPrivacyUserId(null);
+      return;
+    }
+
+    if (fetchedPrivacyUserId !== userId) {
+      setBlockedCount(0);
+      setRestrictedCount(0);
       void fetchPrivacyCounts();
       fetchUserCounts?.();
     }
-  }, [userId, hasFetchedPrivacy, fetchPrivacyCounts, fetchUserCounts]);
+  }, [userId, fetchedPrivacyUserId, fetchPrivacyCounts, fetchUserCounts]);
 
   // Contacts section items
   const contactsItems = useMemo(() => {


### PR DESCRIPTION
### Motivation
- The component previously used a one-shot `hasFetchedPrivacy` flag stored at component-level which caused blocked/restricted counts to persist across account switches and skip fetching for the newly active user.

### Description
- Replace the global one-shot flag with a user-scoped marker by introducing `fetchedPrivacyUserId` and clearing counts when the active `userId` changes or becomes unavailable, in `packages/accounts/app/(tabs)/sharing.tsx`.
- Add an `activePrivacyUserIdRef` and use it to ignore stale in-flight async responses so results from a previous user do not overwrite the new user's counts.
- Ensure we reset `blockedCount` and `restrictedCount` before fetching for a newly active user so the UI never shows the prior account's counts during switches.

### Testing
- Ran a static assertion script (`python3 - <<'PY' ... PY`) verifying the one-shot flag was removed and new user-scoped guards exist, which succeeded.
- Attempted to run package tests with `bun run test --filter=accounts`, but the run failed because `turbo` is not available in the environment (test runner exit due to missing `turbo`).
- Attempted `bun install` to install dependencies for full test runs, but it failed due to npm registry 403 responses preventing dependency installation, so full automated test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7c9ac8323a540128f8d62ad55)