### PR TITLE
feat(session): centralized cross-domain session-sync foundation (Phases 1-3, additive)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-session-sync-phase1-server-authority.md
+++ b/docs/superpowers/plans/2026-07-01-session-sync-phase1-server-authority.md
@@ -1,0 +1,923 @@
+# Sesión centralizada — Fase 1: Contratos + Autoridad del servidor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construir la autoridad central del estado de sesión del dispositivo en el servidor (`@oxyhq/contracts` + `oxy-api`): modelo `DeviceSession`, servicio con `revision`, rutas REST `/session/device/{state,add,switch,signout}`, y broadcast por Socket.IO al room `device:<deviceId>`. Aditivo — no toca ningún cliente y no rompe las rutas `/auth/*` existentes todavía.
+
+**Architecture:** Un `DeviceSession` por dispositivo físico agrega cuentas `[{accountId, sessionId, authuser, operatedByUserId?}]` + `activeAccountId` + `revision` monótono. Las mutaciones REST persisten + suben `revision` + difunden el `SessionState` (sin tokens) al room del dispositivo. Reutiliza `session.service` (createSession/deactivate), `refreshToken.service` (revocación), `requireSameSiteOrigin`, y el singleton `getIO()`.
+
+**Tech Stack:** TypeScript, Express, Mongoose (globalmente mockeado en tests), Socket.IO, Zod (`@oxyhq/contracts`), Jest + ts-jest (sin supertest, sin mongodb-memory-server).
+
+## Global Constraints
+
+- Package manager: **bun** (`bun run test`, nunca `bun test` en `packages/api` → ~81 falsos fallos). Test runner de la API = **jest** vía `bunx jest <file>`.
+- **Sin `as any`, sin `@ts-ignore`, sin `!` non-null, sin `console.log`, sin `catch {}` vacío, sin `var`.** `const` por defecto. Tipos explícitos.
+- **Corte limpio**: no back-compat, no shims, no `@deprecated`. (En esta fase NO se borra aún `/auth/*` — se hace en Fase 3+ cuando los clientes migren; Fase 1 es aditiva.)
+- Rate-limit: cada `rateLimit(...)` requiere un `prefix` único `rl:<scope>:`.
+- Sockets: el room se deriva SIEMPRE de la identidad del token/servidor, nunca de input del cliente (anti-IDOR).
+- Contratos nuevos van en `@oxyhq/contracts` (Zod), validados con `safeParseContract`. `@oxyhq/contracts` se **publica primero** antes que la API lo consuma en prod (en dev/CI se resuelve de `src` vía `moduleNameMapper`).
+- Igualdad de secretos con `verifySecret`, nunca `===`.
+- Baseline de tests de la API: **997** (no debe bajar; esta fase añade tests).
+
+---
+
+## Estructura de ficheros (Fase 1)
+
+| Fichero | Responsabilidad |
+|---|---|
+| `packages/contracts/src/deviceSession.ts` (crear) | `sessionAccountSchema`, `deviceSessionStateSchema`, tipos `SessionAccount`/`DeviceSessionState`. |
+| `packages/contracts/src/index.ts` (modificar) | Exportar los nuevos schemas + tipos. |
+| `packages/contracts/src/__tests__/deviceSession.test.ts` (crear) | Tests de parse/reject del contrato. |
+| `packages/api/src/models/DeviceSession.ts` (crear) | Modelo mongoose `DeviceSession` (colección `devicesessions`). |
+| `packages/api/src/services/deviceSession.service.ts` (crear) | `getState`/`addAccount`/`switchActive`/`signout` + `revision`; proyección a `DeviceSessionState`. |
+| `packages/api/src/services/__tests__/deviceSession.service.test.ts` (crear) | Tests del servicio (modelo mockeado). |
+| `packages/api/src/utils/socket.ts` (modificar) | `broadcastDeviceState(deviceId, state)` helper de emit. |
+| `packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts` (crear) | Test del helper de emit. |
+| `packages/api/src/routes/sessionDevice.ts` (crear) | Router REST `/session/device/{state,add,switch,signout}`. |
+| `packages/api/src/routes/__tests__/sessionDevice.test.ts` (crear) | Tests de rutas + emit (patrón `http.request`). |
+| `packages/api/src/server.ts` (modificar) | Join del room `device:<deviceId>`; montar `sessionDeviceRouter`. |
+
+---
+
+### Task 1: Contrato `DeviceSessionState` en `@oxyhq/contracts`
+
+**Files:**
+- Create: `packages/contracts/src/deviceSession.ts`
+- Modify: `packages/contracts/src/index.ts:13-37` (bloques de export)
+- Test: `packages/contracts/src/__tests__/deviceSession.test.ts`
+
+**Interfaces:**
+- Produces: `sessionAccountSchema`, `deviceSessionStateSchema` (Zod), tipos `SessionAccount`, `DeviceSessionState`. Firma de tipos:
+  - `SessionAccount = { accountId: string; sessionId: string; authuser: number; operatedByUserId?: string }`
+  - `DeviceSessionState = { deviceId: string; accounts: SessionAccount[]; activeAccountId: string | null; revision: number; updatedAt: number }`
+
+- [ ] **Step 1: Escribir el test que falla**
+
+```ts
+// packages/contracts/src/__tests__/deviceSession.test.ts
+import { deviceSessionStateSchema, sessionAccountSchema, safeParseContract } from '../index';
+
+describe('deviceSessionStateSchema', () => {
+  const account = { accountId: 'a1', sessionId: 's1', authuser: 0 };
+  const state = { deviceId: 'd1', accounts: [account], activeAccountId: 'a1', revision: 3, updatedAt: 1720000000000 };
+
+  it('parses a valid state', () => {
+    expect(safeParseContract(deviceSessionStateSchema, state)).toEqual(state);
+  });
+
+  it('accepts an optional operatedByUserId on an account', () => {
+    const withOp = { ...account, operatedByUserId: 'op1' };
+    expect(safeParseContract(sessionAccountSchema, withOp)).toEqual(withOp);
+  });
+
+  it('accepts activeAccountId=null (device signed out of all)', () => {
+    const parsed = safeParseContract(deviceSessionStateSchema, { ...state, accounts: [], activeAccountId: null });
+    expect(parsed?.activeAccountId).toBeNull();
+  });
+
+  it('rejects a negative authuser', () => {
+    expect(safeParseContract(sessionAccountSchema, { ...account, authuser: -1 })).toBeNull();
+  });
+
+  it('rejects a state missing revision', () => {
+    const { revision, ...noRev } = state;
+    expect(safeParseContract(deviceSessionStateSchema, noRev)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Ejecutar el test → falla**
+
+Run: `cd packages/contracts && bunx jest src/__tests__/deviceSession.test.ts`
+Expected: FAIL — `Cannot find module '../index'`-derived exports `deviceSessionStateSchema`/`sessionAccountSchema` are undefined.
+
+- [ ] **Step 3: Crear el contrato**
+
+```ts
+// packages/contracts/src/deviceSession.ts
+import { z } from 'zod';
+
+export const sessionAccountSchema = z.object({
+  accountId: z.string(),
+  sessionId: z.string(),
+  authuser: z.number().int().nonnegative(),
+  operatedByUserId: z.string().optional(),
+});
+
+export const deviceSessionStateSchema = z.object({
+  deviceId: z.string(),
+  accounts: z.array(sessionAccountSchema),
+  activeAccountId: z.string().nullable(),
+  revision: z.number().int().nonnegative(),
+  updatedAt: z.number(),
+});
+
+export type SessionAccount = z.infer<typeof sessionAccountSchema>;
+export type DeviceSessionState = z.infer<typeof deviceSessionStateSchema>;
+```
+
+- [ ] **Step 4: Exportar desde `index.ts`**
+
+En `packages/contracts/src/index.ts`, en el bloque de value-exports añade (junto a los otros `export { ... } from './...'`):
+
+```ts
+export { sessionAccountSchema, deviceSessionStateSchema } from './deviceSession';
+```
+
+y en el bloque `export type { ... }`:
+
+```ts
+export type { SessionAccount, DeviceSessionState } from './deviceSession';
+```
+
+(Imports extensionless, como el resto del fichero — el post-proceso ESM añade `.js`.)
+
+- [ ] **Step 5: Ejecutar el test → pasa**
+
+Run: `cd packages/contracts && bunx jest src/__tests__/deviceSession.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Verificar build de contracts**
+
+Run: `cd packages/contracts && bun run build`
+Expected: build OK (cjs+esm+types), sin errores tsc.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/contracts/src/deviceSession.ts packages/contracts/src/index.ts packages/contracts/src/__tests__/deviceSession.test.ts
+git commit -m "feat(contracts): add DeviceSessionState + SessionAccount schemas"
+```
+
+---
+
+### Task 2: Modelo `DeviceSession` (mongoose)
+
+**Files:**
+- Create: `packages/api/src/models/DeviceSession.ts`
+- Test: `packages/api/src/models/__tests__/deviceSession.model.test.ts`
+
+**Interfaces:**
+- Produces: `IDeviceSession` interface + default-export model `DeviceSession` (colección `devicesessions`). Campos: `deviceId: string` (unique), `accounts: [{ accountId: ObjectId, sessionId: string, authuser: number, addedAt: Date, operatedByUserId?: ObjectId }]`, `activeAccountId: ObjectId | null`, `revision: number`, `timestamps:true`.
+
+- [ ] **Step 1: Escribir el test que falla**
+
+El mock global de mongoose no permite instanciar el schema real; se opta por mongoose real (patrón `accountsSwitch.test.ts:27`). El test valida forma y defaults del schema.
+
+```ts
+// packages/api/src/models/__tests__/deviceSession.model.test.ts
+jest.mock('mongoose', () => jest.requireActual('mongoose'));
+import mongoose from 'mongoose';
+import DeviceSession from '../DeviceSession';
+
+describe('DeviceSession model', () => {
+  it('registers on the "devicesessions" collection', () => {
+    expect(DeviceSession.collection.name).toBe('devicesessions');
+  });
+
+  it('defaults revision to 0 and activeAccountId to null', () => {
+    const doc = new DeviceSession({ deviceId: 'd1' });
+    expect(doc.revision).toBe(0);
+    expect(doc.activeAccountId).toBeNull();
+    expect(doc.accounts).toHaveLength(0);
+  });
+
+  it('requires deviceId', () => {
+    const doc = new DeviceSession({});
+    const err = doc.validateSync();
+    expect(err?.errors?.deviceId).toBeDefined();
+  });
+
+  it('stores an account subdocument with authuser + sessionId', () => {
+    const accountId = new mongoose.Types.ObjectId();
+    const doc = new DeviceSession({ deviceId: 'd1', accounts: [{ accountId, sessionId: 's1', authuser: 0 }] });
+    expect(doc.accounts[0].sessionId).toBe('s1');
+    expect(doc.accounts[0].authuser).toBe(0);
+    expect(doc.accounts[0].addedAt).toBeInstanceOf(Date);
+  });
+});
+```
+
+- [ ] **Step 2: Ejecutar → falla**
+
+Run: `cd packages/api && bunx jest src/models/__tests__/deviceSession.model.test.ts`
+Expected: FAIL — `Cannot find module '../DeviceSession'`.
+
+- [ ] **Step 3: Crear el modelo**
+
+```ts
+// packages/api/src/models/DeviceSession.ts
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface IDeviceSessionAccount {
+  accountId: mongoose.Types.ObjectId;
+  sessionId: string;
+  authuser: number;
+  addedAt: Date;
+  operatedByUserId?: mongoose.Types.ObjectId | null;
+}
+
+export interface IDeviceSession extends Document {
+  deviceId: string;
+  accounts: IDeviceSessionAccount[];
+  activeAccountId: mongoose.Types.ObjectId | null;
+  revision: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const AccountSchema = new Schema<IDeviceSessionAccount>(
+  {
+    accountId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    sessionId: { type: String, required: true },
+    authuser: { type: Number, required: true, min: 0 },
+    addedAt: { type: Date, default: Date.now },
+    operatedByUserId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { _id: false },
+);
+
+const DeviceSessionSchema = new Schema<IDeviceSession>(
+  {
+    deviceId: { type: String, required: true },
+    accounts: { type: [AccountSchema], default: [] },
+    activeAccountId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+    revision: { type: Number, default: 0 },
+  },
+  { timestamps: true },
+);
+
+DeviceSessionSchema.index({ deviceId: 1 }, { unique: true });
+
+export default mongoose.model<IDeviceSession>('DeviceSession', DeviceSessionSchema);
+```
+
+- [ ] **Step 4: Ejecutar → pasa**
+
+Run: `cd packages/api && bunx jest src/models/__tests__/deviceSession.model.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/models/DeviceSession.ts packages/api/src/models/__tests__/deviceSession.model.test.ts
+git commit -m "feat(api): add DeviceSession model (device account set + revision)"
+```
+
+---
+
+### Task 3: `deviceSession.service.ts` (autoridad + revision)
+
+**Files:**
+- Create: `packages/api/src/services/deviceSession.service.ts`
+- Test: `packages/api/src/services/__tests__/deviceSession.service.test.ts`
+
+**Interfaces:**
+- Consumes: `DeviceSession` model (Task 2); `sessionService.deactivateSession` (existente); `DeviceSessionState` (Task 1).
+- Produces (default-export singleton `deviceSessionService`):
+  - `getState(deviceId: string): Promise<DeviceSessionState>` — crea el doc si no existe; proyecta a `DeviceSessionState` (siempre devuelve un estado, `accounts:[]` si vacío).
+  - `addAccount(deviceId: string, input: { accountId: string; sessionId: string; operatedByUserId?: string }): Promise<DeviceSessionState>` — upsert de la cuenta (reemplaza si ya existe misma `accountId`), asigna `authuser` = menor índice libre, pone `activeAccountId = accountId`, `revision++`.
+  - `switchActive(deviceId: string, accountId: string): Promise<DeviceSessionState | null>` — si la cuenta existe, `activeAccountId = accountId`, `revision++`; `null` si no existe.
+  - `signout(deviceId: string, target: { accountId: string } | { all: true }): Promise<DeviceSessionState>` — quita la(s) cuenta(s), revoca su `Session` (`sessionService.deactivateSession(sessionId)`), recalcula `activeAccountId` (primera restante o `null`), `revision++`.
+  - `projectState(doc: IDeviceSession): DeviceSessionState` (helper puro exportado para tests/rutas).
+
+- [ ] **Step 1: Escribir el test que falla**
+
+```ts
+// packages/api/src/services/__tests__/deviceSession.service.test.ts
+const mockFindOne = jest.fn();
+const mockFindOneAndUpdate = jest.fn();
+const mockDeactivate = jest.fn();
+
+jest.mock('../../models/DeviceSession', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...a: unknown[]) => mockFindOne(...a),
+    findOneAndUpdate: (...a: unknown[]) => mockFindOneAndUpdate(...a),
+  },
+}));
+jest.mock('../session.service', () => ({
+  __esModule: true,
+  default: { deactivateSession: (...a: unknown[]) => mockDeactivate(...a) },
+}));
+jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+
+import deviceSessionService, { projectState } from '../deviceSession.service';
+
+const lean = (v: unknown) => ({ lean: () => Promise.resolve(v) });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('projectState', () => {
+  it('maps a doc to DeviceSessionState with string ids', () => {
+    const doc = {
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+      updatedAt: new Date(1720000000000),
+    };
+    expect(projectState(doc as never)).toEqual({
+      deviceId: 'd1',
+      accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }],
+      activeAccountId: 'a1',
+      revision: 2,
+      updatedAt: 1720000000000,
+    });
+  });
+});
+
+describe('addAccount', () => {
+  it('adds a new account at authuser 0, sets it active, bumps revision', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's1' });
+    expect(state.activeAccountId).toBe('a1');
+    expect(state.accounts[0].authuser).toBe(0);
+    expect(state.revision).toBe(1);
+  });
+});
+
+describe('signout', () => {
+  it('revokes the account session and drops it from the set', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+    }));
+    mockDeactivate.mockResolvedValueOnce(true);
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 2, updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.signout('d1', { accountId: 'a1' });
+    expect(mockDeactivate).toHaveBeenCalledWith('s1');
+    expect(state.accounts).toHaveLength(0);
+    expect(state.activeAccountId).toBeNull();
+    expect(state.revision).toBe(2);
+  });
+});
+
+describe('switchActive', () => {
+  it('returns null when the account is not on the device', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
+    expect(await deviceSessionService.switchActive('d1', 'ghost')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Ejecutar → falla**
+
+Run: `cd packages/api && bunx jest src/services/__tests__/deviceSession.service.test.ts`
+Expected: FAIL — `Cannot find module '../deviceSession.service'`.
+
+- [ ] **Step 3: Implementar el servicio**
+
+```ts
+// packages/api/src/services/deviceSession.service.ts
+import type { DeviceSessionState, SessionAccount } from '@oxyhq/contracts';
+import DeviceSession, { IDeviceSession, IDeviceSessionAccount } from '../models/DeviceSession';
+import sessionService from './session.service';
+import { logger } from '../utils/logger';
+
+function idToString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object' && 'toString' in (value as object)) return (value as { toString(): string }).toString();
+  return String(value);
+}
+
+export function projectState(doc: IDeviceSession): DeviceSessionState {
+  const accounts: SessionAccount[] = (doc.accounts ?? []).map((a: IDeviceSessionAccount) => {
+    const operatedBy = idToString(a.operatedByUserId ?? null);
+    const account: SessionAccount = { accountId: idToString(a.accountId) ?? '', sessionId: a.sessionId, authuser: a.authuser };
+    if (operatedBy) account.operatedByUserId = operatedBy;
+    return account;
+  });
+  return {
+    deviceId: doc.deviceId,
+    accounts,
+    activeAccountId: idToString(doc.activeAccountId),
+    revision: doc.revision ?? 0,
+    updatedAt: (doc.updatedAt ?? new Date()).getTime(),
+  };
+}
+
+function lowestFreeAuthuser(accounts: IDeviceSessionAccount[]): number {
+  const used = new Set(accounts.map((a) => a.authuser));
+  let i = 0;
+  while (used.has(i)) i += 1;
+  return i;
+}
+
+class DeviceSessionService {
+  private async load(deviceId: string): Promise<IDeviceSession | null> {
+    return DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
+  }
+
+  async getState(deviceId: string): Promise<DeviceSessionState> {
+    const existing = await this.load(deviceId);
+    if (existing) return projectState(existing);
+    const created = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      { $setOnInsert: { deviceId, accounts: [], activeAccountId: null, revision: 0 } },
+      { new: true, upsert: true },
+    ).lean<IDeviceSession>();
+    return projectState(created as IDeviceSession);
+  }
+
+  async addAccount(
+    deviceId: string,
+    input: { accountId: string; sessionId: string; operatedByUserId?: string },
+  ): Promise<DeviceSessionState> {
+    const current = (await this.load(deviceId)) ?? { deviceId, accounts: [], activeAccountId: null, revision: 0 } as IDeviceSession;
+    const others = (current.accounts ?? []).filter((a) => idToString(a.accountId) !== input.accountId);
+    const authuser = lowestFreeAuthuser(others);
+    const account = {
+      accountId: input.accountId,
+      sessionId: input.sessionId,
+      authuser,
+      addedAt: new Date(),
+      operatedByUserId: input.operatedByUserId ?? null,
+    };
+    const updated = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      {
+        $set: { accounts: [...others, account], activeAccountId: input.accountId },
+        $inc: { revision: 1 },
+      },
+      { new: true, upsert: true },
+    ).lean<IDeviceSession>();
+    return projectState(updated as IDeviceSession);
+  }
+
+  async switchActive(deviceId: string, accountId: string): Promise<DeviceSessionState | null> {
+    const current = await this.load(deviceId);
+    if (!current || !(current.accounts ?? []).some((a) => idToString(a.accountId) === accountId)) return null;
+    const updated = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      { $set: { activeAccountId: accountId }, $inc: { revision: 1 } },
+      { new: true },
+    ).lean<IDeviceSession>();
+    return projectState(updated as IDeviceSession);
+  }
+
+  async signout(deviceId: string, target: { accountId: string } | { all: true }): Promise<DeviceSessionState> {
+    const current = await this.load(deviceId);
+    if (!current) return this.getState(deviceId);
+    const removing = 'all' in target ? current.accounts ?? [] : (current.accounts ?? []).filter((a) => idToString(a.accountId) === target.accountId);
+    for (const a of removing) {
+      try {
+        await sessionService.deactivateSession(a.sessionId);
+      } catch (error) {
+        logger.warn('deviceSession.signout: deactivate failed', { sessionId: a.sessionId, error });
+      }
+    }
+    const remaining = 'all' in target ? [] : (current.accounts ?? []).filter((a) => idToString(a.accountId) !== target.accountId);
+    const activeStillPresent = remaining.some((a) => idToString(a.accountId) === idToString(current.activeAccountId));
+    const nextActive = activeStillPresent ? idToString(current.activeAccountId) : (remaining[0] ? idToString(remaining[0].accountId) : null);
+    const updated = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      { $set: { accounts: remaining, activeAccountId: nextActive }, $inc: { revision: 1 } },
+      { new: true, upsert: true },
+    ).lean<IDeviceSession>();
+    return projectState(updated as IDeviceSession);
+  }
+}
+
+const deviceSessionService = new DeviceSessionService();
+export default deviceSessionService;
+```
+
+- [ ] **Step 4: Ejecutar → pasa**
+
+Run: `cd packages/api && bunx jest src/services/__tests__/deviceSession.service.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/services/deviceSession.service.ts packages/api/src/services/__tests__/deviceSession.service.test.ts
+git commit -m "feat(api): deviceSession.service — device account authority with revision"
+```
+
+---
+
+### Task 4: `broadcastDeviceState` (emit helper)
+
+**Files:**
+- Modify: `packages/api/src/utils/socket.ts:1-16`
+- Test: `packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts`
+
+**Interfaces:**
+- Consumes: `getIO()` (existente en `utils/socket.ts`), `DeviceSessionState` (Task 1).
+- Produces: `export function broadcastDeviceState(state: DeviceSessionState): void` — emite el evento `session_state` (con el `state`) al room `device:<state.deviceId>`. No-op seguro si `getIO()` es null.
+
+- [ ] **Step 1: Escribir el test que falla**
+
+`broadcastDeviceState` vive en `utils/socket.ts` junto a `getIO`/`initializeIO`. Como llama a `getIO()` del mismo módulo (no se puede auto-mockear una función del propio módulo), el test inyecta un io falso vía `initializeIO(...)` y lo limpia con `closeIO()`:
+
+```ts
+// packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts
+jest.mock('../logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+import { initializeIO, closeIO, broadcastDeviceState } from '../socket';
+import type { DeviceSessionState } from '@oxyhq/contracts';
+
+const state: DeviceSessionState = { deviceId: 'd1', accounts: [], activeAccountId: null, revision: 5, updatedAt: 1720000000000 };
+
+afterEach(() => closeIO());
+
+describe('broadcastDeviceState', () => {
+  it('emits session_state to the device room', () => {
+    const emit = jest.fn();
+    const to = jest.fn().mockReturnValue({ emit });
+    initializeIO({ to } as never);
+    broadcastDeviceState(state);
+    expect(to).toHaveBeenCalledWith('device:d1');
+    expect(emit).toHaveBeenCalledWith('session_state', state);
+  });
+
+  it('is a no-op when io is not initialised', () => {
+    closeIO();
+    expect(() => broadcastDeviceState(state)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Ejecutar → falla**
+
+Run: `cd packages/api && bunx jest src/utils/__tests__/deviceStateBroadcast.test.ts`
+Expected: FAIL — `broadcastDeviceState` no existe.
+
+- [ ] **Step 3: Añadir el helper a `utils/socket.ts`**
+
+Al final de `packages/api/src/utils/socket.ts` (que ya tiene `io`, `initializeIO`, `getIO`, `closeIO`):
+
+```ts
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { logger } from './logger';
+
+export function broadcastDeviceState(state: DeviceSessionState): void {
+  const server = getIO();
+  if (!server) {
+    logger.debug('broadcastDeviceState: io not initialised', { deviceId: state.deviceId });
+    return;
+  }
+  server.to(`device:${state.deviceId}`).emit('session_state', state);
+}
+```
+
+- [ ] **Step 4: Ejecutar → pasa**
+
+Run: `cd packages/api && bunx jest src/utils/__tests__/deviceStateBroadcast.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/utils/socket.ts packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts
+git commit -m "feat(api): broadcastDeviceState — emit session_state to device room"
+```
+
+---
+
+### Task 5: Rutas REST `/session/device/{state,add,switch,signout}`
+
+**Files:**
+- Create: `packages/api/src/routes/sessionDevice.ts`
+- Modify: `packages/api/src/server.ts` (montar el router)
+- Test: `packages/api/src/routes/__tests__/sessionDevice.test.ts`
+
+**Interfaces:**
+- Consumes: `deviceSessionService` (Task 3), `broadcastDeviceState` (Task 4), `authMiddleware` (existente, pone `req.user`), `requireSameSiteOrigin`.
+- `deviceId` de esta fase: se deriva de la **sesión del bearer del llamante** (su `req` → sesión → `deviceId`). Se lee vía un helper `resolveCallerDeviceId(req)` que decodifica el bearer (`decodeToken`) → `deviceId` claim. (La unificación del `deviceId` cross-domain por el IdP es Task 6 / fase posterior; aquí basta el `deviceId` de la sesión.)
+- Rutas (todas `authMiddleware` + `requireSameSiteOrigin`):
+  - `GET /session/device/state` → `200 { data: DeviceSessionState }`.
+  - `POST /session/device/add { accountId, sessionId, operatedByUserId? }` → persist + broadcast → `200 { data: DeviceSessionState }`.
+  - `POST /session/device/switch { accountId }` → `200 { data }` o `404 { error }` si la cuenta no está.
+  - `POST /session/device/signout { accountId? , all? }` → persist + broadcast → `200 { data }`.
+
+- [ ] **Step 1: Escribir el test que falla** (patrón `http.request`, mocks a nivel de módulo)
+
+```ts
+// packages/api/src/routes/__tests__/sessionDevice.test.ts
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+
+const mockAuthMiddleware = jest.fn();
+const mockGetState = jest.fn();
+const mockAddAccount = jest.fn();
+const mockSwitchActive = jest.fn();
+const mockSignout = jest.fn();
+const mockBroadcast = jest.fn();
+const mockDecodeToken = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (...a: unknown[]) => mockAuthMiddleware(...a),
+}));
+jest.mock('../../middleware/originGuard', () => ({
+  requireSameSiteOrigin: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../middleware/rateLimiter', () => ({ rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next() }));
+jest.mock('../../middleware/authUtils', () => ({
+  decodeToken: (...a: unknown[]) => mockDecodeToken(...a),
+  extractTokenFromRequest: () => 'tkn',
+}));
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: {
+    getState: (...a: unknown[]) => mockGetState(...a),
+    addAccount: (...a: unknown[]) => mockAddAccount(...a),
+    switchActive: (...a: unknown[]) => mockSwitchActive(...a),
+    signout: (...a: unknown[]) => mockSignout(...a),
+  },
+}));
+jest.mock('../../utils/socket', () => ({ broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a) }));
+jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+
+import sessionDeviceRouter from '../sessionDevice';
+import { errorHandler } from '../../middleware/errorHandler';
+
+const STATE = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
+
+async function requestJson(server: http.Server, method: string, path: string, payload?: unknown) {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? '' : JSON.stringify(payload);
+  return new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
+    const req = http.request({ method, host: '127.0.0.1', port: address.port, path,
+      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body), Authorization: 'Bearer t' } },
+      (res) => { let raw = ''; res.on('data', c => { raw += c; }); res.on('end', () => { resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }); }); });
+    req.on('error', reject); if (body) req.write(body); req.end();
+  });
+}
+
+let server: http.Server;
+beforeAll((done) => {
+  mockAuthMiddleware.mockImplementation((req: { user?: unknown }, _res: unknown, next: () => void) => {
+    (req as { user?: unknown }).user = { _id: { toString: () => '64b0000000000000000000aa' }, id: '64b0000000000000000000aa' };
+    next();
+  });
+  mockDecodeToken.mockReturnValue({ sessionId: 's1', deviceId: 'd1' });
+  const app = express();
+  app.use(express.json());
+  app.use('/session/device', sessionDeviceRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+afterAll((done) => server.close(done));
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /session/device/state', () => {
+  it('returns the device state', async () => {
+    mockGetState.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'GET', '/session/device/state');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(STATE);
+    expect(mockGetState).toHaveBeenCalledWith('d1');
+  });
+});
+
+describe('POST /session/device/switch', () => {
+  it('switches active account and broadcasts', async () => {
+    mockSwitchActive.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'a1' });
+    expect(res.status).toBe(200);
+    expect(mockSwitchActive).toHaveBeenCalledWith('d1', 'a1');
+    expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+  });
+
+  it('404 when the account is not on the device', async () => {
+    mockSwitchActive.mockResolvedValueOnce(null);
+    const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'ghost' });
+    expect(res.status).toBe(404);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /session/device/signout', () => {
+  it('signs out one account and broadcasts', async () => {
+    const after = { ...STATE, accounts: [], activeAccountId: null, revision: 2 };
+    mockSignout.mockResolvedValueOnce(after);
+    const res = await requestJson(server, 'POST', '/session/device/signout', { accountId: 'a1' });
+    expect(res.status).toBe(200);
+    expect(mockSignout).toHaveBeenCalledWith('d1', { accountId: 'a1' });
+    expect(mockBroadcast).toHaveBeenCalledWith(after);
+  });
+
+  it('signs out all when { all: true }', async () => {
+    const after = { ...STATE, accounts: [], activeAccountId: null, revision: 2 };
+    mockSignout.mockResolvedValueOnce(after);
+    const res = await requestJson(server, 'POST', '/session/device/signout', { all: true });
+    expect(res.status).toBe(200);
+    expect(mockSignout).toHaveBeenCalledWith('d1', { all: true });
+  });
+});
+
+describe('POST /session/device/add', () => {
+  it('adds an account and broadcasts', async () => {
+    mockAddAccount.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'POST', '/session/device/add', { accountId: 'a1', sessionId: 's1' });
+    expect(res.status).toBe(200);
+    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: 'a1', sessionId: 's1', operatedByUserId: undefined });
+    expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+  });
+});
+```
+
+- [ ] **Step 2: Ejecutar → falla**
+
+Run: `cd packages/api && bunx jest src/routes/__tests__/sessionDevice.test.ts`
+Expected: FAIL — `Cannot find module '../sessionDevice'`.
+
+- [ ] **Step 3: Implementar el router**
+
+```ts
+// packages/api/src/routes/sessionDevice.ts
+import { Router, Response } from 'express';
+import { authMiddleware, AuthRequest } from '../middleware/auth';
+import { requireSameSiteOrigin } from '../middleware/originGuard';
+import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
+import deviceSessionService from '../services/deviceSession.service';
+import { broadcastDeviceState } from '../utils/socket';
+import { asyncHandler } from '../middleware/asyncHandler';
+
+const router = Router();
+
+function resolveCallerDeviceId(req: AuthRequest): string | null {
+  const token = extractTokenFromRequest(req);
+  const decoded = token ? decodeToken(token) : null;
+  return decoded?.deviceId ?? null;
+}
+
+router.use(requireSameSiteOrigin, authMiddleware);
+
+router.get('/state', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  res.json({ data: await deviceSessionService.getState(deviceId) });
+}));
+
+router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  const { accountId, sessionId, operatedByUserId } = req.body ?? {};
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  if (!accountId || !sessionId) { res.status(400).json({ error: 'accountId and sessionId required' }); return; }
+  const state = await deviceSessionService.addAccount(deviceId, { accountId, sessionId, operatedByUserId });
+  broadcastDeviceState(state);
+  res.json({ data: state });
+}));
+
+router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  const { accountId } = req.body ?? {};
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  if (!accountId) { res.status(400).json({ error: 'accountId required' }); return; }
+  const state = await deviceSessionService.switchActive(deviceId, accountId);
+  if (!state) { res.status(404).json({ error: 'Account not on this device' }); return; }
+  broadcastDeviceState(state);
+  res.json({ data: state });
+}));
+
+router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  const { accountId, all } = req.body ?? {};
+  const target = all === true ? { all: true as const } : accountId ? { accountId } : null;
+  if (!target) { res.status(400).json({ error: 'accountId or all required' }); return; }
+  const state = await deviceSessionService.signout(deviceId, target);
+  broadcastDeviceState(state);
+  res.json({ data: state });
+}));
+
+export default router;
+```
+
+> Nota: confirmar el path exacto de `asyncHandler` (grep `export.*asyncHandler` en `packages/api/src/middleware`). Si no existe como módulo propio, envolver los handlers en try/catch que llamen `next(error)` (el proyecto ya usa `asyncHandler` en `routes/auth.ts`, así que existe — usar ese import).
+
+- [ ] **Step 4: Ejecutar → pasa**
+
+Run: `cd packages/api && bunx jest src/routes/__tests__/sessionDevice.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Montar el router en `server.ts`**
+
+En `packages/api/src/server.ts`, junto a `import sessionRouter from './routes/session'` (línea ~8):
+
+```ts
+import sessionDeviceRouter from './routes/sessionDevice';
+```
+
+y junto a `app.use('/session', userRateLimiter, csrfProtection, sessionRouter);` (línea ~515), ANTES de esa línea (para que `/session/device/*` no lo capture el genérico), montar:
+
+```ts
+app.use('/session/device', userRateLimiter, sessionDeviceRouter);
+```
+
+(El router ya aplica `requireSameSiteOrigin`+`authMiddleware`; no lleva `csrfProtection` porque son escrituras con bearer, no cookie ambiental — coherente con el spec §9.)
+
+- [ ] **Step 6: Verificar que la suite completa de la API sigue verde**
+
+Run: `cd packages/api && bun run test`
+Expected: PASS — baseline 997 + los nuevos (≈ 997 + 16). Sin regresiones.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/api/src/routes/sessionDevice.ts packages/api/src/routes/__tests__/sessionDevice.test.ts packages/api/src/server.ts
+git commit -m "feat(api): /session/device/{state,add,switch,signout} routes + broadcast"
+```
+
+---
+
+### Task 6: Join del room `device:<deviceId>` en el socket
+
+**Files:**
+- Modify: `packages/api/src/server.ts:263-282` (`io.on('connection')`)
+- Test: `packages/api/src/utils/__tests__/deviceRoom.test.ts` (test de una función extraída `joinDeviceRoom`)
+
+**Interfaces:**
+- Consumes: el `socket` autenticado (`socket.user.id` ya lo pone el auth middleware del socket; el `deviceId` viene del token en `socket.handshake.auth`).
+- Produces: helper puro `export function deviceRoomFor(decoded: { deviceId?: string }): string | null` en `utils/socket.ts` (o junto al connection handler) que devuelve `device:<deviceId>` o null. El connection handler hace `socket.join(room)` además del `user:<id>` existente.
+
+> **Diseño testeable:** el `io.on('connection')` de `server.ts` no está bajo test (ningún test importa `../server`). Para poder testear, se extrae la derivación del room a una función pura en `utils/socket.ts` y el handler la usa. El test cubre la función; el `socket.join` se verifica en integración manual (§verificación).
+
+- [ ] **Step 1: Escribir el test que falla**
+
+```ts
+// packages/api/src/utils/__tests__/deviceRoom.test.ts
+import { deviceRoomFor } from '../socket';
+
+describe('deviceRoomFor', () => {
+  it('returns device:<deviceId> when present', () => {
+    expect(deviceRoomFor({ deviceId: 'd1' })).toBe('device:d1');
+  });
+  it('returns null when deviceId is absent', () => {
+    expect(deviceRoomFor({})).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Ejecutar → falla**
+
+Run: `cd packages/api && bunx jest src/utils/__tests__/deviceRoom.test.ts`
+Expected: FAIL — `deviceRoomFor` no existe.
+
+- [ ] **Step 3: Añadir `deviceRoomFor` a `utils/socket.ts`**
+
+```ts
+export function deviceRoomFor(decoded: { deviceId?: string | null }): string | null {
+  return decoded?.deviceId ? `device:${decoded.deviceId}` : null;
+}
+```
+
+- [ ] **Step 4: Usarlo en `server.ts` connection handler**
+
+En `io.on('connection', (socket: AuthenticatedSocket) => { ... })` (líneas 263-282), tras el `socket.join('user:'+id)` existente, añadir (el token decodificado ya está disponible en `socket.user` gracias al middleware de auth del socket, que hace `socket.user = { id, ...decoded }`):
+
+```ts
+const deviceRoom = deviceRoomFor(socket.user ?? {});
+if (deviceRoom) socket.join(deviceRoom);
+```
+
+y añadir el import: `import { deviceRoomFor } from './utils/socket';` (junto a `initializeIO`).
+
+- [ ] **Step 5: Ejecutar → pasa** + suite API verde
+
+Run: `cd packages/api && bunx jest src/utils/__tests__/deviceRoom.test.ts && bun run test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/utils/socket.ts packages/api/src/utils/__tests__/deviceRoom.test.ts packages/api/src/server.ts
+git commit -m "feat(api): join device:<deviceId> socket room on connection"
+```
+
+---
+
+## Verificación de integración (manual, tras Fase 1)
+
+Fase 1 es servidor puro y no la consume ningún cliente todavía, así que se verifica con `curl`/un cliente socket de prueba (no requiere navegador):
+
+1. Con un bearer válido, `POST /session/device/add {accountId, sessionId}` → `200 {data}` con `revision:1`, `activeAccountId=accountId`.
+2. `GET /session/device/state` → devuelve la misma cuenta.
+3. Conectar un cliente Socket.IO con `auth.token=<bearer>` → debe unirse a `device:<deviceId>`; un segundo `POST /session/device/switch` → el cliente recibe `session_state` con `revision:2`.
+4. `POST /session/device/signout {all:true}` → `accounts:[]`, `activeAccountId:null`, `revision:3`, y las `Session` revocadas (`isActive:false`).
+
+(La verificación en navegador real cross-domain llega en la fase de cliente — Fase 3+ — donde el `SessionClient` consume esto.)
+
+---
+
+## Fuera de alcance de la Fase 1 (fases siguientes)
+
+- **Unificación del `deviceId` central por el IdP** (propagación FedCM/`/sso/establish` para que apps de dominios distintos compartan `deviceId`): Fase 1b / servidor-IdP. En Fase 1 el `deviceId` es el de la sesión del bearer (suficiente para same-app/same-device pruebas).
+- **Borrado de `/auth/refresh`, `/auth/refresh-all`, `/auth/session`, `/auth/logout` + esquema `oxy_rt`**: se hace cuando los clientes migren (Fase 3+), para no romper prod. Fase 1 es aditiva.
+- **`SessionClient` + `TokenTransport`** (`@oxyhq/core`): Fase 2.
+- **Refactor de `services`/`auth-sdk`/`accounts`**: Fases 3-5.

--- a/docs/superpowers/plans/2026-07-01-session-sync-phase2-core-sessionclient.md
+++ b/docs/superpowers/plans/2026-07-01-session-sync-phase2-core-sessionclient.md
@@ -1,0 +1,598 @@
+# Sesión centralizada — Fase 2: `SessionClient` + `TokenTransport` en `@oxyhq/core` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]` checkboxes.
+
+**Goal:** Un `SessionClient` framework-agnóstico en `@oxyhq/core` que es el cliente de la autoridad central de Fase 1: mantiene el `DeviceSessionState`, se suscribe al canal Socket.IO central (`session_state`), muta vía REST `/session/device/*`, valida todo con `safeParseContract`, y delega el minteo del token de la cuenta activa a un `TokenTransport` inyectable. Sin React (core lo prohíbe). Unit-testeable con fetch-stub + fake socket.
+
+**Architecture:** `SessionClient` orquesta estado + socket + REST; `TokenTransport` (interfaz inyectada) obtiene el token per-dominio de la cuenta activa (impls concretas web/native en Fases 3/4). `SessionState` es la única autoridad; el socket empuja, el cliente aplica con last-writer-wins por `revision`.
+
+**Tech Stack:** TypeScript (dual CJS+ESM, NO `require()` en fuente ESM — usar `await import`), `socket.io-client` (ya es dep dura de core `^4.8.1`), Zod contracts, Jest + ts-jest.
+
+## Global Constraints
+
+- **bun** (`bunx jest <file>` en `packages/core`; nunca `bun test`). Core test runner = jest.
+- Sin `as any`, `@ts-ignore`, `!` non-null, `console.log` (usar `logger`/`createDebugLogger` de core), `catch {}` vacío, `var`. Tipos explícitos.
+- **ESM/CJS**: `packages/core` NO puede tener `require()` en fuente. Cargar `socket.io-client` con `await import('socket.io-client')` (patrón `getSocketIO`), nunca `import io from 'socket.io-client'` estático (mantiene el bundle ESM limpio y no fuerza socket.io en todos los consumidores).
+- Core **no importa react / react-native / expo**. `SessionClient` es una clase plana; la integración con React vive en los consumidores (Fase 3/4).
+- Contratos desde `@oxyhq/contracts` (`deviceSessionStateSchema`, `safeParseContract`, `DeviceSessionState`). Core resuelve `@oxyhq/contracts` por su **dist construido** (NO hay moduleNameMapper a src en core jest) → si el test importa el símbolo nuevo, **construir contracts primero**: `bun run --filter @oxyhq/contracts build` (ya está construido en este worktree con `deviceSessionStateSchema` desde Fase 1).
+- Validar TODO estado entrante (REST y socket) con `safeParseContract(deviceSessionStateSchema, raw)`; descartar (log warn) si no valida — NUNCA aplicar estado no validado (previene el bug de deriva a logged-out).
+- Rooms/identidad las decide el servidor; el cliente solo manda su token en el handshake (`auth: cb => cb({ token })`), token fresco por (re)conexión.
+- Core baseline de tests: **724** (57 suites). No bajar.
+
+---
+
+## Estructura de ficheros (Fase 2)
+
+| Fichero | Responsabilidad |
+|---|---|
+| `packages/core/src/session/SessionClient.ts` (crear) | La clase `SessionClient` + `TokenTransport`/`SessionClientOptions` interfaces. Estado + REST + socket + subscribe. |
+| `packages/core/src/session/socketLoader.ts` (crear) | `getSocketIO()` lazy loader + tipos `MinimalSocket`/`SocketIOFactory` (portados de auth-sdk, framework-agnósticos). |
+| `packages/core/src/session/__tests__/SessionClient.state.test.ts` (crear) | Estado: applyState + revision-gate + subscribe. |
+| `packages/core/src/session/__tests__/SessionClient.rest.test.ts` (crear) | REST: bootstrap/switchAccount/signOut/addCurrentAccount (makeRequest spy) + validación. |
+| `packages/core/src/session/__tests__/SessionClient.socket.test.ts` (crear) | Socket: connect + session_state apply + token-change reconnect + stop. |
+| `packages/core/src/index.ts` (modificar) | Exportar `SessionClient`, `TokenTransport`, tipos. |
+
+---
+
+### Task 1: `socketLoader.ts` (lazy `socket.io-client`) + `SessionClient` estado/subscribe
+
+**Files:**
+- Create: `packages/core/src/session/socketLoader.ts`
+- Create: `packages/core/src/session/SessionClient.ts`
+- Test: `packages/core/src/session/__tests__/SessionClient.state.test.ts`
+
+**Interfaces:**
+- Produces `socketLoader.ts`:
+  - `interface MinimalSocket { connected: boolean; on(event: string, handler: (...args: unknown[]) => void): void; off(event: string, handler?: (...args: unknown[]) => void): void; connect(): void; disconnect(): void; }`
+  - `type SocketIOFactory = (uri: string, opts?: Record<string, unknown>) => MinimalSocket;`
+  - `function getSocketIO(): Promise<SocketIOFactory | null>` — lazy dynamic import singleton.
+- Produces `SessionClient.ts`:
+  - `interface TokenTransport { ensureActiveToken(state: DeviceSessionState): Promise<void>; }`
+  - `interface SessionClientHost { makeRequest<T>(method: 'GET' | 'POST', url: string, data?: unknown, options?: { cache?: boolean }): Promise<T>; getBaseURL(): string; getAccessToken(): string | null; onTokensChanged(listener: (token: string | null) => void): () => void; }`
+  - `interface SessionClientOptions { transport?: TokenTransport; }`
+  - `class SessionClient` with (this task): `constructor(host: SessionClientHost, options?: SessionClientOptions)`, `getState(): DeviceSessionState | null`, `subscribe(listener: (state: DeviceSessionState | null) => void): () => void`, and a `protected applyState(raw: unknown): boolean` (validates via `safeParseContract`, applies only if `revision` strictly greater than current, notifies subscribers, fires `transport.ensureActiveToken` best-effort; returns whether applied).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/session/__tests__/SessionClient.state.test.ts
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { SessionClient, type SessionClientHost, type TokenTransport } from '../SessionClient';
+
+function makeHost(): SessionClientHost {
+  return {
+    makeRequest: jest.fn(),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 't',
+    onTokensChanged: () => () => undefined,
+  };
+}
+const STATE = (rev: number, active: string | null = 'a1'): DeviceSessionState => ({
+  deviceId: 'd1', accounts: active ? [{ accountId: 'a1', sessionId: 's1', authuser: 0 }] : [], activeAccountId: active, revision: rev, updatedAt: 1720000000000,
+});
+
+// SessionClient.applyState is protected; a tiny subclass exposes it for the unit test.
+class TestClient extends SessionClient { public apply(raw: unknown): boolean { return this.applyState(raw); } }
+
+describe('SessionClient state', () => {
+  it('starts with null state', () => {
+    expect(new SessionClient(makeHost()).getState()).toBeNull();
+  });
+
+  it('applies a valid state and notifies subscribers', () => {
+    const c = new TestClient(makeHost());
+    const seen: (DeviceSessionState | null)[] = [];
+    c.subscribe((s) => seen.push(s));
+    expect(c.apply(STATE(1))).toBe(true);
+    expect(c.getState()?.revision).toBe(1);
+    expect(seen.at(-1)?.revision).toBe(1);
+  });
+
+  it('ignores a stale or equal revision (last-writer-wins)', () => {
+    const c = new TestClient(makeHost());
+    c.apply(STATE(5));
+    expect(c.apply(STATE(5))).toBe(false);
+    expect(c.apply(STATE(4))).toBe(false);
+    expect(c.getState()?.revision).toBe(5);
+  });
+
+  it('rejects an invalid (unvalidated) state without applying', () => {
+    const c = new TestClient(makeHost());
+    expect(c.apply({ deviceId: 'd1', accounts: 'nope', revision: 1 })).toBe(false);
+    expect(c.getState()).toBeNull();
+  });
+
+  it('calls transport.ensureActiveToken when a state is applied', () => {
+    const transport: TokenTransport = { ensureActiveToken: jest.fn().mockResolvedValue(undefined) };
+    const c = new TestClient(makeHost(), { transport });
+    c.apply(STATE(1));
+    expect(transport.ensureActiveToken).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const c = new TestClient(makeHost());
+    const seen: unknown[] = [];
+    const off = c.subscribe((s) => seen.push(s));
+    off();
+    c.apply(STATE(1));
+    expect(seen).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run → fails**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx jest src/session/__tests__/SessionClient.state.test.ts`
+Expected: FAIL — `Cannot find module '../SessionClient'`.
+
+- [ ] **Step 3: Implement `socketLoader.ts`**
+
+```ts
+// packages/core/src/session/socketLoader.ts
+import { logger } from '../utils/logger';
+
+export interface MinimalSocket {
+  connected: boolean;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  off(event: string, handler?: (...args: unknown[]) => void): void;
+  connect(): void;
+  disconnect(): void;
+}
+
+export type SocketIOFactory = (uri: string, opts?: Record<string, unknown>) => MinimalSocket;
+
+let cachedFactory: SocketIOFactory | null = null;
+let loadAttempted = false;
+
+export async function getSocketIO(): Promise<SocketIOFactory | null> {
+  if (cachedFactory) return cachedFactory;
+  if (loadAttempted) return null;
+  loadAttempted = true;
+  try {
+    const mod = (await import('socket.io-client')) as { io?: SocketIOFactory; default?: SocketIOFactory };
+    cachedFactory = mod.io ?? mod.default ?? null;
+    return cachedFactory;
+  } catch (error) {
+    logger.warn('[SessionClient] socket.io-client import failed; realtime session sync disabled', error);
+    return null;
+  }
+}
+```
+
+> Verify the logger import path: core's shared logger is at `packages/core/src/utils/logger.ts` exporting `{ logger }` (used across core). Confirm and match; if it's a default export, adjust.
+
+- [ ] **Step 4: Implement `SessionClient.ts` (state half)**
+
+```ts
+// packages/core/src/session/SessionClient.ts
+import { deviceSessionStateSchema, safeParseContract, type DeviceSessionState } from '@oxyhq/contracts';
+import { logger } from '../utils/logger';
+import type { MinimalSocket } from './socketLoader';
+
+export interface TokenTransport {
+  /** Ensure this app holds a per-domain access token for state.activeAccountId (mint via FedCM/silent/sso/keychain). Best-effort. */
+  ensureActiveToken(state: DeviceSessionState): Promise<void>;
+}
+
+export interface SessionClientHost {
+  makeRequest<T>(method: 'GET' | 'POST', url: string, data?: unknown, options?: { cache?: boolean }): Promise<T>;
+  getBaseURL(): string;
+  getAccessToken(): string | null;
+  onTokensChanged(listener: (token: string | null) => void): () => void;
+}
+
+export interface SessionClientOptions {
+  transport?: TokenTransport;
+}
+
+type StateListener = (state: DeviceSessionState | null) => void;
+
+export class SessionClient {
+  private state: DeviceSessionState | null = null;
+  private readonly listeners = new Set<StateListener>();
+  protected socket: MinimalSocket | null = null;
+  private tokenUnsub: (() => void) | null = null;
+  private started = false;
+
+  constructor(
+    protected readonly host: SessionClientHost,
+    protected readonly options: SessionClientOptions = {},
+  ) {}
+
+  getState(): DeviceSessionState | null {
+    return this.state;
+  }
+
+  subscribe(listener: StateListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  protected notify(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(this.state);
+      } catch (error) {
+        logger.error('[SessionClient] subscriber threw', error);
+      }
+    }
+  }
+
+  /** Validate + last-writer-wins by revision. Returns true if applied. */
+  protected applyState(raw: unknown): boolean {
+    const next = safeParseContract(deviceSessionStateSchema, raw);
+    if (!next) {
+      logger.warn('[SessionClient] discarded invalid session state');
+      return false;
+    }
+    if (this.state && next.revision <= this.state.revision) {
+      return false;
+    }
+    this.state = next;
+    this.notify();
+    if (this.options.transport) {
+      void this.options.transport.ensureActiveToken(next).catch((error) => {
+        logger.warn('[SessionClient] ensureActiveToken failed', error);
+      });
+    }
+    return true;
+  }
+}
+```
+
+- [ ] **Step 5: Run → passes**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx jest src/session/__tests__/SessionClient.state.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/session/socketLoader.ts packages/core/src/session/SessionClient.ts packages/core/src/session/__tests__/SessionClient.state.test.ts
+git commit -m "feat(core): SessionClient state core + socket.io lazy loader"
+```
+
+---
+
+### Task 2: REST bootstrap + mutations
+
+**Files:**
+- Modify: `packages/core/src/session/SessionClient.ts`
+- Test: `packages/core/src/session/__tests__/SessionClient.rest.test.ts`
+
+**Interfaces:**
+- Consumes: `SessionClient` (Task 1), `host.makeRequest`.
+- Produces (added to `SessionClient`): `bootstrap(): Promise<void>` (`GET /session/device/state`), `switchAccount(accountId: string): Promise<void>` (`POST /session/device/switch`), `signOut(target: { accountId: string } | { all: true }): Promise<void>` (`POST /session/device/signout`), `addCurrentAccount(): Promise<void>` (`POST /session/device/add`). Each pipes the response through `applyState`. All calls use `{ cache: false }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/session/__tests__/SessionClient.rest.test.ts
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+
+const STATE = (rev: number): DeviceSessionState => ({
+  deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000,
+});
+
+function makeHost(makeRequest: jest.Mock): SessionClientHost {
+  return { makeRequest, getBaseURL: () => 'http://test.invalid', getAccessToken: () => 't', onTokensChanged: () => () => undefined };
+}
+
+describe('SessionClient REST', () => {
+  it('bootstrap GETs /session/device/state and applies it', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(3));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.bootstrap();
+    expect(makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    expect(c.getState()?.revision).toBe(3);
+  });
+
+  it('switchAccount POSTs and applies the returned state', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(4));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.switchAccount('a1');
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/switch', { accountId: 'a1' }, { cache: false });
+    expect(c.getState()?.revision).toBe(4);
+  });
+
+  it('signOut one account POSTs { accountId }', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(5));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.signOut({ accountId: 'a1' });
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { accountId: 'a1' }, { cache: false });
+  });
+
+  it('signOut all POSTs { all: true }', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(6));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.signOut({ all: true });
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { all: true }, { cache: false });
+  });
+
+  it('addCurrentAccount POSTs /session/device/add with no body', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(2));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.addCurrentAccount();
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/add', undefined, { cache: false });
+  });
+
+  it('does not throw / does not apply when the server returns invalid state', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce({ bogus: true });
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.bootstrap();
+    expect(c.getState()).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run → fails**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx jest src/session/__tests__/SessionClient.rest.test.ts`
+Expected: FAIL — `c.bootstrap is not a function`.
+
+- [ ] **Step 3: Add the REST methods to `SessionClient`**
+
+Add inside the `SessionClient` class:
+
+```ts
+  async bootstrap(): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('GET', '/session/device/state', undefined, { cache: false });
+    this.applyState(raw);
+  }
+
+  async switchAccount(accountId: string): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/switch', { accountId }, { cache: false });
+    this.applyState(raw);
+  }
+
+  async signOut(target: { accountId: string } | { all: true }): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
+    this.applyState(raw);
+  }
+
+  async addCurrentAccount(): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
+    this.applyState(raw);
+  }
+```
+
+- [ ] **Step 4: Run → passes**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx jest src/session/__tests__/SessionClient.rest.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/session/SessionClient.ts packages/core/src/session/__tests__/SessionClient.rest.test.ts
+git commit -m "feat(core): SessionClient REST bootstrap + switch/signout/add mutations"
+```
+
+---
+
+### Task 3: Socket lifecycle (connect, session_state, reconnect, stop)
+
+**Files:**
+- Modify: `packages/core/src/session/SessionClient.ts`
+- Test: `packages/core/src/session/__tests__/SessionClient.socket.test.ts`
+
+**Interfaces:**
+- Consumes: `getSocketIO` (Task 1), `host.getBaseURL/getAccessToken/onTokensChanged`, `applyState` (Task 1).
+- Produces (added to `SessionClient`): `start(): Promise<void>` (bootstrap + connectSocket + subscribe to token changes), `stop(): void` (disconnect socket + unsubscribe token listener), private `connectSocket(): Promise<void>`. The socket connects to `host.getBaseURL()` with `{ transports: ['websocket'], autoConnect: !!token, auth: cb => cb({ token: host.getAccessToken() ?? '' }) }`, listens `session_state` → `applyState`, and reconnects when a token arrives after being disconnected.
+- The socket factory is obtained via `getSocketIO()`; if null (import failed), the client works REST-only (no throw).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/core/src/session/__tests__/SessionClient.socket.test.ts
+import type { DeviceSessionState } from '@oxyhq/contracts';
+
+type Handler = (...args: unknown[]) => void;
+class FakeSocket {
+  connected = false;
+  handlers = new Map<string, Handler[]>();
+  on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
+  off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+  connect() { this.connected = true; this.trigger('connect'); }
+  disconnect() { this.connected = false; }
+  trigger(event: string, ...args: unknown[]) { for (const h of this.handlers.get(event) ?? []) h(...args); }
+}
+let fakeSocket: FakeSocket;
+const ioMock = jest.fn((_uri: string, opts?: Record<string, unknown>) => {
+  // honor autoConnect like real socket.io (connect immediately unless autoConnect:false)
+  if (!opts || opts.autoConnect !== false) fakeSocket.connected = true;
+  return fakeSocket;
+});
+jest.mock('socket.io-client', () => ({ __esModule: true, io: (...args: unknown[]) => ioMock(...(args as [string, Record<string, unknown>?])) }));
+
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+
+const STATE = (rev: number): DeviceSessionState => ({ deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000 });
+
+function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
+  return {
+    makeRequest: jest.fn().mockResolvedValue(STATE(1)),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 'tok',
+    onTokensChanged: () => () => undefined,
+    ...over,
+  };
+}
+
+beforeEach(() => { fakeSocket = new FakeSocket(); ioMock.mockClear(); });
+
+describe('SessionClient socket', () => {
+  it('start() bootstraps then opens ONE socket to the base URL with a token-in-handshake auth callback', async () => {
+    const host = makeHost();
+    const c = new SessionClient(host);
+    await c.start();
+    expect(host.makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    expect(ioMock).toHaveBeenCalledTimes(1);
+    const [uri, opts] = ioMock.mock.calls[0];
+    expect(uri).toBe('http://test.invalid');
+    const authCb = jest.fn();
+    (opts?.auth as (cb: (d: { token: string }) => void) => void)(authCb);
+    expect(authCb).toHaveBeenCalledWith({ token: 'tok' });
+    c.stop();
+  });
+
+  it('applies a pushed session_state event', async () => {
+    const c = new SessionClient(makeHost());
+    await c.start();
+    fakeSocket.trigger('session_state', STATE(9));
+    expect(c.getState()?.revision).toBe(9);
+    c.stop();
+  });
+
+  it('does not connect the socket when there is no token (autoConnect false)', async () => {
+    const c = new SessionClient(makeHost({ getAccessToken: () => null }));
+    await c.start();
+    const [, opts] = ioMock.mock.calls[0];
+    expect(opts?.autoConnect).toBe(false);
+    c.stop();
+  });
+
+  it('reconnects when a token arrives after being disconnected', async () => {
+    let tokenListener: ((t: string | null) => void) | null = null;
+    const host = makeHost({ getAccessToken: () => null, onTokensChanged: (l) => { tokenListener = l; return () => undefined; } });
+    const c = new SessionClient(host);
+    await c.start();
+    fakeSocket.connected = false;
+    tokenListener?.('fresh-token');
+    expect(fakeSocket.connected).toBe(true);
+    c.stop();
+  });
+
+  it('stop() disconnects the socket', async () => {
+    const c = new SessionClient(makeHost());
+    await c.start();
+    c.stop();
+    expect(fakeSocket.connected).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run → fails**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx jest src/session/__tests__/SessionClient.socket.test.ts`
+Expected: FAIL — `c.start is not a function`.
+
+- [ ] **Step 3: Add `start`/`stop`/`connectSocket` to `SessionClient`**
+
+Add the import at the top: `import { getSocketIO } from './socketLoader';` and add these methods to the class:
+
+```ts
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    this.tokenUnsub = this.host.onTokensChanged((token) => {
+      if (token && this.socket && !this.socket.connected) {
+        this.socket.connect();
+      }
+    });
+    await this.bootstrap();
+    await this.connectSocket();
+  }
+
+  stop(): void {
+    this.started = false;
+    if (this.tokenUnsub) {
+      this.tokenUnsub();
+      this.tokenUnsub = null;
+    }
+    if (this.socket) {
+      this.socket.disconnect();
+      this.socket = null;
+    }
+  }
+
+  private async connectSocket(): Promise<void> {
+    const io = await getSocketIO();
+    if (!io) {
+      logger.warn('[SessionClient] no socket.io-client; running REST-only (no realtime sync)');
+      return;
+    }
+    if (!this.started) return; // stopped while the dynamic import was in flight
+    const hasToken = Boolean(this.host.getAccessToken());
+    const socket = io(this.host.getBaseURL(), {
+      transports: ['websocket'],
+      autoConnect: hasToken,
+      auth: (cb: (data: { token: string }) => void) => {
+        cb({ token: this.host.getAccessToken() ?? '' });
+      },
+    });
+    socket.on('session_state', (payload: unknown) => {
+      this.applyState(payload);
+    });
+    this.socket = socket;
+  }
+```
+
+> Note: `applyState` is already defined (Task 1). `logger` already imported (Task 1). `MinimalSocket`/`getSocketIO` come from `./socketLoader`.
+
+- [ ] **Step 4: Run → passes**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx jest src/session/__tests__/SessionClient.socket.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/session/SessionClient.ts packages/core/src/session/__tests__/SessionClient.socket.test.ts
+git commit -m "feat(core): SessionClient socket lifecycle — connect, session_state, reconnect, stop"
+```
+
+---
+
+### Task 4: Export from `@oxyhq/core` + full-suite green
+
+**Files:**
+- Modify: `packages/core/src/index.ts`
+
+**Interfaces:**
+- Produces: public exports `SessionClient`, `TokenTransport`, `SessionClientHost`, `SessionClientOptions` from the package root.
+
+- [ ] **Step 1: Add exports to `index.ts`**
+
+Read `packages/core/src/index.ts`, and in the appropriate value/type export area add:
+
+```ts
+export { SessionClient } from './session/SessionClient';
+export type { TokenTransport, SessionClientHost, SessionClientOptions } from './session/SessionClient';
+```
+
+(Match the file's existing export style — if it uses grouped `export { ... } from './...'` blocks, add there; keep value vs `export type` consistent.)
+
+- [ ] **Step 2: Type-check + build core**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx tsc --noEmit 2>&1 | grep -E 'session/SessionClient|session/socketLoader' || echo "no tsc errors in new files"`
+Expected: "no tsc errors in new files".
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bun run build`
+Expected: dual build succeeds (cjs+esm+types), no `require()` emitted in ESM for socket.io (it's a dynamic import). Spot-check: `grep -c "require(" dist/esm/session/socketLoader.js` → should be 0 (dynamic import stays `import(...)`).
+
+- [ ] **Step 3: Full core suite green**
+
+Run: `cd /home/nate/Oxy/OxyHQServices-p1/packages/core && bunx jest --silent 2>&1 | tail -4`
+Expected: baseline 724 + 17 new = **741 tests**, all suites green (the benign "worker failed to exit" note may appear — not a failure).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/index.ts
+git commit -m "feat(core): export SessionClient + TokenTransport from @oxyhq/core"
+```
+
+---
+
+## Verificación (Fase 2)
+
+Unit-testeable en su totalidad (fetch-stub + fake socket). No hay integración con app todavía (eso es Fase 3/4, donde se inyecta el `TokenTransport` web/native concreto y se monta en `OxyContext`/`WebOxyProvider`). La verificación real cross-domain en navegador llega cuando la Fase 3/4 cablea el cliente.
+
+## Fuera de alcance (Fase 3+)
+- Impls concretas de `TokenTransport` (web: FedCM/silent/sso; native: keychain) — Fase 3/4.
+- Montaje en `OxyContext` (services) y `WebOxyProvider` (auth-sdk); borrado del cold-boot enredado / `AuthManager` / `useSessionSocket` per-dominio.
+- Borrado de `/auth/refresh*`, `/auth/session`, `oxy_rt` — Fase 5/6 (cuando ya nadie los use).

--- a/docs/superpowers/plans/2026-07-01-session-sync-phase3-active-token.md
+++ b/docs/superpowers/plans/2026-07-01-session-sync-phase3-active-token.md
@@ -1,0 +1,224 @@
+# Sesión centralizada — Fase 3: Propagación del token de la cuenta activa — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Resolver cómo cada app obtiene el token per-dominio de la **cuenta activa** (incluida una subcuenta) sin cookies `oxy_rt`: el servidor mintea y devuelve el access token de la cuenta activa en la respuesta REST de `/session/device/{state,switch,add}` (desde la sesión que ya está en el dispositivo). El `SessionClient` planta ese token. El socket sigue sin llevar tokens (empuja estado; la app hace `GET /state` para obtener el token de la nueva activa).
+
+**Architecture:** Extiende Fase 1 (server) + Fase 2 (core), aditivo, sin tocar comportamiento vivo de apps (las rutas siguen sin consumirse por clientes). Modelo de confianza: cualquier token válido del dispositivo D puede obtener el token de una cuenta que YA está en D (mismo que las cookies `oxy_rt` retiradas). El socket NUNCA lleva tokens.
+
+**Tech Stack:** TS, Express, Mongoose (mockeado en tests), Zod contracts, Jest.
+
+## Global Constraints
+- **bun** (`bunx jest`); nunca `bun test` en api/core. Sin `as any`/`@ts-ignore`/`!`/`console.log`/`catch{}` vacío/`var`. Tipos explícitos.
+- Corte limpio, aditivo en esta fase (no borra `/auth/*`).
+- Contratos nuevos en `@oxyhq/contracts` (Zod). El token de la respuesta se valida en cliente con `safeParseContract`.
+- El **socket `session_state` NO lleva token** — solo estado. El token solo viaja en respuestas REST al llamante autenticado del MISMO dispositivo.
+- api baseline 1264 tests, core 741 — no bajar.
+
+## Estructura de ficheros
+| Fichero | Responsabilidad |
+|---|---|
+| `packages/contracts/src/deviceSession.ts` (modificar) | `activeTokenSchema` + `deviceSessionSyncSchema` ({state, activeToken}) + tipos. |
+| `packages/contracts/src/index.ts` (modificar) | Exportar los nuevos. |
+| `packages/contracts/src/__tests__/deviceSession.test.ts` (modificar) | Tests del sync schema. |
+| `packages/api/src/services/deviceSession.service.ts` (modificar) | `resolveActiveToken(state)` → mintea el token de la cuenta activa vía `sessionService.getAccessToken(activeSessionId)`. |
+| `packages/api/src/routes/sessionDevice.ts` (modificar) | Respuestas `{ data: { state, activeToken } }` en state/switch/add (signout puede omitir token si no hay activa). |
+| `packages/api/src/routes/__tests__/sessionDevice.test.ts` (modificar) | Actualizar aserciones al nuevo envelope. |
+| `packages/core/src/session/SessionClient.ts` (modificar) | REST parsea `{state, activeToken}` + `host.setTokens(activeToken.accessToken)`; socket-push que cambia la activa → `GET /state` para obtener+plantar token. |
+| `packages/core/src/session/__tests__/SessionClient.rest.test.ts` (modificar) | Aserción del planting del token. |
+
+---
+
+### Task 1: Contrato `deviceSessionSyncSchema` ({ state, activeToken })
+
+**Files:** Modify `packages/contracts/src/deviceSession.ts`, `packages/contracts/src/index.ts`, `packages/contracts/src/__tests__/deviceSession.test.ts`.
+
+**Interfaces:** Produces `activeTokenSchema` (`{ accessToken: string; expiresAt: string }`), `deviceSessionSyncSchema` (`{ state: DeviceSessionState; activeToken: ActiveToken | null }`), types `ActiveToken`, `DeviceSessionSync`.
+
+- [ ] **Step 1: Add tests to `deviceSession.test.ts`** (append inside the file, after existing tests, importing the new symbols at top):
+
+```ts
+// add imports at top of packages/contracts/src/__tests__/deviceSession.test.ts:
+import { deviceSessionSyncSchema } from '../index';
+
+describe('deviceSessionSyncSchema', () => {
+  const state = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
+  it('parses { state, activeToken }', () => {
+    const v = { state, activeToken: { accessToken: 'jwt', expiresAt: '2026-07-07T00:00:00.000Z' } };
+    expect(safeParseContract(deviceSessionSyncSchema, v)).toEqual(v);
+  });
+  it('accepts activeToken=null', () => {
+    expect(safeParseContract(deviceSessionSyncSchema, { state, activeToken: null })?.activeToken).toBeNull();
+  });
+  it('rejects a state-less sync', () => {
+    expect(safeParseContract(deviceSessionSyncSchema, { activeToken: null })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run → fails** — `cd packages/contracts && bunx jest src/__tests__/deviceSession.test.ts` → FAIL (`deviceSessionSyncSchema` undefined).
+
+- [ ] **Step 3: Add to `deviceSession.ts`** (after `deviceSessionStateSchema`):
+
+```ts
+export const activeTokenSchema = z.object({
+  accessToken: z.string(),
+  expiresAt: z.string(),
+});
+
+export const deviceSessionSyncSchema = z.object({
+  state: deviceSessionStateSchema,
+  activeToken: activeTokenSchema.nullable(),
+});
+
+export type ActiveToken = z.infer<typeof activeTokenSchema>;
+export type DeviceSessionSync = z.infer<typeof deviceSessionSyncSchema>;
+```
+
+- [ ] **Step 4: Export in `index.ts`** — add `activeTokenSchema, deviceSessionSyncSchema` to the value-export block for `./deviceSession` and `ActiveToken, DeviceSessionSync` to the `export type` block.
+
+- [ ] **Step 5: Run → passes** — `cd packages/contracts && bunx jest src/__tests__/deviceSession.test.ts` (9 tests) and `bun run build` (must succeed — the api/core resolve contracts from dist).
+
+- [ ] **Step 6: Commit**
+```bash
+git add packages/contracts/src/deviceSession.ts packages/contracts/src/index.ts packages/contracts/src/__tests__/deviceSession.test.ts
+git commit -m "feat(contracts): deviceSessionSync schema (state + active account token)"
+```
+
+---
+
+### Task 2: Server mints + returns the active account token
+
+**Files:** Modify `packages/api/src/services/deviceSession.service.ts`, `packages/api/src/routes/sessionDevice.ts`, `packages/api/src/routes/__tests__/sessionDevice.test.ts`.
+
+**Interfaces:**
+- Consumes: `sessionService.getAccessToken(sessionId): Promise<{ accessToken: string; expiresAt: Date } | null>` (existing), the device `SessionState`.
+- Produces on `deviceSessionService`: `async resolveActiveToken(state: DeviceSessionState): Promise<{ accessToken: string; expiresAt: string } | null>` — finds `state.activeAccountId`'s account in `state.accounts`, calls `sessionService.getAccessToken(account.sessionId)`, returns `{ accessToken, expiresAt: expiresAt.toISOString() }` or null (no active / no session / mint failed).
+- Routes now respond `{ data: { state, activeToken } }` for `/state`, `/switch`, `/add`; `/signout` responds `{ data: { state, activeToken } }` too (activeToken null when no active remains).
+
+- [ ] **Step 1: Update the route test** `packages/api/src/routes/__tests__/sessionDevice.test.ts`:
+  - Add a mock for `sessionService.getAccessToken`: at top with the other mocks add `const mockGetAccessToken = jest.fn();` and mock `../../services/session.service` → `{ __esModule: true, default: { getAccessToken: (...a: unknown[]) => mockGetAccessToken(...a) } }`.
+  - In `beforeEach`, `mockGetAccessToken.mockResolvedValue({ accessToken: 'jwt-active', expiresAt: new Date('2026-07-07T00:00:00.000Z') })`.
+  - Change the `GET /state` assertion from `expect(res.body.data).toEqual(STATE)` to:
+    ```ts
+    expect(res.body.data.state).toEqual(STATE);
+    expect(res.body.data.activeToken).toEqual({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' });
+    ```
+  - In the `switch` success test, keep `mockSwitchActive` returning STATE and additionally assert `res.body.data.state` + `res.body.data.activeToken.accessToken === 'jwt-active'`.
+
+  > NOTE: the service is mocked in this route test (deviceSessionService methods are jest.fn), so `resolveActiveToken` is ALSO a mocked method here — add it to the `../../services/deviceSession.service` mock: `resolveActiveToken: (...a) => mockResolveActiveToken(...a)` with `const mockResolveActiveToken = jest.fn().mockResolvedValue({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' })` in beforeEach. (The route calls `deviceSessionService.resolveActiveToken(state)`, not sessionService directly — so mock resolveActiveToken, not getAccessToken, in the ROUTE test. The getAccessToken mock belongs in the SERVICE test, Step 3.)
+
+- [ ] **Step 2: Update the routes** in `packages/api/src/routes/sessionDevice.ts` — after each mutation/read that produces `state`, compute the token and wrap:
+```ts
+// helper at top of the file
+async function withActiveToken(state: DeviceSessionState) {
+  const activeToken = await deviceSessionService.resolveActiveToken(state);
+  return { state, activeToken };
+}
+```
+  - `/state`: `res.json({ data: await withActiveToken(await deviceSessionService.getState(deviceId)) });`
+  - `/add`, `/switch`, `/signout`: after computing `state` and `broadcastDeviceState(state)`, respond `res.json({ data: await withActiveToken(state) });`. (Broadcast stays state-only; the token only goes in the REST response.)
+  - Import the `DeviceSessionState` type from `@oxyhq/contracts`.
+
+- [ ] **Step 3: Add `resolveActiveToken` to the SERVICE** `packages/api/src/services/deviceSession.service.ts` + a service test.
+
+Add to the service class:
+```ts
+async resolveActiveToken(state: DeviceSessionState): Promise<{ accessToken: string; expiresAt: string } | null> {
+  if (!state.activeAccountId) return null;
+  const account = state.accounts.find((a) => a.accountId === state.activeAccountId);
+  if (!account) return null;
+  const token = await sessionService.getAccessToken(account.sessionId);
+  if (!token) return null;
+  return { accessToken: token.accessToken, expiresAt: token.expiresAt.toISOString() };
+}
+```
+Add to `packages/api/src/services/__tests__/deviceSession.service.test.ts` (the file already mocks `../session.service`; extend that mock with `getAccessToken: (...a: unknown[]) => mockGetAccessToken(...a)` and add `const mockGetAccessToken = jest.fn();`):
+```ts
+describe('resolveActiveToken', () => {
+  const STATE = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
+  it('mints the active account token', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'jwt', expiresAt: new Date('2026-07-07T00:00:00.000Z') });
+    expect(await deviceSessionService.resolveActiveToken(STATE as never)).toEqual({ accessToken: 'jwt', expiresAt: '2026-07-07T00:00:00.000Z' });
+    expect(mockGetAccessToken).toHaveBeenCalledWith('s1');
+  });
+  it('returns null when there is no active account', async () => {
+    expect(await deviceSessionService.resolveActiveToken({ ...STATE, activeAccountId: null } as never)).toBeNull();
+  });
+  it('returns null when the session cannot mint a token', async () => {
+    mockGetAccessToken.mockResolvedValueOnce(null);
+    expect(await deviceSessionService.resolveActiveToken(STATE as never)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 4: Verify** — `cd packages/api && bunx jest src/routes/__tests__/sessionDevice.test.ts src/services/__tests__/deviceSession.service.test.ts` → PASS. Then full suite `bun run test` → green (1264 + new).
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/api/src/services/deviceSession.service.ts packages/api/src/routes/sessionDevice.ts packages/api/src/routes/__tests__/sessionDevice.test.ts packages/api/src/services/__tests__/deviceSession.service.test.ts
+git commit -m "feat(api): device routes return active-account token (state-only broadcast unchanged)"
+```
+
+---
+
+### Task 3: `SessionClient` plants the active token + fetches on socket push
+
+**Files:** Modify `packages/core/src/session/SessionClient.ts`, `packages/core/src/session/__tests__/SessionClient.rest.test.ts`, `packages/core/src/session/__tests__/SessionClient.socket.test.ts`.
+
+**Interfaces:**
+- Consumes: `deviceSessionSyncSchema`/`safeParseContract`, `host.setTokens` — ADD `setTokens(accessToken: string): void` to `SessionClientHost`.
+- REST methods now expect `{ state, activeToken }`: add `private applySync(raw: unknown): void` that `safeParseContract(deviceSessionSyncSchema, raw)`, applies `state` (via existing `applyState`) and if `activeToken` present calls `host.setTokens(activeToken.accessToken)`. `bootstrap`/`switchAccount`/`signOut`/`addCurrentAccount` call `applySync` instead of `applyState`.
+- Socket `session_state` (state only): on receipt, `applyState(payload)`; if it applied AND `state.activeAccountId` differs from the token the app currently holds, call `bootstrap()` (GET /state) to fetch+plant the new active token. (Guard against loops: bootstrap only when active changed.)
+
+- [ ] **Step 1: Update `SessionClientHost`** — add `setTokens(accessToken: string): void;`. Update the two test host factories (`makeHost`) to include `setTokens: jest.fn()`.
+
+- [ ] **Step 2: REST test** `SessionClient.rest.test.ts` — change the mocked `makeRequest` responses from bare `STATE(n)` to `{ state: STATE(n), activeToken: { accessToken: 'jwt-'+n, expiresAt: 'x' } }`, and in `bootstrap`/`switch` tests assert `host.setTokens` was called with the token, and `c.getState()?.revision` still tracks `state.revision`. Add a test: `activeToken: null` → `setTokens` NOT called, state still applied.
+
+- [ ] **Step 3: Implement `applySync`** and reroute the REST methods:
+```ts
+import { deviceSessionSyncSchema, deviceSessionStateSchema, safeParseContract, type DeviceSessionState } from '@oxyhq/contracts';
+
+  private applySync(raw: unknown): void {
+    const sync = safeParseContract(deviceSessionSyncSchema, raw);
+    if (!sync) { logger.warn('[SessionClient] discarded invalid session sync'); return; }
+    const applied = this.applyState(sync.state);
+    if (applied && sync.activeToken) {
+      this.host.setTokens(sync.activeToken.accessToken);
+    }
+  }
+```
+Change each REST method's last line from `this.applyState(raw)` to `this.applySync(raw)`.
+
+- [ ] **Step 4: Socket → fetch active token on active-account change.** In `connectSocket`, change the `session_state` handler:
+```ts
+socket.on('session_state', (payload: unknown) => {
+  const applied = this.applyState(payload);
+  if (applied) {
+    const active = this.state?.activeAccountId ?? null;
+    if (active && active !== this.host.getCurrentAccountId()) {
+      void this.bootstrap().catch((error) => logger.warn('[SessionClient] post-push token fetch failed', { component: 'SessionClient' }, error));
+    }
+  }
+});
+```
+Add `getCurrentAccountId(): string | null;` to `SessionClientHost` (maps to `oxy.getCurrentUserId()`); update host factories in tests with `getCurrentAccountId: () => null` (default) or a controllable value.
+
+  > Loop-safety: `bootstrap()` GETs `/state` which returns `{state (same revision), activeToken}`; `applyState` ignores the same revision (no re-apply, no re-notify), and `applySync` plants the token — but bootstrap here calls `applySync`, which plants the token and applies-or-ignores state; since revision is equal it won't re-trigger. No loop.
+
+- [ ] **Step 5: Socket test** — add a case: after `fakeSocket.trigger('session_state', STATE(9))` where host.getCurrentAccountId() !== state.activeAccountId, assert `host.makeRequest` was called with `('GET','/session/device/state', ...)` (the token fetch). And a case where active === current → no extra fetch.
+
+- [ ] **Step 6: Verify** — `cd packages/core && bunx jest src/session` → all green; `bunx tsc --noEmit 2>&1 | grep session || echo ok`; `bun run build`.
+
+- [ ] **Step 7: Commit**
+```bash
+git add packages/core/src/session/SessionClient.ts packages/core/src/session/__tests__/SessionClient.rest.test.ts packages/core/src/session/__tests__/SessionClient.socket.test.ts
+git commit -m "feat(core): SessionClient plants active-account token + fetches it on socket push"
+```
+
+---
+
+## Fuera de alcance (fases siguientes, browser-gated)
+- `WebTokenTransport`/`NativeTokenTransport` para el **bootstrap** del primer token (FedCM-silent / keychain) — el token de subcuentas ya lo da el server (esta fase). El transport solo cubre el arranque en frío sin token.
+- Montaje en `OxyContext`/`WebOxyProvider`; borrado del cold-boot enredado; borrado de `oxy_rt`/`/auth/refresh*`.
+- Verificación real cross-domain en navegador.

--- a/docs/superpowers/specs/2026-07-01-cross-domain-session-sync-design.md
+++ b/docs/superpowers/specs/2026-07-01-cross-domain-session-sync-design.md
@@ -1,0 +1,303 @@
+# Sesión centralizada y sincronizada cross-domain (web + nativo)
+
+**Fecha:** 2026-07-01
+**Estado:** Diseño aprobado (pendiente de revisión del spec por el usuario → plan de implementación)
+**Autor:** Nate + Claude
+
+---
+
+## 1. Contexto y motivación
+
+Las apps del ecosistema Oxy corren en **dominios distintos** (`accounts.oxy.so`, `console.oxy.so`, `mention.earth`, `homiio.com`, `allo`, `alia.onl`, …) y en **dos plataformas** (Expo web + nativo). Hoy la sesión se apoya en un esquema **por-dominio de cookies `oxy_rt_<authuser>`** (host-only en cada `api.<apex>`) más una **cadena de cold-boot de 8 pasos** que "adivina" qué cuenta está activa. Ese modelo:
+
+- **No sincroniza** entre apps/dominios: cerrar sesión o cambiar de cuenta en una app no se refleja en las demás.
+- Es **frágil**: la plantación de la cookie `oxy_rt` cross-origin la **bloquea** el navegador cuando el usuario tiene "bloquear cookies de terceros" (comprobado con evidencia real en Chrome, 2026-07-01 — ver §14). Sin ese cimiento, **cambiar a una subcuenta no persiste al recargar** (el bug que originó este trabajo: al recargar vuelve a la cuenta primaria).
+- Está **mal estructurado**: lógica de sesión duplicada por app, `selectActiveRefreshAccount(... ?? accounts[0])` que enmascara fallos, `activeAuthuser` en `localStorage` tratado como autoridad, dos `authStore` paralelos, iframes de polling, etc.
+
+**Objetivo:** una **única sesión central del dispositivo**, compartida por todas las apps y dominios, que se **sincroniza al instante** (cerrar sesión, añadir cuenta, cambiar cuenta activa) en **web y nativo, como si fuera la misma app** — con código limpio, sin tricky things, sin back-compat ni migración, y con la lógica transversal viviendo en el SDK compartido.
+
+---
+
+## 2. Requisitos (de las clarificaciones)
+
+| # | Requisito | Decisión |
+|---|-----------|----------|
+| R1 | Modelo de sesión | **Conjunto de cuentas compartido** (añadir/quitar/cerrar se propaga a todas) **+ cuenta activa global** (cambiar la activa cambia en todas). |
+| R2 | Alcance de dominios | **Todos** los dominios Oxy (familia `oxy.so`, `mention.earth`, `homiio.com`, `allo`, `alia`, resto). |
+| R3 | Alcance de sincronización | **Mismo dispositivo** (varias apps/pestañas del mismo navegador; varias apps nativas del mismo móvil). No se requiere push cross-device en tiempo real. |
+| R4 | Latencia | **Instantáneo** en web y nativo por igual, "como si fuera la misma app". |
+| R5 | Perfil | El perfil (nombre, avatar, color) **no se snapshotea** en la sesión; se resuelve por el sistema central de usuarios (`POST /users/by-ids` + React Query) y se re-sincroniza cuando el usuario edita sus datos. |
+| R6 | Offline | **Offline-first (estilo Instagram)**: la app es usable sin red — sesión persistida localmente, datos cacheados visibles, escrituras encoladas; reconcilia al reconectar. Ver §6.1. |
+
+---
+
+## 3. Principios de diseño (rectores del spec)
+
+1. **Autoridad central única.** El estado de sesión del dispositivo lo posee el servidor (IdP `auth.oxy.so` + `api.oxy.so`). Los clientes son proyecciones de ese estado. Nada de "adivinar" la sesión desde cookies/slots locales.
+2. **Corte limpio.** Todo lo que la autoridad central reemplaza se **borra** — sin shims, sin `@deprecated`, sin back-compat, sin migración de datos. Ver §11 "Código a eliminar".
+3. **Máxima reutilización / SDK-first.** La lógica transversal (estado, socket, transporte de token) vive en `@oxyhq/core`/`@oxyhq/services`; las apps son finas. Se **reutilizan verbatim** las primitivas probadas (FedCM, `/auth/silent`, `/sso/establish`, keychain, `authSocket`, `requireSameSiteOrigin`, `users/by-ids`) — ver §8 y §11 "Reutilizar".
+4. **Tokens por-dominio, sin fugas.** El canal transporta **estado**, nunca tokens crudos. Cada app acuña su propio token de la cuenta activa con las primitivas first-party. Se preserva el hardening #251 (ningún refresh token cruza dominios; cookies host-only).
+5. **Contract-first.** Los contratos (`SessionState`, eventos del socket) viven en `@oxyhq/contracts` (Zod), validados con `safeParseContract` en cada respuesta/evento.
+6. **Testeable por piezas.** Responsabilidades separadas: estado / socket / transporte de token / UI, cada una aislable y testeable.
+
+---
+
+## 4. Arquitectura
+
+Cuatro piezas; cada app es un cliente fino del SDK.
+
+```
+   [Mention web]  [Homiio web]  [Accounts web]   [Mention nativo]  [Homiio nativo]
+        │              │              │                 │                 │
+        └──── WSS (token en handshake, room = device:<deviceId>) ─────────┘
+                                   │
+                        ┌──────────┴───────────┐
+                        │  Autoridad central    │  fuente de verdad: {deviceId, accounts[], activeAccountId, revision}
+                        │  auth.oxy.so + api    │  acuña tokens por-dominio (primitivas first-party)
+                        └───────────────────────┘
+```
+
+1. **Autoridad central** (`api.oxy.so` + IdP `auth.oxy.so`): posee y persiste el `SessionState` del dispositivo. Mutaciones vía REST (`/session/device/{state,switch,add,signout}`).
+2. **Canal en tiempo real por-dispositivo**: **una** conexión Socket.IO central por app (web y nativo), autenticada con **token en el handshake** (no cookies → inmune al bloqueo de 3PC), room `device:<deviceId>`. Cualquier mutación → el servidor emite `session_state` a todas las conexiones del mismo dispositivo → instantáneo.
+3. **Tokens por-dominio**: cada app acuña su token de la cuenta activa con las primitivas first-party existentes (web: FedCM / `/auth/silent` / `/sso/establish`; nativo: keychain compartido).
+4. **SDK unificado** (`@oxyhq/core` `SessionClient` + bindings web/nativo): estado + socket + flujos + restore. Web y nativo comparten el núcleo; solo difiere el `TokenTransport`.
+
+**Consecuencia:** el bug original desaparece — el conjunto de cuentas es **estado autoritativo del servidor**, no depende de la cookie `oxy_rt` frágil, que **se elimina por completo** (corte limpio, ver §11.4).
+
+---
+
+## 5. Modelo de datos
+
+### 5.1 Cliente (`@oxyhq/core`) — sin tokens, sin perfil
+
+```ts
+interface SessionAccount {
+  accountId: string;        // user _id — identidad estable
+  sessionId: string;        // sesión de ESTE dispositivo para esa cuenta
+  authuser: number;         // índice de orden estable del dispositivo (estilo Google `authuser=N`),
+                            // asignado por el servidor — NO ligado a cookies
+}
+interface SessionState {
+  deviceId: string;
+  accounts: SessionAccount[];      // solo referencias de identidad
+  activeAccountId: string | null;  // "cuenta activa global" del dispositivo
+  revision: number;                // contador monótono (orden/idempotencia)
+  updatedAt: number;
+}
+```
+
+El **perfil** de cada `accountId` se resuelve con el sistema central de usuarios (`getUsersByIds` → `POST /users/by-ids` + React Query). La capa de sesión **no cachea perfil**.
+
+### 5.2 Servidor (autoridad canónica)
+
+Se **reescribe** el modelo de sesión: hoy hay un `Session` por `(user, device)` que **almacena sus propios tokens**; pasa a haber **un `DeviceSession` por dispositivo físico** que agrega cuentas:
+
+```
+DeviceSession { deviceId, accounts: [{ accountId, sessionId, addedAt, operatedByUserId? }], activeAccountId, revision, updatedAt }
+```
+
+- Los `Session` dejan de almacenar `accessToken`/`refreshToken`/`previousRefreshToken` (borrados). La **revocación** vive en el `RefreshToken` opaco (hash-only, rotación single-use, reuse-detection) — **se conserva**. El access token es **efímero y se acuña, nunca se persiste**.
+- `operatedByUserId` (auditoría act_as de subcuentas) se conserva como campo de la entrada de cuenta.
+
+### 5.3 Contrato del canal + REST (`@oxyhq/contracts`)
+
+- `deviceSessionStateSchema` / `sessionAccountSchema` (extienden el `deviceSessionAccountSchema` ya existente; añaden `deviceId`, `activeAccountId`, `authuser`, `revision`).
+- Evento socket `session_state`: el `SessionState` **sin tokens**, **idempotente** — la app reemplaza su estado local si `revision` recibido > aplicado (last-writer-wins por revisión).
+- Evento `user_changed:<accountId>`: señal barata (solo el id) → la app invalida la query de ese usuario → refetch del servicio central (perfil siempre sincronizado, sin datos en el canal).
+
+### 5.4 Regla de escritura/lectura
+
+- **Mutaciones** → **REST autenticado** (`POST /session/device/{switch,add,signout}`): el servidor persiste, sube `revision`, y **difunde** por el socket.
+- **Socket = solo-recepción** (push). Nunca se escribe/confía estado por socket → sin IDOR/spoof.
+- **(Re)conexión / arranque** → `GET /session/device/state` (resync por `revision`) y luego suscribe. Si el socket cae, revalida al enfocar (capa de resiliencia).
+
+---
+
+## 6. Flujos
+
+Todas las mutaciones: **REST → persistir + `revision++` + difundir a `device:<deviceId>`**. Las apps son reactivas.
+
+**A) Cerrar sesión de una cuenta** — `POST /session/device/signout { accountId }`
+1. Servidor revoca el `Session`/`RefreshToken` de esa cuenta en el dispositivo (revocación real), la quita de `accounts`, y si era la activa recalcula `activeAccountId` (siguiente cuenta o `null`).
+2. `revision++`, difunde `session_state`.
+3. Todas las apps del dispositivo reciben el estado → quitan la cuenta; si era la activa, montan la nueva activa (o "sin sesión"). Instantáneo.
+
+**B) Cambiar cuenta activa** — `POST /session/device/switch { accountId }`
+1. Servidor: `activeAccountId = accountId` (re-check act_as si es subcuenta), `revision++`, difunde.
+2. Cada app recibe el estado → **acuña su token de la nueva activa** (web: FedCM/`/auth/silent`/`/sso`; nativo: keychain) y re-renderiza. Cuenta activa global, instantánea.
+
+**C) Añadir cuenta** — login normal → `POST /session/device/add` (implícito al iniciar sesión)
+1. Se asocia el `Session` de la cuenta al `DeviceSession`, `activeAccountId = nueva`, `revision++`, difunde.
+2. Aparece en la lista de todas las apps al instante.
+
+**Reconexión/arranque:** `GET /session/device/state` → suscribe. Socket caído → revalidar al enfocar. Nunca desincronizado.
+
+### 6.1 Offline-first (estilo Instagram)
+
+La app debe ser **usable sin red**. El diseño lo cumple reutilizando el offline-first ya existente + persistencia durable del estado de sesión:
+
+- **Sigues logueado offline.** El cliente cachea **durablemente** el último `SessionState` **y** el token por-dominio: web en storage persistido (localStorage/IndexedDB), **nativo en el keychain de app-group** (durable por naturaleza). En arranque offline, `SessionClient` **bootea desde la caché** — logueado y usable, **sin llamadas de red**. Estar "logueado" no requiere hablar con el servidor.
+- **Datos de la app.** Se reutiliza el offline-first existente (`@tanstack/react-query-persist-client`, `networkMode:'offlineFirst'`, whitelist persistida, cola de mutaciones con `mutationKey` estable — ver §11 KEEP `queryClient`). Contenido cacheado visible + interacción; escrituras **encoladas** y **vaciadas al reconectar**.
+- **Reconexión.** El socket vuelve → `GET /session/device/state` resync por `revision` + reconciliación last-writer-wins → recupera lo ocurrido mientras estuvo offline. La conexión del socket usa el patrón de reintento existente.
+- **Mutaciones de sesión offline** (switch/signout/add): **update optimista local** + encolar; al reconectar se confirman contra el servidor y el `session_state` autoritativo reconcilia. Un signout offline limpia local y **encola la revocación real** (que se ejecuta al volver).
+- **Token expirado offline.** Si el token cacheado caducó y no hay red para re-acuñar, la app permanece en modo lectura/offline (React Query sirve caché) y re-acuña en cuanto vuelve la red; nunca se fuerza un logout por falta de red.
+- **Indicadores.** `useOnlineStatus()` (ya existe, KEEP) alimenta banners "sin conexión" / "sincronizando".
+
+**Consecuencia de diseño:** el `SessionState` debe ser **serializable y persistible** (lo es — solo ids + `revision`), y `SessionClient` arranca **caché-primero, red-después** (nunca bloquea el primer render esperando al servidor).
+
+---
+
+## 7. Identidad de dispositivo cross-domain
+
+Con 3PC bloqueado, cada RP llega al IdP por hosts CNAME first-party (`auth.<apex>`), orígenes distintos con cookies separadas. Para enrutar el push al **mismo dispositivo**:
+
+- **El `deviceId` lo posee y emite el IdP central** (`auth.oxy.so`) en una cookie de dispositivo **first-party a `auth.oxy.so`** (host-only, httpOnly, larga duración). Hoy `deriveServiceDeviceId`/`deriveStableDeviceId` re-derivan el id por (user, RP)/UA/IP → se **reescribe** para emitir **un `deviceId` estable persistido por dispositivo físico**.
+- Se **propaga** a cada sesión RP: FedCM (claims de la aserción, first-party al IdP) y `/sso/establish` (dentro del token `et` firmado). Todas las apps web del mismo navegador acaban con el mismo `deviceId` central.
+- **Nativo**: en el primer login la app pide el `deviceId` al central (llamada directa, sin 3PC) y lo guarda en el keychain de app-group → todas las apps nativas del dispositivo lo comparten.
+- **Enrutado del socket**: el room se deriva del `deviceId` **dentro del token firmado** del handshake (`authSocket`), nunca de input del cliente. Ownership-check antes del join.
+
+**Limitación aceptada (§13):** una app **nativa** y un **navegador web** en el mismo teléfono físico son identidades de dispositivo separadas (sandbox del SO); se sincronizan por el estado del servidor al siguiente fetch/enfoque, no por el push instantáneo. Sin enlace explícito (YAGNI).
+
+---
+
+## 8. Transporte por plataforma (web vs nativo)
+
+El **núcleo es uno** (`SessionClient`: estado + socket + flujos). Solo se inyecta el binding `TokenTransport` (cómo obtener el token de una cuenta).
+
+**Web (por dominio)** — primitivas first-party **reutilizadas verbatim** (KEEP):
+- FedCM silent/interactivo (`OxyServices.fedcm.ts`) → `POST /fedcm/nonce` + `POST /fedcm/exchange`.
+- Iframe `/auth/silent` per-apex (`OxyServices.silent.ts` + `packages/auth` `GET /auth/silent` + `mintSessionForClient`, `iss` SIEMPRE `auth.oxy.so`).
+- Bounce top-level `/sso` → `/sso/establish` (`packages/auth`) → code → `exchangeSsoCode` (`OxyServices.sso.ts` → `POST /sso/exchange`).
+- **El esquema de cookies `oxy_rt` se elimina** (ver §11.4): web acuña **siempre** por primitivas first-party; el token efímero se guarda en memoria (`tokenStore`), no en cookie de refresh.
+
+**Nativo (Expo)** — primitivas **reutilizadas** (KEEP):
+- Keychain de app-group `group.so.oxy.shared` (`KeyManager`) + `requestChallenge`/`verifyChallenge`/`signInWithSharedIdentity` (`SignatureService`).
+
+**Socket central**: `api.oxy.so`, room `device:<deviceId>`, construido sobre `authSocket` (`@oxyhq/core`). Reemplaza el `useSessionSocket` per-dominio.
+
+```
+@oxyhq/core: SessionClient (estado + socket + flujos)   ← idéntico web/nativo
+     ├── TokenTransport.web    → FedCM / /auth/silent / /sso/establish
+     └── TokenTransport.native → keychain app-group (KeyManager + verifyChallenge)
+```
+
+---
+
+## 9. Seguridad
+
+- **Qué viaja por el canal:** solo estado (ids de cuenta, activa, `revision`). Nunca tokens crudos ni refresh tokens. → preserva #251.
+- **Auth del socket:** `authSocket` (token firmado en handshake, `validateSession` obligatorio, `claimedUserId === session.userId`). Room `device:<deviceId>` del token; ownership-check antes del join → anti-IDOR.
+- **Escrituras solo REST bearer**; socket solo-recepción → sin spoof por socket. Bearer → sin CSRF token; `requireSameSiteOrigin` + `createOxyCors` en `/session/device/*`.
+- **Aislamiento por dominio:** cada app acuña su token first-party; un dominio comprometido no obtiene tokens de otro.
+- **Cerrar sesión = revocación REAL** server-side (RefreshToken/deactivateSession), no solo limpiar cliente.
+- **Comparación de secretos** con `verifySecret` (constant-time), nunca `===`.
+- **Cookie `deviceId` central:** host-only `auth.oxy.so`, httpOnly → no exfiltrable por XSS de un RP.
+- Identidad del actor server-side vía `getRequiredOxyUserId` — nunca ids del cliente (anti mass-assignment/IDOR).
+
+---
+
+## 10. Refactor del cliente (apps)
+
+- **`packages/accounts`**: `managed-accounts.tsx` (switch), `sessions.tsx`, `security.tsx`, gates de `(auth)`/`(tabs)` → consumen `SessionState`/`SessionClient`; se borra el polling manual (`refreshSessions` en pull-to-refresh, doble-tap del logo, reload). El montaje de `<OxyProvider>` no cambia (la lógica vive en el SDK).
+- **`packages/services`**: `OxyContext` (cold-boot, `switchToAccount`, `useSessionSocket`, `restoreViaRefreshCookie`, `restoreStoredSession`), `useSessionManagement`, `silentSessionRestore`, `activeAuthuser`, `useDeviceAccounts` → reconsolidados sobre `SessionClient`. Los contenedores de UI (`AccountSwitcher`, `SignInModal`, `OxyAuthScreen`, `OxySignInButton`) **se conservan** (siguen las nuevas rutas por debajo).
+- **`packages/auth-sdk`**: `WebOxyProvider` reescrito sobre `SessionClient`; `AuthManager`, `useSessionSocket`, `authStore`, `accountStore`, `sessionHelpers`, `storageHelpers` → borrados/reescritos (ver §11).
+
+---
+
+## 11. Código a eliminar / reescribir / reutilizar (exacto, del barrido)
+
+> Leyenda: 🔴 borrar · 🟡 reescribir/consolidar en el modelo central · 🟢 reutilizar verbatim.
+
+### 11.1 `@oxyhq/core`
+
+**🔴 BORRAR**
+- `mixins/OxyServices.auth.ts`: `refreshAllSessions`(+`RefreshAllOptions`), `refreshTokenViaCookie`/`_refreshCookieRaw`, `getUserBySession`/`getUsersBySessions`, `_decodeSessionIdFromAccessToken`.
+- `OxyServices.base.ts`: `establishDeviceRefreshSlot`.
+- `AuthManager.ts`: `restoreFromCookies`(+`_lastRestoreAt`), `refreshToken`/`_doRefreshToken`, `activeAuthuser` + `get/read/write/clearActiveAuthuser` + `STORAGE_KEYS.ACTIVE_AUTHUSER`, BroadcastChannel cross-tab (`_initBroadcastChannel`/`_handleCrossTabMessage`/`_broadcast`/…), `_hydrateUnknownUser`/`toMinimalUser`, `decodeSessionIdFromAccessToken`/`decodeAuthuserFromAccessToken`.
+- `utils/coldBoot.ts`: `runColdBoot` (+ tipos).
+- `CrossDomainAuth.ts`: clase completa.
+- `utils/sessionUtils.ts`: `normalize/sort/deduplicate/merge…Sessions`.
+- `models/session.ts`: `StorageKeys(sessions, activeSessionId)`. `models/interfaces.ts`: `RefreshAllAccount(+User+Response)`, `RefreshCookieResponse`. `AuthManagerTypes.ts`: `RestoreFromCookiesResult/Options`.
+
+**🟡 REESCRIBIR → `SessionClient`**
+- `AuthManager.ts` (clase → proyección de `SessionState` sobre socket): `switchAuthuser`, `signOutAuthuser`/`signOutAllViaCookies`, `setupCookieRefresh`, `handleAuthSuccess`, superficie pública (`initialize`/`signOut`/`getAccounts`/…). `AuthManagerTypes.ts`: `AuthManagerAccount`, `SwitchAuthuserResult`.
+- `mixins/OxyServices.auth.ts`: `logoutSessionByAuthuser`, `logoutAllSessionsViaCookie`, `getSessionsBySessionId`/`logoutSession`/`logoutAllSessions`, `validateSession`. `mixins/OxyServices.accounts.ts`: `switchToAccount`.
+- `utils/ssoBounce.ts`: `allowSsoBounce`/`ssoPriorSessionKey` (gate por presencia en `SessionState`).
+- `models/session.ts`: `ClientSession`, `MinimalUserData`, `SessionLoginResponse`. `models/interfaces.ts`: `DeviceSession*`, `LoginResponse`.
+- `HttpService.ts`: `refreshAccessToken`/`setAuthRefreshHandler` (rewire del handler a `SessionClient`).
+
+**🟢 REUTILIZAR** (primitivas de mint/token/transporte, verbatim)
+- Mint web: `OxyServices.fedcm.ts`, `OxyServices.silent.ts` (`silentSignIn`), `OxyServices.sso.ts` (`exchangeSsoCode`/`generateSsoState`), `OxyServices.redirect.ts`, `utils/ssoReturn.ts` (`consumeSsoReturn`), `utils/ssoBounce.ts` (guards de loop, `ssoSignedOutKey`).
+- Mint nativo: `OxyServices.auth.ts` (`requestChallenge`/`verifyChallenge`/`signInWithSharedIdentity`, `claimSessionByToken`, Commons/QR), `crypto/keyManager.ts`, `crypto/signatureService.ts`.
+- Token store: `OxyServices.base.ts` (`setTokens`/`getAccessToken`/`onTokensChanged`/`getSessionBaseUrl`/`createLinkedClient`/`waitForAuth`), `HttpService.ts` (`tokenStore`).
+- Transporte/infra: `OxyServices.utility.ts` (`authSocket`, `auth()`/`serviceAuth()`), `utils/fapiAutoDetect.ts` (`registrableApex`/`autoDetectAuthWebUrl`), `utils/authWebUrl.ts`, `utils/authHelpers.ts`.
+- Servicio de usuarios: `OxyServices.user.ts` (`getUsersByIds`).
+
+### 11.2 `@oxyhq/services`
+
+**🔴 BORRAR**: `OxyContext.tsx` → `restoreViaRefreshCookie`, `persistSessionDurably`, `clearPriorSessionHint`, IdP session-check iframe (`checkIdPSession`…), `useWebSSO` auto-check. `silentSessionRestore.ts` → `selectActiveRefreshAccount`. `activeAuthuser.ts` → `read/write/clearActiveAuthuser`, `markSignedOut`/`clearSignedOut`/`isSilentRestoreSuppressed`, `clearSsoBounceState`. `useSessionManagement.ts` → `findReplacementSession`. `sessionHelpers.ts` → `validateSessionBatch`. `useDeviceAccounts.ts` → `markCurrentAccount`. `hooks/useAuthOperations.ts` → `clearPriorSessionHintSafe`.
+
+**🟡 REESCRIBIR**: `OxyContext.tsx` (`OxyProvider`/`OxyContextState`/`restoreSessionsFromStorage`(8 pasos)/`restoreStoredSession`/`handleWebSSOSession`/`switchToAccount`/`signInWithPassword`/`clearAllAccountData`/`useSessionSocket` wiring/`handleTokenChange`/`markAuthResolved`), `useSessionManagement.ts`(`useSessionManagement`/`switchSession`/`refreshSessions`), `useSessionSocket.ts`, `inSessionTokenRefresh.ts`(`createInSessionRefreshHandler` — quitar el brazo refresh-cookie), `useWebSSO.ts`(auto silent), `hooks/useAuthOperations.ts`(`signIn`/`logout`/`logoutAll`), `crossApex.ts`, `sessionHelpers.ts`(`fetchSessionsWithFallback`), `useDeviceAccounts.ts`, `useDeviceManagement.ts`, `queries/useServicesQueries.ts`(`useSessions`).
+
+**🟢 REUTILIZAR**: `silentSessionRestore.ts`(`mintSessionViaPerApexIframe`), `runSsoReturn`, `inSessionTokenRefresh.ts`(`startTokenRefreshScheduler`), `useWebSSO.ts`(`signInWithFedCM` interactivo, `isWebBrowser`), UI (`SignInModal`, `OxyAuthScreen`, `AccountSwitcher(+Screen)`, `OxySignInButton`, `OxyProvider` wrapper), `authStore.ts`, `useAuth.ts`, `useOxyAuthSession.ts`/`deviceFlowSignIn.ts` (device-flow QR), `queries/useAccountQueries.ts` (perfil vía user-data), `queryKeys.ts`, storage init.
+
+### 11.3 `@oxyhq/auth` (auth-sdk web)
+
+**🔴 BORRAR**: `WebOxyProvider.tsx` → cold-boot `cookie-restore` step, `hasPriorSessionWeb`/`markPriorSessionWeb`/`clearPriorSessionWeb`, `markSignedOutWeb`/`clearSignedOutWeb`. `hooks/useSessionSocket.ts` (per-dominio) → `handleSessionUpdate` whitelist + `triggerLocalSignOut`; el hook entero se sustituye por la suscripción central. `stores/authStore.ts` (duplicado). `utils/sessionHelpers.ts` → `fetchSessionsWithFallback`/`validateSessionBatch`. `utils/storageHelpers.ts` → `getStorageKeys`/`SessionStorageKeys`.
+
+**🟡 REESCRIBIR**: `WebOxyProvider.tsx` (componente + `authManager`/`createAuthManager` + `initAuth` cold-boot + `evaluateSsoBounce` + estado `accounts/activeAuthuser` + `handleAuthSuccess`/`commitClaimedSession` + `switchAccount`/`switchSession`/`signOutAccount`/`signOutAll` + `signOut` + `useAuth`/`WebAuthState`/contexto). `stores/accountStore.ts`. `useSessionSocket.ts`(`getSocketIO`/transporte → mueve al `SessionClient`). `utils/sessionHelpers.ts`(`mapSessionsToClient`). `queries/useServicesQueries.ts`, `mutations/useServicesMutations.ts`, `queries/useAccountQueries.ts`, `queryKeys.ts`(namespaces sessions/accounts).
+
+**🟢 REUTILIZAR**: `WebOxyProvider.tsx` → `runSsoReturn`/intercept + bfcache, `runSsoBounce`/guards de loop, `fedcmSilentSignInAttempted` + fedcm-silent step, `signIn`/`signInWithFedCM`/`signInWithRedirect`. `hooks/useWebSSO.ts`, `hooks/useCommonsSignIn.ts`, `hooks/queryClient.ts`, `utils/storageHelpers.ts`(`createPlatformStorage`…).
+
+### 11.4 `oxy-api` (servidor)
+
+**🔴 BORRAR**: `models/Session.ts` → campos `accessToken`/`refreshToken`/`previousRefreshToken`/`tokenRotatedAt`. `services/refreshToken.service.ts` → `buildUserIdToAuthuserMap`/`pickLruAuthuser`/`classifyRefreshCandidates`/`selectActiveCandidate`, `parseAllRefreshCookies`/`refreshCookieName`/`REFRESH_COOKIE_NAME_RE`/`MAX_DEVICE_ACCOUNTS`/`setRefreshCookie`/`clearRefreshCookie`/`clearAllRefreshCookies`/`clearLegacyParentRefreshCookie`. `services/session.service.ts` → `refreshTokens` (+ grace path). `controllers/session.controller.ts` → `getUserBySession`, `getUsersBySessions`.
+
+**🟡 REESCRIBIR**: `models/Session.ts`(`Session`→entrada de cuenta en `DeviceSession`). `services/refreshToken.service.ts`(`issueAndSetRefreshCookie`→`/session/device/add`). `services/session.service.ts`(`createSession`→upsert en `DeviceSession`). `controllers/session.controller.ts`(`getUserSessions`/`getDeviceSessions`→`GET /session/device/state`; `logoutSession`/`logoutAllSessions`/`logoutAllDeviceSessions`→`POST /session/device/signout`). `routes/auth.ts`(`POST /auth/refresh`, `/auth/refresh-all`→`GET /session/device/state`; `/auth/session`→`/session/device/add`; `/auth/logout`→`/session/device/signout`). `server.ts`(socket: `io.use` inline + room `user:<id>` + `emitSessionUpdate`→`authSocket` + room `device:<deviceId>` + broadcast `SessionState`). `utils/deviceUtils.ts`(`deriveServiceDeviceId`/`deriveStableDeviceId`→un `deviceId` persistido).
+
+**🟢 REUTILIZAR**: `models/RefreshToken.ts`, `models/AuthSession.ts`, `services/refreshToken.service.ts`(`issueRefreshToken`/`rotateRefreshToken`/`revokeFamily*`), `services/session.service.ts`(`validateSession*`/`getSession*`/`getAccessToken`/`deactivateSession*`/`ensureManagedSessionAuthorized`), `services/authSession.service.ts`, `utils/sessionCache.ts`, `controllers/session.controller.ts`(`validateSession*`/`updateDeviceName`), `routes/auth.ts` device-flow QR, `utils/authSessionSocket.ts`, `utils/sessionUtils.ts`(`generateSessionTokens` access-half/`validateAccessToken`), `routes/sso.ts` + `services/ssoCode.service.ts` + `services/fedcm.service.ts`, `routes/fedcm.ts`, `middleware/originGuard.ts` + `middleware/auth.ts`, `packages/auth/server` (FedCM IdP + `/auth/silent` + `/sso`/`/sso/establish` + `mintSessionForClient`).
+
+### 11.5 Compartidos (KEEP)
+
+`@oxyhq/core/server`: `authSocket`, `requireSameSiteOrigin`, `verifySecret`, `safeFetch`, `createOxyCors`, `createOxyAuthMiddleware`/`getRequiredOxyUserId`. `packages/protocol`: `canonicalJson`/`signingInput`. `@oxyhq/contracts`: `deviceSessionAccountSchema` (base a extender), `safeParseContract`/`resolveUserId`. `POST /users/by-ids` + `OxyServices.user.getUsersByIds` + hooks React Query de perfil.
+
+---
+
+## 12. Fases de implementación
+
+Orden de construcción (contracts → core → consumidores). Cada fase es un corte limpio de su alcance.
+
+- **Fase 1 — Contracts + autoridad servidor** (aditivo). `@oxyhq/contracts`: schemas de `SessionState` + eventos. `oxy-api`: `DeviceSession`, rutas `/session/device/{state,switch,add,signout}`, canal `device:<deviceId>` (`authSocket`), emisión de `deviceId` en el IdP. **Publicar contracts primero.**
+- **Fase 2 — `@oxyhq/core` `SessionClient`** (estado + socket + flujos + `TokenTransport`). Borrar piezas core reemplazadas. Tests jest.
+- **Fase 3 — `@oxyhq/services`**: `OxyContext` sobre `SessionClient`; borrar cold-boot enredado, `useSessionSocket`, `silentSessionRestore`, `activeAuthuser`; recablear pantallas.
+- **Fase 4 — `@oxyhq/auth`**: `WebOxyProvider` sobre `SessionClient` (`TokenTransport.web`); borrar `AuthManager`/stores duplicados.
+- **Fase 5 — Apps**: `accounts` (switcher, sesiones, seguridad, gates); Mention/Homiio/etc = bump de versión + wiring. Publicación coordinada + bump de consumidores + lockfiles en el mismo commit.
+- **Fase 6 — Barrido de código muerto + docs**: eliminar huérfanos; actualizar AGENTS.md.
+
+**Nota:** el servidor (Fase 1) es el mayor bloque — `Session` deja de almacenar tokens y todo el esquema `oxy_rt` desaparece. Es corte limpio, no migración de datos (sesiones vivas se re-acuñan por las primitivas first-party al primer arranque).
+
+---
+
+## 13. Riesgos y limitaciones
+
+- **Nativo-app ↔ web-en-el-mismo-móvil**: identidades de dispositivo separadas (sandbox del SO) → no instantáneo entre ellos; se reconcilian por estado al enfocar. Sin enlace explícito (YAGNI). Documentado y aceptado.
+- **Verificación real obligatoria**: el comportamiento cross-domain/3PC/socket **no** lo captan jest/tsc — hay que verlo en navegador real (dos dominios) y en nativo (ver §14).
+- **Migración operacional**: al desplegar, las cookies `oxy_rt` existentes quedan huérfanas (inertes); las sesiones se re-acuñan. No hay pérdida de sesión si las primitivas first-party (FedCM/silent/sso) están sanas.
+- **`deviceId` estable**: emitir un id persistido por dispositivo sin colisionar ni fragmentar es delicado; es el punto técnico a validar con más cuidado.
+
+---
+
+## 14. Fuera de alcance
+
+- **Sync cross-device en tiempo real** (cerrar en móvil → cerrar en portátil al instante). Queda en el comportamiento actual (eventual, vía gestión de sesiones/revocación).
+- **Enlace explícito nativo↔web** en el mismo dispositivo físico.
+
+---
+
+## 15. Evidencia que fundamenta el diseño (2026-07-01, navegador real)
+
+Verificado en vivo en `accounts.oxy.so` con Chrome "bloquear cookies de terceros":
+- `accounts.oxy.so → api.oxy.so` es **same-site** (`Sec-Fetch-Site: same-site`, `eTLD+1 = oxy.so`).
+- Con sesión primaria activa, `POST /auth/refresh-all` devolvía **0 cuentas** y `POST /auth/refresh?authuser=0` **401** → **el primario no tenía cookie `oxy_rt_0`**; la sesión se restauraba solo por FedCM/silent.
+- `POST /auth/session` respondía **200** con `Set-Cookie` válido (curl lo almacena y reautentica), pero el **navegador descartaba la escritura cross-origin** en estado virgen. Tras visitar `api.oxy.so` first-party una vez, todas las escrituras funcionaban.
+- Reproducción end-to-end: con el slot plantado + `activeAccountId`, recargar **sí** restauraba la subcuenta — confirmando que la lógica de switch/restore es correcta y el fallo está en el **cimiento** (la cookie que no se planta). → justifica mover la autoridad al servidor + canal, no a cookies cross-origin.

--- a/packages/api/src/models/DeviceSession.ts
+++ b/packages/api/src/models/DeviceSession.ts
@@ -1,0 +1,43 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export interface IDeviceSessionAccount {
+  accountId: mongoose.Types.ObjectId;
+  sessionId: string;
+  authuser: number;
+  addedAt: Date;
+  operatedByUserId?: mongoose.Types.ObjectId | null;
+}
+
+export interface IDeviceSession extends Document {
+  deviceId: string;
+  accounts: IDeviceSessionAccount[];
+  activeAccountId: mongoose.Types.ObjectId | null;
+  revision: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const AccountSchema = new Schema<IDeviceSessionAccount>(
+  {
+    accountId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    sessionId: { type: String, required: true },
+    authuser: { type: Number, required: true, min: 0 },
+    addedAt: { type: Date, default: Date.now },
+    operatedByUserId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { _id: false },
+);
+
+const DeviceSessionSchema = new Schema<IDeviceSession>(
+  {
+    deviceId: { type: String, required: true },
+    accounts: { type: [AccountSchema], default: [] },
+    activeAccountId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+    revision: { type: Number, default: 0 },
+  },
+  { timestamps: true },
+);
+
+DeviceSessionSchema.index({ deviceId: 1 }, { unique: true });
+
+export default mongoose.model<IDeviceSession>('DeviceSession', DeviceSessionSchema);

--- a/packages/api/src/models/__tests__/deviceSession.model.test.ts
+++ b/packages/api/src/models/__tests__/deviceSession.model.test.ts
@@ -1,0 +1,30 @@
+jest.mock('mongoose', () => jest.requireActual('mongoose'));
+import mongoose from 'mongoose';
+import DeviceSession from '../DeviceSession';
+
+describe('DeviceSession model', () => {
+  it('registers on the "devicesessions" collection', () => {
+    expect(DeviceSession.collection.name).toBe('devicesessions');
+  });
+
+  it('defaults revision to 0 and activeAccountId to null', () => {
+    const doc = new DeviceSession({ deviceId: 'd1' });
+    expect(doc.revision).toBe(0);
+    expect(doc.activeAccountId).toBeNull();
+    expect(doc.accounts).toHaveLength(0);
+  });
+
+  it('requires deviceId', () => {
+    const doc = new DeviceSession({});
+    const err = doc.validateSync();
+    expect(err?.errors?.deviceId).toBeDefined();
+  });
+
+  it('stores an account subdocument with authuser + sessionId', () => {
+    const accountId = new mongoose.Types.ObjectId();
+    const doc = new DeviceSession({ deviceId: 'd1', accounts: [{ accountId, sessionId: 's1', authuser: 0 }] });
+    expect(doc.accounts[0].sessionId).toBe('s1');
+    expect(doc.accounts[0].authuser).toBe(0);
+    expect(doc.accounts[0].addedAt).toBeInstanceOf(Date);
+  });
+});

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -7,6 +7,7 @@ const mockGetState = jest.fn();
 const mockAddAccount = jest.fn();
 const mockSwitchActive = jest.fn();
 const mockSignout = jest.fn();
+const mockResolveActiveToken = jest.fn();
 const mockBroadcast = jest.fn();
 const mockDecodeToken = jest.fn();
 
@@ -28,6 +29,7 @@ jest.mock('../../services/deviceSession.service', () => ({
     addAccount: (...a: unknown[]) => mockAddAccount(...a),
     switchActive: (...a: unknown[]) => mockSwitchActive(...a),
     signout: (...a: unknown[]) => mockSignout(...a),
+    resolveActiveToken: (...a: unknown[]) => mockResolveActiveToken(...a),
   },
 }));
 jest.mock('../../utils/socket', () => ({ broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a) }));
@@ -63,14 +65,18 @@ beforeAll((done) => {
   server = app.listen(0, '127.0.0.1', done);
 });
 afterAll((done) => { server.close(done); });
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolveActiveToken.mockResolvedValue({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' });
+});
 
 describe('GET /session/device/state', () => {
   it('returns the device state', async () => {
     mockGetState.mockResolvedValueOnce(STATE);
     const res = await requestJson(server, 'GET', '/session/device/state');
     expect(res.status).toBe(200);
-    expect(res.body.data).toEqual(STATE);
+    expect(res.body.data.state).toEqual(STATE);
+    expect(res.body.data.activeToken).toEqual({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' });
     expect(mockGetState).toHaveBeenCalledWith('d1');
   });
 });
@@ -82,6 +88,8 @@ describe('POST /session/device/switch', () => {
     expect(res.status).toBe(200);
     expect(mockSwitchActive).toHaveBeenCalledWith('d1', 'a1');
     expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+    expect(res.body.data.state).toEqual(STATE);
+    expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
   });
 
   it('404 when the account is not on the device', async () => {
@@ -100,6 +108,7 @@ describe('POST /session/device/signout', () => {
     expect(res.status).toBe(200);
     expect(mockSignout).toHaveBeenCalledWith('d1', { accountId: 'a1' });
     expect(mockBroadcast).toHaveBeenCalledWith(after);
+    expect(res.body.data.state).toEqual(after);
   });
 
   it('signs out all when { all: true }', async () => {
@@ -118,5 +127,7 @@ describe('POST /session/device/add', () => {
     expect(res.status).toBe(200);
     expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
     expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+    expect(res.body.data.state).toEqual(STATE);
+    expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
   });
 });

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -1,0 +1,122 @@
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+
+const mockAuthMiddleware = jest.fn();
+const mockGetState = jest.fn();
+const mockAddAccount = jest.fn();
+const mockSwitchActive = jest.fn();
+const mockSignout = jest.fn();
+const mockBroadcast = jest.fn();
+const mockDecodeToken = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (...a: unknown[]) => mockAuthMiddleware(...a),
+}));
+jest.mock('../../middleware/originGuard', () => ({
+  requireSameSiteOrigin: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../middleware/rateLimiter', () => ({ rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next() }));
+jest.mock('../../middleware/authUtils', () => ({
+  decodeToken: (...a: unknown[]) => mockDecodeToken(...a),
+  extractTokenFromRequest: () => 'tkn',
+}));
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: {
+    getState: (...a: unknown[]) => mockGetState(...a),
+    addAccount: (...a: unknown[]) => mockAddAccount(...a),
+    switchActive: (...a: unknown[]) => mockSwitchActive(...a),
+    signout: (...a: unknown[]) => mockSignout(...a),
+  },
+}));
+jest.mock('../../utils/socket', () => ({ broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a) }));
+jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+
+import sessionDeviceRouter from '../sessionDevice';
+import { errorHandler } from '../../middleware/errorHandler';
+
+const STATE = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
+
+async function requestJson(server: http.Server, method: string, path: string, payload?: unknown) {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? '' : JSON.stringify(payload);
+  return new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
+    const req = http.request({ method, host: '127.0.0.1', port: address.port, path,
+      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body), Authorization: 'Bearer t' } },
+      (res) => { let raw = ''; res.on('data', c => { raw += c; }); res.on('end', () => { resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }); }); });
+    req.on('error', reject); if (body) req.write(body); req.end();
+  });
+}
+
+let server: http.Server;
+beforeAll((done) => {
+  mockAuthMiddleware.mockImplementation((req: { user?: unknown }, _res: unknown, next: () => void) => {
+    (req as { user?: unknown }).user = { _id: { toString: () => '64b0000000000000000000aa' }, id: '64b0000000000000000000aa' };
+    next();
+  });
+  mockDecodeToken.mockReturnValue({ sessionId: 's1', deviceId: 'd1' });
+  const app = express();
+  app.use(express.json());
+  app.use('/session/device', sessionDeviceRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+afterAll((done) => { server.close(done); });
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /session/device/state', () => {
+  it('returns the device state', async () => {
+    mockGetState.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'GET', '/session/device/state');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(STATE);
+    expect(mockGetState).toHaveBeenCalledWith('d1');
+  });
+});
+
+describe('POST /session/device/switch', () => {
+  it('switches active account and broadcasts', async () => {
+    mockSwitchActive.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'a1' });
+    expect(res.status).toBe(200);
+    expect(mockSwitchActive).toHaveBeenCalledWith('d1', 'a1');
+    expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+  });
+
+  it('404 when the account is not on the device', async () => {
+    mockSwitchActive.mockResolvedValueOnce(null);
+    const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'ghost' });
+    expect(res.status).toBe(404);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /session/device/signout', () => {
+  it('signs out one account and broadcasts', async () => {
+    const after = { ...STATE, accounts: [], activeAccountId: null, revision: 2 };
+    mockSignout.mockResolvedValueOnce(after);
+    const res = await requestJson(server, 'POST', '/session/device/signout', { accountId: 'a1' });
+    expect(res.status).toBe(200);
+    expect(mockSignout).toHaveBeenCalledWith('d1', { accountId: 'a1' });
+    expect(mockBroadcast).toHaveBeenCalledWith(after);
+  });
+
+  it('signs out all when { all: true }', async () => {
+    const after = { ...STATE, accounts: [], activeAccountId: null, revision: 2 };
+    mockSignout.mockResolvedValueOnce(after);
+    const res = await requestJson(server, 'POST', '/session/device/signout', { all: true });
+    expect(res.status).toBe(200);
+    expect(mockSignout).toHaveBeenCalledWith('d1', { all: true });
+  });
+});
+
+describe('POST /session/device/add', () => {
+  it('adds an account and broadcasts', async () => {
+    mockAddAccount.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'POST', '/session/device/add', { accountId: 'a1', sessionId: 's1' });
+    expect(res.status).toBe(200);
+    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: 'a1', sessionId: 's1', operatedByUserId: undefined });
+    expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+  });
+});

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -114,9 +114,9 @@ describe('POST /session/device/signout', () => {
 describe('POST /session/device/add', () => {
   it('adds an account and broadcasts', async () => {
     mockAddAccount.mockResolvedValueOnce(STATE);
-    const res = await requestJson(server, 'POST', '/session/device/add', { accountId: 'a1', sessionId: 's1' });
+    const res = await requestJson(server, 'POST', '/session/device/add', {});
     expect(res.status).toBe(200);
-    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: 'a1', sessionId: 's1', operatedByUserId: undefined });
+    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
     expect(mockBroadcast).toHaveBeenCalledWith(STATE);
   });
 });

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -14,6 +14,13 @@ function resolveCallerDeviceId(req: AuthRequest): string | null {
   return decoded?.deviceId ?? null;
 }
 
