### PR TITLE
fix(api): bind access tokens to active session

### DIFF
--- a/packages/api/src/models/Session.ts
+++ b/packages/api/src/models/Session.ts
@@ -17,6 +17,7 @@ export interface ISession extends Document {
     fingerprint?: string; // Device fingerprint for identification
   };
   accessToken: string; // Current access token for this session
+  previousAccessToken?: string; // Previous access token kept for grace period after rotation/re-issue
   refreshToken: string; // Refresh token for this session
   previousRefreshToken?: string; // Previous refresh token kept for grace period after rotation
   tokenRotatedAt?: Date; // When the refresh token was last rotated
@@ -58,6 +59,10 @@ const SessionSchema: Schema = new Schema(
       type: String,
       required: true,
     },
+    previousAccessToken: {
+      type: String,
+      default: null,
+    },
     refreshToken: {
       type: String,
       required: true,
@@ -96,6 +101,7 @@ SessionSchema.index({ userId: 1, isActive: 1, expiresAt: 1 }); // Active session
 SessionSchema.index({ deviceId: 1, isActive: 1, expiresAt: 1 }); // Optimized compound index for device sessions query
 SessionSchema.index({ accessToken: 1 }, { unique: true, sparse: true }); // Token-based lookups (sparse for performance)
 SessionSchema.index({ refreshToken: 1 }, { unique: true, sparse: true }); // Refresh token lookups (sparse for performance)
+SessionSchema.index({ previousAccessToken: 1, tokenRotatedAt: 1 }, { sparse: true }); // Access-token grace validation after rotation/re-issue
 SessionSchema.index({ previousRefreshToken: 1, tokenRotatedAt: 1 }, { sparse: true }); // Grace period lookups for concurrent tab refreshes
 SessionSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 }); // Auto-cleanup expired sessions
 SessionSchema.index({ 'deviceInfo.fingerprint': 1, isActive: 1, expiresAt: 1 }); // Optimized for findExistingDeviceId queries

