### PR TITLE
fix: preserve inbox export failures

### DIFF
--- a/packages/inbox/scripts/export-web.js
+++ b/packages/inbox/scripts/export-web.js
@@ -58,8 +58,9 @@ child.stderr.on('data', (data) => {
 
 child.on('exit', (code) => {
   if (!done) {
-    // Process exited on its own (no hang) — check if it succeeded
-    if (code === 0 || existsSync(distPath)) {
+    // Process exited on its own (no hang) — preserve the actual export result.
+    // Only timeout/hang paths may treat an existing dist as successful.
+    if (code === 0) {
       finish(0);
     } else {
       console.error(`\nExport failed with exit code ${code}`);
@@ -79,7 +80,7 @@ setTimeout(() => {
       console.log('\nExport timed out but dist exists. Exiting successfully.');
       finish(0);
     } else {
-      console.error('\nExport timed out after 4 minutes with no output.');
+      console.error('\nExport timed out after 8 minutes with no output.');
       finish(1);
     }
   }


### PR DESCRIPTION
### Motivation
- The export wrapper could mask real `expo export` failures when a stale `packages/inbox/dist/index.html` existed, so failed builds might be treated as successful during CI/deploy.

### Description
- Update `packages/inbox/scripts/export-web.js` so a normal child-process exit only succeeds when the process exit `code === 0` (the previous `existsSync(distPath)` check is limited to the timeout/hang path), and correct the timeout message to match the 8-minute limit.

### Testing
- Performed a syntax check with `node --check packages/inbox/scripts/export-web.js` and ran a targeted fake-`bun` invocation where `bun x expo export --platform web` exited `42` while a stale `packages/inbox/dist/index.html` existed, and confirmed the wrapper now exits with status `1` (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18ba82fc8323b3a446adf1bd69ee)