### PR TITLE
Fix: persist phone/address/birthday from personal-info editor

### DIFF
--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -162,6 +162,8 @@ export interface IUser extends Document {
   };
   bio?: string;
   description?: string;
+  address?: string;
+  birthday?: string;
   locations?: Array<{
     id: string;
     name: string;
@@ -448,6 +450,8 @@ const UserSchema: Schema = new Schema(
     },
     bio: { type: String },
     description: { type: String },
+    address: { type: String, trim: true },
+    birthday: { type: String, trim: true },
     locations: [{
       id: { type: String, required: true },
       name: { type: String, required: true },

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -230,7 +230,10 @@ router.get(
     }
 
     logger.debug('GET /users/me', { userId: req.user.id });
-    sendSuccess(res, userService.formatUserResponse(user));
+    sendSuccess(
+      res,
+      userService.formatUserResponse(user, undefined, { includePrivateFields: true })
+    );
   })
 );
 
@@ -339,7 +342,10 @@ router.put(
         updatedFields: Object.keys(req.body),
       });
 
-      sendSuccess(res, userService.formatUserResponse(updatedUser));
+      sendSuccess(
+        res,
+        userService.formatUserResponse(updatedUser, undefined, { includePrivateFields: true })
+      );
     } catch (error) {
       // Handle known errors from service layer
       if (error instanceof Error) {

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -123,7 +123,7 @@ export class UserService {
   async getCurrentUser(userId: string): Promise<IUser | null> {
     // `lean({ virtuals: true })` populates `name.full` from the User schema virtual.
     return await User.findById(userId)
-      .select('-password -refreshToken')
+      .select('-password -refreshToken +phone')
       .lean({ virtuals: true }) as IUser | null;
   }
 
@@ -145,6 +145,9 @@ export class UserService {
       'color',
       'bio',
       'description',
+      'phone',
+      'address',
+      'birthday',
       'links',
       'linksMetadata',
       'locations',
@@ -937,7 +940,11 @@ export class UserService {
   /**
    * Format user response with stats
    */
-  formatUserResponse(user: IUser | UserProfile, stats?: UserStatistics): PublicUserProfile {
+  formatUserResponse(
+    user: IUser | UserProfile,
+    stats?: UserStatistics,
+    options: { includePrivateFields?: boolean } = {}
+  ): PublicUserProfile {
     // Handle both IUser (Mongoose document) and UserData (plain object)
     // Use publicKey as id - publicKey is the primary identifier, fallback to _id
     const userAsIUser = user as IUser;
@@ -965,6 +972,12 @@ export class UserService {
       createdAt: userAny.createdAt as Date | undefined,
       updatedAt: userAny.updatedAt as Date | undefined,
     };
+
+    if (options.includePrivateFields) {
+      response.phone = userAny.phone as string | undefined;
+      response.address = userAny.address as string | undefined;
+      response.birthday = userAny.birthday as string | undefined;
+    }
 
     if (userAny.type) {
       response.type = userAny.type;

--- a/packages/contracts/src/userResponse.ts
+++ b/packages/contracts/src/userResponse.ts
@@ -95,6 +95,9 @@ export const userResponseSchema = z
         publicKey: z.string().optional(),
         username: z.string().optional(),
         email: z.string().optional(),
+        phone: z.string().optional(),
+        address: z.string().optional(),
+        birthday: z.string().optional(),
         /** Avatar file id (string) or null. */
         avatar: z.string().nullable().optional(),
         /** Named Bloom color preset (e.g. `"blue"`) or null. */
@@ -121,6 +124,9 @@ export const userProfileUpdateSchema = z
         color: z.string().nullable().optional(),
         bio: z.string().optional(),
         description: z.string().optional(),
+        phone: z.string().optional(),
+        address: z.string().optional(),
+        birthday: z.string().optional(),
         location: z.string().optional(),
         locations: z.array(z.unknown()).optional(),
         links: z.array(z.string()).optional(),

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -113,6 +113,9 @@ export interface User {
    */
   name: UserNameResponse;
   bio?: string;
+  phone?: string;
+  address?: string;
+  birthday?: string;
   location?: string;
   website?: string;
   createdAt?: string;

--- a/packages/services/src/ui/hooks/useProfileEditing.ts
+++ b/packages/services/src/ui/hooks/useProfileEditing.ts
@@ -29,6 +29,9 @@ export interface ProfileUpdateData {
     links?: string[];
     linksMetadata?: ProfileLinkMetadata[];
     avatar?: string;
+    phone?: string;
+    address?: string;
+    birthday?: string;
 }
 
 type ProfileFieldValue = string | ProfileLocation[] | ProfileLinkMetadata[];
@@ -81,6 +84,15 @@ export const useProfileEditing = () => {
         if (updates.avatar !== undefined) {
             updateData.avatar = updates.avatar;
         }
+        if (updates.phone !== undefined) {
+            updateData.phone = updates.phone;
+        }
+        if (updates.address !== undefined) {
+            updateData.address = updates.address;
+        }
+        if (updates.birthday !== undefined) {
+            updateData.birthday = updates.birthday;
+        }
 
         // Handle name field
         if (updates.firstName !== undefined || updates.lastName !== undefined) {
@@ -123,6 +135,18 @@ export const useProfileEditing = () => {
             case 'bio':
                 if (typeof value !== 'string') return false;
                 updates.bio = value;
+                break;
+            case 'phone':
+                if (typeof value !== 'string') return false;
+                updates.phone = value;
+                break;
+            case 'address':
+                if (typeof value !== 'string') return false;
+                updates.address = value;
+                break;
+            case 'birthday':
+                if (typeof value !== 'string') return false;
+                updates.birthday = value;
                 break;
             case 'location':
                 if (!isProfileLocationArray(value)) return false;


### PR DESCRIPTION
### Motivation
- The personal-info editor exposed `phone`, `address`, and `birthday` fields but the client-side save path and server allowlist did not include those keys, causing silent no-ops when users tried to save them. The change wires the UI → SDK → API path so these fields persist.

### Description
- Wire client save/update flow: `useProfileEditing.saveProfile` and `updateField` now include `phone`, `address`, and `birthday` when building the `UserProfileUpdate` payload (`packages/services/src/ui/hooks/useProfileEditing.ts`).
- API model and persistence: add `address` and `birthday` fields to the `IUser` model and schema; `phone` already exists and is now selected for authenticated reads (`packages/api/src/models/User.ts`).
- Server allowlist and response shaping: add `phone`, `address`, and `birthday` to the profile update allowlist and include them in `formatUserResponse` only when returning authenticated `/users/me` responses via an `includePrivateFields` option (`packages/api/src/services/user.service.ts`, `packages/api/src/routes/users.ts`).
- Contracts and types: expose the new fields in the shared contract `UserProfileUpdate` / `UserResponse` and the core `User` interface so client + server agree on shapes (`packages/contracts/src/userResponse.ts`, `packages/core/src/models/interfaces.ts`).

### Testing
- `git diff --check` passed locally.
- `bun run services:build` was attempted but blocked by an external npm registry 403 for `react-native-builder-bob` so the services build could not complete.
- `bun run core:build` and `bun run --filter @oxyhq/api build` were attempted but blocked by existing TypeScript configuration deprecation/rootDir issues in the environment, so the TypeScript builds could not complete.
- Package tests (`bun run --filter @oxyhq/api test`, `bun run --filter @oxyhq/contracts test`) could not be run because `jest` is not available in the execution environment, so automated unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8a3a083238f088d941636849b)