### PR TITLE
fix(api): validate bulk follow request body

### DIFF
--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -54,6 +54,14 @@ interface PaginationQuery {
 // Maximum number of users that can be followed in a single bulk request.
 const MAX_BULK_FOLLOW = 200;
 
+const getUserIdsFromRequestBody = (body: unknown): unknown => {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return undefined;
+  }
+
+  return (body as { userIds?: unknown }).userIds;
+};
+
 import { PAGINATION } from '../utils/constants';
 import { federationService } from '../services/federation.service';
 
@@ -389,7 +397,7 @@ router.post(
       throw new UnauthorizedError('Authentication required');
     }
 
-    const { userIds } = req.body;
+    const userIds = getUserIdsFromRequestBody(req.body);
 
     if (!Array.isArray(userIds)) {
       throw new BadRequestError('userIds must be an array');
@@ -443,7 +451,7 @@ router.post(
       throw new UnauthorizedError('Authentication required');
     }
 
-    const { userIds } = req.body;
+    const userIds = getUserIdsFromRequestBody(req.body);
 
     if (!Array.isArray(userIds)) {
       throw new BadRequestError('userIds must be an array');


### PR DESCRIPTION
### Motivation
- The bulk follow/unfollow endpoints destructured `req.body` directly (`const { userIds } = req.body`) which throws a `TypeError` when `req.body` is `null` or otherwise not an object, causing avoidable 500s and log noise. 
- The intent is to reject malformed JSON bodies as a 400 Bad Request rather than surfacing an internal server error from a destructuring exception.

### Description
- Added a small defensive accessor `getUserIdsFromRequestBody(body: unknown)` in `packages/api/src/routes/users.ts` to safely extract `userIds` only when the request body is a non-array object. 
- Replaced direct destructuring with the accessor in both `POST /users/follow/bulk` and `POST /users/unfollow/bulk` so malformed/`null` bodies now hit the existing `BadRequestError` validation. 
- Preserved existing validation logic and service calls so behavior for valid requests is unchanged.

### Testing
- Ran `git diff --check` on the change which reported no whitespace or patch errors. 
- Attempted to run package tests with `bun run --cwd packages/api test --runInBand` but execution was blocked because `jest` was not available in the environment. 
- Attempted to install dependencies with `bun install --frozen-lockfile` and run `bun --check` but both were blocked by registry access errors (npm registry returned 403) which prevented full local test/type-check execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce87db48323968d63b7c1a82b4d)