### PR TITLE
Fix pending RTL direction persistence

### DIFF
--- a/packages/accounts/lib/i18n/locale-context.tsx
+++ b/packages/accounts/lib/i18n/locale-context.tsx
@@ -136,10 +136,7 @@ export function LocaleProvider({ children }: LocaleProviderProps) {
   // typical UX is "change language -> brief sync indicator -> next session
   // shows RTL". This is the same pattern React Native docs recommend.
   useEffect(() => {
-    const wantRTL = isRTLLocale(locale);
-    if (I18nManager.isRTL !== wantRTL) {
-      I18nManager.forceRTL(wantRTL);
-    }
+    I18nManager.forceRTL(isRTLLocale(locale));
   }, [locale]);
 
   const value = useMemo<LocaleContextValue>(

--- a/packages/inbox/lib/i18n/locale-context.tsx
+++ b/packages/inbox/lib/i18n/locale-context.tsx
@@ -132,10 +132,7 @@ export function LocaleProvider({ children }: LocaleProviderProps) {
   // Keep RN layout direction in sync with the active locale. `forceRTL`
   // only takes effect after a JS bundle reload, so we set it eagerly here.
   useEffect(() => {
-    const wantRTL = isRTLLocale(locale);
-    if (I18nManager.isRTL !== wantRTL) {
-      I18nManager.forceRTL(wantRTL);
-    }
+    I18nManager.forceRTL(isRTLLocale(locale));
   }, [locale]);
 
   const value = useMemo<LocaleContextValue>(


### PR DESCRIPTION
### Motivation
- Ensure the RN `I18nManager.forceRTL` setting persisted for the final selected locale even when users switch locales multiple times before restarting, because the previous conditional (`I18nManager.isRTL !== wantRTL`) could skip calls and leave a queued opposite direction for the next launch.

### Description
- Replace the conditional check with an unconditional call to `I18nManager.forceRTL(isRTLLocale(locale))` in `packages/accounts/lib/i18n/locale-context.tsx` and `packages/inbox/lib/i18n/locale-context.tsx` so the next-launch RTL/LTR persisted value always matches the active locale.

### Testing
- Ran `git diff --check` which succeeded, and attempted `bun run test` / `bun run lint` in the modified packages but those commands were blocked in this environment due to missing `jest`/`expo` binaries; the change was committed as `46555c2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7c174832386b0500e0affe5a6)