### PR TITLE
fix(services): megaphone→bullhorn glyph + restore 13.1.2 icon-type fixes — 13.1.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -583,7 +583,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "13.1.2",
+      "version": "13.1.3",
       "dependencies": {
         "@oxyhq/contracts": "0.7.0",
       },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.1.2",
+  "version": "13.1.3",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/components/SettingsIcon.tsx
+++ b/packages/services/src/ui/components/SettingsIcon.tsx
@@ -5,7 +5,7 @@ import { darkenColor } from '../utils/colorUtils';
 
 interface SettingsIconProps {
     /** MaterialCommunityIcons icon name */
-    name: string;
+    name: React.ComponentProps<typeof MaterialCommunityIcons>['name'];
     /** Background color for the circle */
     color: string;
     /** Icon size (default 14, fits bloom's 20x20 container) */
@@ -26,7 +26,7 @@ const SettingsIconComponent: React.FC<SettingsIconProps> = ({
     size = 20,
 }) => (
     <View style={[styles.circle, { width: size, height: size, borderRadius: size / 2, backgroundColor: color }]}>
-        <MaterialCommunityIcons name={name as any} size={iconSize} color={darkenColor(color)} />
+        <MaterialCommunityIcons name={name} size={iconSize} color={darkenColor(color)} />
     </View>
 );
 

--- a/packages/services/src/ui/components/fileManagement/FileViewer.tsx
+++ b/packages/services/src/ui/components/fileManagement/FileViewer.tsx
@@ -102,7 +102,7 @@ export const FileViewer: React.FC<FileViewerProps> = ({
     }, [imageDimensions, containerWidth]);
 
     const fileDetailItems = useMemo(() => {
-        const items: Array<{ id: string; iconName: string; iconColor: string; title: string; description: string }> = [
+        const items: Array<{ id: string; iconName: React.ComponentProps<typeof MaterialCommunityIcons>['name']; iconColor: string; title: string; description: string }> = [
             {
                 id: 'filename',
                 iconName: 'file-document',

--- a/packages/services/src/ui/components/payment/types.ts
+++ b/packages/services/src/ui/components/payment/types.ts
@@ -1,4 +1,6 @@
+import type React from 'react';
 import type { Animated } from 'react-native';
+import type { Ionicons } from '@expo/vector-icons';
 
 export type PaymentItem = {
     type: 'product' | 'subscription' | 'service' | 'fee' | string;
@@ -25,7 +27,7 @@ export interface CardDetails {
 export interface PaymentMethod {
     key: string;
     label: string;
-    icon: string;
+    icon: React.ComponentProps<typeof Ionicons>['name'];
     description: string;
 }
 

--- a/packages/services/src/ui/screens/FeedbackScreen.tsx
+++ b/packages/services/src/ui/screens/FeedbackScreen.tsx
@@ -12,7 +12,7 @@ import type { BaseScreenProps } from '../types/navigation';
 import { normalizeTheme } from '@oxyhq/core';
 import { packageInfo } from '@oxyhq/core';
 import { useTheme } from '@oxyhq/bloom/theme';
-import { Ionicons } from '@expo/vector-icons';
+import { Ionicons, MaterialCommunityIcons } from '@expo/vector-icons';
 import { toast } from '@oxyhq/bloom';
 import { H2, Text } from '@oxyhq/bloom/typography';
 import { Button } from '@oxyhq/bloom/button';
@@ -38,7 +38,7 @@ const LAST_STEP_INDEX = TOTAL_STEPS - 1;
 const SUCCESS_RESET_DELAY_MS = 3000;
 
 /** Maps each feedback type to a Bloom theme role + MaterialCommunityIcons glyph. */
-const TYPE_ICON_GLYPH: Record<FeedbackData['type'], string> = {
+const TYPE_ICON_GLYPH: Record<FeedbackData['type'], React.ComponentProps<typeof MaterialCommunityIcons>['name']> = {
     bug: 'bug',
     feature: 'lightbulb-on',
     general: 'chat',
@@ -46,7 +46,7 @@ const TYPE_ICON_GLYPH: Record<FeedbackData['type'], string> = {
 };
 
 /** Maps each priority level to a MaterialCommunityIcons glyph. */
-const PRIORITY_ICON_GLYPH: Record<FeedbackData['priority'], string> = {
+const PRIORITY_ICON_GLYPH: Record<FeedbackData['priority'], React.ComponentProps<typeof MaterialCommunityIcons>['name']> = {
     low: 'arrow-down',
     medium: 'minus',
     high: 'arrow-up',

--- a/packages/services/src/ui/screens/NotificationsScreen.tsx
+++ b/packages/services/src/ui/screens/NotificationsScreen.tsx
@@ -159,7 +159,7 @@ const NotificationsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
                         <SettingsListItem
                             icon={
                                 <SettingsIcon
-                                    name="megaphone"
+                                    name="bullhorn"
                                     color={bloomTheme.colors.secondary}
                                 />
                             }


### PR DESCRIPTION
## Summary
Fixes a second consumer-visible `tsc` regression exposed by the 13.1.x icon-type hardening, and brings `main` up to (and past) published npm 13.1.2/13.1.3.

`NotificationsScreen.tsx` used `<SettingsIcon name="megaphone" />` in the Marketing section, but `"megaphone"` is **not** a MaterialCommunityIcons glyph (absent from `@expo/vector-icons`' glyphmap; `bullhorn`/`bullhorn-outline` are the real glyphs). Once `SettingsIcon.name` was hardened to the strict glyph union, consumers hit:

```
NotificationsScreen.tsx(162,37): error TS2322: Type '"megaphone"' is not
assignable to type '"symbol" | ...7429 more... | "blank"'.
```

The fix is the **data**, not the type: `name="megaphone"` → `name="bullhorn"` (semantically correct announcement glyph). No `as any`, no type loosening.

## Superset of published 13.1.2
`main`'s merged 13.1.2 PR (#466) only carried the concrete `@oxyhq/contracts` dep + the ProfileMenu icon-type fix. The other 13.1.2 source hardenings (published to npm from commit `aa3b3193`) never landed on `main`. Since 13.1.3 must be a strict superset of published 13.1.2, this PR re-applies them:
- `SettingsIcon.tsx`: `name: string` → MaterialCommunityIcons glyph union; removed `name={name as any}` cast
- `FeedbackScreen.tsx`: `TYPE_ICON_GLYPH` / `PRIORITY_ICON_GLYPH` record value type `string` → glyph union
- `payment/types.ts`: `PaymentMethod.icon` `string` → Ionicons glyph union
- `fileManagement/FileViewer.tsx`: `fileDetailItems.iconName` `string` → glyph union

## Validation
- Validated every string-literal icon `name=` usage (229 across `src`) plus all record-based glyph literals against the real `@expo/vector-icons` glyphmaps **and** the `.d.ts` strict unions — `megaphone` was the ONLY invalid glyph.
- In-package `tsc` (typecheck): 0 errors. Full build (commonjs/module/typescript): green.
- Pack-inspect gate: packed manifest has `@oxyhq/contracts: 0.7.0` (dep) + `@oxyhq/core: 5.2.0` (peer), **NO `workspace:*` leak**.

## Published
`@oxyhq/services@13.1.3` published to npm via `bun publish` (concrete deps, no workspace leak).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)