### PR TITLE
core: route sync asset URLs through API stream to support unlisted assets

### DIFF
--- a/packages/core/src/mixins/OxyServices.assets.ts
+++ b/packages/core/src/mixins/OxyServices.assets.ts
@@ -21,42 +21,16 @@ export function OxyServicesAssetsMixin<T extends typeof OxyServicesBase>(Base: T
     /**
      * Build a synchronous file URL from an Oxy asset id.
      *
-     * This is the single chokepoint every Oxy app uses to turn a stored file id
-     * (avatars, post media, etc.) into a `<img src>`-ready URL, so it resolves to
-     * one of two forms depending on whether the caller needs a signed/private URL:
-     *
-     * - **Public asset (default)** — no access token planted on the client AND no
-     *   `expiresIn` requested → returns the clean CDN form
-     *   `${cloudURL}/<id>[?variant=...]` (e.g. `https://cloud.oxy.so/<id>?variant=thumb`).
-     *   CloudFront resolves the id against the public media origin. No token,
-     *   `fallback`, or origin query params are emitted — these URLs are cacheable
-     *   and shareable.
-     * - **Signed / private asset** — an access token is present on the client OR
-     *   `expiresIn` was passed (the caller explicitly wants an expiring/authorized
-     *   URL) → keeps the authenticated origin form
-     *   `${baseURL}/assets/<id>/stream?...&token=...`. Private assets are NOT on
-     *   the public CDN, so they must go through the API origin that can authorize
-     *   the request.
-     *
-     * `cloudURL` (default `https://cloud.oxy.so`) is configured once on the
-     * `OxyServices` constructor and read via `getCloudURL()`; the API origin is
-     * `getBaseURL()` (e.g. `https://api.oxy.so`).
+     * This helper intentionally routes through the API stream endpoint. The
+     * caller only has an id here, not file visibility metadata, and Oxy supports
+     * `unlisted` assets that are accessible by direct link but are not resolvable
+     * from the public CDN origin. The stream route performs the authoritative
+     * access check and redirects public CDN-backed assets to the CDN when safe.
      *
      * For a CDN-signed URL fetched from the API, use {@link getFileDownloadUrlAsync}.
      */
     getFileDownloadUrl(fileId: string, variant?: string, expiresIn?: number): string {
       const token = this.getClient().getAccessToken();
-
-      // Public case: no auth token and no expiry requested → clean CDN URL.
-      // CloudFront serves the public media origin under `${cloudURL}/<id>`.
-      if (!token && !expiresIn) {
-        const variantQs = variant ? `?variant=${encodeURIComponent(variant)}` : '';
-        return `${this.getCloudURL()}/${encodeURIComponent(fileId)}${variantQs}`;
-      }
-
-      // Signed / private case: route through the authenticated API origin's
-      // stream endpoint so the request can be authorized (private assets are not
-      // exposed on the public CDN).
       const base = this.getBaseURL();
       const params = new URLSearchParams();
       if (variant) params.set('variant', variant);

--- a/packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts
+++ b/packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts
@@ -2,43 +2,40 @@
  * `OxyServices.getFileDownloadUrl()` resolution tests.
  *
  * This is the single chokepoint every Oxy app uses to turn a stored asset id
- * into a `<img src>`-ready URL. It resolves to one of two forms:
- *
- *   - PUBLIC (no access token planted, no `expiresIn`) → the clean CDN form
- *     `${cloudURL}/<id>[?variant=...]` (default `https://cloud.oxy.so/<id>`),
- *     which CloudFront resolves against the public media origin.
- *   - SIGNED / PRIVATE (an access token is present OR `expiresIn` is passed) →
- *     the authenticated API origin form
- *     `${baseURL}/assets/<id>/stream?...&token=...` — private assets are not on
- *     the public CDN.
+ * into a `<img src>`-ready URL. Because a bare id does not carry visibility
+ * metadata, the synchronous helper must use the API stream endpoint. That route
+ * can serve direct-link `unlisted` assets and can redirect public CDN-backed
+ * assets to the CDN after the server has checked the file record.
  */
 
 import { OxyServices } from '../../OxyServices';
 
 describe('OxyServices.getFileDownloadUrl', () => {
-  describe('public assets (no token, no expiresIn) → CDN', () => {
-    it('returns the clean cloud.oxy.so URL for a bare file id', () => {
+  describe('asset stream URL generation', () => {
+    it('returns the API stream endpoint for a bare file id', () => {
       const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
 
-      expect(oxy.getFileDownloadUrl('file123')).toBe('https://cloud.oxy.so/file123');
-    });
-
-    it('appends only a variant query param (no token/fallback) for the thumb variant', () => {
-      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
-
-      expect(oxy.getFileDownloadUrl('file123', 'thumb')).toBe(
-        'https://cloud.oxy.so/file123?variant=thumb',
+      expect(oxy.getFileDownloadUrl('file123')).toBe(
+        'https://api.oxy.so/assets/file123/stream?fallback=placeholderVisible',
       );
     });
 
-    it('uses the configured cloudURL when overridden', () => {
+    it('appends a variant query param for thumbnails', () => {
+      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+
+      expect(oxy.getFileDownloadUrl('file123', 'thumb')).toBe(
+        'https://api.oxy.so/assets/file123/stream?variant=thumb&fallback=placeholderVisible',
+      );
+    });
+
+    it('does not use cloudURL because visibility is unknown to the sync helper', () => {
       const oxy = new OxyServices({
         baseURL: 'https://api.oxy.so',
         cloudURL: 'https://cdn.example.test',
       });
 
       expect(oxy.getFileDownloadUrl('file123', 'thumb')).toBe(
-        'https://cdn.example.test/file123?variant=thumb',
+        'https://api.oxy.so/assets/file123/stream?variant=thumb&fallback=placeholderVisible',
       );
     });
 
@@ -46,13 +43,13 @@ describe('OxyServices.getFileDownloadUrl', () => {
       const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
 
       expect(oxy.getFileDownloadUrl('a/b c', 'large size')).toBe(
-        'https://cloud.oxy.so/a%2Fb%20c?variant=large%20size',
+        'https://api.oxy.so/assets/a%2Fb%20c/stream?variant=large+size&fallback=placeholderVisible',
       );
     });
   });
 
-  describe('signed / private assets → authenticated API origin', () => {
-    it('returns the stream endpoint with the token when an access token is present', () => {
+  describe('signed / expiring assets', () => {
+    it('includes the token when an access token is present', () => {
       const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
       oxy.setTokens('access-token-abc');
 
@@ -66,7 +63,7 @@ describe('OxyServices.getFileDownloadUrl', () => {
       expect(url).not.toContain('cloud.oxy.so');
     });
 
-    it('routes through the stream endpoint when expiresIn is requested even without a token', () => {
+    it('includes expiresIn when requested even without a token', () => {
       const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
 
       const url = oxy.getFileDownloadUrl('file123', 'thumb', 3600);


### PR DESCRIPTION
### Motivation
- A recent change returned the clean CDN URL whenever the client had no access token and no `expiresIn`, which assumes an asset is public and causes unauthenticated direct-link `unlisted` assets to 404 via the CDN origin. 
- The synchronous helper only has a file id (no visibility metadata), so it must use the API-origin stream path that can serve unlisted direct links or redirect to the CDN when the server verifies the file is public.

### Description
- Change `getFileDownloadUrl` in `packages/core/src/mixins/OxyServices.assets.ts` to always build the API `/assets/<id>/stream` URL so the origin performs authoritative access checks and redirects when safe. 
- Preserve existing query behavior: `variant`, `expiresIn`, `fallback`, `token`, and proper URL encoding are still emitted on the stream URL. 
- Keep `getFileDownloadUrlAsync` behaviour unchanged so callers can still obtain a CDN-signed URL asynchronously and fall back to the stream endpoint when needed. 
- Update targeted unit tests in `packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts` to assert stream-URL generation and document why `cloudURL` is not used by the synchronous helper.

### Testing
- Updated unit test `packages/core/src/mixins/__tests__/getFileDownloadUrl.test.ts` to reflect the new stream URL expectations and to continue covering token/expiry/variant cases. 
- Attempted to run the test via `bun run test -- getFileDownloadUrl.test.ts`, but the test runner invocation failed because `jest` is not available in the current environment. 
- Attempted `bun install` to prepare the test environment, but dependency installation failed due to npm registry tarball 403 responses, preventing automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8c0b483239b5aec37cc5e639f)