### PR TITLE
fix(api): require reputation scope for civic validations

### DIFF
--- a/packages/api/src/routes/__tests__/civicValidations.test.ts
+++ b/packages/api/src/routes/__tests__/civicValidations.test.ts
@@ -17,6 +17,7 @@ const mockOpen = jest.fn();
 const mockVote = jest.fn();
 const mockDeny = jest.fn();
 const mockInbox = jest.fn();
+let mockServiceScopes = ['reputation:write'];
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (req: { user?: unknown }, _res: unknown, next: () => void) => {
@@ -24,7 +25,7 @@ jest.mock('../../middleware/auth', () => ({
     next();
   },
   serviceAuthMiddleware: (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
-    req.serviceApp = { appId: 'app1', scopes: [] };
+    req.serviceApp = { appId: 'app1', scopes: mockServiceScopes };
     next();
   },
 }));
@@ -89,9 +90,23 @@ beforeAll((done) => {
   server = app.listen(0, '127.0.0.1', done);
 });
 afterAll((done) => { server.close(done); });
-beforeEach(() => { jest.clearAllMocks(); });
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockServiceScopes = ['reputation:write'];
+});
 
 describe('POST /civic/validations', () => {
+  it('rejects service tokens without reputation write scope', async () => {
+    mockServiceScopes = [];
+
+    const res = await send(server, 'POST', '/civic/validations', {
+      subjectUserId: 'b'.repeat(24), actionType: 'claim', sourceActionId: 'src1', payload: { x: 1 },
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
   it('returns 201 with the open result', async () => {
     mockOpen.mockResolvedValueOnce({
       _id: { toString: () => REQ_ID },

--- a/packages/api/src/routes/civic.ts
+++ b/packages/api/src/routes/civic.ts
@@ -52,6 +52,8 @@ import {
 
 const router = Router();
 
+const REQUIRED_VALIDATION_SCOPE = 'reputation:write';
+
 const attestationLimiter = rateLimit({
   prefix: 'rl:civic:attest:',
   windowMs: 60 * 1000,
@@ -173,6 +175,14 @@ function throwForCredentialIssueReason(reason: CredentialIssueRejectionReason): 
       throw new ConflictError(`Credential rejected: ${reason}`);
     default:
       throw new BadRequestError(`Credential rejected: ${reason}`);
+  }
+}
+
+/** Assert the service credential can open reputation-mutating validation workflows. */
+function assertValidationScope(req: ServiceAuthRequest): void {
+  const scopes = req.serviceApp?.scopes ?? [];
+  if (!scopes.includes(REQUIRED_VALIDATION_SCOPE)) {
+    throw new ForbiddenError(`Missing required scope: ${REQUIRED_VALIDATION_SCOPE}`);
   }
 }
 
@@ -313,6 +323,8 @@ router.post(
   validationLimiter,
   validate({ body: validationOpenRequestSchema }),
   asyncHandler(async (req: ServiceAuthRequest, res: Response) => {
+    assertValidationScope(req);
+
     const { subjectUserId, actionType, sourceActionId, payload, highValue } = req.body;
     if (!isValidObjectId(subjectUserId)) {
       throw new BadRequestError('Invalid subjectUserId');


### PR DESCRIPTION
### Motivation
- The `POST /civic/validations` route accepted any service token and persisted caller-provided `subjectUserId`, enabling low-privileged service tokens to create validation requests that can later award reputation for arbitrary users.
- Reputation mutation is a privileged operation guarded by the `reputation:write` service scope elsewhere in the codebase, so the validator-open path must enforce the same scope.

### Description
- Added a `REQUIRED_VALIDATION_SCOPE = 'reputation:write'` constant and an `assertValidationScope(req: ServiceAuthRequest)` helper that throws `ForbiddenError` if the scope is missing.
- Invoked `assertValidationScope` at the top of the `POST /civic/validations` route so only service tokens carrying `reputation:write` may open validation requests.
- Updated the validator-route unit test `packages/api/src/routes/__tests__/civicValidations.test.ts` to mock service token scopes, add a test asserting `403` for unscoped service tokens, and ensure the happy-path test uses a scoped service token.
- Files changed: `packages/api/src/routes/civic.ts` and `packages/api/src/routes/__tests__/civicValidations.test.ts`.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch issues and reviewed the route/test diffs successfully.
- Attempted to run the targeted route tests (`bun --filter @oxyhq/api test --runInBand packages/api/src/routes/__tests__/civicValidations.test.ts`), but test execution was blocked because `jest` is not available in the environment (`jest: command not found`).
- Attempted `bun install --frozen-lockfile` to provision deps for tests, but it failed due to upstream npm registry HTTP 403 errors, preventing a local test run; the updated unit test was exercised only via static inspection in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f213947548323862a6d9f99c969d1)