### PR TITLE
feat(accounts): Gmail-style true account switch + SDK majors

### DIFF
--- a/packages/accounts/app/(tabs)/managed-accounts.tsx
+++ b/packages/accounts/app/(tabs)/managed-accounts.tsx
@@ -15,9 +15,10 @@ import { useTranslation } from '@/lib/i18n';
 import type { AccountNode, AccountRole } from '@oxyhq/core';
 import { getAccountDisplayName as coreGetAccountDisplayName, getAccountFallbackHandle } from '@oxyhq/core';
 
-// Roles that may post/act as the account (delegated identity). Mirrors the
-// `account:act_as` capability mapping in the account role set (owner/admin/editor).
-const ACT_AS_ROLES: readonly AccountRole[] = ['owner', 'admin', 'editor'];
+// Roles whose membership carries the `account:act_as` capability — the only
+// roles that can SWITCH INTO the account (selecting it makes the whole app
+// become that account). Mirrors the account role set (owner/admin/editor).
+const SWITCHABLE_ROLES: readonly AccountRole[] = ['owner', 'admin', 'editor'];
 // Roles that may manage membership + sharing of the account.
 const MANAGE_MEMBER_ROLES: readonly AccountRole[] = ['owner', 'admin'];
 // Roles that may edit the account's profile.
@@ -64,6 +65,7 @@ export default function ManagedAccountsScreen() {
     isLoading: oxyLoading,
     accounts,
     actingAs,
+    activeAccount,
     setActingAs,
     showBottomSheet,
     oxyServices,
@@ -88,9 +90,20 @@ export default function ManagedAccountsScreen() {
     showBottomSheet?.('CreateAccount');
   }, [showBottomSheet]);
 
