### PR TITLE
fix(api): prevent personhood revouch reputation farming

### DIFF
--- a/packages/api/src/models/PersonhoodVouch.ts
+++ b/packages/api/src/models/PersonhoodVouch.ts
@@ -12,8 +12,10 @@ import mongoose, { Document, Schema } from 'mongoose';
  * flips to `slashed` (see `slash.service` / `personhood.service`).
  *
  * Exactly one ACTIVE vouch per (voucher, subject) pair — the unique compound
- * index is the dedup backstop. The `{subjectUserId, status}` index drives the
- * recompute aggregation (the subject's active vouchers).
+ * index is the concurrency backstop. Service-level checks reject any historical
+ * vouch for the same pair (including withdrawn/slashed) before issuing a new
+ * signed record or reputation award. The `{subjectUserId, status}` index drives
+ * the recompute aggregation (the subject's active vouchers).
  */
 export type PersonhoodVouchStatus = 'active' | 'slashed' | 'withdrawn';
 
@@ -48,9 +50,9 @@ const PersonhoodVouchSchema = new Schema<IPersonhoodVouch>(
   { timestamps: true, strict: true },
 );
 
-// One ACTIVE vouch per (voucher, subject) pair — the dedup backstop. Partial on
-// `status: 'active'` so a withdrawn/slashed vouch leaves history yet the pair can
-// be vouched for again later.
+// One ACTIVE vouch per (voucher, subject) pair — the concurrency backstop.
+// Withdrawn/slashed vouches remain audit history; service code still rejects
+// re-vouching a historical pair before a new signed record or award is created.
 PersonhoodVouchSchema.index(
   { voucherUserId: 1, subjectUserId: 1 },
   { unique: true, partialFilterExpression: { status: 'active' } },

--- a/packages/api/src/services/__tests__/civic.personhood.test.ts
+++ b/packages/api/src/services/__tests__/civic.personhood.test.ts
@@ -220,9 +220,10 @@ describe('vouchForPerson', () => {
     expect(await vouchForPerson(envelope(), VOUCHER)).toEqual({ ok: false, reason: 'excluded_shared_device' });
   });
 
-  it('rejects a duplicate active vouch before appending a record', async () => {
-    mockVouchFindOne.mockReturnValue(selectLean({ _id: 'existing' }));
+  it('rejects a duplicate historical vouch before appending a record', async () => {
+    mockVouchFindOne.mockReturnValue(selectLean({ _id: 'existing', status: 'withdrawn' }));
     expect(await vouchForPerson(envelope(), VOUCHER)).toEqual({ ok: false, reason: 'already_vouched' });
+    expect(mockVouchFindOne).toHaveBeenCalledWith({ voucherUserId: VOUCHER, subjectUserId: SUBJECT });
     expect(mockVerifyAndStore).not.toHaveBeenCalled();
   });
 

--- a/packages/api/src/services/civic/personhood.service.ts
+++ b/packages/api/src/services/civic/personhood.service.ts
@@ -315,12 +315,12 @@ export async function vouchForPerson(
     return { ok: false, reason: exclusionReason(relation.reason) };
   }
 
-  // Reject an existing active vouch BEFORE appending a signed record (the unique
-  // partial index is the concurrency backstop).
+  // Reject any existing vouch for this pair BEFORE appending a signed record.
+  // Withdrawn/slashed vouches remain audit history and must not make the pair
+  // eligible for a fresh reputation award.
   const existing = await PersonhoodVouch.findOne({
     voucherUserId,
     subjectUserId,
-    status: 'active',
   })
     .select('_id')
     .lean();
@@ -387,8 +387,9 @@ export type WithdrawResult = { ok: true } | { ok: false; reason: 'not_found' };
  * Withdraw the caller's active vouch for `subjectUserId`. The vouch flips to
  * `withdrawn` (kept for audit) so it no longer contributes to the subject's
  * personhood; the subject is recomputed (which may demote them below θ). The
- * already-awarded `personhood_vouched` reputation points are NOT clawed back —
- * withdrawal only removes the web-of-trust signal.
+ * already-awarded `personhood_vouched` reputation points are NOT clawed back,
+ * and the historical vouch still prevents re-vouching the same pair to avoid
+ * farming reputation through withdraw/re-vouch loops.
  */
 export async function withdrawVouch(voucherUserId: string, subjectUserId: string): Promise<WithdrawResult> {
   const vouch = await PersonhoodVouch.findOneAndUpdate(


### PR DESCRIPTION
### Motivation
- Close a logic vulnerability where withdrawing a vouch then re-vouching the same voucher/subject pair allowed repeated `personhood_vouched` awards and unbounded reputation farming.
- Ensure historical vouches (withdrawn/slashed) remain audit history and cannot be re-used to trigger fresh reputation awards.

### Description
- Add a service-level existence check in `vouchForPerson` to reject any existing vouch for the same `(voucherUserId, subjectUserId)` pair before storing a new signed record or awarding reputation in `packages/api/src/services/civic/personhood.service.ts`.
- Clarify `PersonhoodVouch` model comments in `packages/api/src/models/PersonhoodVouch.ts` to document that the partial unique index is a concurrency backstop and that historical vouches should be rejected at the service layer.
- Update the withdraw documentation comment to state the historical vouch prevents re-vouching and to make the invariant explicit in `packages/api/src/services/civic/personhood.service.ts`.
- Adjust the unit test in `packages/api/src/services/__tests__/civic.personhood.test.ts` to assert that a historical (withdrawn) vouch is rejected before any signed record storage or award is attempted.
- Preserve the existing partial unique index (`partialFilterExpression: { status: 'active' }`) as the DB-level concurrency guard while enforcing historical deduplication in application logic.

### Testing
- Attempted to run the focused unit test with `bun run test --runInBand src/services/__tests__/civic.personhood.test.ts`, but the environment lacked installed dependencies and `jest`, so the test run was blocked (command failed with `jest: command not found`).
- Verified repository diffs and ran `git diff --check` to ensure no whitespace or diff issues; checks passed.
- Committed the changes locally (`fix(api): prevent personhood revouch reputation farming`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f3aa566088323bddd465978855c10)