### PR TITLE
fix: align iOS keychain group with native docs

### DIFF
--- a/packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts
+++ b/packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts
@@ -22,6 +22,11 @@ import { setPlatformOS } from '../../utils/platform';
 // specific (op, key) pair throw to simulate a keychain that fails mid-write or
 // is transiently locked.
 const failPlan: { failKey?: string; failOp?: 'set' | 'get' } = {};
+const setCalls: Array<{
+  key: string;
+  value: string;
+  options?: Record<string, unknown>;
+}> = [];
 
 jest.mock(
   'expo-secure-store',
@@ -36,8 +41,9 @@ jest.mock(
       __esModule: true,
       WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'WHEN_UNLOCKED_THIS_DEVICE_ONLY',
       WHEN_UNLOCKED: 'WHEN_UNLOCKED',
-      setItemAsync: jest.fn(async (key: string, value: string) => {
+      setItemAsync: jest.fn(async (key: string, value: string, options?: Record<string, unknown>) => {
         maybeFail('set', key);
+        setCalls.push({ key, value, options });
         store.set(key, value);
       }),
       getItemAsync: jest.fn(async (key: string) => {
@@ -51,7 +57,9 @@ jest.mock(
         store.clear();
         failPlan.failKey = undefined;
         failPlan.failOp = undefined;
+        setCalls.length = 0;
       },
+      __getSetCalls__: () => setCalls,
       __getStore__: () => store,
       __failPlan__: failPlan,
     };
@@ -92,6 +100,11 @@ jest.mock('../../utils/platformCrypto', () => ({
 interface SecureStoreTestHandle {
   __resetStore__: () => void;
   __getStore__: () => Map<string, string>;
+  __getSetCalls__: () => Array<{
+    key: string;
+    value: string;
+    options?: Record<string, unknown>;
+  }>;
   __failPlan__: { failKey?: string; failOp?: 'set' | 'get' };
 }
 
@@ -117,6 +130,22 @@ describe('KeyManager atomicity & recoverability under flaky storage', () => {
     const km = await import('../keyManager');
     KeyManager = km.KeyManager;
     resetCaches();
+  });
+
+  it('uses the documented iOS keychain access group for shared identity writes', async () => {
+    await KeyManager.createSharedIdentity();
+    const ss = (await import('expo-secure-store' as string)) as unknown as SecureStoreTestHandle;
+
+    const sharedWrites = ss
+      .__getSetCalls__()
+      .filter(
+        (call) => call.key === 'oxy_shared_identity_private_key' || call.key === 'oxy_shared_identity_public_key',
+      );
+
+    expect(sharedWrites).toHaveLength(2);
+    expect(
+      sharedWrites.every((call) => call.options?.keychainAccessGroup === 'group.so.oxy.shared'),
+    ).toBe(true);
   });
 
   it('a failed OVERWRITE leaves the ORIGINAL identity intact and recoverable (no silent switch)', async () => {

--- a/packages/core/src/crypto/keyManager.ts
+++ b/packages/core/src/crypto/keyManager.ts
@@ -85,9 +85,9 @@ const STORAGE_KEYS = {
 /**
  * iOS Keychain Access Group for sharing identities across Oxy apps
  * All Oxy apps must have this access group enabled in their entitlements
- * Format: [Team ID].com.oxy.shared or group.com.oxy.shared
+ * Format: [Team ID].so.oxy.shared or group.so.oxy.shared
  */
-const IOS_KEYCHAIN_GROUP = 'group.com.oxy.shared';
+const IOS_KEYCHAIN_GROUP = 'group.so.oxy.shared';
 
 /**
  * Android Account Manager type for shared authentication


### PR DESCRIPTION
### Motivation

- The repository documentation was changed to instruct iOS entitlements use `group.so.oxy.shared` while the SDK still hard-coded `group.com.oxy.shared`, causing shared-keychain writes to fail with entitlement mismatch on iOS and breaking native cross-app SSO.

### Description

- Update `IOS_KEYCHAIN_GROUP` in `packages/core/src/crypto/keyManager.ts` to `'group.so.oxy.shared'` and adjust the explanatory comment to match the documented format.
- Extend the test SecureStore mock in `packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts` to record `setItemAsync` calls and their options.
- Add a regression test in `packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts` that asserts shared identity writes pass `keychainAccessGroup: 'group.so.oxy.shared'` to SecureStore.

### Testing

- Verified repository references with `rg -n "group\.com\.oxy\.shared|group\.so\.oxy\.shared|IOS_KEYCHAIN_GROUP"` and confirmed the constant and tests now reference `group.so.oxy.shared` (search succeeded).
- Ran `git diff --check` to ensure no whitespace or diff issues (succeeded).
- Attempted to run the package test with `bun run --cwd packages/core test -- keyManager.atomicity.test.ts`, but the container environment lacks `jest`/dependencies so the test run could not be executed here; CI/package-local test runs should run this test successfully when dependencies are installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce90efc83238076006b9adf1df4)