### PR TITLE
fix(auth-sdk): resolve optional sonner dynamically

### DIFF
--- a/packages/auth-sdk/src/types/sonner.d.ts
+++ b/packages/auth-sdk/src/types/sonner.d.ts
@@ -1,0 +1,10 @@
+declare module 'sonner' {
+  export interface ToastT {
+    (message: string): string | number;
+    success: (message: string) => string | number;
+    error: (message: string) => string | number;
+    info: (message: string) => string | number;
+  }
+
+  export const toast: ToastT;
+}

--- a/packages/auth-sdk/src/utils/toast.ts
+++ b/packages/auth-sdk/src/utils/toast.ts
@@ -13,9 +13,9 @@
  *   "toast" is not exported by "__vite-optional-peer-dep:sonner:@oxyhq/auth"
  *
  * tsc does NOT catch this — it only manifests in the consumer's bundler. The
- * fix is to never statically reference `sonner`. Instead we lazily resolve it
- * via a dynamic `import()` whose specifier is hidden behind a variable so no
- * bundler can statically resolve (or fail on) the missing optional peer.
+ * fix is to avoid a top-level static import. Instead we lazily resolve it
+ * via a dynamic `import('sonner')` so bundlers can include the optional peer
+ * when it is installed while still deferring absence to runtime.
  *
  * # Dual CJS + ESM constraint
  *
@@ -55,20 +55,12 @@ let cachedToast: SonnerToast | null = null;
 let loadStarted = false;
 let warnedUnavailable = false;
 
-/**
- * The specifier is held in a variable so static bundler analysis cannot
- * resolve (or fail on) the optional peer. The `import()` expression is a real
- * dynamic import: native in the ESM build, downleveled in the CJS build —
- * never a static `from 'sonner'` reference.
- */
-const SONNER_SPECIFIER = 'sonner';
-
 function ensureSonnerLoaded(): void {
   if (cachedToast || loadStarted) {
     return;
   }
   loadStarted = true;
-  import(/* @vite-ignore */ SONNER_SPECIFIER)
+  import('sonner')
     .then((mod: { toast?: SonnerToast }) => {
       if (mod?.toast) {
         cachedToast = mod.toast;


### PR DESCRIPTION
### Motivation
- Browser bundlers (Vite/Rollup) could not statically resolve the previous variable-based dynamic import (with `@vite-ignore`) for the optional `sonner` peer, which caused apps that had `sonner` installed to still fail to show auth toasts; the change restores bundler-resolvable dynamic import behavior while keeping the peer optional.

### Description
- Replace the variable/`@vite-ignore` dynamic import with a literal dynamic import `import('sonner')` in `packages/auth-sdk/src/utils/toast.ts` so Vite/Rollup-style bundlers can include `sonner` when present while avoiding a top-level static import.
- Add an ambient type declaration at `packages/auth-sdk/src/types/sonner.d.ts` so the optional peer remains type-checkable when not installed in the workspace.
- Preserve the existing fallback semantics where toasts no-op if `sonner` is absent or malformed and a one-time warning is emitted.

### Testing
- Ran `git diff --check` which produced no whitespace/patch problems.
- Ran `bun run --cwd packages/auth-sdk typescript` in this environment which failed due to missing workspace dependencies, and manual inspection confirmed there are no remaining `sonner`/`toast.ts`-specific TypeScript diagnostics.
- Attempted `bun run --cwd packages/auth-sdk test` but `jest` was not available in the container so package tests could not be executed here.
- Attempted lint via `bunx biome lint` but it failed to resolve `biome` (npm registry 403); no lint errors specific to the changed files were observed locally during review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce821ac8323a147a68d5139f76d)