### PR TITLE
fix(api): guard password recovery reset origin

### DIFF
--- a/packages/api/src/routes/__tests__/authSessionLogout.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionLogout.test.ts
@@ -238,6 +238,7 @@ jest.mock('../../models/FedCMGrant', () => ({
   default: { deleteMany: jest.fn(), deleteOne: jest.fn(), find: jest.fn(), findOneAndUpdate: jest.fn() },
 }));
 import authRouter from '../auth';
+import { SessionController } from '../../controllers/session.controller';
 import { errorHandler } from '../../middleware/errorHandler';
 import { REFRESH_COOKIE_PATH } from '../../services/refreshToken.service';
 // sha256Hex is the REAL implementation (the oauthCode mock spreads `...actual`),
@@ -731,6 +732,20 @@ describe('Origin guard on the cookie-credentialed auth endpoints (MED-1)', () =>
     expect(res.body).toEqual(BAD_ORIGIN_BODY);
     expect(mockFindOne).not.toHaveBeenCalled();
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('POST /auth/recover/reset rejects a non-allowlisted Origin before resetting password', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/recover/reset',
+      { password: 'AttackerChosenPassword123!' },
+      { cookieHeader: 'oxy_recovery_token=recovery-jwt', origin: 'https://evil.oxy.so' }
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual(BAD_ORIGIN_BODY);
+    expect(SessionController.resetPassword).not.toHaveBeenCalled();
   });
 
   it('POST /auth/refresh proceeds normally with an allowlisted Origin', async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -447,7 +447,12 @@ router.post('/recover/verify', validate({ body: recoverVerifySchema }), SessionC
  *             schema:
  *               $ref: '#/components/schemas/Error'
  */
-router.post('/recover/reset', validate({ body: recoverResetSchema }), SessionController.resetPassword);
+router.post(
+  '/recover/reset',
+  requireSameSiteOrigin,
+  validate({ body: recoverResetSchema }),
+  SessionController.resetPassword
+);
 
 // ============================================
 // Social OAuth Sign-In Routes


### PR DESCRIPTION
### Motivation
- The recovery reset flow was converted to use an HttpOnly SameSite=Lax cookie, which made `/auth/recover/reset` vulnerable to same-site cross-origin form submissions from other `*.oxy.so` origins because the route lacked the existing Origin/CSRF guard used for other cookie-authenticated writes.

### Description
- Add `requireSameSiteOrigin` middleware to the `POST /auth/recover/reset` route so origin checks run before validation or password-reset handling (`packages/api/src/routes/auth.ts`).
- Add a regression test asserting a non-allowlisted Origin is rejected with 403 and `SessionController.resetPassword` is not called (`packages/api/src/routes/__tests__/authSessionLogout.test.ts`).
- Small formatting tweak to the route registration to keep middleware ordering explicit.

### Testing
- Ran `git diff --check` to validate the patch and reviewed the test diff that adds coverage for origin-guard behavior; the modified test asserts the 403 BAD_ORIGIN behavior.
- Attempted to run `bun run test -- authSessionLogout.test.ts` but the container lacks installed dependencies (`jest` not found), so the test could not be executed here; the new test is included in the commit for CI to run.
- Commit created: `fix(api): guard password recovery reset origin` (files changed: `packages/api/src/routes/auth.ts`, `packages/api/src/routes/__tests__/authSessionLogout.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d547424ac8323a237e0f289dba401)