### PR TITLE
fix(accounts): Account Manager follows active account + services i18n

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/i18n/locales/en-US.json
+++ b/packages/core/src/i18n/locales/en-US.json
@@ -154,6 +154,10 @@
       "skip": "Skip",
       "enter": "Enter",
       "continue": "Continue"
+    },
+    "trust": {
+      "title": "Oxy Trust = Trust & Growth",
+      "body": "Oxy Trust is a reputation system that reacts to what you do. Helpful, respectful, constructive actions earn reputation. Harmful or low‑effort stuff chips it away. More reputation raises your trust tier and can unlock benefits; low reputation can limit features. It keeps things fair and rewards real contribution."
     }
   },
   "language": {
@@ -162,7 +166,8 @@
     "current": "Current Language",
     "available": "Available Languages",
     "changed": "Language changed to {{lang}}",
-    "saveFailed": "Failed to save language preference"
+    "saveFailed": "Failed to save language preference",
+    "search": "Search languages"
   },
   "profile": {
     "edit": "Edit Profile",
@@ -172,7 +177,9 @@
     "reputation": "Reputation",
     "followers": "Followers",
     "following": "Following",
-    "more": "+ {{count}} more"
+    "more": "+ {{count}} more",
+    "errorTitle": "Profile Error",
+    "errorSubtext": "This could happen if the user doesn't exist or the profile service is unavailable."
   },
   "feedback": {
     "type": {
@@ -215,7 +222,8 @@
       "priority": "Priority:",
       "category": "Category:",
       "titleLabel": "Title:",
-      "contact": "Contact:"
+      "contact": "Contact:",
+      "titleField": "Title:"
     },
     "actions": {
       "submit": "Submit Feedback",
@@ -230,7 +238,9 @@
       "thanks": "Thank you for your feedback!",
       "submitFailed": "Failed to submit feedback",
       "submitSuccess": "Feedback submitted successfully!"
-    }
+    },
+    "title": "Feedback",
+    "subtitle": "Tell us what you think"
   },
   "recover": {
     "title": "Recover Account",
@@ -264,7 +274,8 @@
       "accountManagement": "Account Management",
       "multiAccount": "Multi-Account",
       "addAccount": "Add Account",
-      "moreOptions": "More Options"
+      "moreOptions": "More Options",
+      "accounts": "Accounts"
     },
     "quickActions": {
       "overview": "Overview",
@@ -326,7 +337,10 @@
     "sections": {
       "current": "Current Account",
       "otherWithCount": "Other Accounts ({{count}})",
-      "deviceSessions": "Device Sessions"
+      "deviceSessions": "Device Sessions",
+      "sharedWithYou": "Shared with you",
+      "thisDevice": "On this device",
+      "yourAccounts": "Your accounts"
     },
     "currentBadge": "Current",
     "loading": "Loading accounts...",
@@ -361,7 +375,9 @@
     "empty": {
       "title": "No saved accounts",
       "subtitle": "Add another account to switch between them quickly"
-    }
+    },
+    "label": "Account switcher",
+    "searchPlaceholder": "Search accounts"
   },
   "reputation": {
     "faq": {
@@ -522,7 +538,9 @@
     },
     "confirms": {
       "cancelSub": "Are you sure you want to cancel your subscription? You will lose access to premium features at the end of your current billing period.",
-      "unsubscribeFeature": "Are you sure you want to unsubscribe from {{name}}?"
+      "unsubscribeFeature": "Are you sure you want to unsubscribe from {{name}}?",
+      "cancelSubTitle": "Cancel Subscription",
+      "unsubscribeFeatureTitle": "Unsubscribe from Feature"
     },
     "current": {
       "title": "Current Subscription",
@@ -540,11 +558,13 @@
     "billing": {
       "monthly": "Monthly",
       "yearly": "Yearly",
-      "saveYearly": "💰 Save 20% with yearly billing"
+      "saveYearly": "💰 Save 20% with yearly billing",
+      "label": "Billing period"
     },
     "tabs": {
       "plans": "Full Plans",
-      "features": "Individual Features"
+      "features": "Individual Features",
+      "label": "Subscription type"
     },
     "plan": {
       "scope": {
@@ -554,7 +574,8 @@
       },
       "badge": {
         "appExclusive": "App Exclusive",
-        "notAvailable": "Not Available"
+        "notAvailable": "Not Available",
+        "mostPopular": "Most Popular"
       },
       "perInterval": "per {{interval}}",
       "current": "Current Plan",
@@ -566,7 +587,16 @@
         "availableIn": "Available in: {{apps}}"
       },
       "includedInPlan": "Included in your plan",
-      "subscribed": "Subscribed"
+      "subscribed": "Subscribed",
+      "included": "Included",
+      "plansOnly": "Only available in subscription plans"
+    },
+    "features": {
+      "title": "Individual Features",
+      "subtitle": "Subscribe to specific features you need. Some features are included in subscription plans."
+    },
+    "dev": {
+      "appContext": "Test App Context (Dev Only)"
     }
   },
   "editProfile": {
@@ -692,7 +722,8 @@
       "cropMeasureFailed": "Could not measure the image",
       "cropNotReady": "Image not ready yet",
       "cropFailed": "Failed to crop image"
-    }
+    },
+    "changeAvatar": "Change avatar"
   },
   "accountOverview": {
     "title": "Account",
@@ -884,6 +915,9 @@
       "description": "Use your activity to improve search results",
       "updated": "Search personalization updated",
       "error": "Failed to update personalization"
+    },
+    "searchPersonalization": {
+      "error": "Failed to update personalization"
     }
   },
   "privacySettings": {
@@ -945,7 +979,8 @@
     "title": "Account Verification",
     "description": "Request a verified badge for your account. Verified accounts help establish authenticity and credibility.",
     "sections": {
-      "request": "VERIFICATION REQUEST"
+      "request": "VERIFICATION REQUEST",
+      "benefits": "What verification gives you"
     },
     "reasonLabel": "Reason for Verification *",
     "reasonPlaceholder": "Explain why you need a verified badge (e.g., public figure, brand, organization)",
@@ -958,7 +993,13 @@
     "successMessage": "Your verification request has been submitted. Request ID: {{requestId}}",
     "ok": "OK",
     "error": "Service not available",
-    "note": "Note: Verification requests are reviewed manually and may take several days. We will notify you once your request has been reviewed."
+    "note": "Note: Verification requests are reviewed manually and may take several days. We will notify you once your request has been reviewed.",
+    "heroTitle": "Get a verified badge",
+    "benefits": {
+      "authenticity": "Confirms your identity is authentic and trusted",
+      "badge": "Displays a verified badge across the platform",
+      "credibility": "Builds credibility with people who follow you"
+    }
   },
   "help": {
     "title": "Help & Support",
@@ -1069,7 +1110,8 @@
       "verify": "Verify",
       "resetPassword": "Reset Password",
       "signedOut": "Signed out",
-      "close": "Close"
+      "close": "Close",
+      "delete": "Delete"
     },
     "cancel": "Cancel",
     "revoke": "Revoke",
@@ -1088,7 +1130,9 @@
       "email": "Email",
       "password": "Password",
       "confirmPassword": "Confirm Password"
