### PR TITLE
fix(services): require QR code peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -530,7 +530,6 @@
         "expo-linear-gradient",
         "nativewind",
         "react-native-keyboard-controller",
-        "react-native-qrcode-svg",
       ],
     },
     "packages/test-app-expo": {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -195,9 +195,6 @@
     "react-native-keyboard-controller": {
       "optional": true
     },
-    "react-native-qrcode-svg": {
-      "optional": true
-    },
     "expo": {
       "optional": true
     },


### PR DESCRIPTION
### Motivation
- The package declared `react-native-qrcode-svg` as an optional peer but the codebase statically imports it (`AnotherDeviceQR` → `SignInModal`), which can cause consumer build/runtime failures if the peer is omitted.

### Description
- Remove the `optional` flag for `react-native-qrcode-svg` in `packages/services/package.json` so it is a required peer dependency at install time, ensuring consumers must declare it.
- Update lock metadata (`bun.lock`) to remove `react-native-qrcode-svg` from the optional peers list so the packaging metadata and lockfile are consistent.
- No runtime source changes to components were made; this change enforces availability of the QR runtime dependency rather than lazy-loading it.

### Testing
- Verified the package metadata with a quick Node check: `node -e "const p=require('./packages/services/package.json'); if (p.peerDependenciesMeta?.['react-native-qrcode-svg']?.optional) throw new Error('react-native-qrcode-svg is still optional'); if (!p.peerDependencies?.['react-native-qrcode-svg']) throw new Error('missing peer'); console.log('react-native-qrcode-svg is a required peer')"` which succeeded.
- Attempted `bun install --frozen-lockfile` but it was blocked by external registry `403` responses in this environment and could not complete.
- Attempted `bun run services:build` but it was also blocked by registry `403` when fetching build tooling and could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce81ee48323bdf5273965190262)