### PR TITLE
fix(core): guard AuthManager localStorage selection

### DIFF
--- a/packages/core/src/AuthManager.ts
+++ b/packages/core/src/AuthManager.ts
@@ -445,8 +445,14 @@ export class AuthManager {
    * Get default storage based on environment.
    */
   private getDefaultStorage(): StorageAdapter {
-    if (typeof window !== 'undefined' && window.localStorage) {
-      return new LocalStorageAdapter();
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        return new LocalStorageAdapter();
+      }
+    } catch {
+      // Accessing window.localStorage can throw in opaque-origin/sandboxed
+      // browser contexts or when storage is disabled. Fall back to memory so
+      // AuthManager construction remains safe during provider render.
     }
     return new MemoryStorage();
   }

--- a/packages/core/src/__tests__/authManager.security.test.ts
+++ b/packages/core/src/__tests__/authManager.security.test.ts
@@ -164,6 +164,37 @@ describe('AuthManager.switchAuthuser — concurrency lock', () => {
   });
 });
 
+describe('AuthManager default storage selection', () => {
+  const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+  afterEach(() => {
+    if (originalWindow) {
+      Object.defineProperty(globalThis, 'window', originalWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  });
+
+  it('falls back to memory storage when localStorage access throws', () => {
+    const blockedWindow = {};
+    Object.defineProperty(blockedWindow, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('Blocked localStorage', 'SecurityError');
+      },
+    });
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: blockedWindow,
+    });
+
+    expect(() => new AuthManager(makeMockServices() as unknown as OxyServices, {
+      autoRefresh: false,
+      crossTabSync: false,
+    })).not.toThrow();
+  });
+});
+
 describe('AuthManager.switchAuthuser — hydration of unknown slots', () => {
   it('hydrates a slot with no prior user metadata via getCurrentUser()', async () => {
     const services = makeMockServices();


### PR DESCRIPTION
### Motivation
- The `AuthManager` default storage selection accessed `window.localStorage` during construction, which can throw a `SecurityError` in sandboxed/opaque-origin or storage-blocked browser contexts and crash providers that construct it during render (e.g. `WebOxyProvider`).

### Description
- Wrap the `window.localStorage` availability check in `getDefaultStorage()` with a `try/catch` and fall back to `MemoryStorage` when access throws, preserving behavior in normal browsers while avoiding render-time exceptions (`packages/core/src/AuthManager.ts`).
- Add a regression unit test that stubs `globalThis.window.localStorage` to throw a `DOMException` and verifies `new AuthManager(...)` does not throw during construction (`packages/core/src/__tests__/authManager.security.test.ts`).

### Testing
- Ran `git diff --check` locally to validate no whitespace errors; it passed.
- Attempted to run unit tests (`bun run test -- authManager.security.test.ts`) but test execution was blocked because `bun install` failed to fetch registry tarballs (HTTP 403), so `jest` and other deps were not available; tests could not be executed in this environment.
- Added and committed the fix and test to the branch; tests should pass in CI or a developer environment with network access and dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce81ff08323b2fecbcd45d8ce4a)