-    }
+    },
+    "back": "Back",
+    "remove": "Remove"
   },
   "sessionManagement": {
     "title": "Active Sessions",
@@ -1518,5 +1562,335 @@
     "openWithUser": "Account menu for {{name}}",
     "switching": "Switching account…",
     "signOutAccount": "Sign out {{name}}"
+  },
+  "accounts": {
+    "activeAccount": {
+      "a11y": "Active account: {{name}}. Tap to switch accounts.",
+      "label": "Active account"
+    },
+    "roles": {
+      "owner": {
+        "label": "Owner"
+      },
+      "admin": {
+        "label": "Admin"
+      },
+      "editor": {
+        "label": "Editor"
+      },
+      "developer": {
+        "label": "Developer"
+      },
+      "billing": {
+        "label": "Billing"
+      },
+      "viewer": {
+        "label": "Viewer"
+      }
+    },
+    "kinds": {
+      "organization": {
+        "label": "Organization",
+        "description": "A shared team account with members"
+      },
+      "project": {
+        "label": "Project",
+        "description": "A separate account you control"
+      },
+      "bot": {
+        "label": "Bot",
+        "description": "A programmatic account with service credentials"
+      }
+    },
+    "create": {
+      "title": "Create account",
+      "subtitle": "Create an account you control. It will have its own profile, members, and apps.",
+      "displayName": {
+        "label": "Display name"
+      },
+      "bio": {
+        "label": "Bio (optional)"
+      },
+      "username": {
+        "label": "Username",
+        "available": "Username is available",
+        "taken": "Username is taken",
+        "tooShort": "Username must be at least 3 characters",
+        "invalidChars": "Only letters, numbers, hyphens, and underscores",
+        "checkFailed": "Could not check availability"
+      },
+      "toasts": {
+        "success": "Account created",
+        "failed": "Failed to create account"
+      }
+    },
+    "manage": {
+      "create": {
+        "subtitle": "Add an organization, project, or bot"
+      },
+      "switch": {
+        "title": "Switch account",
+        "count": "{{count}} accounts",
+        "empty": "Accounts you own or share"
+      }
+    },
+    "members": {
+      "title": "Members",
+      "subtitle": "People with access to this account.",
+      "empty": "No members yet.",
+      "actions": {
+        "remove": "Remove member",
+        "transfer": "Transfer ownership"
+      },
+      "errors": {
+        "identifierRequired": "Enter a username or email to invite",
+        "missingAccount": "No account selected.",
+        "noPermission": "You do not have permission to view members.",
+        "userNotFound": "User not found"
+      },
+      "invite": {
+        "title": "Add a member",
+        "identifierLabel": "Username or email",
+        "roleLabel": "Role",
+        "submit": "Add member"
+      },
+      "removeConfirm": {
+        "title": "Remove member",
+        "description": "Remove this member from the account? They will lose all access."
+      },
+      "transferConfirm": {
+        "title": "Transfer ownership",
+        "description": "Transfer ownership of this account to this member? You will be demoted to admin. This cannot be undone."
+      },
+      "toasts": {
+        "added": "Member added",
+        "addFailed": "Failed to add member",
+        "removed": "Member removed",
+        "removeFailed": "Failed to remove member",
+        "roleUpdated": "Role updated",
+        "roleFailed": "Failed to update role",
+        "transferred": "Ownership transferred",
+        "transferFailed": "Failed to transfer ownership"
+      }
+    },
+    "settings": {
+      "title": "Account settings",
+      "subtitle": "Manage this account’s profile, members, and access.",
+      "save": "Save changes",
+      "displayName": {
+        "label": "Display name"
+      },
+      "bio": {
+        "label": "Bio (optional)"
+      },
+      "sections": {
+        "access": "Access",
+        "dangerZone": "Danger zone"
+      },
+      "members": {
+        "subtitle": "Invite people and manage roles"
+      },
+      "archive": {
+        "title": "Archive account",
+        "subtitle": "Deactivate this account",
+        "confirmTitle": "Archive account",
+        "confirmDescription": "Archive this account? It will be deactivated and its members will lose access."
+      },
+      "errors": {
+        "missingAccount": "No account selected."
+      },
+      "toasts": {
+        "saved": "Account updated",
+        "saveFailed": "Failed to update account",
+        "archived": "Account archived",
+        "archiveFailed": "Failed to archive account"
+      }
+    }
+  },
+  "deleteAccount": {
+    "title": "Delete Account",
+    "warning": "This action cannot be undone. Your account and all associated data will be permanently deleted.",
+    "confirmLabel": "Type \"{{username}}\" to confirm",
+    "confirm": "Delete Forever",
+    "error": "Failed to delete account"
+  },
+  "manageAccount": {
+    "title": "Manage your Oxy Account",
+    "signOutOfThisAccount": "Sign out of this account",
+    "sections": {
+      "profile": "Profile",
+      "preferences": "Preferences",
+      "security": "Security",
+      "sessions": "Sessions & devices",
+      "legal": "Legal",
+      "dangerZone": "Danger zone"
+    },
+    "items": {
+      "editProfile": {
+        "title": "Edit profile",
+        "subtitle": "Name, username, bio, links"
+      },
+      "theme": {
+        "title": "Theme color",
+        "subtitle": "Personalize your Bloom color"
+      },
+      "security": {
+        "title": "Security settings",
+        "subtitle": "Password, 2FA, recovery"
+      },
+      "billing": {
+        "title": "Billing",
+        "subtitle": "Manage subscription and payment methods"
+      }
+    },
+    "sessions": {
+      "thisDevice": "This device",
+      "lastActive": "Last active {{relative}}",
+      "loading": "Loading sessions…",
+      "empty": "No active sessions",
+      "signOutAllOnThisDevice": "Sign out of all other devices",
+      "signOutAllSubtitle": "End {{count}} other device session(s)"
+    },
+    "confirms": {
+      "removeDeviceTitle": "Remove device",
+      "removeDevice": "Sign out from \"{{name}}\"?",
+      "signOutAllDevicesTitle": "Sign out of all other devices",
+      "signOutAllDevices": "End {{count}} other device session(s)? This won't sign you out here."
+    },
+    "toasts": {
+      "deviceRemoved": "Signed out from {{name}}",
+      "deviceRemoveFailed": "Failed to remove device",
+      "allDevicesSignedOut": "Signed out from all other devices",
+      "allDevicesFailed": "Failed to sign out from other devices"
+    }
+  },
+  "trust": {
+    "tiers": {
+      "new": "New",
+      "trusted": "Trusted",
+      "high_trust": "High Trust",
+      "verified": "Verified",
+      "restricted": "Restricted"
+    },
+    "center": {
+      "title": "Trust Center",
+      "balance": "reputation points",
+      "history": "Reputation History",
+      "noHistory": "No reputation history yet.",
+      "noDescription": "No description",
+      "info": "Reputation can only be earned by positive actions in the Oxy Ecosystem. It cannot be sent or received directly.",
+      "loadError": "Failed to load reputation data",
+      "actions": {
+        "title": "Explore",
+        "about": "About",
+        "faq": "FAQ",
+        "leaderboard": "Leaderboard",
+        "rewards": "Rewards",
+        "rules": "Rules"
+      }
+    },
+    "about": {
+      "title": "About Oxy Trust",
+      "subtitle": "Learn about the reputation system",
+      "intro": "Oxy Trust is a recognition of your positive actions in the Oxy Ecosystem. Reputation cannot be sent or received directly, only earned by contributing to the community.",
+      "how": {
+        "title": "How to Earn Reputation",
+        "contribute": "Contributing content",
+        "help": "Helping other users",
+        "participate": "Participating in events",
+        "report": "Reporting bugs",
+        "other": "Other positive actions"
+      },
+      "why": {
+        "title": "Why Oxy Trust?",
+        "text": "Your reputation and trust tier unlock special features and recognition in the Oxy Ecosystem. The more you contribute, the more you earn!"
+      }
+    },
+    "faq": {
+      "title": "Trust FAQ",
+      "subtitle": "Frequently asked questions about Oxy Trust",
+      "search": "Search FAQ...",
+      "noResults": "No FAQ items found matching \"{{query}}\"",
+      "items": {
+        "what": {
+          "q": "What is Oxy Trust?",
+          "a": "Oxy Trust is a reputation system that recognizes your positive contributions across the Oxy Ecosystem. Your reputation reflects how helpful, respectful, and constructive your actions are."
+        },
+        "earn": {
+          "q": "How do I earn reputation?",
+          "a": "You earn reputation by contributing content, helping other users, participating in events, and reporting bugs. Constructive, positive actions raise your reputation over time."
+        },
+        "lose": {
+          "q": "Can I lose reputation?",
+          "a": "Yes. Harmful, abusive, or low-effort actions can reduce your reputation and lower your trust tier."
+        },
+        "use": {
+          "q": "What is reputation used for?",
+          "a": "Your reputation and trust tier unlock special features, recognition, and privileges across the Oxy Ecosystem."
+        },
+        "transfer": {
+          "q": "Can I send or receive reputation?",
+          "a": "No. Reputation cannot be transferred between accounts. It can only be earned through your own actions."
+        },
+        "support": {
+          "q": "Where can I get help?",
+          "a": "If you have questions about Oxy Trust, read the About section or contact support from the Help screen."
+        }
+      }
+    },
+    "leaderboard": {
+      "title": "Trust Leaderboard",
+      "subtitle": "Top contributors in the community",
+      "rankLabel": "rank {{rank}}",
+      "empty": "No leaderboard data",
+      "emptyDesc": "Top contributors will appear here as the community grows.",
+      "error": "Failed to load leaderboard"
+    },
+    "rewards": {
+      "title": "Trust Rewards",
+      "subtitle": "Unlock special features and recognition"
+    },
+    "rules": {
+      "title": "Trust Rules",
+      "subtitle": "How to earn reputation",
+      "empty": "No rules found.",
+      "categories": {
+        "content": "Content",
+        "social": "Social",
+        "trust": "Trust",
+        "moderation": "Moderation",
+        "physical": "Real Life",
+        "penalty": "Penalties",
+        "other": "Other"
+      }
+    },
+    "achievements": {
+      "unlocked": "Achievements",
+      "locked": "Locked Achievements",
+      "firstStep": "First Step",
+      "firstStepDesc": "Earned your first reputation point",
+      "novice": "Novice",
+      "noviceDesc": "Reached 10 reputation points",
+      "contributor": "Contributor",
+      "contributorDesc": "Reached 50 reputation points",
+      "risingStar": "Rising Star",
+      "risingStarDesc": "Reached 100 reputation points",
+      "communityHero": "Community Hero",
+      "communityHeroDesc": "Reached 500 reputation points",
+      "legend": "Legend",
+      "legendDesc": "Reached 1000 reputation points",
+      "phoenix": "Phoenix",
+      "phoenixDesc": "Reached 2500 reputation points",
+      "unstoppable": "Unstoppable",
+      "unstoppableDesc": "Reached 5000 reputation points",
+      "helper": "Helper",
+      "helperDesc": "Helped 10 users",
+      "bugHunter": "Bug Hunter",
+      "bugHunterDesc": "Reported helpful bugs",
+      "streakMaster": "Streak Master",
+      "streakMasterDesc": "7 day activity streak",
+      "earlyAdopter": "Early Adopter",
+      "earlyAdopterDesc": "Been part of the community from the start"
+    }
   }
 }

--- a/packages/core/src/i18n/locales/es-ES.json
+++ b/packages/core/src/i18n/locales/es-ES.json
@@ -110,7 +110,9 @@
     "reputation": "Reputación",
     "followers": "Seguidores",
     "following": "Siguiendo",
