### PR TITLE
fix(services): honor multi-follow initial state

### DIFF
--- a/packages/services/__tests__/__mocks__/bloom.ts
+++ b/packages/services/__tests__/__mocks__/bloom.ts
@@ -28,4 +28,27 @@ export const toast: {
   },
 );
 
+/**
+ * Stub for `@oxyhq/bloom/theme`'s `useTheme`. Components under test
+ * (`FollowButton`, etc.) only read `colors.*`; return the canonical key set so
+ * any themed component renders without dragging in the real theme provider.
+ */
+export const useTheme = (): { isDark: boolean; colors: Record<string, string> } => ({
+  isDark: false,
+  colors: {
+    primary: '#5e3bff',
+    primaryForeground: '#ffffff',
+    secondary: '#eeeeee',
+    background: '#ffffff',
+    text: '#000000',
+    textSecondary: '#666666',
+    card: '#ffffff',
+    border: '#e0e0e0',
+    success: '#22c55e',
+    error: '#ef4444',
+    warning: '#f59e0b',
+    info: '#3b82f6',
+  },
+});
+
 export default toast;

--- a/packages/services/__tests__/__mocks__/react-native.ts
+++ b/packages/services/__tests__/__mocks__/react-native.ts
@@ -58,12 +58,25 @@ export const Linking = {
   getInitialURL: async (): Promise<string | null> => null,
 };
 
+export const TouchableOpacity = ({
+  children,
+  onPress,
+  disabled,
+  ...props
+}: {
+  children?: React.ReactNode;
+  onPress?: () => void;
+  disabled?: boolean;
+  [key: string]: unknown;
+}) => React.createElement('button', { ...props, disabled, onClick: onPress }, children);
 
-export const TouchableOpacity = ({ children, onPress, disabled, ...props }: any) =>
-  React.createElement('button', { ...props, disabled, onClick: onPress }, children);
+export const Text = ({
+  children,
+  ...props
+}: {
+  children?: React.ReactNode;
+  [key: string]: unknown;
+}) => React.createElement('span', props, children);
 
-export const Text = ({ children, ...props }: any) =>
-  React.createElement('span', props, children);
-
-export const ActivityIndicator = (props: any) =>
+export const ActivityIndicator = (props: Record<string, unknown>) =>
   React.createElement('span', { ...props, role: 'status' });

--- a/packages/services/__tests__/components/FollowButton.multiUser.test.tsx
+++ b/packages/services/__tests__/components/FollowButton.multiUser.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+
+const oxyServicesStub = {
+  getFollowStatus: jest.fn(async () => ({ isFollowing: false })),
+  followUsers: jest.fn(),
+  unfollowUsers: jest.fn(),
+  getCurrentUserId: jest.fn(() => 'me'),
+};
+
+let ctx = {
+  oxyServices: oxyServicesStub,
+  canUsePrivateApi: true,
+  user: { id: 'me' },
+};
+
+jest.mock('../../src/ui/context/OxyContext', () => ({
+  useOxy: () => ctx,
+}));
+
+jest.mock('@oxyhq/core', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn() },
+}));
+
+import FollowButton from '../../src/ui/components/FollowButton';
+import { useFollowStore } from '../../src/ui/stores/followStore';
+
+const renderWithQueryClient = (children: ReactNode) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(createElement(QueryClientProvider, { client }, children));
+};
+
+describe('FollowButton multi-user initial state', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useFollowStore.getState().resetFollowState();
+    ctx = { oxyServices: oxyServicesStub, canUsePrivateApi: true, user: { id: 'me' } };
+  });
+
+  it('honors initiallyAllFollowing before async status fetch populates the store', () => {
+    renderWithQueryClient(
+      <FollowButton userIds={['u1', 'u2']} initiallyAllFollowing followedAllLabel="Following" />,
+    );
+
+    expect(screen.getByText('Following')).toBeTruthy();
+    expect(screen.queryByText('Follow all')).toBeNull();
+  });
+
+  it('lets a known not-following store status override initiallyAllFollowing', () => {
+    useFollowStore.getState().setFollowingStatus('u1', false);
+    useFollowStore.getState().setFollowingStatus('u2', true);
+
+    renderWithQueryClient(
+      <FollowButton userIds={['u1', 'u2']} initiallyAllFollowing followedAllLabel="Following" />,
+    );
+
+    expect(screen.getByText('Follow all')).toBeTruthy();
+    expect(screen.queryByText('Following')).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation
- Restore the public `initiallyAllFollowing` contract for the multi-user `FollowButton` so callers that pass an initial aggregate state see that reflected until the store provides explicit statuses. 
- Fix a UI/API regression where `initiallyAllFollowing` remained a dead prop after a refactor that made `allFollowing` purely store-derived.

### Description
- `FollowButtonMultiInner` now accepts and honors `initiallyAllFollowing`, combining it with the live store aggregate so the initial prop is respected until any member is known to be not-followed. 
- Read unknown per-user statuses from the follow store via `useFollowStore` + `useShallow` and compute `allFollowing` as `storeAllFollowing || (initiallyAllFollowing && !hasKnownNotFollowing)` to preserve reactivity and avoid render loops. 
- Add a test `packages/services/__tests__/components/FollowButton.multiUser.test.tsx` covering the initial-label behavior and an override-by-known-not-following case, and extend the Jest RN mock `packages/services/__tests__/__mocks__/react-native.ts` with `TouchableOpacity`, `Text`, and `ActivityIndicator` stubs so the component can render in tests.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues. 
- Attempted to run the focused test with `bun run test -- FollowButton.multiUser.test.tsx --runInBand` but the environment lacked test tooling (`jest: command not found`), so the test execution was blocked. 
- Attempted `bun run typescript` (local typecheck) but it was blocked by missing installed workspace dependencies and types (e.g., `react`, `react-native`, `@oxyhq/core`, `zustand`), so a full typecheck could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce801ec832380785aedbf8b7abc)