### PR TITLE
fix(assets): make profile avatar/banner public on save so it renders

### DIFF
--- a/packages/api/src/routes/__tests__/usersByIds.test.ts
+++ b/packages/api/src/routes/__tests__/usersByIds.test.ts
@@ -54,6 +54,10 @@ jest.mock('../../services/email.service', () => ({
 jest.mock('../../services/federation.service', () => ({
   federationService: { scheduleAvatarRefresh: jest.fn() },
 }));
+jest.mock('../../services/assetServiceSingleton', () => ({
+  assetService: { ensureOwnedAssetPublic: jest.fn().mockResolvedValue(undefined) },
+  s3Service: {},
+}));
 jest.mock('../../services/user.service', () => ({
   userService: {
     getUsersByIds: mockGetUsersByIds,

--- a/packages/api/src/routes/__tests__/usersResolve.test.ts
+++ b/packages/api/src/routes/__tests__/usersResolve.test.ts
@@ -40,6 +40,10 @@ jest.mock('../../services/email.service', () => ({
 jest.mock('../../services/federation.service', () => ({
   federationService: { scheduleAvatarRefresh: mockScheduleAvatarRefresh },
 }));
+jest.mock('../../services/assetServiceSingleton', () => ({
+  assetService: { ensureOwnedAssetPublic: jest.fn().mockResolvedValue(undefined) },
+  s3Service: {},
+}));
 jest.mock('../../services/user.service', () => ({
   userService: {},
 }));

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -23,6 +23,7 @@ import {
   BadRequestError,
 } from '../utils/error';
 import { userService } from '../services/user.service';
+import { assetService } from '../services/assetServiceSingleton';
 import { UsersController } from '../controllers/users.controller';
 import { resolveUserIdToObjectId } from '../utils/validation';
 import userCache from '../utils/userCache';
@@ -345,6 +346,17 @@ router.put(
         req.body,
         req
       );
+
+      // Profile media (avatar/banner) must be publicly viewable: an <img> can't
+      // send a bearer token, so a private asset renders as a 403 placeholder.
+      // Promote owned assets set as profile media to public (owner-gated,
+      // best-effort — never blocks the profile update).
+      for (const field of ['avatar', 'banner', 'coverPhoto'] as const) {
+        const mediaFileId = (req.body as Record<string, unknown>)[field];
+        if (typeof mediaFileId === 'string' && mediaFileId) {
+          await assetService.ensureOwnedAssetPublic(mediaFileId, req.user.id);
+        }
+      }
 
       logger.info('User profile updated', {
         userId: req.user.id,

--- a/packages/api/src/services/__tests__/assetService.dedupGuards.test.ts
+++ b/packages/api/src/services/__tests__/assetService.dedupGuards.test.ts
@@ -104,7 +104,9 @@ describe('AssetService dedup excludes deleted tombstones (cross-tenant takeover 
 
     const result = await buildAssetService(fakeS3).uploadFileDirect(
       'attacker-user-id',
-      Buffer.from('victim content'),
+      // Valid PNG magic so the image-content guard accepts it and the test
+      // exercises the tombstone-exclusion path (not a 400 content rejection).
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
       'image/png',
       'avatar.png',
     );

--- a/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
+++ b/packages/api/src/services/__tests__/uploadCachedMediaStream.abort.test.ts
@@ -293,7 +293,9 @@ describe('uploadCachedMediaStream — abort cleanup', () => {
 
     const result = await service.uploadFileDirect(
       'fresh-owner',
-      Buffer.from('JPEG'),
+      // Valid JPEG magic (FF D8 FF E0) so the image-content guard accepts it and
+      // the test exercises the fresh-record path rather than a 400 rejection.
+      Buffer.from([0xff, 0xd8, 0xff, 0xe0]),
       'image/jpeg',
       'fresh-avatar.jpg',
       'public',
@@ -444,5 +446,42 @@ describe('AssetService visibility relocation', () => {
     expect(deleteFile).toHaveBeenCalledWith('public/content/2026/06/legacy-avatar.jpg');
     expect(existingKeys.has('content/2026/06/legacy-avatar.jpg')).toBe(true);
     expect(existingKeys.has('public/content/2026/06/legacy-avatar.jpg')).toBe(false);
+  });
+});
+
+describe('ensureOwnedAssetPublic — profile media is promoted to public', () => {
+  type MaybeFile = Awaited<ReturnType<AssetService['getFile']>>;
+  const asFile = (f: { ownerUserId: string; visibility: string }): MaybeFile =>
+    ({ _id: 'f1', ...f }) as unknown as MaybeFile;
+  const okVisibility = (): Awaited<ReturnType<AssetService['updateFileVisibility']>> =>
+    ({} as unknown as Awaited<ReturnType<AssetService['updateFileVisibility']>>);
+
+  it("promotes the owner's private asset to public", async () => {
+    const { service } = buildAssetService({});
+    jest.spyOn(service, 'getFile').mockResolvedValue(asFile({ ownerUserId: 'u1', visibility: 'private' }));
+    const updateVis = jest.spyOn(service, 'updateFileVisibility').mockResolvedValue(okVisibility());
+    await service.ensureOwnedAssetPublic('f1', 'u1');
+    expect(updateVis).toHaveBeenCalledWith('f1', 'public');
+  });
+
+  it('no-ops for non-owner / already-public / missing / temp id', async () => {
+    const { service } = buildAssetService({});
+    const getFile = jest.spyOn(service, 'getFile');
+    const updateVis = jest.spyOn(service, 'updateFileVisibility').mockResolvedValue(okVisibility());
+    getFile.mockResolvedValue(asFile({ ownerUserId: 'u2', visibility: 'private' })); // not owner
+    await service.ensureOwnedAssetPublic('f1', 'u1');
+    getFile.mockResolvedValue(asFile({ ownerUserId: 'u1', visibility: 'public' })); // already public
+    await service.ensureOwnedAssetPublic('f1', 'u1');
+    getFile.mockResolvedValue(null); // missing
+    await service.ensureOwnedAssetPublic('f2', 'u1');
+    await service.ensureOwnedAssetPublic('temp-x', 'u1'); // temp id (getFile never called)
+    expect(updateVis).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the visibility update fails (best-effort)', async () => {
+    const { service } = buildAssetService({});
+    jest.spyOn(service, 'getFile').mockResolvedValue(asFile({ ownerUserId: 'u1', visibility: 'private' }));
+    jest.spyOn(service, 'updateFileVisibility').mockRejectedValue(new Error('boom'));
+    await expect(service.ensureOwnedAssetPublic('f1', 'u1')).resolves.toBeUndefined();
   });
 });

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -1599,6 +1599,31 @@ export class AssetService {
   }
 
   /**
+   * Ensure an asset the user owns is public. Used when a file is set as a
+   * public-facing profile media field (avatar/banner) — those must render
+   * unauthenticated (an `<img>` can't send a bearer token, and private media is
+   * denied to anonymous viewers). Owner-gated and best-effort: it never throws,
+   * so a profile update is never blocked by a visibility flip.
+   */
+  async ensureOwnedAssetPublic(fileId: string, userId: string): Promise<void> {
+    try {
+      if (!fileId || fileId.startsWith('temp-')) return;
+      const file = await this.getFile(fileId);
+      if (!file) return;
+      if (file.ownerUserId?.toString() !== userId.toString()) return;
+      if (file.visibility === 'public') return;
+      await this.updateFileVisibility(fileId, 'public');
+      logger.info('Profile media asset promoted to public', { fileId, userId });
+    } catch (error) {
+      logger.warn('Failed to promote profile media asset to public', {
+        fileId,
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
    * Update file visibility
    */
   async updateFileVisibility(fileId: string, visibility: FileVisibility): Promise<IFile> {


### PR DESCRIPTION
## Bug (the avatar didn't show — not even for the owner)
An avatar uploaded as **private** 403'd on display. The owner couldn't see it either: an `<img>` can't send a bearer token, and `/assets/:id/stream` authenticates **only** via the `Authorization` header (the `?token=` query param is ignored), so the image request is **anonymous** → a private asset is denied → placeholder. Avatars must be **public** (served by CDN, no auth).

## Fix
- `assetService.ensureOwnedAssetPublic(fileId, userId)` — owner-gated, best-effort promote-to-public (reuses `updateFileVisibility`, incl. the `public/` relocation). Never throws.
- `PUT /users/me` promotes the `avatar`/`banner`/`coverPhoto` fileId to public after the profile update — server-side guarantee, not a fragile client call. Route tests mock `assetServiceSingleton` like their other service deps (no dynamic-import hacks).
- **Unblocks `main`:** two dedup/tombstone tests fed non-image buffers declared `image/*`, which the #400 image-content guard now correctly rejects → updated to valid PNG/JPEG magic.
- Adds `ensureOwnedAssetPublic` unit tests.

## Verification
- `@oxyhq/api` build exit 0; full suite **765 passed, 69 suites, 0 fail, 0 skipped**.

Deploys to oxy-api (ECS) on merge. Combined with core 3.10.1 (client uri→Blob), avatars upload real bytes AND render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)