### PR TITLE
feat(services): ProfileButton placement up|down|auto (13.2.0)

### DIFF
--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "13.1.7",
+  "version": "13.2.0",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/components/ProfileButton.tsx
+++ b/packages/services/src/ui/components/ProfileButton.tsx
@@ -73,6 +73,18 @@ export interface ProfileButtonProps {
     onNavigateProfile?: () => void;
     /** Called before the active identity changes so apps can clear scoped state. */
     onBeforeSessionChange?: () => void | Promise<void>;
+    /**
+     * Web-only popover direction relative to the trigger:
+     *  - `'up'` (default): the menu opens UPWARD, for a trigger placed at the
+     *    BOTTOM of a sidebar (the footer pattern). Pixel-identical to prior
+     *    behavior.
+     *  - `'down'`: the menu opens DOWNWARD, for a trigger placed at the TOP of a
+     *    sidebar (the accounts app pattern).
+     *  - `'auto'`: opens downward when there is more room below the trigger than
+     *    above, otherwise upward.
+     * Native (bottom-sheet) is unaffected — this only influences the web popover.
+     */
+    placement?: 'up' | 'down' | 'auto';
     /** Extra className applied to the outer trigger. */
     className?: string;
     /** Extra style applied to the outer trigger. */
@@ -104,6 +116,7 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
     onAddAccount,
     onNavigateProfile,
     onBeforeSessionChange,
+    placement = 'up',
     className,
     style,
 }) => {
@@ -143,7 +156,7 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
             setMenuOpen(true);
             return;
         }
-        node.measure((_x, _y, _w, _h, pageX, pageY) => {
+        node.measure((_x, _y, _w, height, pageX, pageY) => {
             if (typeof pageX !== 'number' || typeof pageY !== 'number') {
                 setAnchor(null);
             } else {
@@ -153,17 +166,33 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
                     window.innerWidth - MENU_WIDTH - VIEWPORT_GUTTER,
                 );
                 const left = Math.min(Math.max(VIEWPORT_GUTTER, pageX), maxLeft);
-                // Anchor the panel's BOTTOM edge just above the trigger top so
-                // the menu opens upward from this footer button.
-                const bottom = Math.max(
-                    VIEWPORT_GUTTER,
-                    window.innerHeight - pageY + VIEWPORT_GUTTER,
-                );
-                setAnchor({ left, bottom });
+                // Bottom edge of the trigger in page coordinates. `height` is a
+                // number for host views; guard defensively for non-web shims.
+                const triggerBottom = pageY + (typeof height === 'number' ? height : 0);
+                // Resolve `'auto'` by comparing the room below the trigger with
+                // the room above it; pick whichever direction has more space.
+                const openDown =
+                    placement === 'down' ||
+                    (placement === 'auto' &&
+                        window.innerHeight - triggerBottom > pageY);
+                if (openDown) {
+                    // Anchor the panel's TOP edge just below the trigger bottom so
+                    // the menu opens downward from a top-of-sidebar trigger.
+                    const top = Math.max(VIEWPORT_GUTTER, triggerBottom + VIEWPORT_GUTTER);
+                    setAnchor({ left, top });
+                } else {
+                    // Anchor the panel's BOTTOM edge just above the trigger top so
+                    // the menu opens upward from this footer button.
+                    const bottom = Math.max(
+                        VIEWPORT_GUTTER,
+                        window.innerHeight - pageY + VIEWPORT_GUTTER,
+                    );
+                    setAnchor({ left, bottom });
+                }
             }
             setMenuOpen(true);
         });
-    }, []);
+    }, [placement]);
 
     const handleClose = useCallback(() => {
         setMenuOpen(false);

--- a/packages/services/src/ui/components/ProfileMenu.tsx
+++ b/packages/services/src/ui/components/ProfileMenu.tsx
@@ -26,15 +26,20 @@ const isWeb = Platform.OS === 'web';
 const MENU_WIDTH = 300;
 
 /**
- * Web-only anchor. `ProfileButton` measures its trigger and anchors the panel's
- * BOTTOM-LEFT corner so the menu opens UPWARD from the sidebar footer. Native
- * ignores the anchor and docks the panel to the bottom as a sheet.
+ * Web-only anchor. `ProfileButton` measures its trigger and anchors the panel to
+ * one corner so the menu opens either UPWARD (footer trigger) or DOWNWARD (a
+ * trigger at the top of a sidebar). Exactly ONE vertical edge is pinned:
+ *  - `bottom` set → the panel's BOTTOM edge is anchored, so it opens UPWARD.
+ *  - `top` set → the panel's TOP edge is anchored, so it opens DOWNWARD.
+ * Native ignores the anchor and docks the panel to the bottom as a sheet.
  */
 export interface ProfileMenuAnchor {
     /** Distance from the viewport left, for the panel's LEFT edge. */
     left: number;
     /** Distance from the viewport bottom, for the panel's BOTTOM edge (opens upward). */
-    bottom: number;
+    bottom?: number;
+    /** Distance from the viewport top, for the panel's TOP edge (opens downward). */
+    top?: number;
 }
 
 export interface ProfileMenuProps {
@@ -353,15 +358,19 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
 }) => {
     const { t } = useI18n();
 
-    // Web: anchor the panel's bottom-left corner to the measured trigger, falling
-    // back to a bottom-left placement when no anchor was captured. Native ignores
-    // this (the panel docks to the bottom via the overlay's flex-end).
+    // Web: anchor the panel to the measured trigger. When the anchor pins `top`
+    // the panel opens DOWNWARD from the trigger; otherwise it pins `bottom` and
+    // opens UPWARD (the default footer behavior). With no anchor captured, fall
+    // back to a bottom-left placement. Native ignores this (the panel docks to
+    // the bottom via the overlay's flex-end).
     const panelAnchorStyle: ViewStyle | undefined = isWeb
         ? {
             position: 'absolute',
             width: MENU_WIDTH,
             left: anchor?.left ?? 8,
-            bottom: anchor?.bottom ?? 8,
+            ...(typeof anchor?.top === 'number'
+                ? { top: anchor.top }
+                : { bottom: anchor?.bottom ?? 8 }),
         }
         : undefined;
 


### PR DESCRIPTION
Adds `ProfileButtonProps.placement?: 'up' | 'down' | 'auto'` (default `'up'` — every current footer caller is pixel-identical). Web popover only. `'down'` anchors the menu's top edge below the trigger (for a top-of-sidebar trigger like the accounts app); `'auto'` picks the side with more room. ProfileMenuAnchor now pins exactly one of top/bottom. Modal-always-mounted + visuals intact. Published @oxyhq/services@13.2.0. tsc+build+pack-inspect green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)