+function resolveCallerSession(req: AuthRequest): { deviceId: string; sessionId: string } | null {
+  const token = extractTokenFromRequest(req);
+  const decoded = token ? decodeToken(token) : null;
+  if (!decoded?.deviceId || !decoded?.sessionId) return null;
+  return { deviceId: decoded.deviceId, sessionId: decoded.sessionId };
+}
+
 router.use(requireSameSiteOrigin, authMiddleware);
 
 router.get('/state', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -23,11 +30,10 @@ router.get('/state', asyncHandler(async (req: AuthRequest, res: Response) => {
 }));
 
 router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
-  const deviceId = resolveCallerDeviceId(req);
-  const { accountId, sessionId, operatedByUserId } = req.body ?? {};
-  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
-  if (!accountId || !sessionId) { res.status(400).json({ error: 'accountId and sessionId required' }); return; }
-  const state = await deviceSessionService.addAccount(deviceId, { accountId, sessionId, operatedByUserId });
+  const session = resolveCallerSession(req);
+  const accountId = req.user?._id?.toString();
+  if (!session?.deviceId || !accountId || !session.sessionId) { res.status(401).json({ error: 'Invalid session' }); return; }
+  const state = await deviceSessionService.addAccount(session.deviceId, { accountId, sessionId: session.sessionId });
   broadcastDeviceState(state);
   res.json({ data: state });
 }));

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -1,0 +1,57 @@
+import { Router, Response } from 'express';
+import { authMiddleware, AuthRequest } from '../middleware/auth';
+import { requireSameSiteOrigin } from '../middleware/originGuard';
+import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
+import deviceSessionService from '../services/deviceSession.service';
+import { broadcastDeviceState } from '../utils/socket';
+import { asyncHandler } from '../utils/asyncHandler';
+
+const router = Router();
+
+function resolveCallerDeviceId(req: AuthRequest): string | null {
+  const token = extractTokenFromRequest(req);
+  const decoded = token ? decodeToken(token) : null;
+  return decoded?.deviceId ?? null;
+}
+
+router.use(requireSameSiteOrigin, authMiddleware);
+
+router.get('/state', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  res.json({ data: await deviceSessionService.getState(deviceId) });
+}));
+
+router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  const { accountId, sessionId, operatedByUserId } = req.body ?? {};
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  if (!accountId || !sessionId) { res.status(400).json({ error: 'accountId and sessionId required' }); return; }
+  const state = await deviceSessionService.addAccount(deviceId, { accountId, sessionId, operatedByUserId });
+  broadcastDeviceState(state);
+  res.json({ data: state });
+}));
+
+router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  const { accountId } = req.body ?? {};
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  if (!accountId) { res.status(400).json({ error: 'accountId required' }); return; }
+  const state = await deviceSessionService.switchActive(deviceId, accountId);
+  if (!state) { res.status(404).json({ error: 'Account not on this device' }); return; }
+  broadcastDeviceState(state);
+  res.json({ data: state });
+}));
+
+router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => {
+  const deviceId = resolveCallerDeviceId(req);
+  if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+  const { accountId, all } = req.body ?? {};
+  const target = all === true ? { all: true as const } : accountId ? { accountId } : null;
+  if (!target) { res.status(400).json({ error: 'accountId or all required' }); return; }
+  const state = await deviceSessionService.signout(deviceId, target);
+  broadcastDeviceState(state);
+  res.json({ data: state });
+}));
+
+export default router;

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -1,4 +1,5 @@
 import { Router, Response } from 'express';
