### PR TITLE
fix(auth-sdk): use static AsyncStorage import

### DIFF
--- a/packages/auth-sdk/package.json
+++ b/packages/auth-sdk/package.json
@@ -78,6 +78,7 @@
     "@oxyhq/contracts": "^0.2.0"
   },
   "peerDependencies": {
+    "@react-native-async-storage/async-storage": "*",
     "@oxyhq/core": "^3.8.0",
     "@tanstack/query-sync-storage-persister": "^5.100",
     "@tanstack/react-query": "^5.100",
@@ -88,6 +89,9 @@
     "zustand": "^5.0.9"
   },
   "peerDependenciesMeta": {
+    "@react-native-async-storage/async-storage": {
+      "optional": true
+    },
     "socket.io-client": {
       "optional": true
     },
@@ -96,6 +100,7 @@
     }
   },
   "devDependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@biomejs/biome": "^1.9.4",
     "@types/react": "^19.2.0",
     "@types/node": "^20.19.9",

--- a/packages/auth-sdk/src/utils/storageHelpers.ts
+++ b/packages/auth-sdk/src/utils/storageHelpers.ts
@@ -115,9 +115,9 @@ const createNativeStorage = async (): Promise<StorageInterface> => {
   }
 
   try {
-    // Variable indirection prevents bundlers (Vite, webpack) from statically resolving this
-    const moduleName = '@react-native-async-storage/async-storage';
-    const asyncStorageModule = (await import(moduleName)) as { default?: unknown };
+    const asyncStorageModule = (await import('@react-native-async-storage/async-storage')) as {
+      default?: unknown;
+    };
     const candidate = asyncStorageModule.default;
     if (!isAsyncStorageLike(candidate)) {
       throw new Error('AsyncStorage default export does not match expected API');


### PR DESCRIPTION
### Motivation
- Restore Metro/Expo bundler compatibility for React Native by ensuring native-only modules are referenced with static specifiers so they are discovered and included in RN bundles.

### Description
- Replaced the variable-based dynamic import of `@react-native-async-storage/async-storage` in `packages/auth-sdk/src/utils/storageHelpers.ts` with a literal dynamic import `import('@react-native-async-storage/async-storage')` so Metro can statically detect the dependency.
- Added `@react-native-async-storage/async-storage` as an optional peer dependency and as a dev dependency in `packages/auth-sdk/package.json` to document the native requirement for RN consumers without forcing web consumers to install it.

### Testing
- Verified absence/presence of nonliteral imports with `rg "const moduleName|import(moduleName)|require(moduleName)" packages/core/src packages/auth-sdk/src -n` and confirmed the auth SDK loader now uses a literal import.
- Ran `git diff --check` to ensure no whitespace/patch issues were introduced and the diff is clean.
- Attempted `bun run lint`, `bun run build`, and `bun run test` but they could not complete in this environment due to missing tool binaries or local TypeScript/config constraints, so those full suites were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce9d674832390a27b916776a9c3)