### PR TITLE
fix(api): stop HTML-escaping profile free-text fields (bio, description, etc.)

### DIFF
--- a/packages/api/scripts/backfill-decode-profile-text.ts
+++ b/packages/api/scripts/backfill-decode-profile-text.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env bun
+/**
+ * One-time migration: decode/clean the free-text profile fields that were
+ * historically stored HTML-entity-ESCAPED.
+ *
+ * Why it exists:
+ *   `bio`, `description`, and `address` used to be run through `sanitizeHtml`
+ *   on every write site (federated resolve, PUT /users/resolve, and the local
+ *   profile-update path via `sanitizeProfileUpdate`). These fields render as
+ *   TEXT in RN/React clients, which auto-escape markup at render time — so the
+ *   entity-escaping double-escaped them and surfaced literal `&#x27;` / `&amp;`
+ *   to users (e.g. bagder's bio: "I don&#x27;t know anything.").
+ *
+ *   The write sites now use `sanitizePlainText` (decode + strip tags), but rows
+ *   written before that change still hold escaped values. This backfill applies
+ *   `sanitizePlainText` to the stored values so they decode in place.
+ *
+ * Behavior:
+ *   - Cursors over `users` where bio/description/address is a non-empty string.
+ *   - Recomputes `sanitizePlainText(value)` for each present field; if it
+ *     differs from the stored value, `$set`s the cleaned value.
+ *   - Writes via `bulkWrite({ ordered: false })` in batches — no validators or
+ *     other hooks fire.
+ *   - Idempotent — safe to re-run. `sanitizePlainText` is a no-op on already-
+ *     clean text, so a second run updates nothing.
+ *
+ * Run:
+ *   cd packages/api && bun run scripts/backfill-decode-profile-text.ts
+ *
+ * Optional env:
+ *   MONGODB_URI    Mongo connection string (required)
+ *   BATCH_SIZE     Number of users to scan/flush per batch (default 500)
+ *   DRY_RUN=true   Report what would change without writing
+ */
+
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import User from '../src/models/User';
+import { sanitizePlainText } from '../src/utils/sanitize';
+import { logger } from '../src/utils/logger';
+
+dotenv.config();
+
+// The stored free-text fields that were historically entity-escaped and render
+// as TEXT in clients. `username`/`phone`/`language` are excluded: they carry a
+// strict charset (never entities/tags) so cleaning is a guaranteed no-op, and
+// they are identity/sensitive fields we do not want to rewrite.
+const TEXT_FIELDS = ['bio', 'description', 'address'] as const;
+type TextField = (typeof TEXT_FIELDS)[number];
+
+interface BackfillStats {
+  scanned: number;
+  updatedBio: number;
+  updatedDescription: number;
+  updatedAddress: number;
+  documentsUpdated: number;
+  errors: number;
+}
+
+const STAT_KEY: Record<TextField, keyof BackfillStats> = {
+  bio: 'updatedBio',
+  description: 'updatedDescription',
+  address: 'updatedAddress',
+};
+
+async function backfillProfileText(): Promise<BackfillStats> {
+  const stats: BackfillStats = {
+    scanned: 0,
+    updatedBio: 0,
+    updatedDescription: 0,
+    updatedAddress: 0,
+    documentsUpdated: 0,
+    errors: 0,
+  };
+
+  const batchSize = Number(process.env.BATCH_SIZE) || 500;
+  const dryRun = process.env.DRY_RUN === 'true';
+
+  if (dryRun) {
+    logger.info('DRY RUN — no writes will be performed');
+  }
+
+  const cursor = User.find(
+    {
+      $or: [
+        { bio: { $type: 'string', $ne: '' } },
+        { description: { $type: 'string', $ne: '' } },
+        { address: { $type: 'string', $ne: '' } },
+      ],
+    },
+    { _id: 1, bio: 1, description: 1, address: 1 },
+  )
+    .lean()
+    .cursor({ batchSize });
+
+  const pending: Array<{
+    updateOne: {
+      filter: { _id: mongoose.Types.ObjectId };
+      update: { $set: Record<string, string> };
+    };
+  }> = [];
+
+  const flush = async (): Promise<void> => {
+    if (pending.length === 0) return;
+    if (dryRun) {
+      pending.length = 0;
+      return;
+    }
+    try {
+      await User.bulkWrite(pending, { ordered: false });
+    } catch (error) {
+      stats.errors += pending.length;
+      logger.error(
+        'bulkWrite failed during profile-text backfill',
+        error instanceof Error ? error : new Error(String(error)),
+        { component: 'backfill', method: 'flush' },
+      );
+    } finally {
+      pending.length = 0;
+    }
+  };
+
+  for await (const doc of cursor) {
+    stats.scanned += 1;
+
+    const $set: Record<string, string> = {};
+
+    for (const field of TEXT_FIELDS) {
+      const raw = (doc as Record<string, unknown>)[field];
+      if (typeof raw !== 'string' || raw === '') continue;
+      const cleaned = sanitizePlainText(raw);
+      if (cleaned !== raw) {
+        $set[field] = cleaned;
+        stats[STAT_KEY[field]] += 1;
+      }
+    }
+
+    if (Object.keys($set).length === 0) continue;
+
+    stats.documentsUpdated += 1;
+    pending.push({
+      updateOne: {
+        filter: { _id: doc._id as mongoose.Types.ObjectId },
+        update: { $set },
+      },
+    });
+
+    if (pending.length >= batchSize) {
+      await flush();
+    }
+  }
+
+  await flush();
+
+  return stats;
+}
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    logger.error('MONGODB_URI is required');
+    process.exit(1);
+  }
+
+  await mongoose.connect(uri);
+  logger.info('Connected to MongoDB');
+
+  try {
+    const startedAt = Date.now();
+    const stats = await backfillProfileText();
+    const elapsedMs = Date.now() - startedAt;
+    const summary = { ...stats, elapsedMs, dryRun: process.env.DRY_RUN === 'true' };
+    logger.info('Profile-text backfill finished', summary);
+    // Final machine-readable summary for one-shot ECS log scraping.
+    process.stdout.write(`${JSON.stringify(summary)}\n`);
+  } finally {
+    await mongoose.connection.close();
+    logger.info('MongoDB connection closed');
+  }
+}
+
+main().catch((error) => {
+  logger.error(
+    'Backfill failed',
+    error instanceof Error ? error : new Error(String(error)),
+    { component: 'backfill', method: 'main' },
+  );
+  process.exit(1);
+});