+import type { DeviceSessionState } from '@oxyhq/contracts';
 import { authMiddleware, AuthRequest } from '../middleware/auth';
 import { requireSameSiteOrigin } from '../middleware/originGuard';
 import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
@@ -7,6 +8,11 @@ import { broadcastDeviceState } from '../utils/socket';
 import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
+
+async function withActiveToken(state: DeviceSessionState) {
+  const activeToken = await deviceSessionService.resolveActiveToken(state);
+  return { state, activeToken };
+}
 
 function resolveCallerDeviceId(req: AuthRequest): string | null {
   const token = extractTokenFromRequest(req);
@@ -26,7 +32,7 @@ router.use(requireSameSiteOrigin, authMiddleware);
 router.get('/state', asyncHandler(async (req: AuthRequest, res: Response) => {
   const deviceId = resolveCallerDeviceId(req);
   if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
-  res.json({ data: await deviceSessionService.getState(deviceId) });
+  res.json({ data: await withActiveToken(await deviceSessionService.getState(deviceId)) });
 }));
 
 router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -35,7 +41,7 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
   if (!session?.deviceId || !accountId || !session.sessionId) { res.status(401).json({ error: 'Invalid session' }); return; }
   const state = await deviceSessionService.addAccount(session.deviceId, { accountId, sessionId: session.sessionId });
   broadcastDeviceState(state);
-  res.json({ data: state });
+  res.json({ data: await withActiveToken(state) });
 }));
 
 router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -46,7 +52,7 @@ router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
   const state = await deviceSessionService.switchActive(deviceId, accountId);
   if (!state) { res.status(404).json({ error: 'Account not on this device' }); return; }
   broadcastDeviceState(state);
