### PR TITLE
feat(api): accept did: actorUri in PUT /users/resolve (atproto external actors)

### DIFF
--- a/packages/api/src/routes/__tests__/usersResolve.test.ts
+++ b/packages/api/src/routes/__tests__/usersResolve.test.ts
@@ -402,6 +402,95 @@ describe('PUT /users/resolve (C4)', () => {
     fetchSpy.mockRestore();
   });
 
+  // ----------------------------------------------------------------------
+  // AT Protocol (Bluesky) external actors are keyed by a hostless DID
+  // (`did:plc:…` / `did:web:…`), not an http(s) ActivityPub actor URL. The DID
+  // is accepted and stored verbatim as the federation dedup key; the URL parse
+  // + hostname/WebFinger host-binding (which are AP-only and impossible for a
+  // hostless identifier) MUST be skipped for it.
+  // ----------------------------------------------------------------------
+
+  it('resolves a did:plc: actorUri verbatim and skips the AP host-binding/WebFinger check', async () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+
+    const leanResult = jest.fn().mockResolvedValue(null);
+    const selectResult = jest.fn().mockReturnValue({ lean: leanResult });
+    mockUserFindOne.mockReturnValueOnce({ select: selectResult });
+
+    const actorUri = 'did:plc:ewvi7nxzyoun6zhxrhs64oiz';
+    const newUserDoc = { _id: 'bsky-user', username: 'alice.bsky.social@bsky.social', type: 'federated' };
+    const updateLean = jest.fn().mockResolvedValue(newUserDoc);
+    const updateSelect = jest.fn().mockReturnValue({ lean: updateLean });
+    mockUserFindOneAndUpdate.mockReturnValueOnce({ select: updateSelect });
+
+    const res = await requestJson(server, 'PUT', '/users/resolve', {
+      type: 'federated',
+      username: 'alice.bsky.social@bsky.social',
+      actorUri,
+      domain: 'bsky.social',
+    });
+
+    expect(res.status).toBe(200);
+    // No WebFinger / host-binding network call for a DID actor.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // DID stored verbatim as both the dedup filter key and the persisted value.
+    expect(mockUserFindOneAndUpdate).toHaveBeenCalledWith(
+      { 'federation.actorUri': actorUri },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          username: 'alice.bsky.social@bsky.social',
+          'federation.actorUri': actorUri,
+          'federation.domain': 'bsky.social',
+          'federation.lastResolvedAt': expect.any(Date),
+        }),
+        $unset: expect.objectContaining({
+          'federation.unavailableAt': '',
+          'federation.unavailableReason': '',
+        }),
+      }),
+      expect.anything(),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it('resolves a did:web: actorUri verbatim and skips the AP host-binding/WebFinger check', async () => {
+    const fetchSpy = jest.spyOn(globalThis, 'fetch');
+
+    const leanResult = jest.fn().mockResolvedValue(null);
+    const selectResult = jest.fn().mockReturnValue({ lean: leanResult });
+    mockUserFindOne.mockReturnValueOnce({ select: selectResult });
+
+    const actorUri = 'did:web:example.com';
+    const newUserDoc = { _id: 'didweb-user', username: 'alice@example.com', type: 'federated' };
+    const updateLean = jest.fn().mockResolvedValue(newUserDoc);
+    const updateSelect = jest.fn().mockReturnValue({ lean: updateLean });
+    mockUserFindOneAndUpdate.mockReturnValueOnce({ select: updateSelect });
+
+    const res = await requestJson(server, 'PUT', '/users/resolve', {
+      type: 'federated',
+      username: 'alice@example.com',
+      actorUri,
+      domain: 'example.com',
+    });
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockUserFindOneAndUpdate).toHaveBeenCalledWith(
+      { 'federation.actorUri': actorUri },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          username: 'alice@example.com',
+          'federation.actorUri': actorUri,
+          'federation.domain': 'example.com',
+        }),
+      }),
+      expect.anything(),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
   it('refresh: schedules an off-request-path avatar download with force=true and returns immediately', async () => {
     const newAvatarUrl = 'https://mastodon.social/avatars/alice.png';
 

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1231,9 +1231,11 @@ router.delete(
  *
  * Hardening (C4):
  *  - Scope check: rejects service tokens that lack `federation:write`.
- *  - Actor URI binding: `actorUri.hostname` must match the asserted
- *    `domain` (so a malicious service can't claim to vouch for a user on
- *    a host they don't actually own).
+ *  - Actor URI binding (http(s) ActivityPub actors only): `actorUri.hostname`
+ *    must match the asserted `domain` (so a malicious service can't claim to
+ *    vouch for a user on a host they don't actually own). AT Protocol (Bluesky)
+ *    actors are identified by a hostless DID (`did:plc:`/`did:web:`); the DID is
+ *    stored verbatim and the host-binding check is skipped for it.
  *  - Username squatting: for `agent` / `automated`, refuse to upsert when
  *    a `local` (or other-type) user already owns the username.
  *  - Type immutability: never let `type` change on an existing user — a
@@ -1241,8 +1243,11 @@ router.delete(
  *
  * @body {'federated' | 'agent' | 'automated'} type
  * @body {string} username      - Unique username (e.g. "user@mastodon.social")
- * @body {string} [actorUri]    - ActivityPub actor URI (required for federated)
- * @body {string} [domain]      - Origin domain (required for federated)
+ * @body {string} [actorUri]    - Actor identifier (required for federated): an
+ *                                http(s) ActivityPub actor URI, or an AT Protocol
+ *                                DID (`did:plc:…` / `did:web:…`) for Bluesky actors
+ * @body {string} [domain]      - Origin domain (required for federated): the
+ *                                handle host (e.g. `bsky.social`) for atproto
  * @body {string} [displayName] - Display name
  * @body {string} [avatar]      - Avatar URL or asset ID
  * @body {string} [bio]         - Profile bio
@@ -1285,6 +1290,21 @@ function normalizeFederatedResolveUsername(username: string): string | null {
 function actorHostnameMatchesFederatedDomain(actorHostname: string, domain: string): boolean {
   const normalizedActorHostname = normalizeFederatedResolveDomain(actorHostname);
   return normalizedActorHostname === domain || normalizedActorHostname === `www.${domain}`;
+}
+
+/**
+ * AT Protocol (Bluesky) external actors are identified by a DID, not an http(s)
+ * ActivityPub actor URL. atproto uses exactly two DID methods — `did:plc:` and
+ * `did:web:` — and the DID is an opaque, globally-unique identifier with no host
+ * to parse. The URL/hostname binding that guards http(s) AP actors is therefore
+ * meaningless (and impossible) for a DID, so a DID actorUri is accepted and
+ * stored verbatim as the federation dedup key. The `did:` scheme and method
+ * name are lower-case per the DID spec; require a non-empty method-specific
+ * identifier after the prefix.
+ */
+const ATPROTO_DID_ACTOR_URI = /^did:(?:plc|web):\S+$/;
+function isAtprotoDidActorUri(actorUri: string): boolean {
+  return ATPROTO_DID_ACTOR_URI.test(actorUri);
 }
 
 async function verifyFederatedWebFingerBinding(username: string, actorUri: string): Promise<boolean> {
@@ -1372,14 +1392,26 @@ router.put(
       if (!domain || typeof domain !== 'string') {
         throw new BadRequestError('domain is required for federated users');
       }
+
+      // AT Protocol (Bluesky) external actors are keyed by a DID
+      // (`did:plc:…` / `did:web:…`) rather than an http(s) ActivityPub actor
+      // URL. A DID carries no host, so the URL parse + hostname/WebFinger
+      // binding below are AP-only and are skipped for it — the DID is stored
+      // verbatim as the dedup key. The `domain` carried alongside is the handle
+      // host (e.g. `bsky.social`) or the did:web host; it is stored as given and
+      // we never try to parse a host out of the DID itself.
+      const isDidActor = isAtprotoDidActorUri(actorUri);
+
       // Bind the actor URI hostname to the asserted domain so a service
       // can't claim "alice@mastodon.social" actually lives at
-      // attacker.example.
-      let actorHostname: string;
-      try {
-        actorHostname = new URL(actorUri).hostname.toLowerCase();
-      } catch {
-        throw new BadRequestError('actorUri must be a valid URL');
+      // attacker.example. http(s) AP actors only — a DID has no host to bind.
+      let actorHostname: string | null = null;
+      if (!isDidActor) {
+        try {
+          actorHostname = new URL(actorUri).hostname.toLowerCase();
+        } catch {
+          throw new BadRequestError('actorUri must be a valid http(s) URL or a did: URI');
+        }
       }
       const normalisedDomain = normalizeFederatedResolveDomain(domain);
       const normalisedUsername = normalizeFederatedResolveUsername(username);
@@ -1401,8 +1433,14 @@ router.put(
         throw new BadRequestError('Cannot resolve a user on an own federation domain');
       }
 
+      // http(s) AP host binding: the actor's host must match the asserted
+      // domain (or the domain must vouch for the handle via WebFinger). DID
+      // actors carry no host and are not WebFinger-resolvable, so this AP-only
+      // check is skipped for them — the `federation:write` scope plus the
+      // username↔domain binding above are the trust anchor for atproto actors.
       if (
-        !actorHostnameMatchesFederatedDomain(actorHostname, normalisedDomain)
+        actorHostname !== null
+        && !actorHostnameMatchesFederatedDomain(actorHostname, normalisedDomain)
         && !(await verifyFederatedWebFingerBinding(normalisedUsername, actorUri))
       ) {
         throw new BadRequestError('actorUri hostname does not match domain');


### PR DESCRIPTION
## Summary

- `PUT /users/resolve` now accepts a `did:plc:…` or `did:web:…` actorUri for Bluesky/AT Protocol external actors
- DID actorUris bypass the URL parse + hostname/WebFinger host-binding check (AP-only — hostless identifiers cannot satisfy it) and are stored verbatim as the federation dedup key
- All existing `http(s)://` ActivityPub behavior, record shape, dedup, and returned id are unchanged
- Adds `did:plc:` and `did:web:` resolve tests to `usersResolve.test.ts`

## Test plan

- [x] Full api jest suite: 1201 passed / 1201 total, 125 suites green (run by caller before push)
- [x] `bunx tsc --noEmit` — zero NEW errors vs main baseline
- [x] `did:plc:` and `did:web:` resolve tests added and passing
- [x] Existing `http(s)://` AP resolve tests unchanged and still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)