### PR TITLE
Fix Dependabot label parsing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       minor-and-patch:
         update-types: [minor, patch]
     labels:
-      - type: deps
+      - "type: deps"
     open-pull-requests-limit: 10
 
   - package-ecosystem: github-actions
@@ -17,4 +17,4 @@ updates:
     schedule:
       interval: monthly
     labels:
-      - type: infra
+      - "type: infra"


### PR DESCRIPTION
### Motivation
- Dependabot `labels` entries containing `: ` were unquoted in `.github/dependabot.yml`, causing YAML to parse them as mappings instead of string label names and breaking Dependabot label validation/automation.

### Description
- Quote the two label entries in `.github/dependabot.yml` so they are strings: `- "type: deps"` and `- "type: infra"`.

### Testing
- Attempted a Python/YAML parse check but `PyYAML` was not available in the environment, so that run was skipped; the Ruby `Psych` parse (`ruby -r psych -e '...Psych.load_file(...)'`) confirmed both labels are strings and succeeded. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18ba86d08323a0997333209df4dd)