### PR TITLE
fix(accounts): switched session joins device multi-account set (no slot clobber)

### DIFF
--- a/packages/api/src/routes/__tests__/accountsSwitch.test.ts
+++ b/packages/api/src/routes/__tests__/accountsSwitch.test.ts
@@ -6,11 +6,17 @@
  * the authorization gate + response shape without a database:
  *  - account.service.verifyActingAs → controls act_as authorization,
  *  - User.findById → the target account doc,
- *  - sessionService.createSession + issueAndSetRefreshCookie → session minting.
+ *  - sessionService.createSession → session minting.
  *
  * Asserts: non-members are rejected (403); a personal account is never a switch
  * target (403); an authorized member mints a session whose user is the target and
  * records the operator; the response mirrors the login/claimSession shape.
+ *
+ * ROOT-CAUSE GUARD (slot-clobber regression): the switch route MUST NOT write any
+ * `oxy_rt_<authuser>` refresh cookie. Those cookies are `Path=/auth` scoped, so
+ * the browser never sends them to this `/accounts/*` route; issuing one blind here
+ * always picks slot 0 and OVERWRITES the operator's own primary session. The SDK
+ * establishes the device cookie via `POST /auth/session` (under `/auth`) instead.
  */
 
 import express from 'express';
@@ -42,12 +48,6 @@ jest.mock('../../services/session.service', () => ({
   default: { createSession: (...args: unknown[]) => mockCreateSession(...args) },
 }));
 
