### PR TITLE
fix(auth): clear login avatar logo on unmount

### DIFF
--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo } from "react"
+import { useState, useRef, useMemo, useEffect } from "react"
 import { useNavigate, Link } from "react-router-dom"
 import { toast } from "sonner"
 import { ArrowLeft, ShieldAlert } from "lucide-react"
@@ -106,6 +106,12 @@ export function LoginForm({
         mountedRef.current = true
         setBasePreset("oxy")
     }
+
+    // Login-specific logo overrides must not leak into sibling auth routes
+    // that share AuthLayout (recover, signup, authorize).
+    useEffect(() => {
+        return () => setLogoSlot(null)
+    }, [setLogoSlot])
 
     // One-time toasts from URL params
     const noticeShownRef = useRef(false)


### PR DESCRIPTION
### Motivation
- Prevent login-specific avatar stored in the shared auth layout (`logoSlot`) from persisting across sibling auth routes (e.g. `/recover`, `/signup`, `/authorize`) when the `LoginForm` unmounts, avoiding a stale UI/privacy issue in the same browser tab.

### Description
- Add a `useEffect` cleanup in `packages/auth/components/login-form.tsx` that calls `setLogoSlot(null)` on unmount and import `useEffect` from React, ensuring the layout override is cleared when the form is removed.

### Testing
- Ran `git diff --check` with no issues reported.
- Attempted `bun run test` in `packages/auth`, but execution was blocked in this environment due to missing dev dependencies (`jsdom` and `react`), so tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce822108323a23a4642006d5ba0)