### PR TITLE
fix(services): ProfileButton full-width row + guard native drawer crash (13.1.5)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -583,7 +583,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "13.1.3",
+      "version": "13.1.5",
       "dependencies": {
         "@oxyhq/contracts": "0.7.0",
       },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.1.4",
+  "version": "13.1.5",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/components/ProfileButton.tsx
+++ b/packages/services/src/ui/components/ProfileButton.tsx
@@ -191,7 +191,7 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
         const signInLabel = t('common.actions.signIn') || 'Sign in';
         return (
             <Pressable
-                className={`flex-row items-center gap-3 rounded-full px-2 py-2 ${className ?? ''}`}
+                className={`${expanded ? 'w-full ' : ''}flex-row items-center gap-3 rounded-full px-2 py-2 ${className ?? ''}`}
                 style={style}
                 onPress={() => { void signIn(); }}
                 accessibilityRole="button"
@@ -349,10 +349,10 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
         : undefined;
 
     return (
-        <View className={className} style={style}>
+        <View className={`w-full ${className ?? ''}`} style={style}>
             <Pressable
                 ref={triggerRef}
-                className="flex-row items-center gap-3 rounded-full px-2 py-2"
+                className="w-full flex-row items-center gap-3 rounded-full px-2 py-2"
                 style={rowStyle}
                 onPress={openMenu}
                 accessibilityRole="button"

--- a/packages/services/src/ui/components/ProfileMenu.tsx
+++ b/packages/services/src/ui/components/ProfileMenu.tsx
@@ -62,7 +62,7 @@ export interface ProfileMenuProps {
  * Renders as an upward-opening popover anchored to the trigger on web, and a
  * bottom-sheet style modal on native.
  */
-const ProfileMenu: React.FC<ProfileMenuProps> = ({
+const ProfileMenuBody: React.FC<ProfileMenuProps> = ({
     open,
     onClose,
     anchor,
@@ -411,6 +411,21 @@ const styles = {
     nativeScrim: {
         backgroundColor: 'rgba(0,0,0,0.32)',
     } satisfies ViewStyle,
+};
+
+/**
+ * Public wrapper: renders nothing — and runs NO hooks — until `open`. Mounting
+ * the body only while open keeps the account hooks (`useDeviceAccounts` /
+ * refresh-all, Bloom dialog/toast controls) off the render path when the menu is
+ * closed, which is every time the sidebar or native drawer mounts
+ * `ProfileButton`. A hook that is unsafe on a given platform (e.g. throws during
+ * a native render) therefore never runs unless the user actually opens the menu.
+ */
+const ProfileMenu: React.FC<ProfileMenuProps> = (props) => {
+    if (!props.open) {
+        return null;
+    }
+    return <ProfileMenuBody {...props} />;
 };
 
 export default ProfileMenu;


### PR DESCRIPTION
Two fixes to the sidebar ProfileButton (published as **@oxyhq/services@13.1.5**):

**Width** — expanded signed-in/out rows now take `w-full`, so the account button fills the sidebar rail like the nav items (and like Bluesky's `w_full` ProfileCard) instead of shrinking to content width.

**Native drawer crash** — `ProfileMenu` ran all its hooks (`useDeviceAccounts`/refresh-all, Bloom dialog + toast controls) on every render, even while closed, so mounting `ProfileButton` (e.g. opening the native drawer) executed them and a platform-unsafe hook crashed. Wrapped `ProfileMenu` so the body + hooks only mount when `open`. Also stops rotating single-use refresh cookies on every ProfileButton mount.

tsc + build green; pack-inspect gate passed (deps concrete, no workspace:*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)