### PR TITLE
fix(inbox): declare Hugeicons core dependency

### DIFF
--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@alia.onl/sdk": "3.1.0",
     "@expo/vector-icons": "^15.0.3",
+    "@hugeicons/core-free-icons": "^3.1.1",
     "@lottiefiles/dotlottie-react": "^0.13.5",
     "@lottiefiles/dotlottie-react-native": "^0.7.1",
     "@oxyhq/bloom": "^0.20.0",


### PR DESCRIPTION
### Motivation
- Inbox components import icons directly from `@hugeicons/core-free-icons` but `packages/inbox/package.json` did not declare that dependency, which can break isolated package installs or stricter package managers.

### Description
- Add `@hugeicons/core-free-icons` `^3.1.1` to `packages/inbox/package.json` dependencies so the Inbox workspace declares the icons it imports.

### Testing
- Verified the dependency string with `node -e "const pkg=require('./packages/inbox/package.json'); if (pkg.dependencies['@hugeicons/core-free-icons'] !== '^3.1.1') process.exit(1); console.log(pkg.dependencies['@hugeicons/core-free-icons']);"` which succeeded; `git diff --check` produced no whitespace errors; an attempted `bun install --lockfile-only` could not complete due to external npm registry `403` responses so no lockfile changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce87d0c832394fbb01bc8eb70c6)