-  res.json({ data: state });
+  res.json({ data: await withActiveToken(state) });
 }));
 
 router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -57,7 +63,7 @@ router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => 
   if (!target) { res.status(400).json({ error: 'accountId or all required' }); return; }
   const state = await deviceSessionService.signout(deviceId, target);
   broadcastDeviceState(state);
-  res.json({ data: state });
+  res.json({ data: await withActiveToken(state) });
 }));
 
 export default router;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -6,6 +6,7 @@ import profilesRouter from "./routes/profiles";
 import usersRouter from "./routes/users";
 import notificationsRouter from "./routes/notifications.routes";
 import sessionRouter from "./routes/session";
+import sessionDeviceRouter from "./routes/sessionDevice";
 import dotenv from "dotenv";
 import User, { IUser } from "./models/User";
 import { ensureFileSha256LiveUniqueIndex } from "./models/File";
@@ -512,6 +513,7 @@ app.use("/profiles", csrfProtection, profilesRouter);
 // the routing topology unambiguous.
 app.use("/users/me/app-data", userRateLimiter, csrfProtection, userDataRouter);
 app.use("/users", userRateLimiter, csrfProtection, usersRouter); // Per-user rate limiting for authenticated routes
+app.use("/session/device", userRateLimiter, sessionDeviceRouter);
 app.use("/session", userRateLimiter, csrfProtection, sessionRouter);
 app.use("/privacy", userRateLimiter, csrfProtection, privacyRoutes);
 app.use("/analytics", userRateLimiter, authMiddleware, analyticsRoutes);

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -75,7 +75,7 @@ import { createCorsMiddleware, SOCKET_IO_CORS_CONFIG } from './config/cors';
 import { refreshOriginRegistry } from './config/dynamicOriginRegistry';
 import { createAdapter } from '@socket.io/redis-adapter';
 import { getRedisClient, closeRedis } from './config/redis';
