### PR TITLE
fix(assets): stop empty avatar/file uploads (web uri→Blob + backend 0-byte guard)

### DIFF
--- a/packages/api/src/routes/assets.ts
+++ b/packages/api/src/routes/assets.ts
@@ -379,6 +379,12 @@ router.post('/:id/upload-direct', authMiddleware, validate({ params: assetIdPara
     throw new BadRequestError('Missing file');
   }
 
+  // Defense-in-depth: reject a present-but-empty upload so an empty object is
+  // never written to the predetermined storage key.
+  if (!req.file.buffer || req.file.buffer.length === 0) {
+    throw new BadRequestError('Empty file');
+  }
+
   const file = await assetService.getFile(fileId);
   if (!file) {
     throw new NotFoundError('File not found');
@@ -442,6 +448,13 @@ router.post('/upload', authMiddleware, upload.single('file'), asyncHandler(async
 
   if (!req.file) {
     throw new BadRequestError('Missing file');
+  }
+
+  // Defense-in-depth: reject a present-but-empty upload before any record is
+  // created. A 0-byte buffer would otherwise hash to the empty-content SHA-256
+  // and persist an empty asset.
+  if (!req.file.buffer || req.file.buffer.length === 0) {
+    throw new BadRequestError('Empty file');
   }
 
   const visibility = (req.body.visibility as FileVisibility) || 'private';

--- a/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
+++ b/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
@@ -379,6 +379,40 @@ describe('uploadCachedMediaStream — abort cleanup', () => {
   });
 });
 
+describe('AssetService.uploadFileDirect — empty-file guard', () => {
+  beforeEach(() => {
+    mockFileFindOne.mockReset();
+    mockGenerateVariants.mockReset();
+    mockGenerateVariants.mockResolvedValue(undefined);
+  });
+
+  it('rejects a 0-byte buffer and creates NO File record or storage object', async () => {
+    const uploadBuffer = jest.fn((key: string, buffer: Buffer, options?: UploadOptions): Promise<FileInfo> => Promise.resolve({
+      key,
+      size: buffer.length,
+      contentType: options?.contentType || 'application/octet-stream',
+    } as FileInfo));
+    const deleteFile = jest.fn((): Promise<void> => Promise.resolve());
+    const { service } = buildAssetService({ deleteFile, uploadBuffer });
+
+    await expect(
+      service.uploadFileDirect(
+        'some-user',
+        Buffer.alloc(0),
+        'image/png',
+        'empty.png',
+        'private',
+      ),
+    ).rejects.toMatchObject({ statusCode: 400, message: 'Cannot store an empty file' });
+
+    // The guard short-circuits before ANY DB lookup, record creation, or S3
+    // write — no empty asset can be persisted.
+    expect(mockFileFindOne).not.toHaveBeenCalled();
+    expect(uploadBuffer).not.toHaveBeenCalled();
+    expect(mockGenerateVariants).not.toHaveBeenCalled();
+  });
+});
+
 describe('AssetService visibility relocation', () => {
   it('deletes legacy backfilled public CDN copies when a non-public DB key is downgraded', async () => {
     const existingKeys = new Set([

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -31,6 +31,7 @@ import {
 import { mediaPrivacyService } from './mediaPrivacyService';
 import { MediaAccessContext } from '../types/mediaPrivacy.types';
 import fileCache from '../utils/fileCache';
+import { BadRequestError } from '../utils/error';
 
 /**
  * A readable stream that may also emit the HTTP `'aborted'` event. Express
@@ -575,6 +576,13 @@ export class AssetService {
       // Calculate SHA256 hash on backend
       const sha256 = crypto.createHash('sha256').update(fileBuffer).digest('hex');
       const size = fileBuffer.length;
+
+      // Defense-in-depth: never persist a 0-byte asset. Protects every caller of
+      // uploadFileDirect, not just the route. Mirrors the federation stream
+      // path's empty-buffer guard.
+      if (size === 0) {
+        throw new BadRequestError('Cannot store an empty file');
+      }
 
       // Check if file already exists by SHA256
       const existingFile = await this.findFileBySha(sha256);

--- a/packages/core/src/mixins/OxyServices.assets.ts
+++ b/packages/core/src/mixins/OxyServices.assets.ts
@@ -1,5 +1,6 @@
 import type { AccountStorageUsageResponse, AssetUploadInput, AssetUrlResponse, AssetVariant, RNFileDescriptor } from '../models/interfaces';
 import type { OxyServicesBase } from '../OxyServices.base';
+import { isReactNative } from '../utils/platform';
 
 interface FileDownloadUrlOptions {
   /** Omit bearer access tokens from generated URLs, even when authenticated. */
@@ -222,10 +223,33 @@ export function OxyServicesAssetsMixin<T extends typeof OxyServicesBase>(Base: T
         } else if (typeof Blob !== 'undefined' && file instanceof Blob) {
           formData.append('file', file, fileName);
         } else if ('uri' in file && typeof (file as RNFileDescriptor).uri === 'string') {
-          // React Native file descriptor — RN's FormData handles {uri, type, name} natively.
-          // It reads the file from disk during the multipart request — no in-JS Blob
-          // conversion (which would fail on Hermes for ArrayBuffer-backed Blobs).
-          formData.append('file', file as unknown as Blob, fileName);
+          const descriptor = file as RNFileDescriptor;
+
+          if (isReactNative()) {
+            // React Native file descriptor — RN's FormData handles {uri, type, name} natively.
+            // It reads the file from disk during the multipart request — no in-JS Blob
+            // conversion (which would fail on Hermes for ArrayBuffer-backed Blobs).
+            formData.append('file', descriptor as unknown as Blob, fileName);
+          } else {
+            // Web (browser/Node): the browser's FormData cannot read bytes from a plain
+            // { uri } object — it would serialize "[object Object]" and the server would
+            // store a 0-byte asset. Materialize the uri into a real Blob first. `fetch`
+            // resolves blob:, data:, and http(s): uris on web, so all picker outputs work.
+            const res = await fetch(descriptor.uri);
+            if (!res.ok) {
+              throw new Error(`Failed to read file from uri (status ${res.status})`);
+            }
+            const fetched = await res.blob();
+            // Preserve the descriptor's declared MIME type when the fetched blob has none.
+            const blob =
+              fetched.type === '' && descriptor.type
+                ? new Blob([fetched], { type: descriptor.type })
+                : fetched;
+            if (blob.size === 0) {
+              throw new Error('Cannot upload an empty file');
+            }
+            formData.append('file', blob, fileName);
+          }
         } else {
           throw new Error('Unsupported file input: expected File, Blob, or { uri, type?, name?, size? } descriptor');
         }

--- a/packages/core/src/mixins/__tests__/assetUpload.test.ts
+++ b/packages/core/src/mixins/__tests__/assetUpload.test.ts
@@ -1,0 +1,191 @@
+/**
+ * `OxyServices.assetUpload()` multipart-body tests.
+ *
+ * `assetUpload` accepts three input shapes: a web `File`, a web `Blob`, or a
+ * React Native `{ uri, type?, name?, size? }` descriptor. The descriptor path
+ * is platform-sensitive:
+ *
+ *   - React Native — RN's FormData reads the file from disk via the uri during
+ *     the multipart request, so the descriptor is appended as-is.
+ *   - Web (browser/Node) — the browser's FormData CANNOT read bytes from a plain
+ *     `{ uri }` object (it would serialize `[object Object]` → the server stores
+ *     a 0-byte asset). The uri must be materialized into a real `Blob` via
+ *     `fetch` before appending. An empty fetched blob must throw instead of
+ *     silently uploading an empty asset.
+ *
+ * These tests assert exactly which value lands in the FormData `file` part for
+ * each platform, and that an empty web source is rejected.
+ */
+
+import { OxyServices } from '../../OxyServices';
+
+/**
+ * Captures every `FormData.append` call so a test can inspect the multipart body
+ * that `assetUpload` built without sending a real network request.
+ */
+function captureUpload(oxy: OxyServices) {
+  const appended: Array<{ name: string; value: unknown; fileName?: string }> = [];
+  // Capture-only: do NOT delegate to the real (undici) FormData.append. Node's
+  // undici rejects a plain { uri } object as not-a-Blob, but real React Native
+  // FormData accepts it — the test asserts on captured args, not a built body.
+  const appendSpy = jest
+    .spyOn(FormData.prototype, 'append')
+    .mockImplementation(function (this: FormData, name: string, value: unknown, fileName?: string) {
+      appended.push({ name, value, fileName });
+    });
+
+  const requestSpy = jest
+    .spyOn(oxy.getClient(), 'request')
+    .mockResolvedValue({ file: { id: 'asset123' } } as never);
+
+  return {
+    appended,
+    requestSpy,
+    restore: () => {
+      appendSpy.mockRestore();
+      requestSpy.mockRestore();
+    },
+  };
+}
+
+describe('OxyServices.assetUpload — uri descriptor', () => {
+  const originalNavigator = (globalThis as { navigator?: unknown }).navigator;
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (originalNavigator === undefined) {
+      delete (globalThis as { navigator?: unknown }).navigator;
+    } else {
+      (globalThis as { navigator?: unknown }).navigator = originalNavigator;
+    }
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('web (NOT React Native)', () => {
+    beforeEach(() => {
+      // Node/jsdom-like: no React Native navigator → isReactNative() === false.
+      delete (globalThis as { navigator?: unknown }).navigator;
+    });
+
+    it('materializes a blob: uri into a real, non-empty Blob before appending', async () => {
+      const bytes = new Blob([new Uint8Array([1, 2, 3, 4, 5])], { type: 'image/png' });
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, blob: async () => bytes });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+      const capture = captureUpload(oxy);
+
+      try {
+        await oxy.assetUpload({ uri: 'blob:https://app.test/abc', type: 'image/png', name: 'avatar.png' });
+
+        expect(fetchMock).toHaveBeenCalledWith('blob:https://app.test/abc');
+
+        const filePart = capture.appended.find((p) => p.name === 'file');
+        expect(filePart).toBeDefined();
+        // The appended value is the fetched Blob with real bytes — NOT the { uri } object.
+        expect(filePart?.value).toBeInstanceOf(Blob);
+        expect((filePart?.value as Blob).size).toBe(5);
+        expect((filePart?.value as { uri?: string }).uri).toBeUndefined();
+        expect(filePart?.fileName).toBe('avatar.png');
+      } finally {
+        capture.restore();
+      }
+    });
+
+    it('wraps a typeless fetched blob with the descriptor MIME type', async () => {
+      const typeless = new Blob([new Uint8Array([9, 9, 9])]); // type === ''
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, blob: async () => typeless });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+      const capture = captureUpload(oxy);
+
+      try {
+        await oxy.assetUpload({ uri: 'data:application/octet-stream;base64,CQkJ', type: 'image/jpeg', name: 'x.jpg' });
+
+        const filePart = capture.appended.find((p) => p.name === 'file');
+        expect(filePart?.value).toBeInstanceOf(Blob);
+        expect((filePart?.value as Blob).size).toBe(3);
+        expect((filePart?.value as Blob).type).toBe('image/jpeg');
+      } finally {
+        capture.restore();
+      }
+    });
+
+    it('throws "Cannot upload an empty file" when the fetched blob is empty', async () => {
+      const empty = new Blob([], { type: 'image/png' });
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue({ ok: true, status: 200, blob: async () => empty });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+      const capture = captureUpload(oxy);
+
+      try {
+        await expect(
+          oxy.assetUpload({ uri: 'blob:https://app.test/empty', type: 'image/png', name: 'empty.png' }),
+        ).rejects.toThrow('Cannot upload an empty file');
+
+        // Nothing was sent — the empty source surfaces instead of creating a 0-byte asset.
+        expect(capture.requestSpy).not.toHaveBeenCalled();
+      } finally {
+        capture.restore();
+      }
+    });
+
+    it('throws when the uri cannot be fetched (non-ok response)', async () => {
+      const fetchMock = jest
+        .fn()
+        .mockResolvedValue({ ok: false, status: 404, blob: async () => new Blob([]) });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+      const capture = captureUpload(oxy);
+
+      try {
+        await expect(
+          oxy.assetUpload({ uri: 'https://cdn.test/missing.png', type: 'image/png', name: 'missing.png' }),
+        ).rejects.toThrow('Failed to read file from uri (status 404)');
+        expect(capture.requestSpy).not.toHaveBeenCalled();
+      } finally {
+        capture.restore();
+      }
+    });
+  });
+
+  describe('React Native', () => {
+    beforeEach(() => {
+      // Make isReactNative() === true: navigator.product === 'ReactNative'.
+      (globalThis as { navigator?: unknown }).navigator = { product: 'ReactNative' };
+    });
+
+    it('appends the descriptor as-is and never calls fetch', async () => {
+      const fetchMock = jest.fn();
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+      const capture = captureUpload(oxy);
+
+      const descriptor = { uri: 'file:///tmp/avatar.png', type: 'image/png', name: 'avatar.png', size: 1024 };
+
+      try {
+        await oxy.assetUpload(descriptor);
+
+        // RN path: the raw descriptor object lands in the multipart body unchanged.
+        const filePart = capture.appended.find((p) => p.name === 'file');
+        expect(filePart?.value).toBe(descriptor);
+        expect(filePart?.fileName).toBe('avatar.png');
+        // No in-JS materialization on RN — FormData reads the file from the uri.
+        expect(fetchMock).not.toHaveBeenCalled();
+      } finally {
+        capture.restore();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Bug
Updating an avatar (and file-manager uploads) created an **empty asset record** in the DB — the file bytes never landed ("crea una imagen vacía, no sube el archivo"). Web only.

## Root cause (traced with prod-log evidence)
The server `uploadFileDirect` works fine (federation uploads succeed with real sizes in CloudWatch). The empty record is **client-side**: on web, the avatar paths pass an **RN-style `{ uri }` descriptor** to `oxyServices.assetUpload`. In core, that descriptor was appended **directly to the browser's `FormData`**, which cannot read bytes from a plain object → an **empty multipart part** → the API stored a 0-byte asset. Native works (RN `FormData` reads the file from the uri).

## Fix (defense-in-depth, two layers)
- **`@oxyhq/core`** (root cause): `assetUpload` now materializes a `{ uri }` descriptor into a real `Blob` via `fetch` on web (RN path unchanged), and throws on an empty blob. Single chokepoint — fixes avatar, file manager, and any future caller.
- **`@oxyhq/api`** (the guard you asked for): `POST /assets/upload`, `POST /assets/:id/upload-direct`, and `assetService.uploadFileDirect()` now reject 0-byte uploads with **400 `Empty file`** instead of persisting an empty record — mirrors the existing federation-stream guard. The backend never stores an empty asset again, regardless of client.

## Verification
- core: `core:build` exit 0, **483 tests** (+5: web uri→Blob, empty-blob reject, non-ok fetch, RN-unchanged)
- api: `api build` exit 0, **724 tests** (+1: `uploadFileDirect(Buffer.alloc(0))` → 400, no record/object created)

> Note: `@oxyhq/core` will be published + downstream-bumped after merge so prod apps get the client fix; the API guard deploys to ECS on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)