### PR TITLE
fix(api): restrict public identity log export

### DIFF
--- a/packages/api/src/routes/__tests__/nodesLog.test.ts
+++ b/packages/api/src/routes/__tests__/nodesLog.test.ts
@@ -2,7 +2,7 @@
  * Route-shape tests for the public node-log endpoints (F5a Oxy→node export).
  *
  *  - GET /identity/log/:userId?since=<seq|recordId>&limit= → { records, count }
- *    forwarding the resolved `since` seq + limit to `getLogSince`.
+ *    forwarding the resolved `since` seq + limit to `getPublicLogSince`.
  *  - GET /identity/head/:userId → { seq, headRecordId, recordCount } (or empty).
  *
  * The repoLog service is mocked (its ordering/capping is covered in
@@ -11,7 +11,7 @@
 
 import type { SignedRecordEnvelope } from '@oxyhq/contracts';
 
-const mockGetLogSince = jest.fn();
+const mockGetPublicLogSince = jest.fn();
 const mockGetHead = jest.fn();
 const mockResolveCursorSeq = jest.fn();
 
@@ -29,7 +29,7 @@ jest.mock('../../services/signedRecord.service', () => ({
 
 jest.mock('../../services/repoLog.service', () => ({
   getHead: (...args: unknown[]) => mockGetHead(...args),
-  getLogSince: (...args: unknown[]) => mockGetLogSince(...args),
+  getPublicLogSince: (...args: unknown[]) => mockGetPublicLogSince(...args),
   resolveCursorSeq: (...args: unknown[]) => mockResolveCursorSeq(...args),
 }));
 
@@ -99,43 +99,43 @@ beforeEach(() => { jest.clearAllMocks(); });
 
 describe('GET /identity/log/:userId', () => {
   it('returns { records, count } from genesis when no since is given', async () => {
-    mockGetLogSince.mockResolvedValueOnce([envelope(0), envelope(1)]);
+    mockGetPublicLogSince.mockResolvedValueOnce([envelope(0), envelope(1)]);
 
     const res = await request(server, 'GET', `/identity/log/${USER_ID}`);
 
     expect(res.status).toBe(200);
-    expect(mockGetLogSince).toHaveBeenCalledWith(USER_ID, -1, undefined);
+    expect(mockGetPublicLogSince).toHaveBeenCalledWith(USER_ID, -1, undefined);
     expect(res.body.count).toBe(2);
     expect(Array.isArray(res.body.records)).toBe(true);
     expect((res.body.records as unknown[]).length).toBe(2);
   });
 
   it('forwards a numeric since (exclusive) and the limit', async () => {
-    mockGetLogSince.mockResolvedValueOnce([envelope(4)]);
+    mockGetPublicLogSince.mockResolvedValueOnce([envelope(4)]);
 
     const res = await request(server, 'GET', `/identity/log/${USER_ID}?since=3&limit=10`);
 
     expect(res.status).toBe(200);
-    expect(mockGetLogSince).toHaveBeenCalledWith(USER_ID, 3, 10);
+    expect(mockGetPublicLogSince).toHaveBeenCalledWith(USER_ID, 3, 10);
   });
 
   it('resolves a recordId cursor to its seq', async () => {
     mockResolveCursorSeq.mockResolvedValueOnce(9);
-    mockGetLogSince.mockResolvedValueOnce([envelope(10)]);
+    mockGetPublicLogSince.mockResolvedValueOnce([envelope(10)]);
 
     const recordId = 'r'.repeat(64);
     const res = await request(server, 'GET', `/identity/log/${USER_ID}?since=${recordId}`);
 
     expect(res.status).toBe(200);
     expect(mockResolveCursorSeq).toHaveBeenCalledWith(USER_ID, recordId);
-    expect(mockGetLogSince).toHaveBeenCalledWith(USER_ID, 9, undefined);
+    expect(mockGetPublicLogSince).toHaveBeenCalledWith(USER_ID, 9, undefined);
   });
 
   it('returns 400 for an unknown recordId cursor', async () => {
     mockResolveCursorSeq.mockResolvedValueOnce(null);
     const res = await request(server, 'GET', `/identity/log/${USER_ID}?since=${'r'.repeat(64)}`);
     expect(res.status).toBe(400);
-    expect(mockGetLogSince).not.toHaveBeenCalled();
+    expect(mockGetPublicLogSince).not.toHaveBeenCalled();
   });
 
   it('returns 404 for an invalid user id', async () => {

--- a/packages/api/src/routes/identity.ts
+++ b/packages/api/src/routes/identity.ts
@@ -42,7 +42,7 @@ import {
   getLatestRecord,
   type SignedRecordSubject,
 } from '../services/signedRecord.service';
-import { getHead, getLogSince, resolveCursorSeq } from '../services/repoLog.service';
+import { getHead, getPublicLogSince, resolveCursorSeq } from '../services/repoLog.service';
 import { materializeNodeFromRecord } from '../services/nodeRegistry.service';
 
 const router = Router();
@@ -247,9 +247,10 @@ router.get(
 
 /**
  * GET /identity/log/:userId?since=<seq|recordId>&limit= — the ordered slice of a
- * subject's verified signed-record chain (the FULL envelopes, so a node or any
- * verifier re-checks them independently). This is the Oxy→node export of the
- * authentic chain. Public, CORS-open, short-cached. A pure Oxy-DB read — it
+ * subject's public-safe verified signed-record chain (identity/profile/node
+ * records only; the FULL envelopes, so a node or any verifier re-checks them
+ * independently). This is the Oxy→node export of the public bootstrap chain.
+ * Public, CORS-open, short-cached. A pure Oxy-DB read — it
  * touches ONLY Oxy's own copy of the chain, never a node. `since` is a chain
  * `seq` (exclusive) or the last-ingested `recordId`; absent → from genesis.
  */
@@ -277,7 +278,7 @@ router.get(
     }
 
     const limitRaw = typeof req.query.limit === 'string' ? Number.parseInt(req.query.limit, 10) : Number.NaN;
-    const records = await getLogSince(userId, sinceSeq, Number.isFinite(limitRaw) ? limitRaw : undefined);
+    const records = await getPublicLogSince(userId, sinceSeq, Number.isFinite(limitRaw) ? limitRaw : undefined);
 
     res.setHeader('Access-Control-Allow-Origin', '*');
     res.setHeader('Cache-Control', 'public, max-age=5');

--- a/packages/api/src/services/__tests__/repoLog.test.ts
+++ b/packages/api/src/services/__tests__/repoLog.test.ts
@@ -25,7 +25,7 @@ jest.mock('../../models/RepoHead', () => ({
   default: { findOne: (...args: unknown[]) => mockHeadFindOne(...args) },
 }));
 
-import { getLogSince, getHead, resolveCursorSeq } from '../repoLog.service';
+import { getLogSince, getPublicLogSince, getHead, resolveCursorSeq, PUBLIC_LOG_COLLECTIONS } from '../repoLog.service';
 
 const USER_ID = '507f1f77bcf86cd799439011';
 
@@ -73,6 +73,35 @@ describe('getLogSince', () => {
 
     await getLogSince(USER_ID, -1);
     expect(capturedLimit).toBe(100);
+  });
+});
+
+
+describe('getPublicLogSince', () => {
+  it('filters to verified public-safe collections only', async () => {
+    let capturedLimit = -1;
+    mockSrFind.mockReturnValue({
+      sort: (sortArg: unknown) => {
+        expect(sortArg).toEqual({ seq: 1 });
+        return {
+          limit: (n: number) => {
+            capturedLimit = n;
+            return { lean: () => Promise.resolve([{ envelope: { seq: 1, type: 'identity' } }]) };
+          },
+        };
+      },
+    });
+
+    const envelopes = await getPublicLogSince(USER_ID, 0, 25);
+
+    expect(mockSrFind).toHaveBeenCalledWith({
+      userId: USER_ID,
+      seq: { $gt: 0 },
+      verified: true,
+      nsid: { $in: [...PUBLIC_LOG_COLLECTIONS] },
+    });
+    expect(capturedLimit).toBe(25);
+    expect(envelopes).toEqual([{ seq: 1, type: 'identity' }]);
   });
 });
 

--- a/packages/api/src/services/repoLog.service.ts
+++ b/packages/api/src/services/repoLog.service.ts
@@ -13,6 +13,10 @@
 import type { SignedRecordEnvelope } from '@oxyhq/contracts';
 import SignedRecord from '../models/SignedRecord';
 import RepoHead from '../models/RepoHead';
+import { NODE_COLLECTION } from '../utils/nodes.constants';
+
+/** Public-safe NSIDs that unauthenticated node bootstrap may export. */
+export const PUBLIC_LOG_COLLECTIONS = ['app.oxy.identity', 'app.oxy.profile', NODE_COLLECTION] as const;
 
 /** Default page size for {@link getLogSince}. */
 const DEFAULT_LOG_LIMIT = 100;
@@ -32,13 +36,42 @@ export interface ChainHead {
  * records have a `seq`, so v1 rows are naturally excluded. Pass `sinceSeq = -1`
  * to start from genesis (`seq === 0`).
  */
+function clampLogLimit(limit: number): number {
+  return Math.max(1, Math.min(Math.trunc(limit) || DEFAULT_LOG_LIMIT, MAX_LOG_LIMIT));
+}
+
 export async function getLogSince(
   userId: string,
   sinceSeq: number,
   limit: number = DEFAULT_LOG_LIMIT,
 ): Promise<SignedRecordEnvelope[]> {
-  const capped = Math.max(1, Math.min(Math.trunc(limit) || DEFAULT_LOG_LIMIT, MAX_LOG_LIMIT));
+  const capped = clampLogLimit(limit);
   const rows = await SignedRecord.find({ userId, seq: { $gt: sinceSeq } })
+    .sort({ seq: 1 })
+    .limit(capped)
+    .lean<Array<{ envelope: SignedRecordEnvelope }>>();
+  return rows.map((row) => row.envelope);
+}
+
+/**
+ * Public node-bootstrap log export. Unlike the internal full-chain helper, this
+ * returns only verified records whose collections are safe to expose to
+ * unauthenticated readers: public identity/profile material plus the user's node
+ * registration. Civic attestations, credentials, reputation provenance, and any
+ * future private record collections stay out of the CORS-open log.
+ */
+export async function getPublicLogSince(
+  userId: string,
+  sinceSeq: number,
+  limit: number = DEFAULT_LOG_LIMIT,
+): Promise<SignedRecordEnvelope[]> {
+  const capped = clampLogLimit(limit);
+  const rows = await SignedRecord.find({
+    userId,
+    seq: { $gt: sinceSeq },
+    verified: true,
+    nsid: { $in: [...PUBLIC_LOG_COLLECTIONS] },
+  })
     .sort({ seq: 1 })
     .limit(capped)
     .lean<Array<{ envelope: SignedRecordEnvelope }>>();


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated, CORS-open leakage of every signed-record envelope via `/identity/log/:userId` which exposed sensitive civic/credential/reputation payloads.
- Limit the public node-bootstrap export to only the record types safe for unauthenticated readers (identity/profile/node registration) and ensure only verified records are published.

### Description
- Add `PUBLIC_LOG_COLLECTIONS` including `app.oxy.identity`, `app.oxy.profile`, and the node registration NSID and introduce `getPublicLogSince()` in `packages/api/src/services/repoLog.service.ts` which enforces `verified: true` and an `nsid` allowlist and reuses a clamped limit helper (`clampLogLimit`).
- Keep the internal `getLogSince()` for full internal reads and introduce `getPublicLogSince()` for the CORS-open export; the public helper returns only the allowed collections' envelopes.
- Update the identity route to call `getPublicLogSince()` instead of `getLogSince()` in `packages/api/src/routes/identity.ts` so `/identity/log/:userId` is now filtered.
- Update unit/route tests to assert the new public-safe behavior in `packages/api/src/services/__tests__/repoLog.test.ts` and `packages/api/src/routes/__tests__/nodesLog.test.ts`.

### Testing
- Updated unit tests `packages/api/src/services/__tests__/repoLog.test.ts` and route tests `packages/api/src/routes/__tests__/nodesLog.test.ts` to cover `getPublicLogSince()` and that the `/identity/log` route delegates to it (tests assert the `verified` + `nsid` filter).  
- Attempted to run the updated tests via the workspace test command, but execution was blocked because `jest` was not available in the environment (`jest: command not found`).
- Attempted to install dependencies with `bun install --frozen-lockfile`, but the run failed due to the environment/npm registry returning HTTP 403 for package tarballs, preventing full test execution in CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a408285cac48323b7495839c5fd2652)