### PR TITLE
fix(accounts): persist switched account across web reload

### DIFF
--- a/packages/services/__tests__/context/refreshCookieRestore.test.tsx
+++ b/packages/services/__tests__/context/refreshCookieRestore.test.tsx
@@ -135,6 +135,11 @@ describe('Cold-boot restore via secure refresh cookies (multi-account)', () => {
     captured = { isAuthenticated: false, userId: undefined, isTokenReady: false };
     setTokensSpy.mockClear();
     isFedCMSupportedSpy.mockClear();
+    // Default: FedCM unsupported (these cross-domain restore cases don't need
+    // it). Reset the IMPLEMENTATION too — `mockClear` only clears call history,
+    // so a test that opts into FedCM via `mockReturnValue(true)` would otherwise
+    // leak that into the next test.
+    isFedCMSupportedSpy.mockReturnValue(false);
     // `accounts.oxy.so` is a first-party RP, NOT the central IdP, so a fully
     // logged-out cold boot ends in the terminal `sso-bounce`. Spy the
     // navigation seam so it is observable and never tears down jsdom.
@@ -263,5 +268,87 @@ describe('Cold-boot restore via secure refresh cookies (multi-account)', () => {
     expect(setTokensSpy).toHaveBeenCalledWith(SLOT_1_TOKEN);
     expect(window.localStorage.getItem(ACTIVE_AUTHUSER_KEY)).toBe('1');
     expect(window.localStorage.getItem(ACTIVE_SESSION_KEY)).toBe(SLOT_1_SESSION_ID);
+  });
+
+  it('CASE switched account survives reload: a persisted non-primary authuser makes the multi-account cookie restore WIN before fedcm-silent (which only knows the primary)', async () => {
+    // REGRESSION GUARD ("switch is lost on reload"): the user previously
+    // SWITCHED into a managed/org account — its REAL session joined the device
+    // multi-account set as slot 1 and the active slot was persisted
+    // (`oxy_active_authuser = 1`). On a hard reload, Chrome `fedcm-silent` WOULD
+    // recover the PRIMARY central session (slot 0) and — before this fix — won
+    // first because it sits ahead of the cookie-restore step, silently reverting
+    // the switch. With the fix, the persisted slot runs the multi-account cookie
+    // restore FIRST (it is the only step that honors WHICH slot was active), so
+    // the switched account is restored, not the primary.
+    window.localStorage.setItem(ACTIVE_AUTHUSER_KEY, '1');
+
+    const SLOT_1_SESSION_ID = 'sess_switched_1';
+    const SLOT_1_USER_ID = 'managed_org_user';
+    const SLOT_1_TOKEN = buildAccessToken({
+      sessionId: SLOT_1_SESSION_ID,
+      userId: SLOT_1_USER_ID,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const stub = baseStub({
+      // After cookie restore plants slot 1, `getCurrentUser` resolves the
+      // canonical (switched) user — so `captured.userId` reflecting it proves
+      // the switched account is the one that was committed.
+      getCurrentUser: jest.fn(async (): Promise<User> => ({ id: SLOT_1_USER_ID, username: 'org' } as User)),
+    });
+    // FedCM is supported AND silent reauthn returns the PRIMARY session, so the
+    // `fedcm-silent` step is genuinely ARMED — if it ran first (the bug) it would
+    // win and clobber the switch back to the primary.
+    isFedCMSupportedSpy.mockReturnValue(true);
+    stub.silentSignInWithFedCM = jest.fn(async () => ({
+      sessionId: COOKIE_SESSION_ID,
+      deviceId: 'dev_primary',
+      accessToken: COOKIE_ACCESS_TOKEN,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      user: { id: COOKIE_USER_ID, username: 'tester' },
+    }));
+    // Unique base URL so the module-level silent run-once guard cannot pre-disable
+    // `fedcm-silent` from a sibling test — the step must be genuinely armed so the
+    // assertion "cookie restore beats it" is meaningful.
+    stub.getBaseURL = () => 'https://api.oxy.so/switched-account';
+    stub.getSessionBaseUrl = () => 'https://api.oxy.so/switched-account';
+    stub.refreshAllSessions = jest.fn(async () => ({
+      accounts: [
+        {
+          authuser: 0,
+          accessToken: COOKIE_ACCESS_TOKEN,
+          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          sessionId: COOKIE_SESSION_ID,
+          user: { id: COOKIE_USER_ID, username: 'tester', avatar: null, color: null },
+        },
+        {
+          authuser: 1,
+          accessToken: SLOT_1_TOKEN,
+          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          sessionId: SLOT_1_SESSION_ID,
+          user: { id: SLOT_1_USER_ID, username: 'org', avatar: null, color: null },
+        },
+      ],
+    }));
+
+    renderProvider(stub);
+
+    await waitFor(() => expect(captured.isAuthenticated).toBe(true));
+
+    // The SWITCHED (slot 1) account is restored — NOT the primary (slot 0).
+    expect(captured.userId).toBe(SLOT_1_USER_ID);
+    // The slot-1 token was planted on the HTTP client.
+    expect(setTokensSpy).toHaveBeenCalledWith(SLOT_1_TOKEN);
+    // Cookie restore won FIRST: the armed fedcm-silent step was never reached.
+    expect(stub.silentSignInWithFedCM).not.toHaveBeenCalled();
+    expect(stub.refreshAllSessions).toHaveBeenCalledTimes(1);
+    // No terminal SSO bounce (a session was recovered).
+    expect(ssoNavigateSpy).not.toHaveBeenCalled();
+
+    // The active slot + session id are (re)persisted to the switched account.
+    await waitFor(() =>
+      expect(window.localStorage.getItem(ACTIVE_SESSION_KEY)).toBe(SLOT_1_SESSION_ID),
+    );
+    expect(window.localStorage.getItem(ACTIVE_AUTHUSER_KEY)).toBe('1');
   });
 });

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -1309,6 +1309,29 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       }
     }
 
