### PR TITLE
fix(auth): disclose OAuth consent permissions

### DIFF
--- a/packages/auth/components/consent-card.tsx
+++ b/packages/auth/components/consent-card.tsx
@@ -1,5 +1,11 @@
 import { Link } from "react-router-dom";
-import { KeyRound, RefreshCw, ShieldCheck } from "lucide-react";
+import {
+  BadgeCheck,
+  Globe,
+  KeyRound,
+  RefreshCw,
+  ShieldCheck,
+} from "lucide-react";
 import { getAccountDisplayName } from "@oxyhq/core";
 import type { PublicApplication } from "@oxyhq/core";
 
@@ -10,6 +16,7 @@ import { BenefitList, BenefitRow } from "@oxyhq/bloom/benefit-list";
 import { Logo } from "@/components/logo";
 import { useTranslation } from "@/lib/i18n/use-translation";
 import { getAvatarUrl } from "@/lib/oxy-api-client";
+import { labelForScope } from "@/lib/scope-labels";
 
 /** Minimal shape of the consenting user rendered in the identity badge. */
 export type ConsentUser = {
@@ -27,6 +34,8 @@ export type ConsentUser = {
 type ConsentCardProps = {
   /** The resolved requesting application (always present on this view). */
   application: PublicApplication;
+  /** OAuth scopes requested by the client, or its registered scope fallback. */
+  requestedScopes: string[];
   /** The account that will authorize the request, when known. */
   user: ConsentUser | null;
   /** Whether the approve/deny actions should be shown (pending + no error). */
@@ -59,6 +68,7 @@ type ConsentCardProps = {
  */
 export function ConsentCard({
   application,
+  requestedScopes,
   user,
   showActions,
   error,
@@ -71,6 +81,15 @@ export function ConsentCard({
   const appName = application.name;
   const displayName = user ? getAccountDisplayName(user) : null;
   const userEmail = user?.email;
+  const provenanceLabel = application.isOfficial
+    ? t("authorize.provenance.official")
+    : application.isInternal
+      ? t("authorize.provenance.internal")
+      : application.developerName
+        ? t("authorize.provenance.developer", {
+            developer: application.developerName,
+          })
+        : t("authorize.provenance.thirdParty");
 
   return (
     <div className="flex flex-col gap-space-24">
@@ -102,15 +121,47 @@ export function ConsentCard({
         </div>
       </div>
 
+      {/* App provenance and requested permissions */}
+      <BenefitList accessibilityLabel={t("authorize.provenance.title")}>
+        <BenefitRow
+          icon={<BadgeCheck className="size-4 text-fill-brand" aria-hidden />}
+          label={provenanceLabel}
+        />
+        {application.websiteUrl ? (
+          <BenefitRow
+            icon={<Globe className="size-4 text-fill-brand" aria-hidden />}
+            label={application.websiteUrl}
+          />
+        ) : null}
+      </BenefitList>
+
+      <div className="flex flex-col gap-space-8">
+        <div className="px-space-4 font-caption text-caption text-text-tertiary">
+          {t("authorize.permissions.title")}
+        </div>
+        <BenefitList accessibilityLabel={t("authorize.permissions.title")}>
+          {requestedScopes.length > 0 ? (
+            requestedScopes.map((scope) => (
+              <BenefitRow
+                key={scope}
+                icon={<KeyRound className="size-4 text-fill-brand" aria-hidden />}
+                label={labelForScope(scope)}
+              />
+            ))
+          ) : (
+            <BenefitRow
+              icon={<ShieldCheck className="size-4 text-fill-brand" aria-hidden />}
+              label={t("authorize.permissions.basic")}
+            />
+          )}
+        </BenefitList>
+      </div>
+
       {/* What authorizing means for an Oxy login */}
-      <BenefitList accessibilityLabel={t("authorize.title", { app: appName })}>
+      <BenefitList accessibilityLabel={t("authorize.benefits.title")}>
         <BenefitRow
           icon={<ShieldCheck className="size-4 text-fill-brand" aria-hidden />}
           label={t("authorize.benefits.secure")}
-        />
-        <BenefitRow
-          icon={<KeyRound className="size-4 text-fill-brand" aria-hidden />}
-          label={t("authorize.benefits.oneAccount")}
         />
         <BenefitRow
           icon={<RefreshCw className="size-4 text-fill-brand" aria-hidden />}

--- a/packages/auth/lib/i18n/locales/en.ts
+++ b/packages/auth/lib/i18n/locales/en.ts
@@ -87,9 +87,21 @@ const en: LocaleDict = {
     subtitle:
       'Use your Oxy account to sign in to {{app}}. Review what this connection means before you continue.',
     benefits: {
+      title: 'What this means',
       secure: 'Sign in securely with your Oxy account — no new password needed',
       oneAccount: 'One account across every Oxy app',
       youControl: 'You choose what you share, and you can revoke access anytime',
+    },
+    provenance: {
+      title: 'Who is requesting access',
+      official: 'Official Oxy application',
+      internal: 'Internal Oxy application',
+      developer: 'Published by {{developer}}',
+      thirdParty: 'Third-party application',
+    },
+    permissions: {
+      title: 'Permissions requested',
+      basic: 'Sign you in and read your basic profile',
     },
     continue: 'Continue to {{app}}',
     cancel: 'Cancel',

--- a/packages/auth/lib/i18n/locales/es.ts
+++ b/packages/auth/lib/i18n/locales/es.ts
@@ -84,11 +84,23 @@ const es: LocaleDict = {
     subtitle:
       'Usa tu cuenta de Oxy para iniciar sesión en {{app}}. Revisa qué implica esta conexión antes de continuar.',
     benefits: {
+      title: 'Qué implica esto',
       secure:
         'Inicia sesión de forma segura con tu cuenta de Oxy, sin nuevas contraseñas',
       oneAccount: 'Una sola cuenta para todas las apps de Oxy',
       youControl:
         'Tú decides qué compartes y puedes revocar el acceso cuando quieras',
+    },
+    provenance: {
+      title: 'Quién solicita acceso',
+      official: 'Aplicación oficial de Oxy',
+      internal: 'Aplicación interna de Oxy',
+      developer: 'Publicada por {{developer}}',
+      thirdParty: 'Aplicación de terceros',
+    },
+    permissions: {
+      title: 'Permisos solicitados',
+      basic: 'Iniciar sesión y leer tu perfil básico',
     },
     continue: 'Continuar a {{app}}',
     cancel: 'Cancelar',

--- a/packages/auth/src/pages/authorize.tsx
+++ b/packages/auth/src/pages/authorize.tsx
@@ -105,6 +105,16 @@ function parseAuthuser(value: string | null): number | null {
   return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
+function parseRequestedScopes(
+  scopeValue: string | null,
+  fallbackScopes: string[] = []
+): string[] {
+  const rawScopes = scopeValue
+    ? scopeValue.split(/\s+/).filter(Boolean)
+    : fallbackScopes;
+  return Array.from(new Set(rawScopes));
+}
+
 export function AuthorizePage() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -678,6 +688,7 @@ export function AuthorizePage() {
            unchanged IdP `handleDecision` flow. */
         <ConsentCard
           application={application}
+          requestedScopes={parseRequestedScopes(scope, application.scopes)}
           user={currentUser}
           showActions={showActions}
           error={pageError}


### PR DESCRIPTION
### Motivation
- The redesigned consent UI stopped displaying requested OAuth scopes and app provenance while the backend continued to accept and persist the `scope` query value, which could allow apps to obtain broader permissions than users were shown. 

### Description
- Parse and deduplicate the URL `scope` parameter with `parseRequestedScopes(scope, application.scopes)` in `packages/auth/src/pages/authorize.tsx` and pass the resolved `requestedScopes` into the consent component. 
- Extend `ConsentCard` (`packages/auth/components/consent-card.tsx`) to accept `requestedScopes`, render app provenance/website info, and list friendly permission labels using `labelForScope`. 
- Add localized copy keys for provenance and permissions to `packages/auth/lib/i18n/locales/en.ts` and `packages/auth/lib/i18n/locales/es.ts` and use those keys in the consent card. 
- The changes preserve the existing IdP decision flow and still delegate approve/deny actions to the unchanged `onDecision` handler; only the presentation now discloses the concrete scopes being requested (falling back to the app's registered `application.scopes` when no `scope` parameter is present). 

### Testing
- Ran `git diff --check` which reported no whitespace/patch errors and passed. 
- Attempted to run `bun run --cwd packages/auth build` but the local build is blocked because `vite` is not available in the environment. 
- Attempted `bun install` to restore dependencies but the registry returned HTTP 403 for required packages, so an environment build/test run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d15f8c0bc83238a56d1e022d65808)