### PR TITLE
fix(services): include link metadata descriptions

### DIFF
--- a/packages/services/src/ui/screens/EditProfileFieldScreen.tsx
+++ b/packages/services/src/ui/screens/EditProfileFieldScreen.tsx
@@ -71,6 +71,9 @@ type EditableListItem = {
     coordinates?: { lat: number; lon: number };
 };
 
+const getLinkTitle = (url: string) => url.replace(/^https?:\/\//, '').replace(/\/$/, '');
+const getLinkDescription = (url: string) => `Link to ${url}`;
+
 /**
  * EditProfileFieldScreen - A dedicated screen for editing profile fields
  *
@@ -282,14 +285,16 @@ const EditProfileFieldScreen: React.FC<EditProfileFieldScreenProps> = ({
                         ...link,
                         id: String(link.id || `link-${i}`),
                         url: String(link.url || ''),
-                        title: String(link.title || ''),
+                        title: String(link.title || getLinkTitle(String(link.url || ''))),
+                        description: String(link.description || getLinkDescription(String(link.url || ''))),
                     })));
                 } else {
                     setListItems(links.map((item, i) => {
                         return {
                             id: `link-${i}`,
                             url: item,
-                            title: item.replace(/^https?:\/\//, '').replace(/\/$/, ''),
+                            title: getLinkTitle(item),
+                            description: getLinkDescription(item),
                         };
                     }));
                 }
@@ -354,7 +359,8 @@ const EditProfileFieldScreen: React.FC<EditProfileFieldScreenProps> = ({
             const newItem = {
                 id: `link-${Date.now()}`,
                 url: newItemValue.trim(),
-                title: newItemValue.replace(/^https?:\/\//, '').replace(/\/$/, ''),
+                title: getLinkTitle(newItemValue.trim()),
+                description: getLinkDescription(newItemValue.trim()),
             };
             setListItems(prev => [...prev, newItem]);
         }
@@ -384,8 +390,8 @@ const EditProfileFieldScreen: React.FC<EditProfileFieldScreenProps> = ({
                     linksMetadata: listItems.map(item => ({
                         id: item.id,
                         url: String(item.url || ''),
-                        ...(item.title !== undefined && { title: String(item.title) }),
-                        ...(item.description !== undefined && { description: String(item.description) }),
+                        title: String(item.title || getLinkTitle(String(item.url || ''))),
+                        description: String(item.description || getLinkDescription(String(item.url || ''))),
                         ...(item.image !== undefined && { image: String(item.image) }),
                     })),
                     links: listItems.map(item => String(item.url || '')),


### PR DESCRIPTION
### Motivation
- A refactor replaced the old Edit Links modal with `EditProfileFieldScreen` but stopped populating the `description` field for new links, causing server-side Mongoose validation (which requires `linksMetadata.description`) to fail when saving profile links.
- Restore a harmless client-side fallback so links created/converted in the UI always satisfy the backend schema and preserve existing UX.

### Description
- Added helper fallbacks `getLinkTitle` and `getLinkDescription` and used them to normalize link items in `packages/services/src/ui/screens/EditProfileFieldScreen.tsx`.
- When initializing list items from `user.linksMetadata` or legacy `user.links`, ensure each item has `title` and `description` before editing.
- When adding a new link and when building the `linksMetadata` save payload, ensure `title` and `description` are present (use fallbacks if missing) so the API receives valid objects.

### Testing
- Verified source-level assertions with a small Node check that the description fallback snippets are present in `EditProfileFieldScreen.tsx` and `git diff --check` returned clean results.
- Attempted `bun run lint`, `bun run typescript`, and `bun run test` in `packages/services`, but those commands are blocked in this environment due to missing local toolchain/dependencies (`biome`, React/RN peers, `jest`), so full type/run tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce89f1483239266111a0e4e893d)