### PR TITLE
fix(services): preserve timed-out sessions during restore

### DIFF
--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -265,13 +265,17 @@ const COOKIE_RESTORE_TIMEOUT = 3000;
 const COLD_BOOT_OVERALL_DEADLINE = 20000;
 
 /**
- * Per-session timeout (ms) for the parallel stored-session validation in
+ * Per-session soft timeout (ms) for the parallel stored-session validation in
  * `restoreStoredSession`. Each `validateSession` call races against this timer
  * so a single slow/offline session never blocks the whole startup validation
- * sweep — sessions that don't answer in time resolve to `null` (treated as
- * unvalidated) and the remaining sessions still settle.
+ * sweep. Sessions that don't answer in time are treated as unvalidated and kept
+ * in the persisted ID list; only explicit invalid-session responses are pruned.
  */
 const VALIDATION_TIMEOUT = 8000;
+const VALIDATION_TIMEOUT_RESULT = 'validation-timeout' as const;
+type StoredSessionValidationResult =
+  | { session: ClientSession | null; timedOut: false }
+  | { sessionId: string; timedOut: true };
 
 /**
  * Fallback client-session validity window (ms) — 7 days — applied when a
@@ -948,14 +952,15 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     ]));
 
     let validSessions: ClientSession[] = [];
+    let unvalidatedSessionIds: string[] = [];
 
     if (storedSessionIds.length > 0) {
       // Validate all sessions in parallel (with a per-session timeout) to avoid
       // sequential blocking that freezes the app on startup
       const results = await Promise.allSettled(
         storedSessionIds.map(async (sessionId) => {
-          const timeoutPromise = new Promise<null>((resolve) =>
-            setTimeout(() => resolve(null), VALIDATION_TIMEOUT),
+          const timeoutPromise = new Promise<typeof VALIDATION_TIMEOUT_RESULT>((resolve) =>
+            setTimeout(() => resolve(VALIDATION_TIMEOUT_RESULT), VALIDATION_TIMEOUT),
           );
           const validationPromise = oxyServices
             .validateSession(sessionId, { useHeaderValidation: true })
@@ -969,6 +974,9 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             });
 
           return Promise.race([validationPromise, timeoutPromise]).then((validation) => {
+            if (validation === VALIDATION_TIMEOUT_RESULT) {
+              return { sessionId, timedOut: true as const };
+            }
             if (validation?.valid && validation.user) {
               const now = new Date();
               const clientSession: ClientSession = {
@@ -982,21 +990,31 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
               if (isWebBrowser() && sessionId === storedActiveSessionId && storedActiveAuthuser !== null) {
                 clientSession.authuser = storedActiveAuthuser;
               }
-              return clientSession;
+              return { session: clientSession, timedOut: false as const };
             }
-            return null;
+            return { session: null, timedOut: false as const };
           });
         }),
       );
 
-      validSessions = results
-        .filter((r): r is PromiseFulfilledResult<ClientSession | null> => r.status === 'fulfilled')
-        .map((r) => r.value)
-        .filter((s): s is ClientSession => s !== null);
+      for (const result of results) {
+        if (result.status !== 'fulfilled') continue;
+        const value: StoredSessionValidationResult = result.value;
+        if (value.timedOut) {
+          unvalidatedSessionIds.push(value.sessionId);
+        } else if (value.session) {
+          validSessions.push(value.session);
+        }
+      }
 
-      // Always persist validated sessions to storage (even empty list)
-      // to clear stale/expired session IDs that would cause 401 loops on restart
-      updateSessionsRef.current(validSessions, { merge: false });
+      // Persist validated sessions while preserving soft-timed-out IDs. This
+      // still clears sessions that were explicitly rejected as invalid, but
+      // avoids logging out valid secondary accounts solely because the API was
+      // slow during startup.
+      updateSessionsRef.current(validSessions, {
+        merge: false,
+        preserveSessionIds: unvalidatedSessionIds,
+      });
     }
 
     if (storedActiveSessionId) {
@@ -1014,7 +1032,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
           await storage.removeItem(storageKeys.activeSessionId);
           updateSessionsRef.current(
             validSessions.filter((session) => session.sessionId !== storedActiveSessionId),
-            { merge: false },
+            { merge: false, preserveSessionIds: unvalidatedSessionIds },
           );
           // Don't log expected session errors during restoration
         } else if (isTimeoutOrNetworkError(switchError)) {

--- a/packages/services/src/ui/hooks/useSessionManagement.ts
+++ b/packages/services/src/ui/hooks/useSessionManagement.ts
@@ -30,7 +30,7 @@ export interface UseSessionManagementResult {
   sessions: ClientSession[];
   activeSessionId: string | null;
   setActiveSessionId: (sessionId: string | null) => void;
-  updateSessions: (incoming: ClientSession[], options?: { merge?: boolean }) => void;
+  updateSessions: (incoming: ClientSession[], options?: { merge?: boolean; preserveSessionIds?: string[] }) => void;
   switchSession: (sessionId: string) => Promise<User>;
   refreshSessions: (activeUserId?: string) => Promise<void>;
   clearSessionState: () => Promise<void>;
@@ -95,14 +95,17 @@ export const useSessionManagement = ({
   );
 
   const updateSessions = useCallback(
-    (incoming: ClientSession[], options: { merge?: boolean } = {}): void => {
+    (incoming: ClientSession[], options: { merge?: boolean; preserveSessionIds?: string[] } = {}): void => {
       setSessions((prevSessions) => {
         const processed = options.merge
           ? mergeSessions(prevSessions, incoming, activeSessionIdRef.current, false)
           : normalizeAndSortSessions(incoming, activeSessionIdRef.current, false);
 
         if (storage) {
-          void saveSessionIds(processed.map((session) => session.sessionId));
+          void saveSessionIds([
+            ...processed.map((session) => session.sessionId),
+            ...(options.preserveSessionIds ?? []),
+          ]);
         }
 
         if (sessionsArraysEqual(prevSessions, processed)) {


### PR DESCRIPTION
### Motivation
- A parallelized stored-session restore used an 8s `Promise.race` timeout that treated timeout winners as invalid and persisted only completed validations, which could permanently drop valid secondary sessions when the API was slow.
- The intent is to avoid logging out valid sessions due to transient latency while still pruning explicitly invalid sessions to prevent 401 loops on restart.

### Description
- Treat per-session validation timeouts as a soft/unvalidated sentinel instead of `null`, by introducing `VALIDATION_TIMEOUT_RESULT` and `StoredSessionValidationResult` in `packages/services/src/ui/context/OxyContext.tsx`.
- Collect `unvalidatedSessionIds` for sessions that timed out and keep them in the persisted ID list instead of removing them immediately.
- Persist validated `ClientSession` objects while passing `preserveSessionIds` to `updateSessions` so timed-out IDs are preserved; extend `updateSessions` in `packages/services/src/ui/hooks/useSessionManagement.ts` with an optional `preserveSessionIds?: string[]` parameter that is included when writing stored session IDs.
- Ensure the active-session invalidation path also preserves soft-timed-out IDs when rewriting the stored session list.

### Testing
- Ran `git diff --check`, which passed without whitespace/errors.
- Attempted `bun run --filter @oxyhq/services test` but it was blocked by the environment (`jest` not available), so test run was not completed.
- Attempted `bun run --filter @oxyhq/services typescript` which reported many missing dependency/type errors (environment lacked `react`, `react-native`, `@oxyhq/core`, etc.), so TypeScript build could not be validated here.
- Attempted `bun run --filter @oxyhq/services lint` and `bun install`, both of which were blocked (missing `biome` and npm registry 403 respectively), so full CI-style validation could not be performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8b0d88323a0e6e873f0c12771)