### PR TITLE
fix(api): require origin proof for trusted session clients

### DIFF
--- a/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
@@ -387,10 +387,10 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
     expect(mockAuthSessionCreate).not.toHaveBeenCalled();
   });
 
-  it('(b4) accepts an official app from a native client that carries no Origin/Referer', async () => {
-    // Native (Expo deviceFlowSignIn) requests attach neither Origin nor Referer.
-    // They cannot prove an origin and must NOT be rejected for lacking one — the
-    // device-flow consent screen still authorises every session interactively.
+  it('(b4) rejects an official app from a no-Origin/no-Referer request', async () => {
+    // Absence of browser headers is not a client authenticator. Server-side
+    // scripts can omit both Origin and Referer, so official public client IDs
+    // must still prove a registered origin before receiving official branding.
     mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
     mockApplicationFindById.mockResolvedValueOnce(officialApp());
 
@@ -399,9 +399,8 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
       clientId: 'oxy_dk_client',
     });
 
-    expect(res.status).toBe(200);
-    const created = mockAuthSessionCreate.mock.calls[0][0] as { applicationId: { toString: () => string } };
-    expect(created.applicationId.toString()).toBe(OFFICIAL_APP_ID);
+    expect(res.status).toBe(403);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
   });
 
   it('(c0) returns 400 when NEITHER clientId nor applicationId is supplied', async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1479,13 +1479,12 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
   const boundOrigin = requestOrigin(req);
 
   // Public OAuth client IDs are routing identifiers, not authenticators. For
-  // trusted first-party/internal app identities, a browser caller must prove it
-  // is running on one of the app's registered redirect origins before the
-  // device-consent UI shows official branding. Native clients attach no Origin /
-  // Referer header (no browser context) and cannot prove an origin, so they are
-  // accepted as-is — the device-flow consent screen still authorises every
-  // session interactively.
-  if (isTrustedApplication(resolvedApp) && hasBrowserContext(req)) {
+  // trusted first-party/internal app identities, the caller must prove it is
+  // running on one of the app's registered redirect origins before the
+  // device-consent UI shows official branding. Absence of Origin/Referer is not
+  // proof of a native client; server-side scripts can also omit both headers, so
+  // trusted public clients must not start an unbound no-origin device flow.
+  if (isTrustedApplication(resolvedApp)) {
     if (!boundOrigin || !applicationAllowsOrigin(resolvedApp, boundOrigin)) {
       throw new ForbiddenError('Application origin is not allowed');
     }
@@ -2252,16 +2251,6 @@ function firstHeaderValue(value: string | string[] | undefined): string | null {
 /** The browser-attached `Origin` of the request, or null when absent. */
 function requestOrigin(req: express.Request): string | null {
   return firstHeaderValue(req.headers.origin);
-}
-
-/**
- * A browser/web context is detectable when the user agent attached an `Origin`
- * or `Referer` header. Native clients (Expo `deviceFlowSignIn`) attach neither,
- * so the absence of BOTH signals a genuine native sign-in that cannot prove an
- * origin and must not be rejected for lacking one.
- */
-function hasBrowserContext(req: express.Request): boolean {
-  return Boolean(requestOrigin(req) || firstHeaderValue(req.headers.referer));
 }
 
 /** True when `origin` is the origin of one of the app's registered redirect URIs. */


### PR DESCRIPTION
### Motivation

- Prevent trusted first-party/internal applications with public client IDs from being abused to start unbound no-Origin device flows that yield secret `sessionToken` and approval payloads. 
- The recent registration of official public clients (Commons / Oxy Auth) made them selectable by mere `clientId`, and the existing flow treated absence of `Origin`/`Referer` as a native-client signal, enabling server-side attackers to initiate phishing flows. 
- The change is intended to harden `/auth/session/create` so official-branded sessions require origin proof.

### Description

- Require a registered origin for trusted applications in the `/auth/session/create` handler by enforcing the origin check when `isTrustedApplication(resolvedApp)` is true, instead of skipping it when `Origin`/`Referer` are absent; the relevant logic is in `packages/api/src/routes/auth.ts` (bound-origin enforcement). 
- Remove the no-origin/native-client bypass that previously allowed trusted apps to be accepted without an `Origin` header, preventing server-side scripts from starting official-branded device flows. 
- Update the regression test `packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts` to expect rejection (403) for official apps submitted with neither `Origin` nor `Referer`.

### Testing

- Ran `git diff --check` to validate the patch formatting and found no CI lint errors. 
- Attempted to run the focused test `bun run test authSessionAppIdentity.test.ts` but execution was blocked because `jest`/test dependencies are not installed in the environment. 
- Attempted `bun install --frozen-lockfile` to reproduce CI but it failed due to registry tarball `403` responses, so full automated test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e544886d08323adbf0c6abfb80621)