### PR TITLE
feat(core,contracts): make name.displayName optional + relax displayName auth gates

### DIFF
--- a/packages/api/src/utils/displayName.ts
+++ b/packages/api/src/utils/displayName.ts
@@ -30,7 +30,13 @@ export interface NameResponse extends Record<string, unknown> {
   first?: string;
   last?: string;
   full?: string;
-  displayName: string;
+  /**
+   * Optional to match the `@oxyhq/contracts` `UserNameResponse` contract.
+   * NOTE: the serializers in this module (`formatUserNameResponse`) STILL
+   * always synthesize a string today — only the type was relaxed. The runtime
+   * synthesis change is a later stage.
+   */
+  displayName?: string;
 }
 
 /**

--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -196,7 +196,9 @@ export function LoginForm({
             const result = await oxy.lookupUsername(username)
             setLookupResult({
                 username: result.username,
-                displayName: result.name.displayName,
+                // `name.displayName` is optional on the contract — fall back to
+                // the username handle when the account has no display name.
+                displayName: result.name.displayName ?? result.username,
                 avatar: result.avatar,
                 color: result.color,
             })

--- a/packages/auth/lib/schemas.ts
+++ b/packages/auth/lib/schemas.ts
@@ -65,7 +65,7 @@ export const lookupResponseSchema = z.object({
     username: z.string(),
     color: z.string().nullable(),
     avatar: z.string().nullable(),
-    displayName: z.string(),
+    displayName: z.string().optional(),
 })
 
 export const tokenResponseSchema = z.object({

--- a/packages/contracts/src/__tests__/recommendations.test.ts
+++ b/packages/contracts/src/__tests__/recommendations.test.ts
@@ -142,14 +142,15 @@ describe('recommendationItemSchema / recommendationResponseSchema', () => {
         expect(parsed?.score).toBeUndefined();
     });
 
-    it('rejects an item missing name.displayName', () => {
+    it('accepts an item missing name.displayName (displayName is now optional)', () => {
         const parsed = safeParseContract(recommendationItemSchema, {
             id: 'x',
             name: { first: 'Bob' },
             mutualCount: 0,
             _count: { followers: 0, following: 0 },
         });
-        expect(parsed).toBeNull();
+        expect(parsed).not.toBeNull();
+        expect(parsed?.name.displayName).toBeUndefined();
     });
 
     it('parses an array response', () => {

--- a/packages/contracts/src/userResponse.ts
+++ b/packages/contracts/src/userResponse.ts
@@ -40,7 +40,10 @@ import { verifiedDomainSchema } from './identity';
  * - `first` / `last` default to `''` in Mongo, so they are optional on the wire.
  * - `full` is a Mongoose virtual — absent unless the query materialised
  *   virtuals or the serializer composed it.
- * - `displayName` is the required canonical app-facing display string.
+ * - `displayName` is the canonical app-facing display string when present.
+ *   It is OPTIONAL on the wire: the API still synthesizes a default today, but
+ *   the contract no longer guarantees it, so consumers fall back to a handle
+ *   (e.g. `getNormalizedUserHandle`) when it is absent.
  *
  * This is declared as an explicit `interface` rather than being inferred from
  * the runtime schema via `z.infer<typeof userNameSchema>`. Inferring it produced
@@ -50,7 +53,7 @@ import { verifiedDomainSchema } from './identity';
  * Under a consumer's `moduleResolution: "node"` (node10), that chain does not
  * always resolve, so `name.displayName` silently widened to `{}` and broke the
  * "render `name.displayName` directly" contract at the type level. An explicit
- * interface emits `displayName: string` literally and survives BOTH `node` and
+ * interface emits `displayName?: string` literally and survives BOTH `node` and
  * `bundler` resolution. The index signature preserves the passthrough behaviour
  * (additive name fields are tolerated without a coordinated contract bump).
  */
@@ -58,8 +61,8 @@ export interface UserNameResponse {
     first?: string;
     last?: string;
     full?: string;
-    /** Required canonical display string — render this directly. */
-    displayName: string;
+    /** Canonical display string when present — render this directly. */
+    displayName?: string;
     [key: string]: unknown;
 }
 
@@ -68,15 +71,17 @@ export const userNameSchema: z.ZodType<UserNameResponse> = z
         first: z.string().optional(),
         last: z.string().optional(),
         full: z.string().optional(),
