### PR TITLE
fix(services): republish 13.1.2 with concrete @oxyhq/contracts dep + ProfileMenu icon type

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -583,15 +583,15 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "13.1.0",
+      "version": "13.1.2",
       "dependencies": {
-        "@oxyhq/contracts": "workspace:*",
+        "@oxyhq/contracts": "0.7.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@commitlint/cli": "^17.6.5",
         "@commitlint/config-conventional": "^17.6.5",
-        "@oxyhq/core": "workspace:^",
+        "@oxyhq/core": "^5.2.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@react-native/babel-preset": "^0.86.0",
@@ -632,7 +632,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.16.0",
-        "@oxyhq/core": "workspace:*",
+        "@oxyhq/core": "5.2.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@tanstack/query-async-storage-persister": "^5.101",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.1.0",
+  "version": "13.1.2",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -106,10 +106,10 @@
     }
   },
   "dependencies": {
-    "@oxyhq/contracts": "workspace:*"
+    "@oxyhq/contracts": "0.7.0"
   },
   "devDependencies": {
-    "@oxyhq/core": "workspace:^",
+    "@oxyhq/core": "^5.2.0",
     "nativewind": "5.0.0-preview.3",
     "react-native-css": "^3.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
@@ -154,7 +154,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.16.0",
 
-    "@oxyhq/core": "workspace:*",
+    "@oxyhq/core": "5.2.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@tanstack/query-async-storage-persister": "^5.101",

--- a/packages/services/src/ui/components/ProfileMenu.tsx
+++ b/packages/services/src/ui/components/ProfileMenu.tsx
@@ -379,7 +379,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
 
 /** Bottom-section action row (Add account / Manage / View profile). */
 const ActionRow: React.FC<{
-    icon: string;
+    icon: React.ComponentProps<typeof MaterialCommunityIcons>['name'];
     iconColor: string;
     label: string;
     disabled: boolean;


### PR DESCRIPTION
## Why

`@oxyhq/services@13.1.1` was a **broken, uninstallable publish**. `bun publish` leaked `workspace:*` verbatim into the published tarball for `@oxyhq/contracts` (and `workspace:*` for the `@oxyhq/core` peer), so `bun add @oxyhq/services@13.1.1` fails downstream with `@oxyhq/contracts@workspace:* failed to resolve`.

Verified:
- `npm view @oxyhq/services@13.1.1 dependencies` -> `{ '@oxyhq/contracts': 'workspace:*' }` (BROKEN)
- `npm view @oxyhq/services@13.1.0 dependencies` -> `{ '@oxyhq/contracts': '0.7.0' }` (how it should ship)

This is the known "bun publish workspace:* stale-lock" gotcha — the substitution regressed in the 13.1.1 publish path.

## What

Republish as **13.1.2** with the dependency specs hardcoded to the concrete published versions (matching how 13.1.0 shipped), independent of any `bun publish` substitution:

| spec | before | after |
|---|---|---|
| `dependencies.@oxyhq/contracts` | `workspace:*` | `0.7.0` |
| `peerDependencies.@oxyhq/core` | `workspace:*` | `5.2.0` |
| `devDependencies.@oxyhq/core` | `workspace:^` | `^5.2.0` |

Also keeps the `ProfileMenu` `ActionRow.icon` type fix — origin/main was still at 13.1.0 and did **not** contain it, so it was re-applied here:

```
icon: string;
->
icon: React.ComponentProps<typeof MaterialCommunityIcons>['name'];
```

No `as any`, no `@ts-ignore`, no callsite casts.

`bun.lock` synced in the same commit.

## Verification

- `13.1.2` published to npm; `npm view @oxyhq/services@13.1.2 dependencies` -> `{ '@oxyhq/contracts': '0.7.0' }`, `npm view @oxyhq/services version` -> `13.1.2`.
- In-package `tsc` (typescript) = 0 errors; manual build (commonjs + module + typescript) green.
- Packed tarball manifest shows concrete `0.7.0` / `5.2.0`, no `workspace:` anywhere.
- Clean external `bun add @oxyhq/services@13.1.2` resolves cleanly with the fixed `icon` type and concrete `@oxyhq/contracts@0.7.0`.

Note: the ~11 pre-existing `src/__tests__/context/*` jsdom SSO/cold-boot failures are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)