### PR TITLE
ci(deploy): drop bun --frozen-lockfile from Cloudflare deploy (bun 1.3.14 false-positive)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -49,7 +49,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-      - run: bun install --frozen-lockfile
+      # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
+      # lock (non-deterministic configVersion churn), failing deploys. Lockfile
+      # sync is already gated pre-push (test-build) and in PR CI, so the deploy
+      # installs without the buggy frozen flag.
+      - run: bun install
       # Builds the Vite SPA AND the FedCM IdP Cloudflare Pages Function
       # (dist/_worker.js) — see packages/auth `build` -> `build:worker`.
       - run: bun x turbo run build --filter=auth
@@ -106,7 +110,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-      - run: bun install --frozen-lockfile
+      # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
+      # lock (non-deterministic configVersion churn), failing deploys. Lockfile
+      # sync is already gated pre-push (test-build) and in PR CI, so the deploy
+      # installs without the buggy frozen flag.
+      - run: bun install
       - run: bun x turbo run build --filter=accounts
       - uses: cloudflare/wrangler-action@v3
         with:
@@ -128,7 +136,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-      - run: bun install --frozen-lockfile
+      # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
+      # lock (non-deterministic configVersion churn), failing deploys. Lockfile
+      # sync is already gated pre-push (test-build) and in PR CI, so the deploy
+      # installs without the buggy frozen flag.
+      - run: bun install
       - run: bun x turbo run build --filter=inbox
       - uses: cloudflare/wrangler-action@v3
         with:
@@ -150,7 +162,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '20.x'
-      - run: bun install --frozen-lockfile
+      # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
+      # lock (non-deterministic configVersion churn), failing deploys. Lockfile
+      # sync is already gated pre-push (test-build) and in PR CI, so the deploy
+      # installs without the buggy frozen flag.
+      - run: bun install
       - run: bun x turbo run build --filter=oxy-console
       - name: Resolve build output directory
         run: |


### PR DESCRIPTION
bun 1.3.14 --frozen-lockfile false-positives on a synced lock and hard-blocks all CF frontend deploys; install without the buggy flag (lock-sync gated pre-push + PR CI).