-const mockIssueCookie = jest.fn();
-jest.mock('../../services/refreshToken.service', () => ({
-  __esModule: true,
-  issueAndSetRefreshCookie: (...args: unknown[]) => mockIssueCookie(...args),
-}));
-
 const mockAuthMiddleware = jest.fn();
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
@@ -68,6 +68,7 @@ import { errorHandler } from '../../middleware/errorHandler';
 
 interface JsonResponse {
   status: number;
+  setCookie: string[];
   body: Record<string, unknown> & {
     user?: { id?: string; username?: string };
     sessionId?: string;
@@ -95,7 +96,12 @@ function post(srv: http.Server, path: string): Promise<JsonResponse> {
         res.on('data', (c) => { raw += c; });
         res.on('end', () => {
           try {
-            resolve({ status: res.statusCode ?? 0, body: raw.length > 0 ? JSON.parse(raw) : {} });
+            const setCookie = res.headers['set-cookie'] ?? [];
+            resolve({
+              status: res.statusCode ?? 0,
+              setCookie: Array.isArray(setCookie) ? setCookie : [setCookie],
+              body: raw.length > 0 ? JSON.parse(raw) : {},
+            });
           } catch (err) { reject(err); }
         });
       }
@@ -126,7 +132,6 @@ beforeEach(() => {
   mockVerifyActingAs.mockReset();
   mockFindById.mockReset();
   mockCreateSession.mockReset();
-  mockIssueCookie.mockReset();
 });
 
 describe('POST /accounts/:id/switch', () => {
@@ -169,7 +174,6 @@ describe('POST /accounts/:id/switch', () => {
       expiresAt: new Date('2030-01-01T00:00:00.000Z'),
       accessToken: 'acc-1',
     });
-    mockIssueCookie.mockResolvedValue({ accessToken: 'acc-1', expiresAt: new Date(), authuser: 2 });
 
     const res = await post(server, `/accounts/${ORG_ID}/switch`);
 
@@ -179,11 +183,35 @@ describe('POST /accounts/:id/switch', () => {
     expect(res.body.user?.username).toBe('acme-org');
     expect(res.body.sessionId).toBe('sess-1');
     expect(res.body.accessToken).toBe('acc-1');
-    expect(res.body.authuser).toBe(2);
     // Operator recorded on the minted session.
     expect(mockCreateSession).toHaveBeenCalledWith(ORG_ID, expect.anything(), { operatedByUserId: OPERATOR_ID });
-    // Added to the device multi-account set.
-    expect(mockIssueCookie).toHaveBeenCalled();
+  });
+
+  it('does NOT write a refresh cookie (slot-clobber guard) — establishment is deferred to /auth/session', async () => {
+    mockVerifyActingAs.mockResolvedValue('admin');
+    mockFindById.mockResolvedValue({
+      _id: new Types.ObjectId(ORG_ID),
+      username: 'acme-org',
+      kind: 'organization',
+      accountStatus: 'active',
+    });
+    mockCreateSession.mockResolvedValue({
+      sessionId: 'sess-1',
+      deviceId: 'dev-1',
+      expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+      accessToken: 'acc-1',
+    });
+
+    const res = await post(server, `/accounts/${ORG_ID}/switch`);
+
+    expect(res.status).toBe(200);
+    // The route lives at /accounts/* — outside the oxy_rt_* cookie's Path=/auth
+    // scope — so it can never see the device's existing slots. Issuing a cookie
+    // here would blindly take slot 0 and destroy the operator's own session.
+    // It MUST leave the cookie untouched; the SDK establishes it via /auth/session.
+    expect(res.setCookie.some((c) => /(^|\s)oxy_rt_\d+=/.test(c) && !/Max-Age=0/.test(c))).toBe(false);
+    // No authuser is resolved by this route — the SDK gets it from /auth/session.
+    expect(res.body.authuser).toBeUndefined();
   });
 
   it('returns 404 for a missing/archived target', async () => {

--- a/packages/api/src/routes/__tests__/authSessionLogout.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionLogout.test.ts
@@ -11,6 +11,10 @@
  *  - bearer-authenticated (authMiddleware sets req.user + next): mints + sets an
  *    `oxy_rt_0` cookie (Path=/auth) for the session derived ONLY from the
  *    caller's own bearer token, and returns { accessToken, expiresAt, authuser }.
+ *  - account-switch coexistence: when an existing `oxy_rt_0` (a DIFFERENT user)
+ *    is presented, the switched bearer's session lands in a NEW slot (`oxy_rt_1`)
+ *    and the operator's slot 0 is neither overwritten nor revoked. This is the
+ *    establishment step the SDK runs after `POST /accounts/:id/switch`.
  *  - invalid/missing bearer (authMiddleware responds 401): 401, no cookie minted.
  *
  * `/auth/logout`:
@@ -396,6 +400,67 @@ describe('POST /auth/session', () => {
     // Value is a real token, not empty (i.e. not a clear).
     const value = (cookie as string).split(';')[0].slice(`${REFRESH_COOKIE_SLOT_0}=`.length);
     expect(value.length).toBeGreaterThan(0);
+  });
+
+  it('allocates a NEW slot (oxy_rt_1) for the switched account and PRESERVES the operator\'s oxy_rt_0 — the account-switch coexistence contract', async () => {
+    // This is EXACTLY what the SDK does immediately after POST /accounts/:id/switch:
+    // the switched managed account is now the bearer, while the operator's primary
+    // session is still parked in oxy_rt_0. Crucially this runs at /auth/session
+    // (Path=/auth), so the browser DOES present oxy_rt_0 here — unlike the
+    // /accounts/* switch route, which never receives it and is why issuing the
+    // cookie there blindly clobbered slot 0. The server sees slot 0 is held by a
+    // DIFFERENT user and allocates slot 1; it must never overwrite or revoke the
+    // operator's slot. Proves: 2nd user gets a NEW slot AND the primary survives.
+    const OPERATOR_ID = '64f7c2a1b8e9d3f4a1c2b3d5'; // distinct from TEST_USER_ID
+    const operatorRaw = 'operator-slot0-raw-token';
+    stageToken(buildStoredToken(operatorRaw, {
+      _id: 'rt-operator',
+      sessionId: 'sess-operator',
+      family: 'fam-operator',
+      userId: { toString: () => OPERATOR_ID },
+    }));
+
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
+    // Bearer = the switched managed account; its session id comes from its token.
+    mockExtractToken.mockReturnValueOnce('switched-bearer-jwt');
+    mockDecodeToken.mockReturnValueOnce({ sessionId: 'sess-switched', userId: TEST_USER_ID });
+    mockCreate.mockResolvedValueOnce({});
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'switched-access-jwt', expiresAt });
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/session',
+      {},
+      {
+        bearer: 'switched-bearer-jwt',
+        origin: 'https://accounts.oxy.so',
+        cookieHeader: `oxy_rt_0=${operatorRaw}`,
+      }
+    );
+
+    expect(res.status).toBe(200);
+    // The switched account lands in a NEW slot — never the operator's slot 0.
+    expect(res.body.authuser).toBe(1);
+
+    // oxy_rt_1 is set with a real (non-empty) token, scoped to /auth.
+    const slot1 = res.setCookie.find((c) => c.startsWith('oxy_rt_1='));
+    expect(slot1).toBeDefined();
+    expect(slot1).toContain('Path=/auth');
+    expect((slot1 as string).split(';')[0].slice('oxy_rt_1='.length).length).toBeGreaterThan(0);
+
+    // The operator's slot 0 is NEVER overwritten (no oxy_rt_0 token write) and
+    // NEVER revoked (no family revoke). Both accounts now coexist on the device.
+    const slot0Token = res.setCookie.find(
+      (c) => c.startsWith('oxy_rt_0=') && !/Max-Age=0/i.test(c)
+    );
+    expect(slot0Token).toBeUndefined();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+
+    // The new cookie is bound to the SWITCHED session + user, not the operator's.
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'sess-switched', userId: TEST_USER_ID })
+    );
   });
 
   it('returns 400 and mints no cookie when the token arrives via ?token= in the URL', async () => {

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -7,13 +7,11 @@ import { validate } from '../middleware/validate';
 import { rateLimit } from '../middleware/rateLimiter';
 import { asyncHandler } from '../utils/asyncHandler';
 import { BadRequestError, ForbiddenError, NotFoundError, UnauthorizedError } from '../utils/error';
-import { logger } from '../utils/logger';
 import { accountService, type AccountNode, type EffectiveAccess } from '../services/account.service';
 import { User, IUser } from '../models/User';
 import { IAccountMember } from '../models/AccountMember';
 import { IAccountCredential } from '../models/AccountCredential';
 import sessionService from '../services/session.service';
-import { issueAndSetRefreshCookie } from '../services/refreshToken.service';
 import type { SessionAuthResponse } from '../types/session';
 import { resolveUserByIdentifier } from '../utils/resolveUserIdentifier';
 import { isPrivilegedScope, type ApplicationScope } from '../utils/applicationScopes';
@@ -281,12 +279,20 @@ router.get(
  * The caller (operator) must hold `account:act_as` over the target. The minted
  * session records the operator (`operatedByUserId`) for audit and binds its
  * validity to that membership — revoking it kills the session (re-checked on
- * validate + refresh). The session is added to the device's multi-account set
- * (`oxy_rt_*` cookie family), so it survives reload and propagates cross-domain
- * via `/auth/refresh-all` exactly like a device account.
+ * validate + refresh).
  *
- * Returns the SAME shape as login / claimSession (`SessionAuthResponse` +
- * `authuser`) so the client plants it as the active session.
+ * The session joins the device's multi-account set (`oxy_rt_<authuser>` cookie
+ * family) so it survives reload and propagates cross-domain via
+ * `/auth/refresh-all` — but that cookie is NOT set here. The refresh cookies are
+ * scoped to `Path=/auth` (REFRESH_COOKIE_PATH), so a browser never sends them to
+ * this `/accounts/*` route; setting one here would run blind to the device's
+ * existing slots and clobber slot 0 (the operator's own session). Instead the SDK
+ * plants the returned `accessToken` and then calls the canonical
+ * `POST /auth/session` — which IS under `/auth`, where the cookies are visible —
+ * to establish this session's refresh cookie in a correctly-allocated NEW slot.
+ *
+ * Returns the SAME shape as login / claimSession (`SessionAuthResponse`) so the
+ * client plants it as the active session.
  */
 router.post(
   '/:id/switch',
@@ -328,25 +334,16 @@ router.post(
       throw new Error('Failed to format account data');
     }
 
-    // Add the managed account to the device's multi-account set so it survives
-    // reload and propagates cross-domain via /auth/refresh-all (best-effort — a
-    // cookie failure must not break the switch).
-    let authuser: number | null = null;
-    try {
-      const issued = await issueAndSetRefreshCookie(res, session.sessionId, account._id, {
-        cookieHeader: req.headers.cookie,
-      });
-      authuser = issued.authuser;
-    } catch (error) {
-      logger.error('Failed to set refresh cookie during account switch', error instanceof Error ? error : new Error(String(error)), {
-        component: 'accounts',
-        method: 'switch',
-        accountId: account._id.toString(),
-      });
-    }
+    // The device multi-account refresh cookie is deliberately NOT set here — see
+    // the route docstring. The `oxy_rt_<authuser>` cookies are `Path=/auth`
+    // scoped, so this `/accounts/*` route never receives them; issuing one blind
+    // would always pick slot 0 and overwrite the operator's own primary session.
+    // The SDK plants the returned `accessToken` and establishes the cookie via
+    // `POST /auth/session` (under `/auth`, where the slots are visible) so the
+    // switched session lands in a correctly-allocated NEW slot.
 
     // Mirror the canonical login / claimSession response shape.
-    const response: SessionAuthResponse & { authuser?: number } = {
+    const response: SessionAuthResponse = {
       sessionId: session.sessionId,
       deviceId: session.deviceId,
       expiresAt: session.expiresAt.toISOString(),
@@ -357,9 +354,6 @@ router.post(
         avatar: userData.avatar,
       },
     };
-    if (authuser !== null) {
-      response.authuser = authuser;
-    }
 
     res.status(200).json(response);
   })

--- a/packages/core/src/mixins/OxyServices.accounts.ts
+++ b/packages/core/src/mixins/OxyServices.accounts.ts
@@ -35,6 +35,8 @@ import type { User } from '../models/interfaces';
 import type { SessionLoginResponse } from '../models/session';
 import type { OxyServicesBase } from '../OxyServices.base';
 import { normalizeUserIdentity } from '../utils/userIdentity';
+import { isWeb } from '../utils/platform';
+import { logger } from '../utils/loggerUtils';
 import { CACHE_TIMES } from './mixinHelpers';
 
 // ---------------------------------------------------------------------------
@@ -520,10 +522,19 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
      * Unlike the removed `X-Acting-As` delegation header, the returned session
      * IS the new identity: this plants `accessToken` as the active token —
      * exactly like `claimSessionByToken` / `verifyChallenge` — so every
-     * subsequent request authenticates as the target account. The refresh token
-     * is the server-set httpOnly `oxy_rt_<authuser>` cookie (never in the body),
-     * so it joins the device multi-account set and survives reload /
-     * `refresh-all` with no extra client work.
+     * subsequent request authenticates as the target account.
+     *
+     * Joining the device multi-account set (so the switch survives a reload and
+     * propagates cross-domain via `/auth/refresh-all`) requires a SECOND call, to
+     * `POST /auth/session`, made here after the token is planted. The switch route
+     * lives at `/accounts/*`, OUTSIDE the `oxy_rt_<authuser>` cookie's `Path=/auth`
+     * scope, so the server never sees the device's existing slots from it and
+     * would clobber slot 0 (destroying the operator's own session). `/auth/session`
+     * runs where those cookies ARE visible, so the server allocates a NEW slot that
+     * coexists with the operator's and returns its `authuser`. This step is
+     * web-only (native multi-account uses stored sessions, not cookies) and
+     * best-effort — a failure leaves the in-session switch intact; the switched
+     * account simply won't survive a reload until the cookie is next established.
      *
      * After planting, the SDK's identity-scoped GET cache is fully cleared so
      * every cached read re-fetches as the new account. (The consuming
@@ -546,10 +557,43 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
 
         // Plant the freshly minted session as the ACTIVE session, mirroring
         // `claimSessionByToken` / `verifyChallenge`: the response body carries
-        // the first access token; the refresh token is the server-set httpOnly
-        // cookie, so there is nothing else to store here.
+        // the first access token. The device refresh cookie is established below.
         if (res?.accessToken) {
           this.setTokens(res.accessToken);
+        }
+
+        // Register the switched session in the device's multi-account set by
+        // establishing its first-party refresh cookie. This MUST be a separate
+        // call to `POST /auth/session`: the switch route is at `/accounts/*`,
+        // outside the `oxy_rt_<authuser>` cookie's `Path=/auth` scope, so it can
+        // never read the device's existing slots and would overwrite slot 0
+        // (destroying the operator's own session). `/auth/session` runs where the
+        // cookies ARE visible, so the server allocates a NEW slot that coexists
+        // with the operator's and returns its `authuser`. Web-only; best-effort.
+        let authuser = res.authuser;
+        if (isWeb()) {
+          try {
+            const established = await this.makeRequest<{ accessToken?: string; authuser?: number }>(
+              'POST',
+              '/auth/session',
+              undefined,
+              { cache: false },
+            );
+            if (typeof established?.authuser === 'number') {
+              authuser = established.authuser;
+            }
+            // /auth/session mints a fresh access token off the same session;
+            // re-plant it so the active token matches the rotated cookie.
+            if (established?.accessToken) {
+              this.setTokens(established.accessToken);
+            }
+          } catch (error) {
+            logger.warn(
+              '[OxyServices] Failed to establish device refresh cookie after account switch; the switch is active in-session but may not survive a reload',
+              { component: 'OxyServices', method: 'switchToAccount' },
+              error,
+            );
+          }
         }
 
         // Identity changed → drop the entire GET response cache so no entry
@@ -561,6 +605,7 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
 
         return {
           ...res,
+          ...(typeof authuser === 'number' ? { authuser } : {}),
           user: normalizeUserIdentity(res.user),
         };
       } catch (error) {

--- a/packages/core/src/mixins/__tests__/accounts.test.ts
+++ b/packages/core/src/mixins/__tests__/accounts.test.ts
@@ -176,55 +176,98 @@ describe('OxyServices.accounts', () => {
   });
 
   describe('switchToAccount', () => {
+    // The switch route NO LONGER returns `authuser` or sets the device cookie —
+    // it can't (it's at /accounts/*, outside the Path=/auth cookie scope). The SDK
+    // establishes the cookie + resolves the slot via a follow-up POST /auth/session.
     const switchResponse: SwitchAccountResult = {
       sessionId: 'sess_switch',
       deviceId: 'dev_switch',
       expiresAt: '2026-06-30T01:00:00.000Z',
       accessToken: 'access_switch',
       user: { id: 'acc1', username: 'oxy-org', name: { displayName: 'Oxy Org' } },
-      authuser: 2,
     };
+    // POST /auth/session establishes the cookie in a correctly-allocated NEW slot
+    // and returns that slot + a fresh access token off the same session.
+    const sessionResponse = { accessToken: 'access_session', authuser: 1 };
 
-    it('posts to /:id/switch (no body, no cache), plants the token, sweeps the cache, and returns the session', async () => {
+    // Route makeRequest by path: the switch call vs the /auth/session establishment.
+    const routeByPath = (response = switchResponse) =>
+      makeRequestSpy.mockImplementation((_method: string, path: string) =>
+        Promise.resolve(path === '/auth/session' ? sessionResponse : response),
+      );
+
+    it('posts to /:id/switch then establishes the cookie via POST /auth/session, planting both tokens and sweeping the cache', async () => {
       const setTokensSpy = jest.spyOn(oxy, 'setTokens');
       const clearCacheSpy = jest.spyOn(oxy, 'clearCache');
-      makeRequestSpy.mockResolvedValue(switchResponse);
+      routeByPath();
 
       const result = await oxy.switchToAccount('acc1');
 
-      // Request shape: POST, exact path, no body, cache disabled.
+      // Switch request shape: POST, exact path, no body, cache disabled.
       expect(makeRequestSpy).toHaveBeenCalledWith(
         'POST',
         '/accounts/acc1/switch',
         undefined,
         expect.objectContaining({ cache: false }),
       );
+      // Then the canonical refresh-cookie establishment under /auth (where the
+      // device's oxy_rt_* slots ARE visible, so a NEW slot is allocated).
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/auth/session',
+        undefined,
+        expect.objectContaining({ cache: false }),
+      );
 
-      // Session planting: the access token from the body is installed as the
-      // active token (mirrors claimSessionByToken / verifyChallenge).
-      expect(setTokensSpy).toHaveBeenCalledWith('access_switch');
-      expect(oxy.getAccessToken()).toBe('access_switch');
+      // The switch token is planted first; /auth/session's fresh token re-planted.
+      expect(setTokensSpy).toHaveBeenNthCalledWith(1, 'access_switch');
+      expect(setTokensSpy).toHaveBeenNthCalledWith(2, 'access_session');
+      expect(oxy.getAccessToken()).toBe('access_session');
       expect(oxy.hasValidToken()).toBe(true);
 
-      // Identity changed → the whole GET cache is swept so reads refetch as the
-      // new account, AND it happens AFTER the token is planted.
+      // Cache swept once, AFTER both tokens are planted.
       expect(clearCacheSpy).toHaveBeenCalledTimes(1);
-      expect(setTokensSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(setTokensSpy.mock.invocationCallOrder[1]).toBeLessThan(
         clearCacheSpy.mock.invocationCallOrder[0],
       );
 
-      // The returned session carries the target account (id-normalised) + authuser.
-      expect(result).toEqual({ ...switchResponse, user: { id: 'acc1', username: 'oxy-org', name: { displayName: 'Oxy Org' } } });
-      expect(result.authuser).toBe(2);
+      // The returned session carries the target account (id-normalised) and the
+      // slot resolved by /auth/session — NEVER the clobbering slot 0.
+      expect(result.sessionId).toBe('sess_switch');
+      expect(result.user).toEqual({ id: 'acc1', username: 'oxy-org', name: { displayName: 'Oxy Org' } });
+      expect(result.authuser).toBe(1);
 
       setTokensSpy.mockRestore();
       clearCacheSpy.mockRestore();
     });
 
     it('URL-encodes the accountId path segment', async () => {
-      makeRequestSpy.mockResolvedValue(switchResponse);
+      routeByPath();
       await oxy.switchToAccount('a b/c');
       expect(makeRequestSpy.mock.calls[0][1]).toBe('/accounts/a%20b%2Fc/switch');
+    });
+
+    it('keeps the switch active in-session when /auth/session fails (best-effort cookie)', async () => {
+      const setTokensSpy = jest.spyOn(oxy, 'setTokens');
+      const clearCacheSpy = jest.spyOn(oxy, 'clearCache');
+      makeRequestSpy.mockImplementation((_method: string, path: string) =>
+        path === '/auth/session'
+          ? Promise.reject(Object.assign(new Error('origin'), { response: { status: 403 } }))
+          : Promise.resolve(switchResponse),
+      );
+
+      const result = await oxy.switchToAccount('acc1');
+
+      // The in-session switch survives: the switch token stays planted and the
+      // cache is still swept. The switched account just won't survive a reload
+      // until the cookie is next established (no authuser resolved).
+      expect(setTokensSpy).toHaveBeenCalledWith('access_switch');
+      expect(oxy.getAccessToken()).toBe('access_switch');
+      expect(clearCacheSpy).toHaveBeenCalledTimes(1);
+      expect(result.authuser).toBeUndefined();
+
+      setTokensSpy.mockRestore();
+      clearCacheSpy.mockRestore();
     });
 
     it('does NOT plant or sweep when the operator is not authorized (403 surfaces via handleError)', async () => {
@@ -235,9 +278,16 @@ describe('OxyServices.accounts', () => {
       );
 
       await expect(oxy.switchToAccount('acc1')).rejects.toThrow();
-      // A failed switch must NOT mutate session state.
+      // A failed switch must NOT mutate session state, and must NOT attempt the
+      // /auth/session establishment.
       expect(setTokensSpy).not.toHaveBeenCalled();
       expect(clearCacheSpy).not.toHaveBeenCalled();
+      expect(makeRequestSpy).not.toHaveBeenCalledWith(
+        'POST',
+        '/auth/session',
+        undefined,
+        expect.anything(),
+      );
 
       setTokensSpy.mockRestore();
       clearCacheSpy.mockRestore();


### PR DESCRIPTION
oxy_rt cookies are Path=/auth scoped so the /accounts switch route ran blind and clobbered slot 0; switchToAccount now establishes the cookie via the canonical /auth/session in a new slot. Primary session survives + switch persists across reload.