### PR TITLE
fix: align iOS keychain group with Expo docs

### DIFF
--- a/packages/core/src/crypto/__tests__/keyManager.test.ts
+++ b/packages/core/src/crypto/__tests__/keyManager.test.ts
@@ -33,10 +33,10 @@ jest.mock(
       __esModule: true,
       WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
       WHEN_UNLOCKED: 'WHEN_UNLOCKED',
-      setItemAsync: jest.fn(async (key: string, value: string) => {
+      setItemAsync: jest.fn(async (key: string, value: string, _options?: unknown) => {
         store.set(key, value);
       }),
-      getItemAsync: jest.fn(async (key: string) => store.get(key) ?? null),
+      getItemAsync: jest.fn(async (key: string, _options?: unknown) => store.get(key) ?? null),
       deleteItemAsync: jest.fn(async (key: string) => {
         store.delete(key);
       }),
@@ -144,6 +144,25 @@ describe('KeyManager safety invariants', () => {
       expect(m.get('oxy_identity_backup_private_key')).toBeTruthy();
       expect(m.get('oxy_identity_backup_public_key')).toBeTruthy();
       expect(m.get('oxy_identity_backup_timestamp')).toBeTruthy();
+    });
+
+    it('persists iOS shared identity keys with the documented keychain access group', async () => {
+      await KeyManager.createIdentity();
+
+      const store = (await import('expo-secure-store' as string)) as unknown as {
+        setItemAsync: jest.Mock;
+      };
+
+      expect(store.setItemAsync).toHaveBeenCalledWith(
+        'oxy_shared_identity_private_key',
+        expect.any(String),
+        expect.objectContaining({ keychainAccessGroup: 'group.so.oxy.shared' }),
+      );
+      expect(store.setItemAsync).toHaveBeenCalledWith(
+        'oxy_shared_identity_public_key',
+        expect.any(String),
+        expect.objectContaining({ keychainAccessGroup: 'group.so.oxy.shared' }),
+      );
     });
 
     it('refuses to overwrite an existing identity without explicit consent', async () => {

--- a/packages/core/src/crypto/keyManager.ts
+++ b/packages/core/src/crypto/keyManager.ts
@@ -85,9 +85,9 @@ const STORAGE_KEYS = {
 /**
  * iOS Keychain Access Group for sharing identities across Oxy apps
  * All Oxy apps must have this access group enabled in their entitlements
- * Format: [Team ID].com.oxy.shared or group.com.oxy.shared
+ * Format: [Team ID].group.so.oxy.shared or group.so.oxy.shared
  */
-const IOS_KEYCHAIN_GROUP = 'group.com.oxy.shared';
+const IOS_KEYCHAIN_GROUP = 'group.so.oxy.shared';
 
 /**
  * Android Account Manager type for shared authentication


### PR DESCRIPTION
### Motivation
- The Expo 54 guide and other docs were changed to instruct `group.so.oxy.shared` for iOS Keychain Sharing while the runtime constant still used `group.com.oxy.shared`, causing entitlement mismatches that break cross-app shared identities/sessions on iOS.
- Aligning the SDK runtime value with the documented entitlement prevents `errSecMissingEntitlement` and preserves cross-app SSO compatibility for apps that follow the guide.

### Description
- Updated the iOS keychain access group constant from `group.com.oxy.shared` to `group.so.oxy.shared` in `packages/core/src/crypto/keyManager.ts` so runtime requests match the docs.
- Added a regression unit test `persists iOS shared identity keys with the documented keychain access group` to `packages/core/src/crypto/__tests__/keyManager.test.ts` that asserts `expo-secure-store` calls include `keychainAccessGroup: 'group.so.oxy.shared'` when writing shared identity keys.
- Adjusted the mocked `expo-secure-store` signatures in the test to accept optional `options` so the test can assert on the `keychainAccessGroup` option.
- Changes touch `packages/core/src/crypto/keyManager.ts` and `packages/core/src/crypto/__tests__/keyManager.test.ts` and align runtime behavior with the existing `docs/EXPO_54_GUIDE.md` documentation.

### Testing
- Ran repository checks including `rg`/search for `group.so.oxy.shared`/`group.com.oxy.shared` and `git diff --check`, which showed the updated occurrences and no diff issues.
- Attempted to run the package test via `bun run test` / `jest` for the modified test, but the environment is missing `jest` so the unit test could not be executed here (test run blocked). 
- No runtime or integration test failures observed from local static checks; the added unit test is intended to be executed in CI where `jest` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8a3e88323b579ce29bb635bac)