### PR TITLE
feat(api): stop synthesizing display names; emit name.displayName only for real names

### DIFF
--- a/packages/api/src/controllers/sso.controller.ts
+++ b/packages/api/src/controllers/sso.controller.ts
@@ -72,17 +72,19 @@ function parseSessionPayload(value: unknown): SsoSessionPayload | null {
   const userRecord = user as Record<string, unknown>;
   if (typeof userRecord.id !== 'string' || userRecord.id.length === 0) return null;
 
-  // `name` MUST be the structured UserNameResponse with a non-empty
-  // `displayName` — the contract the SDK's `userResponseSchema` enforces on
-  // redemption. Fail closed: a string `name`, a missing `name`, or an object
-  // without a usable `displayName` rejects the whole payload so a session code
-  // is never minted without a valid display name (which would log every RP out).
+  // `name` MUST be the structured UserNameResponse object — the contract the
+  // SDK's `userResponseSchema` enforces on redemption. Fail closed on a string
+  // or missing `name` (which would silently drop the structured shape the RP
+  // parses). `name.displayName` is OPTIONAL (contracts 0.6.0): present only when
+  // the user has a real name and absent for username-only accounts; RP clients
+  // fall back to the handle, so we do NOT require it here. A present
+  // `displayName` must still be a string.
   const nameRecord = userRecord.name;
   if (typeof nameRecord !== 'object' || nameRecord === null || Array.isArray(nameRecord)) {
     return null;
   }
   const displayName = (nameRecord as Record<string, unknown>).displayName;
-  if (typeof displayName !== 'string' || displayName.trim().length === 0) {
+  if (typeof displayName !== 'undefined' && typeof displayName !== 'string') {
     return null;
   }
 

--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -810,24 +810,23 @@ UserSchema.virtual('name.full').get(function() {
   return '';
 });
 
-// Virtual for structured display name — authoritative server-side default.
+// Virtual for the structured display name — the user's REAL name only.
 //
-// Composition preference order (see `utils/displayName.ts`, the single source of
-// truth shared with the unit tests):
-//   1. name.full (composed from name.first / name.last; first-only is valid —
-//      there is NO requirement that both parts exist)
-//   2. username
-//   3. truncated publicKey handle
-//   4. 'Anonymous'
+// Composition (see `utils/displayName.ts`, the single source of truth shared
+// with the unit tests):
+//   1. explicit name.displayName, else
+//   2. name.full (composed from name.first / name.last; first-only is valid —
+//      there is NO requirement that both parts exist), else
+//   3. undefined.
 //
-// This is the DERIVED default only. All raw fields (`name.first`, `name.last`,
-// `name.full`, `username`, `publicKey`) remain intact. Public DTO serializers
-// expose it as `name.displayName`; clients should render that field directly.
+// It does NOT synthesize a name from `username` / `publicKey`. When the user has
+// no real name the getter returns `undefined` and the field is simply absent in
+// the serialized JSON — clients fall back to the handle. All raw fields
+// (`name.first`, `name.last`, `name.full`, `username`, `publicKey`) remain
+// intact. Public DTO serializers expose it as `name.displayName`.
 UserSchema.virtual('name.displayName').get(function() {
   return composeDisplayName({
     name: this.name as { first?: string; last?: string } | undefined,
-    username: this.username as string | undefined,
-    publicKey: this.publicKey as string | undefined,
   });
 });
 

--- a/packages/api/src/routes/__tests__/sso.test.ts
+++ b/packages/api/src/routes/__tests__/sso.test.ts
@@ -76,9 +76,10 @@ const VALID_SESSION = {
   sessionId: 'sess-abc',
   accessToken: 'access-jwt-xyz',
   expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
-  // `name` MUST be the structured UserNameResponse with a required displayName —
-  // a bare string name is rejected by `parseSessionPayload` (the contract the
-  // SDK's `userResponseSchema` enforces on redemption).
+  // `name` MUST be the structured UserNameResponse object — a bare string name
+  // is rejected by `parseSessionPayload`. `displayName` is OPTIONAL (contracts
+  // 0.6.0); it is included here because this fixture models a user with a real
+  // name.
   user: { id: '64f7c2a1b8e9d3f4a1c2b3d4', username: 'alice', name: { displayName: 'Alice' } },
 };
 
@@ -206,8 +207,8 @@ describe('POST /sso/code', () => {
   });
 
   it('returns 400 when user.name is a bare string (structured UserNameResponse required)', async () => {
-    // A string name silently drops the displayName the SDK requires → the
-    // session must never be minted. Fail closed at 400.
+    // A string name drops the structured shape the SDK parses on redemption →
+    // the session must never be minted. Fail closed at 400.
     const res = await requestJson(
       server,
       'POST',
@@ -245,7 +246,12 @@ describe('POST /sso/code', () => {
     expect(mockRedis.set).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when user.name is an object without a non-empty displayName', async () => {
+  it('mints a code when user.name is a structured object without a displayName (handle fallback on the client)', async () => {
+    // `name.displayName` is OPTIONAL (contracts 0.6.0): a username-only account
+    // legitimately has no real name. The structured `name` object is still
+    // required (a bare string is rejected above), but the absence of a
+    // displayName no longer fails the payload — RP clients fall back to the
+    // handle.
     const res = await requestJson(
       server,
       'POST',
@@ -254,7 +260,27 @@ describe('POST /sso/code', () => {
         session: {
           sessionId: 'sess-x',
           accessToken: 'access-x',
-          user: { id: '64f7c2a1b8e9d3f4a1c2b3d4', username: 'alice', name: { first: 'Alice', displayName: '   ' } },
+          user: { id: '64f7c2a1b8e9d3f4a1c2b3d4', username: 'alice', name: {} },
+        },
+        clientOrigin: 'https://mention.earth',
+      },
+      { 'x-oxy-internal': process.env.SSO_INTERNAL_SECRET as string }
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.code).toEqual(expect.any(String));
+    expect(mockRedis.set).toHaveBeenCalled();
+  });
+
+  it('returns 400 when user.name carries a non-string displayName', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/code',
+      {
+        session: {
+          sessionId: 'sess-x',
+          accessToken: 'access-x',
+          user: { id: '64f7c2a1b8e9d3f4a1c2b3d4', username: 'alice', name: { first: 'Alice', displayName: 42 } },
         },
         clientOrigin: 'https://mention.earth',
       },

--- a/packages/api/src/services/__tests__/fedcm.service.test.ts
+++ b/packages/api/src/services/__tests__/fedcm.service.test.ts
@@ -333,16 +333,19 @@ describe('FedCM exchangeIdToken (H9)', () => {
     expect(name.last).toBe('Liddell');
   });
 
-  it('falls back to username for displayName when the user has no structured name', async () => {
+  it('OMITS displayName when the user has no structured name (RP falls back to the handle)', async () => {
     // Default mock user is { _id: 'user-123', username: 'alice' } with no name.
+    // The API no longer synthesizes a display name from the username — the
+    // structured `name` object is still emitted, but without `displayName`.
     const token = mintToken();
     const result = await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
 
     expect('error' in result).toBe(false);
     if ('error' in result) return;
+    expect(typeof result.user.name).toBe('object');
+    expect(result.user.name).not.toBeNull();
     const name = result.user.name as { displayName?: unknown };
-    expect(typeof name.displayName).toBe('string');
-    expect(name.displayName).toBe('alice');
+    expect(name.displayName).toBeUndefined();
   });
 
   it('records a FedCM grant for the user+origin on a successful exchange', async () => {

--- a/packages/api/src/services/fedcm.service.ts
+++ b/packages/api/src/services/fedcm.service.ts
@@ -729,9 +729,10 @@ class FedCMService {
       };
       const idValue = userDoc._id?.toString() ?? userDoc.id ?? '';
       // Compose the canonical structured name (`UserNameResponse`) via the
-      // single source of truth — the SDK's `userResponseSchema` requires
-      // `name.displayName`, so we MUST emit the structured object, never a
-      // string. Falls back to username/publicKey/'Anonymous' for displayName.
+      // single source of truth — we MUST emit the structured object, never a
+      // bare string. `name.displayName` is present only when the user has a real
+      // name and is OMITTED otherwise (optional in `userResponseSchema`); RP
+      // clients fall back to the handle.
       const name = formatUserNameResponse({
         name: userDoc.name,
         username: userDoc.username,

--- a/packages/api/src/services/federation.service.ts
+++ b/packages/api/src/services/federation.service.ts
@@ -612,11 +612,10 @@ export async function getUserActor(user: IUser, domain: string = AP_DOMAIN): Pro
   const username = user.username.split('@')[0]; // strip @domain if present
   const keyPair = await getUserKeyPair(username, domain);
 
-  const displayName = composeDisplayName({
-    name: user.name,
-    username,
-    publicKey: typeof user.publicKey === 'string' ? user.publicKey : undefined,
-  });
+  // An ActivityPub actor's `name` field requires a non-empty string. The API no
+  // longer synthesizes a display name, so fall back to the handle (`username` is
+  // guaranteed here — `getUserActor` returns null above when it is absent).
+  const displayName = composeDisplayName({ name: user.name }) ?? username;
 
   const avatar = await resolveActorAvatarUrl(user.avatar);
 

--- a/packages/api/src/services/ssoCode.service.ts
+++ b/packages/api/src/services/ssoCode.service.ts
@@ -52,10 +52,12 @@ export interface SsoSessionPayload {
   sessionId: string;
   accessToken: string;
   /**
-   * `user.name` is the structured {@link UserNameResponse} (required
-   * `displayName`), NOT a bare string — this is the canonical contract the SDK's
-   * `userResponseSchema` enforces on redemption. A string name would make
-   * `exchangeSsoCode` throw and every RP show logged-out.
+   * `user.name` is the structured {@link UserNameResponse}, NOT a bare string —
+   * this is the canonical contract the SDK's `userResponseSchema` enforces on
+   * redemption. A string name would make `exchangeSsoCode` throw and every RP
+   * show logged-out. `name.displayName` is OPTIONAL (present only when the user
+   * has a real name); username-only accounts omit it and RP clients fall back to
+   * the handle.
    */
   user: { id: string; username?: string; email?: string; avatar?: string; name: UserNameResponse };
   expiresAt?: string;

--- a/packages/api/src/utils/__tests__/displayName.test.ts
+++ b/packages/api/src/utils/__tests__/displayName.test.ts
@@ -1,12 +1,14 @@
 /**
- * Unit tests for the authoritative `name.displayName` composition (the logic
- * backing the `User.name.displayName` Mongoose virtual — see `models/User.ts`).
+ * Unit tests for the `name.displayName` composition (the logic backing the
+ * `User.name.displayName` Mongoose virtual — see `models/User.ts`).
  *
- * The composition was previously `username || truncatedPublicKey`, which IGNORED
- * the structured `name` subdocument and made the server's display default
- * unreliable. The fix composes in preference order:
+ * The composition returns the user's REAL name only:
  *
- *   name.full → username → truncated publicKey handle → 'Anonymous'
+ *   explicit name.displayName → name.full (from first/last) → undefined
+ *
+ * It does NOT synthesize a name from `username` / `publicKey` / `'Anonymous'`.
+ * When there is no real name the helper returns `undefined`, the serializer
+ * omits `name.displayName`, and consumers fall back to the handle.
  *
  * The API jest setup mocks Mongoose wholesale, so the model's virtual getter
  * never runs under test; the rules are exercised here against the pure helper
@@ -20,7 +22,7 @@ import {
   truncatePublicKeyHandle,
 } from '../displayName';
 
-describe('composeDisplayName (authoritative User.name.displayName default)', () => {
+describe('composeDisplayName (User.name.displayName — real name only)', () => {
   it('composes the full name when first AND last are present', () => {
     expect(
       composeDisplayName({
@@ -31,7 +33,7 @@ describe('composeDisplayName (authoritative User.name.displayName default)', () 
     ).toBe('Jane Doe');
   });
 
-  it('composes a FIRST-ONLY name (does not require both parts) over username', () => {
+  it('composes a FIRST-ONLY name (does not require both parts)', () => {
     expect(
       composeDisplayName({
         name: { first: 'Cher' },
@@ -40,7 +42,7 @@ describe('composeDisplayName (authoritative User.name.displayName default)', () 
     ).toBe('Cher');
   });
 
-  it('composes a LAST-ONLY name over username', () => {
+  it('composes a LAST-ONLY name', () => {
     expect(
       composeDisplayName({
         name: { last: 'Prince' },
@@ -49,47 +51,38 @@ describe('composeDisplayName (authoritative User.name.displayName default)', () 
     ).toBe('Prince');
   });
 
-  it('falls back to username when there is no usable name', () => {
+  it('prefers an explicit name.displayName (trimmed) over a composed full name', () => {
+    expect(
+      composeDisplayName({
+        name: { first: 'Jane', last: 'Doe', displayName: '  Janey  ' },
+      })
+    ).toBe('Janey');
+  });
+
+  it('returns undefined when there is no usable name (username is NOT a fallback)', () => {
     expect(
       composeDisplayName({
         name: { first: '', last: '' },
         username: 'fallbackuser',
         publicKey: '0x1234567890abcdef',
       })
-    ).toBe('fallbackuser');
+    ).toBeUndefined();
   });
 
-  it('falls back to username when the name subdocument is absent', () => {
-    expect(composeDisplayName({ username: 'noname' })).toBe('noname');
+  it('returns undefined when the name subdocument is absent (username only)', () => {
+    expect(composeDisplayName({ username: 'noname' })).toBeUndefined();
   });
 
-  it('falls back to the truncated 0x publicKey handle when neither name nor username exists', () => {
+  it('returns undefined for a publicKey-only user (no handle synthesis)', () => {
     expect(
       composeDisplayName({
         publicKey: '0x1234567890abcdef1234567890abcdef',
       })
-    ).toBe('0x123456...abcdef');
+    ).toBeUndefined();
   });
 
-  it('falls back to the truncated bare-hex publicKey handle (no 0x prefix)', () => {
-    expect(
-      composeDisplayName({
-        publicKey: 'abcdef1234567890fedcba',
-      })
-    ).toBe('abcdef...fedcba');
-  });
-
-  it("returns 'Anonymous' when name, username, and publicKey are all absent", () => {
-    expect(composeDisplayName({})).toBe('Anonymous');
-  });
-
-  it('ignores a whitespace-only username and falls through to the publicKey handle', () => {
-    expect(
-      composeDisplayName({
-        username: '   ',
-        publicKey: '0xabcdef1234567890abcdef',
-      })
-    ).toBe('0xabcdef...abcdef');
+  it('returns undefined when name, username, and publicKey are all absent', () => {
+    expect(composeDisplayName({})).toBeUndefined();
   });
 
   it('prefers the name even when a username is also present (name wins)', () => {
@@ -136,13 +129,30 @@ describe('formatUserNameResponse', () => {
     });
   });
 
-  it('emits displayName from username when structured names are empty', () => {
+  it('OMITS displayName (and first/last/full) for a username-only user', () => {
     expect(
       formatUserNameResponse({
         name: { first: '', last: '' },
         username: 'janedoe',
       })
-    ).toEqual({ displayName: 'janedoe' });
+    ).toEqual({});
+  });
+
+  it('OMITS displayName for a publicKey-only user (no synthesis)', () => {
+    expect(
+      formatUserNameResponse({
+        publicKey: '0x1234567890abcdef',
+      })
+    ).toEqual({});
+  });
+
+  it('emits a first-only displayName/full without a last name', () => {
+    expect(
+      formatUserNameResponse({
+        name: { first: 'Cher' },
+        username: 'mononym',
+      })
+    ).toEqual({ first: 'Cher', full: 'Cher', displayName: 'Cher' });
   });
 });
 

--- a/packages/api/src/utils/__tests__/displayNameSanitize.test.ts
+++ b/packages/api/src/utils/__tests__/displayNameSanitize.test.ts
@@ -4,16 +4,32 @@ import {
   isValidDisplayName,
 } from '../displayNameSanitize';
 
-// Non-ASCII strings use explicit \u escapes so expected values are unambiguous
-// regardless of how the source file is Unicode-normalized on disk.
-const RENEE = 'Renée'; // Renée (precomposed)
-const RAMEE = 'Axe vert de La Ramée'; // Axe vert de La Ramée
-const MUNOZ = 'Renée Muñoz'; // Renée Muñoz
-const CYRILLIC = 'Владимир'; // Владимир
-const CJK = '山田太郎'; // 山田太郎
-const PENGUIN = '\u{1f427}'; // 🐧
-const ASTERISM = '⁂'; // ⁂
-const EARTH_GROUND = '⏚'; // ⏚
+// Every non-ASCII fixture is spelled out with explicit \u escapes so its exact
+// code points (and thus NFC/combining behaviour) are unambiguous regardless of
+// how this source file is Unicode-normalized on disk.
+const RENEE = 'Renée'; // "Renee" with precomposed e-acute (U+00E9)
+const RAMEE = 'Axe vert de La Ramée'; // "...Ramee" with precomposed e-acute
+const MUNOZ = 'Renée Muñoz'; // "Renee Munoz" with e-acute + n-tilde
+const CYRILLIC = 'Владимир'; // Vladimir (Cyrillic)
+const CJK = '山田太郎'; // CJK name
+const PENGUIN = '\u{1f427}'; // penguin emoji
+const ASTERISM = '⁂'; // asterism, General_Category Po
+const EARTH_GROUND = '⏚'; // earth-ground symbol, General_Category So
+
+// Orphaned-combining-mark fixtures. Lengths are asserted in the tests below.
+const TIBETAN_MARK = '༘'; // Tibetan astrological sign, General_Category Mn (combining)
+const STAR_OPERATOR = '⋆'; // star operator, General_Category Sm (symbol)
+const ORPHAN_PAIR = `${TIBETAN_MARK}${STAR_OPERATOR}`; // the real prod example (U+0F18 U+22C6)
+// "Renee" written decomposed: base 'e' + combining acute U+0301 -> NFC e-acute.
+const RENEE_DECOMPOSED = 'Renée';
+// Devanagari with a virama (U+094D, Mn) and a vowel sign (U+0947, Mn).
+const DEVANAGARI = 'नमस्ते';
+// Thai consonant KO KAI + SARA I (U+0E34, Mn), a real combining vowel mark.
+const THAI = 'กิ';
+// Arabic letters interleaved with harakat (U+064F damma, U+064E fatha; Mn).
+const ARABIC_MARKS = 'مُحَمَد';
+const HEART = '❤'; // heavy black heart, General_Category So (symbol)
+const VS16 = '️'; // VARIATION SELECTOR-16, General_Category Mn (combining)
 
 describe('displayNameSanitize', () => {
   describe('cleanDisplayName — user-reported examples', () => {
@@ -31,8 +47,37 @@ describe('displayNameSanitize', () => {
     });
   });
 
+  describe('cleanDisplayName — orphaned combining marks', () => {
+    it('cleans the real prod example U+0F18 U+22C6 (Mn + Sm) to empty', () => {
+      // U+0F18 is a combining mark allowed by the \p{M}-friendly policy, but it
+      // is base-less here, so it must be stripped along with the U+22C6 symbol.
+      expect(ORPHAN_PAIR).toHaveLength(2);
+      expect(cleanDisplayName(ORPHAN_PAIR)).toBe('');
+    });
+
+    it('cleans a lone combining mark (U+0F18) to empty', () => {
+      expect(TIBETAN_MARK).toHaveLength(1);
+      expect(cleanDisplayName(TIBETAN_MARK)).toBe('');
+    });
+
+    it('strips a leading orphaned mark but keeps the following letters', () => {
+      expect(cleanDisplayName(`${TIBETAN_MARK}Anna`)).toBe('Anna');
+    });
+
+    it('strips the trailing VS16 left after an emoji base is removed', () => {
+      // "Mark Holmwood " + heart (U+2764) + VS16 (U+FE0F). The heart is a symbol
+      // -> stripped to a space; the variation selector is a combining mark that
+      // is now orphaned -> must also be removed, with no stray trailing space.
+      const input = `Mark Holmwood ${HEART}${VS16}`;
+      const result = cleanDisplayName(input);
+      expect(result).toBe('Mark Holmwood');
+      expect(result.endsWith(' ')).toBe(false);
+      expect(result).not.toContain(VS16);
+    });
+  });
+
   describe('cleanDisplayName — allowed characters', () => {
-    it('keeps Latin accents and ñ', () => {
+    it('keeps Latin accents and n-tilde', () => {
       expect(cleanDisplayName(MUNOZ)).toBe(MUNOZ);
     });
 
@@ -46,6 +91,31 @@ describe('displayNameSanitize', () => {
 
     it("keeps the straight apostrophe in O'Brien", () => {
       expect(cleanDisplayName("O'Brien")).toBe("O'Brien");
+    });
+
+    it('keeps a precomposed accented name (Renee) unchanged', () => {
+      expect(cleanDisplayName(RENEE)).toBe(RENEE);
+    });
+
+    it('recomposes a decomposed accent and keeps the mark on its base letter', () => {
+      // The combining acute is attached to a base 'e', so the negative
+      // lookbehind protects it; NFC then recomposes it into a precomposed char.
+      expect(RENEE_DECOMPOSED).toHaveLength(6); // R e n e <combining acute> e
+      const result = cleanDisplayName(RENEE_DECOMPOSED);
+      expect(result).toBe(RENEE);
+      expect(result.normalize('NFC')).toBe(result);
+    });
+
+    it('preserves Devanagari combining marks attached to base letters', () => {
+      expect(cleanDisplayName(DEVANAGARI)).toBe(DEVANAGARI);
+    });
+
+    it('preserves a Thai combining vowel mark on its base letter', () => {
+      expect(cleanDisplayName(THAI)).toBe(THAI);
+    });
+
+    it('preserves Arabic harakat attached to base letters', () => {
+      expect(cleanDisplayName(ARABIC_MARKS)).toBe(ARABIC_MARKS);
     });
   });
 
@@ -79,10 +149,10 @@ describe('displayNameSanitize', () => {
 
   describe('cleanDisplayName — normalization', () => {
     it('NFC-normalizes decomposed sequences', () => {
-      // "Cafe" + combining acute U+0301 (NFD) → precomposed "Café" (NFC).
+      // "Cafe" + combining acute U+0301 (NFD) -> precomposed "Cafe-acute" (NFC).
       const decomposed = 'Café';
       expect(decomposed).toHaveLength(5);
-      const expected = 'Café'; // precomposed é
+      const expected = 'Café'; // precomposed e-acute
       const result = cleanDisplayName(decomposed);
       expect(result).toBe(expected);
       expect(result).toHaveLength(4);
@@ -119,18 +189,29 @@ describe('displayNameSanitize', () => {
   });
 
   describe('isValidDisplayName', () => {
-    it.each([`${RENEE} O'Brien`, CYRILLIC, CJK, 'Ada Lovelace', ''])(
-      'returns true for clean name %p',
-      (name) => {
-        expect(isValidDisplayName(name)).toBe(true);
-      },
-    );
+    it.each([
+      `${RENEE} O'Brien`,
+      CYRILLIC,
+      CJK,
+      'Ada Lovelace',
+      '',
+      RENEE,
+      RENEE_DECOMPOSED,
+      DEVANAGARI,
+      THAI,
+      ARABIC_MARKS,
+    ])('returns true for clean name %p', (name) => {
+      expect(isValidDisplayName(name)).toBe(true);
+    });
 
     it.each([
       `Dabid ${ASTERISM}`,
       `${RAMEE} ${EARTH_GROUND}`,
       'Laura :bongoCat:',
       `nixCraft ${PENGUIN}`,
+      ORPHAN_PAIR,
+      TIBETAN_MARK,
+      `${TIBETAN_MARK}Anna`,
     ])('returns false for dirty name %p', (name) => {
       expect(isValidDisplayName(name)).toBe(false);
     });

--- a/packages/api/src/utils/__tests__/userTransform.contract.test.ts
+++ b/packages/api/src/utils/__tests__/userTransform.contract.test.ts
@@ -10,9 +10,11 @@
  * these tests fail — exactly the class of bug that motivated the contract.
  *
  * The load-bearing assertion is that `name.full` and `name.displayName` are
- * ALWAYS composed (first-only included) even when the source document was
- * loaded WITHOUT Mongoose virtuals (a `.lean()` query), because the
- * `/auth/refresh-all` handler reads users via `.lean()`.
+ * composed from a REAL name (first-only included) even when the source document
+ * was loaded WITHOUT Mongoose virtuals (a `.lean()` query), because the
+ * `/auth/refresh-all` handler reads users via `.lean()`. When the user has no
+ * real name (username-only / publicKey-only) `name.displayName` is OMITTED and
+ * the client falls back to the handle.
  */
 
 import { formatUserResponse } from '../userTransform';
@@ -101,7 +103,7 @@ describe('formatUserResponse → @oxyhq/contracts userResponseSchema (producer c
     expect(safeParseContract(userResponseSchema, formatted)).not.toBeNull();
   });
 
-  it('emits name.displayName for a publicKey-only user with no username and no human name', () => {
+  it('OMITS name.displayName for a publicKey-only user with no username and no human name', () => {
     const formatted = formatUserResponse(
       leanDoc('507f1f77bcf86cd799439014', {
         publicKey: '0x1234567890abcdef',
@@ -110,7 +112,9 @@ describe('formatUserResponse → @oxyhq/contracts userResponseSchema (producer c
 
     expect(formatted).not.toBeNull();
     expect(formatted?.username).toBeUndefined();
-    expect(formatted?.name).toEqual({ displayName: '0x123456...abcdef' });
+    // No real name → name is an empty object; displayName is absent and the
+    // client falls back to the handle.
+    expect(formatted?.name).toEqual({});
 
     // Still a valid contract object — id is the only guaranteed field.
     const parsed = safeParseContract(userResponseSchema, formatted);
@@ -118,7 +122,7 @@ describe('formatUserResponse → @oxyhq/contracts userResponseSchema (producer c
     expect(parsed && resolveUserId(parsed)).toBe('507f1f77bcf86cd799439014');
   });
 
-  it('omits empty full when first and last are both empty strings but still emits name.displayName', () => {
+  it('OMITS name.displayName when first and last are both empty strings (username-only)', () => {
     const formatted = formatUserResponse(
       leanDoc('507f1f77bcf86cd799439015', {
         username: 'blanknames',
@@ -126,7 +130,7 @@ describe('formatUserResponse → @oxyhq/contracts userResponseSchema (producer c
       })
     );
 
-    expect(formatted?.name).toEqual({ displayName: 'blanknames' });
+    expect(formatted?.name).toEqual({});
     expect(safeParseContract(userResponseSchema, formatted)).not.toBeNull();
   });
 

--- a/packages/api/src/utils/displayName.ts
+++ b/packages/api/src/utils/displayName.ts
@@ -31,10 +31,11 @@ export interface NameResponse extends Record<string, unknown> {
   last?: string;
   full?: string;
   /**
-   * Optional to match the `@oxyhq/contracts` `UserNameResponse` contract.
-   * NOTE: the serializers in this module (`formatUserNameResponse`) STILL
-   * always synthesize a string today — only the type was relaxed. The runtime
-   * synthesis change is a later stage.
+   * The user's REAL display name (explicit `displayName`, or composed from
+   * `first`/`last`). OMITTED when the user has no real name — the API no longer
+   * synthesizes one from `username` / `publicKey` / `'Anonymous'`. Matches the
+   * optional `@oxyhq/contracts` `UserNameResponse` contract; consumers fall back
+   * to the handle when this field is absent.
    */
   displayName?: string;
 }
@@ -71,14 +72,21 @@ export function truncatePublicKeyHandle(publicKey: string | null | undefined): s
 }
 
 /**
- * Compose the authoritative default `name.displayName` in preference order:
+ * Compose the user's REAL display name, or `undefined` when they have none.
  *
- *   1. `name.full` (composed from `name.first` / `name.last`; first-only valid)
- *   2. `username`
- *   3. truncated `publicKey` handle
- *   4. `'Anonymous'`
+ *   1. explicit `name.displayName` (trimmed), else
+ *   2. `name.full` (composed from `name.first` / `name.last`; first-only valid),
+ *      else
+ *   3. `undefined`.
+ *
+ * It deliberately does NOT fall back to `username`, a truncated `publicKey`
+ * handle, or `'Anonymous'` — the API must not synthesize a display name. When
+ * this returns `undefined` the serializer omits `name.displayName` entirely and
+ * consumers fall back to the handle. Call sites that genuinely need a non-empty
+ * string (e.g. an ActivityPub actor `name`, an email greeting) add their OWN
+ * local fallback to the handle/username — never re-add it here.
  */
-export function composeDisplayName(source: DisplayNameSource): string {
+export function composeDisplayName(source: DisplayNameSource): string | undefined {
   const explicitDisplayName =
     typeof source.name?.displayName === 'string' ? source.name.displayName.trim() : '';
   if (explicitDisplayName) {
@@ -91,24 +99,18 @@ export function composeDisplayName(source: DisplayNameSource): string {
     return full;
   }
 
-  if (typeof source.username === 'string' && source.username.trim()) {
-    return source.username;
-  }
-
-  const handle = truncatePublicKeyHandle(source.publicKey);
-  if (handle) {
-    return handle;
-  }
-
-  return 'Anonymous';
+  return undefined;
 }
 
 /**
  * Build the canonical structured name emitted by user DTO serializers.
  *
- * `name.displayName` is the app-facing display string. It is always present on
- * formatted user responses, while `first`, `last`, and `full` preserve the raw
- * structured human-name fields when they exist.
+ * `name.displayName` is the app-facing display string. It is present ONLY when
+ * the user has a REAL name (explicit `displayName`, or composed from
+ * `first`/`last`); it is OMITTED otherwise — the API never synthesizes a name
+ * from `username` / `publicKey`, so consumers fall back to the handle. `first`,
+ * `last`, and `full` preserve the raw structured human-name fields when they
+ * exist.
  */
 export function formatUserNameResponse(source: DisplayNameSource): NameResponse {
   const rawName = source.name;
@@ -117,18 +119,19 @@ export function formatUserNameResponse(source: DisplayNameSource): NameResponse 
   const explicitFull = typeof rawName?.full === 'string' ? rawName.full.trim() : '';
   const full = explicitFull || composeFullName({ first, last });
 
-  const name: NameResponse = {
-    displayName: composeDisplayName({
-      ...source,
-      name: {
-        first,
-        last,
-        full,
-        displayName: rawName?.displayName,
-      },
-    }),
-  };
+  const name: NameResponse = {};
 
+  const displayName = composeDisplayName({
+    name: {
+      first,
+      last,
+      full,
+      displayName: rawName?.displayName,
+    },
+  });
+  if (displayName) {
+    name.displayName = displayName;
+  }
   if (first) {
     name.first = first;
   }

--- a/packages/api/src/utils/displayNameSanitize.ts
+++ b/packages/api/src/utils/displayNameSanitize.ts
@@ -37,15 +37,40 @@ const DISALLOWED_PATTERN = /[^\p{L}\p{M}\s']/gu;
 const DISALLOWED_PROBE = /[^\p{L}\p{M}\s']/u;
 
 /**
+ * Matches a run of combining marks (`\p{M}`) that is NOT attached to a base
+ * letter — i.e. the first mark of the run is preceded by something that is
+ * neither a letter nor another mark (string start, whitespace, the apostrophe,
+ * or a position vacated by a stripped character). The whole orphaned run is
+ * removed. A mark preceded by `\p{L}` (a base letter, e.g. the decomposed
+ * accent in "Renée") or by another `\p{M}` (a multi-mark cluster) is KEPT
+ * because the negative lookbehind fails at its position.
+ *
+ * This catches lone Tibetan/diacritic marks (e.g. U+0F18 in `"༘⋆"`) and the
+ * trailing variation selector (U+FE0F) left behind after an emoji base such as
+ * U+2764 (❤) is stripped, both of which would otherwise survive the
+ * `\p{M}`-friendly policy as meaningless garbage.
+ */
+const ORPHANED_MARK_PATTERN = /(?<![\p{L}\p{M}])\p{M}+/gu;
+
+/** Single test for the presence of an orphaned combining mark (non-global). */
+const ORPHANED_MARK_PROBE = /(?<![\p{L}\p{M}])\p{M}/u;
+
+/**
  * Produce a clean display name from arbitrary (possibly federated/untrusted)
  * input. The transformation order is significant:
  *
- *   1. NFC-normalize so visually-identical strings compare/store identically.
+ *   1. NFC-normalize so visually-identical strings compare/store identically
+ *      (this also recomposes e.g. `e`+◌́ into a precomposed `é`, so legitimate
+ *      decomposed accents never reach step 4 as standalone marks).
  *   2. Strip `:shortcode:` tokens FIRST — otherwise step 3 would only remove
  *      the surrounding colons and leave the bare word (`:bongoCat:` → `bongoCat`).
  *   3. Replace every disallowed character with a space.
- *   4. Collapse runs of whitespace to a single space and trim the ends.
- *   5. Cap the length to {@link MAX_DISPLAY_NAME_LENGTH}, trimming again in case
+ *   4. Remove orphaned combining marks — any `\p{M}` run not attached to a base
+ *      letter (e.g. a lone Tibetan mark `U+0F18`, or a `U+FE0F` variation
+ *      selector left after its emoji base was stripped in step 3). Marks that
+ *      are still attached to a base letter are kept.
+ *   5. Collapse runs of whitespace to a single space and trim the ends.
+ *   6. Cap the length to {@link MAX_DISPLAY_NAME_LENGTH}, trimming again in case
  *      the slice landed on a boundary space.
  */
 export function cleanDisplayName(raw: string): string {
@@ -53,6 +78,7 @@ export function cleanDisplayName(raw: string): string {
     .normalize('NFC')
     .replace(SHORTCODE_PATTERN, ' ')
     .replace(DISALLOWED_PATTERN, ' ')
+    .replace(ORPHANED_MARK_PATTERN, '')
     .replace(/\s+/g, ' ')
     .trim();
 
@@ -63,15 +89,22 @@ export function cleanDisplayName(raw: string): string {
 }
 
 /**
- * Whether `raw` already satisfies the display-name character policy, i.e. it
- * contains no disallowed characters. Used to REJECT native (signup / profile
- * edit) names with a 400 rather than silently stripping them.
+ * Whether `raw` already satisfies the display-name policy, i.e. it contains no
+ * disallowed characters AND no orphaned combining marks. Used to REJECT native
+ * (signup / profile edit) names with a 400 rather than silently stripping them.
  *
- * The function only checks for disallowed characters; an empty or
- * whitespace-only string is considered valid (`true`). Call sites that require
- * a non-empty name enforce that separately — this check is purely about the
- * character set.
+ * This mirrors {@link cleanDisplayName}: a value that the cleaner would alter
+ * (beyond whitespace collapsing) is invalid here. The orphaned-mark probe runs
+ * on the NFC-normalized form so a legitimate decomposed accent (`e`+◌́) — which
+ * the cleaner recomposes into `é` — is NOT rejected, while a lone, base-less
+ * mark (e.g. `"༘"`) IS.
+ *
+ * The function only checks the character set; an empty or whitespace-only
+ * string is considered valid (`true`). Call sites that require a non-empty name
+ * enforce that separately.
  */
 export function isValidDisplayName(raw: string): boolean {
-  return !DISALLOWED_PROBE.test(raw);
+  return (
+    !DISALLOWED_PROBE.test(raw) && !ORPHANED_MARK_PROBE.test(raw.normalize('NFC'))
+  );
 }

--- a/packages/api/src/utils/userTransform.ts
+++ b/packages/api/src/utils/userTransform.ts
@@ -84,12 +84,13 @@ function toNameParts(value: unknown): NameParts | undefined {
  * id = MongoDB ObjectId (_id.toString())
  * publicKey = separate field for authentication
  *
- * Self-sufficient name composition: the returned `name.full` and
- * `name.displayName` are ALWAYS correct whether or not the source document was
- * loaded with Mongoose virtuals. This is the canonical producer of the
- * `@oxyhq/core` `userResponseSchema` contract — the api
- * `userTransform.contract.test.ts` locks the output to that schema so the
- * producer cannot silently drift from it again.
+ * Self-sufficient name composition: the returned `name.full` is composed
+ * whether or not the source document was loaded with Mongoose virtuals, and
+ * `name.displayName` is present ONLY when the user has a real name (omitted for
+ * username-only / publicKey-only accounts — consumers fall back to the handle).
+ * This is the canonical producer of the `@oxyhq/core` `userResponseSchema`
+ * contract — the api `userTransform.contract.test.ts` locks the output to that
+ * schema so the producer cannot silently drift from it again.
  */
 export function formatUserResponse(user: unknown) {
   if (!isRecord(user)) {


### PR DESCRIPTION
Final stage of the optional-displayName rollout. The API now omits name.displayName for no-name users; clients (already deployed) render the handle. Note: relaxes sso.controller parseSessionPayload + federation getUserActor for the optional contract — auth path, worth a look.

## Summary
- `composeDisplayName` returns `undefined` instead of synthesizing a fallback from username/publicKey/"Anonymous" — only real names (explicit `displayName` or first/last) are emitted
- `formatUserNameResponse` omits `displayName` from the payload when there is no real name, so clients fall back to the handle (optional contract shipped in `contracts@0.6.0` / `core@3.18.1`)
- Relaxes `sso.controller parseSessionPayload` and `federation.service getUserActor` to accept an absent `displayName` (uses `?? username` fallback) — these would otherwise 400/break against the new contract
- Includes the held orphaned-mark fix: `cleanDisplayName` now strips combining marks left behind after emoji removal (e.g. variation selector `️` alone), so a name that is only marks/symbols cleans to empty

## Test plan
- [ ] `bunx tsc --noEmit` in `packages/api` — clean
- [ ] `bun run test` in `packages/api` — 125 suites / 1224 tests, all pass
- [ ] Mention Deploy to AWS gate for PR #269 (`22c68f8c`) — `completed success` (relaxed-gate SDK already live)
- [ ] After merge: watch "Deploy to AWS" run for oxy-api to `success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->