### PR TITLE
Add root heroku-postbuild to build API during Heroku/buildpack deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build:all": "turbo run build",
     "build:workspaces": "bun run build --filter '*'",
+    "heroku-postbuild": "bun run api:build",
     "start": "cd packages/api && node dist/server.js",
     "dev": "turbo run dev",
     "test": "turbo run test",


### PR DESCRIPTION
### Motivation
- Heroku/buildpack-style deployments launch the Procfile which runs `cd packages/api && npm start`, and the API expects compiled `packages/api/dist/server.js` to exist so the app must be built during the build lifecycle.

### Description
- Added a root `heroku-postbuild` lifecycle script to `package.json` that runs `bun run api:build`, ensuring `packages/api` is compiled before the Procfile starts the server.

### Testing
- Verified the new script value with `node -e "const pkg=require('./package.json'); if(pkg.scripts['heroku-postbuild'] !== 'bun run api:build') process.exit(1); console.log(pkg.scripts['heroku-postbuild'])"` which succeeded.
- Attempted `npm run heroku-postbuild` to build the API end-to-end, but the run was blocked in this environment due to missing/uninstallable dependencies (registry fetches returned `403`) and a global TypeScript mismatch, so the build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7c08c8323bf175c239b201dbd)