### PR TITLE
fix(api): allow asset uploads after deleted sha tombstones

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,7 +16,8 @@
     "lint:fix": "eslint . --fix",
     "openapi:generate": "bun scripts/generate-openapi.ts",
     "prepublishOnly": "bun run clean && bun run build",
-    "release": "rm -rf dist && bun run build && release-it"
+    "release": "rm -rf dist && bun run build && release-it",
+    "migrate:file-sha256-index": "bun scripts/migrate-file-sha256-index.ts"
   },
   "release-it": {
     "git": {

--- a/packages/api/scripts/migrate-file-sha256-index.ts
+++ b/packages/api/scripts/migrate-file-sha256-index.ts
@@ -1,0 +1,48 @@
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import { File } from '../src/models/File';
+
+dotenv.config();
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error('MONGODB_URI is required');
+  }
+
+  await mongoose.connect(uri);
+  const collection = File.collection;
+
+  const indexes = await collection.indexes();
+  const legacyShaIndex = indexes.find((index) =>
+    index.name === 'sha256_1' &&
+    JSON.stringify(index.key) === JSON.stringify({ sha256: 1 }) &&
+    !index.partialFilterExpression
+  );
+
+  if (legacyShaIndex) {
+    await collection.dropIndex(legacyShaIndex.name);
+    console.log(`Dropped legacy global sha256 index: ${legacyShaIndex.name}`);
+  } else {
+    console.log('Legacy global sha256 index not found; skipping drop.');
+  }
+
+  await collection.createIndex(
+    { sha256: 1 },
+    {
+      unique: true,
+      partialFilterExpression: { $or: [{ status: 'active' }, { status: 'trash' }] },
+      name: 'sha256_not_deleted_unique',
+    },
+  );
+  console.log('Ensured partial unique sha256_not_deleted_unique index for non-deleted files.');
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await mongoose.connection.close();
+  });

--- a/packages/api/src/models/File.ts
+++ b/packages/api/src/models/File.ts
@@ -88,8 +88,7 @@ const FileVariantSchema = new Schema<IFileVariant>({
 const FileSchema = new Schema<IFile>({
   sha256: { 
     type: String, 
-    required: true, 
-    unique: true,
+    required: true,
     index: true 
   },
   size: { type: Number, required: true },
@@ -139,6 +138,14 @@ FileSchema.index({ ownerUserId: 1, status: 1 });
 FileSchema.index({ ownerUserId: 1, visibility: 1, status: 1 });
 FileSchema.index({ visibility: 1, status: 1 }); // For public file queries
 FileSchema.index({ 'links.app': 1, 'links.entityType': 1, 'links.entityId': 1 });
+FileSchema.index(
+  { sha256: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { $or: [{ status: 'active' }, { status: 'trash' }] },
+    name: 'sha256_not_deleted_unique',
+  }
+);
 FileSchema.index({ sha256: 1, status: 1 });
 FileSchema.index({ purpose: 1, ownerUserId: 1, status: 1 }); // For cache-namespace lookups
 FileSchema.index({ createdAt: -1 });

--- a/packages/api/src/models/__tests__/File.indexes.test.ts
+++ b/packages/api/src/models/__tests__/File.indexes.test.ts
@@ -1,0 +1,21 @@
+import { File } from '../File';
+
+describe('File indexes', () => {
+  it('uses a partial unique sha256 index so deleted tombstones do not block new uploads', () => {
+    const indexes = File.schema.indexes();
+
+    expect(indexes).toContainEqual([
+      { sha256: 1 },
+      expect.objectContaining({
+        unique: true,
+        name: 'sha256_not_deleted_unique',
+        partialFilterExpression: { $or: [{ status: 'active' }, { status: 'trash' }] },
+      }),
+    ]);
+
+    expect(indexes).not.toContainEqual([
+      { sha256: 1 },
+      expect.objectContaining({ unique: true, partialFilterExpression: undefined }),
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- A recent change excluded `deleted` tombstones from SHA-256 dedup lookups but left a global unique index on `File.sha256`, which caused `E11000` duplicate-key failures when a tombstone with the same hash exists and blocked fresh uploads of identical content.  
- The intent is to preserve deduplication for live assets while allowing new inserts when only a deleted tombstone remains, restoring availability without reintroducing the prior revive/reassign ownership path.

### Description
- Removed the field-level global `unique: true` constraint from the `sha256` field and added a named partial unique index that applies only to non-deleted files (`status: 'active' | 'trash'`) via `FileSchema.index(... { partialFilterExpression: ... })` in `packages/api/src/models/File.ts`.  
- Added a migration helper script `packages/api/scripts/migrate-file-sha256-index.ts` and a `migrate:file-sha256-index` npm script to drop any legacy global `sha256` index and ensure the new partial unique index exists in deployed databases.  
- Added regression coverage `packages/api/src/models/__tests__/File.indexes.test.ts` asserting the schema exposes the partial unique `sha256` index and does not define a global unique `sha256` index.  
- Kept existing duplicate-race recovery and tombstone-exclusion behavior intact so uploads that collide with active records remain deduped while tombstoned hashes no longer block new inserts.

### Testing
- Ran a local source assertion that verified the `File` schema no longer contains the field-level global `unique: true` and that the named partial unique index `sha256_not_deleted_unique` with `partialFilterExpression` for `active`/`trash` is present, which succeeded.  
- Added a unit test `packages/api/src/models/__tests__/File.indexes.test.ts` to assert the new index shape (test file present but full `jest` execution could not be run in this environment).  
- Attempted to run package tests via `bun run --cwd packages/api test ...` but `jest` and other dependencies were unavailable in the execution environment, and `bun install --frozen-lockfile` failed due to registry 403 errors, so full automated test runs could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d49fa41a883238261e8836cb3246f)