+    // LAST-ACTIVE-ACCOUNT priority (web multi-account). When the user has an
+    // explicit persisted active slot (`oxy_active_authuser`, written on every
+    // device sign-in / account SWITCH / cookie restore), the multi-account
+    // refresh-cookie restore is the ONLY cold-boot step that honors WHICH slot
+    // was last active — `restoreViaRefreshCookie` selects it via
+    // `selectActiveRefreshAccount(accounts, readActiveAuthuser())`. The
+    // `fedcm-silent` and per-apex `silent-iframe` steps only ever recover the
+    // PRIMARY central IdP session, so if either ran first they would clobber a
+    // switched (managed/org) account back to the primary on reload — the exact
+    // "switch is lost on reload" regression. So when a slot selection exists we
+    // run cookie-restore BEFORE those probes (and disable the later duplicate).
+    //
+    // Read ONCE here (synchronously usable by the step `enabled` gates below).
+    // It is non-null ONLY on first-party `*.oxy.so` web apps that persist the
+    // slot — a cross-apex RP never writes it (its restore funnels through
+    // `handleWebSSOSession`, which does not touch the authuser), and native has
+    // no localStorage, so both keep their existing order untouched. The
+    // earlier `stored-session` step still runs first (FIX-A latency), and when
+    // a slot exists but its cookies have all lapsed, cookie-restore simply
+    // returns no accounts and the chain falls through to the cross-domain
+    // fallbacks exactly as before.
+    const prioritizeMultiAccount = isWebBrowser() && readActiveAuthuser() !== null;
+
     try {
       const outcome = await runColdBoot<true>({
         steps: [
@@ -1404,6 +1427,28 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             },
           },
           {
+            // 2.75) LAST-ACTIVE multi-account restore (WEB, prioritized). Runs
+            // ONLY when an explicit persisted slot selection exists
+            // (`prioritizeMultiAccount`) — i.e. the user previously signed in or
+            // SWITCHED accounts on this first-party app. It runs BEFORE the
+            // `fedcm-silent` / `silent-iframe` probes (which only ever recover the
+            // PRIMARY central session) so a switched managed/org account survives
+            // reload instead of being clobbered back to the primary. The restore
+            // itself is the SAME `restoreViaRefreshCookie` as the terminal-tier
+            // step below: it rotates every device-local `oxy_rt_<authuser>` cookie
+            // and picks the persisted slot via `selectActiveRefreshAccount`,
+            // committing it (token + state + durable persistence + `markAuthResolved`).
+            // When no slot is persisted this is disabled and the original order is
+            // unchanged; when the slot's cookies have lapsed it returns no accounts
+            // and the chain falls through to the cross-domain fallbacks below.
+            id: 'cookie-restore-active',
+            enabled: () => prioritizeMultiAccount,
+            run: async () => {
+              const restored = await restoreViaRefreshCookie();
+              return restored ? { kind: 'session', session: true } : { kind: 'skip' };
+            },
+          },
+          {
             // 3) FedCM silent reauthn (Chrome) against the CENTRAL IdP
             // (auth.oxy.so). `silentSignInWithFedCM` plants the access token
             // internally; we commit the returned session via
@@ -1477,8 +1522,15 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             // is correct; cross-domain restore is handled by the SSO bounce.
             // FIX-D: `restoreViaRefreshCookie` bounds the request with
             // `COOKIE_RESTORE_TIMEOUT` so a cross-domain stall cannot hang here.
+            //
+            // Disabled when `prioritizeMultiAccount` already ran the
+            // `cookie-restore-active` step above (an explicit persisted slot) — that
+            // earlier step is the identical restore, so this terminal-tier copy
+            // would be a redundant second `refreshAllSessions`. It still runs in the
+            // common no-persisted-slot case (e.g. first visit to a first-party app
+            // whose central refresh cookies already exist).
             id: 'cookie-restore',
-            enabled: () => isWebBrowser(),
+            enabled: () => isWebBrowser() && !prioritizeMultiAccount,
             run: async () => {
               const restored = await restoreViaRefreshCookie();
               return restored ? { kind: 'session', session: true } : { kind: 'skip' };


### PR DESCRIPTION
Cold-boot multi-account restore now wins over fedcm-silent when a switch was made, so reload keeps the switched account.

## What changed

A persisted non-null active authuser (set when the user deliberately switches accounts) now triggers a `cookie-restore-active` cold-boot step that runs **before** `fedcm-silent`. Previously, fedcm-silent restored the primary IdP session first and won the race, reverting the switched account on every web reload.

## Scope

- `packages/services/src/ui/context/OxyContext.tsx` — new `cookie-restore-active` step in the cold-boot chain
- `packages/services/__tests__/context/refreshCookieRestore.test.tsx` — test coverage for the new step

Cross-apex RPs, native cold-boot, and first-visit flows are unchanged; all existing cold-boot safety guards preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)