### PR TITLE
fix(services): add fallback Bloom theme provider

### DIFF
--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -4,6 +4,7 @@ import type { OxyProviderProps } from '../types/navigation';
 import { OxyContextProvider, type OxyContextProviderProps } from '../context/OxyContext';
 import { QueryClientProvider, focusManager, onlineManager } from '@tanstack/react-query';
 import { BloomDialogProvider } from '@oxyhq/bloom';
+import { BloomThemeProvider, useTheme as useBloomTheme } from '@oxyhq/bloom/theme';
 import { ToastOutlet } from '@oxyhq/bloom/toast';
 import { logger as loggerUtil } from '@oxyhq/core';
 import { setupFonts } from './FontLoader';
@@ -25,6 +26,15 @@ import { createPlatformStorage, type StorageInterface } from '../utils/storageHe
  * jarring than `null` (transparent) on either theme.
  */
 const BOOT_BG_COLOR = '#ffffff';
+
+const BloomThemeFallback: FC<{ children: ReactNode }> = ({ children }) => {
+    try {
+        useBloomTheme();
+        return <>{children}</>;
+    } catch {
+        return <BloomThemeProvider mode="system">{children}</BloomThemeProvider>;
+    }
+};
 
 const bootStyles = StyleSheet.create({
     bootShell: {
@@ -284,32 +294,34 @@ const OxyProvider: FC<OxyProviderProps> = ({
 
     // Core content: QueryClient + OxyContext + UI overlays.
     //
-    // Theming is owned by `@oxyhq/bloom`. Consumers must mount their own
-    // `<BloomThemeProvider>` in their app root and configure it directly
+    // Theming is owned by `@oxyhq/bloom`. Consumers should mount their own
+    // `<BloomThemeProvider>` in the app root to configure it directly
     // (defaultColorPreset, defaultMode, persistKey, storage, fonts, etc.).
-    // OxyProvider does NOT wrap a BloomThemeProvider — that would create a
-    // duplicate scope that silently shadows the consumer's configuration.
+    // For backwards compatibility with documented OxyProvider-only usage,
+    // install a default Bloom provider only when no upstream provider exists.
     const coreContent = (
         <QueryClientProvider client={queryClient}>
-            <BloomDialogProvider>
-                <OxyContextProvider
-                    oxyServices={oxyServices as OxyContextProviderProps['oxyServices']}
-                    baseURL={baseURL}
-                    authWebUrl={authWebUrl}
-                    authRedirectUri={authRedirectUri}
-                    storageKeyPrefix={storageKeyPrefix}
-                    clientId={clientId}
-                    disableAutoSso={disableAutoSso}
-                    onAuthStateChange={onAuthStateChange as OxyContextProviderProps['onAuthStateChange']}
-                >
-                    {children}
-                    <Suspense fallback={null}>
-                        <LazyBottomSheetRouter />
-                        <LazySignInModal />
-                    </Suspense>
-                    <ToastOutlet />
-                </OxyContextProvider>
-            </BloomDialogProvider>
+            <BloomThemeFallback>
+                <BloomDialogProvider>
+                    <OxyContextProvider
+                        oxyServices={oxyServices as OxyContextProviderProps['oxyServices']}
+                        baseURL={baseURL}
+                        authWebUrl={authWebUrl}
+                        authRedirectUri={authRedirectUri}
+                        storageKeyPrefix={storageKeyPrefix}
+                        clientId={clientId}
+                        disableAutoSso={disableAutoSso}
+                        onAuthStateChange={onAuthStateChange as OxyContextProviderProps['onAuthStateChange']}
+                    >
+                        {children}
+                        <Suspense fallback={null}>
+                            <LazyBottomSheetRouter />
+                            <LazySignInModal />
+                        </Suspense>
+                        <ToastOutlet />
+                    </OxyContextProvider>
+                </BloomDialogProvider>
+            </BloomThemeFallback>
         </QueryClientProvider>
     );
 


### PR DESCRIPTION
### Motivation

- Migrated overlays (`BottomSheetRouter`, `SignInModal`) now call Bloom's `useTheme()` but `OxyProvider` does not always mount a `BloomThemeProvider`, which can throw during render for consumers that only use `<OxyProvider>`.
- The repository already provides a compatibility hook that falls back when Bloom context is absent, but several migrated components bypassed that fallback and caused a client-side crash/regression.

### Description

- Add a local `BloomThemeFallback` to `packages/services/src/ui/components/OxyProvider.tsx` that calls Bloom's `useTheme()` and only installs a default `<BloomThemeProvider mode="system">` when no upstream provider exists.
- Import `BloomThemeProvider` and `useTheme as useBloomTheme` from `@oxyhq/bloom/theme` and wrap the overlay subtree (lazy overlays, `ToastOutlet`, etc.) in the fallback so overlays always have Bloom theme context when mounted by `OxyProvider`.
- Preserve existing behavior when an app already provides its own `BloomThemeProvider` by detecting and reusing the upstream provider rather than replacing consumer configuration.

### Testing

- Ran `git diff --check` to ensure no whitespace/merge errors and it passed.
- Attempted `bun run --cwd packages/services typescript` to typecheck the package but it was blocked by missing local dependencies/type declarations in the execution environment (e.g. `react`, `react-native`, `@oxyhq/bloom`).
- Attempted `biome`/lint checks (`bunx --bun @biomejs/biome`) but the environment failed to resolve the registry (HTTP 403), so automated lint validation could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7fcb083239c6f822707dd54ae)