### PR TITLE
Fix bulk email routes and preserve mailbox counters

### DIFF
--- a/packages/api/src/controllers/email.controller.ts
+++ b/packages/api/src/controllers/email.controller.ts
@@ -278,18 +278,7 @@ export async function bulkUpdateFlags(req: AuthRequest, res: Response): Promise<
     }
   }
 
-  const flagUpdates = Object.entries(filtered).reduce(
-    (acc, [key, value]) => {
-      acc[`flags.${key}`] = value;
-      return acc;
-    },
-    {} as Record<string, boolean>,
-  );
-
-  const result = await Message.updateMany(
-    { _id: { $in: messageIds }, userId },
-    { $set: flagUpdates },
-  );
+  const result = await emailService.bulkUpdateMessageFlags(userId, messageIds, filtered);
 
   res.json({ data: { matched: result.matchedCount, modified: result.modifiedCount } });
 }
@@ -308,14 +297,7 @@ export async function bulkMoveMessages(req: AuthRequest, res: Response): Promise
     throw new BadRequestError('mailboxId is required');
   }
 
-  // Verify target mailbox belongs to user
-  const mailbox = await emailService.getMailboxById(userId, mailboxId);
-  if (!mailbox) throw new NotFoundError('Target mailbox not found');
-
-  const result = await Message.updateMany(
-    { _id: { $in: messageIds }, userId },
-    { $set: { mailboxId } },
-  );
+  const result = await emailService.bulkMoveMessages(userId, messageIds, mailboxId);
 
   res.json({ data: { matched: result.matchedCount, modified: result.modifiedCount } });
 }

