### PR TITLE
fix(sso): guard storage cleanup failures

### DIFF
--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -203,14 +203,16 @@ function silentSignInKey(oxyServices: OxyServices): string {
  * No-ops off-web and on any storage failure (best-effort).
  */
 function clearSsoBounceStateWeb(): void {
-  if (!isWebBrowser() || typeof window.sessionStorage === 'undefined') return;
-  const origin = window.location.origin;
+  if (!isWebBrowser()) return;
   try {
-    window.sessionStorage.removeItem(ssoAttemptedKey(origin));
-    window.sessionStorage.removeItem(ssoNoSessionKey(origin));
-    window.sessionStorage.removeItem(ssoGuardKey(origin));
-    window.sessionStorage.removeItem(ssoStateKey(origin));
-    window.sessionStorage.removeItem(ssoDestKey(origin));
+    const storage = window.sessionStorage;
+    if (!storage) return;
+    const origin = window.location.origin;
+    storage.removeItem(ssoAttemptedKey(origin));
+    storage.removeItem(ssoNoSessionKey(origin));
+    storage.removeItem(ssoGuardKey(origin));
+    storage.removeItem(ssoStateKey(origin));
+    storage.removeItem(ssoDestKey(origin));
   } catch {
     // Best-effort; swallow SecurityError (e.g. Safari private mode).
   }

--- a/packages/services/__tests__/utils/storageHelpers.test.ts
+++ b/packages/services/__tests__/utils/storageHelpers.test.ts
@@ -98,3 +98,30 @@ describe('createPlatformStorage', () => {
     expect(await storage.getItem('two')).toBeNull();
   });
 });
+
+describe('clearSsoBounceState', () => {
+  const originalSessionStorageDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    'sessionStorage'
+  );
+
+  afterEach(() => {
+    if (originalSessionStorageDescriptor) {
+      Object.defineProperty(window, 'sessionStorage', originalSessionStorageDescriptor);
+    }
+    jest.resetModules();
+  });
+
+  it('no-ops when accessing sessionStorage throws', async () => {
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+    });
+
+    const { clearSsoBounceState } = await import('../../src/ui/utils/activeAuthuser');
+
+    expect(() => clearSsoBounceState()).not.toThrow();
+  });
+});

--- a/packages/services/src/ui/utils/activeAuthuser.ts
+++ b/packages/services/src/ui/utils/activeAuthuser.ts
@@ -32,8 +32,13 @@ function hasLocalStorage(): boolean {
   return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
 }
 
-function hasSessionStorage(): boolean {
-  return typeof window !== 'undefined' && typeof window.sessionStorage !== 'undefined';
+function getSessionStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -96,14 +101,15 @@ export function clearActiveAuthuser(): void {
  * No-ops on native and on any storage failure (best-effort).
  */
 export function clearSsoBounceState(): void {
-  if (!hasSessionStorage()) return;
-  const origin = window.location.origin;
+  const storage = getSessionStorage();
+  if (!storage) return;
   try {
-    window.sessionStorage.removeItem(ssoAttemptedKey(origin));
-    window.sessionStorage.removeItem(ssoNoSessionKey(origin));
-    window.sessionStorage.removeItem(ssoGuardKey(origin));
-    window.sessionStorage.removeItem(ssoStateKey(origin));
-    window.sessionStorage.removeItem(ssoDestKey(origin));
+    const origin = window.location.origin;
+    storage.removeItem(ssoAttemptedKey(origin));
+    storage.removeItem(ssoNoSessionKey(origin));
+    storage.removeItem(ssoGuardKey(origin));
+    storage.removeItem(ssoStateKey(origin));
+    storage.removeItem(ssoDestKey(origin));
   } catch {
     // Best-effort; swallow SecurityError (e.g. Safari private mode).
   }


### PR DESCRIPTION
### Motivation
- A `SecurityError` thrown when reading `window.sessionStorage` could escape the intended best-effort cleanup and abort logout/local session cleanup, so the SSO bounce cleanup must tolerate storage access failures.

### Description
- Replace the unsafe `hasSessionStorage()` check with a safe `getSessionStorage()` accessor that returns `null` on thrown errors and use the returned `Storage` object for operations in `packages/services/src/ui/utils/activeAuthuser.ts`.
- Move `window.sessionStorage` access inside the existing `try/catch` in `packages/auth-sdk/src/WebOxyProvider.tsx` so storage getter errors are swallowed as intended by the helper.
- Add a regression test in `packages/services/__tests__/utils/storageHelpers.test.ts` that stubs a throwing `sessionStorage` getter and asserts `clearSsoBounceState()` does not throw.

### Testing
- Ran `git diff --check` to validate the working tree (clean).
- Added a targeted Jest regression test for `clearSsoBounceState()` but running `bun run test -- --runTestsByPath __tests__/utils/storageHelpers.test.ts` was blocked because `jest`/package dependencies are not installed in this environment. 
- Attempted `bun run typescript` for `packages/auth-sdk` to validate types but it was blocked due to missing workspace dependencies in this checkout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce9831483238f1ca29d4408a9d3)