### PR TITLE
fix: make account data export return Blobs and avoid calling non-existent history endpoint

### DIFF
--- a/packages/accounts/app/(tabs)/data.tsx
+++ b/packages/accounts/app/(tabs)/data.tsx
@@ -201,37 +201,16 @@ export default function DataScreen() {
     },
   ], [colors, dataSharing, locationSharing, analyticsSharing, showActivity, handlePrivacyUpdate, pendingPrivacyKey, t]);
 
-  // Handle clear history
-  const handleClearHistory = useCallback(async (type: 'activity' | 'location') => {
-    const title = type === 'activity' ? t('data.activity.clearActivityTitle') : t('data.activity.clearLocationTitle');
+  // Handle clear history. Keep this as an informational action until the API
+  // exposes scoped deletion endpoints for activity and location history.
+  const handleClearHistory = useCallback((type: 'activity' | 'location') => {
+    const title = type === 'activity' ? t('data.activity.activityHistory') : t('data.activity.locationHistory');
     const message = type === 'activity'
-      ? t('data.activity.clearActivityMessage')
-      : t('data.activity.clearLocationMessage');
+      ? t('data.activity.activityHistoryUnavailable')
+      : t('data.activity.locationHistoryUnavailable');
 
-    alert(title, message, [
-      { text: t('common.cancel'), style: 'cancel' },
-      {
-        text: t('data.activity.clear'),
-        style: 'destructive',
-        onPress: async () => {
-          if (!oxyServices) return;
-          try {
-            await oxyServices.clearUserHistory();
-            const successMessage = type === 'activity'
-              ? t('data.activity.clearedActivity')
-              : t('data.activity.clearedLocation');
-            toast.success(successMessage);
-          } catch (error) {
-            const fallback = type === 'activity'
-              ? t('data.activity.clearFailedActivity')
-              : t('data.activity.clearFailedLocation');
-            const message = error instanceof Error ? error.message : fallback;
-            toast.error(message);
-          }
-        },
-      },
-    ]);
-  }, [alert, oxyServices, t]);
+    alert(title, message, [{ text: t('common.ok') }]);
+  }, [alert, t]);
 
   // Activity management section
   const activityItems = useMemo(() => [

--- a/packages/accounts/lib/i18n/locales/en.json
+++ b/packages/accounts/lib/i18n/locales/en.json
@@ -408,8 +408,10 @@
     "activity": {
       "activityHistory": "Activity history",
       "activityHistorySubtitle": "View and manage your activity history",
+      "activityHistoryUnavailable": "Activity history management is not available yet.",
       "locationHistory": "Location history",
       "locationHistorySubtitle": "View and manage your location data",
+      "locationHistoryUnavailable": "Location history management is not available yet.",
       "clearActivityTitle": "Clear Activity History",
       "clearLocationTitle": "Clear Location History",
       "clearActivityMessage": "This will permanently delete all your activity history. This action cannot be undone.",

--- a/packages/accounts/lib/i18n/locales/es.json
+++ b/packages/accounts/lib/i18n/locales/es.json
@@ -408,8 +408,10 @@
     "activity": {
       "activityHistory": "Historial de actividad",
       "activityHistorySubtitle": "Consulta y gestiona tu historial de actividad",
+      "activityHistoryUnavailable": "La gestión del historial de actividad aún no está disponible.",
       "locationHistory": "Historial de ubicación",
       "locationHistorySubtitle": "Consulta y gestiona tus datos de ubicación",
+      "locationHistoryUnavailable": "La gestión del historial de ubicación aún no está disponible.",
       "clearActivityTitle": "Borrar historial de actividad",
       "clearLocationTitle": "Borrar historial de ubicación",
       "clearActivityMessage": "Esto eliminará permanentemente todo tu historial de actividad. Esta acción no se puede deshacer.",

--- a/packages/core/src/HttpService.ts
+++ b/packages/core/src/HttpService.ts
@@ -68,6 +68,7 @@ export interface RequestOptions {
   timeout?: number;
   signal?: AbortSignal;
   headers?: Record<string, string>;
+  responseType?: 'blob';
 }
 
 interface RequestConfig extends RequestOptions {
@@ -568,7 +569,9 @@ export class HttpService {
         const contentType = response.headers.get('content-type');
         let responseData: unknown;
         
-        if (contentType && contentType.includes('application/json')) {
+        if (config.responseType === 'blob') {
+          responseData = await response.blob();
+        } else if (contentType && contentType.includes('application/json')) {
           // Use response.json() directly for better performance
           try {
             responseData = await response.json();

--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -555,6 +555,7 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
           url: `/users/me/data`,
           params: { format },
           cache: false,
+          responseType: 'blob',
         });
         
         return result;


### PR DESCRIPTION
### Motivation
- The web data export UI passed the result of `oxyServices.downloadAccountData()` directly to `URL.createObjectURL()`, but the generic HTTP layer parsed `application/json` and `text/csv` responses into objects/strings instead of returning a `Blob`, causing `TypeError` at download time. 
- Activity and Location history UI actions invoked a generic `clearUserHistory()` that issued `DELETE /history`, but the API in this repository does not mount a generic `/history` endpoint and scoped deletion endpoints do not exist, so the UI was performing a nonfunctional/destructive action.

### Description
- Add a `responseType?: 'blob'` option to the core `RequestOptions` and handle `config.responseType === 'blob'` in `HttpService` by calling `response.blob()` before JSON/text parsing so callers can explicitly request raw `Blob` bodies. (`packages/core/src/HttpService.ts`)
- Request account data exports with `responseType: 'blob'` in `downloadAccountData()` so `/users/me/data?format=` responses are returned as `Blob`s and can be consumed by `URL.createObjectURL()` or native sharing. (`packages/core/src/mixins/OxyServices.user.ts`)
- Replace the destructive history-clear flow in the accounts DataScreen with an informational alert until scoped API endpoints for activity/location deletion exist, preventing accidental calls to a non-mounted endpoint. (`packages/accounts/app/(tabs)/data.tsx`)
- Add English and Spanish copy keys for the informational messages. (`packages/accounts/lib/i18n/locales/en.json`, `packages/accounts/lib/i18n/locales/es.json`)

### Testing
- Ran `bun install` to prepare the workspace; this failed due to registry `403` errors when fetching package tarballs, so dependency-driven checks were blocked. (failed)
- Ran lint in `packages/core` via the repository script (`bun run lint`); it could not run because development tooling (`biome`) and deps were unavailable. (failed / blocked)
- Ran TypeScript checks in `packages/core` (`bun run typescript`); this was blocked by missing dependencies/types after the failed install. (failed / blocked)
- Attempted package tests (`bun run test` / Jest) in `packages/accounts`; `jest` was not available due to the install failure, so tests could not be executed. (failed / blocked)
- Ran `git diff --check` and basic repository checks after changes; no diff-check issues were reported. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbce8ca988323b39aed48fff43325)