### PR TITLE
fix(api): allow legacy user hex colors

### DIFF
--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -7,6 +7,27 @@ import {
   type TrustTier,
 } from "../utils/reputation.constants";
 
+export const USER_COLOR_PRESETS = [
+  'teal',
+  'blue',
+  'green',
+  'amber',
+  'red',
+  'purple',
+  'pink',
+  'sky',
+  'orange',
+  'mint',
+  'oxy',
+] as const;
+
+const LEGACY_HEX_COLOR_PATTERN = /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i;
+
+export function isValidUserColor(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  return (USER_COLOR_PRESETS as readonly string[]).includes(value) || LEGACY_HEX_COLOR_PATTERN.test(value);
+}
+
 /**
  * Represents an authentication method linked to a user account.
  * Users can have multiple auth methods (identity, password, social) linked to the same account.
@@ -436,9 +457,12 @@ const UserSchema: Schema = new Schema(
       type: String,
       trim: true,
       lowercase: true,
-      enum: ['teal', 'blue', 'green', 'amber', 'red', 'purple', 'pink', 'sky', 'orange', 'mint', 'oxy'],
+      validate: {
+        validator: isValidUserColor,
+        message: 'Color must be a known preset or legacy hex color',
+      },
       default: () => {
-        const colors = ['teal', 'blue', 'green', 'amber', 'red', 'purple', 'pink', 'sky', 'orange', 'mint'];
+        const colors = USER_COLOR_PRESETS.filter((color) => color !== 'oxy');
         return colors[Math.floor(Math.random() * colors.length)];
       },
     },

--- a/packages/api/src/models/__tests__/User.test.ts
+++ b/packages/api/src/models/__tests__/User.test.ts
@@ -1,0 +1,22 @@
+import { User } from '../User';
+
+describe('User model color validation', () => {
+  it('accepts named color presets', () => {
+    const user = new User({ username: 'named-color-user', color: 'teal' });
+
+    expect(user.validateSync()?.errors.color).toBeUndefined();
+  });
+
+  it('accepts legacy hex colors so existing users can save unrelated changes', () => {
+    const user = new User({ username: 'legacy-color-user', color: '#4285f4' });
+    user.name = { first: 'Legacy' };
+
+    expect(user.validateSync()?.errors.color).toBeUndefined();
+  });
+
+  it('rejects arbitrary non-preset color strings', () => {
+    const user = new User({ username: 'invalid-color-user', color: 'not-a-color' });
+
+    expect(user.validateSync()?.errors.color).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Motivation
- Narrowing `User.color` to a fixed enum made existing user documents that store legacy hex values (e.g. `#4285f4`) fail Mongoose validation when the document is loaded and `save()` is called for unrelated updates, causing availability/data-compatibility issues.
- Provide a minimal compatibility path so legacy records remain writable without a heavy migration while preserving the new named-presets policy and premium-only `oxy` semantics.

### Description
- Replaced the strict `enum` on `User.color` with a custom validator that accepts both the new named presets and legacy hex color formats by adding `USER_COLOR_PRESETS`, `LEGACY_HEX_COLOR_PATTERN`, and `isValidUserColor` in `packages/api/src/models/User.ts`.
- Switched the schema entry to use `validate: { validator: isValidUserColor }` and preserved a random default drawn from the named presets while excluding the premium-only `oxy` from random assignment.
- Added a unit test file `packages/api/src/models/__tests__/User.test.ts` that asserts acceptance of named presets and legacy hex colors and rejects arbitrary invalid strings.
- Changes touch `packages/api/src/models/User.ts` and the new test file above.

### Testing
- Ran source assertions that confirmed the new validator and legacy-hex pattern are present via a small Python check, which succeeded (`assert 'validator: isValidUserColor'`, `assert 'LEGACY_HEX_COLOR_PATTERN'`).
- Ran `git diff --check` to ensure no whitespace/patch problems, which returned clean results.
- Added focused model tests (`packages/api/src/models/__tests__/User.test.ts`) exercising validation of preset names, legacy hex strings, and invalid strings, but executing the test runner was blocked: invoking the package `test` script failed because `jest` was not available in the environment (dependency installation with `bun install` produced registry `403` errors), so the Jest run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d18b9e3488323b5c043701dbe9667)