### PR TITLE
fix(accounts): account switch refetches + follows active account

### DIFF
--- a/packages/accounts/app/(tabs)/index.tsx
+++ b/packages/accounts/app/(tabs)/index.tsx
@@ -32,7 +32,11 @@ export default function HomeScreen() {
   const { t } = useTranslation();
 
   // OxyServices integration — auth is enforced by the `(tabs)` layout.
-  const { user, isLoading: oxyLoading, refreshSessions, sessions, accounts, actingAs } = useOxy();
+  // `activeAccount` is the account the user is currently switched INTO (a true
+  // Google-style switch; equals the session `user` when not switched). Identity
+  // display (name / avatar / profile fields) follows `activeAccount`; the login
+  // security surfaces below stay on the session `user`.
+  const { user, activeAccount, isLoading: oxyLoading, refreshSessions, sessions, accounts, actingAs } = useOxy();
   // Hydrate the user record from the server (createdAt + any fields that were
   // missing from a cached signIn response). useCurrentUser handles staleness
   // via TanStack Query and re-fetches on mount / staleTime expiry, then
@@ -54,10 +58,10 @@ export default function HomeScreen() {
     isLoading: biometricLoading,
   } = useBiometricSettings();
 
-  // Compute user data
-  const displayName = useMemo(() => getDisplayName(user), [user]);
-  const accountCreatedDate = useMemo(() => formatDate(user?.createdAt), [user?.createdAt]);
-  const avatarUrl = useAvatarUrl(user);
+  // Compute active-account identity data (the account switched into).
+  const displayName = useMemo(() => getDisplayName(activeAccount), [activeAccount]);
+  const accountCreatedDate = useMemo(() => formatDate(activeAccount?.createdAt), [activeAccount?.createdAt]);
+  const avatarUrl = useAvatarUrl(activeAccount);
 
   const handlePressIn = useHapticPress();
 
@@ -93,7 +97,7 @@ export default function HomeScreen() {
 
   // Section item builders — each owns its own memoization.
   const recommendations = useHomeRecommendations({
-    username: user?.username,
+    username: activeAccount?.username,
     handleSetUsername: handlers.handleSetUsername,
   });
   const quickActions = useQuickActions(handlers);
@@ -109,7 +113,7 @@ export default function HomeScreen() {
   const quickStatsCards = useQuickStatsCards({
     deviceCount: devices.length,
     sessions,
-    username: user?.username,
+    username: activeAccount?.username,
     handleDevices: handlers.handleDevices,
     handleSecurity: handlers.handleSecurity,
     handlePersonalInfo: handlers.handlePersonalInfo,

--- a/packages/accounts/app/(tabs)/personal-info.tsx
+++ b/packages/accounts/app/(tabs)/personal-info.tsx
@@ -18,7 +18,10 @@ export default function PersonalInfoScreen() {
   const { t } = useTranslation();
 
   // OxyServices integration — auth is enforced by the `(tabs)` layout.
-  const { user, isLoading: oxyLoading, showBottomSheet } = useOxy();
+  // This screen views/edits the ACTIVE account's profile (the account the user
+  // switched into), so all identity fields read from `activeAccount`. Edits flow
+  // through the bottom sheet, which already targets the active account.
+  const { activeAccount, isLoading: oxyLoading, showBottomSheet } = useOxy();
   const handlePressIn = useHapticPress();
   const handleEditField = useCallback((field: string) => {
     showBottomSheet?.({
@@ -27,12 +30,12 @@ export default function PersonalInfoScreen() {
     });
   }, [showBottomSheet]);
 
-  // Compute user data
-  const displayName = useMemo(() => getDisplayName(user), [user]);
-  const userEmail = useMemo(() => user?.email ?? t('personalInfo.fields.noEmail'), [user?.email, t]);
-  const extendedUser = user as ExtendedUser | undefined;
+  // Compute active-account profile data.
+  const displayName = useMemo(() => getDisplayName(activeAccount), [activeAccount]);
+  const userEmail = useMemo(() => activeAccount?.email ?? t('personalInfo.fields.noEmail'), [activeAccount?.email, t]);
+  const extendedUser = activeAccount as ExtendedUser | undefined;
   const userPhone = useMemo(() => extendedUser?.phone ?? null, [extendedUser]);
-  const userAddress = useMemo(() => user?.location ?? extendedUser?.address ?? null, [user, extendedUser]);
+  const userAddress = useMemo(() => activeAccount?.location ?? extendedUser?.address ?? null, [activeAccount, extendedUser]);
   const userBirthday = useMemo(() => {
     const birthday = extendedUser?.birthday ?? extendedUser?.dateOfBirth;
     return birthday ? formatDate(birthday) : null;
@@ -84,9 +87,9 @@ export default function PersonalInfoScreen() {
       icon: 'calendar-outline',
       iconColor: colors.sidebarIconData,
       title: t('personalInfo.fields.accountCreated'),
-      value: user?.createdAt ? formatDate(user.createdAt) : t('common.unknown'),
+      value: activeAccount?.createdAt ? formatDate(activeAccount.createdAt) : t('common.unknown'),
     },
-  ], [colors.sidebarIconPersonalInfo, colors.sidebarIconSecurity, colors.sidebarIconData, colors.sidebarIconFamily, displayName, userEmail, userPhone, userAddress, userBirthday, user?.createdAt, handleEditField, t]);
+  ], [colors.sidebarIconPersonalInfo, colors.sidebarIconSecurity, colors.sidebarIconData, colors.sidebarIconFamily, displayName, userEmail, userPhone, userAddress, userBirthday, activeAccount?.createdAt, handleEditField, t]);
 
   const contactItems = useMemo(() => [
     {

--- a/packages/accounts/components/header.tsx
+++ b/packages/accounts/components/header.tsx
@@ -38,18 +38,20 @@ export function Header({ }: HeaderProps) {
     const isDesktop = Platform.OS === 'web' && width >= 768;
     const { t } = useTranslation();
 
-    const { user, oxyServices, showBottomSheet, isAuthenticated, refreshSessions } = useOxy();
+    // The header avatar + name reflect the ACTIVE account (the account switched
+    // into), so a Google-style account switch is mirrored in the chrome.
+    const { activeAccount, oxyServices, showBottomSheet, isAuthenticated, refreshSessions } = useOxy();
 
     const lastPressRef = useRef<number>(0);
     const pressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    const displayName = useMemo(() => getDisplayName(user), [user]);
+    const displayName = useMemo(() => getDisplayName(activeAccount), [activeAccount]);
     const avatarUrl = useMemo(() => {
-        if (user?.avatar && oxyServices) {
-            return oxyServices.getFileDownloadUrl(user.avatar, 'thumb');
+        if (activeAccount?.avatar && oxyServices) {
+            return oxyServices.getFileDownloadUrl(activeAccount.avatar, 'thumb');
         }
         return undefined;
-    }, [user?.avatar, oxyServices]);
+    }, [activeAccount?.avatar, oxyServices]);
 
     const clearPressTimeout = useCallback(() => {
         if (pressTimeoutRef.current) {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.0.0",
+  "version": "13.0.1",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -2090,6 +2090,13 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   const setActingAs = useCallback((accountId: string | null) => {
     oxyServices.setActingAs(accountId);
     setActingAsState(accountId);
+    // Switching the acting-as identity changes every server response, but React
+    // Query keys are not namespaced by the acting-as target, so the cache would
+    // otherwise keep serving the previous account's data. Invalidate everything
+    // so each query refetches under the new identity (the next request carries
+    // the updated `X-Acting-As` header). `invalidateQueries` (not `clear`) keeps
+    // the account list/switcher populated mid-switch instead of blanking out.
+    queryClient.invalidateQueries();
     // Persist to storage
     if (storage) {
       if (accountId) {
@@ -2102,7 +2109,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
         });
       }
     }
-  }, [oxyServices, storage, storageKeyPrefix]);
+  }, [oxyServices, storage, storageKeyPrefix, queryClient]);
   setActingAsRef.current = setActingAs;
 
   // The account switched into, resolved from the loaded graph.


### PR DESCRIPTION
Within-app account-switch fixes: invalidate React Query on switch; identity surfaces read activeAccount. services@13.0.1.