--- a/packages/api/src/routes/email.ts
+++ b/packages/api/src/routes/email.ts
@@ -117,6 +117,13 @@ router.delete('/mailboxes/:mailboxId', validate({ params: mailboxIdParams }), as
 
 router.get('/messages', asyncHandler(listMessages));
 router.get('/messages/bundled', asyncHandler(listBundledMessages));
+// ─── Bulk Operations ─────────────────────────────────────────────
+// Register these before /messages/:messageId routes so "bulk" is not
+// captured as a messageId by Express' first-match routing.
+
+router.post('/messages/bulk/flags', validate({ body: bulkUpdateFlagsSchema }), asyncHandler(bulkUpdateFlags));
+router.post('/messages/bulk/move', validate({ body: bulkMoveMessagesSchema }), asyncHandler(bulkMoveMessages));
+
 router.get('/messages/:messageId', validate({ params: messageIdParams }), asyncHandler(getMessage));
 router.get('/messages/:messageId/thread', validate({ params: messageIdParams }), asyncHandler(getThread));
 router.get('/messages/:messageId/export', validate({ params: messageIdParams }), asyncHandler(exportMessage));
@@ -126,11 +133,6 @@ router.post('/messages/:messageId/move', validate({ params: messageIdParams, bod
 router.delete('/messages/:messageId', validate({ params: messageIdParams }), asyncHandler(deleteMessage));
 router.post('/messages/:messageId/snooze', validate({ params: messageIdParams, body: snoozeMessageSchema }), asyncHandler(snoozeMessage));
 router.post('/messages/:messageId/unsnooze', validate({ params: messageIdParams }), asyncHandler(unsnoozeMessage));
-
-// ─── Bulk Operations ─────────────────────────────────────────────
-
-router.post('/messages/bulk/flags', validate({ body: bulkUpdateFlagsSchema }), asyncHandler(bulkUpdateFlags));
-router.post('/messages/bulk/move', validate({ body: bulkMoveMessagesSchema }), asyncHandler(bulkMoveMessages));
 
 // ─── Labels ──────────────────────────────────────────────────────
 

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -607,6 +607,118 @@ class EmailService {
     return message.toJSON();
   }
 
+  async bulkUpdateMessageFlags(
+    userId: string,
+    messageIds: string[],
+    flags: Partial<IMessage['flags']>
+  ): Promise<{ matchedCount: number; modifiedCount: number }> {
+    const update: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(flags)) {
+      update[`flags.${key}`] = value;
+    }
+
+    const messages = await Message.find({ _id: { $in: messageIds }, userId })
+      .select('mailboxId flags.seen')
+      .lean();
+
+    const unseenDeltas = new Map<string, number>();
+    if ('seen' in flags) {
+      for (const message of messages) {
+        if (message.flags.seen === flags.seen) {
+          continue;
+        }
+        const mailboxId = message.mailboxId.toString();
+        const delta = flags.seen ? -1 : 1;
+        unseenDeltas.set(mailboxId, (unseenDeltas.get(mailboxId) ?? 0) + delta);
+      }
+    }
+
+    const result = await Message.updateMany(
+      { _id: { $in: messageIds }, userId },
+      { $set: update }
+    );
+
+    if (unseenDeltas.size > 0) {
+      await Mailbox.bulkWrite(
+        Array.from(unseenDeltas.entries()).map(([mailboxId, unseenMessages]) => ({
+          updateOne: {
+            filter: { _id: mailboxId, userId },
+            update: { $inc: { unseenMessages } },
+          },
+        }))
+      );
+    }
+
+    return { matchedCount: result.matchedCount, modifiedCount: result.modifiedCount };
+  }
+
+  async bulkMoveMessages(
+    userId: string,
+    messageIds: string[],
+    targetMailboxId: string
+  ): Promise<{ matchedCount: number; modifiedCount: number }> {
+    const [messages, targetMailbox] = await Promise.all([
+      Message.find({ _id: { $in: messageIds }, userId })
+        .select('mailboxId flags.seen size')
+        .lean(),
+      Mailbox.findOne({ _id: targetMailboxId, userId }),
+    ]);
+
+    if (!targetMailbox) throw new NotFoundError('Target mailbox not found');
+
+    const mailboxDeltas = new Map<
+      string,
+      { totalMessages: number; unseenMessages: number; size: number }
+    >();
+
+    const addDelta = (
+      mailboxId: string,
+      totalMessages: number,
+      unseenMessages: number,
+      size: number
+    ) => {
+      const current = mailboxDeltas.get(mailboxId) ?? {
+        totalMessages: 0,
+        unseenMessages: 0,
+        size: 0,
+      };
+      current.totalMessages += totalMessages;
+      current.unseenMessages += unseenMessages;
+      current.size += size;
+      mailboxDeltas.set(mailboxId, current);
+    };
+
+    const targetId = targetMailbox._id.toString();
+    for (const message of messages) {
+      const sourceId = message.mailboxId.toString();
+      if (sourceId === targetId) {
+        continue;
+      }
+
+      const unseenDelta = message.flags.seen ? 0 : 1;
+      addDelta(sourceId, -1, -unseenDelta, -message.size);
+      addDelta(targetId, 1, unseenDelta, message.size);
+    }
+
+    const result = await Message.updateMany(
+      { _id: { $in: messageIds }, userId },
+      { $set: { mailboxId: targetMailbox._id } }
+    );
+
+    if (mailboxDeltas.size > 0) {
+      await Mailbox.bulkWrite(
+        Array.from(mailboxDeltas.entries()).map(([mailboxId, delta]) => ({
+          updateOne: {
+            filter: { _id: mailboxId, userId },
+            update: { $inc: delta },
+          },
+        }))
+      );
+    }
+
+    return { matchedCount: result.matchedCount, modifiedCount: result.modifiedCount };
+  }
+
   async deleteMessage(userId: string, messageId: string, permanent: boolean = false): Promise<void> {
     const message = await Message.findOne({ _id: messageId, userId });
     if (!message) throw new NotFoundError('Message not found');


### PR DESCRIPTION
### Motivation
- The newly-added bulk email endpoints were being shadowed by the parameterized `/messages/:messageId` routes and the bulk handlers directly updated `Message` documents, bypassing mailbox counter maintenance and causing data-integrity drift.  
- The change makes bulk archive/delete/flag operations reliable and preserves `Mailbox.totalMessages`, `Mailbox.unseenMessages`, and `Mailbox.size` invariants during bulk operations.

### Description
- Register the bulk routes `POST /messages/bulk/flags` and `POST /messages/bulk/move` before the parameterized `/messages/:messageId` routes so Express does not match `bulk` as a `messageId` (file: `packages/api/src/routes/email.ts`).
- Route the bulk controllers to service-level implementations instead of calling `Message.updateMany` directly (file: `packages/api/src/controllers/email.controller.ts`).
- Add `emailService.bulkUpdateMessageFlags(userId, messageIds, flags)` which computes per-mailbox unseen deltas for `seen` changes, performs the message updates, and updates `Mailbox.unseenMessages` via `bulkWrite` (file: `packages/api/src/services/email.service.ts`).
- Add `emailService.bulkMoveMessages(userId, messageIds, targetMailboxId)` which validates the target mailbox, computes per-mailbox `totalMessages`, `unseenMessages`, and `size` deltas, performs the message move, and applies mailbox counter adjustments with `bulkWrite` (file: `packages/api/src/services/email.service.ts`).

### Testing
- Attempted to build the API with `bun run --filter @oxyhq/api build`, which failed due to existing TypeScript configuration deprecation/errors in `packages/contracts/tsconfig.cjs.json` (unrelated to this change).  
- Attempted to run package tests with `bun run --filter @oxyhq/api test -- --runInBand`, which could not run in this environment because test tooling (`jest`) and package dependencies are not installed.  
- A local route-order and source diff verification was performed to ensure `bulk` routes are now registered before parameterized routes and controllers delegate to the new service methods, and the service logic mirrors the single-message side effects for mailbox counters (non-automated source checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18b9bbf48323bc97ffffd3289212)