### PR TITLE
feat(api): service-token batch asset metadata endpoint POST /assets/service/by-ids

### DIFF
--- a/packages/api/src/routes/__tests__/assetsServiceCache.test.ts
+++ b/packages/api/src/routes/__tests__/assetsServiceCache.test.ts
@@ -42,6 +42,7 @@ const mockDeleteCachedMedia = jest.fn();
 const mockUploadFileDirect = jest.fn();
 const mockGetDeletionSummary = jest.fn();
 const mockDeleteFile = jest.fn();
+const mockGetFilesByIds = jest.fn();
 const mockUserFindOne = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
@@ -83,6 +84,7 @@ jest.mock('../../services/assetServiceSingleton', () => ({
     uploadFileDirect: (...args: unknown[]) => mockUploadFileDirect(...args),
     getDeletionSummary: (...args: unknown[]) => mockGetDeletionSummary(...args),
     deleteFile: (...args: unknown[]) => mockDeleteFile(...args),
+    getFilesByIds: (...args: unknown[]) => mockGetFilesByIds(...args),
   },
   s3Service: {},
 }));
@@ -97,9 +99,23 @@ jest.mock('../../models/User', () => ({
 import assetsRouter from '../assets';
 import { errorHandler } from '../../middleware/errorHandler';
 
+interface AssetMetadata {
+  id: string;
+  sha256: string;
+  mime: string;
+  size: number;
+  status: string;
+}
+
 interface JsonResponse {
   status: number;
-  body: { data?: { file?: { id?: string; sha256?: string }; message?: string }; error?: string; message?: string };
+  body: {
+    data?:
+      | { file?: { id?: string; sha256?: string }; message?: string }
+      | AssetMetadata[];
+    error?: string;
+    message?: string;
+  };
 }
 
 async function requestRaw(
@@ -192,6 +208,7 @@ beforeEach(() => {
       lean: () => Promise.resolve({ _id: FEDERATED_OWNER_ID, type: 'federated' }),
     }),
   });
+  mockGetFilesByIds.mockResolvedValue([]);
 
   // Default user principal for session-only routes.
   mockAuthMiddleware.mockImplementation(
@@ -456,6 +473,137 @@ describe('DELETE /assets/service/cache/:id', () => {
     );
 
     expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /assets/service/by-ids', () => {
+  function postByIds(ids: string[]): Promise<JsonResponse> {
+    const payload = Buffer.from(JSON.stringify({ ids }));
+    return requestRaw(
+      server,
+      'POST',
+      '/assets/service/by-ids',
+      { 'content-type': 'application/json', 'content-length': String(payload.length) },
+      payload
+    );
+  }
+
+  // Service principal carrying the files:read scope this route requires (the
+  // shared default principal only carries files:write/federation:write).
+  function grantFilesReadOnce(): void {
+    mockServiceAuthMiddleware.mockImplementationOnce(
+      (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
+        req.serviceApp = {
+          type: 'service',
+          appId: 'mention-app',
+          appName: 'mention',
+          scopes: ['files:read', 'files:write', 'federation:write'],
+        };
+        next();
+      }
+    );
+  }
+
+  it('returns metadata-only DTOs for known ids and omits deleted ones', async () => {
+    grantFilesReadOnce();
+    mockGetFilesByIds.mockResolvedValueOnce([
+      {
+        _id: { toString: () => CACHE_FILE_ID },
+        sha256: 'a'.repeat(64),
+        mime: 'image/png',
+        size: 1234,
+        status: 'active',
+        // Fields below must NOT leak into the response.
+        storageKey: 'public/content/2026/06/aa/secret.png',
+        ownerUserId: 'owner-1',
+        links: [{ app: 'mention' }],
+        variants: [{ type: 'thumb', key: 'k' }],
+      },
+      {
+        _id: { toString: () => USER_FILE_ID },
+        sha256: 'b'.repeat(64),
+        mime: 'video/mp4',
+        size: 9999,
+        status: 'deleted',
+      },
+    ]);
+
+    const res = await postByIds([CACHE_FILE_ID, USER_FILE_ID]);
+
+    expect(res.status).toBe(200);
+    expect(mockServiceAuthMiddleware).toHaveBeenCalledTimes(1);
+    expect(mockAuthMiddleware).not.toHaveBeenCalled();
+    expect(mockGetFilesByIds).toHaveBeenCalledWith([CACHE_FILE_ID, USER_FILE_ID]);
+
+    const data = res.body.data as AssetMetadata[];
+    expect(Array.isArray(data)).toBe(true);
+    // Deleted id is omitted.
+    expect(data).toHaveLength(1);
+    expect(data[0]).toEqual({
+      id: CACHE_FILE_ID,
+      sha256: 'a'.repeat(64),
+      mime: 'image/png',
+      size: 1234,
+      status: 'active',
+    });
+    // Metadata-only contract: no bytes/url/owner/links/variants/storageKey.
+    expect(Object.keys(data[0]).sort()).toEqual(['id', 'mime', 'sha256', 'size', 'status']);
+  });
+
+  it('omits unknown ids (no whole-batch 404)', async () => {
+    grantFilesReadOnce();
+    // Only one of the two requested ids resolves to a live file.
+    mockGetFilesByIds.mockResolvedValueOnce([
+      {
+        _id: { toString: () => CACHE_FILE_ID },
+        sha256: 'c'.repeat(64),
+        mime: 'image/jpeg',
+        size: 42,
+        status: 'active',
+      },
+    ]);
+
+    const res = await postByIds([CACHE_FILE_ID, USER_FILE_ID]);
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as AssetMetadata[];
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe(CACHE_FILE_ID);
+  });
+
+  it('requires the files:read service scope', async () => {
+    mockServiceAuthMiddleware.mockImplementationOnce(
+      (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
+        req.serviceApp = {
+          type: 'service',
+          appId: 'mention-app',
+          appName: 'mention',
+          scopes: ['files:write', 'federation:write'],
+        };
+        next();
+      }
+    );
+
+    const res = await postByIds([CACHE_FILE_ID]);
+
+    expect(res.status).toBe(403);
+    expect(mockGetFilesByIds).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty ids array with 400', async () => {
+    const res = await postByIds([]);
+
+    expect(res.status).toBe(400);
+    expect(mockGetFilesByIds).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than 100 ids with 400', async () => {
+    const ids = Array.from({ length: 101 }, (_v, i) => `64c00000000000000000${String(i).padStart(4, '0')}`);
+
+    const res = await postByIds(ids);
+
+    expect(res.status).toBe(400);
+    expect(mockGetFilesByIds).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/routes/assets.ts
+++ b/packages/api/src/routes/assets.ts
@@ -17,6 +17,7 @@ import {
   assetUrlQuerySchema,
   updateVisibilitySchema,
   batchAccessSchema,
+  assetsByIdsBodySchema,
 } from '../schemas/assets.schemas';
 import { generateMissingFilePlaceholder, TRANSPARENT_PNG_PLACEHOLDER } from '../utils/placeholders';
 import { buildCdnUrl, stripPublicPrefix, isPublicKey, CDN_REDIRECT_MAX_AGE_SECONDS } from '../config/cdn';
@@ -761,6 +762,101 @@ router.delete(
     });
 
     sendSuccess(res, { message: 'Cached asset deleted successfully' });
+  })
+);
+
+/**
+ * @openapi
+ * /assets/service/by-ids:
+ *   post:
+ *     tags:
+ *       - Files
+ *     summary: Batch-resolve asset metadata for a service
+ *     description: >
+ *       Service-token-only batch metadata read. Given up to 100 file ids,
+ *       returns the content hash (`sha256`), `mime`, `size`, and `status` for
+ *       each KNOWN, non-deleted file. This is a METADATA-ONLY surface — it never
+ *       returns bytes, signed URLs, owner ids, links, or any other field, so a
+ *       service token can map a file id to its content hash without being able
+ *       to read private file contents. Unknown, invalid, or deleted ids are
+ *       silently omitted from `data` (the batch never 404s as a whole).
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - ids
+ *             properties:
+ *               ids:
+ *                 type: array
+ *                 minItems: 1
+ *                 maxItems: 100
+ *                 items:
+ *                   type: string
+ *     responses:
+ *       200:
+ *         description: Resolved asset metadata (order not guaranteed).
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       sha256:
+ *                         type: string
+ *                       mime:
+ *                         type: string
+ *                       size:
+ *                         type: integer
+ *                       status:
+ *                         type: string
+ *                         enum: [active, trash]
+ *       400:
+ *         description: Validation failed (empty array or more than 100 ids).
+ *       401:
+ *         description: Missing or expired service token.
+ *       403:
+ *         description: Not a service token, or missing the files:read scope.
+ */
+router.post(
+  '/service/by-ids',
+  serviceAuthMiddleware,
+  validate({ body: assetsByIdsBodySchema }),
+  asyncHandler(async (req: ServiceAuthRequest, res: express.Response) => {
+    requireServiceScope(req, 'files:read');
+
+    const { ids } = req.body as { ids: string[] };
+
+    const files = await assetService.getFilesByIds(ids);
+
+    // Metadata only: never expose bytes, signed URLs, owner ids, storage keys,
+    // links, or variants. Deleted tombstones are omitted so a resolved id always
+    // maps to a live asset.
+    const data = files
+      .filter((file) => file.status !== 'deleted')
+      .map((file) => ({
+        id: file._id.toString(),
+        sha256: file.sha256,
+        mime: file.mime,
+        size: file.size,
+        status: file.status,
+      }));
+
+    logger.debug('POST /assets/service/by-ids', {
+      appId: req.serviceApp?.appId,
+      requested: ids.length,
+      resolved: data.length,
+    });
+
+    sendSuccess(res, data);
   })
 );
 

--- a/packages/api/src/schemas/assets.schemas.ts
+++ b/packages/api/src/schemas/assets.schemas.ts
@@ -32,3 +32,16 @@ export const batchAccessSchema = z.object({
   fileIds: z.array(z.string().min(1)).min(1).max(100),
   context: z.any().optional(),
 });
+
+// Maximum number of ids accepted by POST /assets/service/by-ids in a single
+// request. Mirrors the POST /users/by-ids cap so a single service call can
+// resolve all media of one post at once without unbounded fan-out.
+export const MAX_ASSETS_BY_IDS = 100;
+
+// POST /assets/service/by-ids
+export const assetsByIdsBodySchema = z.object({
+  ids: z
+    .array(z.string().trim().min(1))
+    .min(1, 'ids must not be empty')
+    .max(MAX_ASSETS_BY_IDS, `Cannot request more than ${MAX_ASSETS_BY_IDS} assets at once`),
+});


### PR DESCRIPTION
## Summary

- Adds `POST /assets/service/by-ids` — service-token-authenticated (serviceAuthMiddleware + `files:read` scope) batch asset metadata read
- Returns `{id, sha256, mime, size, status}` for up to `MAX_ASSETS_BY_IDS` IDs per request; metadata-only, no bytes or download URLs
- Enables MTN blob-ref resolution from backend service clients (Mention backend → oxy-api) without exposing signed CDN URLs
- New `assetsByIdsBodySchema` + `MAX_ASSETS_BY_IDS` constant in `assets.schemas.ts`; `@openapi` doc block on the route
- New tests in `assetsServiceCache.test.ts` covering auth enforcement, payload validation, and response shape

## Test plan

- [ ] `bun run test` in `packages/api` — new `assetsServiceCache.test.ts` suite green
- [ ] `bun run build` in root — tsc clean
- [ ] Hit the endpoint with a valid service token + `files:read` scope and verify `{id,sha256,mime,size,status}` shape
- [ ] Verify a request without service auth returns 401/403
- [ ] Verify a batch over the cap returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)