-import { initializeIO } from './utils/socket';
+import { initializeIO, deviceRoomFor } from './utils/socket';
 import performanceMiddleware, { getMemoryStats, getConnectionPoolStats } from './middleware/performance';
 import { performanceMonitor } from './utils/performanceMonitor';
 import { waitForMongoConnection } from './utils/dbConnection';
@@ -269,7 +269,10 @@ io.on('connection', (socket: AuthenticatedSocket) => {
     socket.join(room);
     logger.debug('User joined notification room', { userId: socket.user.id, room });
   }
-  
+
+  const deviceRoom = deviceRoomFor(socket.user ?? {});
+  if (deviceRoom) socket.join(deviceRoom);
+
   socket.on('disconnect', () => {
     logger.debug('Socket disconnected', { socketId: socket.id });
   });

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -225,6 +225,7 @@ app.set('io', io);
 interface AuthenticatedSocket extends Socket {
   user?: {
     id: string;
+    deviceId?: string;
     [key: string]: any;
   };
 }
@@ -270,7 +271,7 @@ io.on('connection', (socket: AuthenticatedSocket) => {
     logger.debug('User joined notification room', { userId: socket.user.id, room });
   }
 
-  const deviceRoom = deviceRoomFor(socket.user ?? {});
+  const deviceRoom = socket.user ? deviceRoomFor(socket.user) : null;
   if (deviceRoom) socket.join(deviceRoom);
 
   socket.on('disconnect', () => {

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -1,6 +1,7 @@
 const mockFindOne = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
 const mockDeactivate = jest.fn();
+const mockGetAccessToken = jest.fn();
 
 jest.mock('../../models/DeviceSession', () => ({
   __esModule: true,
@@ -11,7 +12,10 @@ jest.mock('../../models/DeviceSession', () => ({
 }));
 jest.mock('../session.service', () => ({
   __esModule: true,
-  default: { deactivateSession: (...a: unknown[]) => mockDeactivate(...a) },
+  default: {
+    deactivateSession: (...a: unknown[]) => mockDeactivate(...a),
+    getAccessToken: (...a: unknown[]) => mockGetAccessToken(...a),
+  },
 }));
 jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
 
@@ -81,5 +85,21 @@ describe('switchActive', () => {
   it('returns null when the account is not on the device', async () => {
     mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
     expect(await deviceSessionService.switchActive('d1', 'ghost')).toBeNull();
+  });
+});
+
+describe('resolveActiveToken', () => {
+  const STATE = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
+  it('mints the active account token', async () => {
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'jwt', expiresAt: new Date('2026-07-07T00:00:00.000Z') });
+    expect(await deviceSessionService.resolveActiveToken(STATE as never)).toEqual({ accessToken: 'jwt', expiresAt: '2026-07-07T00:00:00.000Z' });
+    expect(mockGetAccessToken).toHaveBeenCalledWith('s1');
+  });
+  it('returns null when there is no active account', async () => {
+    expect(await deviceSessionService.resolveActiveToken({ ...STATE, activeAccountId: null } as never)).toBeNull();
+  });
+  it('returns null when the session cannot mint a token', async () => {
+    mockGetAccessToken.mockResolvedValueOnce(null);
+    expect(await deviceSessionService.resolveActiveToken(STATE as never)).toBeNull();
   });
 });

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -1,0 +1,85 @@
+const mockFindOne = jest.fn();
+const mockFindOneAndUpdate = jest.fn();
+const mockDeactivate = jest.fn();
+
+jest.mock('../../models/DeviceSession', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...a: unknown[]) => mockFindOne(...a),
+    findOneAndUpdate: (...a: unknown[]) => mockFindOneAndUpdate(...a),
+  },
+}));
+jest.mock('../session.service', () => ({
+  __esModule: true,
+  default: { deactivateSession: (...a: unknown[]) => mockDeactivate(...a) },
+}));
+jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+
+import deviceSessionService, { projectState } from '../deviceSession.service';
+
+const lean = (v: unknown) => ({ lean: () => Promise.resolve(v) });
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('projectState', () => {
+  it('maps a doc to DeviceSessionState with string ids', () => {
+    const doc = {
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+      updatedAt: new Date(1720000000000),
+    };
+    expect(projectState(doc as never)).toEqual({
+      deviceId: 'd1',
+      accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }],
+      activeAccountId: 'a1',
+      revision: 2,
+      updatedAt: 1720000000000,
+    });
+  });
+});
+
+describe('addAccount', () => {
+  it('adds a new account at authuser 0, sets it active, bumps revision', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's1' });
+    expect(state.activeAccountId).toBe('a1');
+    expect(state.accounts[0].authuser).toBe(0);
+    expect(state.revision).toBe(1);
+  });
+});
+
+describe('signout', () => {
+  it('revokes the account session and drops it from the set', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+    }));
+    mockDeactivate.mockResolvedValueOnce(true);
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 2, updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.signout('d1', { accountId: 'a1' });
+    expect(mockDeactivate).toHaveBeenCalledWith('s1');
+    expect(state.accounts).toHaveLength(0);
+    expect(state.activeAccountId).toBeNull();
+    expect(state.revision).toBe(2);
+  });
+});
+
+describe('switchActive', () => {
+  it('returns null when the account is not on the device', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
+    expect(await deviceSessionService.switchActive('d1', 'ghost')).toBeNull();
+  });
+});

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -1,0 +1,112 @@
+import type { DeviceSessionState, SessionAccount } from '@oxyhq/contracts';
+import DeviceSession, { IDeviceSession, IDeviceSessionAccount } from '../models/DeviceSession';
+import sessionService from './session.service';
+import { logger } from '../utils/logger';
+
+function idToString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object' && 'toString' in (value as object)) return (value as { toString(): string }).toString();
+  return String(value);
+}
+
+export function projectState(doc: IDeviceSession): DeviceSessionState {
+  const accounts: SessionAccount[] = (doc.accounts ?? []).map((a: IDeviceSessionAccount) => {
+    const operatedBy = idToString(a.operatedByUserId ?? null);
+    const account: SessionAccount = { accountId: idToString(a.accountId) ?? '', sessionId: a.sessionId, authuser: a.authuser };
+    if (operatedBy) account.operatedByUserId = operatedBy;
+    return account;
+  });
+  return {
+    deviceId: doc.deviceId,
+    accounts,
+    activeAccountId: idToString(doc.activeAccountId),
+    revision: doc.revision ?? 0,
+    updatedAt: (doc.updatedAt ?? new Date()).getTime(),
+  };
+}
+
+function lowestFreeAuthuser(accounts: IDeviceSessionAccount[]): number {
+  const used = new Set(accounts.map((a) => a.authuser));
+  let i = 0;
+  while (used.has(i)) i += 1;
+  return i;
+}
+
+class DeviceSessionService {
+  private async load(deviceId: string): Promise<IDeviceSession | null> {
+    return DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
+  }
+
+  async getState(deviceId: string): Promise<DeviceSessionState> {
+    const existing = await this.load(deviceId);
+    if (existing) return projectState(existing);
+    const created = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      { $setOnInsert: { deviceId, accounts: [], activeAccountId: null, revision: 0 } },
+      { new: true, upsert: true },
+    ).lean<IDeviceSession>();
+    return projectState(created as IDeviceSession);
+  }
+
+  async addAccount(
+    deviceId: string,
+    input: { accountId: string; sessionId: string; operatedByUserId?: string },
+  ): Promise<DeviceSessionState> {
+    const current = await this.load(deviceId);
+    const others = (current?.accounts ?? []).filter((a) => idToString(a.accountId) !== input.accountId);
+    const authuser = lowestFreeAuthuser(others);
+    const account = {
+      accountId: input.accountId,
+      sessionId: input.sessionId,
+      authuser,
+      addedAt: new Date(),
+      operatedByUserId: input.operatedByUserId ?? null,
+    };
+    const updated = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      {
+        $set: { accounts: [...others, account], activeAccountId: input.accountId },
+        $inc: { revision: 1 },
+      },
+      { new: true, upsert: true },
+    ).lean<IDeviceSession>();
+    return projectState(updated as IDeviceSession);
+  }
+
+  async switchActive(deviceId: string, accountId: string): Promise<DeviceSessionState | null> {
+    const current = await this.load(deviceId);
+    if (!current || !(current.accounts ?? []).some((a) => idToString(a.accountId) === accountId)) return null;
+    const updated = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      { $set: { activeAccountId: accountId }, $inc: { revision: 1 } },
+      { new: true },
+    ).lean<IDeviceSession>();
+    return projectState(updated as IDeviceSession);
+  }
+
+  async signout(deviceId: string, target: { accountId: string } | { all: true }): Promise<DeviceSessionState> {
+    const current = await this.load(deviceId);
+    if (!current) return this.getState(deviceId);
+    const removing = 'all' in target ? current.accounts ?? [] : (current.accounts ?? []).filter((a) => idToString(a.accountId) === target.accountId);
+    for (const a of removing) {
+      try {
+        await sessionService.deactivateSession(a.sessionId);
+      } catch (error) {
+        logger.warn('deviceSession.signout: deactivate failed', { sessionId: a.sessionId, error });
+      }
+    }
+    const remaining = 'all' in target ? [] : (current.accounts ?? []).filter((a) => idToString(a.accountId) !== target.accountId);
+    const activeStillPresent = remaining.some((a) => idToString(a.accountId) === idToString(current.activeAccountId));
+    const nextActive = activeStillPresent ? idToString(current.activeAccountId) : (remaining[0] ? idToString(remaining[0].accountId) : null);
+    const updated = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      { $set: { accounts: remaining, activeAccountId: nextActive }, $inc: { revision: 1 } },
+      { new: true, upsert: true },
+    ).lean<IDeviceSession>();
+    return projectState(updated as IDeviceSession);
+  }
+}
+
+const deviceSessionService = new DeviceSessionService();
+export default deviceSessionService;

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -82,13 +82,15 @@ class DeviceSessionService {
       { $set: { activeAccountId: accountId }, $inc: { revision: 1 } },
       { new: true },
     ).lean<IDeviceSession>();
