### PR TITLE
fix(assets): reject image uploads whose bytes aren't a real image (magic-byte guard)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ Backend APIs use `@oxyhq/core/server` for request identity and security:
 - No unnecessary abstractions or over-engineering
 - `packages/core/` and `packages/auth-sdk/` build with `tsc` (CJS + ESM + types -> `dist/`)
 - `packages/services/` builds with `react-native-builder-bob` (-> `lib/`)
+- **Lockfiles before push (any repo):** after any dependency/version bump, run `bun install` to regenerate `bun.lock` and verify `bun install --frozen-lockfile` passes (CI's exact gate) BEFORE pushing — commit the lockfile in the SAME commit as the `package.json` change. A desynced lockfile red-fails CI and blocks deploys. When bumping a dep across multiple repos, do this per-repo.
 
 ## @oxyhq/contracts — Contract-First API Schemas
 

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -32,6 +32,7 @@ import { mediaPrivacyService } from './mediaPrivacyService';
 import { MediaAccessContext } from '../types/mediaPrivacy.types';
 import fileCache from '../utils/fileCache';
 import { BadRequestError } from '../utils/error';
+import { isDeclaredImageContentValid } from '../utils/imageContentSignature';
 
 /**
  * A readable stream that may also emit the HTTP `'aborted'` event. Express
@@ -537,6 +538,13 @@ export class AssetService {
       // path's empty-buffer guard.
       if (size === 0) {
         throw new BadRequestError('Cannot store an empty file');
+      }
+
+      // Defense-in-depth: reject content declared as an image whose bytes are
+      // not actually an image (e.g. a serialized {uri} descriptor from a broken
+      // web client). Non-zero garbage slips past the 0-byte guard otherwise.
+      if (!isDeclaredImageContentValid(fileBuffer, mimeType)) {
+        throw new BadRequestError('Uploaded file content does not match the declared image type');
       }
 
       // Check if file already exists by SHA256 (active records only).

--- a/packages/api/src/utils/__tests__/imageContentSignature.test.ts
+++ b/packages/api/src/utils/__tests__/imageContentSignature.test.ts
@@ -1,0 +1,46 @@
+import { isDeclaredImageContentValid } from '../imageContentSignature';
+
+const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00]);
+const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+const gif = Buffer.from('GIF89a-rest', 'latin1');
+const bmp = Buffer.from('BM......', 'latin1');
+const webp = Buffer.concat([Buffer.from('RIFF', 'latin1'), Buffer.from([0, 0, 0, 0]), Buffer.from('WEBP', 'latin1')]);
+const avif = Buffer.concat([Buffer.from([0, 0, 0, 0]), Buffer.from('ftypavif', 'latin1')]);
+const garbage = Buffer.from('[object Object]', 'utf8');
+
+describe('isDeclaredImageContentValid', () => {
+  it('rejects non-image content declared as an image (the broken-upload case)', () => {
+    expect(isDeclaredImageContentValid(garbage, 'image/png')).toBe(false);
+    expect(isDeclaredImageContentValid(garbage, 'image/jpeg')).toBe(false);
+    expect(isDeclaredImageContentValid(Buffer.from('not a webp'), 'image/webp')).toBe(false);
+  });
+
+  it('rejects an empty buffer declared as an image', () => {
+    expect(isDeclaredImageContentValid(Buffer.alloc(0), 'image/png')).toBe(false);
+  });
+
+  it('accepts real image content matching the declared type', () => {
+    expect(isDeclaredImageContentValid(png, 'image/png')).toBe(true);
+    expect(isDeclaredImageContentValid(jpeg, 'image/jpeg')).toBe(true);
+    expect(isDeclaredImageContentValid(gif, 'image/gif')).toBe(true);
+    expect(isDeclaredImageContentValid(bmp, 'image/bmp')).toBe(true);
+    expect(isDeclaredImageContentValid(webp, 'image/webp')).toBe(true);
+    expect(isDeclaredImageContentValid(avif, 'image/avif')).toBe(true);
+  });
+
+  it('validates SVG structurally', () => {
+    expect(isDeclaredImageContentValid(Buffer.from('<svg xmlns="...">'), 'image/svg+xml')).toBe(true);
+    expect(isDeclaredImageContentValid(Buffer.from('  <?xml version="1.0"?><svg/>'), 'image/svg+xml')).toBe(true);
+    expect(isDeclaredImageContentValid(garbage, 'image/svg+xml')).toBe(false);
+  });
+
+  it('never rejects non-image uploads (out of scope)', () => {
+    expect(isDeclaredImageContentValid(garbage, 'application/pdf')).toBe(true);
+    expect(isDeclaredImageContentValid(Buffer.from('text'), 'text/plain')).toBe(true);
+    expect(isDeclaredImageContentValid(garbage, '')).toBe(true);
+  });
+
+  it('accepts unknown image subtypes with no known signature (sniff-known-garbage, not allow-list)', () => {
+    expect(isDeclaredImageContentValid(Buffer.from('whatever'), 'image/x-unknown-format')).toBe(true);
+  });
+});

--- a/packages/api/src/utils/imageContentSignature.ts
+++ b/packages/api/src/utils/imageContentSignature.ts
@@ -1,0 +1,100 @@
+/**
+ * Magic-byte validation for image uploads.
+ *
+ * Defense-in-depth: a broken client can declare `image/*` while sending bytes
+ * that are not actually an image (e.g. a `{uri}` descriptor serialized to
+ * "[object Object]" by the browser's FormData). Such payloads are non-empty,
+ * so the 0-byte guard misses them, and they get stored as a broken avatar.
+ * This validates that content declared as an image really begins with a known
+ * image signature before it is persisted.
+ *
+ * Scope: only enforced when the declared MIME is `image/*`. Non-image uploads
+ * (documents, etc.) are out of scope and always pass — this is a
+ * sniff-the-known-garbage guard, not an exhaustive allow-list (route/cache
+ * allow-lists own which types are permitted at all).
+ */
+
+const ASCII = (s: string): number[] => Array.from(s, (c) => c.charCodeAt(0));
+
+/** True if `buf` starts with `sig` at `offset`. */
+function matchesAt(buf: Buffer, sig: readonly number[], offset = 0): boolean {
+  if (buf.length < offset + sig.length) return false;
+  for (let i = 0; i < sig.length; i++) {
+    if (buf[offset + i] !== sig[i]) return false;
+  }
+  return true;
+}
+
+const JPEG = [0xff, 0xd8, 0xff];
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const BMP = ASCII('BM');
+const GIF87 = ASCII('GIF87a');
+const GIF89 = ASCII('GIF89a');
+const RIFF = ASCII('RIFF');
+const WEBP = ASCII('WEBP');
+const FTYP = ASCII('ftyp');
+const ICO = [0x00, 0x00, 0x01, 0x00];
+const TIFF_LE = [0x49, 0x49, 0x2a, 0x00];
+const TIFF_BE = [0x4d, 0x4d, 0x00, 0x2a];
+
+/** ISO-BMFF brands that denote an image (`ftyp` box at byte 4). */
+const IMAGE_FTYP_BRANDS = new Set([
+  'avif', 'avis', 'heic', 'heix', 'heif', 'hevc', 'hevx', 'mif1', 'msf1',
+]);
+
+function isIsoBmffImage(buf: Buffer): boolean {
+  if (!matchesAt(buf, FTYP, 4)) return false;
+  const brand = buf.subarray(8, 12).toString('latin1');
+  return IMAGE_FTYP_BRANDS.has(brand);
+}
+
+function isSvgContent(buf: Buffer): boolean {
+  // Strip an optional UTF-8 BOM, then leading whitespace, then require an
+  // XML/SVG opening token. (Whether SVG is permitted at all is governed by the
+  // existing allow-lists — this only rejects garbage declared as SVG.)
+  let start = 0;
+  if (buf.length >= 3 && buf[0] === 0xef && buf[1] === 0xbb && buf[2] === 0xbf) start = 3;
+  const head = buf.subarray(start, start + 256).toString('utf8').trimStart().toLowerCase();
+  return head.startsWith('<?xml') || head.startsWith('<svg') || head.startsWith('<!doctype svg');
+}
+
+/**
+ * Returns `true` when `buffer` is acceptable for the declared `mime`:
+ * - non-`image/*` MIME → always `true` (out of scope here)
+ * - `image/*` → `true` only if the bytes start with a recognized image
+ *   signature (or, for an unknown `image/*` subtype with no known magic, `true`
+ *   so we never reject formats we simply don't have a signature for).
+ * An empty buffer declared as an image is rejected.
+ */
+export function isDeclaredImageContentValid(buffer: Buffer, mime: string): boolean {
+  const m = (mime || '').toLowerCase().trim();
+  if (!m.startsWith('image/')) return true;
+  if (buffer.length === 0) return false;
+
+  if (m === 'image/svg+xml') return isSvgContent(buffer);
+
+  const knownImageSubtype =
+    m === 'image/jpeg' || m === 'image/jpg' || m === 'image/pjpeg' ||
+    m === 'image/png' || m === 'image/apng' ||
+    m === 'image/gif' || m === 'image/bmp' || m === 'image/x-ms-bmp' ||
+    m === 'image/webp' ||
+    m === 'image/avif' || m === 'image/heic' || m === 'image/heif' ||
+    m === 'image/x-icon' || m === 'image/vnd.microsoft.icon' ||
+    m === 'image/tiff';
+
+  const matchesAnyImageSignature =
+    matchesAt(buffer, JPEG) ||
+    matchesAt(buffer, PNG) ||
+    matchesAt(buffer, GIF87) || matchesAt(buffer, GIF89) ||
+    matchesAt(buffer, BMP) ||
+    (matchesAt(buffer, RIFF) && matchesAt(buffer, WEBP, 8)) ||
+    isIsoBmffImage(buffer) ||
+    matchesAt(buffer, ICO) ||
+    matchesAt(buffer, TIFF_LE) || matchesAt(buffer, TIFF_BE);
+
+  if (matchesAnyImageSignature) return true;
+
+  // Known image subtype that failed every signature → reject (this is the
+  // garbage case). Unknown image subtype with no signature we recognize → accept.
+  return !knownImageSubtype;
+}


### PR DESCRIPTION
## Why
The 0-byte guard (PR #399) only catches truly empty uploads. A broken web client appended an RN `{uri}` descriptor to FormData → the server received a small **non-image** payload declared as `image/*` (non-zero, so it slipped past `size === 0`) and stored it as a broken avatar. The backend should reject content that doesn't match the declared image type.

## Change
- New `packages/api/src/utils/imageContentSignature.ts` — `isDeclaredImageContentValid(buffer, mime)`: for `image/*`, validates the leading magic bytes (JPEG/PNG/GIF/BMP/WEBP/AVIF-HEIC-HEIF/ICO/TIFF; SVG validated structurally). Non-`image/*` always passes (out of scope). Empty image → rejected. Unknown `image/*` subtype with no known signature → accepted (sniff-known-garbage, not an allow-list).
- `assetService.uploadFileDirect()` rejects invalid image content with **400** right after the 0-byte guard — protects every caller.
- AGENTS.md: concise rule to regenerate + verify `bun install --frozen-lockfile` before any push to main (per-repo on multi-repo dep bumps).

## Verification
- `@oxyhq/api` build (tsc) exit 0; new util test **6/6 pass**.
- Non-image uploads unaffected; only `image/*`-declared garbage is rejected.

> Layer 3 of the avatar-upload fix: client (core 3.10.1 web `{uri}`→Blob) + backend 0-byte guard (#399) + this content guard. Deploys to oxy-api (ECS) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)