### PR TITLE
feat(accounts): SDK ProfileButton at top of sidebar (placement=down)

### DIFF
--- a/packages/accounts/app/_layout.tsx
+++ b/packages/accounts/app/_layout.tsx
@@ -16,9 +16,11 @@ configureReanimatedLogger({
   strict: false,
 });
 
+import type { ReactNode } from 'react';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { OxyProvider } from '@oxyhq/services';
 import { BloomThemeProvider, useNavigationTheme } from '@oxyhq/bloom/theme';
+import { ImageResolverProvider } from '@oxyhq/bloom/image-resolver';
 
 import { useOxy } from '@oxyhq/services';
 
@@ -110,21 +112,41 @@ function RootLayoutInner() {
             theme mode from ThemeModeProvider. */}
         <BloomThemeProvider mode={themeMode}>
           <OxyProvider baseURL={API_URL} clientId={OXY_CLIENT_ID}>
-            <LocaleProvider>
-              <AppHead />
-              {!appIsReady ? (
-                <AppSplashScreen
-                  startFade={startFade}
-                  onFadeComplete={handleSplashFadeComplete}
-                />
-              ) : (
-                <AppStackContent />
-              )}
-            </LocaleProvider>
+            <AppImageResolver>
+              <LocaleProvider>
+                <AppHead />
+                {!appIsReady ? (
+                  <AppSplashScreen
+                    startFade={startFade}
+                    onFadeComplete={handleSplashFadeComplete}
+                  />
+                ) : (
+                  <AppStackContent />
+                )}
+              </LocaleProvider>
+            </AppImageResolver>
           </OxyProvider>
         </BloomThemeProvider>
       </KeyboardProvider>
     </GestureHandlerRootView>
+  );
+}
+
+/**
+ * Registers the canonical Oxy `ImageResolver` so every Bloom `Avatar` in the
+ * tree (e.g. the sidebar `ProfileButton`) resolves a bare file id to a
+ * variant-aware URL via `oxyServices.getFileDownloadUrl`. Without it, avatars
+ * fall back to rendering initials. Must live inside `OxyProvider` so `useOxy()`
+ * has a client. Defaults the variant to `thumb` for the small avatar surfaces.
+ */
+function AppImageResolver({ children }: { children: ReactNode }) {
+  const { oxyServices } = useOxy();
+  return (
+    <ImageResolverProvider
+      value={(id, variant) => oxyServices.getFileDownloadUrl(id, variant ?? 'thumb')}
+    >
+      {children}
+    </ImageResolverProvider>
   );
 }
 

--- a/packages/accounts/components/ui/sidebar-content.tsx
+++ b/packages/accounts/components/ui/sidebar-content.tsx
@@ -9,6 +9,7 @@ import { darkenColor } from '@/utils/color-utils';
 import { useHapticPress } from '@/hooks/use-haptic-press';
 import type { MaterialCommunityIconName } from '@/types/icons';
 import { useTranslation } from '@/lib/i18n';
+import { ProfileButton } from '@oxyhq/services';
 
 // Narrow to the string variant of Href so menu items can be used as React
 // keys and compared to `pathname` strings without casting.
@@ -56,6 +57,19 @@ export function SidebarContent({ onNavigate }: SidebarContentProps) {
 
     return (
         <>
+            <View style={styles.profileContainer}>
+                <ProfileButton
+                    placement="down"
+                    onNavigateManage={() => {
+                        router.push('/(tabs)');
+                        onNavigate?.();
+                    }}
+                    onAddAccount={() => {
+                        router.push('/(auth)');
+                        onNavigate?.();
+                    }}
+                />
+            </View>
             <View style={styles.menuContainer}>
                 {menuItems.map((item) => {
                     const isActive = pathname === item.path || (item.path === '/(tabs)' && (pathname === '/(tabs)' || pathname === '/(tabs)/'));
@@ -102,6 +116,10 @@ export function SidebarContent({ onNavigate }: SidebarContentProps) {
 }
 
 const styles = StyleSheet.create({
+    profileContainer: {
+        marginBottom: 12,
+        alignSelf: 'stretch',
+    },
     menuContainer: {
         gap: 4,
         alignItems: 'flex-start',


### PR DESCRIPTION
Adds the shared `ProfileButton` at the TOP of the accounts sidebar (both desktop + drawer via the shared SidebarContent), opening downward via `placement="down"` (services 13.2.0). manage→/(tabs), addAccount→/(auth). Registers ImageResolverProvider inside OxyProvider (accounts had none) so the avatar resolves. Web build green; tsc errors are the pre-existing accounts baseline (proven by stash), none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)