-    return projectState(updated as IDeviceSession);
+    if (!updated) return null;
+    return projectState(updated);
   }
 
   async signout(deviceId: string, target: { accountId: string } | { all: true }): Promise<DeviceSessionState> {
     const current = await this.load(deviceId);
     if (!current) return this.getState(deviceId);
     const removing = 'all' in target ? current.accounts ?? [] : (current.accounts ?? []).filter((a) => idToString(a.accountId) === target.accountId);
+    if (!('all' in target) && removing.length === 0) return projectState(current);
     for (const a of removing) {
       try {
         await sessionService.deactivateSession(a.sessionId);

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -86,6 +86,15 @@ class DeviceSessionService {
     return projectState(updated);
   }
 
+  async resolveActiveToken(state: DeviceSessionState): Promise<{ accessToken: string; expiresAt: string } | null> {
+    if (!state.activeAccountId) return null;
+    const account = state.accounts.find((a) => a.accountId === state.activeAccountId);
+    if (!account) return null;
+    const token = await sessionService.getAccessToken(account.sessionId);
+    if (!token) return null;
+    return { accessToken: token.accessToken, expiresAt: token.expiresAt.toISOString() };
+  }
+
   async signout(deviceId: string, target: { accountId: string } | { all: true }): Promise<DeviceSessionState> {
     const current = await this.load(deviceId);
     if (!current) return this.getState(deviceId);

--- a/packages/api/src/utils/__tests__/deviceRoom.test.ts
+++ b/packages/api/src/utils/__tests__/deviceRoom.test.ts
@@ -1,0 +1,10 @@
+import { deviceRoomFor } from '../socket';
+
+describe('deviceRoomFor', () => {
+  it('returns device:<deviceId> when present', () => {
+    expect(deviceRoomFor({ deviceId: 'd1' })).toBe('device:d1');
+  });
+  it('returns null when deviceId is absent', () => {
+    expect(deviceRoomFor({})).toBeNull();
+  });
+});

--- a/packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts
+++ b/packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts
@@ -1,0 +1,23 @@
+jest.mock('../logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+import { initializeIO, closeIO, broadcastDeviceState } from '../socket';
+import type { DeviceSessionState } from '@oxyhq/contracts';
+
+const state: DeviceSessionState = { deviceId: 'd1', accounts: [], activeAccountId: null, revision: 5, updatedAt: 1720000000000 };
+
+afterEach(() => closeIO());
+
+describe('broadcastDeviceState', () => {
+  it('emits session_state to the device room', () => {
+    const emit = jest.fn();
+    const to = jest.fn().mockReturnValue({ emit });
+    initializeIO({ to } as never);
+    broadcastDeviceState(state);
+    expect(to).toHaveBeenCalledWith('device:d1');
+    expect(emit).toHaveBeenCalledWith('session_state', state);
+  });
+
+  it('is a no-op when io is not initialised', () => {
+    closeIO();
+    expect(() => broadcastDeviceState(state)).not.toThrow();
+  });
+});

--- a/packages/api/src/utils/socket.ts
+++ b/packages/api/src/utils/socket.ts
@@ -1,4 +1,6 @@
 import { Server as SocketIOServer } from 'socket.io';
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { logger } from './logger';
 
 let io: SocketIOServer | null = null;
 
@@ -12,7 +14,16 @@ export const getIO = () => {
 
 export const closeIO = () => {
   if (io) {
-    io.close();
+    if (typeof io.close === 'function') io.close();
     io = null;
   }
 };
+
+export function broadcastDeviceState(state: DeviceSessionState): void {
+  const server = getIO();
+  if (!server) {
+    logger.debug('broadcastDeviceState: io not initialised', { deviceId: state.deviceId });
+    return;
+  }
+  server.to(`device:${state.deviceId}`).emit('session_state', state);
+}

--- a/packages/api/src/utils/socket.ts
+++ b/packages/api/src/utils/socket.ts
@@ -27,3 +27,7 @@ export function broadcastDeviceState(state: DeviceSessionState): void {
   }
   server.to(`device:${state.deviceId}`).emit('session_state', state);
 }
+
+export function deviceRoomFor(decoded: { deviceId?: string | null }): string | null {
+  return decoded?.deviceId ? `device:${decoded.deviceId}` : null;
+}

--- a/packages/contracts/src/__tests__/deviceSession.test.ts
+++ b/packages/contracts/src/__tests__/deviceSession.test.ts
@@ -1,0 +1,29 @@
+import { deviceSessionStateSchema, sessionAccountSchema, safeParseContract } from '../index';
+
+describe('deviceSessionStateSchema', () => {
+  const account = { accountId: 'a1', sessionId: 's1', authuser: 0 };
+  const state = { deviceId: 'd1', accounts: [account], activeAccountId: 'a1', revision: 3, updatedAt: 1720000000000 };
+
+  it('parses a valid state', () => {
+    expect(safeParseContract(deviceSessionStateSchema, state)).toEqual(state);
+  });
+
+  it('accepts an optional operatedByUserId on an account', () => {
+    const withOp = { ...account, operatedByUserId: 'op1' };
+    expect(safeParseContract(sessionAccountSchema, withOp)).toEqual(withOp);
+  });
+
+  it('accepts activeAccountId=null (device signed out of all)', () => {
+    const parsed = safeParseContract(deviceSessionStateSchema, { ...state, accounts: [], activeAccountId: null });
+    expect(parsed?.activeAccountId).toBeNull();
+  });
+
+  it('rejects a negative authuser', () => {
+    expect(safeParseContract(sessionAccountSchema, { ...account, authuser: -1 })).toBeNull();
+  });
+
+  it('rejects a state missing revision', () => {
+    const { revision, ...noRev } = state;
+    expect(safeParseContract(deviceSessionStateSchema, noRev)).toBeNull();
+  });
+});

--- a/packages/contracts/src/__tests__/deviceSession.test.ts
+++ b/packages/contracts/src/__tests__/deviceSession.test.ts
@@ -1,4 +1,4 @@
-import { deviceSessionStateSchema, sessionAccountSchema, safeParseContract } from '../index';
+import { deviceSessionStateSchema, sessionAccountSchema, deviceSessionSyncSchema, safeParseContract } from '../index';
 
 describe('deviceSessionStateSchema', () => {
   const account = { accountId: 'a1', sessionId: 's1', authuser: 0 };
@@ -25,5 +25,19 @@ describe('deviceSessionStateSchema', () => {
   it('rejects a state missing revision', () => {
     const { revision, ...noRev } = state;
     expect(safeParseContract(deviceSessionStateSchema, noRev)).toBeNull();
+  });
+});
+
+describe('deviceSessionSyncSchema', () => {
+  const state = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
+  it('parses { state, activeToken }', () => {
+    const v = { state, activeToken: { accessToken: 'jwt', expiresAt: '2026-07-07T00:00:00.000Z' } };
+    expect(safeParseContract(deviceSessionSyncSchema, v)).toEqual(v);
+  });
+  it('accepts activeToken=null', () => {
+    expect(safeParseContract(deviceSessionSyncSchema, { state, activeToken: null })?.activeToken).toBeNull();
+  });
+  it('rejects a state-less sync', () => {
+    expect(safeParseContract(deviceSessionSyncSchema, { activeToken: null })).toBeNull();
   });
 });

--- a/packages/contracts/src/deviceSession.ts
+++ b/packages/contracts/src/deviceSession.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const sessionAccountSchema = z.object({
+  accountId: z.string(),
+  sessionId: z.string(),
+  authuser: z.number().int().nonnegative(),
+  operatedByUserId: z.string().optional(),
+});
+
+export const deviceSessionStateSchema = z.object({
+  deviceId: z.string(),
+  accounts: z.array(sessionAccountSchema),
+  activeAccountId: z.string().nullable(),
+  revision: z.number().int().nonnegative(),
+  updatedAt: z.number(),
+});
+
+export type SessionAccount = z.infer<typeof sessionAccountSchema>;
+export type DeviceSessionState = z.infer<typeof deviceSessionStateSchema>;

--- a/packages/contracts/src/deviceSession.ts
+++ b/packages/contracts/src/deviceSession.ts
@@ -15,5 +15,17 @@ export const deviceSessionStateSchema = z.object({
   updatedAt: z.number(),
 });
 
+export const activeTokenSchema = z.object({
+  accessToken: z.string(),
+  expiresAt: z.string(),
+});
+
+export const deviceSessionSyncSchema = z.object({
+  state: deviceSessionStateSchema,
+  activeToken: activeTokenSchema.nullable(),
+});
+
 export type SessionAccount = z.infer<typeof sessionAccountSchema>;
 export type DeviceSessionState = z.infer<typeof deviceSessionStateSchema>;
+export type ActiveToken = z.infer<typeof activeTokenSchema>;
+export type DeviceSessionSync = z.infer<typeof deviceSessionSyncSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -201,3 +201,7 @@ export type {
     LinkPreviewBatchRequest,
     LinkPreviewBatchResponse,
 } from './links';
+
+export { sessionAccountSchema, deviceSessionStateSchema } from './deviceSession';
+
+export type { SessionAccount, DeviceSessionState } from './deviceSession';

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -202,6 +202,16 @@ export type {
     LinkPreviewBatchResponse,
 } from './links';
 
-export { sessionAccountSchema, deviceSessionStateSchema } from './deviceSession';
+export {
+    sessionAccountSchema,
+    deviceSessionStateSchema,
+    activeTokenSchema,
+    deviceSessionSyncSchema,
+} from './deviceSession';
 
-export type { SessionAccount, DeviceSessionState } from './deviceSession';
+export type {
+    SessionAccount,
+    DeviceSessionState,
+    ActiveToken,
+    DeviceSessionSync,
+} from './deviceSession';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -562,6 +562,12 @@ export type {
     RunColdBootOptions,
 } from './utils/coldBoot';
 
+// ---------------------------------------------------------------------------
+// Session sync (device-scoped multi-account session client)
+// ---------------------------------------------------------------------------
+export { SessionClient } from './session/SessionClient';
+export type { TokenTransport, SessionClientHost, SessionClientOptions } from './session/SessionClient';
+
 // API response contracts (request/response Zod schemas + inferred types) live in
 // `@oxyhq/contracts` — the single source of truth shared by the backend and every
 // client SDK. Import them directly from `@oxyhq/contracts`; `@oxyhq/core` does NOT

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -81,37 +81,43 @@ export class SessionClient {
     return true;
   }
 
-  /** Validate `{ state, activeToken }`, apply the state, and plant the active token host-side. */
+  /**
+   * Validate `{ state, activeToken }`, apply the state, and plant the active token host-side.
+   * Token-planting is decoupled from whether `applyState` advanced the revision: a socket push
+   * followed by this same `GET /state` fetch returns the SAME revision (applyState no-ops), but
+   * the token still needs to be planted. The account-match guard rejects a stale response for an
+   * account that is no longer active.
+   */
   private applySync(raw: unknown): void {
     const sync = safeParseContract(deviceSessionSyncSchema, raw);
     if (!sync) {
       logger.warn('[SessionClient] discarded invalid session sync');
       return;
     }
-    const applied = this.applyState(sync.state);
-    if (applied && sync.activeToken) {
+    this.applyState(sync.state);
+    if (sync.activeToken && this.state && sync.state.activeAccountId === this.state.activeAccountId) {
       this.host.setTokens(sync.activeToken.accessToken);
     }
   }
 
   async bootstrap(): Promise<void> {
-    const raw = await this.host.makeRequest<unknown>('GET', '/session/device/state', undefined, { cache: false });
-    this.applySync(raw);
+    const res = await this.host.makeRequest<{ data?: unknown }>('GET', '/session/device/state', undefined, { cache: false });
+    this.applySync(res?.data);
   }
 
   async switchAccount(accountId: string): Promise<void> {
-    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/switch', { accountId }, { cache: false });
-    this.applySync(raw);
+    const res = await this.host.makeRequest<{ data?: unknown }>('POST', '/session/device/switch', { accountId }, { cache: false });
+    this.applySync(res?.data);
   }
 
   async signOut(target: { accountId: string } | { all: true }): Promise<void> {
-    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
-    this.applySync(raw);
+    const res = await this.host.makeRequest<{ data?: unknown }>('POST', '/session/device/signout', target, { cache: false });
+    this.applySync(res?.data);
   }
 
   async addCurrentAccount(): Promise<void> {
-    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
-    this.applySync(raw);
+    const res = await this.host.makeRequest<{ data?: unknown }>('POST', '/session/device/add', undefined, { cache: false });
+    this.applySync(res?.data);
   }
 
   async start(): Promise<void> {

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -1,4 +1,9 @@
-import { deviceSessionStateSchema, safeParseContract, type DeviceSessionState } from '@oxyhq/contracts';
+import {
+  deviceSessionStateSchema,
+  deviceSessionSyncSchema,
+  safeParseContract,
+  type DeviceSessionState,
+} from '@oxyhq/contracts';
 import { logger } from '../utils/loggerUtils';
 import { getSocketIO } from './socketLoader';
 import type { MinimalSocket } from './socketLoader';
@@ -13,6 +18,8 @@ export interface SessionClientHost {
   getBaseURL(): string;
   getAccessToken(): string | null;
   onTokensChanged(listener: (token: string | null) => void): () => void;
+  setTokens(accessToken: string): void;
+  getCurrentAccountId(): string | null;
 }
 
 export interface SessionClientOptions {
@@ -74,24 +81,37 @@ export class SessionClient {
     return true;
   }
 
+  /** Validate `{ state, activeToken }`, apply the state, and plant the active token host-side. */
+  private applySync(raw: unknown): void {
+    const sync = safeParseContract(deviceSessionSyncSchema, raw);
+    if (!sync) {
+      logger.warn('[SessionClient] discarded invalid session sync');
+      return;
+    }
+    const applied = this.applyState(sync.state);
+    if (applied && sync.activeToken) {
+      this.host.setTokens(sync.activeToken.accessToken);
+    }
+  }
+
   async bootstrap(): Promise<void> {
     const raw = await this.host.makeRequest<unknown>('GET', '/session/device/state', undefined, { cache: false });
-    this.applyState(raw);
+    this.applySync(raw);
   }
 
   async switchAccount(accountId: string): Promise<void> {
     const raw = await this.host.makeRequest<unknown>('POST', '/session/device/switch', { accountId }, { cache: false });
-    this.applyState(raw);
+    this.applySync(raw);
   }
 
   async signOut(target: { accountId: string } | { all: true }): Promise<void> {
     const raw = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
-    this.applyState(raw);
+    this.applySync(raw);
   }
 
   async addCurrentAccount(): Promise<void> {
     const raw = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
-    this.applyState(raw);
+    this.applySync(raw);
   }
 
   async start(): Promise<void> {
@@ -134,7 +154,15 @@ export class SessionClient {
       },
     });
     socket.on('session_state', (payload: unknown) => {
-      this.applyState(payload);
+      const applied = this.applyState(payload);
+      if (applied) {
+        const active = this.state?.activeAccountId ?? null;
+        if (active && active !== this.host.getCurrentAccountId()) {
+          void this.bootstrap().catch((error) => {
+            logger.warn('[SessionClient] post-push token fetch failed', { component: 'SessionClient' }, error);
+          });
+        }
+      }
     });
     this.socket = socket;
   }

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -72,4 +72,24 @@ export class SessionClient {
     }
     return true;
   }
+
+  async bootstrap(): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('GET', '/session/device/state', undefined, { cache: false });
+    this.applyState(raw);
+  }
+
+  async switchAccount(accountId: string): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/switch', { accountId }, { cache: false });
+    this.applyState(raw);
+  }
+
+  async signOut(target: { accountId: string } | { all: true }): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
+    this.applyState(raw);
+  }
+
+  async addCurrentAccount(): Promise<void> {
+    const raw = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
+    this.applyState(raw);
+  }
 }

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -1,5 +1,6 @@
 import { deviceSessionStateSchema, safeParseContract, type DeviceSessionState } from '@oxyhq/contracts';
 import { logger } from '../utils/loggerUtils';
+import { getSocketIO } from './socketLoader';
 import type { MinimalSocket } from './socketLoader';
 
 export interface TokenTransport {
@@ -91,5 +92,50 @@ export class SessionClient {
   async addCurrentAccount(): Promise<void> {
     const raw = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
     this.applyState(raw);
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    this.tokenUnsub = this.host.onTokensChanged((token) => {
+      if (token && this.socket && !this.socket.connected) {
+        this.socket.connect();
+      }
+    });
+    await this.bootstrap();
+    await this.connectSocket();
+  }
+
+  stop(): void {
+    this.started = false;
+    if (this.tokenUnsub) {
+      this.tokenUnsub();
+      this.tokenUnsub = null;
+    }
+    if (this.socket) {
+      this.socket.disconnect();
+      this.socket = null;
+    }
+  }
+
+  private async connectSocket(): Promise<void> {
+    const io = await getSocketIO();
+    if (!io) {
+      logger.warn('[SessionClient] no socket.io-client; running REST-only (no realtime sync)', { component: 'SessionClient' });
+      return;
+    }
+    if (!this.started) return; // stopped while the dynamic import was in flight
+    const hasToken = Boolean(this.host.getAccessToken());
+    const socket = io(this.host.getBaseURL(), {
+      transports: ['websocket'],
+      autoConnect: hasToken,
+      auth: (cb: (data: { token: string }) => void) => {
+        cb({ token: this.host.getAccessToken() ?? '' });
+      },
+    });
+    socket.on('session_state', (payload: unknown) => {
+      this.applyState(payload);
+    });
+    this.socket = socket;
   }
 }

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -1,0 +1,75 @@
+import { deviceSessionStateSchema, safeParseContract, type DeviceSessionState } from '@oxyhq/contracts';
+import { logger } from '../utils/loggerUtils';
+import type { MinimalSocket } from './socketLoader';
+
+export interface TokenTransport {
+  /** Ensure this app holds a per-domain access token for state.activeAccountId (mint via FedCM/silent/sso/keychain). Best-effort. */
+  ensureActiveToken(state: DeviceSessionState): Promise<void>;
+}
+
+export interface SessionClientHost {
+  makeRequest<T>(method: 'GET' | 'POST', url: string, data?: unknown, options?: { cache?: boolean }): Promise<T>;
+  getBaseURL(): string;
+  getAccessToken(): string | null;
+  onTokensChanged(listener: (token: string | null) => void): () => void;
+}
+
+export interface SessionClientOptions {
+  transport?: TokenTransport;
+}
+
+type StateListener = (state: DeviceSessionState | null) => void;
+
+export class SessionClient {
+  private state: DeviceSessionState | null = null;
+  private readonly listeners = new Set<StateListener>();
+  protected socket: MinimalSocket | null = null;
+  private tokenUnsub: (() => void) | null = null;
+  private started = false;
+
+  constructor(
+    protected readonly host: SessionClientHost,
+    protected readonly options: SessionClientOptions = {},
+  ) {}
+
+  getState(): DeviceSessionState | null {
+    return this.state;
+  }
+
+  subscribe(listener: StateListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  protected notify(): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(this.state);
+      } catch (error) {
+        logger.error('[SessionClient] subscriber threw', error);
+      }
+    }
+  }
+
+  /** Validate + last-writer-wins by revision. Returns true if applied. */
+  protected applyState(raw: unknown): boolean {
+    const next = safeParseContract(deviceSessionStateSchema, raw);
+    if (!next) {
+      logger.warn('[SessionClient] discarded invalid session state');
+      return false;
+    }
+    if (this.state && next.revision <= this.state.revision) {
+      return false;
+    }
+    this.state = next;
+    this.notify();
+    if (this.options.transport) {
+      void this.options.transport.ensureActiveToken(next).catch((error) => {
+        logger.warn('[SessionClient] ensureActiveToken failed', { component: 'SessionClient' }, error);
+      });
+    }
+    return true;
+  }
+}

--- a/packages/core/src/session/__tests__/SessionClient.rest.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.rest.test.ts
@@ -16,7 +16,8 @@ function makeHost(makeRequest: jest.Mock): SessionClientHost {
   };
 }
 
-const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
+// The server wraps the sync payload in a REST `{ data }` envelope; makeRequest does NOT unwrap it.
+const SYNC = (rev: number) => ({ data: { state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } } });
 
 describe('SessionClient REST', () => {
   it('bootstrap GETs /session/device/state and applies it', async () => {
@@ -68,7 +69,7 @@ describe('SessionClient REST', () => {
   });
 
   it('applies state but does not plant a token when activeToken is null', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce({ state: STATE(7), activeToken: null });
+    const makeRequest = jest.fn().mockResolvedValueOnce({ data: { state: STATE(7), activeToken: null } });
     const host = makeHost(makeRequest);
     const c = new SessionClient(host);
     await c.bootstrap();

--- a/packages/core/src/session/__tests__/SessionClient.rest.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.rest.test.ts
@@ -6,42 +6,55 @@ const STATE = (rev: number): DeviceSessionState => ({
 });
 
 function makeHost(makeRequest: jest.Mock): SessionClientHost {
-  return { makeRequest, getBaseURL: () => 'http://test.invalid', getAccessToken: () => 't', onTokensChanged: () => () => undefined };
+  return {
+    makeRequest,
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 't',
+    onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => null,
+  };
 }
+
+const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
 
 describe('SessionClient REST', () => {
   it('bootstrap GETs /session/device/state and applies it', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(3));
-    const c = new SessionClient(makeHost(makeRequest));
+    const makeRequest = jest.fn().mockResolvedValueOnce(SYNC(3));
+    const host = makeHost(makeRequest);
+    const c = new SessionClient(host);
     await c.bootstrap();
     expect(makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
     expect(c.getState()?.revision).toBe(3);
+    expect(host.setTokens).toHaveBeenCalledWith('jwt-3');
   });
 
   it('switchAccount POSTs and applies the returned state', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(4));
-    const c = new SessionClient(makeHost(makeRequest));
+    const makeRequest = jest.fn().mockResolvedValueOnce(SYNC(4));
+    const host = makeHost(makeRequest);
+    const c = new SessionClient(host);
     await c.switchAccount('a1');
     expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/switch', { accountId: 'a1' }, { cache: false });
     expect(c.getState()?.revision).toBe(4);
+    expect(host.setTokens).toHaveBeenCalledWith('jwt-4');
   });
 
   it('signOut one account POSTs { accountId }', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(5));
+    const makeRequest = jest.fn().mockResolvedValueOnce(SYNC(5));
     const c = new SessionClient(makeHost(makeRequest));
     await c.signOut({ accountId: 'a1' });
     expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { accountId: 'a1' }, { cache: false });
   });
 
   it('signOut all POSTs { all: true }', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(6));
+    const makeRequest = jest.fn().mockResolvedValueOnce(SYNC(6));
     const c = new SessionClient(makeHost(makeRequest));
     await c.signOut({ all: true });
     expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { all: true }, { cache: false });
   });
 
   it('addCurrentAccount POSTs /session/device/add with no body', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(2));
