### PR TITLE
fix(services): ProfileButton three-dot ellipsis icon (13.1.6)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -583,7 +583,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "13.1.5",
+      "version": "13.1.6",
       "dependencies": {
         "@oxyhq/contracts": "0.7.0",
       },

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.1.5",
+  "version": "13.1.6",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/components/ProfileButton.tsx
+++ b/packages/services/src/ui/components/ProfileButton.tsx
@@ -372,7 +372,7 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
                 </View>
                 <View style={chevronStyle}>
                     <MaterialCommunityIcons
-                        name="unfold-more-horizontal"
+                        name="dots-horizontal"
                         size={18}
                         color={colors.textSecondary}
                     />


### PR DESCRIPTION
Swaps the sidebar ProfileButton row affordance from `unfold-more-horizontal` to `dots-horizontal`, matching Bluesky ProfileCard's three-dot `DotGrid3x1` EllipsisIcon. Published as **@oxyhq/services@13.1.6**. tsc+build green, pack-inspect gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)