### PR TITLE
Allow mailbox-only email searches (backend validation)

### DIFF
--- a/packages/api/src/controllers/__tests__/email.controller.search.test.ts
+++ b/packages/api/src/controllers/__tests__/email.controller.search.test.ts
@@ -1,0 +1,97 @@
+import type { Response } from 'express';
+
+const mockSearchMessages = jest.fn();
+
+jest.mock('../../services/email.service', () => ({
+  emailService: {
+    searchMessages: (...args: unknown[]) => mockSearchMessages(...args),
+  },
+}));
+
+jest.mock('../../services/smtp.outbound', () => ({
+  smtpOutbound: {},
+}));
+
+jest.mock('../../services/assetServiceSingleton', () => ({
+  assetService: {},
+}));
+
+jest.mock('../../config/email.config', () => ({
+  resolveEmailAddress: jest.fn(),
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../models/Message', () => ({
+  Message: {},
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), debug: jest.fn(), warn: jest.fn() },
+}));
+
+import { searchMessages } from '../email.controller';
+import { BadRequestError } from '../../utils/error';
+
+describe('email.controller searchMessages', () => {
+  const userId = '64b0000000000000000000aa';
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = {
+      json: jest.fn().mockReturnThis(),
+    };
+    mockSearchMessages.mockResolvedValue({
+      data: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  it('accepts mailbox-only searches', async () => {
+    const req = {
+      user: { id: userId },
+      query: { mailbox: '507f1f77bcf86cd799439012' },
+    };
+
+    await searchMessages(req as never, res as Response);
+
+    expect(mockSearchMessages).toHaveBeenCalledWith(userId, '', {
+      limit: 50,
+      offset: 0,
+      mailboxId: '507f1f77bcf86cd799439012',
+      from: undefined,
+      to: undefined,
+      subject: undefined,
+      hasAttachment: undefined,
+      dateAfter: undefined,
+      dateBefore: undefined,
+    });
+    expect(res.json).toHaveBeenCalledWith({
+      data: [],
+      pagination: {
+        total: 0,
+        limit: 50,
+        offset: 0,
+        hasMore: false,
+      },
+    });
+  });
+
+  it('still rejects searches with no criteria', async () => {
+    const req = {
+      user: { id: userId },
+      query: {},
+    };
+
+    await expect(
+      searchMessages(req as never, res as Response),
+    ).rejects.toThrow(BadRequestError);
+    expect(mockSearchMessages).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/controllers/email.controller.ts
+++ b/packages/api/src/controllers/email.controller.ts
@@ -562,7 +562,16 @@ export async function searchMessages(req: AuthRequest, res: Response): Promise<v
   const offset = parseInt(req.query.offset as string) || 0;
 
   // At least one search criterion required
-  if (!q && !from && !to && !subject && !hasAttachment && !dateAfter && !dateBefore) {
+  if (
+    !q &&
+    !mailboxId &&
+    !from &&
+    !to &&
+    !subject &&
+    !hasAttachment &&
+    !dateAfter &&
+    !dateBefore
+  ) {
     throw new BadRequestError('At least one search parameter is required');
   }
 


### PR DESCRIPTION
### Motivation
- The inbox UI started submitting mailbox-only searches (e.g. `in:spam`) but the API `/email/search` controller still rejected requests that did not include q/from/to/subject/hasAttachment/dateAfter/dateBefore, causing a functional regression; the backend must accept `mailbox` as a valid search criterion so mailbox-only queries reach the search service.

### Description
- Include `mailboxId` in the controller's required-criteria check in `packages/api/src/controllers/email.controller.ts` so `mailbox` counts as a valid filter and mailbox-only searches are allowed to proceed to `emailService.searchMessages`.
- Add a controller unit test `packages/api/src/controllers/__tests__/email.controller.search.test.ts` that verifies mailbox-only searches call `emailService.searchMessages` with the expected args and that requests with no criteria are still rejected.
- Preserve existing call-site behavior so `emailService.searchMessages` receives the same parameters (`q || ''`, `limit`, `offset`, `mailboxId`, `from`, `to`, `subject`, `hasAttachment`, `dateAfter`, `dateBefore`).

### Testing
- Added a Jest unit test file `packages/api/src/controllers/__tests__/email.controller.search.test.ts` covering mailbox-only success and the no-criteria rejection; the test is included in the PR.
- Attempted to run `bun run test -- email.controller.search.test.ts`, but execution was blocked because `jest` was not available in the environment and `bun install` failed due to registry 403 responses, so automated tests could not be executed here.
- Performed static/code inspection to confirm the controller now treats `mailbox` as a valid filter and that the service call arguments are unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18bae388832399f8573c4a82a512)