### PR TITLE
fix(auth): primary web sessions join device refresh-cookie set + signed-out gate

### DIFF
--- a/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
@@ -100,6 +100,8 @@ jest.mock('@oxyhq/core', () => {
     ssoDestKey: actual.ssoDestKey,
     ssoAttemptedKey: actual.ssoAttemptedKey,
     ssoPriorSessionKey: actual.ssoPriorSessionKey,
+    ssoSignedOutKey: actual.ssoSignedOutKey,
+    silentRestoreSuppressed: actual.silentRestoreSuppressed,
     isCentralIdPOrigin: actual.isCentralIdPOrigin,
     guardActive: actual.guardActive,
     allowSsoBounce: actual.allowSsoBounce,
@@ -156,6 +158,7 @@ import {
   ssoDestKey,
   ssoAttemptedKey,
   ssoPriorSessionKey,
+  ssoSignedOutKey,
   SSO_CALLBACK_PATH,
   buildSsoBounceUrl,
 } from '@oxyhq/core';
@@ -333,6 +336,24 @@ describe('WebOxyProvider cold boot (central SSO)', () => {
     expect(latest.userId).toBe('u1');
     expect(stubs.managerInitialize).not.toHaveBeenCalled();
     expect(bounced()).toBe(false);
+  });
+
+  it('5b) DELIBERATELY-SIGNED-OUT gate: fedcm-silent is SKIPPED when the signed-out flag is set', async () => {
+    resetStubs('https://api.test-5b');
+    // FedCM WOULD succeed — but the user deliberately signed out, so silent
+    // restore must NOT run and must NOT sign them back in on this cold boot.
+    stubs.isFedCMSupported.mockReturnValue(true);
+    stubs.silentSignInWithFedCM.mockResolvedValue(makeSession({ id: 'u1', username: 'tester' }));
+    window.localStorage.setItem(ssoSignedOutKey(ORIGIN), '1');
+
+    let latest: ProbeState = { isAuthenticated: false, userId: null, isLoading: true };
+    renderProvider(stubs.baseURL, (s) => { latest = s; });
+
+    // The chain falls through to the terminal bounce (the beforeEach seeds the
+    // returning-visitor hint), proving fedcm-silent did not silently restore.
+    await waitFor(() => expect(bounced()).toBe(true));
+    expect(stubs.silentSignInWithFedCM).not.toHaveBeenCalled();
+    expect(latest.isAuthenticated).toBe(false);
   });
 
   it('6) cookie-restore hydrates a real user and commits when prior steps skip', async () => {

--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -31,6 +31,8 @@ import {
   ssoDestKey,
   ssoAttemptedKey,
   ssoPriorSessionKey,
+  ssoSignedOutKey,
+  silentRestoreSuppressed,
   isCentralIdPOrigin,
   guardActive,
   allowSsoBounce,
@@ -275,6 +277,47 @@ function clearPriorSessionWeb(): void {
   }
 }
 
+/**
+ * Set the durable "deliberately signed out" flag (core {@link ssoSignedOutKey}).
+ * Called ONLY on EXPLICIT full sign-out so the next cold boot does not silently
+ * re-mint a session from a still-live IdP session via `fedcm-silent`. Cleared by
+ * any deliberate sign-in (see {@link clearSignedOutWeb}). No-ops off-web / on
+ * storage failure (best-effort).
+ */
+function markSignedOutWeb(): void {
+  if (!isWebBrowser()) return;
+  try {
+    window.localStorage.setItem(ssoSignedOutKey(window.location.origin), '1');
+  } catch {
+    // Best-effort; swallow QuotaExceededError / SecurityError (private mode).
+  }
+}
+
+/**
+ * Clear the durable "deliberately signed out" flag. Called on ANY deliberate
+ * sign-in so a real sign-in fully re-enables automatic silent restore — no
+ * "stuck signed out" state. No-ops off-web / on storage failure.
+ */
+function clearSignedOutWeb(): void {
+  if (!isWebBrowser()) return;
+  try {
+    window.localStorage.removeItem(ssoSignedOutKey(window.location.origin));
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Whether AUTOMATIC silent restore is suppressed because the user deliberately
+ * signed out (durable flag, read via the core {@link silentRestoreSuppressed}
+ * predicate). Gates the `fedcm-silent` cold-boot step. Returns `false` off-web /
+ * on storage failure (fail safe toward normal restore).
+ */
+function silentRestoreSuppressedWeb(): boolean {
+  if (!isWebBrowser()) return false;
+  return silentRestoreSuppressed(window.localStorage, window.location.origin);
+}
+
 function isOnSsoCallbackPath(): boolean {
   return isWebBrowser() && window.location.pathname === SSO_CALLBACK_PATH;
 }
@@ -453,6 +496,11 @@ export function WebOxyProvider({
     // (FedCM / redirect / SSO return / claimed device-flow) funnels through
     // here, so this is the single chokepoint for the hint.
     markPriorSessionWeb();
+    // A committed session re-enables automatic silent restore: clear the durable
+    // "deliberately signed out" flag. The `fedcm-silent` step is GATED on the
+    // flag, so when it is set that step never runs and never reaches here — this
+    // clear is only hit on a genuine (re-)sign-in or when restore was permitted.
+    clearSignedOutWeb();
 
     // A fresh login appends a new device-local slot server-side (via
     // `Set-Cookie: oxy_rt_${n}`). Pull the canonical snapshot so the
@@ -695,6 +743,17 @@ export function WebOxyProvider({
       // session. A placeholder user (empty id) is never exposed (R4).
       const ssoKey = silentSignInKey(oxyServices);
 
+      // DELIBERATELY-SIGNED-OUT gate (web): when the user pressed "Sign out", the
+      // central IdP session can still be live, so the silent `fedcm-silent` step
+      // below would re-mint a session on the next cold boot and sign the user back
+      // in without intent. Read the durable flag ONCE here (synchronously usable by
+      // the step `enabled` gate) and skip `fedcm-silent` while it is set. Any
+      // deliberate sign-in clears it. The terminal `sso-bounce` is already
+      // self-suppressed after sign-out (its prior-session hint is cleared), and the
+      // `cookie-restore` step reads only first-party cookies that an explicit
+      // sign-out already cleared.
+      const silentRestoreBlocked = silentRestoreSuppressedWeb();
+
       const steps: ReadonlyArray<ColdBootStep<ColdBootSession>> = [
         {
           // 0) SSO return: we are back from a top-level bounce to the central
@@ -717,6 +776,7 @@ export function WebOxyProvider({
           id: 'fedcm-silent',
           enabled: () =>
             isWebBrowser() &&
+            !silentRestoreBlocked &&
             oxyServices.isFedCMSupported() === true &&
             !fedcmSilentSignInAttempted.has(ssoKey),
           run: async () => {
@@ -1039,6 +1099,11 @@ export function WebOxyProvider({
       // after an explicit sign-out). The passive cookie-expiry path leaves it
       // intact so an expired session still recovers via a returning-user bounce.
       clearPriorSessionWeb();
+      // EXPLICIT sign-out: set the durable "deliberately signed out" flag so the
+      // `fedcm-silent` cold-boot step does not silently re-mint a session from a
+      // still-live IdP session on the next reload. Cleared on any deliberate
+      // sign-in.
+      markSignedOutWeb();
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Sign out failed';
       setError(errorMessage);
@@ -1052,6 +1117,9 @@ export function WebOxyProvider({
       await authManager.switchAuthuser(authuser);
       const active = authManager.getActiveAccount();
       if (active) {
+        // A switch is a deliberate sign-in into an account: re-enable automatic
+        // silent restore by clearing any prior "deliberately signed out" flag.
+        clearSignedOutWeb();
         setActiveSessionId(active.sessionId);
         // Fetch the canonical User shape with the freshly planted token —
         // the refresh-all projection is minimal (id/username/avatar/...)
@@ -1106,6 +1174,10 @@ export function WebOxyProvider({
         setUser(null);
         setActiveSessionId(null);
         clearQueryCache(queryClient);
+        // No slots remain — this is a deliberate full sign-out. Suppress automatic
+        // silent restore on the next cold boot so a still-live IdP session does not
+        // re-mint a session (cleared on any deliberate sign-in).
+        markSignedOutWeb();
       }
       syncAccountsFromManager();
     } catch (err) {
@@ -1132,6 +1204,9 @@ export function WebOxyProvider({
     // hint so the next cold boot is treated as first-time anonymous.
     clearSsoBounceStateWeb();
     clearPriorSessionWeb();
+    // Suppress automatic silent restore until a deliberate sign-in (parity with
+    // `signOut`): a still-live IdP session must not silently re-mint here.
+    markSignedOutWeb();
   }, [authManager, syncAccountsFromManager, queryClient]);
 
   useEffect(() => {

--- a/packages/core/src/AuthManager.ts
+++ b/packages/core/src/AuthManager.ts
@@ -509,11 +509,35 @@ export class AuthManager {
 
     this.currentAuthMethod = method;
 
-    const decodedAuthuser = session.accessToken
-      ? AuthManager.decodeAuthuserFromAccessToken(session.accessToken)
+    // Register this primary session in the device's first-party multi-account
+    // refresh-cookie set (web only). Every web primary commit funnels through
+    // here (FedCM, central `/sso` return, credentials), but only a same-apex
+    // `/fedcm/exchange` plants an `oxy_rt_<authuser>` slot as a side effect — the
+    // cross-origin/credential-less restores (`/sso/exchange`, the IdP
+    // `/auth/silent` postMessage) cannot set an `api.oxy.so` cookie. WITHOUT this
+    // call those primaries never join the device set, so `refresh-all` returns no
+    // accounts and account-switch persistence has no foundation. The shared
+    // `POST /auth/session` primitive plants/reuses this user's slot where the
+    // cookies ARE visible, re-plants the rotated access token, and returns the
+    // AUTHORITATIVE `authuser` slot (the one actually written) — preferred over the
+    // JWT-decoded guess, which may not correspond to a real cookie. No-op on native
+    // (returns `null`); best-effort on transient failure.
+    const establishedAuthuser = await this.oxyServices.establishDeviceRefreshSlot();
+    // The slot mint rotated the access token; pick it up so the registry and the
+    // refresh authority track the cookie just written. Falls back to the original
+    // session token when the slot was a no-op (native) or failed.
+    const rotatedToken =
+      (establishedAuthuser !== null ? this.oxyServices.getAccessToken() : null) ??
+      session.accessToken;
+    if (rotatedToken) {
+      this._lastKnownAccessToken = rotatedToken;
+    }
+
+    const decodedAuthuser = rotatedToken
+      ? AuthManager.decodeAuthuserFromAccessToken(rotatedToken)
       : null;
-    const authuser = decodedAuthuser ?? 0;
-    if (session.accessToken && session.sessionId) {
+    const authuser = establishedAuthuser ?? decodedAuthuser ?? 0;
+    if (rotatedToken && session.sessionId) {
       this.accounts.set(authuser, {
         authuser,
         sessionId: session.sessionId,
@@ -523,7 +547,7 @@ export class AuthManager {
           name: session.user.name,
           avatar: session.user.avatar ?? null,
         },
-        accessToken: session.accessToken,
+        accessToken: rotatedToken,
         expiresAt: session.expiresAt,
       });
       this.activeAuthuser = authuser;

--- a/packages/core/src/OxyServices.base.ts
+++ b/packages/core/src/OxyServices.base.ts
@@ -9,6 +9,9 @@ import { handleHttpError } from './utils/errorUtils';
 import { HttpService, type AuthRefreshReason, type RequestOptions } from './HttpService';
 import { OxyAuthenticationError, OxyAuthenticationTimeoutError } from './OxyServices.errors';
 import { resolveCentralAuthUrl } from './utils/authWebUrl';
+import { isWeb } from './utils/platform';
+import { registrableApex } from './utils/fapiAutoDetect';
+import { logger } from './utils/loggerUtils';
 
 export interface OxyConfig extends OxyConfigBase {
   cloudURL?: string;
@@ -308,6 +311,82 @@ export class OxyServicesBase {
    */
   public getAccessToken(): string | null {
     return this.httpService.getAccessToken();
+  }
+
+  /**
+   * Register the CURRENTLY-ACTIVE session in the device's first-party
+   * multi-account refresh-cookie set by calling `POST /auth/session`.
+   *
+   * This is the single, shared primitive every web primary-session commit and the
+   * account switch use to plant their `oxy_rt_<authuser>` slot. It MUST be a
+   * dedicated call to `/auth/session` rather than relying on whichever endpoint
+   * established the session: that endpoint is frequently OUTSIDE the cookie's
+   * `Path=/auth` scope (`/accounts/:id/switch`) or is a cross-origin/credential-
+   * less restore (`/sso/exchange`, the IdP `/auth/silent` postMessage) that cannot
+   * set an `api.oxy.so` cookie at all. `/auth/session` runs where the device's
+   * existing slots ARE visible, so the server resolves this user's slot (reusing an
+   * existing one or allocating a new one) without clobbering a sibling account,
+   * mints a fresh access token bound to the same session, and returns the resolved
+   * `authuser`.
+   *
+   * Behaviour:
+   * - Requires a planted bearer (the caller must have already installed the
+   *   session's access token); `/auth/session` derives the session from it.
+   * - On success re-plants the rotated access token (so the active token matches
+   *   the freshly-rotated cookie) and returns the device `authuser` slot.
+   * - WEB-ONLY: on native there are no first-party refresh cookies → returns
+   *   `null`.
+   * - FIRST-PARTY-ONLY: the cookie is host-only on the API host with
+   *   `SameSite=Lax`, so it only sticks when the page is SAME-SITE (same
+   *   registrable apex) as the API. On a cross-apex RP (`mention.earth` calling
+   *   `api.oxy.so`) the browser rejects the `Set-Cookie` as a third-party cookie,
+   *   so a returned slot would be a phantom never enumerated by `refresh-all`.
+   *   Those RPs durably restore via the per-apex `/auth/silent` iframe + `/sso`
+   *   bounce, NOT this device set → returns `null` without calling the API.
+   * - BEST-EFFORT: a failure (e.g. transient network) never throws — the session
+   *   stays active in-memory; only its reload durability via the device set is at
+   *   risk. The caller treats `null` as "not registered in the device set".
+   *
+   * @returns The resolved device `authuser` slot, or `null` on native / cross-apex
+   *   / failure.
+   */
+  public async establishDeviceRefreshSlot(): Promise<number | null> {
+    if (!isWeb()) {
+      return null;
+    }
+    if (typeof window !== 'undefined' && window.location?.hostname) {
+      const pageApex = registrableApex(window.location.hostname);
+      let apiApex: string | null = null;
+      try {
+        apiApex = registrableApex(new URL(this.getBaseURL()).hostname);
+      } catch {
+        apiApex = null;
+      }
+      if (!pageApex || !apiApex || pageApex !== apiApex) {
+        return null;
+      }
+    }
+    try {
+      const established = await this.makeRequest<{ accessToken?: string; authuser?: number }>(
+        'POST',
+        '/auth/session',
+        undefined,
+        { cache: false },
+      );
+      // `/auth/session` mints a fresh access token off the same session; re-plant
+      // it so the active token matches the rotated cookie.
+      if (established?.accessToken) {
+        this.setTokens(established.accessToken);
+      }
+      return typeof established?.authuser === 'number' ? established.authuser : null;
+    } catch (error) {
+      logger.warn(
+        '[OxyServices] Failed to establish device refresh cookie via POST /auth/session; the session is active in-session but may not survive a reload as part of the device account set',
+        { component: 'OxyServices', method: 'establishDeviceRefreshSlot' },
+        error,
+      );
+      return null;
+    }
   }
 
   /**

--- a/packages/core/src/__tests__/establishDeviceRefreshSlot.test.ts
+++ b/packages/core/src/__tests__/establishDeviceRefreshSlot.test.ts
@@ -1,0 +1,221 @@
+/**
+ * `establishDeviceRefreshSlot` + primary-session slot-registration tests.
+ *
+ * ROOT CAUSE these lock in: a web PRIMARY session (FedCM exchange, central `/sso`
+ * return, IdP `/auth/silent` iframe, password) plants only an access token. The
+ * cross-origin/credential-less restore endpoints (`/sso/exchange`, `/auth/silent`)
+ * cannot set the device's `oxy_rt_<authuser>` cookie, so without an explicit
+ * `POST /auth/session` the primary never joins the device refresh-cookie set:
+ * `/auth/refresh-all` returns zero accounts and account-switch persistence has no
+ * foundation. `establishDeviceRefreshSlot()` is the single shared primitive (on the
+ * base, reused by `switchToAccount` and `AuthManager.handleAuthSuccess`) that plants
+ * the slot where the cookie is visible, re-plants the rotated token, and returns the
+ * authoritative `authuser`.
+ *
+ * `testEnvironment` is `node`, where `getPlatformOS()` resolves to `'web'`
+ * (`isWeb()` is true) and `window` is undefined — so the FIRST-PARTY apex gate is
+ * inert and the method exercises its happy path. Browser-only apex gating is
+ * verified separately by stubbing a `window`.
+ */
+
+import { OxyServices } from '../OxyServices';
+import { AuthManager } from '../AuthManager';
+import type { StorageAdapter } from '../AuthManager';
+import type { RefreshAllResponse, RefreshCookieResponse, User } from '../models/interfaces';
+import type { SessionLoginResponse } from '../models/session';
+
+function buildAccessToken(claims: Record<string, unknown>): string {
+  const b64url = (value: string): string =>
+    Buffer.from(value).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify(claims));
+  return `${header}.${payload}.signature`;
+}
+
+describe('OxyServices.establishDeviceRefreshSlot', () => {
+  let oxy: OxyServices;
+  let makeRequestSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    oxy.httpService.setTokens('primary-token');
+    makeRequestSpy = jest.spyOn(oxy, 'makeRequest');
+  });
+
+  afterEach(() => {
+    makeRequestSpy.mockRestore();
+  });
+
+  it('POSTs to /auth/session, re-plants the rotated access token, and returns the server authuser', async () => {
+    makeRequestSpy.mockResolvedValue({ accessToken: 'rotated-token', authuser: 2 });
+
+    const authuser = await oxy.establishDeviceRefreshSlot();
+
+    expect(authuser).toBe(2);
+    expect(makeRequestSpy).toHaveBeenCalledWith('POST', '/auth/session', undefined, { cache: false });
+    // The rotated token from /auth/session is now the active token.
+    expect(oxy.getAccessToken()).toBe('rotated-token');
+  });
+
+  it('returns the authuser even when the response carries no rotated token (keeps the existing token)', async () => {
+    makeRequestSpy.mockResolvedValue({ authuser: 0 });
+
+    const authuser = await oxy.establishDeviceRefreshSlot();
+
+    expect(authuser).toBe(0);
+    expect(oxy.getAccessToken()).toBe('primary-token');
+  });
+
+  it('returns null when the server omits a numeric authuser', async () => {
+    makeRequestSpy.mockResolvedValue({ accessToken: 'rotated-token' });
+
+    const authuser = await oxy.establishDeviceRefreshSlot();
+
+    expect(authuser).toBeNull();
+  });
+
+  it('is best-effort: a failed /auth/session resolves null and never throws', async () => {
+    makeRequestSpy.mockRejectedValue(new Error('network down'));
+
+    await expect(oxy.establishDeviceRefreshSlot()).resolves.toBeNull();
+  });
+
+  it('FIRST-PARTY gate: skips /auth/session when the page apex differs from the API apex (cross-apex RP)', async () => {
+    // Simulate a cross-apex RP page (mention.earth) calling api.oxy.so.
+    const rp = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    rp.httpService.setTokens('primary-token');
+    const rpSpy = jest.spyOn(rp, 'makeRequest');
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = { location: { hostname: 'mention.earth' } };
+    try {
+      const authuser = await rp.establishDeviceRefreshSlot();
+      expect(authuser).toBeNull();
+      expect(rpSpy).not.toHaveBeenCalled();
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      }
+      rpSpy.mockRestore();
+    }
+  });
+
+  it('FIRST-PARTY gate: proceeds when the page apex matches the API apex (first-party *.oxy.so)', async () => {
+    const fp = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    fp.httpService.setTokens('primary-token');
+    const fpSpy = jest.spyOn(fp, 'makeRequest').mockResolvedValue({ accessToken: 'rotated', authuser: 1 });
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = { location: { hostname: 'accounts.oxy.so' } };
+    try {
+      const authuser = await fp.establishDeviceRefreshSlot();
+      expect(authuser).toBe(1);
+      expect(fpSpy).toHaveBeenCalledWith('POST', '/auth/session', undefined, { cache: false });
+    } finally {
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      }
+      fpSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuthManager.handleAuthSuccess — every web primary now joins the device set
+// ---------------------------------------------------------------------------
+
+class InMemoryStorage implements StorageAdapter {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null { return this.store.get(key) ?? null; }
+  setItem(key: string, value: string): void { this.store.set(key, value); }
+  removeItem(key: string): void { this.store.delete(key); }
+  raw(): Map<string, string> { return this.store; }
+}
+
+interface MockHttpService {
+  setTokens: jest.Mock;
+  setAuthRefreshHandler: jest.Mock;
+}
+
+interface MockServices {
+  establishDeviceRefreshSlot: jest.Mock<Promise<number | null>, []>;
+  getAccessToken: jest.Mock<string | null, []>;
+  refreshAllSessions: jest.Mock<Promise<RefreshAllResponse>, []>;
+  refreshTokenViaCookie: jest.Mock<Promise<RefreshCookieResponse | null>, [{ authuser?: number }]>;
+  logoutSessionByAuthuser: jest.Mock<Promise<void>, [number]>;
+  logoutAllSessionsViaCookie: jest.Mock<Promise<void>, []>;
+  getCurrentUser: jest.Mock<Promise<User>, []>;
+  httpService: MockHttpService;
+}
+
+const ACTIVE_AUTHUSER_KEY = 'oxy_active_authuser';
+
+function makeMockServices(): MockServices {
+  return {
+    establishDeviceRefreshSlot: jest.fn(async () => null),
+    getAccessToken: jest.fn(() => null),
+    refreshAllSessions: jest.fn(async (): Promise<RefreshAllResponse> => ({ accounts: [] })),
+    refreshTokenViaCookie: jest.fn(),
+    logoutSessionByAuthuser: jest.fn(async () => undefined),
+    logoutAllSessionsViaCookie: jest.fn(async () => undefined),
+    getCurrentUser: jest.fn(async (): Promise<User> => ({ id: 'user-fedcm', publicKey: '0xabc', username: 'nate' } as User)),
+    httpService: { setTokens: jest.fn(), setAuthRefreshHandler: jest.fn() },
+  };
+}
+
+function makeManager(services: MockServices, storage: InMemoryStorage): AuthManager {
+  return new AuthManager(services as unknown as OxyServices, {
+    storage,
+    autoRefresh: false,
+    crossTabSync: false,
+  });
+}
+
+function fedcmSession(): SessionLoginResponse {
+  // No `authuser` claim in the FedCM-restored token — mirrors a cross-domain
+  // restore whose token is not slot-bound until /auth/session runs.
+  return {
+    accessToken: buildAccessToken({ sessionId: 'sess-fedcm', userId: 'user-fedcm', exp: 9999999999 }),
+    sessionId: 'sess-fedcm',
+    deviceId: 'dev-1',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+    user: { id: 'user-fedcm', username: 'nate', name: { displayName: 'Nate' } },
+  } as SessionLoginResponse;
+}
+
+describe('AuthManager.handleAuthSuccess — primary session joins the device set', () => {
+  it('establishes the device refresh slot and adopts the server-authoritative authuser', async () => {
+    const services = makeMockServices();
+    // /auth/session allocated slot 3 and rotated the token.
+    services.establishDeviceRefreshSlot.mockResolvedValueOnce(3);
+    const rotated = buildAccessToken({ sessionId: 'sess-fedcm', userId: 'user-fedcm', authuser: 3, exp: 9999999999 });
+    services.getAccessToken.mockReturnValue(rotated);
+    const storage = new InMemoryStorage();
+    const manager = makeManager(services, storage);
+
+    await manager.handleAuthSuccess(fedcmSession(), 'fedcm');
+
+    expect(services.establishDeviceRefreshSlot).toHaveBeenCalledTimes(1);
+    // The authoritative slot from /auth/session is recorded as the active account.
+    expect(manager.getActiveAuthuser()).toBe(3);
+    expect(storage.raw().get(ACTIVE_AUTHUSER_KEY)).toBe('3');
+    expect(manager.getActiveAccount()?.authuser).toBe(3);
+  });
+
+  it('falls back to the JWT-decoded authuser (then 0) when /auth/session is a no-op (native / cross-apex)', async () => {
+    const services = makeMockServices();
+    services.establishDeviceRefreshSlot.mockResolvedValueOnce(null);
+    const storage = new InMemoryStorage();
+    const manager = makeManager(services, storage);
+
+    // FedCM session token carries no authuser claim → falls back to slot 0.
+    await manager.handleAuthSuccess(fedcmSession(), 'fedcm');
+
+    expect(manager.getActiveAuthuser()).toBe(0);
+    // getAccessToken() is only consulted for the rotated token when a slot was
+    // actually established — a null slot must not re-read it.
+    expect(services.getAccessToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -539,12 +539,14 @@ export {
     ssoNoSessionKey,
     ssoAttemptedKey,
     ssoPriorSessionKey,
+    ssoSignedOutKey,
     ssoCallbackBootstrapKey,
     ssoNavigate,
     getSsoCallbackBootstrapScript,
     buildSsoBounceUrl,
     isCentralIdPOrigin,
     guardActive,
+    silentRestoreSuppressed,
     allowSsoBounce,
 } from './utils/ssoBounce';
 export type { SsoBounceGate } from './utils/ssoBounce';

--- a/packages/core/src/mixins/OxyServices.accounts.ts
+++ b/packages/core/src/mixins/OxyServices.accounts.ts
@@ -35,8 +35,6 @@ import type { User } from '../models/interfaces';
 import type { SessionLoginResponse } from '../models/session';
 import type { OxyServicesBase } from '../OxyServices.base';
 import { normalizeUserIdentity } from '../utils/userIdentity';
-import { isWeb } from '../utils/platform';
-import { logger } from '../utils/loggerUtils';
 import { CACHE_TIMES } from './mixinHelpers';
 
 // ---------------------------------------------------------------------------
@@ -564,37 +562,16 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
 
         // Register the switched session in the device's multi-account set by
         // establishing its first-party refresh cookie. This MUST be a separate
-        // call to `POST /auth/session`: the switch route is at `/accounts/*`,
-        // outside the `oxy_rt_<authuser>` cookie's `Path=/auth` scope, so it can
-        // never read the device's existing slots and would overwrite slot 0
-        // (destroying the operator's own session). `/auth/session` runs where the
-        // cookies ARE visible, so the server allocates a NEW slot that coexists
-        // with the operator's and returns its `authuser`. Web-only; best-effort.
-        let authuser = res.authuser;
-        if (isWeb()) {
-          try {
-            const established = await this.makeRequest<{ accessToken?: string; authuser?: number }>(
-              'POST',
-              '/auth/session',
-              undefined,
-              { cache: false },
-            );
-            if (typeof established?.authuser === 'number') {
-              authuser = established.authuser;
-            }
-            // /auth/session mints a fresh access token off the same session;
-            // re-plant it so the active token matches the rotated cookie.
-            if (established?.accessToken) {
-              this.setTokens(established.accessToken);
-            }
-          } catch (error) {
-            logger.warn(
-              '[OxyServices] Failed to establish device refresh cookie after account switch; the switch is active in-session but may not survive a reload',
-              { component: 'OxyServices', method: 'switchToAccount' },
-              error,
-            );
-          }
-        }
+        // call to `POST /auth/session` (the shared `establishDeviceRefreshSlot`
+        // primitive): the switch route is at `/accounts/*`, outside the
+        // `oxy_rt_<authuser>` cookie's `Path=/auth` scope, so it can never read
+        // the device's existing slots and would overwrite slot 0 (destroying the
+        // operator's own session). `/auth/session` runs where the cookies ARE
+        // visible, so the server allocates a NEW slot that coexists with the
+        // operator's and returns its `authuser`. Web-only; best-effort (the helper
+        // re-plants the rotated access token and returns `null` on native/failure).
+        const establishedAuthuser = await this.establishDeviceRefreshSlot();
+        const authuser = establishedAuthuser ?? res.authuser;
 
         // Identity changed → drop the entire GET response cache so no entry
         // personalised for the previous identity is reused. Cache keys are

--- a/packages/core/src/utils/__tests__/ssoBounce.test.ts
+++ b/packages/core/src/utils/__tests__/ssoBounce.test.ts
@@ -16,9 +16,11 @@ import {
   ssoNoSessionKey,
   ssoAttemptedKey,
   ssoPriorSessionKey,
+  ssoSignedOutKey,
   buildSsoBounceUrl,
   isCentralIdPOrigin,
   guardActive,
+  silentRestoreSuppressed,
   allowSsoBounce,
 } from '../ssoBounce';
 import { CENTRAL_AUTH_URL } from '../authWebUrl';
@@ -40,11 +42,50 @@ describe('per-origin key builders', () => {
     expect(ssoNoSessionKey(origin)).toBe('oxy_sso_no_session:https://mention.earth');
     expect(ssoAttemptedKey(origin)).toBe('oxy_sso_attempted:https://mention.earth');
     expect(ssoPriorSessionKey(origin)).toBe('oxy_sso_prior_session:https://mention.earth');
+    expect(ssoSignedOutKey(origin)).toBe('oxy_signed_out:https://mention.earth');
   });
 
   it('namespaces keys per origin so two RPs never collide', () => {
     expect(ssoStateKey('https://a.test')).not.toBe(ssoStateKey('https://b.test'));
     expect(ssoPriorSessionKey('https://a.test')).not.toBe(ssoPriorSessionKey('https://b.test'));
+    expect(ssoSignedOutKey('https://a.test')).not.toBe(ssoSignedOutKey('https://b.test'));
+  });
+});
+
+describe('silentRestoreSuppressed (deliberately-signed-out gate)', () => {
+  const origin = 'https://accounts.oxy.so';
+
+  function storageWith(value: string | null): Pick<Storage, 'getItem'> {
+    return { getItem: (key: string) => (key === ssoSignedOutKey(origin) ? value : null) };
+  }
+
+  it('is SUPPRESSED when the signed-out flag is set to "1" for this origin', () => {
+    expect(silentRestoreSuppressed(storageWith('1'), origin)).toBe(true);
+  });
+
+  it('is NOT suppressed when the flag is absent (normal restore)', () => {
+    expect(silentRestoreSuppressed(storageWith(null), origin)).toBe(false);
+  });
+
+  it('is NOT suppressed for any non-"1" value (only the exact set value gates)', () => {
+    expect(silentRestoreSuppressed(storageWith('0'), origin)).toBe(false);
+    expect(silentRestoreSuppressed(storageWith(''), origin)).toBe(false);
+  });
+
+  it('is per-origin: another origin\'s flag does not suppress this one', () => {
+    const otherOriginFlag: Pick<Storage, 'getItem'> = {
+      getItem: (key: string) => (key === ssoSignedOutKey('https://other.test') ? '1' : null),
+    };
+    expect(silentRestoreSuppressed(otherOriginFlag, origin)).toBe(false);
+  });
+
+  it('fails safe (NOT suppressed, never throws) when getItem throws', () => {
+    const throwing: Pick<Storage, 'getItem'> = {
+      getItem: () => {
+        throw new Error('storage locked');
+      },
+    };
+    expect(silentRestoreSuppressed(throwing, origin)).toBe(false);
   });
 });
 

--- a/packages/core/src/utils/ssoBounce.ts
+++ b/packages/core/src/utils/ssoBounce.ts
@@ -69,6 +69,7 @@ const NO_SESSION_KEY_PREFIX = 'oxy_sso_no_session:';
 const ATTEMPTED_KEY_PREFIX = 'oxy_sso_attempted:';
 const CALLBACK_BOOTSTRAP_KEY_PREFIX = 'oxy_sso_callback_bootstrap:';
 const PRIOR_SESSION_KEY_PREFIX = 'oxy_sso_prior_session:';
+const SIGNED_OUT_KEY_PREFIX = 'oxy_signed_out:';
 
 /** Per-origin CSRF state key (matched on return to defeat fragment forgery). */
 export function ssoStateKey(origin: string): string {
@@ -123,6 +124,37 @@ export function ssoAttemptedKey(origin: string): string {
  */
 export function ssoPriorSessionKey(origin: string): string {
   return `${PRIOR_SESSION_KEY_PREFIX}${origin}`;
+}
+
+/**
+ * Per-origin DURABLE "the user DELIBERATELY signed out on this device/origin"
+ * flag.
+ *
+ * Like {@link ssoPriorSessionKey} this lives in DURABLE storage (web
+ * `localStorage`; services uses its own `storageKeyPrefix`-scoped key), NOT the
+ * per-tab `sessionStorage` the loop-breaker keys use — it must survive a reload.
+ *
+ * It exists purely to suppress AUTOMATIC silent restore after a deliberate
+ * sign-out: a still-live IdP session (the central `fedcm_session` / the FedCM
+ * credential association) would otherwise let `fedcm-silent` / the per-apex
+ * `/auth/silent` iframe re-mint a session on the very next cold boot, so a user
+ * who pressed "Sign out" gets silently signed back in on reload. With this flag
+ * set, those silent cold-boot steps are skipped while the Gmail-style
+ * returning-account fast-path is otherwise preserved.
+ *
+ * Lifecycle (mirrors the existing gate machinery — set on a definitive event,
+ * cleared on its inverse):
+ *   - SET on EXPLICIT full sign-out (alongside clearing the prior-session hint
+ *     and the SSO bounce state).
+ *   - CLEARED on ANY deliberate sign-in (password, FedCM, account switch, device
+ *     claim) so a real sign-in fully re-enables silent restore — there is no
+ *     "stuck signed out" state.
+ *
+ * NOTE: this gates only AUTOMATIC/silent restore. An INTERACTIVE sign-in always
+ * clears it first, so the user can always sign back in.
+ */
+export function ssoSignedOutKey(origin: string): string {
+  return `${SIGNED_OUT_KEY_PREFIX}${origin}`;
 }
 
 /**
@@ -265,6 +297,35 @@ export function guardActive(
     return false;
   }
   return now - ts < SSO_GUARD_TTL_MS;
+}
+
+/**
+ * Whether AUTOMATIC silent restore is SUPPRESSED for this origin because the
+ * user deliberately signed out (the durable {@link ssoSignedOutKey} flag).
+ *
+ * When `true`, the silent cold-boot steps that can re-mint a session from a
+ * still-live IdP session WITHOUT user intent — `fedcm-silent` and the per-apex
+ * `/auth/silent` iframe — MUST be skipped, so a user who pressed "Sign out" is
+ * not silently signed back in on the next reload. Interactive sign-in clears the
+ * flag, so this never blocks a deliberate re-sign-in.
+ *
+ * Defensive: a `getItem` that throws (locked/disabled storage) is treated as NOT
+ * suppressed, so the gate fails toward the normal restore behaviour rather than
+ * wedging the user out.
+ *
+ * @param storage - The DURABLE storage to read (web `localStorage`; injected for
+ *   testability).
+ * @param origin - The page origin whose signed-out flag to evaluate.
+ */
+export function silentRestoreSuppressed(
+  storage: Pick<Storage, 'getItem'>,
+  origin: string,
+): boolean {
+  try {
+    return storage.getItem(ssoSignedOutKey(origin)) === '1';
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/services/__tests__/context/useAuthOperations.test.tsx
+++ b/packages/services/__tests__/context/useAuthOperations.test.tsx
@@ -58,6 +58,7 @@ import * as sessionHelpers from '../../src/ui/utils/sessionHelpers';
 interface FakeServices {
   requestChallenge: jest.Mock;
   verifyChallenge: jest.Mock;
+  establishDeviceRefreshSlot: jest.Mock;
   setTokens: jest.Mock;
   getUserBySession: jest.Mock;
   logoutSession: jest.Mock;
@@ -82,6 +83,10 @@ const makeOxyServices = (overrides: Partial<FakeServices> = {}): FakeServices =>
     refreshToken: 'verify-refresh-token',
     user: { id: 'user-1', username: 'alice' },
   })),
+  // `/auth/verify` mints the session but does NOT plant the device refresh slot,
+  // so `performSignIn` registers it via this shared primitive. Mock resolves
+  // `null` (its real return off a registrable-apex-less jsdom origin / native).
+  establishDeviceRefreshSlot: jest.fn(async (): Promise<number | null> => null),
   setTokens: jest.fn(),
   getUserBySession: jest.fn(async (): Promise<User> => ({
     id: 'user-1',

--- a/packages/services/__tests__/utils/silentRestoreGate.test.ts
+++ b/packages/services/__tests__/utils/silentRestoreGate.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Deliberately-signed-out gate (Option B) — services consumer helpers.
+ *
+ * After an EXPLICIT full sign-out, a still-live central IdP session (FedCM
+ * credential association / per-apex `fedcm_session` cookie) would let the
+ * `fedcm-silent` / per-apex `/auth/silent` cold-boot steps silently re-mint a
+ * session on the next reload, signing the user back in without intent. The
+ * durable per-origin "deliberately signed out" flag (core `ssoSignedOutKey`,
+ * read via `silentRestoreSuppressed`) gates those steps off until the next
+ * deliberate sign-in clears it.
+ *
+ * These helpers are the consumer side of that contract: `markSignedOut` (set on
+ * full sign-out), `clearSignedOut` (cleared on any deliberate sign-in), and
+ * `isSilentRestoreSuppressed` (read by the cold-boot `enabled` gates). They are
+ * pure `localStorage` wrappers over the core key, so they run under the jsdom
+ * test env without rendering any React.
+ */
+
+import { ssoSignedOutKey } from '@oxyhq/core';
+import {
+  markSignedOut,
+  clearSignedOut,
+  isSilentRestoreSuppressed,
+} from '../../src/ui/utils/activeAuthuser';
+
+// jsdom's default origin.
+const ORIGIN = 'http://localhost';
+const KEY = ssoSignedOutKey(ORIGIN);
+
+describe('silent-restore gate helpers (Option B)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('defaults to NOT suppressed when nothing was signed out', () => {
+    expect(isSilentRestoreSuppressed()).toBe(false);
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('markSignedOut sets the durable flag → silent restore is suppressed', () => {
+    markSignedOut();
+    expect(window.localStorage.getItem(KEY)).toBe('1');
+    expect(isSilentRestoreSuppressed()).toBe(true);
+  });
+
+  it('clearSignedOut removes the flag → silent restore is re-enabled (no stuck state)', () => {
+    markSignedOut();
+    expect(isSilentRestoreSuppressed()).toBe(true);
+
+    clearSignedOut();
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+    expect(isSilentRestoreSuppressed()).toBe(false);
+  });
+
+  it('a deliberate sign-in after sign-out fully clears suppression (sign-out → sign-in cycle)', () => {
+    // Sign out: suppressed.
+    markSignedOut();
+    expect(isSilentRestoreSuppressed()).toBe(true);
+    // Deliberate sign-in clears it: silent restore works again on the next boot.
+    clearSignedOut();
+    expect(isSilentRestoreSuppressed()).toBe(false);
+    // A subsequent sign-out re-arms it (idempotent, repeatable).
+    markSignedOut();
+    expect(isSilentRestoreSuppressed()).toBe(true);
+  });
+});

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -43,7 +43,7 @@ import { useAuthOperations } from './hooks/useAuthOperations';
 import { useDeviceManagement } from '../hooks/useDeviceManagement';
 import { getStorageKeys, createPlatformStorage, type StorageInterface } from '../utils/storageHelpers';
 import { isInvalidSessionError, isTimeoutOrNetworkError } from '../utils/errorHandlers';
-import { readActiveAuthuser, writeActiveAuthuser } from '../utils/activeAuthuser';
+import { readActiveAuthuser, writeActiveAuthuser, clearSignedOut, isSilentRestoreSuppressed } from '../utils/activeAuthuser';
 import type { RouteName } from '../navigation/routes';
 import { showBottomSheet as globalShowBottomSheet } from '../navigation/bottomSheetManager';
 import { useQueryClient } from '@tanstack/react-query';
@@ -1322,15 +1322,29 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     // run cookie-restore BEFORE those probes (and disable the later duplicate).
     //
     // Read ONCE here (synchronously usable by the step `enabled` gates below).
-    // It is non-null ONLY on first-party `*.oxy.so` web apps that persist the
-    // slot — a cross-apex RP never writes it (its restore funnels through
-    // `handleWebSSOSession`, which does not touch the authuser), and native has
-    // no localStorage, so both keep their existing order untouched. The
-    // earlier `stored-session` step still runs first (FIX-A latency), and when
-    // a slot exists but its cookies have all lapsed, cookie-restore simply
-    // returns no accounts and the chain falls through to the cross-domain
-    // fallbacks exactly as before.
+    // It is non-null ONLY on first-party web apps that persist the slot. Both the
+    // device sign-in/switch paths AND `handleWebSSOSession` (FedCM/SSO/credentials
+    // commit funnel) now persist it — but only when the session genuinely joined
+    // the device set: `establishDeviceRefreshSlot` returns an `authuser` ONLY on
+    // first-party web (same registrable apex as the API), so a cross-apex RP never
+    // writes a phantom slot and native has no localStorage. Both therefore keep
+    // their existing order untouched. The earlier `stored-session` step still runs
+    // first (FIX-A latency), and when a slot exists but its cookies have all
+    // lapsed, cookie-restore simply returns no accounts and the chain falls through
+    // to the cross-domain fallbacks exactly as before.
     const prioritizeMultiAccount = isWebBrowser() && readActiveAuthuser() !== null;
+
+    // DELIBERATELY-SIGNED-OUT gate (web): when the user pressed "Sign out", the
+    // central IdP session (FedCM credential association / per-apex `fedcm_session`
+    // cookie) can still be live, so the AUTOMATIC silent steps below
+    // (`fedcm-silent`, `silent-iframe`) would re-mint a session on the very next
+    // cold boot and sign the user back in without intent. Read the durable flag
+    // ONCE here (synchronously usable by the step `enabled` gates) and skip those
+    // two steps while it is set. Any deliberate sign-in clears it. The `sso-bounce`
+    // step is already self-suppressed after sign-out (its `hasPriorSession` hint is
+    // cleared), and the local restore steps (`stored-session`, cookie-restore) are
+    // unaffected — a deliberate sign-out clears those credentials anyway.
+    const silentRestoreBlocked = isSilentRestoreSuppressed();
 
     try {
       const outcome = await runColdBoot<true>({
@@ -1461,7 +1475,10 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             // valid local bearer, and skipping it avoids the silent round-trip.
             id: 'fedcm-silent',
             enabled: () =>
-              !storedSessionRestored && fedcmSupported && !servicesSilentAttempted.has(silentKey),
+              !storedSessionRestored &&
+              !silentRestoreBlocked &&
+              fedcmSupported &&
+              !servicesSilentAttempted.has(silentKey),
             run: async () => {
               servicesSilentAttempted.add(silentKey);
               const session = await oxyServices.silentSignInWithFedCM?.();
@@ -1496,7 +1513,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             // FIX-D: bounded by `SILENT_IFRAME_TIMEOUT` (plus `iframe.onerror`
             // fail-fast in core) so a no-message iframe cannot stall cold boot.
             id: 'silent-iframe',
-            enabled: () => !storedSessionRestored && isWebBrowser(),
+            enabled: () => !storedSessionRestored && !silentRestoreBlocked && isWebBrowser(),
             run: async () => {
               if (!commitWebSession) {
                 return { kind: 'skip' };
@@ -1779,6 +1796,38 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     }
     oxyServices.httpService.setTokens(session.accessToken);
 
+    // A committed web session re-enables automatic silent restore: clear the
+    // durable "deliberately signed out" flag. This funnel is reached by deliberate
+    // sign-ins (password, interactive FedCM, `/sso` return) AND by the silent
+    // cold-boot steps — but those are GATED on the flag, so when it is set they
+    // never run and never reach here; clearing is therefore only hit on a genuine
+    // (re-)sign-in or when restore was already permitted, both correct.
+    clearSignedOut();
+
+    // Register this primary session in the device's first-party multi-account
+    // refresh-cookie set (web only). Every web primary-session restore funnels
+    // through here — FedCM silent (`/fedcm/exchange`), per-apex `/auth/silent`
+    // iframe, central `/sso` return, and keyless password sign-in. Of those, only
+    // a same-apex `/fedcm/exchange` plants an `oxy_rt_<authuser>` slot as a side
+    // effect; the cross-origin/credential-less restores (`/sso/exchange`,
+    // `/auth/silent` postMessage) cannot set an `api.oxy.so` cookie at all. So
+    // WITHOUT this call a web primary never joins the device set: `refresh-all`
+    // returns zero accounts, and account-switch persistence + the
+    // `cookie-restore-active` cold-boot step have no foundation. Calling the shared
+    // `POST /auth/session` primitive here makes EVERY primary participate in the
+    // set, re-plants the rotated token, and records the active `authuser` so the
+    // next cold boot's `cookie-restore-active` reconciles the persisted active
+    // (possibly switched) account instead of `fedcm-silent` clobbering it back to
+    // the primary. Best-effort: a `null` result (native / transient failure)
+    // leaves the in-session token untouched.
+    const primaryAuthuser = await oxyServices.establishDeviceRefreshSlot();
+    // A non-null slot is returned ONLY on first-party web (the helper gates on
+    // platform + same registrable apex), so recording the active slot here is safe
+    // and never writes a phantom authuser for a cross-apex RP or native.
+    if (typeof primaryAuthuser === 'number') {
+      writeActiveAuthuser(primaryAuthuser);
+    }
+
     const clientSession = {
       sessionId: session.sessionId,
       deviceId: session.deviceId || '',
@@ -1786,6 +1835,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       lastActive: new Date().toISOString(),
       userId: session.user.id?.toString() ?? '',
       isCurrent: true,
+      ...(typeof primaryAuthuser === 'number' ? { authuser: primaryAuthuser } : null),
     };
 
     updateSessions([clientSession], { merge: true });
@@ -2098,6 +2148,10 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     if (!result?.user || !result?.sessionId) {
       throw new Error('Account switch did not return a valid session');
     }
+
+    // A switch is a deliberate sign-in into an account: re-enable automatic silent
+    // restore by clearing any prior "deliberately signed out" flag.
+    clearSignedOut();
 
     // `oxyServices.switchToAccount` already planted `result.accessToken` as the
     // active token; mirror the minted session into the multi-account store and

--- a/packages/services/src/ui/context/hooks/useAuthOperations.ts
+++ b/packages/services/src/ui/context/hooks/useAuthOperations.ts
@@ -9,7 +9,13 @@ import type { StorageInterface } from '../../utils/storageHelpers';
 import type { OxyServices } from '@oxyhq/core';
 import { SignatureService } from '@oxyhq/core';
 import { isWebBrowser } from '../../hooks/useWebSSO';
-import { clearActiveAuthuser, clearSsoBounceState } from '../../utils/activeAuthuser';
+import {
+  clearActiveAuthuser,
+  clearSsoBounceState,
+  writeActiveAuthuser,
+  markSignedOut,
+  clearSignedOut,
+} from '../../utils/activeAuthuser';
 import { isCrossApexWeb, CrossApexDirectSignInError } from '../../../utils/crossApex';
 
 export interface UseAuthOperationsOptions {
@@ -132,6 +138,23 @@ export const useAuthOperations = ({
         deviceName,
         deviceFingerprint,
       );
+
+      // Deliberate sign-in re-enables automatic silent restore: clear the durable
+      // "deliberately signed out" flag so a prior sign-out no longer suppresses
+      // the `fedcm-silent` / per-apex iframe cold-boot steps.
+      clearSignedOut();
+
+      // Register this primary session in the device's first-party multi-account
+      // refresh-cookie set so a web key-based sign-in survives reload via
+      // `refresh-all` and coexists with switched accounts. `/auth/verify` mints the
+      // session but (unlike `/auth/login` / `/fedcm/exchange`) does NOT plant an
+      // `oxy_rt_<authuser>` slot, so we establish it here through the shared
+      // `POST /auth/session` primitive. No-op on native and cross-apex (returns
+      // `null`); records the active slot when one is genuinely allocated.
+      const verifyAuthuser = await oxyServices.establishDeviceRefreshSlot();
+      if (typeof verifyAuthuser === 'number') {
+        writeActiveAuthuser(verifyAuthuser);
+      }
 
       // Get full user data
       fullUser = await oxyServices.getUserBySession(sessionResponse.sessionId);
@@ -260,7 +283,14 @@ export const useAuthOperations = ({
             await switchSession(filteredSessions[0].sessionId);
           } else {
             // Genuine FULL sign-out (no sessions remain): clear the per-origin
-            // SSO bounce state so a fresh deliberate sign-in can re-probe.
+            // SSO bounce state so a fresh deliberate sign-in can re-probe, drop
+            // the persisted active device slot so the next cold boot does not
+            // prioritize a now-signed-out `oxy_active_authuser`, and SET the
+            // deliberately-signed-out flag so the silent cold-boot steps
+            // (`fedcm-silent` / per-apex iframe) do not re-mint a session from a
+            // still-live IdP session on the next reload (mirrors `logoutAll`).
+            markSignedOut();
+            clearActiveAuthuser();
             clearSsoBounceState();
             clearPriorSessionHintSafe(clearPriorSessionHint, logger);
             await clearSessionState();
@@ -322,6 +352,9 @@ export const useAuthOperations = ({
       if (isWebBrowser()) {
         await oxyServices.logoutAllSessionsViaCookie();
         clearActiveAuthuser();
+        // Deliberate full sign-out: suppress automatic silent restore on the next
+        // cold boot so a still-live IdP session does not re-mint a session.
+        markSignedOut();
       }
       // logoutAll is ALWAYS a full sign-out: clear the per-origin SSO bounce
       // state (web-guarded internally) so a fresh sign-in can re-probe, and drop

--- a/packages/services/src/ui/utils/activeAuthuser.ts
+++ b/packages/services/src/ui/utils/activeAuthuser.ts
@@ -24,6 +24,8 @@ import {
   ssoGuardKey,
   ssoStateKey,
   ssoDestKey,
+  ssoSignedOutKey,
+  silentRestoreSuppressed,
 } from '@oxyhq/core';
 
 const ACTIVE_AUTHUSER_KEY = 'oxy_active_authuser';
@@ -90,6 +92,50 @@ export function clearActiveAuthuser(): void {
   } catch {
     // Best-effort.
   }
+}
+
+/**
+ * Mark this origin as DELIBERATELY signed out (durable `localStorage`, via the
+ * core {@link ssoSignedOutKey}). Called ONLY on EXPLICIT full sign-out so that
+ * the next cold boot does NOT silently re-mint a session from a still-live IdP
+ * session (`fedcm-silent` / per-apex `/auth/silent` iframe). Cleared by any
+ * deliberate sign-in (see {@link clearSignedOut}). No-ops on native / storage
+ * failure (best-effort).
+ */
+export function markSignedOut(): void {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.setItem(ssoSignedOutKey(window.location.origin), '1');
+  } catch {
+    // Best-effort; swallow QuotaExceededError / SecurityError (private mode).
+  }
+}
+
+/**
+ * Clear the durable deliberately-signed-out flag. Called on ANY deliberate
+ * sign-in (password, FedCM, account switch, device claim) so a real sign-in
+ * fully re-enables automatic silent restore — there is no "stuck signed out"
+ * state. No-ops on native / storage failure.
+ */
+export function clearSignedOut(): void {
+  if (!hasLocalStorage()) return;
+  try {
+    window.localStorage.removeItem(ssoSignedOutKey(window.location.origin));
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Whether AUTOMATIC silent restore is suppressed for the current origin because
+ * the user deliberately signed out. Reads the durable flag through the core
+ * {@link silentRestoreSuppressed} predicate. Returns `false` off-web and on any
+ * storage failure (fail safe toward normal restore). Used to gate the
+ * `fedcm-silent` and `silent-iframe` cold-boot steps.
+ */
+export function isSilentRestoreSuppressed(): boolean {
+  if (!hasLocalStorage()) return false;
+  return silentRestoreSuppressed(window.localStorage, window.location.origin);
 }
 
 /**


### PR DESCRIPTION
Traced fix: primary FedCM/SSO web sessions never got an oxy_rt slot (refresh-all empty) so account-switch persistence had no foundation and fedcm-silent clobbered the switch on reload. Adds shared establishDeviceRefreshSlot() (reused by all primary-commit funnels + switchToAccount, removing duplication) + Option B signed-out gate (mirrors NO_SESSION). core 720 / auth-sdk 76 / api tsc 0.