### PR TITLE
fix(core): return narrowed cached user id

### DIFF
--- a/packages/core/src/OxyServices.base.ts
+++ b/packages/core/src/OxyServices.base.ts
@@ -287,8 +287,9 @@ export class OxyServicesBase {
 
     try {
       const decoded = jwtDecode<JwtPayload>(accessToken);
-      this._cachedUserId = decoded.userId || decoded.id || null;
-      return this._cachedUserId;
+      const userId = decoded.userId || decoded.id || null;
+      this._cachedUserId = userId;
+      return userId;
     } catch {
       this._cachedUserId = null;
       return null;


### PR DESCRIPTION
### Motivation
- Fix a TypeScript strict-mode reliability bug where `getCurrentUserId()` could be inferred to return `undefined` because the cache field `_cachedUserId` is typed `string | null | undefined` and was returned directly.

### Description
- In `packages/core/src/OxyServices.base.ts` assign the decoded id to a local `userId: string | null`, set `this._cachedUserId = userId`, and `return userId` so the method cannot return the cache's `undefined` sentinel.

### Testing
- Attempted `bun run core:build` and `bun run --cwd packages/core lint`; both could not complete in this environment (`tsc` surfaced TypeScript 6 config/deprecation/rootDir issues and `biome` was not installed), so the change could not be validated by a full build/lint run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce9d5f88323bbfb4f2d99627a21)