### PR TITLE
fix: avoid csrf retry dedupe deadlock

### DIFF
--- a/packages/core/src/HttpService.ts
+++ b/packages/core/src/HttpService.ts
@@ -530,7 +530,7 @@ export class HttpService {
               const errBody = await clonedResponse.json() as { code?: string } | null;
               if (errBody?.code === 'CSRF_TOKEN_INVALID' || errBody?.code === 'CSRF_TOKEN_MISSING') {
                 this.tokenStore.clearCsrfToken();
-                return this.request<T>({ ...config, _isCsrfRetry: true, retry: false });
+                return this.request<T>({ ...config, _isCsrfRetry: true, retry: false, deduplicate: false });
               }
             } catch {
               // Failed to parse error body — not a CSRF error

--- a/packages/core/src/__tests__/httpServiceCsrf.test.ts
+++ b/packages/core/src/__tests__/httpServiceCsrf.test.ts
@@ -157,4 +157,47 @@ describe('HttpService CSRF behavior', () => {
     expect(headers.Authorization).toBeUndefined();
     expect(headers['X-CSRF-Token']).toBe('csrf_1');
   });
+
+  it('bypasses request deduplication for the internal CSRF retry', async () => {
+    const calls: FetchCall[] = [];
+    let csrfFetches = 0;
+    let postFetches = 0;
+
+    globalThis.fetch = async (input, init) => {
+      const url = String(input);
+      calls.push({ url, init });
+
+      if (url.endsWith('/csrf-token')) {
+        csrfFetches += 1;
+        return new Response(JSON.stringify({ csrfToken: `csrf_${csrfFetches}` }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      postFetches += 1;
+      if (postFetches === 1) {
+        return new Response(JSON.stringify({ code: 'CSRF_TOKEN_INVALID' }), {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+
+      return jsonResponse({ ok: true });
+    };
+
+    const http = new HttpService({ baseURL: 'https://api.mention.earth', enableRetry: false });
+
+    await expect(http.post('/posts', { text: 'hello' })).resolves.toEqual({ ok: true });
+    expect(calls.map((call) => call.url)).toEqual([
+      'https://api.mention.earth/csrf-token',
+      'https://api.mention.earth/posts',
+      'https://api.mention.earth/csrf-token',
+      'https://api.mention.earth/posts',
+    ]);
+
+    expect(readHeaders(calls[1].init)['X-CSRF-Token']).toBe('csrf_1');
+    expect(readHeaders(calls[3].init)['X-CSRF-Token']).toBe('csrf_2');
+  });
 });


### PR DESCRIPTION
### Motivation
- The CSRF retry path cleared the cached CSRF token and recursively called `request()` but did not disable request deduplication, which allowed the retry to reuse the same dedupe key and create a promise self-dependency that could hang the request pipeline. 
- The change prevents client-side availability regressions where stale CSRF tokens cause state-changing calls to deadlock instead of retrying or failing cleanly.

### Description
- When a `403` with `CSRF_TOKEN_INVALID` or `CSRF_TOKEN_MISSING` is observed, the code now calls `this.request()` with `deduplicate: false` in addition to `retry: false` and the `_isCsrfRetry` flag to ensure the internal retry bypasses the `RequestDeduplicator` backpressure. 
- Added a regression test `it('bypasses request deduplication for the internal CSRF retry', ...)` to `packages/core/src/__tests__/httpServiceCsrf.test.ts` that simulates a stale CSRF token, verifies a fresh token is fetched, and confirms the retried write completes with distinct CSRF fetches. 
- Change touches `packages/core/src/HttpService.ts` and the CSRF-related unit test in `packages/core/src/__tests__/httpServiceCsrf.test.ts`.

### Testing
- Ran `git diff --check` locally to validate diffs and formatting, which succeeded. 
- Added a focused Jest regression test that exercises the CSRF retry/dedupe behavior, but executing `bun run test -- httpServiceCsrf.test.ts` failed in this environment because `jest` is not installed (`command not found`). 
- Attempted `bun install` to run the suite, but it was blocked by npm registry errors (multiple `403` responses), so the full test run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18b9d81883238f0f2a01fba55639)