### PR TITLE
feat(session): cross-apex deviceId unification (chain central deviceId into RP sessions)

### DIFF
--- a/packages/api/src/controllers/__tests__/sessionAccess.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/sessionAccess.controller.test.ts
@@ -116,7 +116,7 @@ jest.mock('../../server', () => ({
   emitSessionUpdate: jest.fn(),
 }));
 
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { SessionController } from '../session.controller';
 import type { AuthRequest } from '../../middleware/auth';
 
@@ -219,5 +219,64 @@ describe('SessionController.getUserSessions (C1)', () => {
     expect(res.json).toHaveBeenCalledWith([
       expect.objectContaining({ sessionId: TARGET_SESSION_ID, deviceId: 'dev-1' }),
     ]);
+  });
+});
+
+describe('SessionController.validateSession (deviceId chaining)', () => {
+  it('includes deviceId in the response so the IdP can chain it into new sessions', async () => {
+    const expiresAt = new Date('2026-08-01T00:00:00.000Z');
+    const lastActive = new Date('2026-07-01T00:00:00.000Z');
+    mockValidateSessionById.mockResolvedValueOnce({
+      session: {
+        userId: SESSION_OWNER_ID,
+        sessionId: TARGET_SESSION_ID,
+        deviceId: 'dev-xyz',
+        expiresAt,
+        deviceInfo: { lastActive },
+      },
+      user: { _id: SESSION_OWNER_ID, username: 'me' },
+    });
+    const req = { params: { sessionId: TARGET_SESSION_ID }, header: jest.fn().mockReturnValue(undefined) } as unknown as Request;
+    const res = createMockRes();
+
+    await SessionController.validateSession(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      valid: true,
+      expiresAt: expiresAt.toISOString(),
+      lastActivity: lastActive.toISOString(),
+      deviceId: 'dev-xyz',
+      user: { id: SESSION_OWNER_ID, username: 'me' },
+    });
+  });
+});
+
+describe('SessionController.validateSessionFromHeader (deviceId chaining)', () => {
+  it('includes deviceId in the response so the IdP can chain it into new sessions', async () => {
+    const expiresAt = new Date('2026-08-01T00:00:00.000Z');
+    const lastActive = new Date('2026-07-01T00:00:00.000Z');
+    mockValidateSessionById.mockResolvedValueOnce({
+      session: {
+        userId: SESSION_OWNER_ID,
+        sessionId: TARGET_SESSION_ID,
+        deviceId: 'dev-xyz',
+        expiresAt,
+        deviceInfo: { lastActive },
+      },
+      user: { _id: SESSION_OWNER_ID, username: 'me' },
+    });
+    const req = { params: { sessionId: TARGET_SESSION_ID }, header: jest.fn().mockReturnValue(undefined) } as unknown as Request;
+    const res = createMockRes();
+
+    await SessionController.validateSessionFromHeader(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      valid: true,
+      expiresAt: expiresAt.toISOString(),
+      lastActivity: lastActive.toISOString(),
+      deviceId: 'dev-xyz',
+      user: { id: SESSION_OWNER_ID, username: 'me' },
+      sessionId: TARGET_SESSION_ID,
+    });
   });
 });

--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -1273,10 +1273,11 @@ export class SessionController {
         return res.status(500).json({ message: 'Failed to format user data' });
       }
 