-    "more": "+ {{count}} más"
+    "more": "+ {{count}} más",
+    "errorTitle": "Error de perfil",
+    "errorSubtext": "Esto puede ocurrir si el usuario no existe o el servicio de perfiles no está disponible."
   },
   "language": {
     "title": "Idioma",
@@ -118,7 +120,8 @@
     "current": "Idioma actual",
     "available": "Idiomas disponibles",
     "changed": "Idioma cambiado a {{lang}}",
-    "saveFailed": "Error al guardar la preferencia de idioma"
+    "saveFailed": "Error al guardar la preferencia de idioma",
+    "search": "Buscar idiomas"
   },
   "recover": {
     "title": "Recuperar cuenta",
@@ -269,7 +272,8 @@
       "cropMeasureFailed": "No se pudo medir la imagen",
       "cropNotReady": "La imagen aún no está lista",
       "cropFailed": "No se pudo recortar la imagen"
-    }
+    },
+    "changeAvatar": "Cambiar avatar"
   },
   "common": {
     "actions": {
@@ -283,7 +287,8 @@
       "verify": "Verificar",
       "resetPassword": "Restablecer contraseña",
       "signedOut": "Sesión cerrada",
-      "close": "Cerrar"
+      "close": "Cerrar",
+      "delete": "Eliminar"
     },
     "cancel": "Cancelar",
     "revoke": "Revocar",
@@ -314,7 +319,9 @@
     "status": {
       "notSignedIn": "No has iniciado sesión",
       "loading": "Cargando..."
-    }
+    },
+    "back": "Atrás",
+    "remove": "Eliminar"
   },
   "accountOverview": {
     "title": "Cuenta",
@@ -459,7 +466,8 @@
       "accountManagement": "Gestión de la cuenta",
       "multiAccount": "Multi‑cuenta",
       "addAccount": "Añadir cuenta",
-      "moreOptions": "Más opciones"
+      "moreOptions": "Más opciones",
+      "accounts": "Cuentas"
     },
     "quickActions": {
       "overview": "Resumen",
@@ -521,7 +529,10 @@
     "sections": {
       "current": "Cuenta actual",
       "otherWithCount": "Otras cuentas ({{count}})",
-      "deviceSessions": "Sesiones de dispositivo"
+      "deviceSessions": "Sesiones de dispositivo",
+      "sharedWithYou": "Compartidas contigo",
+      "thisDevice": "En este dispositivo",
+      "yourAccounts": "Tus cuentas"
     },
     "currentBadge": "Actual",
     "loading": "Cargando cuentas...",
@@ -556,7 +567,9 @@
     "empty": {
       "title": "No hay cuentas guardadas",
       "subtitle": "Añade otra cuenta para cambiar rápidamente entre ellas"
-    }
+    },
+    "label": "Selector de cuentas",
+    "searchPlaceholder": "Buscar cuentas"
   },
   "feedback": {
     "type": {
@@ -599,7 +612,8 @@
       "priority": "Prioridad:",
       "category": "Categoría:",
       "titleLabel": "Título:",
-      "contact": "Contacto:"
+      "contact": "Contacto:",
+      "titleField": "Título:"
     },
     "actions": {
       "submit": "Enviar comentario",
@@ -614,7 +628,9 @@
       "thanks": "¡Gracias por tu comentario!",
       "submitFailed": "Error al enviar el comentario",
       "submitSuccess": "¡Comentario enviado correctamente!"
-    }
+    },
+    "title": "Comentarios",
+    "subtitle": "Cuéntanos qué opinas"
   },
   "reputation": {
     "faq": {
@@ -775,7 +791,9 @@
     },
     "confirms": {
       "cancelSub": "¿Seguro que quieres cancelar tu suscripción? Perderás el acceso a las funciones premium al final del periodo de facturación.",
-      "unsubscribeFeature": "¿Seguro que quieres darte de baja de {{name}}?"
+      "unsubscribeFeature": "¿Seguro que quieres darte de baja de {{name}}?",
+      "cancelSubTitle": "Cancelar suscripción",
+      "unsubscribeFeatureTitle": "Cancelar suscripción a la función"
     },
     "current": {
       "title": "Suscripción actual",
@@ -793,11 +811,13 @@
     "billing": {
       "monthly": "Mensual",
       "yearly": "Anual",
-      "saveYearly": "💰 Ahorra un 20% con la facturación anual"
+      "saveYearly": "💰 Ahorra un 20% con la facturación anual",
+      "label": "Periodo de facturación"
     },
     "tabs": {
       "plans": "Planes completos",
-      "features": "Funciones individuales"
+      "features": "Funciones individuales",
+      "label": "Tipo de suscripción"
     },
     "plan": {
       "scope": {
@@ -807,7 +827,8 @@
       },
       "badge": {
         "appExclusive": "Exclusivo de la app",
-        "notAvailable": "No disponible"
+        "notAvailable": "No disponible",
+        "mostPopular": "Más popular"
       },
       "perInterval": "por {{interval}}",
       "current": "Plan actual",
@@ -819,7 +840,16 @@
         "availableIn": "Disponible en: {{apps}}"
       },
       "includedInPlan": "Incluido en tu plan",
-      "subscribed": "Suscrito"
+      "subscribed": "Suscrito",
+      "included": "Incluido",
+      "plansOnly": "Solo disponible en los planes de suscripción"
+    },
+    "features": {
+      "title": "Funciones individuales",
+      "subtitle": "Suscríbete a las funciones concretas que necesitas. Algunas funciones están incluidas en los planes de suscripción."
+    },
+    "dev": {
+      "appContext": "Contexto de app de prueba (solo desarrollo)"
     }
   },
   "welcomeNew": {
@@ -874,6 +904,10 @@
       "skip": "Omitir",
       "enter": "Entrar",
       "continue": "Continuar"
+    },
+    "trust": {
+      "title": "Oxy Trust = Confianza y crecimiento",
+      "body": "Oxy Trust es un sistema de reputación que reacciona a lo que haces. Las acciones útiles, respetuosas y constructivas ganan reputación. Lo dañino o de poco esfuerzo la reduce. Más reputación eleva tu nivel de confianza y puede desbloquear beneficios; una reputación baja puede limitar funciones. Mantiene las cosas justas y recompensa la contribución real."
     }
   },
   "history": {
@@ -929,6 +963,9 @@
       "description": "Usa tu actividad para mejorar los resultados de búsqueda",
       "updated": "Personalización de búsqueda actualizada",
       "error": "Error al actualizar la personalización"
+    },
+    "searchPersonalization": {
+      "error": "No se pudo actualizar la personalización"
     }
   },
   "privacySettings": {
@@ -990,7 +1027,8 @@
     "title": "Verificación de cuenta",
     "description": "Solicita una insignia verificada para tu cuenta. Las cuentas verificadas ayudan a establecer autenticidad y credibilidad.",
     "sections": {
-      "request": "SOLICITUD DE VERIFICACIÓN"
+      "request": "SOLICITUD DE VERIFICACIÓN",
+      "benefits": "Qué te aporta la verificación"
     },
     "reasonLabel": "Motivo de la verificación *",
     "reasonPlaceholder": "Explica por qué necesitas una insignia verificada (p. ej., figura pública, marca, organización)",
@@ -1003,7 +1041,13 @@
     "successMessage": "Tu solicitud de verificación ha sido enviada. ID de solicitud: {{requestId}}",
     "ok": "OK",
     "error": "Servicio no disponible",
-    "note": "Nota: Las solicitudes de verificación se revisan manualmente y pueden tardar varios días. Te notificaremos cuando tu solicitud haya sido revisada."
+    "note": "Nota: Las solicitudes de verificación se revisan manualmente y pueden tardar varios días. Te notificaremos cuando tu solicitud haya sido revisada.",
+    "heroTitle": "Consigue una insignia de verificación",
+    "benefits": {
+      "authenticity": "Confirma que tu identidad es auténtica y de confianza",
+      "badge": "Muestra una insignia de verificación en toda la plataforma",
+      "credibility": "Genera credibilidad ante quienes te siguen"
+    }
   },
   "help": {
     "title": "Ayuda y soporte",
@@ -1518,5 +1562,335 @@
     "openWithUser": "Menú de cuenta de {{name}}",
     "switching": "Cambiando de cuenta…",
     "signOutAccount": "Cerrar sesión de {{name}}"
+  },
+  "accounts": {
+    "activeAccount": {
+      "a11y": "Cuenta activa: {{name}}. Toca para cambiar de cuenta.",
+      "label": "Cuenta activa"
+    },
+    "roles": {
+      "owner": {
+        "label": "Propietario"
+      },
+      "admin": {
+        "label": "Administrador"
+      },
+      "editor": {
+        "label": "Editor"
+      },
+      "developer": {
+        "label": "Desarrollador"
+      },
+      "billing": {
+        "label": "Facturación"
+      },
+      "viewer": {
+        "label": "Lector"
+      }
+    },
+    "kinds": {
+      "organization": {
+        "label": "Organización",
+        "description": "Una cuenta de equipo compartida con miembros"
+      },
+      "project": {
+        "label": "Proyecto",
+        "description": "Una cuenta independiente que tú controlas"
+      },
+      "bot": {
+        "label": "Bot",
+        "description": "Una cuenta programática con credenciales de servicio"
+      }
+    },
+    "create": {
+      "title": "Crear cuenta",
+      "subtitle": "Crea una cuenta que tú controlas. Tendrá su propio perfil, miembros y aplicaciones.",
+      "displayName": {
+        "label": "Nombre visible"
+      },
+      "bio": {
+        "label": "Biografía (opcional)"
+      },
+      "username": {
+        "label": "Nombre de usuario",
+        "available": "El nombre de usuario está disponible",
+        "taken": "El nombre de usuario ya está en uso",
+        "tooShort": "El nombre de usuario debe tener al menos 3 caracteres",
+        "invalidChars": "Solo letras, números, guiones y guiones bajos",
+        "checkFailed": "No se pudo comprobar la disponibilidad"
+      },
+      "toasts": {
+        "success": "Cuenta creada",
+        "failed": "No se pudo crear la cuenta"
+      }
+    },
+    "manage": {
+      "create": {
+        "subtitle": "Añade una organización, proyecto o bot"
+      },
+      "switch": {
+        "title": "Cambiar de cuenta",
+        "count": "{{count}} cuentas",
+        "empty": "Cuentas que posees o compartes"
+      }
+    },
+    "members": {
+      "title": "Miembros",
+      "subtitle": "Personas con acceso a esta cuenta.",
+      "empty": "Aún no hay miembros.",
+      "actions": {
+        "remove": "Eliminar miembro",
+        "transfer": "Transferir propiedad"
+      },
+      "errors": {
+        "identifierRequired": "Introduce un nombre de usuario o correo para invitar",
+        "missingAccount": "Ninguna cuenta seleccionada.",
+        "noPermission": "No tienes permiso para ver los miembros.",
+        "userNotFound": "Usuario no encontrado"
+      },
+      "invite": {
+        "title": "Añadir un miembro",
+        "identifierLabel": "Nombre de usuario o correo",
+        "roleLabel": "Rol",
+        "submit": "Añadir miembro"
+      },
+      "removeConfirm": {
+        "title": "Eliminar miembro",
+        "description": "¿Eliminar a este miembro de la cuenta? Perderá todo el acceso."
+      },
+      "transferConfirm": {
+        "title": "Transferir propiedad",
+        "description": "¿Transferir la propiedad de esta cuenta a este miembro? Pasarás a ser administrador. Esto no se puede deshacer."
+      },
+      "toasts": {
+        "added": "Miembro añadido",
+        "addFailed": "No se pudo añadir el miembro",
+        "removed": "Miembro eliminado",
+        "removeFailed": "No se pudo eliminar el miembro",
+        "roleUpdated": "Rol actualizado",
+        "roleFailed": "No se pudo actualizar el rol",
+        "transferred": "Propiedad transferida",
+        "transferFailed": "No se pudo transferir la propiedad"
+      }
+    },
+    "settings": {
+      "title": "Configuración de la cuenta",
+      "subtitle": "Gestiona el perfil, los miembros y el acceso de esta cuenta.",
+      "save": "Guardar cambios",
+      "displayName": {
+        "label": "Nombre visible"
+      },
+      "bio": {
+        "label": "Biografía (opcional)"
+      },
+      "sections": {
+        "access": "Acceso",
+        "dangerZone": "Zona de peligro"
+      },
+      "members": {
+        "subtitle": "Invita a personas y gestiona los roles"
+      },
+      "archive": {
+        "title": "Archivar cuenta",
+        "subtitle": "Desactivar esta cuenta",
+        "confirmTitle": "Archivar cuenta",
+        "confirmDescription": "¿Archivar esta cuenta? Se desactivará y sus miembros perderán el acceso."
+      },
+      "errors": {
+        "missingAccount": "Ninguna cuenta seleccionada."
+      },
+      "toasts": {
+        "saved": "Cuenta actualizada",
+        "saveFailed": "No se pudo actualizar la cuenta",
+        "archived": "Cuenta archivada",
+        "archiveFailed": "No se pudo archivar la cuenta"
+      }
+    }
+  },
+  "deleteAccount": {
+    "title": "Eliminar cuenta",
+    "warning": "Esta acción no se puede deshacer. Tu cuenta y todos los datos asociados se eliminarán de forma permanente.",
+    "confirmLabel": "Escribe \"{{username}}\" para confirmar",
+    "confirm": "Eliminar para siempre",
+    "error": "No se pudo eliminar la cuenta"
+  },
+  "manageAccount": {
+    "title": "Gestiona tu cuenta de Oxy",
+    "signOutOfThisAccount": "Cerrar sesión de esta cuenta",
+    "sections": {
+      "profile": "Perfil",
+      "preferences": "Preferencias",
+      "security": "Seguridad",
+      "sessions": "Sesiones y dispositivos",
+      "legal": "Legal",
+      "dangerZone": "Zona de peligro"
+    },
+    "items": {
+      "editProfile": {
+        "title": "Editar perfil",
+        "subtitle": "Nombre, usuario, biografía, enlaces"
+      },
+      "theme": {
+        "title": "Color del tema",
+        "subtitle": "Personaliza tu color de Bloom"
+      },
+      "security": {
+        "title": "Configuración de seguridad",
+        "subtitle": "Contraseña, 2FA, recuperación"
+      },
+      "billing": {
+        "title": "Facturación",
+        "subtitle": "Gestiona la suscripción y los métodos de pago"
+      }
+    },
+    "sessions": {
+      "thisDevice": "Este dispositivo",
+      "lastActive": "Última actividad {{relative}}",
+      "loading": "Cargando sesiones…",
+      "empty": "No hay sesiones activas",
+      "signOutAllOnThisDevice": "Cerrar sesión en los demás dispositivos",
+      "signOutAllSubtitle": "Finalizar {{count}} sesión(es) de otros dispositivos"
+    },
+    "confirms": {
+      "removeDeviceTitle": "Eliminar dispositivo",
+      "removeDevice": "¿Cerrar sesión en \"{{name}}\"?",
+      "signOutAllDevicesTitle": "Cerrar sesión en los demás dispositivos",
+      "signOutAllDevices": "¿Finalizar {{count}} sesión(es) de otros dispositivos? No se cerrará tu sesión aquí."
+    },
+    "toasts": {
+      "deviceRemoved": "Sesión cerrada en {{name}}",
+      "deviceRemoveFailed": "No se pudo eliminar el dispositivo",
+      "allDevicesSignedOut": "Sesión cerrada en todos los demás dispositivos",
+      "allDevicesFailed": "No se pudo cerrar sesión en los demás dispositivos"
+    }
+  },
+  "trust": {
+    "tiers": {
+      "new": "Nuevo",
+      "trusted": "De confianza",
+      "high_trust": "Alta confianza",
+      "verified": "Verificado",
+      "restricted": "Restringido"
+    },
+    "center": {
+      "title": "Centro de confianza",
+      "balance": "puntos de reputación",
+      "history": "Historial de reputación",
+      "noHistory": "Aún no hay historial de reputación.",
+      "noDescription": "Sin descripción",
+      "info": "La reputación solo se gana con acciones positivas en el ecosistema Oxy. No se puede enviar ni recibir directamente.",
+      "loadError": "No se pudieron cargar los datos de reputación",
+      "actions": {
+        "title": "Explorar",
+        "about": "Acerca de",
+        "faq": "Preguntas frecuentes",
+        "leaderboard": "Clasificación",
+        "rewards": "Recompensas",
+        "rules": "Reglas"
+      }
+    },
+    "about": {
+      "title": "Acerca de Oxy Trust",
+      "subtitle": "Conoce el sistema de reputación",
+      "intro": "Oxy Trust es un reconocimiento de tus acciones positivas en el ecosistema Oxy. La reputación no se puede enviar ni recibir directamente, solo se gana contribuyendo a la comunidad.",
+      "how": {
+        "title": "Cómo ganar reputación",
+        "contribute": "Aportar contenido",
+        "help": "Ayudar a otros usuarios",
+        "participate": "Participar en eventos",
+        "report": "Reportar errores",
+        "other": "Otras acciones positivas"
+      },
+      "why": {
+        "title": "¿Por qué Oxy Trust?",
+        "text": "Tu reputación y tu nivel de confianza desbloquean funciones especiales y reconocimiento en el ecosistema Oxy. ¡Cuanto más contribuyas, más ganas!"
+      }
+    },
+    "faq": {
+      "title": "Preguntas frecuentes de Trust",
+      "subtitle": "Preguntas frecuentes sobre Oxy Trust",
+      "search": "Buscar preguntas frecuentes...",
+      "noResults": "No se encontraron preguntas que coincidan con \"{{query}}\"",
+      "items": {
+        "what": {
+          "q": "¿Qué es Oxy Trust?",
+          "a": "Oxy Trust es un sistema de reputación que reconoce tus contribuciones positivas en todo el ecosistema Oxy. Tu reputación refleja lo útiles, respetuosas y constructivas que son tus acciones."
+        },
+        "earn": {
+          "q": "¿Cómo gano reputación?",
+          "a": "Ganas reputación aportando contenido, ayudando a otros usuarios, participando en eventos y reportando errores. Las acciones constructivas y positivas elevan tu reputación con el tiempo."
+        },
+        "lose": {
+          "q": "¿Puedo perder reputación?",
+          "a": "Sí. Las acciones dañinas, abusivas o de poco esfuerzo pueden reducir tu reputación y bajar tu nivel de confianza."
+        },
+        "use": {
+          "q": "¿Para qué sirve la reputación?",
+          "a": "Tu reputación y tu nivel de confianza desbloquean funciones especiales, reconocimiento y privilegios en todo el ecosistema Oxy."
+        },
+        "transfer": {
+          "q": "¿Puedo enviar o recibir reputación?",
+          "a": "No. La reputación no se puede transferir entre cuentas. Solo se puede ganar con tus propias acciones."
+        },
+        "support": {
+          "q": "¿Dónde puedo conseguir ayuda?",
+          "a": "Si tienes preguntas sobre Oxy Trust, lee la sección Acerca de o contacta con soporte desde la pantalla de Ayuda."
+        }
+      }
+    },
+    "leaderboard": {
+      "title": "Clasificación de Trust",
+      "subtitle": "Principales colaboradores de la comunidad",
+      "rankLabel": "puesto {{rank}}",
+      "empty": "No hay datos de clasificación",
+      "emptyDesc": "Los principales colaboradores aparecerán aquí a medida que crezca la comunidad.",
+      "error": "No se pudo cargar la clasificación"
+    },
+    "rewards": {
+      "title": "Recompensas de Trust",
+      "subtitle": "Desbloquea funciones especiales y reconocimiento"
+    },
+    "rules": {
+      "title": "Reglas de Trust",
+      "subtitle": "Cómo ganar reputación",
+      "empty": "No se encontraron reglas.",
+      "categories": {
+        "content": "Contenido",
+        "social": "Social",
+        "trust": "Confianza",
+        "moderation": "Moderación",
+        "physical": "Vida real",
+        "penalty": "Penalizaciones",
+        "other": "Otros"
+      }
+    },
+    "achievements": {
+      "unlocked": "Logros",
+      "locked": "Logros bloqueados",
+      "firstStep": "Primer paso",
+      "firstStepDesc": "Ganaste tu primer punto de reputación",
+      "novice": "Principiante",
+      "noviceDesc": "Alcanzaste 10 puntos de reputación",
+      "contributor": "Colaborador",
+      "contributorDesc": "Alcanzaste 50 puntos de reputación",
+      "risingStar": "Estrella emergente",
+      "risingStarDesc": "Alcanzaste 100 puntos de reputación",
+      "communityHero": "Héroe de la comunidad",
+      "communityHeroDesc": "Alcanzaste 500 puntos de reputación",
+      "legend": "Leyenda",
+      "legendDesc": "Alcanzaste 1000 puntos de reputación",
+      "phoenix": "Fénix",
+      "phoenixDesc": "Alcanzaste 2500 puntos de reputación",
+      "unstoppable": "Imparable",
+      "unstoppableDesc": "Alcanzaste 5000 puntos de reputación",
+      "helper": "Ayudante",
+      "helperDesc": "Ayudaste a 10 usuarios",
+      "bugHunter": "Cazador de errores",
+      "bugHunterDesc": "Reportaste errores útiles",
+      "streakMaster": "Maestro de la racha",
+      "streakMasterDesc": "Racha de actividad de 7 días",
+      "earlyAdopter": "Pionero",
+      "earlyAdopterDesc": "Has formado parte de la comunidad desde el principio"
+    }
   }
 }

