### PR TITLE
fix(build): pin services + auth-sdk @oxyhq/core to workspace:*

### DIFF
--- a/packages/auth-sdk/package.json
+++ b/packages/auth-sdk/package.json
@@ -79,7 +79,8 @@
     "qrcode": "^1.5.4"
   },
   "peerDependencies": {
-    "@oxyhq/core": "^3.15.0 || ^4.0.0 || ^5.0.0",
+
+    "@oxyhq/core": "workspace:*",
     "@tanstack/query-sync-storage-persister": "^5.100",
     "@tanstack/react-query": "^5.100",
     "@tanstack/react-query-persist-client": "^5.100",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -152,7 +152,8 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.16.0",
-    "@oxyhq/core": "^4.0.0 || ^5.0.0",
+
+    "@oxyhq/core": "workspace:*",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@tanstack/query-async-storage-persister": "^5.101",


### PR DESCRIPTION
Range-spec @oxyhq/core in services/auth-sdk caused TS2307 in cold frontend builds once turbo cache was invalidated; workspace:* fixes it (matches contracts).