### PR TITLE
fix(auth): gate every silent cold-boot restore step on deliberate sign-out

### DIFF
--- a/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
@@ -356,6 +356,49 @@ describe('WebOxyProvider cold boot (central SSO)', () => {
     expect(latest.isAuthenticated).toBe(false);
   });
 
+  it('5c) DELIBERATELY-SIGNED-OUT gate: cookie-restore is SKIPPED when the signed-out flag is set', async () => {
+    resetStubs('https://api.test-5c');
+    // The refresh cookie is STILL present (PR #455: the primary web session joins
+    // the device `oxy_rt` set), so `authManager.initialize()` WOULD restore a real
+    // user — but the user deliberately signed out, so the cookie-restore step must
+    // NOT run and must NOT silently re-log them in on this cold boot.
+    stubs.isFedCMSupported.mockReturnValue(false);
+    stubs.managerInitialize.mockResolvedValue(realUser);
+    stubs.getActiveAccount.mockReturnValue({ sessionId: 'sess_cookie' });
+    stubs.getCurrentUser.mockResolvedValue(realUser);
+    window.localStorage.setItem(ssoSignedOutKey(ORIGIN), '1');
+
+    let latest: ProbeState = { isAuthenticated: false, userId: null, isLoading: true };
+    renderProvider(stubs.baseURL, (s) => { latest = s; });
+
+    // The chain falls through to the terminal bounce (the beforeEach seeds the
+    // returning-visitor hint), proving cookie-restore did not silently restore.
+    await waitFor(() => expect(bounced()).toBe(true));
+    expect(stubs.managerInitialize).not.toHaveBeenCalled();
+    expect(latest.isAuthenticated).toBe(false);
+  });
+
+  it('5d) deliberate sign-in CLEARS the signed-out flag → cookie-restore restores again on the next boot', async () => {
+    resetStubs('https://api.test-5d');
+    // Arm the signed-out flag, then clear it (simulating a deliberate sign-in /
+    // account switch, which both call `clearSignedOut*`). The very next cold boot
+    // must restore normally — there is no "stuck signed out" state.
+    window.localStorage.setItem(ssoSignedOutKey(ORIGIN), '1');
+    window.localStorage.removeItem(ssoSignedOutKey(ORIGIN));
+    stubs.isFedCMSupported.mockReturnValue(false);
+    stubs.managerInitialize.mockResolvedValue(realUser);
+    stubs.getActiveAccount.mockReturnValue({ sessionId: 'sess_cookie' });
+    stubs.getCurrentUser.mockResolvedValue(realUser);
+
+    let latest: ProbeState = { isAuthenticated: false, userId: null, isLoading: true };
+    renderProvider(stubs.baseURL, (s) => { latest = s; });
+
+    await waitFor(() => expect(latest.isAuthenticated).toBe(true));
+    expect(latest.userId).toBe('u1');
+    expect(stubs.managerInitialize).toHaveBeenCalled();
+    expect(bounced()).toBe(false);
+  });
+
   it('6) cookie-restore hydrates a real user and commits when prior steps skip', async () => {
     resetStubs('https://api.test-6');
     stubs.managerInitialize.mockResolvedValue(realUser);

--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -743,15 +743,21 @@ export function WebOxyProvider({
       // session. A placeholder user (empty id) is never exposed (R4).
       const ssoKey = silentSignInKey(oxyServices);
 
-      // DELIBERATELY-SIGNED-OUT gate (web): when the user pressed "Sign out", the
-      // central IdP session can still be live, so the silent `fedcm-silent` step
-      // below would re-mint a session on the next cold boot and sign the user back
-      // in without intent. Read the durable flag ONCE here (synchronously usable by
-      // the step `enabled` gate) and skip `fedcm-silent` while it is set. Any
-      // deliberate sign-in clears it. The terminal `sso-bounce` is already
-      // self-suppressed after sign-out (its prior-session hint is cleared), and the
-      // `cookie-restore` step reads only first-party cookies that an explicit
-      // sign-out already cleared.
+      // DELIBERATELY-SIGNED-OUT gate (web): when the user pressed "Sign out", any
+      // credential that can silently re-mint a session may still be live on the
+      // next cold boot — the central IdP session (so `fedcm-silent` would re-mint)
+      // AND the device refresh cookies. Since PR #455 the PRIMARY web session also
+      // joins the `oxy_rt_<authuser>` device set, so `cookie-restore` would
+      // `refresh-all` that still-present cookie and silently sign the user back in.
+      // So this flag gates BOTH silent-restore steps — `fedcm-silent` AND
+      // `cookie-restore` — not a cookie wipe: the account may stay "known" for a
+      // fast deliberate re-sign-in, but no step restores it silently while the flag
+      // is set. Read the durable flag ONCE here (synchronously usable by the step
+      // `enabled` gates). Any deliberate sign-in (handleAuthSuccess / switch) clears
+      // it, so there is no "stuck signed out" state. The terminal `sso-bounce` needs
+      // no extra gate — it is already self-suppressed after sign-out (its
+      // prior-session hint is cleared). `sso-return` is NOT gated: it commits the
+      // result of a deliberate top-level `/sso` bounce the user just initiated.
       const silentRestoreBlocked = silentRestoreSuppressedWeb();
 
       const steps: ReadonlyArray<ColdBootStep<ColdBootSession>> = [
@@ -795,8 +801,13 @@ export function WebOxyProvider({
           // cross-domain RP (mention.earth, …) the cookie never reaches
           // `api.<apex>`, so `POST /auth/refresh-all` returns no accounts and
           // this skips. That is correct; the `sso-bounce` step handles it.
+          //
+          // SIGNED-OUT GATE: since PR #455 the primary's `oxy_rt` slot survives a
+          // deliberate sign-out, so without this gate this step would `refresh-all`
+          // that still-present cookie and silently re-log-in the user on reload.
+          // The flag is cleared by any deliberate sign-in (incl. account switch).
           id: 'cookie-restore',
-          enabled: () => isWebBrowser(),
+          enabled: () => isWebBrowser() && !silentRestoreBlocked,
           run: async () => {
             // FIX-D: bound the cookie restore so a cross-domain/stalled
             // `refresh-all` cannot hang cold boot in front of the terminal

--- a/packages/services/__tests__/context/coldBootOrder.test.tsx
+++ b/packages/services/__tests__/context/coldBootOrder.test.tsx
@@ -275,4 +275,72 @@ describe('Cold-boot order (web cross-domain, central SSO)', () => {
     expect(captured.isAuthenticated).toBe(false);
     expect(setTokensSpy).not.toHaveBeenCalled();
   });
+
+  it('DELIBERATELY-SIGNED-OUT: every silent restore step is gated → NO step restores and NO bounce', async () => {
+    // After a deliberate full sign-out the durable signed-out flag is set AND the
+    // returning-user hint is cleared (both done by the sign-out path). The stored
+    // session + a still-present refresh cookie (PR #455: the primary joins the
+    // device `oxy_rt` set) would otherwise let `stored-session` / `cookie-restore`
+    // silently re-log the user in. Gmail-style: nothing may restore on reload.
+    const STORED_SESSION_ID = 'sess_signed_out';
+    window.localStorage.setItem('oxy_session_session_ids', JSON.stringify([STORED_SESSION_ID]));
+    window.localStorage.setItem('oxy_session_active_session_id', STORED_SESSION_ID);
+    // The sign-out path clears the returning-user hint, so the terminal bounce is
+    // self-suppressed too — the user simply stays signed out.
+    window.localStorage.removeItem('oxy_session_prior_session');
+    window.localStorage.setItem(oxyCore.ssoSignedOutKey('https://app.mention.earth'), '1');
+
+    const { stub, refreshAllSessions, baseURL } = buildStub({
+      fedcmSupported: true,
+      silentFedCM: fedcmSession,
+      // The refresh cookie WOULD resurrect an account — but the gate must skip it.
+      refreshAllResult: async () => ({ accounts: [{ authuser: 0, username: 'tester' }] }),
+      currentUserId: FEDCM_USER_ID,
+      initialAccessToken: 'stored.access.token',
+      baseURL: 'https://api.mention.earth/case-signed-out',
+    });
+
+    renderProvider(stub, baseURL);
+
+    // Auth resolves (the loading gate clears) but to the SIGNED-OUT state.
+    await waitFor(() => expect(captured.isTokenReady).toBe(true));
+    expect(captured.isAuthenticated).toBe(false);
+    // NOT ONE silent restore step ran: stored-session (bearer validation),
+    // fedcm-silent, the per-apex iframe, and cookie-restore are all gated off.
+    expect(stub.validateSession).not.toHaveBeenCalled();
+    expect(stub.silentSignInWithFedCM).not.toHaveBeenCalled();
+    expect(stub.silentSignIn).not.toHaveBeenCalled();
+    expect(refreshAllSessions).not.toHaveBeenCalled();
+    // No terminal bounce (the sign-out cleared the returning-user hint).
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+
+  it('deliberate sign-in CLEARS the flag → stored-session restores normally on the next boot (no stuck state)', async () => {
+    // Arm then clear the signed-out flag, simulating sign-out followed by a
+    // deliberate sign-in (which calls `clearSignedOut`). The next cold boot must
+    // restore the local session exactly as before — there is no "stuck signed out".
+    const STORED_SESSION_ID = 'sess_resignin';
+    window.localStorage.setItem('oxy_session_session_ids', JSON.stringify([STORED_SESSION_ID]));
+    window.localStorage.setItem('oxy_session_active_session_id', STORED_SESSION_ID);
+    window.localStorage.setItem(oxyCore.ssoSignedOutKey('https://app.mention.earth'), '1');
+    window.localStorage.removeItem(oxyCore.ssoSignedOutKey('https://app.mention.earth'));
+
+    const { stub, refreshAllSessions, baseURL } = buildStub({
+      fedcmSupported: true,
+      silentFedCM: fedcmSession,
+      currentUserId: FEDCM_USER_ID,
+      initialAccessToken: 'stored.access.token',
+      baseURL: 'https://api.mention.earth/case-resignin',
+    });
+
+    renderProvider(stub, baseURL);
+
+    await waitFor(() => expect(captured.isAuthenticated).toBe(true));
+    expect(captured.userId).toBe(FEDCM_USER_ID);
+    // stored-session won (its bearer was validated); the slow probes never ran.
+    expect(stub.validateSession).toHaveBeenCalled();
+    expect(stub.silentSignInWithFedCM).not.toHaveBeenCalled();
+    expect(refreshAllSessions).not.toHaveBeenCalled();
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/services/__tests__/context/refreshCookieRestore.test.tsx
+++ b/packages/services/__tests__/context/refreshCookieRestore.test.tsx
@@ -351,4 +351,41 @@ describe('Cold-boot restore via secure refresh cookies (multi-account)', () => {
     );
     expect(window.localStorage.getItem(ACTIVE_AUTHUSER_KEY)).toBe('1');
   });
+
+  it('CASE signed-out gate also covers the prioritized multi-account path: a persisted slot does NOT restore while the signed-out flag is set', async () => {
+    // The user had a persisted active slot (`oxy_active_authuser = 1`) but then
+    // DELIBERATELY signed out. PR #455 means the device refresh cookies survive, so
+    // the prioritized `cookie-restore-active` step would `refresh-all` and silently
+    // restore — the gate must skip it. The sign-out also cleared the returning-user
+    // hint, so the terminal bounce is self-suppressed: the user stays signed out.
+    window.localStorage.setItem(ACTIVE_AUTHUSER_KEY, '1');
+    window.localStorage.removeItem('oxy_session_prior_session');
+    window.localStorage.setItem(oxyCore.ssoSignedOutKey('https://accounts.oxy.so'), '1');
+
+    const stub = baseStub();
+    // The cookie set WOULD resurrect both slots — but no step may run while signed
+    // out, so this must never be called.
+    stub.refreshAllSessions = jest.fn(async () => ({
+      accounts: [
+        {
+          authuser: 1,
+          accessToken: COOKIE_ACCESS_TOKEN,
+          expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+          sessionId: 'sess_switched_signed_out',
+          user: { id: 'managed_org_user', username: 'org', avatar: null, color: null },
+        },
+      ],
+    }));
+
+    renderProvider(stub);
+
+    // Auth resolves to the SIGNED-OUT state without restoring.
+    await waitFor(() => expect(captured.isTokenReady).toBe(true));
+    expect(captured.isAuthenticated).toBe(false);
+    // The prioritized multi-account restore was gated off.
+    expect(stub.refreshAllSessions).not.toHaveBeenCalled();
+    expect(setTokensSpy).not.toHaveBeenCalled();
+    // No terminal bounce (the returning-user hint was cleared on sign-out).
+    expect(ssoNavigateSpy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -1334,16 +1334,27 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     // to the cross-domain fallbacks exactly as before.
     const prioritizeMultiAccount = isWebBrowser() && readActiveAuthuser() !== null;
 
-    // DELIBERATELY-SIGNED-OUT gate (web): when the user pressed "Sign out", the
-    // central IdP session (FedCM credential association / per-apex `fedcm_session`
-    // cookie) can still be live, so the AUTOMATIC silent steps below
-    // (`fedcm-silent`, `silent-iframe`) would re-mint a session on the very next
-    // cold boot and sign the user back in without intent. Read the durable flag
-    // ONCE here (synchronously usable by the step `enabled` gates) and skip those
-    // two steps while it is set. Any deliberate sign-in clears it. The `sso-bounce`
-    // step is already self-suppressed after sign-out (its `hasPriorSession` hint is
-    // cleared), and the local restore steps (`stored-session`, cookie-restore) are
-    // unaffected — a deliberate sign-out clears those credentials anyway.
+    // DELIBERATELY-SIGNED-OUT gate (web): when the user pressed "Sign out", any
+    // credential that can silently re-mint a session may still be live on the
+    // next reload — the central IdP session (FedCM credential association /
+    // per-apex `fedcm_session` cookie) AND the device refresh cookies. Since
+    // PR #455 the PRIMARY web session also joins the `oxy_rt_<authuser>` device
+    // set, so the un-gated cookie-restore steps would `refresh-all` that still-
+    // present cookie and sign the user back in without intent — exactly the
+    // "sign-out is silently undone" regression. So this flag gates EVERY
+    // AUTOMATIC silent-restore cold-boot step: `stored-session`,
+    // `cookie-restore-active`, `fedcm-silent`, `silent-iframe`, and
+    // `cookie-restore`. The gate — not a cookie wipe — is the authority: the
+    // account may stay "known" for a fast deliberate re-sign-in, but no step
+    // restores it silently while the flag is set. Read the durable flag ONCE here
+    // (synchronously usable by every step `enabled` gate). Any deliberate sign-in
+    // (password, FedCM, account switch, device claim) clears it, so there is no
+    // "stuck signed out" state. The `sso-bounce` step needs no extra gate: it is
+    // already self-suppressed after sign-out (its `hasPriorSession` hint is
+    // cleared). `sso-return` is NOT gated — it commits the result of a deliberate
+    // top-level `/sso` bounce the user just initiated. `shared-key-signin` is
+    // native-only and the flag never sets on native (`markSignedOut` no-ops
+    // off-web), so its gate would be moot; it is left untouched.
     const silentRestoreBlocked = isSilentRestoreSuppressed();
 
     try {
@@ -1363,12 +1374,17 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             },
           },
           {
-            // 2) Stored-session bearer restore. NO `enabled` gate — runs on ALL
-            // platforms. This is native's ONLY restore path (every web-only step
-            // is disabled off-browser, so native reaches exactly this) AND the
-            // common WEB reload winner.
+            // 2) Stored-session bearer restore. Runs on ALL platforms EXCEPT when
+            // the deliberately-signed-out flag is set (web only — it never sets on
+            // native, so native still always reaches exactly this step, its ONLY
+            // restore path). This is also the common WEB reload winner.
             //
-            // ORDERING (FIX A): this step now runs BEFORE the slow web-only
+            // SIGNED-OUT GATE: after a deliberate full sign-out the stored session
+            // state is cleared, so this would normally skip anyway — but the gate
+            // makes that authoritative rather than incidental, so no residual
+            // stored token can silently restore while the user is signed out.
+            //
+            // ORDERING (FIX A): this step runs BEFORE the slow web-only
             // probes (`fedcm-silent`, `silent-iframe`, `cookie-restore`). On a
             // normal reload the local bearer validates in one round-trip and
             // wins; `runColdBoot` then short-circuits and never even evaluates
@@ -1379,6 +1395,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             // local session this step skips and the cross-domain fallback chain
             // (fedcm → iframe → cookie → sso-bounce) runs exactly as before.
             id: 'stored-session',
+            enabled: () => !silentRestoreBlocked,
             run: async () => {
               const restored = await restoreStoredSession();
               if (restored) {
@@ -1455,8 +1472,14 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             // When no slot is persisted this is disabled and the original order is
             // unchanged; when the slot's cookies have lapsed it returns no accounts
             // and the chain falls through to the cross-domain fallbacks below.
+            //
+            // SIGNED-OUT GATE: since PR #455 the primary's `oxy_rt` slot survives a
+            // deliberate sign-out, so without this gate `refresh-all` would re-mint
+            // and silently re-log-in the user on reload. The flag is cleared by any
+            // deliberate sign-in (including an account SWITCH, which also writes the
+            // new active slot), so the switch-survives-reload path is unaffected.
             id: 'cookie-restore-active',
-            enabled: () => prioritizeMultiAccount,
+            enabled: () => prioritizeMultiAccount && !silentRestoreBlocked,
             run: async () => {
               const restored = await restoreViaRefreshCookie();
               return restored ? { kind: 'session', session: true } : { kind: 'skip' };
@@ -1546,8 +1569,13 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             // would be a redundant second `refreshAllSessions`. It still runs in the
             // common no-persisted-slot case (e.g. first visit to a first-party app
             // whose central refresh cookies already exist).
+            //
+            // SIGNED-OUT GATE (same rationale as `cookie-restore-active`): the
+            // primary's `oxy_rt` slot survives a deliberate sign-out (PR #455), so
+            // this must be skipped while the signed-out flag is set or it would
+            // silently re-restore the primary on reload.
             id: 'cookie-restore',
-            enabled: () => isWebBrowser() && !prioritizeMultiAccount,
+            enabled: () => isWebBrowser() && !prioritizeMultiAccount && !silentRestoreBlocked,
             run: async () => {
               const restored = await restoreViaRefreshCookie();
               return restored ? { kind: 'session', session: true } : { kind: 'skip' };


### PR DESCRIPTION
Sign-out was silently undone on reload because cookie-restore / cookie-restore-active / stored-session weren't gated by the signed-out flag (only fedcm-silent was). Gate them all with the existing helper. Switch persistence unaffected.