### PR TITLE
fix(api): accept first-party FedCM issuers

### DIFF
--- a/packages/api/src/services/__tests__/fedcm.service.test.ts
+++ b/packages/api/src/services/__tests__/fedcm.service.test.ts
@@ -283,6 +283,27 @@ describe('FedCM exchangeIdToken (H9)', () => {
     });
   });
 
+  it('accepts a first-party auth.<audience-apex> issuer for multi-domain FedCM', async () => {
+    const token = mintToken({ iss: 'https://auth.party.example' });
+    const result = await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(result.sessionId).toBe('sess-123');
+    expect(mockCreateSession).toHaveBeenCalledWith('user-123', expect.anything(), {
+      deviceName: 'FedCM Sign-In',
+      stableDeviceKey: APPROVED_ORIGIN,
+    });
+  });
+
+  it('rejects a dynamic issuer that is not the auth sibling of the token audience', async () => {
+    const token = mintToken({ iss: 'https://auth.evil.example' });
+    const result = await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect(result).toEqual({ error: 'invalid_issuer' });
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
   it('returns the user with a structured name.displayName (canonical serializer), never a string name', async () => {
     // Contract: a session-establishing exchange MUST emit the structured
     // `UserNameResponse` so the SDK's `userResponseSchema` accepts it. A bare

--- a/packages/api/src/services/fedcm.service.ts
+++ b/packages/api/src/services/fedcm.service.ts
@@ -28,6 +28,18 @@ const DEV_NATIVE_APPROVED_ORIGINS = [
 
 const NONCE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 const NONCE_BYTES = 32;
+const MULTIPART_TLDS = new Set([
+  'co.uk',
+  'com.au',
+  'co.jp',
+  'co.nz',
+  'com.br',
+  'co.za',
+  'com.mx',
+  'co.in',
+  'co.kr',
+  'com.sg',
+]);
 
 /** SHA-256 hex digest helper — never persist or compare raw nonces. */
 function sha256Hex(value: string): string {
@@ -55,6 +67,47 @@ function normaliseOriginOrThrow(value: string): string {
     throw new TypeError(`Invalid URL: ${value}`);
   }
   return normalised;
+}
+
+function registrableApex(hostname: string): string | null {
+  const host = hostname.toLowerCase();
+  if (!host) return null;
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) return null;
+  if (host.startsWith('[') || host.includes(':')) return null;
+  const labels = host.split('.');
+  if (labels.length < 2) return null;
+  const lastTwo = labels.slice(-2).join('.');
+  if (MULTIPART_TLDS.has(lastTwo)) return null;
+  return lastTwo;
+}
+
+/**
+ * FedCM assertions may be minted either by the central Oxy IdP
+ * (`https://auth.oxy.so`) or by an approved RP's first-party CNAME host
+ * (`https://auth.<rp-apex>`). Accept the explicit configured central issuer for
+ * local/test overrides, and otherwise require the dynamic issuer to be the
+ * HTTPS `auth.` sibling of the token audience's registrable apex.
+ */
+function isAllowedFedCMIssuer(issuer: string | undefined, audience: string): boolean {
+  if (!issuer) return false;
+  let normalizedIssuer: string;
+  try {
+    normalizedIssuer = normaliseOriginOrThrow(issuer);
+  } catch {
+    return false;
+  }
+  if (timingSafeStringEqual(normalizedIssuer, FEDCM_ISSUER)) return true;
+
+  let audienceOrigin: URL;
+  try {
+    audienceOrigin = new URL(normaliseOriginOrThrow(audience));
+  } catch {
+    return false;
+  }
+  const apex = registrableApex(audienceOrigin.hostname);
+  if (!apex) return false;
+  const expectedDynamicIssuer = `https://auth.${apex}`;
+  return timingSafeStringEqual(normalizedIssuer, expectedDynamicIssuer);
 }
 
 // FedCM ID token issuer - must match auth server's NEXT_PUBLIC_OXY_AUTH_URL
@@ -552,9 +605,15 @@ class FedCMService {
         return { error: 'missing_required_fields' };
       }
 
-      // Verify issuer (normalize trailing slashes for comparison)
-      if (tokenPayload.iss?.replace(/\/+$/, '') !== FEDCM_ISSUER) {
-        logger.warn('FedCM: Invalid issuer', { expected: FEDCM_ISSUER, got: tokenPayload.iss });
+      // Verify issuer. The browser-native multi-domain FedCM flow mints
+      // tokens from `https://auth.<rp-apex>`, while server-side SSO assertions
+      // continue to use the configured central issuer.
+      if (!isAllowedFedCMIssuer(tokenPayload.iss, tokenPayload.aud)) {
+        logger.warn('FedCM: Invalid issuer', {
+          expected: `${FEDCM_ISSUER} or https://auth.<audience-apex>`,
+          got: tokenPayload.iss,
+          aud: tokenPayload.aud,
+        });
         return { error: 'invalid_issuer' };
       }
 


### PR DESCRIPTION
### Motivation
- The auth worker now mints FedCM ID tokens with an issuer derived from the request host (per-apex `https://auth.<rp-apex>`), but the API verifier only accepted a single configured issuer, causing valid multi-domain tokens to be rejected during `/fedcm/exchange`.
- This change restores interoperability for the new Clerk-style multi-domain FedCM flow while keeping the existing central issuer override for tests/local dev.

### Description
- Added `MULTIPART_TLDS` and a `registrableApex` helper to safely derive an audience apex while avoiding multi-part public-suffix pitfalls in `packages/api/src/services/fedcm.service.ts`.
- Implemented `isAllowedFedCMIssuer(issuer, audience)` which accepts either the configured central `FEDCM_ISSUER` or the dynamic `https://auth.<audience-apex>` first-party issuer and used it in the token issuer validation path.
- Replaced the strict equality issuer check with the new allowlist helper and improved logging to show expected values and the token `aud` on failure.
- Added two regression tests in `packages/api/src/services/__tests__/fedcm.service.test.ts` to cover: acceptance of a valid first-party `auth.<audience-apex>` issuer and rejection of an unrelated dynamic issuer.

### Testing
- Added automated tests `accepts a first-party auth.<audience-apex> issuer for multi-domain FedCM` and `rejects a dynamic issuer that is not the auth sibling of the token audience` in `packages/api/src/services/__tests__/fedcm.service.test.ts` (these tests were added but not executed in this environment).
- Attempted to run the targeted test (`bun run test -- fedcm.service.test.ts`) but `jest` was not available in the container, causing the test run to fail.
- Attempted `bun install` to fetch test dependencies but the npm registry returned `403` errors for required packages (including `jest`/`ts-jest`), preventing full automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce97a4083239e7f734e7faa023e)