### PR TITLE
fix(api): initialize socket singleton for inbound email events

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -58,6 +58,7 @@ import { csrfProtection, getCsrfToken } from './middleware/csrf';
 import { createCorsMiddleware, SOCKET_IO_CORS_CONFIG } from './config/cors';
 import { createAdapter } from '@socket.io/redis-adapter';
 import { getRedisClient, closeRedis } from './config/redis';
+import { initializeIO } from './utils/socket';
 import performanceMiddleware, { getMemoryStats, getConnectionPoolStats } from './middleware/performance';
 import { performanceMonitor } from './utils/performanceMonitor';
 import { waitForMongoConnection } from './utils/dbConnection';
@@ -170,6 +171,7 @@ const server = http.createServer(app);
 const io = new SocketIOServer(server, {
   cors: SOCKET_IO_CORS_CONFIG,
 });
+initializeIO(io);
 
 // Attach Redis adapter for multi-instance broadcast (if Redis available)
 const redis = getRedisClient();


### PR DESCRIPTION
### Motivation
- The inbound email route uses the module singleton `getIO()` to emit socket events but the server created a `SocketIOServer` and stored it on `app` without calling `initializeIO(...)`, causing `getIO()` to be null and the `email:new` / `email:unread_count` events to never emit.

### Description
- Import `initializeIO` from `./utils/socket` in `packages/api/src/server.ts` and call `initializeIO(io)` immediately after creating the `SocketIOServer` so code paths that use `getIO()` can emit through the initialized singleton.

### Testing
- Ran `git diff --check` which passed locally; attempted `bun run test -- emailInbound.socket.test.ts` but `jest` was not available in this environment so the Jest test could not be executed. `bun install --frozen-lockfile` also failed due to npm registry `403` responses, preventing full test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8082883239a44d22164c7b3d5)