+    const makeRequest = jest.fn().mockResolvedValueOnce(SYNC(2));
     const c = new SessionClient(makeHost(makeRequest));
     await c.addCurrentAccount();
     expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/add', undefined, { cache: false });
@@ -52,5 +65,14 @@ describe('SessionClient REST', () => {
     const c = new SessionClient(makeHost(makeRequest));
     await c.bootstrap();
     expect(c.getState()).toBeNull();
+  });
+
+  it('applies state but does not plant a token when activeToken is null', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce({ state: STATE(7), activeToken: null });
+    const host = makeHost(makeRequest);
+    const c = new SessionClient(host);
+    await c.bootstrap();
+    expect(c.getState()?.revision).toBe(7);
+    expect(host.setTokens).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/session/__tests__/SessionClient.rest.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.rest.test.ts
@@ -1,0 +1,56 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+
+const STATE = (rev: number): DeviceSessionState => ({
+  deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000,
+});
+
+function makeHost(makeRequest: jest.Mock): SessionClientHost {
+  return { makeRequest, getBaseURL: () => 'http://test.invalid', getAccessToken: () => 't', onTokensChanged: () => () => undefined };
+}
+
+describe('SessionClient REST', () => {
+  it('bootstrap GETs /session/device/state and applies it', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(3));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.bootstrap();
+    expect(makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    expect(c.getState()?.revision).toBe(3);
+  });
+
+  it('switchAccount POSTs and applies the returned state', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(4));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.switchAccount('a1');
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/switch', { accountId: 'a1' }, { cache: false });
+    expect(c.getState()?.revision).toBe(4);
+  });
+
+  it('signOut one account POSTs { accountId }', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(5));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.signOut({ accountId: 'a1' });
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { accountId: 'a1' }, { cache: false });
+  });
+
+  it('signOut all POSTs { all: true }', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(6));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.signOut({ all: true });
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { all: true }, { cache: false });
+  });
+
+  it('addCurrentAccount POSTs /session/device/add with no body', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(STATE(2));
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.addCurrentAccount();
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/add', undefined, { cache: false });
+  });
+
+  it('does not throw / does not apply when the server returns invalid state', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce({ bogus: true });
+    const c = new SessionClient(makeHost(makeRequest));
+    await c.bootstrap();
+    expect(c.getState()).toBeNull();
+  });
+});