-        displayName: z.string(),
+        displayName: z.string().optional(),
     })
     .passthrough();
 
 /**
  * The canonical user object emitted by `formatUserResponse`.
  *
- * `id` and `name.displayName` are guaranteed on formatted user DTOs. The rest
- * is forwarded from the user document and may be absent depending on the query's
+ * `id` is present on formatted user DTOs. `name.displayName` is OPTIONAL on the
+ * contract — the API still synthesizes a default today, but consumers must not
+ * assume it is present and should fall back to a handle when it is absent. The
+ * rest is forwarded from the user document and may be absent depending on the query's
  * `.select(...)`/`.lean()` projection. Both `id` and `_id` are accepted because
  * some raw-document responses carry `_id` instead of `id`; resolve the
  * identifier with {@link resolveUserId}.

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -1026,7 +1026,9 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
           continue;
         }
         const userId = e.user.id ?? e.user._id;
-        if (!userId || !e.user.username || !e.user.name?.displayName) {
+        // `name.displayName` is optional on the contract — do NOT drop no-name
+        // accounts. Only an absent userId or username makes the entry unusable.
+        if (!userId || !e.user.username) {
           continue;
         }
         if (typeof e.authuser !== 'number') {
@@ -1040,7 +1042,9 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
           user: {
             id: userId,
             username: e.user.username,
-            name: e.user.name,
+            // `name.displayName` is optional; carry whatever structured name the
+            // server sent (possibly an empty object) and let consumers fall back.
+            name: e.user.name ?? {},
             avatar: e.user.avatar ?? null,
             email: e.user.email,
             color: e.user.color ?? null,

--- a/packages/core/src/mixins/OxyServices.sso.ts
+++ b/packages/core/src/mixins/OxyServices.sso.ts
@@ -171,14 +171,17 @@ export function OxyServicesSsoMixin<T extends typeof OxyServicesBase>(Base: T) {
       }
 
       const userId = payload.user?.id ?? payload.user?._id;
-      if (!userId || typeof payload.user?.username !== 'string' || typeof payload.user.name?.displayName !== 'string') {
+      if (!userId || typeof payload.user?.username !== 'string') {
         throw this.handleError(new Error('SSO exchange returned an invalid user'));
       }
 
       const user: MinimalUserData = {
         id: userId,
         username: payload.user.username,
-        name: payload.user.name,
+        // `name.displayName` is optional on the contract. A no-name user is
+        // valid; carry whatever structured name the server sent (possibly an
+        // empty object) and let consumers fall back to a handle.
+        name: payload.user.name ?? {},
         avatar: payload.user.avatar,
       };
 

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -108,8 +108,10 @@ export interface User {
   privacySettings?: PrivacySettings;
   /**
    * Structured human name. `name.displayName` is the canonical display string
-   * resolved by the API; consumers render it directly instead of recomposing
-   * names from `first` / `last` / `full` / `username`.
+   * resolved by the API when present; consumers render it directly instead of
+   * recomposing names from `first` / `last` / `full` / `username`. It is now
+   * OPTIONAL (see `UserNameResponse`) — when absent, fall back to a handle
+   * (e.g. `getNormalizedUserHandle`) rather than recomposing a name locally.
    */
   name: UserNameResponse;
   bio?: string;

--- a/packages/inbox/components/settings/SettingsHero.tsx
+++ b/packages/inbox/components/settings/SettingsHero.tsx
@@ -15,6 +15,7 @@ import { H3, P, Text } from '@oxyhq/bloom/typography';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { ChevronRight_Stroke2_Corner0_Rounded } from '@oxyhq/bloom/icons';
 import { useOxy, OxySignInButton } from '@oxyhq/services';
+import { getNormalizedUserHandle } from '@oxyhq/core';
 import { useRouter } from 'expo-router';
 
 import { useColors } from '@/constants/theme';
@@ -48,7 +49,7 @@ export function SettingsHero() {
     );
   }
 
-  const fullName = user.name.displayName;
+  const fullName = user?.name?.displayName || getNormalizedUserHandle(user) || '';
   const emailHandle = user.email || `${user.username}@oxy.so`;
 
   return (


### PR DESCRIPTION
## Summary

- `name.displayName` is now `string | undefined` in `@oxyhq/contracts` (`userNameSchema`) and `@oxyhq/core` (`User`), so no-name users are never silently dropped
- SSO exchange (`OxyServices.sso`) and refresh-all (`OxyServices.auth`) no longer require a `displayName` field — login/SSO succeeds even when the API hasn't emitted one yet
- API serializer (`composeDisplayName`) is unchanged this stage — it still emits a synthesized string; the optional gate is prep for a future stage that removes the synthesis
- Oxy frontends that assumed `displayName` was non-null now fall back to the username/handle (`inbox/SettingsHero`, `auth/login-form`)

## Test plan

- [x] `@oxyhq/contracts` build + 81 tests green
- [x] `@oxyhq/core` build + 681 tests green
- [x] `@oxyhq/api` 1222 tests green
- [x] `bun install --frozen-lockfile` passes (lockfile gate)
- [ ] Verify `displayNameSanitize.ts` + its test remain dirty/uncommitted (orphaned-mark fix, belongs to a later commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->