-  const handleActAs = useCallback((accountId: string) => {
-    setActingAs(actingAs === accountId ? null : accountId);
-  }, [actingAs, setActingAs]);
+  // True account switch — selecting an account makes the whole app become it.
+  // This is NOT a toggle: returning to the personal account is itself a switch
+  // (via the banner below / `setActingAs(null)`), never an "un-act-as".
+  const handleSwitchTo = useCallback((accountId: string) => {
+    setActingAs(accountId);
+  }, [setActingAs]);
+
+  // The display name of the account currently switched into, for the
+  // "switch back to your personal account" banner. `null` on the personal
+  // account (no banner shown).
+  const activeAccountName = useMemo(
+    () => (actingAs && activeAccount ? coreGetAccountDisplayName(activeAccount, locale) : null),
+    [actingAs, activeAccount, locale],
+  );
 
   const handleManageMembers = useCallback((accountId: string) => {
     showBottomSheet?.({ screen: 'AccountMembers', props: { accountId } });
@@ -144,13 +157,18 @@ export default function ManagedAccountsScreen() {
     // rather than showing "No username set".
     const fallbackHandle = getAccountFallbackHandle(node.account ?? null);
     const role = getNodeRole(node);
-    const isActingAs = actingAs === node.accountId;
+    // "Current" = the account the app is switched INTO. `actingAs` is the id
+    // form of the effective active account (the same value that drives
+    // `activeAccount`); it is the account id, so it matches `node.accountId`
+    // directly. The personal/self account (not listed here) is current when
+    // `actingAs` is null.
+    const isCurrent = actingAs === node.accountId;
     const isArchiving = archivingId === node.accountId;
     const avatarUri = node.account?.avatar
       ? oxyServices.getFileDownloadUrl(node.account.avatar, 'thumb')
       : undefined;
     const badgeColor = getRoleBadgeColor(role, colors);
-    const canActAs = ACT_AS_ROLES.includes(role);
+    const canSwitchInto = SWITCHABLE_ROLES.includes(role);
     const canManageMembers = MANAGE_MEMBER_ROLES.includes(role);
     const canEdit = EDIT_ROLES.includes(role);
     const canArchive = role === 'owner';
@@ -161,14 +179,7 @@ export default function ManagedAccountsScreen() {
       subtitle: username
         ? `@${username}`
         : (fallbackHandle ?? t('managedAccounts.noUsernameYet')),
-      customIcon: (
-        <View style={styles.avatarContainer}>
-          <Avatar name={name} uri={avatarUri} size={40} />
-          {isActingAs && (
-            <View style={[styles.activeIndicator, { backgroundColor: colors.success }]} />
-          )}
-        </View>
-      ),
+      customIcon: <Avatar name={name} uri={avatarUri} size={40} />,
       customContent: (
         <View style={styles.accountActions}>
           <View style={[styles.roleBadge, { backgroundColor: badgeColor + '20', borderColor: badgeColor + '40' }]}>
@@ -178,23 +189,29 @@ export default function ManagedAccountsScreen() {
             <ActivityIndicator size="small" color={colors.text} />
           ) : (
             <View style={styles.actionButtons}>
-              {canActAs && (
+              {isCurrent ? (
+                // Single "current account" indicator (Gmail-style). Not a toggle:
+                // the account is already active, so there is nothing to press.
+                <View
+                  style={styles.currentIndicator}
+                  accessible
+                  accessibilityRole="image"
+                  accessibilityLabel={t('a11y.stopActingAs')}
+                >
+                  <MaterialCommunityIcons name="check" size={20} color={colors.tint} />
+                </View>
+              ) : canSwitchInto ? (
                 <TouchableOpacity
-                  style={[styles.actionButton, { backgroundColor: isActingAs ? colors.success + '20' : colors.card }]}
+                  style={[styles.actionButton, { backgroundColor: colors.card }]}
                   onPressIn={handlePressIn}
-                  onPress={() => handleActAs(node.accountId)}
+                  onPress={() => handleSwitchTo(node.accountId)}
                   activeOpacity={0.7}
                   accessibilityRole="button"
-                  accessibilityLabel={isActingAs ? t('a11y.stopActingAs') : t('a11y.actAs')}
-                  accessibilityState={{ selected: isActingAs }}
+                  accessibilityLabel={t('a11y.actAs')}
                 >
-                  <MaterialCommunityIcons
-                    name={isActingAs ? 'account-check' : 'account-switch'}
-                    size={16}
-                    color={isActingAs ? colors.success : colors.text}
-                  />
+                  <MaterialCommunityIcons name="swap-horizontal" size={16} color={colors.text} />
                 </TouchableOpacity>
-              )}
+              ) : null}
               {canManageMembers && (
                 <TouchableOpacity
                   style={[styles.actionButton, { backgroundColor: colors.card }]}
@@ -235,9 +252,18 @@ export default function ManagedAccountsScreen() {
           )}
         </View>
       ),
-      onPress: canActAs ? () => handleActAs(node.accountId) : () => handleManageMembers(node.accountId),
+      // Tapping the row switches INTO the account (Gmail-style). The current
+      // account is not pressable (it is already active); accounts the caller
+      // can't switch into fall back to the manage-members affordance.
+      onPress: isCurrent
+        ? undefined
+        : canSwitchInto
+          ? () => handleSwitchTo(node.accountId)
+          : canManageMembers
+            ? () => handleManageMembers(node.accountId)
+            : undefined,
     };
-  }, [actingAs, archivingId, oxyServices, colors, handlePressIn, handleActAs, handleManageMembers, handleEditProfile, handleArchiveAccount, t, locale]);
+  }, [actingAs, archivingId, oxyServices, colors, handlePressIn, handleSwitchTo, handleManageMembers, handleEditProfile, handleArchiveAccount, t, locale]);
 
   // Partition the accessible forest: accounts the caller owns (grouped by kind)
   // and accounts shared with them via membership. The caller's own personal
@@ -293,11 +319,13 @@ export default function ManagedAccountsScreen() {
             <Section title="">
               <AccountCard>
                 <GroupedSection items={[{
-                  id: 'acting-as-info',
-                  icon: 'information-outline',
+                  id: 'switch-to-personal',
+                  icon: 'account-arrow-left',
                   iconColor: colors.sidebarIconSecurity,
-                  title: t('managedAccounts.actingAsTitle'),
-                  subtitle: t('managedAccounts.actingAsSubtitle'),
+                  title: t('managedAccounts.switchBackTitle'),
+                  subtitle: activeAccountName
+                    ? t('managedAccounts.switchBackSubtitle', { name: activeAccountName })
+                    : undefined,
                   onPress: () => setActingAs(null),
                   showChevron: false,
                 }]} />
@@ -386,19 +414,6 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
-  avatarContainer: {
-    position: 'relative',
-  },
-  activeIndicator: {
-    position: 'absolute',
-    bottom: 0,
-    right: 0,
-    width: 12,
-    height: 12,
-    borderRadius: 6,
-    borderWidth: 2,
-    borderColor: '#FFFFFF',
-  },
   accountActions: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -408,6 +423,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
+  },
+  currentIndicator: {
+    width: 32,
+    height: 32,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   actionButton: {
     width: 32,

--- a/packages/accounts/app/_layout.tsx
+++ b/packages/accounts/app/_layout.tsx
@@ -17,7 +17,7 @@ configureReanimatedLogger({
 });
 
 import { KeyboardProvider } from 'react-native-keyboard-controller';
-import { OxyProvider, ActingAsBanner } from '@oxyhq/services';
+import { OxyProvider, ActiveAccountBanner } from '@oxyhq/services';
 import { BloomThemeProvider, useNavigationTheme } from '@oxyhq/bloom/theme';
 
 import { useOxy } from '@oxyhq/services';
@@ -162,7 +162,7 @@ function AppStackContent() {
     <SafeAreaProvider>
       <ScrollProvider>
         <ThemeProvider value={navTheme}>
-          <ActingAsBanner />
+          <ActiveAccountBanner />
           <Stack>
             <Stack.Screen name="(tabs)" redirect={needsAuth} options={{ headerShown: false }} />
             <Stack.Screen name="(auth)" redirect={!needsAuth} options={{ headerShown: false }} />

--- a/packages/accounts/components/ui/sidebar-content.tsx
+++ b/packages/accounts/components/ui/sidebar-content.tsx
@@ -52,10 +52,10 @@ export function SidebarContent({ onNavigate }: SidebarContentProps) {
     const handlePressIn = useHapticPress();
     const { actingAs, accounts } = useOxy();
 
-    // Compute the acting-as display name for the indicator using the canonical
-    // helper so the fallback chain (name → username → publicKey → "Unnamed")
-    // is identical across the app.
-    const actingAsName = useMemo(() => {
+    // Compute the active (switched-into) account's display name for the context
+    // cue using the canonical helper so the fallback chain (name → username →
+    // publicKey → "Unnamed") is identical across the app.
+    const activeAccountName = useMemo(() => {
         if (!actingAs || !accounts.length) return null;
         const node = accounts.find((a) => a.accountId === actingAs);
         if (!node?.account) return null;
@@ -69,12 +69,12 @@ export function SidebarContent({ onNavigate }: SidebarContentProps) {
 
     return (
         <>
-            {/* Acting-as indicator */}
-            {actingAs && actingAsName && (
+            {/* Active-account context cue — which account the app is using now */}
+            {actingAs && activeAccountName && (
                 <View style={[styles.actingAsContainer, { backgroundColor: colors.sidebarIconSecurity + '14' }]}>
-                    <View style={[styles.actingAsDot, { backgroundColor: colors.success }]} />
+                    <View style={[styles.actingAsDot, { backgroundColor: colors.sidebarIconSecurity }]} />
                     <Text style={[styles.actingAsText, { color: colors.sidebarIconSecurity }]} numberOfLines={1}>
-                        {t('sidebar.actingAs', { name: actingAsName })}
+                        {t('sidebar.actingAs', { name: activeAccountName })}
                     </Text>
                 </View>
             )}

--- a/packages/accounts/lib/i18n/locales/en.json
+++ b/packages/accounts/lib/i18n/locales/en.json
@@ -126,7 +126,7 @@
       "managedCount": "{{count}} managed accounts",
       "managedCount_one": "{{count}} managed account",
       "managedSubtitle": "Tap to view all",
-      "managedActingAs": "Currently acting as another account",
+      "managedActingAs": "Currently using another account",
       "createNew": "Create account",
       "manageAll": "Manage All",
       "noManaged": "No managed accounts yet",
@@ -408,8 +408,8 @@
     "subtitle": "Manage accounts you own and accounts shared with you. Each has its own profile, username, and content.",
     "createNew": "Create account",
     "noUsernameYet": "No username set yet",
-    "actingAsTitle": "You're acting as another account",
-    "actingAsSubtitle": "Actions in other apps will be performed as this account. Tap to stop.",
+    "switchBackTitle": "Switch back to your personal account",
+    "switchBackSubtitle": "You're currently using {{name}}",
     "groups": {
       "organizations": "Organizations",
       "projects": "Projects",
@@ -697,7 +697,7 @@
     }
   },
   "sidebar": {
-    "actingAs": "Acting as {{name}}",
+    "actingAs": "Using {{name}}",
     "managedAccountFallback": "Managed Account"
   },
   "search": {
@@ -757,8 +757,8 @@
     "removeDevice": "Remove device",
     "removeSession": "Remove session",
     "switchSession": "Switch to this session",
-    "actAs": "Act as this account",
-    "stopActingAs": "Stop acting as this account",
+    "actAs": "Switch to this account",
+    "stopActingAs": "Current account",
     "manageMembers": "Manage members and sharing",
     "editProfile": "Edit profile",
     "deleteAccount": "Delete account",

--- a/packages/accounts/lib/i18n/locales/es.json
+++ b/packages/accounts/lib/i18n/locales/es.json
@@ -126,7 +126,7 @@
       "managedCount": "{{count}} cuentas gestionadas",
       "managedCount_one": "{{count}} cuenta gestionada",
       "managedSubtitle": "Toca para ver todas",
-      "managedActingAs": "Actuando como otra cuenta",
+      "managedActingAs": "Usando otra cuenta",
       "createNew": "Crear cuenta",
       "manageAll": "Gestionar todas",
       "noManaged": "Aún no tienes cuentas gestionadas",
@@ -408,8 +408,8 @@
     "subtitle": "Gestiona las cuentas que posees y las que comparten contigo. Cada una tiene su propio perfil, nombre de usuario y contenido.",
     "createNew": "Crear cuenta",
     "noUsernameYet": "Aún sin nombre de usuario",
-    "actingAsTitle": "Estás actuando como otra cuenta",
-    "actingAsSubtitle": "Las acciones en otras apps se realizarán como esta cuenta. Toca para detener.",
+    "switchBackTitle": "Vuelve a tu cuenta personal",
+    "switchBackSubtitle": "Actualmente estás usando {{name}}",
     "groups": {
       "organizations": "Organizaciones",
       "projects": "Proyectos",
@@ -697,7 +697,7 @@
     }
   },
   "sidebar": {
-    "actingAs": "Actuando como {{name}}",
+    "actingAs": "Usando {{name}}",
     "managedAccountFallback": "Cuenta gestionada"
   },
   "search": {
@@ -757,8 +757,8 @@
     "removeDevice": "Quitar dispositivo",
     "removeSession": "Quitar sesión",
     "switchSession": "Cambiar a esta sesión",
-    "actAs": "Actuar como esta cuenta",
-    "stopActingAs": "Dejar de actuar como esta cuenta",
+    "actAs": "Cambiar a esta cuenta",
+    "stopActingAs": "Cuenta actual",
     "manageMembers": "Gestionar miembros y uso compartido",
     "editProfile": "Editar perfil",
     "deleteAccount": "Eliminar cuenta",

--- a/packages/auth-sdk/package.json
+++ b/packages/auth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/auth",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "OxyHQ Web Authentication SDK — headless auth with React hooks for Next.js, Vite, and web apps",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -79,7 +79,7 @@
     "qrcode": "^1.5.4"
   },
   "peerDependencies": {
-    "@oxyhq/core": "^3.15.0",
+    "@oxyhq/core": "^3.15.0 || ^4.0.0",
     "@tanstack/query-sync-storage-persister": "^5.100",
     "@tanstack/react-query": "^5.100",
     "@tanstack/react-query-persist-client": "^5.100",

--- a/packages/commons/app/_layout.tsx
+++ b/packages/commons/app/_layout.tsx
@@ -18,7 +18,7 @@ configureReanimatedLogger({
 });
 
 import { KeyboardProvider } from 'react-native-keyboard-controller';
-import { OxyProvider, ActingAsBanner } from '@oxyhq/services';
+import { OxyProvider, ActiveAccountBanner } from '@oxyhq/services';
 import { BloomThemeProvider, useNavigationTheme } from '@oxyhq/bloom/theme';
 
 import { ScrollProvider } from '@/contexts/scroll-context';
@@ -149,7 +149,7 @@ function AppStackContent() {
     <SafeAreaProvider>
       <ScrollProvider>
         <ThemeProvider value={navTheme}>
-          <ActingAsBanner />
+          <ActiveAccountBanner />
           <Stack>
             {/*
               Bidirectional onboarding guard.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "3.18.1",
+  "version": "4.0.0",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/docs/index.mdx
+++ b/packages/services/docs/index.mdx
@@ -92,7 +92,7 @@ Screen modules are loaded on demand via `screenLoaders` in `ui/navigation/routes
 - `<OxySignInButton />` — the canonical sign-in CTA
 - `<Avatar />` — image + initials fallback + verified badge
 - `<OxyLogo />` / `<LogoIcon />` / `<LogoText />` — Bloom-themed brand marks
-- `<ActingAsBanner />` — managed-account banner showing the active sub-account
+- `<ActiveAccountBanner />` — subtle cue showing which account is active when switched into a non-personal account
 - `<FollowButton />` — toggleable follow state with optimistic update
 
 ## Common patterns

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "12.2.0",
+  "version": "13.0.0",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -152,7 +152,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.16.0",
-    "@oxyhq/core": "^3.17.0",
+    "@oxyhq/core": "^4.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@tanstack/query-async-storage-persister": "^5.100",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -205,8 +205,10 @@ export type { FollowButtonProps, SingleFollowButtonProps, MultiFollowButtonProps
 export { LogoIcon } from './ui/components/logo/LogoIcon';
 export { LogoText } from './ui/components/logo/LogoText';
 
-// Acting-as banner for delegated accounts (account graph, not Commons/DID)
-export { default as ActingAsBanner } from './ui/components/ActingAsBanner';
+// Subtle "active account" context cue for the account graph (not Commons/DID).
+// Shows which account is active when the user has switched into a non-personal
+// account; reads as the current account, not as delegation.
+export { default as ActiveAccountBanner } from './ui/components/ActiveAccountBanner';
 
 // Unified account menu (device-only switcher — popover on web, sheet on native)
 export { default as AccountMenu } from './ui/components/AccountMenu';

--- a/packages/services/src/ui/components/AccountMenuButton.tsx
+++ b/packages/services/src/ui/components/AccountMenuButton.tsx
@@ -22,7 +22,14 @@ const isWeb = Platform.OS === 'web';
 
 /**
  * Avatar entry-point that opens the unified {@link AccountSwitcher}. Reads the
- * active account from `useOxy()` — never receive user data via props.
+ * EFFECTIVE active account from `useOxy().activeAccount` — never receives user
+ * data via props.
+ *
+ * The chip reflects the account the user is currently switched into (an org /
+ * project / bot / shared account) exactly as it reflects their personal account:
+ * a switch makes the whole app — including this header avatar — become that
+ * account. `activeAccount` falls back to the personal user when no switch is
+ * active, so the chip always shows the current account.
  *
  * Renders a small avatar chip (top-right friendly). Click → opens the switcher
  * (device sign-ins + account graph). Pure component: owns only the open-state
@@ -34,7 +41,7 @@ const AccountMenuButton: React.FC<AccountMenuButtonProps> = ({
     onNavigateManage,
     onAddAccount,
 }) => {
-    const { user, oxyServices, isAuthenticated } = useOxy();
+    const { activeAccount, oxyServices, isAuthenticated } = useOxy();
     const { t, locale } = useI18n();
     const [open, setOpen] = useState(false);
     const [anchor, setAnchor] = useState<AccountMenuAnchor | null>(null);
@@ -70,9 +77,9 @@ const AccountMenuButton: React.FC<AccountMenuButtonProps> = ({
         }
     }, [measureAnchor, open]);
 
-    const displayName = getAccountDisplayName(user, locale);
-    const avatarUri = user?.avatar
-        ? oxyServices.getFileDownloadUrl(user.avatar, 'thumb')
+    const displayName = getAccountDisplayName(activeAccount, locale);
+    const avatarUri = activeAccount?.avatar
+        ? oxyServices.getFileDownloadUrl(activeAccount.avatar, 'thumb')
         : undefined;
 
     const accessibilityLabel = isAuthenticated

--- a/packages/services/src/ui/components/AccountSwitcher.tsx
+++ b/packages/services/src/ui/components/AccountSwitcher.tsx
@@ -164,11 +164,22 @@ export const AccountSwitcherView: React.FC<AccountSwitcherActions> = ({
     );
 
     const handleSwitchDevice = useCallback(async (sessionId: string) => {
-        if (sessionId === activeSessionId || busySessionId) return;
+        if (busySessionId) return;
+        // Tapping the already-active sign-in returns to that sign-in's own
+        // personal account (clearing any account-graph switch). When already on
+        // the personal account this just closes.
+        if (sessionId === activeSessionId) {
+            if (actingAs !== null) setActingAs(null);
+            onClose();
+            return;
+        }
         setBusySessionId(sessionId);
         try {
             await onBeforeSessionChange?.();
             await switchSession(sessionId);
+            // The active sign-in changed; any account-graph switch belonged to the
+            // previous sign-in, so the new sign-in starts on its personal account.
+            if (actingAs !== null) setActingAs(null);
             toast.success(t('accountSwitcher.toasts.switchSuccess') || 'Switched account');
             onClose();
         } catch (error) {
@@ -179,7 +190,7 @@ export const AccountSwitcherView: React.FC<AccountSwitcherActions> = ({
         } finally {
             setBusySessionId(null);
         }
-    }, [activeSessionId, busySessionId, switchSession, t, onClose, onBeforeSessionChange]);
+    }, [activeSessionId, busySessionId, actingAs, setActingAs, switchSession, t, onClose, onBeforeSessionChange]);
 
     const handleRemoveDevice = useCallback(async (sessionId: string) => {
         if (sessionId === activeSessionId || removingSessionId) return;
@@ -322,18 +333,23 @@ export const AccountSwitcherView: React.FC<AccountSwitcherActions> = ({
             {deviceRows.map((row) => {
                 const isBusy = busySessionId === row.sessionId;
                 const isRemoving = removingSessionId === row.sessionId;
+                // The active sign-in is THE current account only when no
+                // account-graph switch is in effect; otherwise a switched-into
+                // account is current and this row reads as the signed-in (but not
+                // active) account — tappable to return to it.
+                const isCurrentAccount = row.isActive && actingAs === null;
                 return (
                     <TouchableOpacity
                         key={`device-${row.sessionId}`}
                         accessibilityRole="menuitem"
                         accessibilityLabel={row.displayName}
-                        accessibilityState={{ selected: row.isActive }}
+                        accessibilityState={{ selected: isCurrentAccount }}
                         onPress={() => handleSwitchDevice(row.sessionId)}
-                        disabled={row.isActive || isBusy || isSwitching}
+                        disabled={isCurrentAccount || isBusy || isSwitching}
                         activeOpacity={0.6}
                         style={[
                             styles.accountRow,
-                            row.isActive && { backgroundColor: colors.primarySubtle },
+                            isCurrentAccount && { backgroundColor: colors.primarySubtle },
                             isSwitching && !row.isActive && styles.rowDisabled,
                         ]}
                     >
@@ -353,8 +369,13 @@ export const AccountSwitcherView: React.FC<AccountSwitcherActions> = ({
                         </View>
                         {isBusy ? (
                             <ActivityIndicator color={colors.primary} size="small" />
-                        ) : row.isActive ? (
+                        ) : isCurrentAccount ? (
                             <Ionicons name="checkmark" size={20} color={colors.primary} />
+                        ) : row.isActive ? (
+                            // Active sign-in while switched into another account:
+                            // no current-checkmark, no sign-out (can't sign out the
+                            // active session here) — tap the row to return to it.
+                            null
                         ) : isRemoving ? (
                             <ActivityIndicator color={colors.textSecondary} size="small" />
                         ) : (

--- a/packages/services/src/ui/components/ActiveAccountBanner.tsx
+++ b/packages/services/src/ui/components/ActiveAccountBanner.tsx
@@ -7,30 +7,39 @@ import {
   Platform,
   Image,
 } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useOxy } from '../context/OxyContext';
 import { getAccountDisplayName } from '@oxyhq/core';
 import { useI18n } from '../hooks/useI18n';
 
 /**
- * ActingAsBanner - Shows a subtle banner when the caller is acting as another
- * account from the account graph (delegated identity via `X-Acting-As`).
+ * ActiveAccountBanner — a subtle context cue shown when the active account is an
+ * account the user switched INTO (an org / project / bot / shared account)
+ * rather than their own personal account.
  *
- * - Tap to open the unified {@link AccountSwitcher}.
- * - Long-press to switch back to the personal account immediately.
+ * Framing: this reads as the CURRENT account, NOT as delegation. There is no
+ * "acting as" / "on behalf of" copy and no "switch back" affordance — switching
+ * into an account makes the whole app become that account, and the banner simply
+ * confirms which account is active. To change accounts (including returning to
+ * the personal account) the user opens the unified account switcher and picks
+ * one; tapping the banner opens it.
  *
- * Place this component in your app's layout where you want the banner to appear
- * (typically at the top of the screen or below the header). The "identity"
- * here is the Account, NOT the cryptographic Commons/DID identity.
+ * Renders nothing on the personal account. Place it in your app's layout where a
+ * persistent "you're in <Account>" cue is useful (typically below the header).
+ * The "account" here is the relational Account, NOT the cryptographic
+ * Commons/DID identity.
  */
-const ActingAsBanner: React.FC = () => {
+const ActiveAccountBanner: React.FC = () => {
   const bloomTheme = useTheme();
-  const { actingAs, actingAsAccount, setActingAs, showBottomSheet, oxyServices } = useOxy();
+  const { actingAsAccount, showBottomSheet, oxyServices } = useOxy();
   const { t, locale } = useI18n();
 
   const account = actingAsAccount?.account ?? null;
 
-  if (!actingAs || !account) {
+  // Only a switched-into account warrants the cue; the personal account is the
+  // default and needs no banner.
+  if (!account) {
     return null;
   }
 
@@ -40,23 +49,15 @@ const ActingAsBanner: React.FC = () => {
     showBottomSheet?.('AccountSwitcher');
   };
 
-  const handleLongPress = () => {
-    setActingAs(null);
-  };
-
-  const label = t('accounts.actingAs.label', { name: displayName }) || `Acting as ${displayName}`;
-  const switchBack = t('accounts.actingAs.switchBack') || 'Switch back';
-
   return (
     <TouchableOpacity
       style={[styles.container, { backgroundColor: `${bloomTheme.colors.primary}14` }]}
       onPress={handlePress}
-      onLongPress={handleLongPress}
       activeOpacity={0.7}
       accessibilityRole="button"
       accessibilityLabel={
-        t('accounts.actingAs.a11y', { name: displayName })
-        || `Acting as ${displayName}. Tap to switch accounts, long press to switch back.`
+        t('accounts.activeAccount.a11y', { name: displayName })
+        || `Active account: ${displayName}. Tap to switch accounts.`
       }
     >
       <View style={styles.content}>
@@ -73,15 +74,14 @@ const ActingAsBanner: React.FC = () => {
           </View>
         )}
         <View style={styles.textContainer}>
-          <Text style={[styles.label, { color: bloomTheme.colors.primary }]} numberOfLines={1}>
-            {label}
+          <Text style={[styles.name, { color: bloomTheme.colors.primary }]} numberOfLines={1}>
+            {displayName}
+          </Text>
+          <Text style={[styles.caption, { color: bloomTheme.colors.primary }]} numberOfLines={1}>
+            {t('accounts.activeAccount.label') || 'Active account'}
           </Text>
         </View>
-        <View style={[styles.switchBackHint, { borderColor: `${bloomTheme.colors.primary}40` }]}>
-          <Text style={[styles.switchBackText, { color: bloomTheme.colors.primary }]}>
-            {switchBack}
-          </Text>
-        </View>
+        <Ionicons name="chevron-down" size={18} color={bloomTheme.colors.primary} />
       </View>
     </TouchableOpacity>
   );
@@ -116,20 +116,15 @@ const styles = StyleSheet.create({
     flex: 1,
     marginLeft: 10,
   },
-  label: {
+  name: {
     fontSize: 14,
-    fontWeight: Platform.OS === 'web' ? '500' : undefined,
+    fontWeight: Platform.OS === 'web' ? '600' : undefined,
   },
-  switchBackHint: {
-    borderWidth: 1,
-    borderRadius: 12,
-    paddingHorizontal: 10,
-    paddingVertical: 4,
-  },
-  switchBackText: {
-    fontSize: 12,
-    fontWeight: Platform.OS === 'web' ? '500' : undefined,
+  caption: {
+    fontSize: 11,
+    opacity: 0.8,
+    marginTop: 1,
   },
 });
 
-export default React.memo(ActingAsBanner);
+export default React.memo(ActiveAccountBanner);

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -159,16 +159,43 @@ export interface OxyContextState {
 
   // Unified account graph (self, owned orgs/projects/bots, accounts shared with
   // the caller). The cryptographic Commons/DID "identity" is a SEPARATE concept.
-  /** The account id currently being acted-as (`X-Acting-As`), or `null` for the sign-in's own personal account. */
+  //
+  // UX concept: the user picks an account and the WHOLE app becomes that account
+  // — a genuine switch, NOT an "acting on behalf of" delegation. `actingAs` +
+  // `X-Acting-As` remain the underlying transport (the only one that works for
+  // passwordless org/project/bot accounts), but the framing everywhere is simply
+  // "this is the active account". Read {@link activeAccount} for "who am I"
+  // surfaces; `actingAs` is the low-level mechanism state.
+  /**
+   * The id of the account switched INTO (`X-Acting-As`), or `null` when the
+   * active account is the sign-in's own personal account. This is the underlying
+   * mechanism state — UI should present the result through {@link activeAccount}
+   * rather than framing it as delegation.
+   */
   actingAs: string | null;
   /** Every account the caller can access — own personal root, owned, and shared — from `listAccounts()`. */
   accounts: AccountNode[];
   /**
-   * The {@link AccountNode} currently being acted-as, resolved from `accounts`
-   * by `actingAs`. `null` when acting as the sign-in's own personal account, or
-   * when the acting-as id is not (yet) present in the loaded `accounts` list.
+   * The {@link AccountNode} switched into, resolved from `accounts` by
+   * `actingAs`. `null` when the active account is the sign-in's own personal
+   * account, or while the switched-into id has not yet appeared in the loaded
+   * `accounts` list.
    */
   actingAsAccount: AccountNode | null;
+  /**
+   * The effective ACTIVE account presented across the whole app — the account
+   * the user switched into when one is set and resolved, otherwise the signed-in
+   * user's own personal account. This is the single "who am I" source every
+   * identity surface (header avatar/name, profile chrome, context cues) should
+   * read, so a switch is reflected everywhere as a real account change.
+   *
+   * It is a {@link User} (the personal user, or the switched-into account's
+   * embedded user) so every identity surface renders it identically. Falls back
+   * to the personal `user` during the brief window after a switch before
+   * `accounts` has loaded the switched-into node, so the header never flashes
+   * empty. `null` only when signed out.
+   */
+  activeAccount: User | null;
   setActingAs: (accountId: string | null) => void;
   refreshAccounts: () => Promise<void>;
   createAccount: (data: CreateAccountInput) => Promise<AccountNode>;
@@ -1994,6 +2021,15 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   const [actingAs, setActingAsState] = useState<string | null>(null);
   const [accounts, setAccounts] = useState<AccountNode[]>([]);
 
+  // Latest `actingAs`, mirrored into a ref so `refreshAccounts` can reconcile a
+  // stale switch without taking `actingAs` as a dependency (which would re-run
+  // the account load on every switch). See the reconciliation block below.
+  const actingAsRef = useRef(actingAs);
+  actingAsRef.current = actingAs;
+  // `setActingAs` is declared after `refreshAccounts`; route the reconciliation
+  // clear through a ref so the load callback can call the latest implementation.
+  const setActingAsRef = useRef<((accountId: string | null) => void) | null>(null);
+
   // Restore actingAs from storage on startup
   useEffect(() => {
     if (!storage || !initialized) return;
@@ -2024,6 +2060,15 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     try {
       const list = await oxyServices.listAccounts();
       setAccounts(list);
+      // Reconcile a stale switch: if the active account was switched INTO an id
+      // that is no longer accessible (account removed/archived, or it belonged
+      // to a now-inactive sign-in), drop back to the personal account so the
+      // app never keeps sending a dead `X-Acting-As` header. `list` is the
+      // authoritative accessible set on a successful fetch.
+      const current = actingAsRef.current;
+      if (current && !list.some((node) => node.accountId === current)) {
+        setActingAsRef.current?.(null);
+      }
     } catch (err) {
       if (isUnauthorizedStatus(err)) {
         setAccounts([]);
@@ -2058,12 +2103,24 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       }
     }
   }, [oxyServices, storage, storageKeyPrefix]);
+  setActingAsRef.current = setActingAs;
 
-  // The account currently being acted-as, resolved from the loaded graph.
+  // The account switched into, resolved from the loaded graph.
   const actingAsAccount = useMemo<AccountNode | null>(() => {
     if (!actingAs) return null;
     return accounts.find((node) => node.accountId === actingAs) ?? null;
   }, [actingAs, accounts]);
+
+  // The effective ACTIVE account presented across the app: the switched-into
+  // account's user when a switch is set and resolved, otherwise the signed-in
+  // user's own personal account. Derived (no effect) so identity surfaces always
+  // render the current account without separate syncing. Falls back to `user`
+  // while a just-set switch has not yet resolved in `accounts`, so the header
+  // never flashes empty mid-switch.
+  const activeAccount = useMemo<User | null>(
+    () => (actingAs && actingAsAccount ? actingAsAccount.account : user),
+    [actingAs, actingAsAccount, user],
+  );
 
   const createAccountFn = useCallback(async (data: CreateAccountInput): Promise<AccountNode> => {
     const account = await oxyServices.createAccount(data);
@@ -2116,6 +2173,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     actingAs,
     accounts,
     actingAsAccount,
+    activeAccount,
     setActingAs,
     refreshAccounts,
     createAccount: createAccountFn,
@@ -2162,6 +2220,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     actingAs,
     accounts,
     actingAsAccount,
+    activeAccount,
     setActingAs,
     refreshAccounts,
     createAccountFn,
@@ -2234,6 +2293,7 @@ const LOADING_STATE: OxyContextState = {
   actingAs: null,
   accounts: [],
   actingAsAccount: null,
+  activeAccount: null,
   setActingAs: () => {},
   refreshAccounts: () => rejectMissingProvider<void>(),
   createAccount: () => rejectMissingProvider<AccountNode>(),

--- a/packages/services/src/ui/screens/AccountSettingsScreen.tsx
+++ b/packages/services/src/ui/screens/AccountSettingsScreen.tsx
@@ -92,7 +92,7 @@ const AccountSettingsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack, nav
     mutationKey: ['accounts', 'archive', id],
     mutationFn: () => oxyServices.archiveAccount(id),
     onSuccess: () => {
-      // If we were acting as this account, drop back to the personal account.
+      // If this was the active account, drop back to the personal account.
       if (actingAs === id) {
         setActingAs(null);
       }

--- a/packages/services/src/ui/screens/AccountSwitcherScreen.tsx
+++ b/packages/services/src/ui/screens/AccountSwitcherScreen.tsx
@@ -8,7 +8,7 @@ import { useI18n } from '../hooks/useI18n';
 
 /**
  * Bottom-sheet route wrapper around {@link AccountSwitcherView}. Used when the
- * switcher is opened as a sheet (e.g. from {@link ActingAsBanner} or the
+ * switcher is opened as a sheet (e.g. from the `ActiveAccountBanner` cue or the
  * "Your accounts" entry in ManageAccount) rather than as the header-chip
  * popover (which uses the `AccountSwitcher` modal directly).
  */


### PR DESCRIPTION
Reworks account switching to a true Google-style switch (no acting-as framing). Publishes @oxyhq/core@4.0.0 / @oxyhq/auth@6.1.0 / @oxyhq/services@13.0.0. Builds on the already-merged unified Account graph.

## Summary
- Switching into a sub-account/org/project/bot is now a real account switch (the whole app becomes that account, like Google's switcher), replacing the acting-as/on-behalf-of delegation framing
- `ActingAsBanner` renamed to `ActiveAccountBanner` (no acting-as copy); `AccountSwitcher` active-state fixed; `refreshAccounts` reconciles dead `X-Acting-As`
- Accounts app tab reworked to switch-into rows with a single current-account check; act-as copy → switch copy (en+es)
- `X-Acting-As` mechanism unchanged at the HTTP layer
- Publishes `@oxyhq/core@4.0.0`, `@oxyhq/auth@6.1.0`, `@oxyhq/services@13.0.0`

## Test plan
- [ ] Sign in to multiple accounts; verify account switcher shows all accounts with correct active indicator
- [ ] Switch accounts; verify whole app adopts switched account identity (header, avatar, identity surfaces)
- [ ] Verify `X-Acting-As` header still propagates correctly at HTTP layer
- [ ] Verify en/es i18n copy is switch-framed (no "acting as" copy remaining)
- [ ] Verify `ActiveAccountBanner` renders correctly (no acting-as copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)