### PR TITLE
feat(did): advertise #atproto_pds + Multikey VM for atproto-bridged users

### DIFF
--- a/packages/api/src/services/__tests__/did.service.test.ts
+++ b/packages/api/src/services/__tests__/did.service.test.ts
@@ -249,3 +249,105 @@ describe('buildDidDocument — personal data node (F5a)', () => {
     expect(doc.service.some((s) => s.id.endsWith('#oxy-node'))).toBe(false);
   });
 });
+
+describe('buildDidDocument — atproto BE-DISCOVERED seam (C4)', () => {
+  const publicKey = newPublicKey();
+  const selfSovereign = {
+    _id: '507f1f77bcf86cd799439011',
+    publicKey,
+    username: 'nate',
+    authMethods: [{ type: 'identity', metadata: { publicKey } }],
+    type: 'local',
+  };
+  const custodial = {
+    _id: '507f1f77bcf86cd799439012',
+    username: 'paula',
+    authMethods: [{ type: 'password', metadata: { email: 'paula@oxy.so' } }],
+    type: 'local',
+  };
+
+  const ORIGINAL_BRIDGE_ENABLED = process.env.ATPROTO_BRIDGE_ENABLED;
+  const ORIGINAL_PDS_ENDPOINT = process.env.ATPROTO_PDS_ENDPOINT;
+  const PDS = 'https://mention.earth';
+
+  function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+
+  afterEach(() => {
+    restoreEnv('ATPROTO_BRIDGE_ENABLED', ORIGINAL_BRIDGE_ENABLED);
+    restoreEnv('ATPROTO_PDS_ENDPOINT', ORIGINAL_PDS_ENDPOINT);
+  });
+
+  function enableBridge(): void {
+    process.env.ATPROTO_BRIDGE_ENABLED = 'true';
+    process.env.ATPROTO_PDS_ENDPOINT = PDS;
+  }
+
+  it('adds the #atproto_pds service + a Multikey VM for a bridged self-sovereign user', () => {
+    enableBridge();
+    const doc = buildDidDocument(selfSovereign);
+    const did = buildUserDid(selfSovereign._id);
+
+    expect(() => didDocumentSchema.parse(doc)).not.toThrow();
+
+    // PDS service points at the configured bridge base URL.
+    expect(doc.service).toContainEqual({
+      id: `${did}#atproto_pds`,
+      type: 'AtprotoPersonalDataServer',
+      serviceEndpoint: PDS,
+    });
+
+    // Multikey VM alongside the existing secp256k1 VM, same key, atproto form.
+    const atprotoVm = doc.verificationMethod.find((vm) => vm.id === `${did}#atproto`);
+    expect(atprotoVm).toBeDefined();
+    expect(atprotoVm).toMatchObject({ id: `${did}#atproto`, type: 'Multikey', controller: did });
+    // secp256k1 Multikeys are the `zQ3sh…` did:key form.
+    expect(atprotoVm && 'publicKeyMultibase' in atprotoVm && atprotoVm.publicKeyMultibase).toMatch(/^zQ3sh/);
+
+    // The atproto VM is referenced as an authentication + assertion method.
+    expect(doc.authentication).toContain(`${did}#atproto`);
+    expect(doc.assertionMethod).toContain(`${did}#atproto`);
+
+    // The canonical secp256k1 #key-1 VM is untouched.
+    expect(doc.verificationMethod).toContainEqual({
+      id: `${did}#key-1`,
+      type: 'EcdsaSecp256k1VerificationKey2019',
+      controller: did,
+      publicKeyHex: publicKey,
+    });
+  });
+
+  it('leaves a self-sovereign document byte-identical when the bridge is OFF', () => {
+    restoreEnv('ATPROTO_BRIDGE_ENABLED', undefined);
+    restoreEnv('ATPROTO_PDS_ENDPOINT', undefined);
+    const off = buildDidDocument(selfSovereign);
+
+    expect(off.service.some((s) => s.id.endsWith('#atproto_pds'))).toBe(false);
+    expect(off.verificationMethod.some((vm) => vm.type === 'Multikey')).toBe(false);
+    expect(off.authentication).not.toContain(`${buildUserDid(selfSovereign._id)}#atproto`);
+  });
+
+  it('does NOT add the atproto seam to a custodial (no own key) user even when enabled', () => {
+    enableBridge();
+    process.env.OXY_PUBLIC_KEY = newPublicKey();
+    const doc = buildDidDocument(custodial);
+
+    expect(() => didDocumentSchema.parse(doc)).not.toThrow();
+    expect(doc.service.some((s) => s.id.endsWith('#atproto_pds'))).toBe(false);
+    expect(doc.verificationMethod.some((vm) => vm.type === 'Multikey')).toBe(false);
+  });
+
+  it('FAILS CLOSED when enabled but no PDS endpoint is configured', () => {
+    process.env.ATPROTO_BRIDGE_ENABLED = 'true';
+    delete process.env.ATPROTO_PDS_ENDPOINT;
+    const doc = buildDidDocument(selfSovereign);
+
+    expect(doc.service.some((s) => s.id.endsWith('#atproto_pds'))).toBe(false);
+    expect(doc.verificationMethod.some((vm) => vm.type === 'Multikey')).toBe(false);
+  });
+});

