### PR TITLE
fix(assets): render owner's own private media (resolve viewer from ?token=)

### DIFF
--- a/packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts
+++ b/packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts
@@ -20,6 +20,10 @@
 // The global mongoose mock (jest.setup.cjs) omits `Types`, which optionalAuth's
 // resolveViewerId uses (`Types.ObjectId.isValid`). Restore the REAL mongoose.
 jest.mock('mongoose', () => jest.requireActual('mongoose'));
+// jest.setup.cjs globally stubs jsonwebtoken (verify always returns a fixed
+// user and never throws). getMediaViewerUserId's whole contract is real
+// signature verification + ignoreExpiration, so restore the REAL jsonwebtoken.
+jest.mock('jsonwebtoken', () => jest.requireActual('jsonwebtoken'));
 import { Types } from 'mongoose';
 import type { Response } from 'express';
 
@@ -47,9 +51,11 @@ jest.mock('../../utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
+import jwt from 'jsonwebtoken';
 import {
   optionalUserOrServiceAuth,
   resolveViewerId,
+  getMediaViewerUserId,
   type OptionalUserOrServiceRequest,
 } from '../optionalAuth';
 
@@ -177,5 +183,79 @@ describe('resolveViewerId', () => {
 
   it('returns undefined when no principal is present', () => {
     expect(resolveViewerId(makeReq())).toBeUndefined();
+  });
+});
+
+/**
+ * getMediaViewerUserId — resolves the viewer for `<img src>`/`<a download>`
+ * media URLs that cannot carry an Authorization header but DO carry the
+ * SDK-issued access token in `?token=`. Uses the REAL `jsonwebtoken` (not
+ * mocked) signed with a test ACCESS_TOKEN_SECRET.
+ */
+describe('getMediaViewerUserId (private media owner-from-query-token)', () => {
+  const SECRET = 'test-access-secret';
+  let prevSecret: string | undefined;
+
+  function makeMediaReq(
+    query: Record<string, unknown>,
+    user?: { _id: string },
+  ): OptionalUserOrServiceRequest {
+    return { headers: {}, query, user } as unknown as OptionalUserOrServiceRequest;
+  }
+
+  beforeAll(() => {
+    prevSecret = process.env.ACCESS_TOKEN_SECRET;
+    process.env.ACCESS_TOKEN_SECRET = SECRET;
+  });
+
+  afterAll(() => {
+    if (prevSecret === undefined) {
+      delete process.env.ACCESS_TOKEN_SECRET;
+    } else {
+      process.env.ACCESS_TOKEN_SECRET = prevSecret;
+    }
+  });
+
+  it('prefers the authenticated session user and ignores the query token', () => {
+    const otherToken = jwt.sign({ userId: 'attacker' }, SECRET);
+    const req = makeMediaReq({ token: otherToken }, { _id: 'session-owner' });
+    expect(getMediaViewerUserId(req)).toBe('session-owner');
+  });
+
+  it('resolves the owner from a valid ?token= when no session user is present', () => {
+    const token = jwt.sign({ userId: 'owner-123', type: 'access' }, SECRET, { expiresIn: '15m' });
+    expect(getMediaViewerUserId(makeMediaReq({ token }))).toBe('owner-123');
+  });
+
+  it('still resolves the owner from an EXPIRED token (stale cached <img> URL)', () => {
+    // Signed 1h ago with a 15m TTL → already expired, but the owner must still
+    // be able to render their own private media from a cached URL.
+    const token = jwt.sign({ userId: 'owner-123', iat: Math.floor(1_700_000_000) }, SECRET, {
+      expiresIn: '15m',
+    });
+    // Re-sign as definitively expired.
+    const expired = jwt.sign({ userId: 'owner-123', exp: 1, iat: 1 }, SECRET);
+    expect(getMediaViewerUserId(makeMediaReq({ token: expired }))).toBe('owner-123');
+    expect(getMediaViewerUserId(makeMediaReq({ token }))).toBe('owner-123');
+  });
+
+  it('returns undefined for a token signed with the WRONG secret (forged)', () => {
+    const forged = jwt.sign({ userId: 'attacker' }, 'wrong-secret');
+    expect(getMediaViewerUserId(makeMediaReq({ token: forged }))).toBeUndefined();
+  });
+
+  it('returns undefined for a garbage / malformed token', () => {
+    expect(getMediaViewerUserId(makeMediaReq({ token: 'not-a-jwt' }))).toBeUndefined();
+  });
+
+  it('returns undefined when no token and no session user are present', () => {
+    expect(getMediaViewerUserId(makeMediaReq({}))).toBeUndefined();
+  });
+
+  it('returns undefined when ACCESS_TOKEN_SECRET is not configured', () => {
+    const token = jwt.sign({ userId: 'owner-123' }, SECRET);
+    delete process.env.ACCESS_TOKEN_SECRET;
+    expect(getMediaViewerUserId(makeMediaReq({ token }))).toBeUndefined();
+    process.env.ACCESS_TOKEN_SECRET = SECRET;
   });
 });

--- a/packages/api/src/middleware/optionalAuth.ts
+++ b/packages/api/src/middleware/optionalAuth.ts
@@ -8,6 +8,7 @@
 
 import { Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
+import jwt from 'jsonwebtoken';
 import { logger } from '../utils/logger';
 import { authenticateRequestNonBlocking, AuthenticatedRequest, extractTokenFromRequest } from './authUtils';
 import { verifyServiceToken, type ServiceTokenPayload } from './auth';
@@ -46,6 +47,54 @@ export async function optionalAuthMiddleware(
  */
 export function getUserId(req: AuthenticatedRequest): string | undefined {
   return req.user?._id;
+}
+
+/**
+ * Resolve the viewer user id for a MEDIA stream/download request.
+ *
+ * A browser `<img src>` / `<a download>` cannot send an `Authorization` header,
+ * so the SDK embeds the access token in the URL query (`?token=`) for private
+ * assets (see `@oxyhq/core` `getFileDownloadUrl`). This resolves that query
+ * token to its owner user id so the OWNER can render their own private media.
+ *
+ * Important properties:
+ * - The token only IDENTIFIES the viewer. It grants no access by itself — the
+ *   caller still runs `canUserAccessFile` / `checkMediaAccess`, which is the
+ *   real authorization gate (ownership / privacy rules).
+ * - The signature is verified with `ACCESS_TOKEN_SECRET`, but expiration is
+ *   IGNORED: a cached `<img>` URL whose short-lived token already expired must
+ *   still let the owner see their own file. A forged/garbage token fails
+ *   signature verification and yields `undefined` (anonymous).
+ * - Header/session auth always wins; the query token is only a fallback when no
+ *   authenticated user is present on the request.
+ *
+ * Scope it to media stream/download routes only — never wire it into a global
+ * auth middleware (token-in-URL must not authenticate arbitrary endpoints).
+ */
+export function getMediaViewerUserId(req: AuthenticatedRequest): string | undefined {
+  const sessionUserId = getUserId(req);
+  if (sessionUserId) {
+    return sessionUserId;
+  }
+
+  const queryToken = typeof req.query?.token === 'string' ? req.query.token : undefined;
+  if (!queryToken || !process.env.ACCESS_TOKEN_SECRET) {
+    return undefined;
+  }
+
+  try {
+    const decoded = jwt.verify(queryToken, process.env.ACCESS_TOKEN_SECRET, {
+      ignoreExpiration: true,
+    }) as { userId?: string; id?: string; _id?: string };
+    return decoded.userId || decoded.id || decoded._id || undefined;
+  } catch (error) {
+    // Invalid signature / malformed token → treat as anonymous (the access
+    // check below still runs). Logged at debug for diagnostics only.
+    logger.debug('getMediaViewerUserId: query token did not verify', {
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
 }
 
 /**

--- a/packages/api/src/routes/__tests__/assetsStreamCdn.test.ts
+++ b/packages/api/src/routes/__tests__/assetsStreamCdn.test.ts
@@ -49,6 +49,10 @@ jest.mock('../../middleware/auth', () => ({
 jest.mock('../../middleware/optionalAuth', () => ({
   optionalAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
   getUserId: () => undefined,
+  // The stream/download routes resolve the viewer via getMediaViewerUserId
+  // (session user OR `?token=` owner). These CDN-redirect tests issue
+  // tokenless requests → anonymous viewer.
+  getMediaViewerUserId: () => undefined,
 }));
 
 jest.mock('../../middleware/mediaHeaders', () => ({

--- a/packages/api/src/routes/assets.ts
+++ b/packages/api/src/routes/assets.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import { assetService, s3Service } from '../services/assetServiceSingleton';
 import { authMiddleware, serviceAuthMiddleware, type ServiceAuthRequest } from '../middleware/auth';
-import { optionalAuthMiddleware, getUserId } from '../middleware/optionalAuth';
+import { optionalAuthMiddleware, getMediaViewerUserId } from '../middleware/optionalAuth';
 import { mediaHeadersMiddleware } from '../middleware/mediaHeaders';
 import { rateLimit } from '../middleware/rateLimiter';
 import { logger } from '../utils/logger';
@@ -1075,7 +1075,10 @@ router.get('/:id/exists', authMiddleware, validate({ params: assetIdParams }), a
  *         description: File not found (and no fallback requested).
  */
 router.get('/:id/stream', mediaHeadersMiddleware, validate({ params: assetIdParams }), optionalAuthMiddleware, asyncHandler(async (req: AuthenticatedRequest, res: express.Response) => {
-  const userId = getUserId(req);
+  // `<img src>` cannot send an Authorization header, so resolve the viewer from
+  // the `?token=` query (SDK-issued) when no session user is present, so owners
+  // can render their own private media. Access is still gated by canUserAccessFile.
+  const userId = getMediaViewerUserId(req);
   const { id: fileId } = req.params;
   const { variant } = req.query;
   const variantType = typeof variant === 'string' ? variant : undefined;
@@ -1282,7 +1285,10 @@ router.get('/:id/stream', mediaHeadersMiddleware, validate({ params: assetIdPara
  * @access Public (with optional authentication for private files)
  */
 router.get('/:id/download', validate({ params: assetIdParams }), optionalAuthMiddleware, asyncHandler(async (req: AuthenticatedRequest, res: express.Response) => {
-  const userId = getUserId(req);
+  // Resolve viewer from the `?token=` query for direct-download links that
+  // cannot carry an Authorization header (owners downloading their own private
+  // files). Access is still gated by canUserAccessFile below.
+  const userId = getMediaViewerUserId(req);
   const { id: fileId } = req.params;
   const { variant, expiresIn } = req.query;
 


### PR DESCRIPTION
## Problem
In the Oxy Cloud file manager (and avatars), **any private file owned by the user failed to render** — only public files loaded. A browser `<img src>` cannot send an `Authorization` header, so `@oxyhq/core` `getFileDownloadUrl` embeds the access token in the URL query (`?token=`) for private assets. The auth refactor reduced `extractTokenFromRequest` to **header-only**, so `/assets/:id/stream` and `/assets/:id/download` stopped consuming that query token → every private asset 403'd for `<img>`, **including the owner's own files**.

This is the regression originally fixed in `21c08ded` ("identify file owner from expired tokens on stream endpoint").

## Fix (scoped to media routes only)
- `getMediaViewerUserId(req)` in `middleware/optionalAuth.ts`: returns the session user when present; otherwise verifies `?token=` with `ACCESS_TOKEN_SECRET` (`ignoreExpiration`, so a stale cached `<img>` URL still identifies the owner) → returns its user id.
- It only **identifies** the viewer. `canUserAccessFile` / `checkMediaAccess` remains the real authorization gate. Forged/garbage tokens fail signature verification → anonymous.
- `/assets/:id/stream` + `/assets/:id/download` use it instead of `getUserId`.
- **Not** wired into any global auth middleware — token-in-URL must never authenticate arbitrary endpoints.

## Tests
- 7 new `getMediaViewerUserId` cases (session-wins, valid/expired owner token, forged secret, garbage, no-token, no-secret) — global `jsonwebtoken` mock unmocked for real verification.
- `assetsStreamCdn` mock updated for the new export.
- Full api suite: **69 suites / 772 tests green**, `tsc` clean.

## Follow-up (security batch domain, not this PR)
Long-term, private-media `<img>` should use short-lived **HMAC-signed URLs** (file-scoped, not a full bearer token in the URL) or a media cookie. This PR restores the existing `?token=` contract the SDK already generates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)