### PR TITLE
fix(api): validate media query tokens as active sessions

### DIFF
--- a/packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts
+++ b/packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts
@@ -20,10 +20,6 @@
 // The global mongoose mock (jest.setup.cjs) omits `Types`, which optionalAuth's
 // resolveViewerId uses (`Types.ObjectId.isValid`). Restore the REAL mongoose.
 jest.mock('mongoose', () => jest.requireActual('mongoose'));
-// jest.setup.cjs globally stubs jsonwebtoken (verify always returns a fixed
-// user and never throws). getMediaViewerUserId's whole contract is real
-// signature verification + ignoreExpiration, so restore the REAL jsonwebtoken.
-jest.mock('jsonwebtoken', () => jest.requireActual('jsonwebtoken'));
 import { Types } from 'mongoose';
 import type { Response } from 'express';
 
@@ -34,24 +30,27 @@ jest.mock('../auth', () => ({
 }));
 
 const mockAuthNonBlocking = jest.fn();
+const mockValidateSessionToken = jest.fn();
+const mockDecodeToken = jest.fn();
 // Fully mock authUtils (rather than requireActual) so loading optionalAuth does
 // NOT pull in the real session.service → Session model chain, which the global
-// mongoose mock cannot construct. We provide only the two members optionalAuth
-// consumes: a pure bearer extractor and the non-blocking authenticator.
+// mongoose mock cannot construct. We provide only the members optionalAuth
+// consumes: a pure bearer extractor, non-blocking authenticator, and session validator.
 jest.mock('../authUtils', () => ({
   __esModule: true,
+  decodeToken: (...args: unknown[]) => mockDecodeToken(...args),
   extractTokenFromRequest: (req: { headers: Record<string, string | undefined> }): string | undefined => {
     const auth = req.headers.authorization;
     return auth && auth.startsWith('Bearer ') ? auth.substring(7) : undefined;
   },
   authenticateRequestNonBlocking: (...args: unknown[]) => mockAuthNonBlocking(...args),
+  validateSessionToken: (...args: unknown[]) => mockValidateSessionToken(...args),
 }));
 
 jest.mock('../../utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
-import jwt from 'jsonwebtoken';
 import {
   optionalUserOrServiceAuth,
   resolveViewerId,
@@ -80,6 +79,10 @@ beforeEach(() => {
   mockVerifyServiceToken.mockReset();
   mockAuthNonBlocking.mockReset();
   mockAuthNonBlocking.mockResolvedValue({ user: null, source: null });
+  mockValidateSessionToken.mockReset();
+  mockValidateSessionToken.mockResolvedValue(null);
+  mockDecodeToken.mockReset();
+  mockDecodeToken.mockReturnValue(null);
 });
 
 describe('optionalUserOrServiceAuth', () => {
@@ -188,9 +191,10 @@ describe('resolveViewerId', () => {
 
 /**
  * getMediaViewerUserId — resolves the viewer for `<img src>`/`<a download>`
- * media URLs that cannot carry an Authorization header but DO carry the
- * SDK-issued access token in `?token=`. Uses the REAL `jsonwebtoken` (not
- * mocked) signed with a test ACCESS_TOKEN_SECRET.
+ * media URLs that cannot carry an Authorization header but DO carry an
+ * SDK-issued access token in `?token=`. Query tokens must validate through the
+ * normal session-token path so expiry, sessionId, and active-session checks are
+ * enforced.
  */
 describe('getMediaViewerUserId (private media owner-from-query-token)', () => {
   const SECRET = 'test-access-secret';
@@ -216,46 +220,69 @@ describe('getMediaViewerUserId (private media owner-from-query-token)', () => {
     }
   });
 
-  it('prefers the authenticated session user and ignores the query token', () => {
-    const otherToken = jwt.sign({ userId: 'attacker' }, SECRET);
-    const req = makeMediaReq({ token: otherToken }, { _id: 'session-owner' });
-    expect(getMediaViewerUserId(req)).toBe('session-owner');
+  it('prefers the authenticated session user and ignores the query token', async () => {
+    mockValidateSessionToken.mockResolvedValue({ _id: 'attacker' });
+    const req = makeMediaReq({ token: 'valid-attacker-token' }, { _id: 'session-owner' });
+    await expect(getMediaViewerUserId(req)).resolves.toBe('session-owner');
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
   });
 
-  it('resolves the owner from a valid ?token= when no session user is present', () => {
-    const token = jwt.sign({ userId: 'owner-123', type: 'access' }, SECRET, { expiresIn: '15m' });
-    expect(getMediaViewerUserId(makeMediaReq({ token }))).toBe('owner-123');
+  it('resolves the owner from an active access-session ?token= when no session user is present', async () => {
+    mockDecodeToken.mockReturnValue({ type: 'access', sessionId: 'session-123', userId: 'owner-123' });
+    mockValidateSessionToken.mockResolvedValue({ _id: 'owner-123' });
+    await expect(getMediaViewerUserId(makeMediaReq({ token: 'active-access-token' }))).resolves.toBe('owner-123');
+    expect(mockDecodeToken).toHaveBeenCalledWith('active-access-token');
+    expect(mockValidateSessionToken).toHaveBeenCalledWith('active-access-token');
   });
 
-  it('still resolves the owner from an EXPIRED token (stale cached <img> URL)', () => {
-    // Signed 1h ago with a 15m TTL → already expired, but the owner must still
-    // be able to render their own private media from a cached URL.
-    const token = jwt.sign({ userId: 'owner-123', iat: Math.floor(1_700_000_000) }, SECRET, {
-      expiresIn: '15m',
-    });
-    // Re-sign as definitively expired.
-    const expired = jwt.sign({ userId: 'owner-123', exp: 1, iat: 1 }, SECRET);
-    expect(getMediaViewerUserId(makeMediaReq({ token: expired }))).toBe('owner-123');
-    expect(getMediaViewerUserId(makeMediaReq({ token }))).toBe('owner-123');
+  it('returns undefined for an expired access token instead of ignoring expiration', async () => {
+    mockValidateSessionToken.mockResolvedValue(null);
+    await expect(getMediaViewerUserId(makeMediaReq({ token: 'expired-access-token' }))).resolves.toBeUndefined();
+    expect(mockDecodeToken).toHaveBeenCalledWith('expired-access-token');
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
   });
 
-  it('returns undefined for a token signed with the WRONG secret (forged)', () => {
-    const forged = jwt.sign({ userId: 'attacker' }, 'wrong-secret');
-    expect(getMediaViewerUserId(makeMediaReq({ token: forged }))).toBeUndefined();
+  it('returns undefined for a 2FA challenge JWT that is not an access session', async () => {
+    mockValidateSessionToken.mockResolvedValue(null);
+    await expect(getMediaViewerUserId(makeMediaReq({ token: '2fa-challenge-login-token' }))).resolves.toBeUndefined();
+    expect(mockDecodeToken).toHaveBeenCalledWith('2fa-challenge-login-token');
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
   });
 
-  it('returns undefined for a garbage / malformed token', () => {
-    expect(getMediaViewerUserId(makeMediaReq({ token: 'not-a-jwt' }))).toBeUndefined();
+  it('returns undefined for a JWT without type access even when it has a userId', async () => {
+    mockDecodeToken.mockReturnValue({ userId: 'owner-123', purpose: '2fa_challenge' });
+    await expect(getMediaViewerUserId(makeMediaReq({ token: 'non-access-token' }))).resolves.toBeUndefined();
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
   });
 
-  it('returns undefined when no token and no session user are present', () => {
-    expect(getMediaViewerUserId(makeMediaReq({}))).toBeUndefined();
+  it('returns undefined for an access JWT without a sessionId', async () => {
+    mockDecodeToken.mockReturnValue({ type: 'access', userId: 'owner-123' });
+    await expect(getMediaViewerUserId(makeMediaReq({ token: 'no-session-token' }))).resolves.toBeUndefined();
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
   });
 
-  it('returns undefined when ACCESS_TOKEN_SECRET is not configured', () => {
-    const token = jwt.sign({ userId: 'owner-123' }, SECRET);
+  it('returns undefined for a revoked/logged-out session token', async () => {
+    mockDecodeToken.mockReturnValue({ type: 'access', sessionId: 'session-123', userId: 'owner-123' });
+    mockValidateSessionToken.mockResolvedValue(null);
+    await expect(getMediaViewerUserId(makeMediaReq({ token: 'revoked-session-token' }))).resolves.toBeUndefined();
+    expect(mockValidateSessionToken).toHaveBeenCalledWith('revoked-session-token');
+  });
+
+  it('returns undefined for a garbage / malformed token', async () => {
+    mockDecodeToken.mockReturnValue(null);
+    await expect(getMediaViewerUserId(makeMediaReq({ token: 'not-a-jwt' }))).resolves.toBeUndefined();
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when no token and no session user are present', async () => {
+    await expect(getMediaViewerUserId(makeMediaReq({}))).resolves.toBeUndefined();
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when ACCESS_TOKEN_SECRET is not configured', async () => {
     delete process.env.ACCESS_TOKEN_SECRET;
-    expect(getMediaViewerUserId(makeMediaReq({ token }))).toBeUndefined();
+    await expect(getMediaViewerUserId(makeMediaReq({ token: 'active-access-token' }))).resolves.toBeUndefined();
+    expect(mockValidateSessionToken).not.toHaveBeenCalled();
     process.env.ACCESS_TOKEN_SECRET = SECRET;
   });
 });

--- a/packages/api/src/middleware/optionalAuth.ts
+++ b/packages/api/src/middleware/optionalAuth.ts
@@ -8,9 +8,8 @@
 
 import { Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
-import jwt from 'jsonwebtoken';
 import { logger } from '../utils/logger';
-import { authenticateRequestNonBlocking, AuthenticatedRequest, extractTokenFromRequest } from './authUtils';
+import { authenticateRequestNonBlocking, AuthenticatedRequest, extractTokenFromRequest, decodeToken, validateSessionToken } from './authUtils';
 import { verifyServiceToken, type ServiceTokenPayload } from './auth';
 
 /**
@@ -58,20 +57,18 @@ export function getUserId(req: AuthenticatedRequest): string | undefined {
  * token to its owner user id so the OWNER can render their own private media.
  *
  * Important properties:
- * - The token only IDENTIFIES the viewer. It grants no access by itself — the
- *   caller still runs `canUserAccessFile` / `checkMediaAccess`, which is the
- *   real authorization gate (ownership / privacy rules).
- * - The signature is verified with `ACCESS_TOKEN_SECRET`, but expiration is
- *   IGNORED: a cached `<img>` URL whose short-lived token already expired must
- *   still let the owner see their own file. A forged/garbage token fails
- *   signature verification and yields `undefined` (anonymous).
+ * - The query token must validate as a real, unexpired access-session token.
+ *   `decodeToken`/`validateSessionToken` enforce the normal access-token signature,
+ *   expiry, `type: 'access'`, `sessionId`, and active-session checks, so expired/logged-out tokens and
+ *   non-session JWTs (for example 2FA challenge tokens) cannot identify a
+ *   private-media viewer.
  * - Header/session auth always wins; the query token is only a fallback when no
  *   authenticated user is present on the request.
  *
  * Scope it to media stream/download routes only — never wire it into a global
  * auth middleware (token-in-URL must not authenticate arbitrary endpoints).
  */
-export function getMediaViewerUserId(req: AuthenticatedRequest): string | undefined {
+export async function getMediaViewerUserId(req: AuthenticatedRequest): Promise<string | undefined> {
   const sessionUserId = getUserId(req);
   if (sessionUserId) {
     return sessionUserId;
@@ -83,14 +80,17 @@ export function getMediaViewerUserId(req: AuthenticatedRequest): string | undefi
   }
 
   try {
-    const decoded = jwt.verify(queryToken, process.env.ACCESS_TOKEN_SECRET, {
-      ignoreExpiration: true,
-    }) as { userId?: string; id?: string; _id?: string };
-    return decoded.userId || decoded.id || decoded._id || undefined;
+    const decoded = decodeToken(queryToken);
+    if (decoded?.type !== 'access' || !decoded.sessionId) {
+      return undefined;
+    }
+
+    const user = await validateSessionToken(queryToken);
+    return user?._id;
   } catch (error) {
-    // Invalid signature / malformed token → treat as anonymous (the access
+    // Invalid/expired/revoked/non-session token → treat as anonymous (the access
     // check below still runs). Logged at debug for diagnostics only.
-    logger.debug('getMediaViewerUserId: query token did not verify', {
+    logger.debug('getMediaViewerUserId: query token did not validate as an active session', {
       reason: error instanceof Error ? error.message : String(error),
     });
     return undefined;

--- a/packages/api/src/routes/assets.ts
+++ b/packages/api/src/routes/assets.ts
@@ -1078,7 +1078,7 @@ router.get('/:id/stream', mediaHeadersMiddleware, validate({ params: assetIdPara
   // `<img src>` cannot send an Authorization header, so resolve the viewer from
   // the `?token=` query (SDK-issued) when no session user is present, so owners
   // can render their own private media. Access is still gated by canUserAccessFile.
-  const userId = getMediaViewerUserId(req);
+  const userId = await getMediaViewerUserId(req);
   const { id: fileId } = req.params;
   const { variant } = req.query;
   const variantType = typeof variant === 'string' ? variant : undefined;
@@ -1288,7 +1288,7 @@ router.get('/:id/download', validate({ params: assetIdParams }), optionalAuthMid
   // Resolve viewer from the `?token=` query for direct-download links that
   // cannot carry an Authorization header (owners downloading their own private
   // files). Access is still gated by canUserAccessFile below.
-  const userId = getMediaViewerUserId(req);
+  const userId = await getMediaViewerUserId(req);
   const { id: fileId } = req.params;
   const { variant, expiresIn } = req.query;
 


### PR DESCRIPTION
### Motivation
- A previous change let `?token=` JWTs identify media viewers by signature only (with `ignoreExpiration: true`) which allowed expired access tokens and unrelated JWTs (e.g. 2FA challenge tokens) to be treated as the file owner and bypass intended session/expiry checks. 
- The goal is to ensure media URL query tokens are only accepted when they represent a real active access session so expired/revoked/non-session tokens cannot authorize private media access.

### Description
- Require media query tokens to be an active access-session by decoding the token and enforcing `type: 'access'` and presence of `sessionId`, then validating via the normal session path (`decodeToken` + `validateSessionToken`) in `packages/api/src/middleware/optionalAuth.ts` by converting `getMediaViewerUserId` to an async function that returns only a validated session user id.
- Update media endpoints to await the viewer resolution so the active-session check runs before authorization, in `packages/api/src/routes/assets.ts` (stream and download handlers now use `await getMediaViewerUserId(req)`).
- Replace raw-query JWT verification with the session validation flow and tighten early-return conditions to reject tokens that are expired, revoked, lack `type: 'access'`, or lack a `sessionId` in `packages/api/src/middleware/optionalAuth.ts`.
- Update and extend unit tests in `packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts` to cover active access-session tokens, expired tokens, 2FA/non-access JWTs, tokens without `sessionId`, revoked sessions, malformed tokens, missing token, and missing secret behavior, and to mock `decodeToken`/`validateSessionToken` accordingly.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it passed without errors. 
- Updated unit tests for `getMediaViewerUserId` (`packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts`) but running `cd packages/api && bun run test` was blocked because `jest` was not available in the runtime; the file-level test invocation could not be executed here. 
- Attempted `bun install --frozen-lockfile` to install dependencies in order to run the package tests, but the install failed due to the npm registry returning `403` for dependency tarballs, so automated test runs could not be completed in this environment. 
- The change is limited and API-facing: media routes now require the session-validation path for query tokens and unit tests were extended to assert the new stricter behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d5753e8b483239d8df87595bdb210)