--- a/packages/api/src/services/civic/credential.service.ts
+++ b/packages/api/src/services/civic/credential.service.ts
@@ -31,7 +31,13 @@
  * envelope — never from the projection's denormalized claims.
  */
 
-import type { SignedRecordEnvelope, VerifiableCredentialResponse, CredentialStatus } from '@oxyhq/contracts';
+import type {
+  SignedRecordEnvelope,
+  VerifiableCredentialResponse,
+  CredentialStatus,
+  DidDocument,
+  Secp256k1VerificationMethod,
+} from '@oxyhq/contracts';
 import { credentialRecordSchema } from '@oxyhq/contracts';
 import { signedRecordSigningInput, verifyEnvelopeSignature, type RejectionReason } from '@oxyhq/protocol';
 import SignatureService from '../signature.service';
@@ -395,7 +401,7 @@ export async function listCredentialsForHolder(
  */
 async function resolveIssuerVmKeys(issuerDid: string): Promise<string[] | null> {
   if (issuerDid === OXY_DID) {
-    return buildOxyDidDocument().verificationMethod.map((vm) => vm.publicKeyHex);
+    return secp256k1KeysOf(buildOxyDidDocument());
   }
   const issuerUserId = parseUserDid(issuerDid);
   if (!issuerUserId || !isValidObjectId(issuerUserId)) {
@@ -407,7 +413,18 @@ async function resolveIssuerVmKeys(issuerDid: string): Promise<string[] | null> 
   if (!issuer) {
     return null;
   }
-  return buildDidDocument(issuer).verificationMethod.map((vm) => vm.publicKeyHex);
+  return secp256k1KeysOf(buildDidDocument(issuer));
+}
+
+/**
+ * The hex public keys of a DID document's secp256k1 verification methods. The
+ * atproto `Multikey` VM carries the SAME key in multibase form (not hex), so it
+ * is intentionally excluded — credential signatures verify against the hex key.
+ */
+function secp256k1KeysOf(document: DidDocument): string[] {
+  return document.verificationMethod
+    .filter((vm): vm is Secp256k1VerificationMethod => vm.type === 'EcdsaSecp256k1VerificationKey2019')
+    .map((vm) => vm.publicKeyHex);
 }
 
 /** Best-effort lazy flip of an expired credential's status (never throws). */

--- a/packages/api/src/services/did.service.ts
+++ b/packages/api/src/services/did.service.ts
@@ -26,6 +26,16 @@ import {
   type DidService,
 } from '@oxyhq/contracts';
 import { OXY_NODE_SERVICE_TYPE, OXY_NODE_SERVICE_FRAGMENT } from '../utils/nodes.constants';
+import {
+  ATPROTO_BRIDGE_ENABLED,
+  ATPROTO_PDS_ENDPOINT_ENV,
+  ATPROTO_PDS_SERVICE_FRAGMENT,
+  ATPROTO_PDS_SERVICE_TYPE,
+  ATPROTO_VERIFICATION_METHOD_FRAGMENT,
+  ATPROTO_MULTIKEY_VM_TYPE,
+} from '../utils/atproto.constants';
+import { secp256k1PublicKeyToMultikey } from '../utils/multikey';
+import { logger } from '../utils/logger';
 
 /**
  * The federation/identity domain — drives webfinger handles, profile URLs, and
@@ -56,6 +66,24 @@ const DID_CONTEXT = [
 ];
 
 const SECP256K1_VM_TYPE = 'EcdsaSecp256k1VerificationKey2019' as const;
+
+/**
+ * The HTTPS base URL of the atproto bridge PDS, or `null` when the seam is not
+ * fully configured. The seam is live ONLY when the bridge is enabled
+ * (`ATPROTO_BRIDGE_ENABLED`) AND a real endpoint is set — a PDS service entry
+ * with no endpoint is worse than none, so it FAILS CLOSED. Both inputs are read
+ * at call time (not module load) so a test or a hot-reconfigured task observes
+ * the current env. {@link ATPROTO_BRIDGE_ENABLED} is the canonical exported gate;
+ * it is re-derived here from the same env var so the check stays call-time-exact.
+ */
+function atprotoPdsEndpoint(): string | null {
+  const enabled = ATPROTO_BRIDGE_ENABLED || process.env.ATPROTO_BRIDGE_ENABLED === 'true';
+  if (!enabled) {
+    return null;
+  }
+  const endpoint = process.env[ATPROTO_PDS_ENDPOINT_ENV]?.trim();
+  return endpoint && endpoint.length > 0 ? endpoint : null;
+}
 
 /**
  * The minimal identity-bearing shape of a user the DID builder reads. Accepts a
@@ -205,6 +233,41 @@ export function buildDidDocument(user: DidUserInput): DidDocument {
       type: OXY_NODE_SERVICE_TYPE,
       serviceEndpoint: user.node.endpoint,
     });
+  }
+
+  // C4 atproto BE-DISCOVERED seam: when the bridge is enabled and a self-sovereign
+  // account holds an own identity key, additively announce the bridge PDS service
+  // and an atproto `Multikey` verification method (the same secp256k1 key, encoded
+  // the way a Bluesky AppView expects). Custodial accounts have no own key, so
+  // they never gain an atproto VM. Derived on demand; the document stays
+  // byte-identical for everyone when the seam is off.
+  const pdsEndpoint = atprotoPdsEndpoint();
+  if (pdsEndpoint && isSelfSovereign) {
+    const atprotoVmId = `${did}${ATPROTO_VERIFICATION_METHOD_FRAGMENT}`;
+    try {
+      // The primary identity key is the atproto signing key (matches `#key-1`).
+      const publicKeyMultibase = secp256k1PublicKeyToMultikey(identityKeys[0]);
+      verificationMethod.push({
+        id: atprotoVmId,
+        type: ATPROTO_MULTIKEY_VM_TYPE,
+        controller: did,
+        publicKeyMultibase,
+      });
+      activeVerificationMethodIds.push(atprotoVmId);
+      service.push({
+        id: `${did}${ATPROTO_PDS_SERVICE_FRAGMENT}`,
+        type: ATPROTO_PDS_SERVICE_TYPE,
+        serviceEndpoint: pdsEndpoint,
+      });
+    } catch (err) {
+      // A malformed stored key must never break the canonical document: skip the
+      // atproto seam for this user and serve the standard document.
+      logger.warn('Skipping atproto DID seam: identity key is not a valid secp256k1 public key', {
+        component: 'did',
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   const document: DidDocument = {

--- a/packages/api/src/utils/__tests__/multikey.test.ts
+++ b/packages/api/src/utils/__tests__/multikey.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the secp256k1 → `Multikey` encoder.
+ *
+ * Verifies the atproto/W3C `did:key` properties WITHOUT a hardcoded vector: the
+ * output round-trips through a base58btc decoder to the exact multicodec prefix +
+ * compressed public key. secp256k1 Multikeys are always the `zQ3sh…` family, so
+ * that prefix is asserted too. Accepting both the uncompressed (stored) and the
+ * compressed key forms is checked for stability.
+ */
+
+import { ec as EC } from 'elliptic';
+import { secp256k1PublicKeyToMultikey } from '../multikey';
+
+const ec = new EC('secp256k1');
+
+/** Standard base58btc decode (Bitcoin alphabet) — inverse of the encoder. */
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+function base58btcDecode(str: string): Uint8Array {
+  const digits: number[] = [];
+  let zeros = 0;
+  while (zeros < str.length && str[zeros] === BASE58_ALPHABET[0]) zeros++;
+  for (let i = zeros; i < str.length; i++) {
+    let carry = BASE58_ALPHABET.indexOf(str[i]);
+    if (carry < 0) throw new Error(`invalid base58 char: ${str[i]}`);
+    for (let j = 0; j < digits.length; j++) {
+      carry += digits[j] * 58;
+      digits[j] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      digits.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+  const out = new Uint8Array(zeros + digits.length);
+  for (let i = 0; i < digits.length; i++) out[zeros + digits.length - 1 - i] = digits[i];
+  return out;
+}
+
+describe('secp256k1PublicKeyToMultikey', () => {
+  it('encodes the multicodec-prefixed compressed key as a zQ3sh… multibase string', () => {
+    const kp = ec.genKeyPair();
+    const uncompressed = kp.getPublic('hex');
+    const compressed = Buffer.from(kp.getPublic().encodeCompressed()).toString('hex');
+
+    const multikey = secp256k1PublicKeyToMultikey(uncompressed);
+
+    // Multibase base58btc prefix, secp256k1 did:key family.
+    expect(multikey.startsWith('z')).toBe(true);
+    expect(multikey.startsWith('zQ3sh')).toBe(true);
+
+    const decoded = base58btcDecode(multikey.slice(1));
+    // secp256k1 multicodec varint (0xe7 0x01) + 33-byte compressed key.
+    expect(decoded.length).toBe(35);
+    expect(decoded[0]).toBe(0xe7);
+    expect(decoded[1]).toBe(0x01);
+    expect(Buffer.from(decoded.slice(2)).toString('hex')).toBe(compressed);
+  });
+
+  it('is stable across the uncompressed and compressed input forms', () => {
+    const kp = ec.genKeyPair();
+    const uncompressed = kp.getPublic('hex');
+    const compressed = Buffer.from(kp.getPublic().encodeCompressed()).toString('hex');
+
+    expect(secp256k1PublicKeyToMultikey(uncompressed)).toBe(
+      secp256k1PublicKeyToMultikey(compressed),
+    );
+  });
+
+  it('is deterministic for the same key', () => {
+    const publicKey = ec.genKeyPair().getPublic('hex');
+    expect(secp256k1PublicKeyToMultikey(publicKey)).toBe(secp256k1PublicKeyToMultikey(publicKey));
+  });
+
+  it('throws on an invalid secp256k1 public key', () => {
+    expect(() => secp256k1PublicKeyToMultikey('deadbeef')).toThrow();
+  });
+});

--- a/packages/api/src/utils/atproto.constants.ts
+++ b/packages/api/src/utils/atproto.constants.ts
@@ -1,0 +1,47 @@
+/**
+ * AtProto (Bluesky) bridge seam constants.
+ *
+ * SINGLE SOURCE OF TRUTH for the tunables that make an Oxy user's canonical
+ * `did:web` document advertise the Mention atproto BE-DISCOVERED bridge.
+ *
+ * The canonical DID document is owned by oxy-api; Mention CANNOT add an
+ * `#atproto_pds` service or an atproto-format verification method to it. This
+ * seam closes that gap: when the bridge is enabled AND a PDS endpoint is
+ * configured, `buildDidDocument` additively announces the bridge PDS + a
+ * `Multikey` verification method (the atproto-format encoding of the user's
+ * existing secp256k1 identity key), so a foreign Bluesky AppView/Relay routes a
+ * Mention user's handle back to the bridge.
+ *
+ * Nothing in the DID composition may hardcode these — import them here.
+ */
+
+/**
+ * Master gate for the atproto BE-DISCOVERED seam. OFF by default — the
+ * `#atproto_pds` service + `Multikey` verification method are only added when
+ * `ATPROTO_BRIDGE_ENABLED === 'true'`. Mirrors Mention's own bridge gate of the
+ * same name so the two sides activate together; defaults closed.
+ */
+export const ATPROTO_BRIDGE_ENABLED = process.env.ATPROTO_BRIDGE_ENABLED === 'true';
+
+/**
+ * Env var naming the HTTPS base URL of the atproto bridge PDS that serves the
+ * user's repo (`com.atproto.repo.*` / `com.atproto.sync.*` under `/xrpc`). This
+ * is the Mention bridge origin (e.g. `https://mention.earth`) — the BASE, NOT
+ * the `/xrpc` path: an atproto client appends `/xrpc/<nsid>` itself. Configurable
+ * via env, never hardcoded. When unset the seam is inert even if
+ * {@link ATPROTO_BRIDGE_ENABLED} is true — a PDS service with no real endpoint
+ * would be worse than none, so the seam FAILS CLOSED (the service/VM are omitted).
+ */
+export const ATPROTO_PDS_ENDPOINT_ENV = 'ATPROTO_PDS_ENDPOINT';
+
+/** The DID-document service-id fragment for the atproto bridge PDS. */
+export const ATPROTO_PDS_SERVICE_FRAGMENT = '#atproto_pds';
+
+/** The DID-document service `type` announced for an atproto Personal Data Server. */
+export const ATPROTO_PDS_SERVICE_TYPE = 'AtprotoPersonalDataServer';
+
+/** The DID-document verification-method-id fragment for the atproto Multikey VM. */
+export const ATPROTO_VERIFICATION_METHOD_FRAGMENT = '#atproto';
+
+/** The atproto verification-method `type` (multibase-encoded public key). */
+export const ATPROTO_MULTIKEY_VM_TYPE = 'Multikey' as const;

--- a/packages/api/src/utils/multikey.ts
+++ b/packages/api/src/utils/multikey.ts
@@ -1,0 +1,91 @@
+/**
+ * `Multikey` encoding for secp256k1 public keys (the atproto / W3C `did:key`
+ * form).
+ *
+ * AtProto verification methods are `Multikey`: `publicKeyMultibase` is the
+ * multibase-`base58btc` (leading `z`) encoding of the multicodec-prefixed,
+ * COMPRESSED public key. For secp256k1 the multicodec prefix is the unsigned
+ * varint of `0xe7` — the two bytes `0xe7 0x01`.
+ *
+ *   multikey = 'z' + base58btc( 0xe7 0x01 || compressedPubKey(33 bytes) )
+ *
+ * Oxy stores secp256k1 public keys as UNCOMPRESSED hex (the `04 || X || Y`,
+ * 65-byte form `elliptic` emits); this module re-derives the 33-byte compressed
+ * point from it. Pure and dependency-light: `elliptic` (already a backend dep)
+ * does the point math, `base58btc` is implemented inline (the standard Bitcoin
+ * alphabet) to avoid pulling a multiformats dependency for ~20 lines.
+ */
+
+import { ec as EC } from 'elliptic';
+
+const secp256k1 = new EC('secp256k1');
+
+/** The Bitcoin/IPFS base58btc alphabet. */
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+/** Unsigned-varint multicodec prefix for secp256k1 public keys (`0xe7`). */
+const SECP256K1_MULTICODEC_PREFIX = Uint8Array.from([0xe7, 0x01]);
+
+/** Multibase prefix for `base58btc`. */
+const MULTIBASE_BASE58BTC_PREFIX = 'z';
+
+/**
+ * Encode bytes as base58btc (no multibase prefix). Uses the canonical Bitcoin
+ * base-256 → base-58 long division over a digit buffer (no `BigInt`, so it is
+ * independent of the compile target). Leading zero bytes map to leading `'1'`s.
+ */
+function base58btcEncode(bytes: Uint8Array): string {
+    let zeros = 0;
+    while (zeros < bytes.length && bytes[zeros] === 0) {
+        zeros++;
+    }
+
+    // Repeated division of the big-endian byte array by 58, collecting remainders.
+    // `digits` holds the base-58 result least-significant first.
+    const digits: number[] = [];
+    for (let i = zeros; i < bytes.length; i++) {
+        let carry = bytes[i];
+        for (let j = 0; j < digits.length; j++) {
+            carry += digits[j] << 8;
+            digits[j] = carry % 58;
+            carry = (carry / 58) | 0;
+        }
+        while (carry > 0) {
+            digits.push(carry % 58);
+            carry = (carry / 58) | 0;
+        }
+    }
+
+    let out = BASE58_ALPHABET[0].repeat(zeros);
+    for (let i = digits.length - 1; i >= 0; i--) {
+        out += BASE58_ALPHABET[digits[i]];
+    }
+    return out;
+}
+
+/**
+ * Compress an `elliptic`-encoded secp256k1 public key (hex) to its 33-byte
+ * compressed form. Accepts the uncompressed (`04…`, 65-byte) form Oxy stores as
+ * well as an already-compressed key. Throws when the input is not a valid
+ * secp256k1 point.
+ */
+function compressSecp256k1PublicKey(publicKeyHex: string): Uint8Array {
+    const key = secp256k1.keyFromPublic(publicKeyHex, 'hex');
+    return Uint8Array.from(key.getPublic().encodeCompressed());
+}
+
+/**
+ * Encode a secp256k1 public key (hex) as an atproto `Multikey`
+ * (`publicKeyMultibase`): `z` + base58btc(`0xe7 0x01` || compressedPubKey).
+ *
+ * @param publicKeyHex - secp256k1 public key in hex (uncompressed or compressed).
+ * @returns the multibase `publicKeyMultibase` string (leading `z`).
+ * @throws when `publicKeyHex` is not a valid secp256k1 public key.
+ */
+export function secp256k1PublicKeyToMultikey(publicKeyHex: string): string {
+    const compressed = compressSecp256k1PublicKey(publicKeyHex);
+    const prefixed = new Uint8Array(SECP256K1_MULTICODEC_PREFIX.length + compressed.length);
+    prefixed.set(SECP256K1_MULTICODEC_PREFIX, 0);
+    prefixed.set(compressed, SECP256K1_MULTICODEC_PREFIX.length);
+    return MULTIBASE_BASE58BTC_PREFIX + base58btcEncode(prefixed);
+}

--- a/packages/contracts/src/identity.ts
+++ b/packages/contracts/src/identity.ts
@@ -45,25 +45,69 @@ import { z } from 'zod';
 /* -------------------------------------------------------------------------- */
 
 /**
- * A single DID verification method. Mirrors the secp256k1 key entries the API
- * derives from `User.publicKey` + each `authMethods[]` of type `identity`.
- * `id` is a fragment reference within the DID document (e.g.
- * `did:web:oxy.so:u:<id>#key-1`); `controller` is the controlling DID;
- * `publicKeyHex` is the uncompressed/compressed secp256k1 public key in hex.
+ * A `EcdsaSecp256k1VerificationKey2019` verification method — the canonical Oxy
+ * key form. Mirrors the secp256k1 key entries the API derives from
+ * `User.publicKey` + each `authMethods[]` of type `identity`. `id` is a fragment
+ * reference within the DID document (e.g. `did:web:oxy.so:u:<id>#key-1`);
+ * `controller` is the controlling DID; `publicKeyHex` is the (uncompressed)
+ * secp256k1 public key in hex.
  */
-export interface VerificationMethod {
+export interface Secp256k1VerificationMethod {
     id: string;
     type: 'EcdsaSecp256k1VerificationKey2019';
     controller: string;
     publicKeyHex: string;
 }
 
-export const verificationMethodSchema: z.ZodType<VerificationMethod> = z.object({
+/**
+ * A `Multikey` verification method — the AtProto/Bluesky key form. The SAME
+ * secp256k1 key as an account's {@link Secp256k1VerificationMethod}, re-encoded
+ * the way atproto expects: `publicKeyMultibase` is the `did:key`-style multibase
+ * (`base58btc`, leading `z`) of the multicodec-prefixed (`0xe7 0x01`, secp256k1)
+ * COMPRESSED public key. This is the verification method a foreign Bluesky
+ * AppView reads when it routes to the user's bridge PDS; it is additive and only
+ * present for atproto-bridged self-sovereign accounts.
+ */
+export interface MultikeyVerificationMethod {
+    id: string;
+    type: 'Multikey';
+    controller: string;
+    publicKeyMultibase: string;
+}
+
+/**
+ * A single DID verification method — either the canonical Oxy secp256k1 form
+ * ({@link Secp256k1VerificationMethod}) or the atproto `Multikey` form
+ * ({@link MultikeyVerificationMethod}). Discriminated on `type`, so an
+ * `EcdsaSecp256k1VerificationKey2019` entry keeps its exact `publicKeyHex` shape
+ * (every document already served verifies byte-identically) and the `Multikey`
+ * entry carries `publicKeyMultibase`.
+ */
+export type VerificationMethod = Secp256k1VerificationMethod | MultikeyVerificationMethod;
+
+// The option schemas are left UN-annotated so they keep their concrete
+// `ZodObject` type — `z.discriminatedUnion` requires object options and an
+// explicit `z.ZodType<>` annotation would erase the shape it discriminates on.
+// `z.object` already infers each option's type exactly (id/type/controller +
+// the key field), so the union is structurally `VerificationMethod`.
+const secp256k1VerificationMethodSchema = z.object({
     id: z.string(),
     type: z.literal('EcdsaSecp256k1VerificationKey2019'),
     controller: z.string(),
     publicKeyHex: z.string(),
 });
+
+const multikeyVerificationMethodSchema = z.object({
+    id: z.string(),
+    type: z.literal('Multikey'),
+    controller: z.string(),
+    publicKeyMultibase: z.string(),
+});
+
+export const verificationMethodSchema = z.discriminatedUnion('type', [
+    secp256k1VerificationMethodSchema,
+    multikeyVerificationMethodSchema,
+]);
 
 /**
  * A DID service entry (the `service[]` array). Oxy publishes its API root and

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -102,6 +102,8 @@ export {
 
 export type {
     VerificationMethod,
+    Secp256k1VerificationMethod,
+    MultikeyVerificationMethod,
     DidService,
     DidDocument,
     SignedRecordEnvelope,

--- a/packages/protocol/src/__tests__/didWebResolver.test.ts
+++ b/packages/protocol/src/__tests__/didWebResolver.test.ts
@@ -84,6 +84,22 @@ describe('createDidWebResolver', () => {
     expect(await resolver.resolve(SUBJECT)).toEqual({ currentPublicKeys: [KEY_A, KEY_B] });
   });
 
+  it('ignores a Multikey VM and collects only the secp256k1 hex keys', async () => {
+    // An atproto-bridged document carries an extra `Multikey` VM (the SAME key in
+    // multibase form, no `publicKeyHex`). The resolver must skip it and resolve to
+    // the hex signing key only.
+    const doc = didDoc({
+      verificationMethod: [
+        { id: `${SUBJECT}#key-1`, type: 'EcdsaSecp256k1VerificationKey2019', controller: SUBJECT, publicKeyHex: KEY_A },
+        { id: `${SUBJECT}#atproto`, type: 'Multikey', controller: SUBJECT, publicKeyMultibase: 'zQ3shFakeMultibaseKey' },
+      ],
+      authentication: [`${SUBJECT}#key-1`, `${SUBJECT}#atproto`],
+      assertionMethod: [`${SUBJECT}#key-1`, `${SUBJECT}#atproto`],
+    });
+    const resolver = createDidWebResolver(async () => jsonResponse(doc));
+    expect(await resolver.resolve(SUBJECT)).toEqual({ currentPublicKeys: [KEY_A] });
+  });
+
   it('returns null for a non-did:web subject (no fetch)', async () => {
     const fetch = jest.fn();
     const resolver = createDidWebResolver(fetch as unknown as NodeFetch);

--- a/packages/protocol/src/node/didWebResolver.ts
+++ b/packages/protocol/src/node/didWebResolver.ts
@@ -17,7 +17,11 @@
  *  - a `%3A` in the host segment is decoded to `:` (an explicit port).
  */
 
-import { didDocumentSchema, type DidDocument } from '@oxyhq/contracts';
+import {
+  didDocumentSchema,
+  type DidDocument,
+  type Secp256k1VerificationMethod,
+} from '@oxyhq/contracts';
 import type {
   ResolvedVerificationMethods,
   VerificationMethodResolver,
@@ -73,14 +77,28 @@ export function didWebToUrl(did: string): string | null {
   return `${base}/${pathParts.join('/')}/did.json`;
 }
 
+/** True for a secp256k1 verification method (carries `publicKeyHex`). */
+function isSecp256k1Vm(
+  vm: DidDocument['verificationMethod'][number],
+): vm is Secp256k1VerificationMethod {
+  return vm.type === 'EcdsaSecp256k1VerificationKey2019';
+}
+
 /**
  * Collect the subject's current verification keys from its DID document: the
- * `publicKeyHex` of every verification method referenced by `assertionMethod`
- * (the keys that may sign assertions/records), deduped. Falls back to ALL
- * `verificationMethod[]` keys when `assertionMethod` references nothing local.
+ * `publicKeyHex` of every secp256k1 verification method referenced by
+ * `assertionMethod` (the keys that may sign assertions/records), deduped. Falls
+ * back to ALL secp256k1 `verificationMethod[]` keys when `assertionMethod`
+ * references nothing local. Non-secp256k1 methods (e.g. the atproto `Multikey`,
+ * which carries the SAME key in multibase form, not hex) are skipped — record
+ * signatures verify against the hex key.
  */
 function collectCurrentPublicKeys(doc: DidDocument): string[] {
-  const byId = new Map(doc.verificationMethod.map((vm) => [vm.id, vm.publicKeyHex] as const));
+  const byId = new Map(
+    doc.verificationMethod
+      .filter(isSecp256k1Vm)
+      .map((vm) => [vm.id, vm.publicKeyHex] as const),
+  );
   const keys: string[] = [];
   for (const id of doc.assertionMethod) {
     const key = byId.get(id);
@@ -89,9 +107,9 @@ function collectCurrentPublicKeys(doc: DidDocument): string[] {
     }
   }
   if (keys.length === 0) {
-    for (const vm of doc.verificationMethod) {
-      if (!keys.includes(vm.publicKeyHex)) {
-        keys.push(vm.publicKeyHex);
+    for (const key of byId.values()) {
+      if (!keys.includes(key)) {
+        keys.push(key);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Widens `VerificationMethod` in `@oxyhq/contracts` to a discriminated union: `Secp256k1VerificationMethod | MultikeyVerificationMethod`
- Exports the two new VM types from contracts index
- `did.service.ts`: env-gated additive `#atproto_pds` service + Multikey VM for atproto-bridged users
- `credential.service.ts`: narrows VM union to secp256k1 hex keys in civic credential path
- New `atproto.constants.ts`: gate + endpoint env constants
- New `multikey.ts`: secp256k1 → Multikey base58btc encoder
- New `multikey.test.ts` + atproto seam tests appended to `did.service.test.ts`

## Test plan
- [x] contracts build: clean
- [x] api tsc --noEmit: 0 errors
- [x] contracts jest: 95/95 pass
- [x] api jest: 130 suites / 1240 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)