### PR TITLE
fix(api): preserve reused session during refresh slot reuse

### DIFF
--- a/packages/api/src/services/__tests__/issueAndSetRefreshCookie.test.ts
+++ b/packages/api/src/services/__tests__/issueAndSetRefreshCookie.test.ts
@@ -225,6 +225,28 @@ describe('issueAndSetRefreshCookie — slot allocation', () => {
     expect(mockDeactivateSession).toHaveBeenCalledWith('sess-a');
   });
 
+  it('does not deactivate the current session when same-user slot reuse targets the reused session', async () => {
+    const existingRaw = 'SAME-SESSION-TOK';
+    stage(buildStored(existingRaw, {
+      sessionId: 'sess-reused',
+      family: 'fam-reused',
+      userId: { toString: () => 'u-same' },
+    }));
+    const { res, calls } = makeResponseStub();
+    const result = await issueAndSetRefreshCookie(res, 'sess-reused', 'u-same', {
+      cookieHeader: `oxy_rt_0=${existingRaw}`,
+    });
+
+    expect(result.authuser).toBe(0);
+    expect(calls[0].name).toBe('oxy_rt_0');
+    expect(mockTokenUpdateMany).toHaveBeenCalledWith(
+      { family: 'fam-reused', revokedAt: null },
+      { $set: { revokedAt: expect.any(Date) } }
+    );
+    expect(mockDeactivateSession).not.toHaveBeenCalled();
+    expect(mockGetAccessToken).toHaveBeenCalledWith('sess-reused');
+  });
+
   it('evicts the LRU slot when all MAX_DEVICE_ACCOUNTS are occupied by different users', async () => {
     // Fill slots 0..MAX-1 with distinct users; slot 3 is the LRU.
     const cookieParts: string[] = [];

--- a/packages/api/src/services/refreshToken.service.ts
+++ b/packages/api/src/services/refreshToken.service.ts
@@ -681,7 +681,14 @@ export async function issueAndSetRefreshCookie(
       const tokenHash = sha256Hex(raw);
       const row = await RefreshToken.findOne({ tokenHash });
       if (row) {
-        await revokeFamily(row.family, row.sessionId);
+        if (String(row.sessionId) === sessionId) {
+          await RefreshToken.updateMany(
+            { family: row.family, revokedAt: null },
+            { $set: { revokedAt: new Date() } }
+          );
+        } else {
+          await revokeFamily(row.family, row.sessionId);
+        }
         break;
       }
     }


### PR DESCRIPTION
### Motivation
- Re-login into a device slot could revoke the previous refresh-token family and call `deactivateSession` using the stored `sessionId`, which incorrectly deactivates the newly-reused session when `createSession` returns the same `sessionId` for the same user+device. 
- This produced successful sign-in responses whose access token/session had already been invalidated, breaking availability for normal re-login flows.

### Description
- In `packages/api/src/services/refreshToken.service.ts` change the same-user slot reuse path to avoid calling `revokeFamily(row.family, row.sessionId)` when `String(row.sessionId) === sessionId`, instead only revoking the token family (`RefreshToken.updateMany`) without deactivating the session. 
- Preserve the existing behavior (revoke+deactivate) for the case where the stored `row.sessionId` differs from the newly-created `sessionId`. 
- Add a regression unit test in `packages/api/src/services/__tests__/issueAndSetRefreshCookie.test.ts` asserting that reuse targeting the reused session revokes the old family but does not call `deactivateSession` and that `getAccessToken` is invoked for the reused session.

### Testing
- Added a focused Jest unit test (`issueAndSetRefreshCookie` slot-allocation test) that covers the same-session reuse scenario and asserts no session deactivation occurs. 
- Attempted to run the package test (`packages/api` Jest job) locally but execution was blocked by missing test tooling / dependencies in this environment (no `jest`/`turbo` installed and `bun install --frozen-lockfile --ignore-scripts` failed due to registry `403` responses), so the new test was not executed here. 
- No automated tests were run to completion in this execution environment; the change is covered by the new unit test and should pass in CI where project dependencies and runners are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce80a1c83239b6eb7cf695c2b12)