### PR TITLE
fix(services): restore TouchableRipple onPress void return

### DIFF
--- a/packages/services/src/ui/components/TouchableRipple/TouchableRipple.native.tsx
+++ b/packages/services/src/ui/components/TouchableRipple/TouchableRipple.native.tsx
@@ -28,7 +28,7 @@ export type Props = PressableProps & {
   background?: PressableAndroidRippleConfig;
   centered?: boolean;
   disabled?: boolean;
-  onPress?: (e: GestureResponderEvent) => undefined | null;
+  onPress?: (e: GestureResponderEvent) => void | null;
   onLongPress?: (e: GestureResponderEvent) => void;
   onPressIn?: (e: GestureResponderEvent) => void;
   onPressOut?: (e: GestureResponderEvent) => void;


### PR DESCRIPTION
### Motivation
- Fix a TypeScript API compatibility regression where the native `TouchableRipple` `onPress` prop was narrowed to `undefined | null`, which made normal React Native void-returning press handlers (e.g. `() => doSomething()`) type-incompatible.

### Description
- Reverted the `onPress` prop signature to `onPress?: (e: GestureResponderEvent) => void | null` in `packages/services/src/ui/components/TouchableRipple/TouchableRipple.native.tsx` to restore correct handler assignability.

### Testing
- Ran `git diff --check` with no new whitespace or diff issues detected; full type/test runs were attempted but blocked by environment dependency resolution issues.
- Attempted `bun run --cwd packages/services typescript` but the TypeScript check failed to run cleanly due to missing workspace dependencies (reported missing `react`, `react-native`, and other types) which require a successful `bun install` first. 
- Attempted `bun install` but the install failed due to registry tarball fetch errors (HTTP 403), so type/test verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce809c48323b3631a2dc03960fe)