### PR TITLE
fix: guard dev checks in session error paths

### DIFF
--- a/packages/services/src/ui/components/AccountMenu.tsx
+++ b/packages/services/src/ui/components/AccountMenu.tsx
@@ -19,7 +19,7 @@ import { useTheme } from '@oxyhq/bloom/theme';
 import Avatar from './Avatar';
 import { useOxy } from '../context/OxyContext';
 import { useI18n } from '../hooks/useI18n';
-import { logger as loggerUtil } from '@oxyhq/core';
+import { isDev, logger as loggerUtil } from '@oxyhq/core';
 import { buildAccountRows, type AccountRow } from './accountMenuRows';
 import { useDeviceAccounts } from '../hooks/useDeviceAccounts';
 
@@ -135,7 +135,7 @@ const AccountMenu: React.FC<AccountMenuProps> = ({
             toast.success(t('accountSwitcher.toasts.switchSuccess') || 'Switched account');
             onClose();
         } catch (error) {
-            if (!__DEV__) {
+            if (!isDev()) {
                 loggerUtil.warn('Switch account failed', { component: 'AccountMenu' }, error as unknown);
             }
             toast.error(t('accountSwitcher.toasts.switchFailed') || 'Failed to switch account');

--- a/packages/services/src/ui/hooks/useSessionManagement.ts
+++ b/packages/services/src/ui/hooks/useSessionManagement.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ApiError, User } from '@oxyhq/core';
+import { isDev, type ApiError, type User } from '@oxyhq/core';
 import type { ClientSession } from '@oxyhq/core';
 import { mergeSessions, normalizeAndSortSessions, sessionsArraysEqual } from '@oxyhq/core';
 import { fetchSessionsWithFallback, validateSessionBatch } from '../utils/sessionHelpers';
@@ -86,7 +86,7 @@ export const useSessionManagement = ({
       } catch (error) {
         if (logger) {
           logger(DEFAULT_SAVE_ERROR_MESSAGE, error);
-        } else if (__DEV__) {
+        } else if (isDev()) {
           console.warn('Failed to save session IDs:', error);
         }
       }
@@ -309,7 +309,7 @@ export const useSessionManagement = ({
           });
           updateSessions(deviceSessions, { merge: true });
         } catch (error) {
-          if (__DEV__) {
+          if (isDev()) {
             console.warn('Failed to synchronize sessions after switch:', error);
           }
         }


### PR DESCRIPTION
### Motivation
- A ReferenceError can be thrown when catch blocks reference the ambient `__DEV__` global in runtimes (web bundlers/non-Metro) that do not define it, which breaks intended error-toasting and availability of session-management flows.
- The project already exports a safe helper `isDev()` from `@oxyhq/core` that performs a guarded development-mode check and should be used instead of direct `__DEV__` references.

### Description
- Replaced direct `__DEV__` checks with the safe `isDev()` helper imported from `@oxyhq/core` in `packages/services/src/ui/hooks/useSessionManagement.ts` to guard dev-only logging in session persistence and sync error paths.
- Updated account-switch failure handling in `packages/services/src/ui/components/AccountMenu.tsx` to use `isDev()` before calling the logger so the user-facing `toast.error` always runs even when `__DEV__` is undefined.
- Changes are minimal and preserve existing behavior in Metro/Expo while preventing ReferenceError crashes in non-Metro web runtimes.

### Testing
- Ran `git diff --check` to ensure no whitespace or patch issues and it passed successfully.
- Attempted to run package tests via `bun run --cwd packages/services test -- --runInBand useSessionManagement AccountMenu`, but the command failed because `jest` was not available in the environment (`command not found`).
- Attempted `bun install` to install test deps, but it failed due to npm registry responses returning `403`, so automated test execution in this environment was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce7b9c48323a64e905b7d2a3144)