### PR TITLE
fix(services): wrap OxyProvider overlays in native providers

### DIFF
--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -1,5 +1,7 @@
 import { lazy, Suspense, useEffect, useRef, useState, type ComponentType, type FC, type ReactNode } from 'react';
 import { AppState, Platform, StyleSheet, View } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import type { OxyProviderProps } from '../types/navigation';
 import { OxyContextProvider, type OxyContextProviderProps } from '../context/OxyContext';
 import { QueryClientProvider, focusManager, onlineManager } from '@tanstack/react-query';
@@ -27,6 +29,9 @@ import { createPlatformStorage, type StorageInterface } from '../utils/storageHe
 const BOOT_BG_COLOR = '#ffffff';
 
 const bootStyles = StyleSheet.create({
+    providerRoot: {
+        flex: 1,
+    },
     bootShell: {
         flex: 1,
         backgroundColor: BOOT_BG_COLOR,
@@ -69,8 +74,9 @@ const LazySignInModal = lazy((): Promise<{ default: ComponentType }> =>
  * OxyProvider - Universal provider for Expo apps (native + web)
  *
  * Provides authentication, session management, query client, and UI overlays.
- * Does NOT wrap in SafeAreaProvider or GestureHandlerRootView — those are the
- * consuming app's responsibility.
+ * Wraps its own overlay stack in SafeAreaProvider and GestureHandlerRootView so
+ * BottomSheetRouter and SignInModal can safely render even when a consuming app
+ * has not mounted those providers yet.
  *
  * Usage:
  * ```tsx
@@ -276,9 +282,13 @@ const OxyProvider: FC<OxyProviderProps> = ({
     // until children can mount under a real <QueryClientProvider>.
     if (!queryClient) {
         return (
-            <KeyboardWrapper>
-                <View style={bootStyles.bootShell} />
-            </KeyboardWrapper>
+            <GestureHandlerRootView style={bootStyles.providerRoot}>
+                <SafeAreaProvider>
+                    <KeyboardWrapper>
+                        <View style={bootStyles.bootShell} />
+                    </KeyboardWrapper>
+                </SafeAreaProvider>
+            </GestureHandlerRootView>
         );
     }
 
@@ -314,9 +324,13 @@ const OxyProvider: FC<OxyProviderProps> = ({
     );
 
     return (
-        <KeyboardWrapper>
-            {coreContent}
-        </KeyboardWrapper>
+        <GestureHandlerRootView style={bootStyles.providerRoot}>
+            <SafeAreaProvider>
+                <KeyboardWrapper>
+                    {coreContent}
+                </KeyboardWrapper>
+            </SafeAreaProvider>
+        </GestureHandlerRootView>
     );
 };
 


### PR DESCRIPTION
### Motivation
- OxyProvider was unwrapped from `SafeAreaProvider` and `GestureHandlerRootView` while still mounting overlay components (`BottomSheetRouter`, `SignInModal`) that call `useSafeAreaInsets` and render gesture detectors, causing consuming apps to crash if they did not mount those wrappers themselves. 
- The change restores a safe default so overlays can render reliably even when an app hasn’t mounted the native layout/gesture providers.

### Description
- Import `GestureHandlerRootView` from `react-native-gesture-handler` and `SafeAreaProvider` from `react-native-safe-area-context` into `packages/services/src/ui/components/OxyProvider.tsx` and add a full-flex `providerRoot` style. 
- Wrap the boot hydration shell with `<GestureHandlerRootView><SafeAreaProvider><KeyboardWrapper>…` so the early mount path has the same provider stack. 
- Wrap the normal provider content (QueryClient + OxyContext + overlays) with the same `<GestureHandlerRootView><SafeAreaProvider><KeyboardWrapper>…` stack and update the component doc comment to reflect the new behavior.

### Testing
- Ran `git diff --check` to validate no trailing whitespace or index issues, which reported no problems. 
- Attempted TypeScript check via `bun run --cwd packages/services typescript`, but it was blocked by dependency installation errors because `bun install` failed to fetch npm tarballs (registry returned 403), so type checks could not be completed. 
- Attempted the lint step `bun run --cwd packages/services lint`, but it was also blocked by the same dependency/CI environment issue (missing `biome` binary).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce81eec8323b131771550fc4bab)