--- a/packages/api/src/routes/__tests__/usersResolve.test.ts
+++ b/packages/api/src/routes/__tests__/usersResolve.test.ts
@@ -281,7 +281,7 @@ describe('PUT /users/resolve (C4)', () => {
     );
   });
 
-  it('strips the federated display name and escapes bio before persistence', async () => {
+  it('strips the federated display name and strips tags from bio before persistence', async () => {
     const leanResult = jest.fn().mockResolvedValue(null);
     const selectResult = jest.fn().mockReturnValue({ lean: leanResult });
     mockUserFindOne.mockReturnValueOnce({ select: selectResult });
@@ -307,8 +307,9 @@ describe('PUT /users/resolve (C4)', () => {
         $set: expect.objectContaining({
           // Display name: disallowed characters stripped (never escaped).
           'name.first': 'img src x onerror alert fediverse xss',
-          // Bio is not a display name and keeps HTML-entity escaping.
-          bio: '&lt;script&gt;alert(&quot;bio&quot;)&lt;/script&gt;',
+          // Bio renders as text in clients: tags are stripped (no executable
+          // markup survives) and the value is NOT HTML-entity-escaped.
+          bio: 'alert("bio")',
         }),
       }),
       expect.anything(),
@@ -522,7 +523,7 @@ describe('PUT /users/resolve (C4)', () => {
     expect(mockUserFindOneAndUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it('strips the federated displayName and escapes bio before persisting (stored-XSS regression)', async () => {
+  it('strips the federated displayName and strips tags from bio before persisting (stored-XSS regression)', async () => {
     // Type-immutability check: no existing user.
     const leanResult = jest.fn().mockResolvedValue(null);
     const selectResult = jest.fn().mockReturnValue({ lean: leanResult });
@@ -551,8 +552,10 @@ describe('PUT /users/resolve (C4)', () => {
     // output can never carry an HTML/XSS vector.
     expect(setFields['name.first']).toBe('img src x onerror alert');
     expect(String(setFields['name.first'])).not.toMatch(/[<>&"]/);
-    // Bio is NOT a display name and keeps HTML-entity escaping.
-    expect(setFields.bio).toBe('hi &lt;script&gt;steal()&lt;/script&gt; &amp; &quot;friends&quot;');
+    // Bio renders as text: HTML tags are stripped (no <script> survives) but the
+    // value is NOT entity-escaped — apostrophes/ampersands stay literal so
+    // clients don't render `&amp;`/`&#x27;`.
+    expect(setFields.bio).toBe('hi steal() & "friends"');
     expect(String(setFields.bio)).not.toContain('<script>');
   });
 

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -44,7 +44,7 @@ import {
   updatePrivacyBodySchema,
   usersByIdsBodySchema,
 } from '../schemas/users.schemas';
-import { sanitizeHtml } from '../utils/sanitize';
+import { sanitizePlainText } from '../utils/sanitize';
 import { cleanDisplayName } from '../utils/displayNameSanitize';
 import { rateLimit } from '../middleware/rateLimiter';
 import { buildExportBundle } from '../services/identityExport.service';
@@ -1443,18 +1443,21 @@ router.put(
     // immutability invariant above already rejected mismatched updates.
     const setOnInsert: Record<string, unknown> = { type };
 
-    // Escape HTML in free-text fields sourced from untrusted remote actors
-    // (federated/agent/automated) before persisting — these render as the
-    // profile display name and bio in client apps, so raw input is a stored-XSS
-    // vector.
+    // Clean free-text fields sourced from untrusted remote actors
+    // (federated/agent/automated) before persisting. The bio renders as TEXT in
+    // client apps, so we decode entities + strip tags (sanitizePlainText) rather
+    // than HTML-entity-escape it — escaping would store a literal `&#x27;`/`&amp;`
+    // that the client then double-renders. XSS protection comes from tag-
+    // stripping here plus the client's text-rendering auto-escape, not entity
+    // escaping. (See utils/sanitize.ts sanitizePlainText.)
     if (typeof displayName === 'string') {
       // Strip disallowed characters (emoji/symbols/shortcodes) from federated
-      // names. cleanDisplayName's output can never contain an XSS vector, so it
-      // replaces sanitizeHtml here (which would mangle the inert apostrophe).
+      // names. cleanDisplayName's output can never contain an XSS vector and is
+      // already clean, so it owns the name field here.
       setFields['name.first'] = cleanDisplayName(displayName);
     }
     if (typeof bio === 'string') {
-      setFields.bio = sanitizeHtml(bio);
+      setFields.bio = sanitizePlainText(bio);
     }
 
     // Avatar handling splits two ways:

--- a/packages/api/src/services/federation.service.ts
+++ b/packages/api/src/services/federation.service.ts
@@ -17,7 +17,7 @@ import { logger } from '../utils/logger';
 import userCache from '../utils/userCache';
 import { composeDisplayName } from '../utils/displayName';
 import { cleanDisplayName } from '../utils/displayNameSanitize';
-import { sanitizeHtml, decodeHtmlEntities } from '../utils/sanitize';
+import { sanitizePlainText, decodeHtmlEntities } from '../utils/sanitize';
 
 const AP_ACCEPT_TYPES = [
   'application/activity+json',
@@ -1109,7 +1109,7 @@ class FederationService {
     };
 
     if (profile.bio) {
-      const safeBio = sanitizeHtml(profile.bio);
+      const safeBio = sanitizePlainText(profile.bio);
       setFields.bio = safeBio;
       setFields.description = safeBio;
     }
@@ -1366,7 +1366,7 @@ class FederationService {
       }
       setFields['federation.lastResolvedAt'] = new Date();
       if (profile.bio) {
-        const safeBio = sanitizeHtml(profile.bio);
+        const safeBio = sanitizePlainText(profile.bio);
         setFields.bio = safeBio;
         setFields.description = safeBio;
       }

--- a/packages/api/src/utils/__tests__/sanitize.test.ts
+++ b/packages/api/src/utils/__tests__/sanitize.test.ts
@@ -1,5 +1,6 @@
 import {
   sanitizeHtml,
+  sanitizePlainText,
   sanitizeString,
   sanitizeObject,
   sanitizeProfileUpdate,
@@ -54,11 +55,66 @@ describe('sanitize utilities', () => {
     });
   });
 
+  describe('sanitizePlainText', () => {
+    it('decodes the hex apostrophe entity (the federated-bio double-escape bug)', () => {
+      expect(sanitizePlainText('I don&#x27;t')).toBe("I don't");
+    });
+
+    it('decodes the named ampersand entity', () => {
+      expect(sanitizePlainText('Arthur &amp; Thomas')).toBe('Arthur & Thomas');
+    });
+
+    it('strips tags so no <script> survives', () => {
+      const result = sanitizePlainText("<script>alert('x')</script>hi");
+      expect(result).not.toContain('<script>');
+      expect(result).not.toContain('</script>');
+      expect(result).toBe("alert('x')hi");
+    });
+
+    it('removes encoded markup by decoding first, then stripping', () => {
+      // &lt;script&gt; decodes to a real tag, which is then stripped — no
+      // executable markup can survive into storage.
+      const result = sanitizePlainText('&lt;script&gt;evil()&lt;/script&gt;ok');
+      expect(result).not.toContain('<script>');
+      expect(result).toBe('evil()ok');
+    });
+
+    it('passes plain text through unchanged', () => {
+      expect(sanitizePlainText('Just a normal bio')).toBe('Just a normal bio');
+    });
+
+    it('trims surrounding whitespace but preserves internal newlines', () => {
+      expect(sanitizePlainText('  line one\nline two  ')).toBe('line one\nline two');
+    });
+
+    it('is idempotent (running twice yields the same result)', () => {
+      const inputs = [
+        'I don&#x27;t',
+        'Arthur &amp; Thomas',
+        "<script>alert('x')</script>hi",
+        'Just a normal bio',
+      ];
+      for (const input of inputs) {
+        const once = sanitizePlainText(input);
+        expect(sanitizePlainText(once)).toBe(once);
+      }
+    });
+
+    it('returns empty/falsy input unchanged', () => {
+      expect(sanitizePlainText('')).toBe('');
+    });
+  });
+
   describe('sanitizeObject', () => {
-    it('sanitizes all string values', () => {
+    it('strips tags from all string values (text rendering)', () => {
       const result = sanitizeObject({ name: '<b>Joe</b>', age: 30 });
-      expect(result.name).toBe('&lt;b&gt;Joe&lt;/b&gt;');
+      expect(result.name).toBe('Joe');
       expect(result.age).toBe(30);
+    });
+
+    it('decodes entities instead of escaping them', () => {
+      const result = sanitizeObject({ note: "don&#x27;t & won&#x27;t" });
+      expect(result.note).toBe("don't & won't");
     });
 
     it('skips fields in skipFields list', () => {
@@ -67,18 +123,31 @@ describe('sanitize utilities', () => {
         ['password']
       );
       expect(result.password).toBe('<script>');
-      expect(result.bio).toBe('&lt;b&gt;hi&lt;/b&gt;');
+      expect(result.bio).toBe('hi');
     });
   });
 
   describe('sanitizeProfileUpdate', () => {
-    it('sanitizes text fields', () => {
+    it('strips tags from text fields without entity-escaping them', () => {
       const result = sanitizeProfileUpdate({
         bio: '<script>alert(1)</script>',
         username: 'test<user>',
       });
-      expect(result.bio).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
-      expect(result.username).toBe('test&lt;user&gt;');
+      expect(result.bio).toBe('alert(1)');
+      expect(result.username).toBe('test');
+    });
+
+    it('does NOT escape apostrophes/ampersands in text fields (renders as text)', () => {
+      // A profile edit with an apostrophe in a free-text field must store the
+      // literal character, NOT `&#x27;` — clients render these fields as text.
+      const result = sanitizeProfileUpdate({
+        description: "Live in O'Brien's town",
+        bio: 'Arthur & Thomas',
+        address: "12 O'Connell St",
+      });
+      expect(result.description).toBe("Live in O'Brien's town");
+      expect(result.bio).toBe('Arthur & Thomas');
+      expect(result.address).toBe("12 O'Connell St");
     });
 
     it('skips avatar, email, password, links, linksMetadata, locations', () => {

--- a/packages/api/src/utils/sanitize.ts
+++ b/packages/api/src/utils/sanitize.ts
@@ -1,9 +1,19 @@
 /**
  * Input Sanitization Utilities
  *
- * Provides HTML entity escaping for user-provided text to prevent XSS attacks.
- * Apply to fields that will be rendered as HTML in client applications.
- * Do NOT apply to passwords, hashes, or binary data.
+ * Two distinct strategies, chosen by how the value is consumed downstream:
+ *
+ *  - `sanitizePlainText` — for FREE-TEXT fields that clients render as TEXT
+ *    (bio, description, address, …). RN/React auto-escape text at render time,
+ *    so storing HTML-entity-escaped data is wrong: it surfaces literal
+ *    `&#x27;` / `&amp;` to users (e.g. `I don&#x27;t`). This helper decodes any
+ *    entities and strips tags instead. Use it for anything shown as text.
+ *
+ *  - `sanitizeHtml` — entity-escaping for values placed into an actual
+ *    HTML/markup context, or combined with `escapeRegex` for safe use inside a
+ *    MongoDB `$regex` (see `sanitizeSearchQuery`). Do NOT use it on text fields.
+ *
+ * Never apply either to passwords, hashes, or binary data.
  */
 
 /**
@@ -42,6 +52,38 @@ export function decodeHtmlEntities(text: string): string {
 }
 
 /**
+ * Sanitize a FREE-TEXT field that clients render as TEXT (bio, description,
+ * address, location, etc.).
+ *
+ * WHY this exists instead of `sanitizeHtml`: these fields are displayed as text
+ * in RN/React clients, which auto-escape markup at render time. That render-time
+ * escaping — combined with the tag-stripping below — is the XSS protection, NOT
+ * HTML-entity-escaping at storage. Storing entity-escaped data (`sanitizeHtml`)
+ * is actively harmful: the client double-escapes it and the user sees a literal
+ * `I don&#x27;t` / `Arthur &amp; Thomas`, and re-escaping already-escaped remote
+ * input (federated bios) compounds the corruption.
+ *
+ * Strategy:
+ *  1. Decode HTML entities first — undoes any prior escaping and remote-encoded
+ *     input, AND turns an encoded `&lt;script&gt;` into a real tag so step 2 can
+ *     remove it (no executable markup survives into storage).
+ *  2. Strip all HTML tags.
+ *  3. Lightly collapse only EXCESSIVE whitespace (runs of spaces/tabs, 3+ blank
+ *     lines) while preserving intentional single spacing and newlines, then trim.
+ *
+ * Idempotent: running it on its own output yields the same string.
+ */
+export function sanitizePlainText(input: string): string {
+  if (!input) return input;
+  const decoded = decodeHtmlEntities(input);
+  const stripped = decoded.replace(/<[^>]*>/g, '');
+  return stripped
+    .replace(/[^\S\r\n]{2,}/g, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
  * Sanitize a string if it's a string, otherwise return as-is.
  */
 export function sanitizeString(value: unknown): unknown {
@@ -52,7 +94,10 @@ export function sanitizeString(value: unknown): unknown {
 }
 
 /**
- * Sanitize all string values in an object (shallow — one level deep).
+ * Sanitize all string values in an object (shallow — one level deep) for TEXT
+ * rendering: each string is run through `sanitizePlainText` (decode + strip
+ * tags), preserving the literal characters clients display as text rather than
+ * HTML-entity-escaping them.
  *
  * Skips fields listed in `skipFields` (e.g. passwords, tokens).
  */
@@ -65,7 +110,7 @@ export function sanitizeObject<T extends Record<string, unknown>>(
     if (skipFields.includes(key)) continue;
     const value = result[key];
     if (typeof value === 'string') {
-      (result as any)[key] = sanitizeHtml(value);
+      (result as any)[key] = sanitizePlainText(value);
     }
   }
   return result;
@@ -74,13 +119,16 @@ export function sanitizeObject<T extends Record<string, unknown>>(
 /**
  * Sanitize user profile update fields.
  *
- * Applies HTML escaping to text fields that could be rendered in UI.
- * Skips: avatar (file ID), links (URLs), email, password.
+ * Every profile field handled here is rendered as TEXT by clients, so values
+ * are run through `sanitizePlainText` (decode + strip tags) — NOT HTML-entity-
+ * escaped. Escaping would surface literal `&#x27;` / `&amp;` in bios,
+ * descriptions, addresses, etc. (see `sanitizePlainText` for the rationale).
+ * Skips non-text fields: avatar (file ID), color, email, password, links
+ * (URLs), linksMetadata, locations.
  *
  * `name` is intentionally skipped: display names are validated against a strict
  * letters/spaces/apostrophe policy upstream (see `utils/displayNameSanitize.ts`)
- * and can never contain an XSS vector, so HTML-escaping them here would only
- * corrupt the inert apostrophe (`O'Brien` → `O&#x27;Brien`, rendered literally).
+ * and are already clean, so reprocessing them here is unnecessary.
  */
 export function sanitizeProfileUpdate(updates: Record<string, unknown>): Record<string, unknown> {
   const skipFields = ['name', 'avatar', 'color', 'email', 'password', 'links', 'linksMetadata', 'locations'];
@@ -90,9 +138,9 @@ export function sanitizeProfileUpdate(updates: Record<string, unknown>): Record<
     if (skipFields.includes(key)) continue;
     const value = result[key];
     if (typeof value === 'string') {
-      (result as any)[key] = sanitizeHtml(value);
+      (result as any)[key] = sanitizePlainText(value);
     } else if (value && typeof value === 'object' && !Array.isArray(value)) {
-      // Handle nested objects like `name: { first, last }`
+      // Handle nested objects like `notificationPreferences` / `userPreferences`
       (result as any)[key] = sanitizeObject(value as Record<string, unknown>);
     }
   }


### PR DESCRIPTION
## Summary

- Free-text profile fields (bio, description, address, etc.) and federated bios were stored HTML-entity-escaped via `sanitizeHtml`, causing clients that render them as plain text to show literal entities (e.g. a federated bio `I don&#x27;t know`).
- New `sanitizePlainText` (decode entities + strip tags, no entity-escaping) replaces `sanitizeHtml` in `sanitizeProfileUpdate`/`sanitizeObject` and the federation + `/users/resolve` bio writes.
- XSS protection for text fields = tag-stripping + client render-time escaping, not storage escaping. `sanitizeHtml` stays for `$regex`/search sinks where raw HTML is expected.
- `scripts/backfill-decode-profile-text.ts` decodes existing stored values — run with `DRY_RUN=true` first, then without.

## Test plan

- [ ] `bunx tsc --noEmit` in `packages/api` — passes clean
- [ ] `bun run test` in `packages/api` — 125 suites / 1199 tests all green
- [ ] After deploy: run `DRY_RUN=true bun run scripts/backfill-decode-profile-text.ts` on ECS one-shot task to audit scope, then run without `DRY_RUN` to decode existing stored entities in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)