### PR TITLE
fix(build): order @oxyhq/core before auth-sdk + services in turbo filtered builds

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -232,13 +232,14 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@oxyhq/core": "workspace:^",
         "@types/node": "^20.19.9",
         "@types/react": "^19.2.17",
         "release-it": "^19.0.6",
         "typescript": "^5.9.2",
       },
       "peerDependencies": {
-        "@oxyhq/core": "^3.15.0 || ^4.0.0",
+        "@oxyhq/core": "^3.15.0 || ^4.0.0 || ^5.0.0",
         "@tanstack/query-sync-storage-persister": "^5.100",
         "@tanstack/react-query": "^5.100",
         "@tanstack/react-query-persist-client": "^5.100",
@@ -588,6 +589,7 @@
         "@biomejs/biome": "^1.9.4",
         "@commitlint/cli": "^17.6.5",
         "@commitlint/config-conventional": "^17.6.5",
+        "@oxyhq/core": "workspace:^",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@react-native/babel-preset": "^0.86.0",
@@ -628,7 +630,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.16.0",
-        "@oxyhq/core": "^4.0.0",
+        "@oxyhq/core": "^4.0.0 || ^5.0.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@tanstack/query-async-storage-persister": "^5.101",

--- a/packages/auth-sdk/package.json
+++ b/packages/auth-sdk/package.json
@@ -98,6 +98,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@oxyhq/core": "workspace:^",
     "@types/react": "^19.2.17",
     "@types/node": "^20.19.9",
     "release-it": "^19.0.6",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -109,6 +109,7 @@
     "@oxyhq/contracts": "workspace:*"
   },
   "devDependencies": {
+    "@oxyhq/core": "workspace:^",
     "nativewind": "5.0.0-preview.3",
     "react-native-css": "^3.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",


### PR DESCRIPTION
## Fix Cloudflare Pages build failure for console / accounts / inbox

After merging #447 (core 5.0.0 + @oxyhq/protocol extraction), the Cloudflare Pages deploy of **console**, **accounts**, and **inbox** failed at the build step with `TS2307: Cannot find module '@oxyhq/core'` (in `auth-sdk`'s `WebOxyProvider.tsx` and `services`).

### Root cause
turbo's `build` task `dependsOn: ["^build"]` orders builds topologically — but turbo's package graph only follows `dependencies`/`devDependencies`, **NOT `peerDependencies`**. `auth-sdk` and `services` declared `@oxyhq/core` *only* as a `peerDependency`, so turbo did not order `core` (and its new dependency `@oxyhq/protocol`) before them in a filtered build (`turbo run build --filter=<app>`). `auth-sdk`/`services` tsc started before `core`'s `dist/types` existed → `Cannot find module '@oxyhq/core'`. Turbo's remote cache had masked this latent race; the core 5.0.0 change busted the cache and exposed it. `deploy-auth` was unaffected (its app doesn't hit the racing node the same way).

### Fix
Add `@oxyhq/core: workspace:^` to the **devDependencies** of `auth-sdk` and `services` (the standard peer+dev pattern). devDependencies are not installed by consumers, so the `peerDependency` remains the published contract — this only gives turbo the build-order edge `core → protocol → contracts` before these packages.

### Verification (clean dist, cache-forced filtered builds)
- `turbo run build --filter=oxy-console` → 5/5 ✅
- `turbo run build --filter=accounts` → 5/5 ✅
- `turbo run build --filter=inbox` → 5/5 ✅
- Fresh-clone `bun install --frozen-lockfile` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)