-      res.json({ 
+      res.json({
         valid: true,
         expiresAt: result.session.expiresAt.toISOString(),
         lastActivity: result.session.deviceInfo.lastActive.toISOString(),
+        deviceId: result.session.deviceId,
         user: userData
       });
     } catch (error) {
@@ -1320,10 +1321,11 @@ export class SessionController {
         return res.status(500).json({ message: 'Failed to format user data' });
       }
 
-      res.json({ 
+      res.json({
         valid: true,
         expiresAt: result.session.expiresAt.toISOString(),
         lastActivity: result.session.deviceInfo.lastActive.toISOString(),
+        deviceId: result.session.deviceId,
         user: userData,
         sessionId: result.session.sessionId
       });

--- a/packages/api/src/services/__tests__/fedcm.service.test.ts
+++ b/packages/api/src/services/__tests__/fedcm.service.test.ts
@@ -122,6 +122,7 @@ interface MintTokenOptions {
   exp?: number;
   iat?: number;
   nonce?: string;
+  deviceId?: string;
 }
 
 function mintToken(opts: MintTokenOptions = {}): string {
@@ -134,6 +135,7 @@ function mintToken(opts: MintTokenOptions = {}): string {
       exp: opts.exp ?? Math.floor(Date.now() / 1000) + 60,
       iat: opts.iat ?? Math.floor(Date.now() / 1000),
       nonce: opts.nonce ?? 'nonce-raw-abc',
+      ...(opts.deviceId ? { deviceId: opts.deviceId } : {}),
     })
   );
   const sig = crypto
@@ -279,6 +281,28 @@ describe('FedCM exchangeIdToken (H9)', () => {
       deviceName: 'FedCM Sign-In',
       stableDeviceKey: APPROVED_ORIGIN,
     });
+  });
+
+  it('threads an explicit deviceId claim from the id_token into createSession (device unification)', async () => {
+    const token = mintToken({ deviceId: 'central-device-abc123' });
+    const result = await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(mockCreateSession).toHaveBeenCalledWith('user-123', expect.anything(), {
+      deviceName: 'FedCM Sign-In',
+      stableDeviceKey: APPROVED_ORIGIN,
+      deviceId: 'central-device-abc123',
+    });
+  });
+
+  it('omits deviceId from createSession options when the id_token carries no deviceId claim (backward-compat)', async () => {
+    const token = mintToken();
+    await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    const optionsArg = mockCreateSession.mock.calls[0][2] as Record<string, unknown>;
+    expect(optionsArg).not.toHaveProperty('deviceId');
   });
 
   it('accepts a first-party auth.<audience-apex> issuer for multi-domain FedCM', async () => {

--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -344,6 +344,90 @@ describe('Session Service', () => {
     });
   });
 
+  /**
+   * Explicit `deviceId` option (device unification plumbing).
+   *
+   * An explicit central deviceId (e.g. threaded from a FedCM id_token
+   * `deviceId` claim) is used VERBATIM — bypassing both the UA/IP-derived
+   * default and the `stableDeviceKey` derivation. Precedence: deviceId >
+   * stableDeviceKey > UA/IP > random.
+   */
+  describe('createSession with an explicit deviceId (unification)', () => {
+    const SAVED_SALT = process.env.DEVICE_ID_SALT;
+
+    afterEach(() => {
+      if (SAVED_SALT === undefined) {
+        delete process.env.DEVICE_ID_SALT;
+      } else {
+        process.env.DEVICE_ID_SALT = SAVED_SALT;
+      }
+    });
+
+    it('uses the explicit deviceId verbatim as the created session deviceId', async () => {
+      mockFindOneResults.push(null); // isNewDevice check: none
+      mockFindOneResults.push(null); // active-session reuse lookup: none
+      mockSave.mockResolvedValueOnce(undefined);
+
+      const result = await sessionService.createSession('user-123', createMockRequest(), {
+        deviceName: 'FedCM Sign-In',
+        deviceId: 'central-device-abc123',
+      });
+
+      expect(result.deviceId).toBe('central-device-abc123');
+      const ctorArgs = (Session as unknown as jest.Mock).mock.calls[0][0] as { deviceId?: string };
+      expect(ctorArgs.deviceId).toBe('central-device-abc123');
+    });
+
+    it('takes precedence over stableDeviceKey when both are supplied', async () => {
+      process.env.DEVICE_ID_SALT = 'x'.repeat(48);
+      mockFindOneResults.push(null); // isNewDevice check: none
+      mockFindOneResults.push(null); // active-session reuse lookup: none
+      mockSave.mockResolvedValueOnce(undefined);
+
+      const result = await sessionService.createSession('user-123', createMockRequest(), {
+        deviceName: 'FedCM Sign-In',
+        stableDeviceKey: 'https://relying.party.example',
+        deviceId: 'central-device-wins',
+      });
+
+      // The explicit deviceId wins outright — it is NOT the 32-hex-char
+      // derived stableDeviceKey id.
+      expect(result.deviceId).toBe('central-device-wins');
+      expect(result.deviceId).not.toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it('reuses the SAME session across repeated calls with the same explicit deviceId', async () => {
+      mockFindOneResults.push(null); // isNewDevice check: none
+      mockFindOneResults.push(null); // active-session reuse lookup: none
+      mockSave.mockResolvedValueOnce(undefined);
+
+      const first = await sessionService.createSession('user-123', createMockRequest(), {
+        deviceName: 'FedCM Sign-In',
+        deviceId: 'central-device-reuse',
+      });
+
+      mockFindOneResults.push({ _id: 'mongo-id-123' }); // isNewDevice check: device already seen
+      mockFindOneResults.push(
+        createMockSession({ sessionId: first.sessionId, deviceId: 'central-device-reuse' })
+      );
+      const refreshed = createMockSession({
+        sessionId: first.sessionId,
+        deviceId: 'central-device-reuse',
+        accessToken: 'refreshed-access-token',
+      });
+      mockFindOneAndUpdate.mockResolvedValueOnce(refreshed);
+
+      const second = await sessionService.createSession('user-123', createMockRequest(), {
+        deviceName: 'FedCM Sign-In',
+        deviceId: 'central-device-reuse',
+      });
+
+      expect(second.sessionId).toBe(first.sessionId);
+      expect(second.accessToken).toBe('refreshed-access-token');
+      expect(mockSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('validateSession', () => {
     it('should validate active session', async () => {
       const mockSession = createMockSession();

--- a/packages/api/src/services/fedcm.service.ts
+++ b/packages/api/src/services/fedcm.service.ts
@@ -709,6 +709,7 @@ class FedCMService {
       const session = await sessionService.createSession(userId, req, {
         deviceName: 'FedCM Sign-In',
         stableDeviceKey: clientOrigin,
+        ...(tokenPayload.deviceId ? { deviceId: tokenPayload.deviceId } : {}),
       });
 
       // Record the grant: the user just actively authorized this RP origin via

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -406,17 +406,20 @@ class SessionService {
     options: SessionCreateOptions = {}
   ): Promise<ISession> {
     try {
-      const { deviceName, deviceFingerprint, stableDeviceKey, operatedByUserId } = options;
+      const { deviceName, deviceFingerprint, stableDeviceKey, deviceId: explicitDeviceId, operatedByUserId } = options;
       // For IdP/FedCM-issued sessions the request is a server-to-server call
       // from the IdP (UA = 'unknown', egress IP varies per call), so the
       // UA/IP-derived deviceId would be random every time and sprawl a new
       // session per exchange. When a `stableDeviceKey` is supplied, derive a
       // deterministic deviceId from (userId, key) and feed it as the provided
       // deviceId so `extractDeviceInfo` skips the UA/IP derivation entirely —
-      // one (user, RP) then reuses a single session via the lookup below.
-      const stableId = stableDeviceKey
+      // one (user, RP) then reuses a single session via the lookup below. An
+      // explicit `deviceId` (e.g. threaded from a FedCM id_token claim) wins
+      // over the derived stable id, letting the caller stamp a unified central
+      // device id verbatim. Precedence: deviceId > stableDeviceKey > UA/IP > random.
+      const stableId = explicitDeviceId ?? (stableDeviceKey
         ? deriveServiceDeviceId(userId, stableDeviceKey)
-        : undefined;
+        : undefined);
       // Pass userId so the derived deviceId is scoped per-user — two users
       // behind the same NAT on the same Chrome no longer collide on the same
       // device-id (security review H1).

--- a/packages/api/src/types/session.types.ts
+++ b/packages/api/src/types/session.types.ts
@@ -25,6 +25,11 @@ export interface SessionCreateOptions {
    */
   stableDeviceKey?: string;
   /**
+   * An explicit central deviceId, used verbatim (bypasses stableDeviceKey/UA-IP
+   * derivation). Precedence: deviceId > stableDeviceKey > UA/IP > random.
+   */
+  deviceId?: string;
+  /**
    * The OPERATOR user id when this session is minted by switching INTO a managed
    * account (`userId` = the managed account). Recorded on the session for audit
    * and to bind its validity to the operator's `account:act_as` membership.

--- a/packages/auth/server/__tests__/deviceIdChain.idp.test.ts
+++ b/packages/auth/server/__tests__/deviceIdChain.idp.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Central deviceId propagation into minted FedCM assertions.
+ *
+ * `/session/validate/:id` (the API's cookie-less session resolver) can now
+ * return a top-level `deviceId` alongside `{ valid, user }`. This test
+ * verifies the IdP worker (`mintSessionForClient`, driven here via
+ * `GET /auth/silent`) chains that `deviceId` into the `id_token` it POSTs to
+ * `/fedcm/exchange` — so the API can stamp the SAME central device id onto
+ * the freshly-minted cross-apex session (cross-domain device unification).
+ *
+ * Backward-compat: when `/session/validate` omits `deviceId` (an older API
+ * deployment), the minted `id_token` must carry NO `deviceId` claim at all.
+ *
+ * Run with `bun test`. Mirrors the stubbing pattern in
+ * `server/__tests__/fedcm.idp.test.ts`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+
+const RP_ORIGIN = 'https://accounts.oxy.so';
+const TEST_SECRET = 'test-fedcm-secret';
+const TEST_USER_ID = '507f1f77bcf86cd799439011';
+const STUB_SERVER_NONCE = 'server-minted-nonce-xyz';
+const STUB_ACCESS_TOKEN = 'oxy-access-token-abc';
+const STUB_EXCHANGE_SESSION_ID = 'sess_exchanged_999';
+const SESSION_COOKIE = 'fedcm_session=sess_abc';
+
+// Configure env BEFORE importing the server module (it reads env at load).
+process.env.FEDCM_TOKEN_SECRET = TEST_SECRET;
+process.env.FEDCM_ISSUER = 'https://auth.oxy.so';
+process.env.OXY_API_URL = 'https://api.oxy.so';
+process.env.SSO_INTERNAL_SECRET = 'test-sso-internal-secret-32-chars-long!!';
+process.env.NODE_ENV = 'test';
+
+const realFetch = globalThis.fetch;
+
+// Mutable so individual tests can flip whether `/session/validate` reports a
+// central deviceId.
+let stubbedDeviceId: string | undefined = 'dev-central-xyz';
+
+// Captures the id_token POSTed to /fedcm/exchange so tests can decode its
+// claims.
+let capturedExchangeIdToken: string | undefined;
+
+function installApiStub(): void {
+  capturedExchangeIdToken = undefined;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.includes('/session/validate/')) {
+      return new Response(
+        JSON.stringify({
+          valid: true,
+          user: { id: TEST_USER_ID, username: 'tester', email: 'tester@oxy.so', name: { full: 'Test User' } },
+          ...(stubbedDeviceId ? { deviceId: stubbedDeviceId } : {}),
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+    if (url.includes('/fedcm/clients/approved')) {
+      return new Response(
+        JSON.stringify({ success: true, clients: [RP_ORIGIN] }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+    if (url.includes('/fedcm/grants/')) {
+      return new Response(
+        JSON.stringify({ origins: [RP_ORIGIN] }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+    if (url.includes('/fedcm/nonce')) {
+      return new Response(
+        JSON.stringify({ nonce: STUB_SERVER_NONCE, expiresAt: new Date(Date.now() + 60000).toISOString() }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+    if (url.includes('/fedcm/exchange')) {
+      const bodyText = typeof init?.body === 'string' ? init.body : '';
+      try {
+        capturedExchangeIdToken = (JSON.parse(bodyText) as { id_token?: string }).id_token;
+      } catch {
+        capturedExchangeIdToken = undefined;
+      }
+      return new Response(
+        JSON.stringify({
+          sessionId: STUB_EXCHANGE_SESSION_ID,
+          expiresAt: new Date(Date.now() + 3600000).toISOString(),
+          accessToken: STUB_ACCESS_TOKEN,
+          user: {
+            id: TEST_USER_ID,
+            username: 'tester',
+            email: 'tester@oxy.so',
+            name: { first: 'Test', last: 'User', full: 'Test User', displayName: 'Test User' },
+          },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let app: { request: (path: string, init?: RequestInit) => Promise<Response> };
+
+beforeAll(async () => {
+  installApiStub();
+  const mod = await import('../index');
+  app = mod.app as typeof app;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
+
+beforeEach(() => {
+  stubbedDeviceId = 'dev-central-xyz';
+  installApiStub();
+});
+
+function decodeIdTokenPayload(idToken: string): Record<string, unknown> {
+  const [, payloadB64] = idToken.split('.');
+  const padded = payloadB64.replace(/-/g, '+').replace(/_/g, '/');
+  return JSON.parse(Buffer.from(padded, 'base64').toString('utf8')) as Record<string, unknown>;
+}
+
+describe('mintSessionForClient chains central deviceId (via GET /auth/silent)', () => {
+  it('embeds the deviceId from /session/validate into the id_token POSTed to /fedcm/exchange', async () => {
+    const res = await app.request(
+      `/auth/silent?client_id=${encodeURIComponent(RP_ORIGIN)}&nonce=rp-nonce-device`,
+      { headers: { cookie: SESSION_COOKIE } }
+    );
+    expect(res.status).toBe(200);
+
+    expect(typeof capturedExchangeIdToken).toBe('string');
+    const payload = decodeIdTokenPayload(capturedExchangeIdToken as string);
+    expect(payload.deviceId).toBe('dev-central-xyz');
+  });
+
+  it('omits the deviceId claim entirely when /session/validate returns no deviceId (backward-compat)', async () => {
+    stubbedDeviceId = undefined;
+    installApiStub();
+
+    const res = await app.request(
+      `/auth/silent?client_id=${encodeURIComponent(RP_ORIGIN)}&nonce=rp-nonce-no-device`,
+      { headers: { cookie: SESSION_COOKIE } }
+    );
+    expect(res.status).toBe(200);
+
+    expect(typeof capturedExchangeIdToken).toBe('string');
+    const payload = decodeIdTokenPayload(capturedExchangeIdToken as string);
+    expect('deviceId' in payload).toBe(false);
+  });
+});

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -292,6 +292,11 @@ interface ResolvedUser {
    */
   name?: UserNameResponse;
   avatar?: string;
+  /**
+   * Central device id from `/session/validate`, chained into minted
+   * assertions for cross-apex device unification.
+   */
+  deviceId?: string;
 }
 
 /**
@@ -379,6 +384,7 @@ async function fetchUserFromAPI(apiBaseUrl: string, sessionId: string): Promise<
     if (!user || typeof userId !== 'string' || !userId) return null;
 
     const username = user.username as string | undefined;
+    const deviceId = typeof payload.deviceId === 'string' ? payload.deviceId : undefined;
 
     return {
       id: userId,
@@ -386,6 +392,7 @@ async function fetchUserFromAPI(apiBaseUrl: string, sessionId: string): Promise<
       username,
       name: structuredName(user.name, username, userId),
       avatar: user.avatar as string | undefined,
+      ...(deviceId ? { deviceId } : {}),
     };
   } catch {
     return null;
@@ -662,6 +669,7 @@ async function mintSessionForClient(
     const idTokenName = displayNameOf(user.name);
     if (idTokenName) idTokenPayload.name = idTokenName;
     if (user.username) idTokenPayload.preferred_username = user.username;
+    if (user.deviceId) idTokenPayload.deviceId = user.deviceId;
     const idToken = await createHS256JWT(idTokenPayload, fedcmTokenSecret);
 
     // 3. Exchange for a real Oxy session. The API re-verifies everything.

--- a/packages/contracts/src/fedcmToken.ts
+++ b/packages/contracts/src/fedcmToken.ts
@@ -44,6 +44,13 @@ export const fedcmTokenPayloadSchema = z
         exp: z.number().optional(),
         iat: z.number().optional(),
         nonce: z.string().optional(),
+        /**
+         * An explicit central deviceId minted by the IdP, threaded through so the
+         * RP session can inherit a unified device id instead of deriving one from
+         * the (userId, RP origin) stableDeviceKey. Optional and additive — omitted
+         * tokens fall back to the existing stableDeviceKey/UA-IP derivation.
+         */
+        deviceId: z.string().optional(),
     })
     .passthrough();
 


### PR DESCRIPTION
## What
Builds on the session-sync foundation (#482). Makes RP sessions across different apex domains inherit the SAME `deviceId`, so the same physical device lands in one `device:<deviceId>` Socket.IO room → cross-domain session sync works. Fully **additive / backward-compatible** (an optional claim + response field; if absent, behavior is unchanged — no regression to FedCM/SSO login).

**The chain:**
1. `GET /session/validate/:id` now returns the session's `deviceId` (additive field).
2. IdP (`packages/auth`): `fetchUserFromAPI` reads that `deviceId` → `ResolvedUser.deviceId` → `mintSessionForClient` embeds it as a `deviceId` claim in the minted id_token. One edit covers all three cross-domain mint paths (`/sso`, `/auth/silent`, `/sso/establish`).
3. api `POST /fedcm/exchange` reads `tokenPayload.deviceId` and `createSession` uses it verbatim (`SessionCreateOptions.deviceId`, precedence: explicit > stableDeviceKey > UA/IP > random). Contract: `fedcmTokenPayloadSchema.deviceId` (optional).

Result: a session authorized by the central `fedcm_session` inherits the central session's `deviceId`; all RPs chaining from it share it.

## Verification
- api suite green (1274 incl. new createSession-precedence + validate-deviceId + fedcm-exchange-threads-claim tests).
- IdP suite green (71 incl. `deviceIdChain.idp.test.ts`: id_token carries `deviceId` when validate returns it; no claim when absent).
- Additive: `/fedcm/assertion` (direct-Chrome per-apex path) intentionally NOT yet touched — follow-up.

Deploys: api (ECS) + IdP auth.oxy.so (Cloudflare Pages). Cross-domain deviceId unification to be browser-verified post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)