### PR TITLE
fix(inbox): declare imported dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -360,6 +360,8 @@
       "dependencies": {
         "@alia.onl/sdk": "3.1.0",
         "@expo/vector-icons": "^15.0.3",
+        "@hugeicons/core-free-icons": "^3.1.1",
+        "@hugeicons/react": "^1.1.4",
         "@lottiefiles/dotlottie-react": "^0.13.5",
         "@lottiefiles/dotlottie-react-native": "^0.7.1",
         "@oxyhq/bloom": "^0.20.0",
@@ -433,6 +435,7 @@
         "socket.io-client": "^4.8.1",
         "tailwind-merge": "^2.6.0",
         "zeego": "^3.0.6",
+        "zod": "^3.25.67",
         "zustand": "^5.0.9",
       },
       "devDependencies": {

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@alia.onl/sdk": "3.1.0",
     "@expo/vector-icons": "^15.0.3",
+    "@hugeicons/core-free-icons": "^3.1.1",
+    "@hugeicons/react": "^1.1.4",
     "@lottiefiles/dotlottie-react": "^0.13.5",
     "@lottiefiles/dotlottie-react-native": "^0.7.1",
     "@oxyhq/bloom": "^0.20.0",
@@ -87,6 +89,7 @@
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^2.6.0",
     "zeego": "^3.0.6",
+    "zod": "^3.25.67",
     "zustand": "^5.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
### Motivation
- Restore missing dependency declarations in the Inbox package so source imports are satisfied by the package manifest instead of relying on hoisted/transitive presence. 
- Prevent native bundling / Metro resolution failures (notably conditional `require('react-native-webview')`) and brittle installs caused by undeclared runtime imports.

### Description
- Added `@hugeicons/react`, `@hugeicons/core-free-icons`, and `zod` to `packages/inbox/package.json` dependencies so components and runtime validation imports are declared. 
- Updated the workspace lock manifest (`bun.lock`) entries for the Inbox workspace to keep the lockfile consistent with the package manifest. 
- Ensures the Inbox package is self-contained for clean installs and native/web bundling without accidental reliance on other workspace hoisting.

### Testing
- Ran a local Node check that verifies the listed modules (`react-native-webview`, `@tanstack/react-query`, `zod`, `@hugeicons/react`, `@hugeicons/core-free-icons`) are declared in `packages/inbox/package.json` and present in `bun.lock`, which succeeded. 
- Ran `git diff --check` to validate no whitespace/syntax issues, which succeeded. 
- Attempted `bun install --frozen-lockfile` to fully validate installs, but it was blocked by the environment returning `403` for registry tarball requests. 
- Attempted `bun run --filter inbox lint`, but it was blocked because `expo` is not available in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7cb548323bb2e9c0b326623c2)