### PR TITLE
fix(auth): fail-safe localStorage access (guard SecurityError getter throw)

### DIFF
--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -232,6 +232,24 @@ function clearSsoBounceStateWeb(): void {
 }
 
 /**
+ * Safely resolve `window.localStorage`, returning `null` when unavailable. The
+ * PROPERTY ACCESS itself (`window.localStorage`) can throw a `SecurityError`
+ * synchronously in opaque-origin / sandboxed iframes or when storage is
+ * disabled — even reading the property evaluates the getter. Every durable
+ * read/write below routes through here so the getter throw is caught once, at
+ * the source, and callers stay clean. Returns `null` off-web and on any access
+ * failure (fail safe).
+ */
+function getLocalStorageWeb(): Storage | null {
+  if (!isWebBrowser()) return null;
+  try {
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Read the DURABLE "this origin has had a signed-in Oxy session before" hint
  * from `localStorage`. Drives the smart {@link allowSsoBounce} gate: a returning
  * visitor (hint present) whose cookie restore came back empty cross-domain
@@ -240,9 +258,10 @@ function clearSsoBounceStateWeb(): void {
  * any storage error (fail safe toward anonymous-browse).
  */
 function hasPriorSessionWeb(): boolean {
-  if (!isWebBrowser()) return false;
+  const storage = getLocalStorageWeb();
+  if (!storage) return false;
   try {
-    return window.localStorage.getItem(ssoPriorSessionKey(window.location.origin)) === '1';
+    return storage.getItem(ssoPriorSessionKey(window.location.origin)) === '1';
   } catch {
     return false;
   }
@@ -253,9 +272,10 @@ function hasPriorSessionWeb(): boolean {
  * or restored. Best-effort; no-ops off-web and swallows storage errors.
  */
 function markPriorSessionWeb(): void {
-  if (!isWebBrowser()) return;
+  const storage = getLocalStorageWeb();
+  if (!storage) return;
   try {
-    window.localStorage.setItem(ssoPriorSessionKey(window.location.origin), '1');
+    storage.setItem(ssoPriorSessionKey(window.location.origin), '1');
   } catch {
     // Best-effort; swallow QuotaExceededError / SecurityError (private mode).
   }
@@ -269,9 +289,10 @@ function markPriorSessionWeb(): void {
  * recovers via a returning-user bounce. No-ops off-web / on storage failure.
  */
 function clearPriorSessionWeb(): void {
-  if (!isWebBrowser()) return;
+  const storage = getLocalStorageWeb();
+  if (!storage) return;
   try {
-    window.localStorage.removeItem(ssoPriorSessionKey(window.location.origin));
+    storage.removeItem(ssoPriorSessionKey(window.location.origin));
   } catch {
     // Best-effort.
   }
@@ -285,9 +306,10 @@ function clearPriorSessionWeb(): void {
  * storage failure (best-effort).
  */
 function markSignedOutWeb(): void {
-  if (!isWebBrowser()) return;
+  const storage = getLocalStorageWeb();
+  if (!storage) return;
   try {
-    window.localStorage.setItem(ssoSignedOutKey(window.location.origin), '1');
+    storage.setItem(ssoSignedOutKey(window.location.origin), '1');
   } catch {
     // Best-effort; swallow QuotaExceededError / SecurityError (private mode).
   }
@@ -299,9 +321,10 @@ function markSignedOutWeb(): void {
  * "stuck signed out" state. No-ops off-web / on storage failure.
  */
 function clearSignedOutWeb(): void {
-  if (!isWebBrowser()) return;
+  const storage = getLocalStorageWeb();
+  if (!storage) return;
   try {
-    window.localStorage.removeItem(ssoSignedOutKey(window.location.origin));
+    storage.removeItem(ssoSignedOutKey(window.location.origin));
   } catch {
     // Best-effort.
   }
@@ -314,8 +337,9 @@ function clearSignedOutWeb(): void {
  * on storage failure (fail safe toward normal restore).
  */
 function silentRestoreSuppressedWeb(): boolean {
-  if (!isWebBrowser()) return false;
-  return silentRestoreSuppressed(window.localStorage, window.location.origin);
+  const storage = getLocalStorageWeb();
+  if (!storage) return false;
+  return silentRestoreSuppressed(storage, window.location.origin);
 }
 
 function isOnSsoCallbackPath(): boolean {

--- a/packages/services/src/ui/utils/__tests__/activeAuthuser.test.ts
+++ b/packages/services/src/ui/utils/__tests__/activeAuthuser.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Fail-safe guarantees for the web `activeAuthuser` storage helpers.
+ *
+ * The PROPERTY ACCESS `window.localStorage` can throw a `SecurityError`
+ * synchronously in opaque-origin / sandboxed iframes or when storage is
+ * disabled — not just `getItem`/`setItem`. These helpers run during cold boot
+ * (and feed render-phase gate values in the providers), so they MUST never
+ * propagate that throw: reads fail safe to a benign default and writes no-op.
+ */
+
+import {
+  readActiveAuthuser,
+  writeActiveAuthuser,
+  clearActiveAuthuser,
+  markSignedOut,
+  clearSignedOut,
+  isSilentRestoreSuppressed,
+} from '../activeAuthuser';
+
+describe('activeAuthuser helpers — localStorage fail-safe', () => {
+  const realDescriptor = Object.getOwnPropertyDescriptor(window, 'localStorage');
+
+  afterEach(() => {
+    if (realDescriptor) {
+      Object.defineProperty(window, 'localStorage', realDescriptor);
+    }
+    window.localStorage?.clear?.();
+  });
+
+  /** Replace the `localStorage` accessor so reading the property throws. */
+  function makeLocalStorageGetterThrow(): void {
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('denied', 'SecurityError');
+      },
+    });
+  }
+
+  it('readActiveAuthuser returns null (never throws) when the getter throws', () => {
+    makeLocalStorageGetterThrow();
+    expect(() => readActiveAuthuser()).not.toThrow();
+    expect(readActiveAuthuser()).toBeNull();
+  });
+
+  it('isSilentRestoreSuppressed returns false (never throws) when the getter throws', () => {
+    makeLocalStorageGetterThrow();
+    expect(() => isSilentRestoreSuppressed()).not.toThrow();
+    expect(isSilentRestoreSuppressed()).toBe(false);
+  });
+
+  it('writeActiveAuthuser / clearActiveAuthuser / markSignedOut / clearSignedOut no-op when the getter throws', () => {
+    makeLocalStorageGetterThrow();
+    expect(() => {
+      writeActiveAuthuser(2);
+      clearActiveAuthuser();
+      markSignedOut();
+      clearSignedOut();
+    }).not.toThrow();
+  });
+
+  it('round-trips normally when storage works (zero behavior change)', () => {
+    writeActiveAuthuser(3);
+    expect(readActiveAuthuser()).toBe(3);
+
+    expect(isSilentRestoreSuppressed()).toBe(false);
+    markSignedOut();
+    expect(isSilentRestoreSuppressed()).toBe(true);
+    clearSignedOut();
+    expect(isSilentRestoreSuppressed()).toBe(false);
+
+    clearActiveAuthuser();
+    expect(readActiveAuthuser()).toBeNull();
+  });
+});

--- a/packages/services/src/ui/utils/activeAuthuser.ts
+++ b/packages/services/src/ui/utils/activeAuthuser.ts
@@ -30,8 +30,22 @@ import {
 
 const ACTIVE_AUTHUSER_KEY = 'oxy_active_authuser';
 
-function hasLocalStorage(): boolean {
-  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+/**
+ * Safely resolve `window.localStorage`, returning `null` when it is
+ * unavailable. The PROPERTY ACCESS itself (`window.localStorage`) can throw a
+ * `SecurityError` synchronously in opaque-origin / sandboxed iframes or when
+ * storage is disabled — even `typeof window.localStorage` evaluates the getter
+ * and throws. Every read/write in this module routes through here so the getter
+ * throw is caught once, at the source, and callers stay clean. Returns `null`
+ * off-web and on any access failure (fail safe).
+ */
+function getLocalStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
 }
 
 function getSessionStorage(): Storage | null {
@@ -51,11 +65,12 @@ function getSessionStorage(): Storage | null {
  * fall back to deterministic selection (lowest authuser).
  */
 export function readActiveAuthuser(): number | null {
-  if (!hasLocalStorage()) {
+  const storage = getLocalStorage();
+  if (!storage) {
     return null;
   }
   try {
-    const raw = window.localStorage.getItem(ACTIVE_AUTHUSER_KEY);
+    const raw = storage.getItem(ACTIVE_AUTHUSER_KEY);
     if (raw === null) return null;
     const parsed = Number.parseInt(raw, 10);
     if (!Number.isFinite(parsed) || parsed < 0) return null;
@@ -71,10 +86,11 @@ export function readActiveAuthuser(): number | null {
  * this succeeding — it is best-effort UX persistence, not authoritative.
  */
 export function writeActiveAuthuser(authuser: number): void {
-  if (!hasLocalStorage()) return;
   if (!Number.isFinite(authuser) || authuser < 0) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   try {
-    window.localStorage.setItem(ACTIVE_AUTHUSER_KEY, String(authuser));
+    storage.setItem(ACTIVE_AUTHUSER_KEY, String(authuser));
   } catch {
     // Best-effort persistence; swallow QuotaExceededError / SecurityError.
   }
@@ -86,9 +102,10 @@ export function writeActiveAuthuser(authuser: number): void {
  * cleared slot.
  */
 export function clearActiveAuthuser(): void {
-  if (!hasLocalStorage()) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   try {
-    window.localStorage.removeItem(ACTIVE_AUTHUSER_KEY);
+    storage.removeItem(ACTIVE_AUTHUSER_KEY);
   } catch {
     // Best-effort.
   }
@@ -103,9 +120,10 @@ export function clearActiveAuthuser(): void {
  * failure (best-effort).
  */
 export function markSignedOut(): void {
-  if (!hasLocalStorage()) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   try {
-    window.localStorage.setItem(ssoSignedOutKey(window.location.origin), '1');
+    storage.setItem(ssoSignedOutKey(window.location.origin), '1');
   } catch {
     // Best-effort; swallow QuotaExceededError / SecurityError (private mode).
   }
@@ -118,9 +136,10 @@ export function markSignedOut(): void {
  * state. No-ops on native / storage failure.
  */
 export function clearSignedOut(): void {
-  if (!hasLocalStorage()) return;
+  const storage = getLocalStorage();
+  if (!storage) return;
   try {
-    window.localStorage.removeItem(ssoSignedOutKey(window.location.origin));
+    storage.removeItem(ssoSignedOutKey(window.location.origin));
   } catch {
     // Best-effort.
   }
@@ -134,8 +153,9 @@ export function clearSignedOut(): void {
  * `fedcm-silent` and `silent-iframe` cold-boot steps.
  */
 export function isSilentRestoreSuppressed(): boolean {
-  if (!hasLocalStorage()) return false;
-  return silentRestoreSuppressed(window.localStorage, window.location.origin);
+  const storage = getLocalStorage();
+  if (!storage) return false;
+  return silentRestoreSuppressed(storage, window.location.origin);
 }
 
 /**


### PR DESCRIPTION
Addresses gemini CRITICAL on #455: the window.localStorage getter itself throws SecurityError in sandboxed iframes / disabled storage; route all signed-out-gate + active-authuser helpers through a try-catch accessor. Zero behavior change when storage works.