--- a/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
+++ b/packages/services/__tests__/hooks/usePaymentQueries.test.tsx
@@ -38,7 +38,9 @@ interface MockOxyState {
   oxyServices: MockOxyServices;
   isAuthenticated: boolean;
   activeSessionId: string | null;
-  user: { id: string } | null;
+  // Payment/wallet/subscription queries scope by the ACTIVE account (the
+  // account switched into), not the device-session owner.
+  activeAccount: { id: string } | null;
 }
 
 const SUBSCRIPTION_FIXTURE: Subscription = {
@@ -100,7 +102,7 @@ const defaultMockState = (): MockOxyState => ({
   oxyServices: makeServices(),
   isAuthenticated: true,
   activeSessionId: 'sess-1',
-  user: { id: 'u1' },
+  activeAccount: { id: 'u1' },
 });
 
 let mockState: MockOxyState = defaultMockState();
@@ -194,8 +196,8 @@ describe('payment query hooks', () => {
       expect(mockState.oxyServices.getCurrentUserSubscription).not.toHaveBeenCalled();
     });
 
-    it('does not call the SDK without a scoped current user id', () => {
-      mockState.user = null;
+    it('does not call the SDK without a scoped active account id', () => {
+      mockState.activeAccount = null;
 
       const { result } = renderHook(() => useUserSubscription(), {
         wrapper: makeWrapper(queryClient),
@@ -271,7 +273,7 @@ describe('payment query hooks', () => {
     });
   });
 
-  it('scopes payment query keys by the authenticated user id', async () => {
+  it('scopes payment query keys by the active account id', async () => {
     const { result: firstResult } = renderHook(() => useUserWallet(), {
       wrapper: makeWrapper(queryClient),
     });
@@ -287,7 +289,7 @@ describe('payment query hooks', () => {
       },
       isAuthenticated: true,
       activeSessionId: 'sess-2',
-      user: { id: 'u2' },
+      activeAccount: { id: 'u2' },
     };
 
     const { result: secondResult } = renderHook(() => useUserWallet(), {

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/hooks/queries/useAccountQueries.ts
+++ b/packages/services/src/ui/hooks/queries/useAccountQueries.ts
@@ -232,8 +232,11 @@ export const useAuthorizedApps = (options?: { enabled?: boolean }) => {
  * Get privacy settings for a user
  */
 export const usePrivacySettings = (userId?: string, options?: { enabled?: boolean }) => {
-  const { oxyServices, activeSessionId, user } = useOxy();
-  const targetUserId = userId || user?.id;
+  const { oxyServices, activeSessionId, activeAccount } = useOxy();
+  // When no explicit user id is supplied, target the ACTIVE account (the
+  // account switched into) so "my privacy settings" reflects the current
+  // account, matching the imperative PrivacySettingsScreen.
+  const targetUserId = userId || activeAccount?.id;
 
   return useQuery({
     queryKey: queryKeys.privacy.settings(targetUserId),

--- a/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
+++ b/packages/services/src/ui/hooks/queries/usePaymentQueries.ts
@@ -34,10 +34,10 @@ import type {
  * API's `{ plan: 'basic' }` fallback when the user has never subscribed.
  */
 export const useUserSubscription = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, activeAccount } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.subscription(user?.id),
+    queryKey: queryKeys.payments.subscription(activeAccount?.id),
     queryFn: async () => {
       return authenticatedApiCall<Subscription>(
         oxyServices,
@@ -45,7 +45,7 @@ export const useUserSubscription = (options?: { enabled?: boolean }) => {
         () => oxyServices.getCurrentUserSubscription(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!activeAccount?.id,
     // Subscription state changes rarely; tolerate a longer fresh window.
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
@@ -59,10 +59,10 @@ export const useUserSubscription = (options?: { enabled?: boolean }) => {
  * returns the user's `deposit` and `purchase` transactions newest-first.
  */
 export const useUserPayments = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, activeAccount } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.history(user?.id),
+    queryKey: queryKeys.payments.history(activeAccount?.id),
     queryFn: async () => {
       return authenticatedApiCall<Payment[]>(
         oxyServices,
@@ -70,7 +70,7 @@ export const useUserPayments = (options?: { enabled?: boolean }) => {
         () => oxyServices.getUserPayments(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!activeAccount?.id,
     // Billing history is append-mostly; a short fresh window is fine.
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
@@ -84,10 +84,10 @@ export const useUserPayments = (options?: { enabled?: boolean }) => {
  * Balance changes frequently, so the fresh window is intentionally short.
  */
 export const useUserWallet = (options?: { enabled?: boolean }) => {
-  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, activeAccount } = useOxy();
 
   return useQuery({
-    queryKey: queryKeys.payments.wallet(user?.id),
+    queryKey: queryKeys.payments.wallet(activeAccount?.id),
     queryFn: async () => {
       return authenticatedApiCall<Wallet>(
         oxyServices,
@@ -95,7 +95,7 @@ export const useUserWallet = (options?: { enabled?: boolean }) => {
         () => oxyServices.getCurrentUserWallet(),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!activeAccount?.id,
     staleTime: 60 * 1000, // 1 minute (balance moves often)
     gcTime: 10 * 60 * 1000, // 10 minutes
   });
@@ -116,12 +116,12 @@ export const useUserWalletTransactions = (
   params?: { limit?: number; offset?: number },
   options?: { enabled?: boolean },
 ) => {
-  const { oxyServices, isAuthenticated, activeSessionId, user } = useOxy();
+  const { oxyServices, isAuthenticated, activeSessionId, activeAccount } = useOxy();
   const limit = params?.limit;
   const offset = params?.offset;
 
   return useQuery({
-    queryKey: queryKeys.payments.walletTransactions(limit, offset, user?.id),
+    queryKey: queryKeys.payments.walletTransactions(limit, offset, activeAccount?.id),
     queryFn: async () => {
       return authenticatedApiCall<WalletTransactionsResponse>(
         oxyServices,
@@ -129,7 +129,7 @@ export const useUserWalletTransactions = (
         () => oxyServices.getCurrentUserWalletTransactions({ limit, offset }),
       );
     },
-    enabled: (options?.enabled !== false) && isAuthenticated && !!user?.id,
+    enabled: (options?.enabled !== false) && isAuthenticated && !!activeAccount?.id,
     staleTime: 60 * 1000, // 1 minute (ledger updates frequently)
     gcTime: 10 * 60 * 1000, // 10 minutes
   });

--- a/packages/services/src/ui/screens/EditProfileFieldScreen.tsx
+++ b/packages/services/src/ui/screens/EditProfileFieldScreen.tsx
@@ -88,7 +88,10 @@ const EditProfileFieldScreen: React.FC<EditProfileFieldScreenProps> = ({
     theme,
     fieldType = 'displayName',
 }) => {
-    const { user } = useOxy();
+    // Editing "my" profile targets the ACTIVE account — writes already route to
+    // it via the X-Acting-As header, so the initial field values must mirror the
+    // active account (an org/project/bot when switched, else the personal user).
+    const { activeAccount } = useOxy();
     const { t } = useI18n();
     const { saveProfile, updateField, isSaving } = useProfileEditing();
     const bloomTheme = useTheme();
@@ -262,11 +265,11 @@ const EditProfileFieldScreen: React.FC<EditProfileFieldScreenProps> = ({
         }
     }, [fieldType, t]);
 
-    // Initialize field values from user data
+    // Initialize field values from the active account's data
     useEffect(() => {
-        if (!user) return;
+        if (!activeAccount) return;
 
-        const userData = user;
+        const userData = activeAccount;
 
         if (fieldConfig.isList) {
             if (fieldType === 'locations') {
@@ -316,7 +319,7 @@ const EditProfileFieldScreen: React.FC<EditProfileFieldScreenProps> = ({
             });
             setFieldValues(initialValues);
         }
-    }, [user, fieldConfig, fieldType]);
+    }, [activeAccount, fieldConfig, fieldType]);
 
     // Field change handler
     const handleFieldChange = useCallback((key: string, value: string) => {

--- a/packages/services/src/ui/screens/FileManagementScreen.tsx
+++ b/packages/services/src/ui/screens/FileManagementScreen.tsx
@@ -763,8 +763,11 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
     defaultVisibility = 'private',
     linkContext,
 }) => {
-    // Use useOxy() hook for OxyContext values
-    const { user, oxyServices } = useOxy();
+    // Use useOxy() hook for OxyContext values. Files are owned by the ACTIVE
+    // account (the org/project/bot when switched, else the personal user): the
+    // default file owner and every "is this mine?" ownership check resolve
+    // against `activeAccount`, so switching shows/manages that account's files.
+    const { activeAccount, oxyServices } = useOxy();
     const { t } = useI18n();
     const uploadFileMutation = useUploadFile();
     // Prompt controls
@@ -1033,7 +1036,7 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
     const backgroundColor = colors.backgroundSecondary;
     const borderColor = colors.border;
 
-    const targetUserId = userId || user?.id;
+    const targetUserId = userId || activeAccount?.id;
 
     const storeSetUploading = useFileStore(s => s.setUploading);
     const storeSetUploadProgress = useFileStore(s => s.setUploadProgress);
@@ -2287,11 +2290,11 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
                     <Ionicons name="images-outline" size={64} color={colors.textTertiary} />
                     <Text style={[fileManagementStyles.emptyStateTitle, { color: colors.text }]}>{t('fileManagement.emptyPhotos.title')}</Text>
                     <Text style={[fileManagementStyles.emptyStateDescription, { color: colors.textSecondary }]}> {
-                        user?.id === targetUserId
+                        activeAccount?.id === targetUserId
                             ? t('fileManagement.emptyPhotos.ownDescription')
                             : t('fileManagement.emptyPhotos.otherDescription')
                     } </Text>
-                    {user?.id === targetUserId && (
+                    {activeAccount?.id === targetUserId && (
                         <TouchableOpacity
                             style={[fileManagementStyles.emptyStateButton, { backgroundColor: colors.primary }]}
                             onPress={handleFileUpload}
@@ -2357,7 +2360,7 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
     }, [
         filteredFiles,
         colors,
-        user?.id,
+        activeAccount?.id,
         targetUserId,
         uploading,
         handleFileUpload,
@@ -2381,12 +2384,12 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
             <Ionicons name="folder-open-outline" size={64} color={colors.textTertiary} />
             <Text style={[fileManagementStyles.emptyStateTitle, { color: colors.text }]}>{t('fileManagement.emptyFiles.title')}</Text>
             <Text style={[fileManagementStyles.emptyStateDescription, { color: colors.textSecondary }]}>
-                {user?.id === targetUserId
+                {activeAccount?.id === targetUserId
                     ? t('fileManagement.emptyFiles.ownDescription')
                     : t('fileManagement.emptyFiles.otherDescription')
                 }
             </Text>
-            {user?.id === targetUserId && (
+            {activeAccount?.id === targetUserId && (
                 <TouchableOpacity
                     style={[fileManagementStyles.emptyStateButton, { backgroundColor: colors.primary }]}
                     onPress={handleFileUpload}
@@ -2596,7 +2599,7 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
         const photosOnly = filteredFiles.filter(
             (file) => file.contentType.startsWith('image/'),
         );
-        const isOwner = user?.id === targetUserId;
+        const isOwner = activeAccount?.id === targetUserId;
         const allowUpload = isOwner && allowUploadInSelectMode;
 
         return (
@@ -2654,14 +2657,14 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
                     onClose={handleCloseFile}
                     onDownload={handleFileDownload}
                     onDelete={confirmFileDelete}
-                    isOwner={user?.id === targetUserId}
+                    isOwner={activeAccount?.id === targetUserId}
                 />
                 <FileDetailsModal
                     control={fileDetailsControl}
                     file={selectedFile}
                     onDownload={handleFileDownload}
                     onDelete={confirmFileDelete}
-                    isOwner={user?.id === targetUserId}
+                    isOwner={activeAccount?.id === targetUserId}
                 />
             </>
         );
@@ -2837,7 +2840,7 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
                         color={colors.textSecondary}
                     />
                 </TouchableOpacity>
-                {user?.id === targetUserId && (!selectMode || (selectMode && allowUploadInSelectMode)) && (
+                {activeAccount?.id === targetUserId && (!selectMode || (selectMode && allowUploadInSelectMode)) && (
                     <TouchableOpacity
                         style={[
                             fileManagementStyles.uploadButton,
@@ -3010,7 +3013,7 @@ const FileManagementScreen: React.FC<FileManagementScreenProps> = ({
                     file={selectedFile}
                     onDownload={handleFileDownload}
                     onDelete={confirmFileDelete}
-                    isOwner={user?.id === targetUserId}
+                    isOwner={activeAccount?.id === targetUserId}
                 />
             )}
 

--- a/packages/services/src/ui/screens/HistoryViewScreen.tsx
+++ b/packages/services/src/ui/screens/HistoryViewScreen.tsx
@@ -15,7 +15,9 @@ import { Dialog, useDialogControl } from '@oxyhq/bloom';
 interface HistoryItem { id: string; query: string; type: 'search' | 'browse'; timestamp: Date; }
 
 const HistoryViewScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => {
-    const { user } = useOxy();
+    // History is scoped to the ACTIVE account so a switch into an org/project/bot
+    // shows that account's history, not the device-session owner's.
+    const { activeAccount } = useOxy();
     const { t } = useI18n();
     const bloomTheme = useTheme();
     const [history, setHistory] = useState<HistoryItem[]>([]);
@@ -45,13 +47,13 @@ const HistoryViewScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => {
             try {
                 setIsLoading(true);
                 const storage = await getStorage();
-                const stored = await storage.getItem(`history_${user?.id || 'guest'}`);
+                const stored = await storage.getItem(`history_${activeAccount?.id || 'guest'}`);
                 if (stored) { const parsed = JSON.parse(stored); setHistory(parsed.map((i: HistoryItem) => ({ ...i, timestamp: new Date(i.timestamp) }))); }
                 else setHistory([]);
             } catch { setHistory([]); } finally { setIsLoading(false); }
         };
         load();
-    }, [user?.id]);
+    }, [activeAccount?.id]);
 
     const handleDeleteLast15Minutes = useCallback(async () => {
         try {
@@ -60,21 +62,21 @@ const HistoryViewScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => {
             const filtered = history.filter(item => item.timestamp < cutoff);
             setHistory(filtered);
             const storage = await getStorage();
-            await storage.setItem(`history_${user?.id || 'guest'}`, JSON.stringify(filtered));
+            await storage.setItem(`history_${activeAccount?.id || 'guest'}`, JSON.stringify(filtered));
             toast.success(t('history.deleteLast15Minutes.success') || 'Last 15 minutes deleted');
         } catch (e) { if (__DEV__) console.error('Failed to delete history:', e); toast.error(t('history.deleteLast15Minutes.error') || 'Failed to delete history'); }
         finally { setIsDeleting(false); }
-    }, [history, user?.id, t]);
+    }, [history, activeAccount?.id, t]);
 
     const handleClearAll = useCallback(async () => {
         try {
             setIsDeleting(true); setHistory([]);
             const storage = await getStorage();
-            await storage.removeItem(`history_${user?.id || 'guest'}`);
+            await storage.removeItem(`history_${activeAccount?.id || 'guest'}`);
             toast.success(t('history.clearAll.success') || 'History cleared');
         } catch (e) { if (__DEV__) console.error('Failed to clear history:', e); toast.error(t('history.clearAll.error') || 'Failed to clear history'); }
         finally { setIsDeleting(false); }
-    }, [user?.id, t]);
+    }, [activeAccount?.id, t]);
 
     const formatTime = (date: Date) => {
         const diff = new Date().getTime() - date.getTime();

--- a/packages/services/src/ui/screens/LanguageSelectorScreen.tsx
+++ b/packages/services/src/ui/screens/LanguageSelectorScreen.tsx
@@ -33,8 +33,10 @@ const LanguageSelectorScreen: React.FC<LanguageSelectorScreenProps> = ({
     onClose,
     theme,
 }) => {
-    // Use useOxy() hook for OxyContext values
-    const { user, currentLanguage, setLanguage, oxyServices, isAuthenticated } = useOxy();
+    // Use useOxy() hook for OxyContext values. The language preference persists
+    // on the ACTIVE account's profile via the X-Acting-As header, so gate the
+    // server sync on the active account.
+    const { activeAccount, currentLanguage, setLanguage, oxyServices, isAuthenticated } = useOxy();
     const { t } = useI18n();
     const bloomTheme = useTheme();
     const normalizedTheme = normalizeTheme(theme);
@@ -53,7 +55,7 @@ const LanguageSelectorScreen: React.FC<LanguageSelectorScreenProps> = ({
             let serverSyncFailed = false;
 
             // If signed in, persist preference to backend user settings
-            if (isAuthenticated && user?.id) {
+            if (isAuthenticated && activeAccount?.id) {
                 try {
                     await oxyServices.updateProfile({ language: languageId });
                 } catch (e: unknown) {
@@ -90,7 +92,7 @@ const LanguageSelectorScreen: React.FC<LanguageSelectorScreenProps> = ({
             toast.error(t('language.saveFailed'));
             setIsLoading(false);
         }
-    }, [currentLanguage, isLoading, isAuthenticated, user?.id, oxyServices, setLanguage, t, onClose, goBack]);
+    }, [currentLanguage, isLoading, isAuthenticated, activeAccount?.id, oxyServices, setLanguage, t, onClose, goBack]);
 
     // Filter the supported languages by the search query (name + native name).
     const filteredLanguages = useMemo(() => {

--- a/packages/services/src/ui/screens/ManageAccountScreen.tsx
+++ b/packages/services/src/ui/screens/ManageAccountScreen.tsx
@@ -89,6 +89,7 @@ const ManageAccountScreen: React.FC<BaseScreenProps> = ({
     const { t, locale } = useI18n();
     const {
         user: contextUser,
+        activeAccount,
         isAuthenticated,
         oxyServices,
         activeSessionId,
@@ -100,6 +101,11 @@ const ManageAccountScreen: React.FC<BaseScreenProps> = ({
     const { data: userFromQuery, isLoading: userLoading } = useCurrentUser({
         enabled: isAuthenticated,
     });
+    // `user` is the device-session OWNER (the human login) — used only for
+    // account/session MANAGEMENT and GDPR-level actions (sign-out, device
+    // sessions, download-data, delete-account). Identity-of-me surfaces (the
+    // profile header, preview-profile target, premium state) read
+    // `activeAccount` so a switch into an org/project/bot is reflected here.
     const user = userFromQuery ?? contextUser;
 
     const { data: subscription } = useUserSubscription({ enabled: isAuthenticated });
@@ -121,13 +127,13 @@ const ManageAccountScreen: React.FC<BaseScreenProps> = ({
     const [signingOutAllDevices, setSigningOutAllDevices] = useState(false);
     const [signingOut, setSigningOut] = useState(false);
 
-    const displayName = useMemo(() => getAccountDisplayName(user, locale), [user, locale]);
-    const handle = useMemo(() => getAccountFallbackHandle(user), [user]);
+    const displayName = useMemo(() => getAccountDisplayName(activeAccount, locale), [activeAccount, locale]);
+    const handle = useMemo(() => getAccountFallbackHandle(activeAccount), [activeAccount]);
     const avatarUri = useMemo(() => {
-        return user?.avatar
-            ? oxyServices.getFileDownloadUrl(user.avatar, 'thumb')
+        return activeAccount?.avatar
+            ? oxyServices.getFileDownloadUrl(activeAccount.avatar, 'thumb')
             : undefined;
-    }, [user?.avatar, oxyServices]);
+    }, [activeAccount?.avatar, oxyServices]);
 
     const handleSignOut = useCallback(async () => {
         if (signingOut) {
@@ -355,12 +361,12 @@ const ManageAccountScreen: React.FC<BaseScreenProps> = ({
                     </H4>
                     {handle ? (
                         <Text className="text-text-secondary text-sm mt-space-2" numberOfLines={1}>
-                            {user?.username ? `@${handle}` : handle}
+                            {activeAccount?.username ? `@${handle}` : handle}
                         </Text>
                     ) : null}
-                    {user?.email ? (
+                    {activeAccount?.email ? (
                         <Text className="text-text-secondary text-sm mt-space-2" numberOfLines={1}>
-                            {user.email}
+                            {activeAccount.email}
                         </Text>
                     ) : null}
                 </View>
@@ -412,9 +418,9 @@ const ManageAccountScreen: React.FC<BaseScreenProps> = ({
                             || 'See how your profile looks to others'
                         }
                         onPress={() =>
-                            user?.id ? navigate?.('Profile', { userId: user.id }) : undefined
+                            activeAccount?.id ? navigate?.('Profile', { userId: activeAccount.id }) : undefined
                         }
-                        disabled={!user?.id}
+                        disabled={!activeAccount?.id}
                     />
                     <SettingsListItem
                         icon={
@@ -581,13 +587,13 @@ const ManageAccountScreen: React.FC<BaseScreenProps> = ({
                             t('accountOverview.items.premium.title') || 'Oxy+'
                         }
                         description={
-                            user?.isPremium
+                            activeAccount?.isPremium
                                 ? (t('accountOverview.items.premium.manage') || 'Manage your premium plan')
                                 : (t('accountOverview.items.premium.upgrade') || 'Upgrade to premium features')
                         }
                         onPress={() => navigate?.('PremiumSubscription')}
                     />
-                    {user?.isPremium || subscription?.status === 'active' ? (
+                    {activeAccount?.isPremium || subscription?.status === 'active' ? (
                         <SettingsListItem
                             icon={
                                 <SettingsIcon

--- a/packages/services/src/ui/screens/PremiumSubscriptionScreen.tsx
+++ b/packages/services/src/ui/screens/PremiumSubscriptionScreen.tsx
@@ -91,8 +91,9 @@ const PremiumSubscriptionScreen: React.FC<BaseScreenProps> = ({
     navigate,
     goBack,
 }) => {
-    // Use useOxy() hook for OxyContext values
-    const { user } = useOxy();
+    // Premium state belongs to the ACTIVE account (the org/project/bot when
+    // switched, else the personal user), not the device-session owner.
+    const { activeAccount } = useOxy();
     const [loading, setLoading] = useState(true);
     const [subscription, setSubscription] = useState<UserSubscription | null>(null);
     const [plans, setPlans] = useState<SubscriptionPlan[]>([]);
@@ -328,7 +329,7 @@ const PremiumSubscriptionScreen: React.FC<BaseScreenProps> = ({
         if (currentAppPackage) {
             loadSubscriptionData();
         }
-    }, [currentAppPackage, user?.isPremium]);
+    }, [currentAppPackage, activeAccount?.isPremium]);
 
     const detectCurrentApp = () => {
         const detectedApp = 'mention';
@@ -345,7 +346,7 @@ const PremiumSubscriptionScreen: React.FC<BaseScreenProps> = ({
             setPlans(availablePlans);
 
             let currentSubscription: UserSubscription | null = null;
-            if (user?.isPremium) {
+            if (activeAccount?.isPremium) {
                 currentSubscription = {
                     id: 'sub_12345',
                     planId: 'oxy-insider',

--- a/packages/services/src/ui/screens/PrivacySettingsScreen.tsx
+++ b/packages/services/src/ui/screens/PrivacySettingsScreen.tsx
@@ -65,7 +65,9 @@ const PrivacySettingsScreen: React.FC<BaseScreenProps> = ({
     onClose,
     goBack,
 }) => {
-    const { oxyServices, user } = useOxy();
+    // Privacy settings belong to the ACTIVE account (the org/project/bot when
+    // switched, else the personal user).
+    const { oxyServices, activeAccount } = useOxy();
     const { t, locale } = useI18n();
     const bloomTheme = useTheme();
     const [isLoading, setIsLoading] = useState(true);
@@ -77,8 +79,8 @@ const PrivacySettingsScreen: React.FC<BaseScreenProps> = ({
     const { values: settings, toggle, savingKeys, setValues } = useSettingToggles<PrivacySettings>({
         initialValues: DEFAULT_PRIVACY_SETTINGS,
         onSave: async (key, value) => {
-            if (!user?.id || !oxyServices) return;
-            await oxyServices.updatePrivacySettings({ [key]: value }, user.id);
+            if (!activeAccount?.id || !oxyServices) return;
+            await oxyServices.updatePrivacySettings({ [key]: value }, activeAccount.id);
         },
         errorMessage: t('privacySettings.updateError') || 'Failed to update privacy setting',
     });
@@ -90,8 +92,8 @@ const PrivacySettingsScreen: React.FC<BaseScreenProps> = ({
         const loadSettings = async () => {
             try {
                 setIsLoading(true);
-                if (user?.id && oxyServices) {
-                    const privacySettings = await oxyServices.getPrivacySettings(user.id);
+                if (activeAccount?.id && oxyServices) {
+                    const privacySettings = await oxyServices.getPrivacySettings(activeAccount.id);
                     if (privacySettings) {
                         setValues(privacySettings);
                     }
@@ -107,7 +109,7 @@ const PrivacySettingsScreen: React.FC<BaseScreenProps> = ({
         };
 
         loadSettings();
-    }, [user?.id, oxyServices, t, setValues]);
+    }, [activeAccount?.id, oxyServices, t, setValues]);
 
     // Load blocked and restricted users
     useEffect(() => {
@@ -131,7 +133,10 @@ const PrivacySettingsScreen: React.FC<BaseScreenProps> = ({
         };
 
         loadUsers();
-    }, [oxyServices]);
+        // Re-load when the active account changes so the block/restrict lists
+        // reflect the account currently switched into (they resolve via the
+        // X-Acting-As header).
+    }, [oxyServices, activeAccount?.id]);
 
     const handleUnblock = useCallback(async (userId: string) => {
         if (!oxyServices) return;

--- a/packages/services/src/ui/screens/ProfileScreen.tsx
+++ b/packages/services/src/ui/screens/ProfileScreen.tsx
@@ -27,8 +27,11 @@ const AVATAR_OVERLAP = -56;
 const INFO_ICON_SIZE = 18;
 
 const ProfileScreen: React.FC<ProfileScreenProps> = ({ userId, username, theme, goBack, navigate }) => {
-    // Use useOxy() hook for OxyContext values
-    const { oxyServices, user: currentUser } = useOxy();
+    // Use useOxy() hook for OxyContext values. "Me" for own-profile detection
+    // and the own-profile fallback is the ACTIVE account (the account switched
+    // into), so previewing my profile while switched into an org/project/bot
+    // resolves "this is mine" against that account, not the session owner.
+    const { oxyServices, activeAccount: currentUser } = useOxy();
     const [profile, setProfile] = useState<User | null>(null);
     const [reputationTotal, setReputationTotal] = useState<number | null>(null);
     const [postsCount, setPostsCount] = useState<number | null>(null);

--- a/packages/services/src/ui/screens/SavesCollectionsScreen.tsx
+++ b/packages/services/src/ui/screens/SavesCollectionsScreen.tsx
@@ -38,8 +38,9 @@ const SavesCollectionsScreen: React.FC<BaseScreenProps> = ({
     onClose,
     goBack,
 }) => {
-    // Use useOxy() hook for OxyContext values
-    const { oxyServices, user } = useOxy();
+    // Saves & collections belong to the ACTIVE account (the org/project/bot when
+    // switched, else the personal user).
+    const { oxyServices, activeAccount } = useOxy();
     const { t } = useI18n();
     const bloomTheme = useTheme();
     const [savedItems, setSavedItems] = useState<SavedItem[]>([]);
@@ -52,10 +53,10 @@ const SavesCollectionsScreen: React.FC<BaseScreenProps> = ({
         const loadData = async () => {
             try {
                 setIsLoading(true);
-                if (user?.id && oxyServices) {
+                if (activeAccount?.id && oxyServices) {
                     const [saved, cols] = await Promise.all([
-                        oxyServices.getSavedItems(user.id),
-                        oxyServices.getCollections(user.id),
+                        oxyServices.getSavedItems(activeAccount.id),
+                        oxyServices.getCollections(activeAccount.id),
                     ]);
                     setSavedItems(saved.map((item) => ({
                         id: item.id,
@@ -79,7 +80,7 @@ const SavesCollectionsScreen: React.FC<BaseScreenProps> = ({
         };
 
         loadData();
-    }, [user?.id, oxyServices, t]);
+    }, [activeAccount?.id, oxyServices, t]);
 
     const formatDate = (date: Date) => {
         return date.toLocaleDateString();

--- a/packages/services/src/ui/screens/SearchSettingsScreen.tsx
+++ b/packages/services/src/ui/screens/SearchSettingsScreen.tsx
@@ -21,7 +21,10 @@ const SearchSettingsScreen: React.FC<BaseScreenProps> = ({
     onClose,
     goBack,
 }) => {
-    const { oxyServices, user } = useOxy();
+    // Search settings are persisted on the ACTIVE account's profile (the
+    // org/project/bot when switched, else the personal user); the read/write
+    // route to it via the X-Acting-As header.
+    const { oxyServices, activeAccount } = useOxy();
     const { t } = useI18n();
     const bloomTheme = useTheme();
     const [isLoading, setIsLoading] = useState(true);
@@ -30,7 +33,7 @@ const SearchSettingsScreen: React.FC<BaseScreenProps> = ({
     const { values: settings, toggle, savingKeys, setValues } = useSettingToggles<SearchSettings>({
         initialValues: { safeSearch: false, searchPersonalization: true },
         onSave: async (key, value) => {
-            if (!user?.id || !oxyServices) return;
+            if (!activeAccount?.id || !oxyServices) return;
 
             const fieldMap: Record<keyof SearchSettings, string> = {
                 safeSearch: 'autoFilter',
@@ -53,7 +56,7 @@ const SearchSettingsScreen: React.FC<BaseScreenProps> = ({
         const loadSettings = async () => {
             try {
                 setIsLoading(true);
-                if (user?.id && oxyServices) {
+                if (activeAccount?.id && oxyServices) {
                     const userData = await oxyServices.getCurrentUser() as User & { privacySettings?: { autoFilter?: boolean; dataSharing?: boolean } };
                     const privacySettings = userData?.privacySettings || {};
 
@@ -72,7 +75,7 @@ const SearchSettingsScreen: React.FC<BaseScreenProps> = ({
         };
 
         loadSettings();
-    }, [user?.id, oxyServices, setValues]);
+    }, [activeAccount?.id, oxyServices, setValues]);
 
     if (isLoading) {
         return (

--- a/packages/services/src/ui/screens/WelcomeNewUserScreen.tsx
+++ b/packages/services/src/ui/screens/WelcomeNewUserScreen.tsx
@@ -63,11 +63,14 @@ const WelcomeNewUserScreen: React.FC<BaseScreenProps & { newUser?: any }> = ({
     theme,
     newUser,
 }) => {
-    // Use useOxy() hook for OxyContext values
-    const { user, oxyServices } = useOxy();
+    // Use useOxy() hook for OxyContext values. The greeting/avatar identity is
+    // the ACTIVE account (the personal user during onboarding, but read through
+    // `activeAccount` so this stays correct everywhere), with the freshly
+    // registered `newUser` as the pre-store-hydration fallback.
+    const { activeAccount, oxyServices } = useOxy();
     const { t, locale } = useI18n();
     const updateProfileMutation = useUpdateProfile();
-    const currentUser = user || newUser; // fallback
+    const currentUser = activeAccount || newUser; // fallback
     const bloomTheme = useTheme();
     const colors = {
         primary: bloomTheme.colors.primary,
@@ -88,14 +91,14 @@ const WelcomeNewUserScreen: React.FC<BaseScreenProps & { newUser?: any }> = ({
     const [lastName, setLastName] = useState(() => (currentUser?.name?.last ?? '').trim());
     const [savingName, setSavingName] = useState(false);
 
-    // Update selectedAvatarId when user changes
+    // Update selectedAvatarId when the active account's avatar changes
     useEffect(() => {
-        if (user?.avatar) {
-            setSelectedAvatarId(user.avatar);
+        if (activeAccount?.avatar) {
+            setSelectedAvatarId(activeAccount.avatar);
         } else if (newUser?.avatar) {
             setSelectedAvatarId(newUser.avatar);
         }
-    }, [user?.avatar, newUser?.avatar]);
+    }, [activeAccount?.avatar, newUser?.avatar]);
 
     const avatarUri = selectedAvatarId ? oxyServices.getFileDownloadUrl(selectedAvatarId, 'thumb') : undefined;
 

--- a/packages/services/src/ui/screens/trust/TrustCenterScreen.tsx
+++ b/packages/services/src/ui/screens/trust/TrustCenterScreen.tsx
@@ -20,8 +20,9 @@ const TrustCenterScreen: React.FC<BaseScreenProps> = ({
     goBack,
     navigate,
 }) => {
-    // Use useOxy() hook for OxyContext values
-    const { user, oxyServices, isAuthenticated } = useOxy();
+    // Reputation/trust is the ACTIVE account's standing (the org/project/bot
+    // when switched, else the personal user).
+    const { activeAccount, oxyServices, isAuthenticated } = useOxy();
     const { t } = useI18n();
     const [reputationTotal, setReputationTotal] = useState<number | null>(null);
     const [trustTier, setTrustTier] = useState<TrustTier | null>(null);
@@ -33,12 +34,12 @@ const TrustCenterScreen: React.FC<BaseScreenProps> = ({
     const primaryColor = bloomTheme.colors.primary;
 
     useEffect(() => {
-        if (!user) return;
+        if (!activeAccount) return;
         setIsLoading(true);
         setError(null);
         Promise.all([
-            oxyServices.getReputationBalance(user.id),
-            oxyServices.getReputationTransactions(user.id, 20, 0),
+            oxyServices.getReputationBalance(activeAccount.id),
+            oxyServices.getReputationTransactions(activeAccount.id, 20, 0),
         ])
             .then(([balance, txns]) => {
                 setReputationTotal(balance.total);
@@ -52,7 +53,7 @@ const TrustCenterScreen: React.FC<BaseScreenProps> = ({
                 );
             })
             .finally(() => setIsLoading(false));
-    }, [user, oxyServices, t]);
+    }, [activeAccount, oxyServices, t]);
 
     const trustTierLabel = useMemo(
         () => (trustTier ? getTrustTierLabel(trustTier, t) : null),

--- a/packages/services/src/ui/screens/trust/TrustRewardsScreen.tsx
+++ b/packages/services/src/ui/screens/trust/TrustRewardsScreen.tsx
@@ -77,7 +77,9 @@ const LOCKED_OPACITY = 0.5;
 
 const TrustRewardsScreen: React.FC<BaseScreenProps> = ({ goBack }) => {
     const { t } = useI18n();
-    const { user, oxyServices, isAuthenticated } = useOxy();
+    // Reputation/trust is the ACTIVE account's standing (the org/project/bot
+    // when switched, else the personal user).
+    const { activeAccount, oxyServices, isAuthenticated } = useOxy();
     const [reputationTotal, setReputationTotal] = useState<number>(0);
     const [, setIsLoading] = useState(true);
 
@@ -85,12 +87,12 @@ const TrustRewardsScreen: React.FC<BaseScreenProps> = ({ goBack }) => {
     const colors = bloomTheme.colors;
 
     useEffect(() => {
-        if (!user || !isAuthenticated) {
+        if (!activeAccount || !isAuthenticated) {
             setIsLoading(false);
             return;
         }
         setIsLoading(true);
-        oxyServices.getReputationBalance(user.id)
+        oxyServices.getReputationBalance(activeAccount.id)
             .then((balance) => {
                 setReputationTotal(balance.total || 0);
             })
@@ -98,7 +100,7 @@ const TrustRewardsScreen: React.FC<BaseScreenProps> = ({ goBack }) => {
                 setReputationTotal(0);
             })
             .finally(() => setIsLoading(false));
-    }, [user, isAuthenticated, oxyServices]);
+    }, [activeAccount, isAuthenticated, oxyServices]);
 
     const achievements: Achievement[] = useMemo(() => [
         {


### PR DESCRIPTION
Identity surfaces across @oxyhq/services now show the active account; populated 230 missing i18n keys (en-US 100% + es-ES). core@4.0.1, services@13.0.2.