--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -290,6 +290,17 @@ describe('Session Service', () => {
       expect(second.sessionId).toBe(firstSessionId);
       expect(second.accessToken).toBe('refreshed-access-token');
       expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+      expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+        { _id: 'mongo-id-123' },
+        expect.objectContaining({
+          $set: expect.objectContaining({
+            previousAccessToken: 'mock-access-token',
+            previousRefreshToken: 'mock-refresh-token',
+            tokenRotatedAt: expect.any(Date),
+          }),
+        }),
+        { new: true }
+      );
       expect(mockSave).toHaveBeenCalledTimes(1);
 
       // Both exchanges keyed the reuse lookup on the SAME derived deviceId
@@ -356,6 +367,33 @@ describe('Session Service', () => {
       expect(result!.user).toBeDefined();
       expect(result!.payload).toBeDefined();
       expect(result!.payload.sessionId).toBe('session-123');
+    });
+
+    it('should accept recently rotated previous access token within grace window', async () => {
+      const mockSession = createMockSession({
+        accessToken: 'new-access-token',
+        previousAccessToken: 'old-access-token',
+        tokenRotatedAt: new Date(),
+      });
+      mockFindOneResults.push(mockSession);
+
+      const result = await sessionService.validateSession('old-access-token');
+
+      expect(result).toBeDefined();
+      expect(result!.session.sessionId).toBe('session-123');
+    });
+
+    it('should reject rotated-out access token after grace window', async () => {
+      const mockSession = createMockSession({
+        accessToken: 'new-access-token',
+        previousAccessToken: 'old-access-token',
+        tokenRotatedAt: new Date(Date.now() - 31_000),
+      });
+      mockFindOneResults.push(mockSession);
+
+      const result = await sessionService.validateSession('old-access-token');
+
+      expect(result).toBeNull();
     });
 
     it('should reject expired session', async () => {

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -28,6 +28,34 @@ const REFRESH_TOKEN_EXPIRES_IN = '7d';
 const OBJECT_ID_LENGTH = 24; // MongoDB ObjectId hex string length
 const TOKEN_ROTATION_GRACE_PERIOD_MS = 30_000; // 30 seconds grace period for concurrent tab refreshes
 
+function timingSafeTokenEqual(a: string | undefined | null, b: string | undefined | null): boolean {
+  if (!a || !b) return false;
+
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+  if (aBuffer.length !== bBuffer.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(aBuffer, bBuffer);
+}
+
+function isWithinTokenRotationGrace(rotatedAt: Date | undefined | null): boolean {
+  if (!rotatedAt) return false;
+  return Date.now() - rotatedAt.getTime() <= TOKEN_ROTATION_GRACE_PERIOD_MS;
+}
+
+function isAccessTokenAcceptedForSession(session: ISession, accessToken: string): boolean {
+  if (timingSafeTokenEqual(accessToken, session.accessToken)) {
+    return true;
+  }
+
+  return (
+    isWithinTokenRotationGrace(session.tokenRotatedAt) &&
+    timingSafeTokenEqual(accessToken, session.previousAccessToken)
+  );
+}
+
 /**
  * Extract userId string from various possible formats (ObjectId, populated object, string)
  * Handles edge cases and corrupted cache entries gracefully
@@ -240,6 +268,10 @@ class SessionService {
 
       const { session } = result;
 
+      if (!isAccessTokenAcceptedForSession(session, accessToken)) {
+        return null;
+      }
+
       if (sessionCache.shouldUpdateLastActive(sessionId)) {
         this.updateLastActivity(sessionId).catch(() => {
           // Silently fail - non-critical operation
@@ -367,7 +399,7 @@ class SessionService {
         deviceId: deviceInfo.deviceId,
         isActive: true,
         expiresAt: { $gt: new Date() }
-      }).select('_id sessionId deviceInfo').lean();
+      }).select('_id sessionId deviceInfo accessToken refreshToken').lean();
 
       if (existingSession) {
         const sessionId = existingSession.sessionId;
@@ -379,8 +411,11 @@ class SessionService {
           { _id: existingSession._id },
           {
             $set: {
+              previousAccessToken: existingSession.accessToken,
               accessToken,
+              previousRefreshToken: existingSession.refreshToken,
               refreshToken,
+              tokenRotatedAt: now,
               expiresAt,
               lastRefresh: now,
               'deviceInfo.lastActive': now,
@@ -527,6 +562,7 @@ class SessionService {
         payload.deviceId || session.deviceId
       );
 
+      session.previousAccessToken = session.accessToken;
       session.previousRefreshToken = session.refreshToken;
       session.tokenRotatedAt = now;
       session.accessToken = newAccessToken;


### PR DESCRIPTION
### Motivation

- Restore replay-resistance for access-token rotation so a rotated-out bearer JWT is rejected once the rotation grace window elapses.  
- The prior change removed the binding between presented access token and the session record, allowing captured old tokens to remain usable until JWT expiry.

### Description

- Add `previousAccessToken` to the `Session` model and create an index for `(previousAccessToken, tokenRotatedAt)` to support bounded grace lookups.  
- Reintroduce timing-safe token comparison helpers (`timingSafeTokenEqual`, `isWithinTokenRotationGrace`, `isAccessTokenAcceptedForSession`) and require `validateSession` to accept only the current `accessToken` or the `previousAccessToken` within the configured grace window.  
- Persist the previous access token on both issuance paths (existing-session reuse / `findOneAndUpdate` and `refreshTokens`) so the short rotation grace works across tab/race/IdP re-issuance scenarios.  
- Add regression tests in `packages/api/src/services/__tests__/session.service.test.ts` to cover: reuse-path rotation metadata, acceptance of a recent `previousAccessToken` within the grace window, and rejection after the grace window.

### Testing

- Added unit tests in `packages/api/src/services/__tests__/session.service.test.ts` covering previous-token acceptance/rejection and reuse-path rotation metadata but they could not be executed in this environment because `jest` is not available (`jest: command not found`).  
- Attempted `bun run build` but the build fails early due to unrelated TypeScript config issues in `@oxyhq/contracts` (TS5107/TS5011) preventing a full build in this environment.  
- `bun install --frozen-lockfile` also failed here due to npm registry HTTP 403 responses, so full CI/test execution was blocked; local static checks (`git diff --check`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4bed6df483238eb31a4fbf8efec5)