### PR TITLE
fix(protocol-node): bound rate-limiter memory + validate sha256 before lookup (review findings)

### DIFF
--- a/packages/node/src/__tests__/server.test.ts
+++ b/packages/node/src/__tests__/server.test.ts
@@ -64,6 +64,7 @@ describe('node HTTP API', () => {
   });
 
   afterEach(() => {
+    app.stop();
     store.close();
   });
 

--- a/packages/node/src/app.ts
+++ b/packages/node/src/app.ts
@@ -13,8 +13,7 @@
  * by tests with an in-memory store and no network.
  */
 
-import type { Express } from 'express';
-import { createNodeApp } from '@oxyhq/protocol/node';
+import { createNodeApp, type NodeApp } from '@oxyhq/protocol/node';
 import type { Logger } from './logger.js';
 import type { NodeConfig } from './config.js';
 import { createOwnerAuth } from './auth.js';
@@ -26,7 +25,7 @@ export interface AppDependencies {
   logger: Logger;
 }
 
-export function createApp(deps: AppDependencies): Express {
+export function createApp(deps: AppDependencies): NodeApp {
   const { store, config, logger } = deps;
   return createNodeApp({
     store,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -47,6 +47,9 @@ function main(): void {
     }
     shuttingDown = true;
     logger.info({ signal }, 'shutting down');
+    // Release the app's background resources (the rate-limiter sweep timer)
+    // before draining HTTP so nothing keeps a reference alive during shutdown.
+    app.stop();
     server.close((closeError) => {
       if (closeError) {
         logger.error({ err: closeError }, 'error while closing HTTP server');

--- a/packages/node/src/store/__tests__/nodeStore.test.ts
+++ b/packages/node/src/store/__tests__/nodeStore.test.ts
@@ -196,4 +196,34 @@ describe('NodeStore', () => {
     await expect(store.putBlob(wrongHash, bytes)).rejects.toThrow(BlobHashMismatchError);
     expect(await store.getBlob(wrongHash)).toBeNull();
   });
+
+  it('getBlob rejects a malformed (non-SHA-256-hex) address as absent before any DB query', async () => {
+    // A blob address that is not a well-formed 64-char SHA-256 hex digest can
+    // never name a stored blob (every address is validated at pin time), so it
+    // must short-circuit to `null` without reaching the DB. Cover the malformed
+    // shapes: too short, too long, non-hex chars, empty, and whitespace.
+    for (const malformed of [
+      '',
+      ' ',
+      'abc123',
+      'g'.repeat(64), // 64 chars but 'g' is out of hex range
+      'a'.repeat(63), // one short
+      'a'.repeat(65), // one long
+      `${'a'.repeat(63)} `, // trailing whitespace breaks the anchored match
+      'not-a-hash',
+    ]) {
+      expect(await store.getBlob(malformed)).toBeNull();
+    }
+  });
+
+  it('getBlob resolves a valid address case-insensitively', async () => {
+    const bytes = Buffer.from('case insensitive lookup');
+    const hash = createHash('sha256').update(bytes).digest('hex'); // lowercase hex
+    await store.putBlob(hash, bytes);
+
+    // Uppercased input is a valid SHA-256 hex shape and must resolve the same
+    // stored blob (the store lowercases before lookup).
+    const upper = hash.toUpperCase();
+    expect(Buffer.from((await store.getBlob(upper)) as Uint8Array).equals(bytes)).toBe(true);
+  });
 });

--- a/packages/node/src/store/nodeStore.ts
+++ b/packages/node/src/store/nodeStore.ts
@@ -290,10 +290,12 @@ export class NodeStore implements RecordStore, BlobStore {
 
   /** The bytes of a pinned blob, or `null` if absent. */
   async getBlob(hash: string): Promise<Uint8Array | null> {
-    // The address comes from a request route param; a tampered non-string can
-    // never address a stored blob — treat it as absent rather than confusing the
-    // `.toLowerCase()` + SQL parameter sink.
-    if (typeof hash !== 'string') {
+    // The address comes from a request route param; a tampered non-string or a
+    // value that is not a well-formed 64-char SHA-256 hex digest can never
+    // address a stored blob (all addresses are validated at pin time). Reject it
+    // as absent BEFORE the DB query so garbage input cannot drive needless reads
+    // or reach the `.toLowerCase()` + SQL parameter sink.
+    if (typeof hash !== 'string' || !SHA256_HEX.test(hash.toLowerCase())) {
       return null;
     }
     const row = this.getBlobStmt.get({ hash: hash.toLowerCase() }) as BlobRow | undefined;

--- a/packages/protocol/src/__tests__/nodeApp.test.ts
+++ b/packages/protocol/src/__tests__/nodeApp.test.ts
@@ -24,7 +24,7 @@ import {
 function makeConfig(
   nodePublicKey: string,
   collections: readonly string[] = [],
-  writeRateLimit?: { windowMs: number; max: number },
+  writeRateLimit?: { windowMs: number; max: number; maxEntries?: number },
 ): NodeAppConfig {
   return {
     wellKnownPath: '/.well-known/oxy-node.json',
@@ -38,10 +38,14 @@ function makeConfig(
   };
 }
 
+// Apps built during a test own a background rate-limiter sweep timer; track them
+// so `afterEach` can stop the timers and leave no open handles between tests.
+const builtApps: Array<ReturnType<typeof createNodeApp>> = [];
+
 function buildApp(
   owner: TestKeyPair,
   collections: readonly string[] = [],
-  writeRateLimit?: { windowMs: number; max: number },
+  writeRateLimit?: { windowMs: number; max: number; maxEntries?: number },
 ) {
   const store = createInMemoryNodeStore();
   const app = createNodeApp({
@@ -50,6 +54,7 @@ function buildApp(
     ownerAuth: createTestOwnerAuth(owner.publicKey),
     logger: silentLogger,
   });
+  builtApps.push(app);
   return { app, store };
 }
 
@@ -58,6 +63,12 @@ describe('createNodeApp', () => {
 
   beforeEach(() => {
     owner = generateKeyPair();
+  });
+
+  afterEach(() => {
+    for (const app of builtApps.splice(0)) {
+      app.stop();
+    }
   });
 
   it('GET /.well-known/oxy-node.json returns identity + liveness (incl. serviceType)', async () => {

--- a/packages/protocol/src/__tests__/nodeClient.test.ts
+++ b/packages/protocol/src/__tests__/nodeClient.test.ts
@@ -88,12 +88,13 @@ describe('trimTrailingSlashes', () => {
 
 describe('NodeClient (end-to-end against createNodeApp)', () => {
   let owner: TestKeyPair;
+  let app: ReturnType<typeof createNodeApp>;
   let server: http.Server;
   let client: NodeClient;
 
   beforeEach(async () => {
     owner = generateKeyPair();
-    const app = createNodeApp({
+    app = createNodeApp({
       store: createInMemoryNodeStore(),
       config: makeConfig(owner.publicKey),
       ownerAuth: createTestOwnerAuth(owner.publicKey),
@@ -107,6 +108,7 @@ describe('NodeClient (end-to-end against createNodeApp)', () => {
   });
 
   afterEach(async () => {
+    app.stop();
     await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 

--- a/packages/protocol/src/__tests__/rateLimit.test.ts
+++ b/packages/protocol/src/__tests__/rateLimit.test.ts
@@ -1,0 +1,172 @@
+/**
+ * `createRateLimiter` unit tests — exercise the limiter directly (no Express
+ * server) so per-key state and the memory-bounding behaviour are deterministic.
+ *
+ * Covers:
+ *  - correct fixed-window budgeting for a legitimate client (allow up to `max`,
+ *    then 429, then reset after the window),
+ *  - the hard-cap LRU backstop: a burst of distinct keys never grows the tracked
+ *    map past `maxEntries`,
+ *  - the active sweep: expired windows are reclaimed on the timer even when their
+ *    keys are never touched again,
+ *  - `stop()` clears the sweep timer.
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import { createRateLimiter, type RateLimiter } from '../node/rateLimit';
+
+/** A minimal `Response` double capturing the status/headers/body the limiter sets. */
+interface ResponseSpy {
+  res: Response;
+  statusCode: number | null;
+  body: unknown;
+  headers: Record<string, string>;
+}
+
+function makeResponseSpy(): ResponseSpy {
+  const spy: ResponseSpy = { res: {} as Response, statusCode: null, body: undefined, headers: {} };
+  const res: Pick<Response, 'status' | 'json' | 'setHeader'> = {
+    status(code: number) {
+      spy.statusCode = code;
+      return res as Response;
+    },
+    json(payload: unknown) {
+      spy.body = payload;
+      return res as Response;
+    },
+    setHeader(name: string, value: string | number | readonly string[]) {
+      spy.headers[name] = String(value);
+      return res as Response;
+    },
+  };
+  spy.res = res as Response;
+  return spy;
+}
+
+/** Drive one request through the limiter for `ip`; returns whether `next()` ran. */
+function call(limiter: RateLimiter, ip: string): { passed: boolean; response: ResponseSpy } {
+  const req = { ip } as Request;
+  const response = makeResponseSpy();
+  let passed = false;
+  const next: NextFunction = () => {
+    passed = true;
+  };
+  limiter(req, response.res, next);
+  return { passed, response };
+}
+
+describe('createRateLimiter', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('allows up to `max` requests per window then responds 429 rate_limited', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, max: 3 });
+    try {
+      expect(call(limiter, '1.1.1.1').passed).toBe(true);
+      expect(call(limiter, '1.1.1.1').passed).toBe(true);
+      expect(call(limiter, '1.1.1.1').passed).toBe(true);
+
+      const fourth = call(limiter, '1.1.1.1');
+      expect(fourth.passed).toBe(false);
+      expect(fourth.response.statusCode).toBe(429);
+      expect(fourth.response.body).toEqual({ error: 'rate_limited' });
+      expect(Number(fourth.response.headers['Retry-After'])).toBeGreaterThanOrEqual(1);
+    } finally {
+      limiter.stop();
+    }
+  });
+
+  it('budgets each client key independently', () => {
+    const limiter = createRateLimiter({ windowMs: 60_000, max: 1 });
+    try {
+      expect(call(limiter, 'a').passed).toBe(true);
+      expect(call(limiter, 'a').passed).toBe(false); // a exhausted
+      expect(call(limiter, 'b').passed).toBe(true); // b independent
+    } finally {
+      limiter.stop();
+    }
+  });
+
+  it('resets a key after its window elapses', () => {
+    jest.useFakeTimers();
+    const limiter = createRateLimiter({ windowMs: 1_000, max: 1 });
+    try {
+      expect(call(limiter, 'x').passed).toBe(true);
+      expect(call(limiter, 'x').passed).toBe(false);
+      jest.advanceTimersByTime(1_001);
+      expect(call(limiter, 'x').passed).toBe(true); // fresh window
+    } finally {
+      limiter.stop();
+    }
+  });
+
+  it('bounds memory: a burst of distinct keys never exceeds maxEntries (LRU eviction)', () => {
+    // With max:1, a SURVIVING key is rate-limited on its second hit, while an
+    // EVICTED key behaves brand new (passes). That makes eviction observable
+    // without reaching into the private map. All requests stay within one window
+    // (no sweep), so only the hard cap can bound the tracked set.
+    const maxEntries = 50;
+    const limiter = createRateLimiter({ windowMs: 60_000, max: 1, maxEntries });
+    try {
+      // Seed the oldest key, exhausting its single-request budget.
+      expect(call(limiter, 'oldest').passed).toBe(true);
+      expect(call(limiter, 'oldest').passed).toBe(false); // exhausted, still tracked
+
+      // Burst well past the cap with distinct keys. Each insertion past the cap
+      // evicts the oldest-inserted entry — 'oldest' is the first to go.
+      for (let i = 0; i < maxEntries * 4; i += 1) {
+        expect(call(limiter, `flood-${i}`).passed).toBe(true);
+      }
+
+      // 'oldest' was evicted by the cap, so it now passes as a brand-new key —
+      // proving the tracked set was bounded rather than growing unboundedly.
+      expect(call(limiter, 'oldest').passed).toBe(true);
+    } finally {
+      limiter.stop();
+    }
+  });
+
+  it('actively sweeps expired windows even for keys never touched again', () => {
+    jest.useFakeTimers();
+    // A burst of keys, then total silence: the active timer must still reclaim
+    // them. With max:1, a surviving key would be rate-limited on its next hit;
+    // a swept (reclaimed) key passes again as brand new.
+    const limiter = createRateLimiter({ windowMs: 1_000, max: 1 });
+    try {
+      for (let i = 0; i < 100; i += 1) {
+        expect(call(limiter, `burst-${i}`).passed).toBe(true);
+      }
+      // Exhaust one specific key so survival is observable.
+      expect(call(limiter, 'burst-0').passed).toBe(false); // exhausted within window
+
+      // Advance past the window: the unref'd interval fires (>= windowMs) and
+      // deletes every expired entry — no further request needed to trigger it.
+      jest.advanceTimersByTime(1_500);
+
+      // The previously-exhausted key was reclaimed by the sweep → passes again.
+      expect(call(limiter, 'burst-0').passed).toBe(true);
+    } finally {
+      limiter.stop();
+    }
+  });
+
+  it('stop() halts the sweep timer and is idempotent', () => {
+    jest.useFakeTimers();
+    const limiter = createRateLimiter({ windowMs: 1_000, max: 1 });
+
+    // Seed and exhaust a key, then stop the limiter.
+    expect(call(limiter, 'k').passed).toBe(true);
+    expect(call(limiter, 'k').passed).toBe(false);
+    limiter.stop();
+    limiter.stop(); // second call must not throw
+
+    // After stop, the active sweep no longer runs — the entry is NOT reclaimed by
+    // the timer. Advancing past the sweep interval leaves the key tracked; only
+    // the lazy expiry-on-access (its window having elapsed) gives it a fresh slot.
+    jest.advanceTimersByTime(10_000);
+    // The window has elapsed, so the next access resets the key lazily; this
+    // proves the limiter still functions while confirming stop() didn't crash.
+    expect(call(limiter, 'k').passed).toBe(true);
+  });
+});

--- a/packages/protocol/src/node/index.ts
+++ b/packages/protocol/src/node/index.ts
@@ -16,6 +16,7 @@
 // ── Express app factory ───────────────────────────────────────────────────────
 export { createNodeApp, BlobHashMismatchError } from './nodeApp';
 export type {
+  NodeApp,
   NodeAppDependencies,
   NodeAppConfig,
   NodeStoreLike,
@@ -24,8 +25,12 @@ export type {
 } from './nodeApp';
 
 // ── Per-IP write rate limiter ──────────────────────────────────────────────────
-export { createRateLimiter, DEFAULT_WRITE_RATE_LIMIT } from './rateLimit';
-export type { RateLimitConfig } from './rateLimit';
+export {
+  createRateLimiter,
+  DEFAULT_WRITE_RATE_LIMIT,
+  DEFAULT_MAX_RATE_LIMIT_ENTRIES,
+} from './rateLimit';
+export type { RateLimitConfig, RateLimiter } from './rateLimit';
 
 // ── Record verification (signature + v2 + content address) ─────────────────────
 export { verifyNodeRecordEnvelope } from './verifyRecord';

--- a/packages/protocol/src/node/nodeApp.ts
+++ b/packages/protocol/src/node/nodeApp.ts
@@ -54,6 +54,20 @@ import {
 } from './constants';
 
 /**
+ * The Express app returned by {@link createNodeApp}, augmented with a {@link stop}
+ * hook that releases the app's background resources (currently the rate-limiter's
+ * sweep timer). The node bootstrap calls it from the graceful-shutdown path.
+ */
+export interface NodeApp extends Express {
+  /**
+   * Release the app's background resources (the rate-limiter sweep timer).
+   * Idempotent and safe to call on shutdown; not required for process exit (the
+   * timer is `unref()`'d) but keeps long-lived test harnesses leak-free.
+   */
+  stop(): void;
+}
+
+/**
  * Thrown by a {@link BlobStore.putBlob} implementation when bytes do not hash to
  * the supplied address. Defined here (rather than in `@oxyhq/node`) so the node
  * app can map it to `hash_mismatch` without importing the store implementation.
@@ -215,13 +229,13 @@ async function toLogWireRecord(env: SignedRecordEnvelope): Promise<{
   };
 }
 
-export function createNodeApp(deps: NodeAppDependencies): Express {
+export function createNodeApp(deps: NodeAppDependencies): NodeApp {
   const { store, config, ownerAuth, logger } = deps;
   // The node holds one subject's repo; the store keys a single global chain and
   // ignores the subject argument. Pass the node's own key as a stable sentinel.
   const subject = config.nodePublicKey;
 
-  const app = express();
+  const app = express() as NodeApp;
   app.disable('x-powered-by');
 
   // JSON parser applies only to JSON bodies (it checks Content-Type), so the raw
@@ -230,7 +244,9 @@ export function createNodeApp(deps: NodeAppDependencies): Express {
 
   // Per-IP rate limiter on the owner-authorized write routes. Caps request rate
   // BEFORE signature verification so a flood of bogus envelopes can't pin CPU.
+  // It owns a background sweep timer; expose its teardown as `app.stop()`.
   const writeRateLimit = createRateLimiter(config.writeRateLimit ?? DEFAULT_WRITE_RATE_LIMIT);
+  app.stop = (): void => writeRateLimit.stop();
 
   app.get('/health', (_req: Request, res: Response) => {
     res.json({ status: 'ok' });

--- a/packages/protocol/src/node/rateLimit.ts
+++ b/packages/protocol/src/node/rateLimit.ts
@@ -10,11 +10,36 @@
  *
  * Fixed-window counting keyed on `req.ip`: each key gets `max` requests per
  * `windowMs`; the window resets lazily on the first request after it elapses.
- * A stale-key sweep bounds memory so a churn of distinct IPs cannot grow the map
- * unboundedly.
+ *
+ * Bounded memory (defence against a key-rotation DoS — spoofed IPs / many DIDs
+ * growing the map without limit → memory exhaustion):
+ *  - An ACTIVE periodic sweep on an `unref()`'d interval deletes every entry
+ *    whose window has fully elapsed, so keys that are never touched again do not
+ *    leak forever (lazy expiry-on-access alone cannot reclaim them). The
+ *    interval is `unref()`'d so it never keeps the node process alive, and
+ *    {@link RateLimiter.stop} clears it for a clean lifecycle teardown.
+ *  - A hard cap on the number of tracked keys ({@link RateLimitConfig.maxEntries})
+ *    evicts the OLDEST window (insertion-order LRU) when exceeded — a synchronous
+ *    backstop against a burst that arrives between sweeps.
  */
 
 import type { Request, Response, NextFunction } from 'express';
+
+// The package's `lib` includes `DOM` (the isomorphic root code uses Web Crypto),
+// so the ambient `setInterval` overload TypeScript picks for a bare call is the
+// browser one returning `number` — which has no `.unref()`. This `node/` subpath
+// is Node-only; reach the Node timer globals through their `@types/node`
+// signatures so the handle is correctly `NodeJS.Timeout` (no cast, no shadowing).
+// Resolved at call time (not captured at module load) so test fake-timers that
+// swap the globals still drive the sweep.
+function nodeSetInterval(handler: () => void, ms: number): NodeJS.Timeout {
+  const set: (handler: () => void, ms: number) => NodeJS.Timeout = globalThis.setInterval;
+  return set(handler, ms);
+}
+function nodeClearInterval(timer: NodeJS.Timeout): void {
+  const clear: (timer: NodeJS.Timeout) => void = globalThis.clearInterval;
+  clear(timer);
+}
 
 /** A request-rate budget: at most `max` requests per `windowMs`. */
 export interface RateLimitConfig {
@@ -22,10 +47,25 @@ export interface RateLimitConfig {
   readonly windowMs: number;
   /** The maximum number of requests permitted within one window. */
   readonly max: number;
+  /**
+   * Hard cap on the number of distinct keys (client identifiers) tracked at
+   * once. When the map exceeds this, the oldest-inserted window is evicted as a
+   * synchronous backstop against a burst of distinct keys arriving between
+   * sweeps. Defaults to {@link DEFAULT_MAX_RATE_LIMIT_ENTRIES}.
+   */
+  readonly maxEntries?: number;
 }
 
 /** Default budget for owner write routes (generous — single-writer model). */
 export const DEFAULT_WRITE_RATE_LIMIT: RateLimitConfig = { windowMs: 60_000, max: 60 };
+
+/**
+ * Default hard cap on tracked keys. Sized so the map's worst-case footprint
+ * stays small (each entry is a short string key + two numbers) while never
+ * evicting a legitimately active key for the single-writer node — the owner
+ * drives traffic from a handful of IPs, far below this ceiling.
+ */
+export const DEFAULT_MAX_RATE_LIMIT_ENTRIES = 10_000;
 
 interface WindowCounter {
   /** Epoch ms when the current window started. */
@@ -35,21 +75,38 @@ interface WindowCounter {
 }
 
 /**
+ * The Express middleware returned by {@link createRateLimiter}, carrying a
+ * {@link stop} hook so the owning app can clear the background sweep on shutdown.
+ */
+export interface RateLimiter {
+  (req: Request, res: Response, next: NextFunction): void;
+  /**
+   * Stop the background sweep timer. Idempotent. Called by the node app's
+   * graceful-shutdown path; not required for process exit (the timer is
+   * `unref()`'d) but keeps long-lived test harnesses leak-free.
+   */
+  stop(): void;
+}
+
+/**
  * Build an Express middleware enforcing a fixed-window per-IP rate limit.
  * Exceeding the budget responds `429 { error: 'rate_limited' }` and does not call
  * `next`. The `key` is `req.ip` (Express's resolved client IP).
+ *
+ * The returned middleware owns a background sweep timer; call {@link RateLimiter.stop}
+ * to release it (e.g. on app shutdown).
  */
-export function createRateLimiter(config: RateLimitConfig) {
+export function createRateLimiter(config: RateLimitConfig): RateLimiter {
   const windows = new Map<string, WindowCounter>();
-  // Sweep keys whose window has fully elapsed, bounded so a churn of distinct
-  // IPs cannot grow the map without limit. Runs at most once per window.
-  let lastSweep = 0;
+  const maxEntries = config.maxEntries ?? DEFAULT_MAX_RATE_LIMIT_ENTRIES;
 
-  function sweep(now: number): void {
-    if (now - lastSweep < config.windowMs) {
-      return;
-    }
-    lastSweep = now;
+  // Active sweep: delete every entry whose window has fully elapsed. Running on
+  // a timer (rather than only on request arrival) reclaims keys that are never
+  // touched again, so a churn of distinct IPs cannot leak memory once traffic
+  // for those keys stops. One pass per window is sufficient: an entry lives at
+  // most `2 * windowMs` before a sweep removes it.
+  function sweepExpired(): void {
+    const now = Date.now();
     for (const [key, counter] of windows) {
       if (now - counter.start >= config.windowMs) {
         windows.delete(key);
@@ -57,13 +114,25 @@ export function createRateLimiter(config: RateLimitConfig) {
     }
   }
 
-  return function rateLimit(req: Request, res: Response, next: NextFunction): void {
-    const now = Date.now();
-    sweep(now);
+  const sweepTimer = nodeSetInterval(sweepExpired, config.windowMs);
+  // Never let the sweep keep the node process alive on its own.
+  sweepTimer.unref();
 
+  function rateLimit(req: Request, res: Response, next: NextFunction): void {
+    const now = Date.now();
     const key = req.ip ?? 'unknown';
     const counter = windows.get(key);
+
     if (!counter || now - counter.start >= config.windowMs) {
+      // Hard cap backstop: if a burst of distinct keys outran the sweep, evict
+      // the oldest-inserted window before admitting a new key. A `Map` preserves
+      // insertion order, so its first key is the oldest tracked entry.
+      if (!counter && windows.size >= maxEntries) {
+        const oldest = windows.keys().next().value;
+        if (oldest !== undefined) {
+          windows.delete(oldest);
+        }
+      }
       windows.set(key, { start: now, count: 1 });
       next();
       return;
@@ -78,5 +147,13 @@ export function createRateLimiter(config: RateLimitConfig) {
 
     counter.count += 1;
     next();
-  };
+  }
+
+  // Attach the lifecycle hook to the middleware, yielding the `RateLimiter`
+  // callable-with-`stop` without a cast.
+  return Object.assign(rateLimit, {
+    stop(): void {
+      nodeClearInterval(sweepTimer);
+    },
+  });
 }


### PR DESCRIPTION
Fixes gemini-code-assist review findings on the merged Workstream-A PR #451, in `@oxyhq/protocol` + `@oxyhq/node`. Code-and-PR change only — no package republish (the node runtime deploys from source).

## Finding 1 (SECURITY-HIGH): unbounded in-memory rate limiter → memory-exhaustion DoS
`packages/protocol/src/node/rateLimit.ts`. The per-IP fixed-window limiter only swept expired windows lazily on request arrival, so keys that were never touched again leaked forever, and a burst of distinct keys (spoofed IPs / many DIDs) could grow the `windows` map without limit — a memory-exhaustion DoS on the unauthenticated write edge.

Fix — bound the limiter's memory two ways:
- **Active periodic sweep** on an `unref()`'d interval that deletes every fully-elapsed window, reclaiming keys even when their traffic stops (lazy expiry-on-access alone cannot).
- **Hard cap** (`maxEntries`, default `10_000`) that evicts the oldest-inserted window (insertion-order LRU) as a synchronous backstop against a burst arriving between sweeps.

The interval is `unref()`'d so it never keeps the process alive. The middleware now carries a `stop()` hook (`RateLimiter` type); `createNodeApp` exposes it as `app.stop()` (`NodeApp` type) and the node bootstrap clears it on graceful shutdown (`packages/node/src/index.ts`). Legitimate-client budgeting is unchanged.

## Finding 2 (MEDIUM): validate sha256 format before DB query in `nodeStore`
`packages/node/src/store/nodeStore.ts` `getBlob`. Previously only checked `typeof hash === 'string'` before hitting SQLite. Now validates the existing `SHA256_HEX` constant (reused from `@oxyhq/protocol/node`, not duplicated) and short-circuits malformed addresses to `null` BEFORE the DB query, mirroring the `putBlob` guard.

## Tests
- `packages/protocol/src/__tests__/rateLimit.test.ts` (new): window budgeting, per-key independence, window reset, hard-cap LRU eviction (burst of distinct keys never grows the tracked set), active sweep reclaiming untouched keys, and `stop()` idempotency.
- `nodeStore.test.ts`: malformed-sha256 rejection (too short/long, non-hex, empty, whitespace) + case-insensitive resolve.
- Test harnesses stop limiters in `afterEach` to leave no open timers.

## Verification
- `packages/protocol`: build clean, 99 tests pass, biome lint clean.
- `packages/node`: tsc clean, 40 tests pass.
- `packages/api`: `bunx tsc --noEmit` clean (no exported-signature breakage; `createNodeApp` now returns `NodeApp extends Express`, a widening; api uses its own rate limiter and does not import the node app factory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)