### PR TITLE
feat(services): Bluesky-style animated hover reveal on ProfileButton (13.1.4)

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.1.3",
+  "version": "13.1.4",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -153,7 +153,6 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.16.0",
-
     "@oxyhq/core": "5.2.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": "^11.4.1",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -22,6 +22,7 @@
  */
 
 /// <reference path="./types/react-native-classname.d.ts" />
+/// <reference path="./types/react-native-web-style.d.ts" />
 
 import { setPlatformOS, type PlatformOS } from '@oxyhq/core';
 import { Platform } from 'react-native';

--- a/packages/services/src/types/react-native-web-style.d.ts
+++ b/packages/services/src/types/react-native-web-style.d.ts
@@ -1,0 +1,27 @@
+// Web-only CSS transition/transform typings for React Native's `ViewStyle`.
+//
+// On web, React Native for Web forwards these CSS properties straight through to
+// the underlying DOM element, so an inline `style={{ transitionProperty: … }}`
+// works at runtime — but RN's `ViewStyle` type (which targets native) does not
+// declare them, so `tsc` rejects the object literal (TS2322 "Object literal may
+// only specify known properties"). Components that reproduce web animations with
+// inline transition styles (e.g. `ProfileButton`'s Bluesky-style hover reveal)
+// need these keys typed without resorting to `as any`.
+//
+// This augmentation adds ONLY the standard CSS animation/transition properties
+// as optional `string`s. It is guarded at the call site behind `Platform.OS ===
+// 'web'`, so native code paths never emit them. The plain `import 'react-native'`
+// makes this a module augmentation (merge) rather than a redeclaration. Consumers
+// load it via the `/// <reference path>` directives in `src/index.ts` and
+// `src/ui/index.ts`, alongside `react-native-classname.d.ts`.
+
+import 'react-native';
+
+declare module 'react-native' {
+  interface ViewStyle {
+    transitionProperty?: string;
+    transitionDuration?: string;
+    transitionDelay?: string;
+    transitionTimingFunction?: string;
+  }
+}

--- a/packages/services/src/ui/components/ProfileButton.tsx
+++ b/packages/services/src/ui/components/ProfileButton.tsx
@@ -28,6 +28,33 @@ const MENU_WIDTH = 300;
 /** Gutter, in px, kept between the popover and the viewport edges on web. */
 const VIEWPORT_GUTTER = 8;
 