--- a/packages/core/src/session/__tests__/SessionClient.socket.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.socket.test.ts
@@ -21,13 +21,16 @@ jest.mock('socket.io-client', () => ({ __esModule: true, io: (...args: unknown[]
 import { SessionClient, type SessionClientHost } from '../SessionClient';
 
 const STATE = (rev: number): DeviceSessionState => ({ deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000 });
+const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
 
 function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
   return {
-    makeRequest: jest.fn().mockResolvedValue(STATE(1)),
+    makeRequest: jest.fn().mockResolvedValue(SYNC(1)),
     getBaseURL: () => 'http://test.invalid',
     getAccessToken: () => 'tok',
     onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => 'a1',
     ...over,
   };
 }
@@ -54,6 +57,30 @@ describe('SessionClient socket', () => {
     await c.start();
     fakeSocket.trigger('session_state', STATE(9));
     expect(c.getState()?.revision).toBe(9);
+    c.stop();
+  });
+
+  it('fetches the active token via bootstrap when a pushed state changes the active account', async () => {
+    const makeRequest = jest.fn().mockResolvedValue(SYNC(1));
+    const host = makeHost({ makeRequest, getCurrentAccountId: () => 'other-account' });
+    const c = new SessionClient(host);
+    await c.start();
+    makeRequest.mockClear();
+    fakeSocket.trigger('session_state', STATE(9));
+    await Promise.resolve();
+    expect(makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    c.stop();
+  });
+
+  it('does not re-fetch when the pushed active account matches the host-held account', async () => {
+    const makeRequest = jest.fn().mockResolvedValue(SYNC(1));
+    const host = makeHost({ makeRequest, getCurrentAccountId: () => 'a1' });
+    const c = new SessionClient(host);
+    await c.start();
+    makeRequest.mockClear();
+    fakeSocket.trigger('session_state', STATE(9));
+    await Promise.resolve();
+    expect(makeRequest).not.toHaveBeenCalled();
     c.stop();
   });
 

--- a/packages/core/src/session/__tests__/SessionClient.socket.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.socket.test.ts
@@ -21,7 +21,8 @@ jest.mock('socket.io-client', () => ({ __esModule: true, io: (...args: unknown[]
 import { SessionClient, type SessionClientHost } from '../SessionClient';
 
 const STATE = (rev: number): DeviceSessionState => ({ deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000 });
-const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
+// The server wraps the sync payload in a REST `{ data }` envelope; makeRequest does NOT unwrap it.
+const SYNC = (rev: number) => ({ data: { state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } } });
 
 function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
   return {
@@ -69,6 +70,25 @@ describe('SessionClient socket', () => {
     fakeSocket.trigger('session_state', STATE(9));
     await Promise.resolve();
     expect(makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    c.stop();
+  });
+
+  it('C1 regression: plants the active token on a socket-pushed switch even when the post-push bootstrap returns the SAME revision as the push', async () => {
+    const setTokens = jest.fn();
+    const makeRequest = jest
+      .fn()
+      .mockResolvedValueOnce(SYNC(1)) // initial bootstrap in start()
+      .mockResolvedValue(SYNC(9)); // post-push bootstrap: same revision as the socket push below
+    const host = makeHost({ makeRequest, setTokens, getCurrentAccountId: () => 'other-account' });
+    const c = new SessionClient(host);
+    await c.start();
+    makeRequest.mockClear();
+    setTokens.mockClear();
+    fakeSocket.trigger('session_state', STATE(9));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    expect(setTokens).toHaveBeenCalledWith('jwt-9');
     c.stop();
   });
 

--- a/packages/core/src/session/__tests__/SessionClient.socket.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.socket.test.ts
@@ -1,0 +1,85 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+
+type Handler = (...args: unknown[]) => void;
+class FakeSocket {
+  connected = false;
+  handlers = new Map<string, Handler[]>();
+  on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
+  off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+  connect() { this.connected = true; this.trigger('connect'); }
+  disconnect() { this.connected = false; }
+  trigger(event: string, ...args: unknown[]) { for (const h of this.handlers.get(event) ?? []) h(...args); }
+}
+let fakeSocket: FakeSocket;
+const ioMock = jest.fn((_uri: string, opts?: Record<string, unknown>) => {
+  // honor autoConnect like real socket.io (connect immediately unless autoConnect:false)
+  if (!opts || opts.autoConnect !== false) fakeSocket.connected = true;
+  return fakeSocket;
+});
+jest.mock('socket.io-client', () => ({ __esModule: true, io: (...args: unknown[]) => ioMock(...(args as [string, Record<string, unknown>?])) }));
+
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+
+const STATE = (rev: number): DeviceSessionState => ({ deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000 });
+
+function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
+  return {
+    makeRequest: jest.fn().mockResolvedValue(STATE(1)),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 'tok',
+    onTokensChanged: () => () => undefined,
+    ...over,
+  };
+}
+
+beforeEach(() => { fakeSocket = new FakeSocket(); ioMock.mockClear(); });
+
+describe('SessionClient socket', () => {
+  it('start() bootstraps then opens ONE socket to the base URL with a token-in-handshake auth callback', async () => {
+    const host = makeHost();
+    const c = new SessionClient(host);
+    await c.start();
+    expect(host.makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    expect(ioMock).toHaveBeenCalledTimes(1);
+    const [uri, opts] = ioMock.mock.calls[0];
+    expect(uri).toBe('http://test.invalid');
+    const authCb = jest.fn();
+    (opts?.auth as (cb: (d: { token: string }) => void) => void)(authCb);
+    expect(authCb).toHaveBeenCalledWith({ token: 'tok' });
+    c.stop();
+  });
+
+  it('applies a pushed session_state event', async () => {
+    const c = new SessionClient(makeHost());
+    await c.start();
+    fakeSocket.trigger('session_state', STATE(9));
+    expect(c.getState()?.revision).toBe(9);
+    c.stop();
+  });
+
+  it('does not connect the socket when there is no token (autoConnect false)', async () => {
+    const c = new SessionClient(makeHost({ getAccessToken: () => null }));
+    await c.start();
+    const [, opts] = ioMock.mock.calls[0];
+    expect(opts?.autoConnect).toBe(false);
+    c.stop();
+  });
+
+  it('reconnects when a token arrives after being disconnected', async () => {
+    let tokenListener: ((t: string | null) => void) | null = null;
+    const host = makeHost({ getAccessToken: () => null, onTokensChanged: (l) => { tokenListener = l; return () => undefined; } });
+    const c = new SessionClient(host);
+    await c.start();
+    fakeSocket.connected = false;
+    tokenListener?.('fresh-token');
+    expect(fakeSocket.connected).toBe(true);
+    c.stop();
+  });
+
+  it('stop() disconnects the socket', async () => {
+    const c = new SessionClient(makeHost());
+    await c.start();
+    c.stop();
+    expect(fakeSocket.connected).toBe(false);
+  });
+});

--- a/packages/core/src/session/__tests__/SessionClient.state.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.state.test.ts
@@ -1,0 +1,62 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { SessionClient, type SessionClientHost, type TokenTransport } from '../SessionClient';
+
+function makeHost(): SessionClientHost {
+  return {
+    makeRequest: jest.fn(),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 't',
+    onTokensChanged: () => () => undefined,
+  };
+}
+const STATE = (rev: number, active: string | null = 'a1'): DeviceSessionState => ({
+  deviceId: 'd1', accounts: active ? [{ accountId: 'a1', sessionId: 's1', authuser: 0 }] : [], activeAccountId: active, revision: rev, updatedAt: 1720000000000,
+});
+
+// SessionClient.applyState is protected; a tiny subclass exposes it for the unit test.
+class TestClient extends SessionClient { public apply(raw: unknown): boolean { return this.applyState(raw); } }
+
+describe('SessionClient state', () => {
+  it('starts with null state', () => {
+    expect(new SessionClient(makeHost()).getState()).toBeNull();
+  });
+
+  it('applies a valid state and notifies subscribers', () => {
+    const c = new TestClient(makeHost());
+    const seen: (DeviceSessionState | null)[] = [];
+    c.subscribe((s) => seen.push(s));
+    expect(c.apply(STATE(1))).toBe(true);
+    expect(c.getState()?.revision).toBe(1);
+    expect(seen.at(-1)?.revision).toBe(1);
+  });
+
+  it('ignores a stale or equal revision (last-writer-wins)', () => {
+    const c = new TestClient(makeHost());
+    c.apply(STATE(5));
+    expect(c.apply(STATE(5))).toBe(false);
+    expect(c.apply(STATE(4))).toBe(false);
+    expect(c.getState()?.revision).toBe(5);
+  });
+
+  it('rejects an invalid (unvalidated) state without applying', () => {
+    const c = new TestClient(makeHost());
+    expect(c.apply({ deviceId: 'd1', accounts: 'nope', revision: 1 })).toBe(false);
+    expect(c.getState()).toBeNull();
+  });
+
+  it('calls transport.ensureActiveToken when a state is applied', () => {
+    const transport: TokenTransport = { ensureActiveToken: jest.fn().mockResolvedValue(undefined) };
+    const c = new TestClient(makeHost(), { transport });
+    c.apply(STATE(1));
+    expect(transport.ensureActiveToken).toHaveBeenCalledWith(expect.objectContaining({ revision: 1 }));
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const c = new TestClient(makeHost());
+    const seen: unknown[] = [];
+    const off = c.subscribe((s) => seen.push(s));
+    off();
+    c.apply(STATE(1));
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/packages/core/src/session/__tests__/SessionClient.state.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.state.test.ts
@@ -7,6 +7,8 @@ function makeHost(): SessionClientHost {
     getBaseURL: () => 'http://test.invalid',
     getAccessToken: () => 't',
     onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => null,
   };
 }
 const STATE = (rev: number, active: string | null = 'a1'): DeviceSessionState => ({

--- a/packages/core/src/session/socketLoader.ts
+++ b/packages/core/src/session/socketLoader.ts
@@ -1,0 +1,28 @@
+import { logger } from '../utils/loggerUtils';
+
+export interface MinimalSocket {
+  connected: boolean;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  off(event: string, handler?: (...args: unknown[]) => void): void;
+  connect(): void;
+  disconnect(): void;
+}
+
+export type SocketIOFactory = (uri: string, opts?: Record<string, unknown>) => MinimalSocket;
+
+let cachedFactory: SocketIOFactory | null = null;
+let loadAttempted = false;
+
+export async function getSocketIO(): Promise<SocketIOFactory | null> {
+  if (cachedFactory) return cachedFactory;
+  if (loadAttempted) return null;
+  loadAttempted = true;
+  try {
+    const mod = (await import('socket.io-client')) as { io?: SocketIOFactory; default?: SocketIOFactory };
+    cachedFactory = mod.io ?? mod.default ?? null;
+    return cachedFactory;
+  } catch (error) {
+    logger.warn('[SessionClient] socket.io-client import failed; realtime session sync disabled', { component: 'SessionClient' }, error);
+    return null;
+  }
+}


### PR DESCRIPTION
## What

Additive foundation for the centralized cross-domain session-sync redesign (one device session, synced across apps/domains). **No client is wired yet; `/auth/*` + `oxy_rt` are untouched — zero behavior change for existing apps.**

- **Phase 1 — server authority:** `DeviceSession` model (device account set + monotonic `revision`), `deviceSession.service` (get/add/switch/signout + `resolveActiveToken`), REST `/session/device/{state,add,switch,signout}` (auth + `requireSameSiteOrigin`; `deviceId` derived from bearer; responds `{data:{state, activeToken}}`), `broadcastDeviceState` → Socket.IO room `device:<deviceId>` (**state only, never a token**), device-room join on connect.
- **Phase 2 — `@oxyhq/core` `SessionClient`:** framework-agnostic client — state + revision-gated `applyState` (validated by `safeParseContract`) + REST + socket lifecycle (lazy `socket.io-client`, `session_state` event, token-change reconnect) + injectable `TokenTransport`.
- **Phase 3 — active-account token propagation:** server returns the active account's token (minted from its on-device session) in REST responses; the socket stays token-free; the client plants it (decoupled from revision advance, account-match guarded) and re-`GET /state` on a socket push. New `deviceSessionSyncSchema`.

## Verification
- **API suite green: 136 suites / 1267 tests.** Core suite green: 60 / 745.
- Whole-branch capstone review: security model sound (socket never carries a token; `deviceId` server-derived from bearer; `resolveActiveToken` only mints for accounts on the device; no IDOR). Two test-masked defects found + fixed (C1 socket-pushed token plant; I2 `{data}` envelope unwrap).

## Not in this PR (browser-verification-gated, follow-ups)
Central `deviceId` unification (IdP — required for true cross-apex sync), wiring `SessionClient` + bootstrap `TokenTransport` into `OxyContext`/`WebOxyProvider`, and deleting `oxy_rt`/`/auth/refresh*`. Design spec + phase plans included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)