### PR TITLE
fix(auth): emit Bloom RGB tokens as rgb CSS

### DIFF
--- a/packages/auth/lib/__tests__/bloom-css.test.ts
+++ b/packages/auth/lib/__tests__/bloom-css.test.ts
@@ -31,6 +31,12 @@ describe("bloom-css", () => {
         expect(css).toContain("--primary:")
     })
 
+    test("getBloomThemeCSS emits Bloom RGB token values as rgb() colors", () => {
+        const css = getBloomThemeCSS("oxy")
+        expect(css).toContain("--primary: rgb(")
+        expect(css).not.toContain("--primary: hsl(")
+    })
+
     test("applyColorPreset injects a scoped <style> element", () => {
         applyColorPreset("blue", "chooser-hover")
         const el = styleEl("chooser-hover")

--- a/packages/auth/lib/bloom-css.ts
+++ b/packages/auth/lib/bloom-css.ts
@@ -27,7 +27,7 @@ function styleIdFor(scope: string): string {
 
 function presetToCSS(vars: Record<string, string>): string {
     return Object.entries(vars)
-        .map(([key, value]) => `  ${key}: hsl(${value});`)
+        .map(([key, value]) => `  ${key}: rgb(${value});`)
         .join("\n")
 }
 


### PR DESCRIPTION
### Motivation
- Bloom changed its color-token contract to emit RGB channel triplets; the auth app still wrapped every token with `hsl(...)`, producing invalid or incorrect CSS on first paint and causing theme visual regressions.

### Description
- Update `packages/auth/lib/bloom-css.ts` to emit `rgb(${value})` instead of `hsl(${value})` when rendering Bloom preset tokens, and add a regression test in `packages/auth/lib/__tests__/bloom-css.test.ts` that asserts `getBloomThemeCSS` includes `--primary: rgb(` and does not contain `--primary: hsl(`.

### Testing
- Ran `git diff --check` which passed for the change; added a unit test file exercising `getBloomThemeCSS` but the full `bun run test` in `packages/auth` could not complete because `bun install` failed in this environment due to registry `403` errors (missing `react`, `jsdom`, and other test deps), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce838448323b2ce0b9ce3f94d47)