### PR TITLE
fix: fail accounts export on stale dist artifacts

### DIFF
--- a/packages/accounts/scripts/export-web.js
+++ b/packages/accounts/scripts/export-web.js
@@ -10,13 +10,10 @@
  */
 
 const { spawn } = require('child_process');
-const { existsSync } = require('fs');
 const path = require('path');
 
 const EXPORT_TIMEOUT_MS = 8 * 60 * 1000; // 8 minutes hard limit (DO build instances are slow)
 const projectRoot = path.resolve(__dirname, '..');
-const distPath = path.join(projectRoot, 'dist', 'index.html');
-
 const child = spawn('bun', ['x', 'expo', 'export', '--platform', 'web'], {
   cwd: projectRoot,
   stdio: ['inherit', 'pipe', 'pipe'],
@@ -53,8 +50,8 @@ child.stderr.on('data', (data) => {
 
 child.on('exit', (code) => {
   if (!done) {
-    // Process exited on its own (no hang) — check if it succeeded
-    if (code === 0 || existsSync(distPath)) {
+    // Process exited on its own (no hang) — rely on Expo's exit status.
+    if (code === 0) {
       finish(0);
     } else {
       console.error(`\nExport failed with exit code ${code}`);
@@ -70,12 +67,7 @@ child.on('error', (err) => {
 
 setTimeout(() => {
   if (!done) {
-    if (existsSync(distPath)) {
-      console.log('\nExport timed out but dist exists. Exiting successfully.');
-      finish(0);
-    } else {
-      console.error('\nExport timed out after 4 minutes with no output.');
-      finish(1);
-    }
+    console.error('\nExport timed out after 8 minutes.');
+    finish(1);
   }
 }, EXPORT_TIMEOUT_MS);


### PR DESCRIPTION
### Motivation
- Prevent the export wrapper in `packages/accounts` from masking failed or timed-out `expo export` runs when a stale `packages/accounts/dist/index.html` already exists, ensuring build/release integrity.

### Description
- Removed the stale-artifact checks in `packages/accounts/scripts/export-web.js` so the wrapper now treats the child process exit code as the authoritative result instead of using `dist/index.html` presence to force success.
- Adjusted the timeout branch to fail after the configured hard limit (8 minutes) and preserved the original Metro-hang workaround that still succeeds when `Exported:` is observed on stdout and then kills the hung process group.

### Testing
- Simulated a failing `expo export` by placing a fake `bun` in `PATH` that exits nonzero while a stale `packages/accounts/dist/index.html` exists, and verified the wrapper now exits with status `1` as expected. (Succeeded)
- Ran a Node syntax check with `node --check packages/accounts/scripts/export-web.js` to validate the script (Succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18b9c7388323a23906f8bdbc83ee)