### PR TITLE
fix(auth): @oxyhq/auth peer @oxyhq/core ^5 (published 7.0.0)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -225,7 +225,7 @@
     },
     "packages/auth-sdk": {
       "name": "@oxyhq/auth",
-      "version": "6.1.0",
+      "version": "7.0.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "qrcode": "^1.5.4",
@@ -239,7 +239,7 @@
         "typescript": "^5.9.2",
       },
       "peerDependencies": {
-        "@oxyhq/core": "workspace:*",
+        "@oxyhq/core": "^5.0.0",
         "@tanstack/query-sync-storage-persister": "^5.100",
         "@tanstack/react-query": "^5.100",
         "@tanstack/react-query-persist-client": "^5.100",

--- a/packages/auth-sdk/package.json
+++ b/packages/auth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/auth",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "OxyHQ Web Authentication SDK — headless auth with React hooks for Next.js, Vite, and web apps",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -79,8 +79,7 @@
     "qrcode": "^1.5.4"
   },
   "peerDependencies": {
-
-    "@oxyhq/core": "workspace:*",
+    "@oxyhq/core": "^5.0.0",
     "@tanstack/query-sync-storage-persister": "^5.100",
     "@tanstack/react-query": "^5.100",
     "@tanstack/react-query-persist-client": "^5.100",


### PR DESCRIPTION
Widens `@oxyhq/auth` peer `@oxyhq/core` to `^5.0.0` (was a stale `^3.15.0 || ^4.0.0` from a hand-substituted `workspace:*`). No code changes — auth-sdk already compiles clean against core 5.2.1 (core 4→5 broke nothing auth consumes; verified tsc exit 0 in an isolated harness). Published @oxyhq/auth@7.0.0. Unblocks every Oxy app from converging on core 5 + services 13 + auth 7 (3-package install verified: single deduped core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)