### PR TITLE
Wire inbox search operators (in:, is:starred, label:) end-to-end

### DIFF
--- a/packages/api/src/controllers/email.controller.ts
+++ b/packages/api/src/controllers/email.controller.ts
@@ -558,11 +558,16 @@ export async function searchMessages(req: AuthRequest, res: Response): Promise<v
   const hasAttachment = req.query.hasAttachment === 'true';
   const dateAfter = req.query.dateAfter as string | undefined;
   const dateBefore = req.query.dateBefore as string | undefined;
+  const starred = req.query.starred === 'true';
+  const label = req.query.label as string | undefined;
   const limit = Math.min(parseInt(req.query.limit as string) || 50, 100);
   const offset = parseInt(req.query.offset as string) || 0;
 
   // At least one search criterion required
-  if (!q && !from && !to && !subject && !hasAttachment && !dateAfter && !dateBefore) {
+  if (
+    !q && !from && !to && !subject && !hasAttachment &&
+    !dateAfter && !dateBefore && !mailboxId && !starred && !label
+  ) {
     throw new BadRequestError('At least one search parameter is required');
   }
 
@@ -570,6 +575,8 @@ export async function searchMessages(req: AuthRequest, res: Response): Promise<v
     limit, offset, mailboxId, from, to, subject,
     hasAttachment: hasAttachment || undefined,
     dateAfter, dateBefore,
+    starred: starred || undefined,
+    label,
   });
   res.json({
     data: result.data,

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -1895,9 +1895,14 @@ class EmailService {
       hasAttachment?: boolean;
       dateAfter?: string;
       dateBefore?: string;
+      starred?: boolean;
+      label?: string;
     } = {}
   ): Promise<{ data: any[]; total: number; limit: number; offset: number }> {
-    const { limit = 50, offset = 0, mailboxId, from, to, subject, hasAttachment, dateAfter, dateBefore } = options;
+    const {
+      limit = 50, offset = 0, mailboxId, from, to, subject,
+      hasAttachment, dateAfter, dateBefore, starred, label,
+    } = options;
 
     const filter: Record<string, unknown> = {
       userId: new mongoose.Types.ObjectId(userId),
@@ -1920,6 +1925,12 @@ class EmailService {
     }
     if (hasAttachment) {
       filter['attachments.0'] = { $exists: true };
+    }
+    if (starred) {
+      filter['flags.starred'] = true;
+    }
+    if (label) {
+      filter.labels = label;
     }
     if (dateAfter || dateBefore) {
       const dateFilter: Record<string, Date> = {};

--- a/packages/inbox/components/SearchList.tsx
+++ b/packages/inbox/components/SearchList.tsx
@@ -163,7 +163,9 @@ export function SearchList({ replaceNavigation }: SearchListProps) {
     subject: nlParsedOptions?.subject || undefined,
     hasAttachment: nlParsedOptions?.hasAttachment || parsedQuery.hasAttachment || filterHasAttachment || undefined,
     mailbox: mailboxIdFromName,
-    // Note: starred/label/unread filters would need backend support
+    starred: nlParsedOptions?.starred || parsedQuery.starred || undefined,
+    label: parsedQuery.label || undefined,
+    // Note: unread filter would need backend support
   }), [nlParsedOptions, parsedQuery, filterFrom, filterHasAttachment, mailboxIdFromName]);
 
   const { data: searchResult, isLoading: searching } = useSearchMessages(searchOptions);

--- a/packages/inbox/hooks/queries/useSearchMessages.ts
+++ b/packages/inbox/hooks/queries/useSearchMessages.ts
@@ -11,6 +11,8 @@ interface SearchOptions {
   dateAfter?: string;
   dateBefore?: string;
   mailbox?: string;
+  starred?: boolean;
+  label?: string;
 }
 
 interface SearchResult {
@@ -29,7 +31,9 @@ export function useSearchMessages(options: SearchOptions) {
     options.hasAttachment ||
     options.dateAfter ||
     options.dateBefore ||
-    options.mailbox?.trim()
+    options.mailbox?.trim() ||
+    options.starred ||
+    options.label?.trim()
   );
 
   return useQuery<SearchResult>({

--- a/packages/inbox/services/emailApi.ts
+++ b/packages/inbox/services/emailApi.ts
@@ -498,6 +498,8 @@ export function createEmailApi(http: HttpService) {
         dateAfter?: string;
         dateBefore?: string;
         mailbox?: string;
+        starred?: boolean;
+        label?: string;
         limit?: number;
         offset?: number;
       } = {},
@@ -511,6 +513,8 @@ export function createEmailApi(http: HttpService) {
       if (options.dateAfter) params.dateAfter = options.dateAfter;
       if (options.dateBefore) params.dateBefore = options.dateBefore;
       if (options.mailbox) params.mailbox = options.mailbox;
+      if (options.starred) params.starred = 'true';
+      if (options.label) params.label = options.label;
       if (options.limit !== undefined) params.limit = String(options.limit);
       if (options.offset !== undefined) params.offset = String(options.offset);
 


### PR DESCRIPTION
### Motivation

- A recent parser added Gmail-style operators (`in:`, `is:starred`, `label:`) but those parsed filters were not propagated through the search hook, API client, or backend, causing operator-only queries to be ignored or to run as broad text searches.
- The change aims to restore functional correctness by plumbing the new operators end-to-end so searches behave as users expect without changing existing semantics otherwise.

### Description

- Frontend: `packages/inbox/components/SearchList.tsx` now includes `starred` and `label` in the `searchOptions` passed to the search hook so parsed Gmail-style operators are forwarded to the API.
- Hook: `packages/inbox/hooks/queries/useSearchMessages.ts` extends `SearchOptions` with `starred` and `label` and updates the `hasFilter` check so operator-only searches (mailbox-only / starred-only / label-only) are allowed to execute.
- API client: `packages/inbox/services/emailApi.ts` accepts `starred` and `label` options and serializes them as query params (`starred=true`, `label=<name>`) when calling the backend search endpoint.
- Backend controller: `packages/api/src/controllers/email.controller.ts` reads `starred` and `label` from `req.query` and treats mailbox/starred/label as valid search criteria so operator-only requests no longer get rejected.
- Backend service: `packages/api/src/services/email.service.ts` accepts `starred` and `label` in `searchMessages` and applies them to the Mongo/Mongoose filter (`flags.starred` and `labels`) so results are correctly filtered server-side.

### Testing

- Ran `git diff --check` which reported no whitespace/patch issues and validated the changeset.
- Attempted a package build via `bun run --filter @oxyhq/api build` but it was blocked by preexisting TypeScript configuration issues in `@oxyhq/contracts` (TS deprecation/rootDir errors), so the build did not complete.
- Attempted `bun install --frozen-lockfile` but dependency fetches were blocked by registry `403` responses, preventing a full test run; subsequent `tsc`/`bunx tsc` invocations also failed due to missing dependencies/types.
- No automated unit/integration tests were successfully executed after the change due to the environment dependency/build blockers described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18ba8cc08323ab61a4859864355c)