### PR TITLE
fix(api): prevent deleted asset tombstones blocking uploads

### DIFF
--- a/packages/api/src/models/File.ts
+++ b/packages/api/src/models/File.ts
@@ -66,6 +66,8 @@ export interface IFile extends Omit<Document, '_id'> {
  */
 export type FilePurpose = 'user' | 'federation-media-cache';
 
+const LIVE_FILE_STATUSES = ['active', 'trash'] as const;
+
 const FileLinkSchema = new Schema<IFileLink>({
   app: { type: String, required: true, index: true },
   entityType: { type: String, required: true, index: true },
@@ -86,11 +88,10 @@ const FileVariantSchema = new Schema<IFileVariant>({
 }, { _id: false });
 
 const FileSchema = new Schema<IFile>({
-  sha256: { 
-    type: String, 
-    required: true, 
-    unique: true,
-    index: true 
+  sha256: {
+    type: String,
+    required: true,
+    index: true
   },
   size: { type: Number, required: true },
   mime: { type: String, required: true, index: true },
@@ -135,6 +136,18 @@ FileSchema.virtual('usageCount').get(function() {
 });
 
 // Compound indexes for efficient queries
+// Keep content-addressed deduplication unique only for live records. Deleted
+// tombstones intentionally remain invisible to upload deduplication, so they
+// must not reserve their sha256 forever and block future uploads of the same
+// bytes by another user or a federation cache flow.
+FileSchema.index(
+  { sha256: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { status: { $in: [...LIVE_FILE_STATUSES] } },
+    name: 'sha256_live_unique'
+  }
+);
 FileSchema.index({ ownerUserId: 1, status: 1 });
 FileSchema.index({ ownerUserId: 1, visibility: 1, status: 1 });
 FileSchema.index({ visibility: 1, status: 1 }); // For public file queries
@@ -152,3 +165,33 @@ FileSchema.index({
 });
 
 export const File = mongoose.model<IFile>('File', FileSchema);
+
+/**
+ * Migrate the legacy global sha256 unique index to the live-record-only unique
+ * index declared above. Auto-indexing can create the new index, but it will not
+ * remove the old `sha256_1` index; leaving that global index in place would let
+ * deleted tombstones keep blocking future uploads of identical content.
+ */
+export async function ensureFileSha256LiveUniqueIndex(): Promise<void> {
+  const indexes = await File.collection.indexes();
+  const legacyGlobalShaIndexName = indexes.find((index) => {
+    const key = index.key as Record<string, unknown> | undefined;
+    return index.name === 'sha256_1'
+      && index.unique === true
+      && key?.sha256 === 1
+      && !index.partialFilterExpression;
+  })?.name;
+
+  if (legacyGlobalShaIndexName) {
+    await File.collection.dropIndex(legacyGlobalShaIndexName);
+  }
+
+  await File.collection.createIndex(
+    { sha256: 1 },
+    {
+      unique: true,
+      partialFilterExpression: { status: { $in: [...LIVE_FILE_STATUSES] } },
+      name: 'sha256_live_unique'
+    }
+  );
+}

--- a/packages/api/src/models/__tests__/file.indexes.test.ts
+++ b/packages/api/src/models/__tests__/file.indexes.test.ts
@@ -1,0 +1,27 @@
+// The global jest.setup.cjs mocks `mongoose` wholesale; the real File schema —
+// its indexes and `sha256` path options under test — only builds against the
+// actual module, so restore it for this suite.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import { File } from '../File';
+
+describe('File sha256 indexes', () => {
+  it('keeps sha256 uniqueness scoped to live records so deleted tombstones do not block replacement uploads', () => {
+    const indexes = File.schema.indexes();
+
+    expect(indexes).toContainEqual([
+      { sha256: 1 },
+      expect.objectContaining({
+        unique: true,
+        name: 'sha256_live_unique',
+        partialFilterExpression: { status: { $in: ['active', 'trash'] } },
+      }),
+    ]);
+
+    const shaPath = File.schema.path('sha256') as { options: { unique?: boolean } };
+    expect(shaPath.options.unique).toBeUndefined();
+  });
+});

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -8,6 +8,7 @@ import notificationsRouter from "./routes/notifications.routes";
 import sessionRouter from "./routes/session";
 import dotenv from "dotenv";
 import User, { IUser } from "./models/User";
+import { ensureFileSha256LiveUniqueIndex } from "./models/File";
 import searchRoutes from "./routes/search";
 import { rateLimiter, authRateLimiter, userRateLimiter, bruteForceProtection, securityHeaders } from "./middleware/security";
 import privacyRoutes from "./routes/privacy";
@@ -333,7 +334,8 @@ const mongoOptions = {
 };
 
 mongoose.connect(process.env.MONGODB_URI as string, mongoOptions)
-.then(() => {
+.then(async () => {
+  await ensureFileSha256LiveUniqueIndex();
   logger.info("Connected to MongoDB successfully", {
     maxPoolSize: mongoOptions.maxPoolSize,
     minPoolSize: mongoOptions.minPoolSize,

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -77,9 +77,9 @@ export class AssetService {
    * tombstone and reassigning its ownership to the next uploader was a
    * cross-tenant ownership-takeover vector (any user who can produce content
    * whose SHA-256 collides with a victim's deleted file could revive that
-   * record under their own ownership). With the `status: { $ne: 'deleted' }`
-   * filter a fresh upload whose content matches only a tombstone simply inserts
-   * a brand-new record owned by the uploader.
+   * record under their own ownership). The File model's sha256 uniqueness is
+   * scoped to live records, so a fresh upload whose content matches only a
+   * tombstone can insert a brand-new record owned by the uploader.
    */
   private async findActiveFileBySha(sha256: string): Promise<IFile | null> {
     return File.findOne({ sha256, status: { $ne: 'deleted' } });


### PR DESCRIPTION
### Motivation
- Deletion left File documents with their `sha256` intact (status `deleted`), while deduplication queries deliberately ignored deleted tombstones, which created a situation where new inserts hit the unchanged global `sha256` unique constraint and failed (targeted availability denial for chosen content).
- The goal is to allow fresh uploads to reuse a SHA-256 previously held by a deleted tombstone while preserving the cross-tenant safety that prevented tombstone revival under a different owner.

### Description
- Remove the schema-level global `unique: true` on `File.sha256` and add a partial unique index `sha256_live_unique` scoped to live records (`status` in `['active','trash']`) so only non-deleted records reserve a sha256.
- Add `ensureFileSha256LiveUniqueIndex()` to detect and drop a legacy global `sha256_1` unique index (if present) and to create the new partial unique index at startup.
- Invoke `ensureFileSha256LiveUniqueIndex()` during MongoDB connection startup so existing deployments are migrated (legacy index removed) automatically when the service starts.
- Update the `AssetService` deduplication comment to reflect the model change and add a regression unit test asserting the new index configuration (`packages/api/src/models/__tests__/file.indexes.test.ts`).

### Testing
- Added a focused regression test `packages/api/src/models/__tests__/file.indexes.test.ts` to assert `sha256` uniqueness is implemented as the `sha256_live_unique` partial unique index and no longer declared on the schema path.
- Attempted to run the targeted tests with `bun run test --runTestsByPath src/services/__tests__/assetService.dedupGuards.test.ts src/models/__tests__/file.indexes.test.ts --runInBand`, but the test run failed because the test runner (`jest`) was not available in the environment (`jest: command not found`).
- Attempted `bun install --frozen-lockfile` to fetch dependencies so tests could run, but the install failed due to registry HTTP 403 responses for required packages (including `jest` and `mongoose`), preventing full automated test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d49f9af9883239deeb2c5c35b550b)