### PR TITLE
fix(api): avoid no-op avatar refresh throttling

### DIFF
--- a/packages/api/src/routes/__tests__/usersResolve.test.ts
+++ b/packages/api/src/routes/__tests__/usersResolve.test.ts
@@ -400,7 +400,7 @@ describe('PUT /users/resolve (C4)', () => {
     expect(mockUserFindOneAndUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it('no refresh flag: still schedules an avatar download with force=false (scheduler decides to skip)', async () => {
+  it('no refresh flag: skips scheduling when an existing stored avatar would make the worker a no-op', async () => {
     const newAvatarUrl = 'https://mastodon.social/avatars/alice.png';
 
     // First findOne: type-immutability check — no existing user found.
@@ -432,12 +432,45 @@ describe('PUT /users/resolve (C4)', () => {
     });
 
     expect(res.status).toBe(200);
-    // Scheduling is unconditional for http avatars; the scheduler (not the
-    // route) decides whether a stored file id makes the download a no-op.
+    expect(mockScheduleAvatarRefresh).not.toHaveBeenCalled();
+    expect(mockUserFindOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('no refresh flag: schedules the initial avatar download when no stored avatar exists', async () => {
+    const newAvatarUrl = 'https://mastodon.social/avatars/alice.png';
+
+    // First findOne: type-immutability check — no existing user found.
+    const immutabilityLean = jest.fn().mockResolvedValue(null);
+    const immutabilitySelect = jest.fn().mockReturnValue({ lean: immutabilityLean });
+    // Second findOne: avatar lookup — no stored file id yet.
+    const avatarLean = jest.fn().mockResolvedValue({ avatar: undefined });
+    const avatarSelect = jest.fn().mockReturnValue({ lean: avatarLean });
+    mockUserFindOne
+      .mockReturnValueOnce({ select: immutabilitySelect })
+      .mockReturnValueOnce({ select: avatarSelect });
+
+    const newUserDoc = {
+      _id: 'new-user',
+      username: 'alice@mastodon.social',
+      type: 'federated',
+    };
+    const updateLean = jest.fn().mockResolvedValue(newUserDoc);
+    const updateSelect = jest.fn().mockReturnValue({ lean: updateLean });
+    mockUserFindOneAndUpdate.mockReturnValueOnce({ select: updateSelect });
+
+    const res = await requestJson(server, 'PUT', '/users/resolve', {
+      type: 'federated',
+      username: 'alice@mastodon.social',
+      actorUri: 'https://mastodon.social/users/alice',
+      domain: 'mastodon.social',
+      avatar: newAvatarUrl,
+    });
+
+    expect(res.status).toBe(200);
     expect(mockScheduleAvatarRefresh).toHaveBeenCalledWith(
       'new-user',
       newAvatarUrl,
-      'file-abc',
+      undefined,
       { force: false },
     );
     expect(mockUserFindOneAndUpdate).toHaveBeenCalledTimes(1);

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1317,7 +1317,10 @@ router.put(
     // resolves the user fresh, honours the throttle + conditional requests, and
     // invalidates the cache again once the new file id is persisted. Never
     // awaited — must not delay the response.
-    if (remoteAvatarUrl) {
+    const hasExistingStoredAvatar = typeof existingAvatarFileId === 'string'
+      && existingAvatarFileId.length > 0
+      && !existingAvatarFileId.startsWith('http');
+    if (remoteAvatarUrl && (forceAvatarRefresh || !hasExistingStoredAvatar)) {
       federationService.scheduleAvatarRefresh(
         user._id.toString(),
         remoteAvatarUrl,


### PR DESCRIPTION
### Motivation
- Non-forced `/users/resolve` calls were unconditionally scheduling background avatar refresh jobs even when the user already had a stored file-id avatar, which caused the in-process throttle (`_lastAvatarAttemptAt`) to be consumed by no-op work and could suppress a subsequent forced refresh within the throttle window.

### Description
- Change `PUT /users/resolve` to compute `hasExistingStoredAvatar` and only call `federationService.scheduleAvatarRefresh(...)` when `forceAvatarRefresh` is true or there is no existing stored file-id avatar (file: `packages/api/src/routes/users.ts`).
- Update unit tests in `packages/api/src/routes/__tests__/usersResolve.test.ts` to assert that non-forced resolves skip scheduling when a stored avatar exists and still schedule when no stored avatar exists.
- Preserve existing behavior for forced refreshes and initial remote-avatar scheduling so functionality and response contract remain unchanged.

### Testing
- Updated Jest unit tests in `packages/api/src/routes/__tests__/usersResolve.test.ts` to cover the skip-case and initial-download case; the tests were updated in this PR but could not be executed here because `jest` was not available in the environment (`jest: command not found`).
- Performed repository checks including `git diff --check` and committed changes as `fix(api): avoid no-op avatar refresh throttling`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce808748323855e210828ec6aee)