+/**
+ * Web-only Bluesky-style hover animation timings, mirrored from
+ * `social-app/src/view/shell/desktop/LeftNav.tsx`. The row background and the
+ * name/handle/chevron opacity cross-fade quickly; the avatar shrink+slide is
+ * slower and more deliberate. A short delay on the LEAVE transition keeps the
+ * row from flickering when the pointer crosses a child boundary.
+ */
+const BG_TRANSITION_MS = 150;
+const AVATAR_TRANSITION_MS = 250;
+const OPACITY_TRANSITION_MS = 150;
+const LEAVE_DELAY_MS = 50;
+
+/** Shrunk-avatar scale on hover, matching Bluesky's `scale: 2/3`. */
+const ACTIVE_AVATAR_SCALE = 2 / 3;
+
+/**
+ * Reads the OS "reduce motion" preference on web. Guards `window`/`matchMedia`
+ * so it is safe during SSR and on native (where it is never called). When
+ * reduced motion is on, the avatar transform snaps instead of transitioning.
+ */
+const prefersReducedMotion = (): boolean => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return false;
+    }
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+};
+
 export interface ProfileButtonProps {
     /**
      * Expanded row (avatar + name + handle + chevron) when `true` (default), or a
@@ -92,6 +119,11 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
 
     const [menuOpen, setMenuOpen] = useState(false);
     const [anchor, setAnchor] = useState<ProfileMenuAnchor | null>(null);
+
+    // Web-only hover/focus tracking for the Bluesky-style reveal animation.
+    // Native has no hover, so these stay false and the row renders statically.
+    const [hovered, setHovered] = useState(false);
+    const [focused, setFocused] = useState(false);
 
     // Trigger ref for the web anchor measurement. RN-Web exposes `measure()` on
     // host views, so we anchor the popover to the button rect and open upward.
@@ -201,16 +233,46 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
         />
     );
 
+    // `active` combines hover, keyboard focus, and menu-open — exactly like
+    // Bluesky's `state.hovered || state.focused || control.isOpen`. Only web
+    // ever sets `hovered`/`focused`, so on native this reduces to `menuOpen`.
+    const active = hovered || focused || menuOpen;
+    const accountLabel = t('accountSwitcher.switchWhileSignedInAs', { name: displayName })
+        || `Switch account, signed in as ${displayName}`;
+
+    // Web-only pointer/focus handlers. RN-Web forwards `onHoverIn`/`onHoverOut`
+    // to the underlying element; native Pressable ignores them harmlessly, but
+    // we only attach them on web to keep the native path pristine.
+    const webInteractionProps = isWeb
+        ? {
+            onHoverIn: () => setHovered(true),
+            onHoverOut: () => setHovered(false),
+            onFocus: () => setFocused(true),
+            onBlur: () => setFocused(false),
+        }
+        : undefined;
+
     if (!expanded) {
+        // Collapsed: avatar-only. On web, hovering just fades a subtle round
+        // background behind the avatar — no shrink, no text.
+        const collapsedBgStyle: ViewStyle | undefined = isWeb
+            ? {
+                backgroundColor: active ? colors.backgroundSecondary : 'transparent',
+                transitionProperty: 'background-color',
+                transitionDuration: `${BG_TRANSITION_MS}ms`,
+                transitionDelay: active ? '0ms' : `${LEAVE_DELAY_MS}ms`,
+            }
+            : undefined;
         return (
             <View className={className} style={style}>
                 <Pressable
                     ref={triggerRef}
                     className="rounded-full"
+                    style={collapsedBgStyle}
                     onPress={openMenu}
                     accessibilityRole="button"
-                    accessibilityLabel={t('accountSwitcher.switchWhileSignedInAs', { name: displayName })
-                        || `Switch account, signed in as ${displayName}`}
+                    accessibilityLabel={accountLabel}
+                    {...webInteractionProps}
                 >
                     {avatarNode}
                 </Pressable>
@@ -227,18 +289,78 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
         );
     }
 
+    // ── Expanded row animation ──────────────────────────────────────────────
+    // On native everything is statically visible (no hover exists). On web we
+    // reproduce Bluesky's reveal: the row fills with a subtle contrast bg, the
+    // avatar shrinks + slides left, and the name/handle/chevron fade in. The
+    // negative left margin tucks the identity block under the shrunk avatar so
+    // it slides out from behind it as the avatar contracts.
+    const reducedMotion = isWeb && prefersReducedMotion();
+
+    // Slide the shrunk avatar left so its visual left edge stays put as it
+    // contracts. The avatar loses `size * (1 - scale)` of width; half of that
+    // (the left half, since scale is centered) is the offset, plus the row's
+    // left padding (px-2 = 8px) so it hugs the row edge like Bluesky's.
+    const activeAvatarTranslateX =
+        -(resolvedAvatarSize * (1 - ACTIVE_AVATAR_SCALE)) / 2 - 8;
+
+    const rowStyle: StyleProp<ViewStyle> = isWeb
+        ? {
+            backgroundColor: active ? colors.backgroundSecondary : 'transparent',
+            transitionProperty: 'background-color',
+            transitionDuration: `${BG_TRANSITION_MS}ms`,
+            transitionDelay: active ? '0ms' : `${LEAVE_DELAY_MS}ms`,
+        }
+        : undefined;
+
+    const avatarWrapperStyle: ViewStyle | undefined = isWeb
+        ? {
+            zIndex: 10,
+            ...(reducedMotion
+                ? {}
+                : {
+                    transitionProperty: 'transform',
+                    transitionDuration: `${AVATAR_TRANSITION_MS}ms`,
+                    transitionDelay: active ? '0ms' : `${LEAVE_DELAY_MS}ms`,
+                }),
+            transform: active
+                ? [{ scale: ACTIVE_AVATAR_SCALE }, { translateX: activeAvatarTranslateX }]
+                : [{ scale: 1 }, { translateX: 0 }],
+        }
+        : undefined;
+
+    const identityStyle: ViewStyle | undefined = isWeb
+        ? {
+            marginLeft: -resolvedAvatarSize / 2,
+            opacity: active ? 1 : 0,
+            transitionProperty: 'opacity',
+            transitionDuration: `${OPACITY_TRANSITION_MS}ms`,
+            transitionDelay: active ? '0ms' : `${LEAVE_DELAY_MS}ms`,
+        }
+        : undefined;
+
+    const chevronStyle: ViewStyle | undefined = isWeb
+        ? {
+            opacity: active ? 1 : 0,
+            transitionProperty: 'opacity',
+            transitionDuration: `${OPACITY_TRANSITION_MS}ms`,
+            transitionDelay: active ? '0ms' : `${LEAVE_DELAY_MS}ms`,
+        }
+        : undefined;
+
     return (
         <View className={className} style={style}>
             <Pressable
                 ref={triggerRef}
                 className="flex-row items-center gap-3 rounded-full px-2 py-2"
+                style={rowStyle}
                 onPress={openMenu}
                 accessibilityRole="button"
-                accessibilityLabel={t('accountSwitcher.switchWhileSignedInAs', { name: displayName })
-                    || `Switch account, signed in as ${displayName}`}
+                accessibilityLabel={accountLabel}
+                {...webInteractionProps}
             >
-                {avatarNode}
-                <View className="min-w-0 flex-1">
+                <View style={avatarWrapperStyle}>{avatarNode}</View>
+                <View className="min-w-0 flex-1" style={identityStyle}>
                     <Text className="font-bold text-foreground" numberOfLines={1}>
                         {displayName}
                     </Text>
@@ -248,11 +370,13 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
                         </Text>
                     ) : null}
                 </View>
-                <MaterialCommunityIcons
-                    name="unfold-more-horizontal"
-                    size={18}
-                    color={colors.textSecondary}
-                />
+                <View style={chevronStyle}>
+                    <MaterialCommunityIcons
+                        name="unfold-more-horizontal"
+                        size={18}
+                        color={colors.textSecondary}
+                    />
+                </View>
             </Pressable>
             <ProfileMenu
                 open={menuOpen}

--- a/packages/services/src/ui/index.ts
+++ b/packages/services/src/ui/index.ts
@@ -13,6 +13,7 @@
  */
 
 /// <reference path="../types/react-native-classname.d.ts" />
+/// <reference path="../types/react-native-web-style.d.ts" />
 
 // Components
 export { default as OxyProvider } from './components/OxyProvider';


### PR DESCRIPTION
Matches Bluesky's sidebar ProfileCard hover UX on `ProfileButton` (signed-in, web): by default only the avatar shows; on hover / focus / menu-open the row bg fades in, the **avatar shrinks (scale 2/3) and slides left**, and the **name + @handle + chevron cross-fade in**. `active = hovered || focused || menuOpen`.

- **Web-only** animation (`onHoverIn/Out`, `onFocus/Blur`); native renders the static row unchanged. Respects `prefers-reduced-motion` (transform snaps; opacity/bg still fade).
- Transitions mirror Bluesky: bg 150ms · avatar transform 250ms · opacity 150ms · +50ms leave delay.
- Clean: NativeWind + Bloom colors; only inline styles are the dynamic transition/transform/opacity values. New heritage-free `ViewStyle` augmentation (`react-native-web-style.d.ts`) types the web `transition*` keys — same pattern as the existing `react-native-classname.d.ts`, no `as any`.
- Published as **`@oxyhq/services@13.1.4`** (deps concrete, pack-inspect gate passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)