### PR TITLE
fix(api): bind managed/org accounts into device-session authority + reject revoked-org switch

### DIFF
--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -10,6 +10,7 @@ const mockSignout = jest.fn();
 const mockResolveActiveToken = jest.fn();
 const mockBroadcast = jest.fn();
 const mockDecodeToken = jest.fn();
+const mockGetSession = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (...a: unknown[]) => mockAuthMiddleware(...a),
@@ -30,6 +31,12 @@ jest.mock('../../services/deviceSession.service', () => ({
     switchActive: (...a: unknown[]) => mockSwitchActive(...a),
     signout: (...a: unknown[]) => mockSignout(...a),
     resolveActiveToken: (...a: unknown[]) => mockResolveActiveToken(...a),
+  },
+}));
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: {
+    getSession: (...a: unknown[]) => mockGetSession(...a),
   },
 }));
 jest.mock('../../utils/socket', () => ({ broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a) }));
@@ -68,6 +75,7 @@ afterAll((done) => { server.close(done); });
 beforeEach(() => {
   jest.clearAllMocks();
   mockResolveActiveToken.mockResolvedValue({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' });
+  mockGetSession.mockResolvedValue(null);
 });
 
 describe('GET /session/device/state', () => {
@@ -125,9 +133,25 @@ describe('POST /session/device/add', () => {
     mockAddAccount.mockResolvedValueOnce(STATE);
     const res = await requestJson(server, 'POST', '/session/device/add', {});
     expect(res.status).toBe(200);
+    expect(mockGetSession).toHaveBeenCalledWith('s1', true);
     expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
     expect(mockBroadcast).toHaveBeenCalledWith(STATE);
     expect(res.body.data.state).toEqual(STATE);
     expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
+  });
+
+  it('passes the operator id through to addAccount for a managed-account session', async () => {
+    mockGetSession.mockResolvedValueOnce({ operatedByUserId: { toString: () => 'op1' } });
+    mockAddAccount.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'POST', '/session/device/add', {});
+    expect(res.status).toBe(200);
+    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1', operatedByUserId: 'op1' });
+  });
+
+  it('does not forward operatedByUserId for an ordinary first-party session', async () => {
+    mockGetSession.mockResolvedValueOnce({ operatedByUserId: null });
+    mockAddAccount.mockResolvedValueOnce(STATE);
+    await requestJson(server, 'POST', '/session/device/add', {});
+    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
   });
 });

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -91,7 +91,7 @@ describe('GET /session/device/state', () => {
 
 describe('POST /session/device/switch', () => {
   it('switches active account and broadcasts', async () => {
-    mockSwitchActive.mockResolvedValueOnce(STATE);
+    mockSwitchActive.mockResolvedValueOnce({ ok: true, state: STATE });
     const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'a1' });
     expect(res.status).toBe(200);
     expect(mockSwitchActive).toHaveBeenCalledWith('d1', 'a1');
@@ -101,9 +101,17 @@ describe('POST /session/device/switch', () => {
   });
 
   it('404 when the account is not on the device', async () => {
-    mockSwitchActive.mockResolvedValueOnce(null);
+    mockSwitchActive.mockResolvedValueOnce({ ok: false, reason: 'not_found' });
     const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'ghost' });
     expect(res.status).toBe(404);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('403 when the target account session is not authorized (e.g. revoked act_as membership)', async () => {
+    mockSwitchActive.mockResolvedValueOnce({ ok: false, reason: 'unauthorized' });
+    const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'org1' });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Account not authorized');
     expect(mockBroadcast).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -4,6 +4,7 @@ import { authMiddleware, AuthRequest } from '../middleware/auth';
 import { requireSameSiteOrigin } from '../middleware/originGuard';
 import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
 import deviceSessionService from '../services/deviceSession.service';
+import sessionService from '../services/session.service';
 import { broadcastDeviceState } from '../utils/socket';
 import { asyncHandler } from '../utils/asyncHandler';
 
@@ -39,7 +40,16 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
   const session = resolveCallerSession(req);
   const accountId = req.user?._id?.toString();
   if (!session?.deviceId || !accountId || !session.sessionId) { res.status(401).json({ error: 'Invalid session' }); return; }
-  const state = await deviceSessionService.addAccount(session.deviceId, { accountId, sessionId: session.sessionId });
+  // The bearer JWT does not carry `operatedByUserId` (it is session-doc-only),
+  // so a managed-account sign-in must be resolved from the session record
+  // itself to bind the device-session entry to its operator.
+  const sessionDoc = await sessionService.getSession(session.sessionId, true);
+  const operatedByUserId = sessionDoc?.operatedByUserId ? sessionDoc.operatedByUserId.toString() : undefined;
+  const state = await deviceSessionService.addAccount(session.deviceId, {
+    accountId,
+    sessionId: session.sessionId,
+    ...(operatedByUserId ? { operatedByUserId } : {}),
+  });
   broadcastDeviceState(state);
   res.json({ data: await withActiveToken(state) });
 }));

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -59,10 +59,14 @@ router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
   const { accountId } = req.body ?? {};
   if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
   if (!accountId) { res.status(400).json({ error: 'accountId required' }); return; }
-  const state = await deviceSessionService.switchActive(deviceId, accountId);
-  if (!state) { res.status(404).json({ error: 'Account not on this device' }); return; }
-  broadcastDeviceState(state);
-  res.json({ data: await withActiveToken(state) });
+  const outcome = await deviceSessionService.switchActive(deviceId, accountId);
+  if (!outcome.ok) {
+    if (outcome.reason === 'unauthorized') { res.status(403).json({ error: 'Account not authorized' }); return; }
+    res.status(404).json({ error: 'Account not on this device' });
+    return;
+  }
+  broadcastDeviceState(outcome.state);
+  res.json({ data: await withActiveToken(outcome.state) });
 }));
 
 router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => {

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -203,9 +203,105 @@ describe('signout', () => {
 });
 
 describe('switchActive', () => {
-  it('returns null when the account is not on the device', async () => {
+  it('returns not_found when the account is not on the device', async () => {
     mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
-    expect(await deviceSessionService.switchActive('d1', 'ghost')).toBeNull();
+    expect(await deviceSessionService.switchActive('d1', 'ghost')).toEqual({ ok: false, reason: 'not_found' });
+    expect(mockValidateSessionById).not.toHaveBeenCalled();
+  });
+
+  it('switches active account and bumps revision when the target session validates', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'other' },
+      revision: 1,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+      updatedAt: new Date(1720000000000),
+    }));
+    const result = await deviceSessionService.switchActive('d1', 'a1');
+    expect(mockValidateSessionById).toHaveBeenCalledWith('s1', false);
+    expect(result).toEqual({ ok: true, state: expect.objectContaining({ activeAccountId: 'a1', revision: 2 }) });
+  });
+
+  it('returns unauthorized and does not commit the switch when validateSessionById rejects the target session (e.g. revoked act_as membership)', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [
+        { accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null },
+        { accountId: { toString: () => 'org1' }, sessionId: 's-org', authuser: 1, operatedByUserId: { toString: () => 'op1' } },
+      ],
+      activeAccountId: { toString: () => 'op1' },
+      revision: 1,
+    }));
+    mockValidateSessionById.mockResolvedValueOnce(null);
+    const result = await deviceSessionService.switchActive('d1', 'org1');
+    expect(mockValidateSessionById).toHaveBeenCalledWith('s-org', false);
+    expect(result).toEqual({ ok: false, reason: 'unauthorized' });
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('getState self-heals a revoked managed active account', () => {
+  it('drops the active managed account when its session fails validateSessionById and re-elects the next remaining account', async () => {
+    const doc = {
+      deviceId: 'd1',
+      accounts: [
+        { accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null },
+        { accountId: { toString: () => 'org1' }, sessionId: 's-org', authuser: 1, operatedByUserId: { toString: () => 'op1' } },
+      ],
+      activeAccountId: { toString: () => 'org1' },
+      revision: 3,
+    };
+    mockFindOne.mockReturnValueOnce(lean(doc)); // getState's initial load
+    mockValidateSessionById.mockResolvedValueOnce(null); // heal check on org1's session fails
+    mockFindOne.mockReturnValueOnce(lean(doc)); // signout()'s own reload
+    mockDeactivate.mockResolvedValueOnce(true);
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'op1' },
+      revision: 4,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.getState('d1');
+    expect(mockValidateSessionById).toHaveBeenCalledWith('s-org', false);
+    expect(mockDeactivate).toHaveBeenCalledWith('s-org');
+    expect(state.accounts).toHaveLength(1);
+    expect(state.accounts[0].accountId).toBe('op1');
+    expect(state.activeAccountId).toBe('op1');
+  });
+
+  it('keeps a managed active account whose session still validates', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'org1' }, sessionId: 's-org', authuser: 0, operatedByUserId: { toString: () => 'op1' } }],
+      activeAccountId: { toString: () => 'org1' },
+      revision: 1,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.getState('d1');
+    expect(mockValidateSessionById).toHaveBeenCalledWith('s-org', false);
+    expect(mockDeactivate).not.toHaveBeenCalled();
+    expect(state.activeAccountId).toBe('org1');
+  });
+
+  it('does not touch a personal (non-managed) active account, even without a validateSessionById call', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'op1' },
+      revision: 1,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.getState('d1');
+    expect(mockValidateSessionById).not.toHaveBeenCalled();
+    expect(mockDeactivate).not.toHaveBeenCalled();
+    expect(state.activeAccountId).toBe('op1');
   });
 });
 

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -2,6 +2,7 @@ const mockFindOne = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
 const mockDeactivate = jest.fn();
 const mockGetAccessToken = jest.fn();
+const mockValidateSessionById = jest.fn();
 
 jest.mock('../../models/DeviceSession', () => ({
   __esModule: true,
@@ -15,6 +16,7 @@ jest.mock('../session.service', () => ({
   default: {
     deactivateSession: (...a: unknown[]) => mockDeactivate(...a),
     getAccessToken: (...a: unknown[]) => mockGetAccessToken(...a),
+    validateSessionById: (...a: unknown[]) => mockValidateSessionById(...a),
   },
 }));
 jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
@@ -23,7 +25,10 @@ import deviceSessionService, { projectState } from '../deviceSession.service';
 
 const lean = (v: unknown) => ({ lean: () => Promise.resolve(v) });
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockValidateSessionById.mockResolvedValue({ session: {} });
+});
 
 describe('projectState', () => {
   it('maps a doc to DeviceSessionState with string ids', () => {
@@ -59,6 +64,65 @@ describe('addAccount', () => {
     expect(state.accounts[0].authuser).toBe(0);
     expect(state.revision).toBe(1);
   });
+
+  it('persists operatedByUserId onto the stored account and projected state', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'org1' }, sessionId: 's-org', authuser: 0, operatedByUserId: { toString: () => 'op1' } }],
+      activeAccountId: { toString: () => 'org1' },
+      revision: 1,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.addAccount('d1', { accountId: 'org1', sessionId: 's-org', operatedByUserId: 'op1' });
+    expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
+      { deviceId: 'd1' },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          accounts: expect.arrayContaining([expect.objectContaining({ accountId: 'org1', sessionId: 's-org', operatedByUserId: 'op1' })]),
+        }),
+      }),
+      expect.anything(),
+    );
+    expect(state.accounts[0].operatedByUserId).toBe('op1');
+  });
+
+  it('deactivates the replaced session when re-adding the same account with a different sessionId', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's-old', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+    }));
+    mockDeactivate.mockResolvedValueOnce(true);
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's-new', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+      updatedAt: new Date(1720000000000),
+    }));
+    await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's-new' });
+    expect(mockDeactivate).toHaveBeenCalledWith('s-old');
+  });
+
+  it('does not deactivate anything when re-adding the same account with the same sessionId', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+      updatedAt: new Date(1720000000000),
+    }));
+    await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's1' });
+    expect(mockDeactivate).not.toHaveBeenCalled();
+  });
 });
 
 describe('signout', () => {
@@ -79,6 +143,63 @@ describe('signout', () => {
     expect(state.activeAccountId).toBeNull();
     expect(state.revision).toBe(2);
   });
+
+  it('cascades: signing out the operator also removes accounts it operates, deactivating both sessions, and never elects the operated account as next-active', async () => {
+    // Device has the operator's personal account (op1, active) and an org
+    // account (org1) the operator switched into (operatedByUserId: op1).
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [
+        { accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null },
+        { accountId: { toString: () => 'org1' }, sessionId: 's-org', authuser: 1, operatedByUserId: { toString: () => 'op1' } },
+      ],
+      activeAccountId: { toString: () => 'org1' },
+      revision: 3,
+    }));
+    mockDeactivate.mockResolvedValue(true);
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 4, updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.signout('d1', { accountId: 'op1' });
+    expect(mockDeactivate).toHaveBeenCalledWith('s-op');
+    expect(mockDeactivate).toHaveBeenCalledWith('s-org');
+    expect(mockDeactivate).toHaveBeenCalledTimes(2);
+    const [, updatePayload] = mockFindOneAndUpdate.mock.calls[0];
+    expect(updatePayload.$set.accounts).toEqual([]);
+    // Neither removed account (the just-signed-out operator nor the cascaded
+    // org account, which was also the previously-active account) may be
+    // elected as the next active account.
+    expect(updatePayload.$set.activeAccountId).toBeNull();
+    expect(state.accounts).toHaveLength(0);
+    expect(state.activeAccountId).toBeNull();
+  });
+
+  it('does not cascade beyond one level and leaves unrelated accounts untouched', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [
+        { accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null },
+        { accountId: { toString: () => 'org1' }, sessionId: 's-org', authuser: 1, operatedByUserId: { toString: () => 'op1' } },
+        { accountId: { toString: () => 'other' }, sessionId: 's-other', authuser: 2, operatedByUserId: null },
+      ],
+      activeAccountId: { toString: () => 'other' },
+      revision: 3,
+    }));
+    mockDeactivate.mockResolvedValue(true);
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'other' }, sessionId: 's-other', authuser: 2, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'other' },
+      revision: 4,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.signout('d1', { accountId: 'op1' });
+    expect(mockDeactivate).toHaveBeenCalledWith('s-op');
+    expect(mockDeactivate).toHaveBeenCalledWith('s-org');
+    expect(mockDeactivate).not.toHaveBeenCalledWith('s-other');
+    expect(state.accounts).toHaveLength(1);
+    expect(state.activeAccountId).toBe('other');
+  });
 });
 
 describe('switchActive', () => {
@@ -90,9 +211,10 @@ describe('switchActive', () => {
 
 describe('resolveActiveToken', () => {
   const STATE = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
-  it('mints the active account token', async () => {
+  it('mints the active account token after re-validating the session', async () => {
     mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'jwt', expiresAt: new Date('2026-07-07T00:00:00.000Z') });
     expect(await deviceSessionService.resolveActiveToken(STATE as never)).toEqual({ accessToken: 'jwt', expiresAt: '2026-07-07T00:00:00.000Z' });
+    expect(mockValidateSessionById).toHaveBeenCalledWith('s1', false);
     expect(mockGetAccessToken).toHaveBeenCalledWith('s1');
   });
   it('returns null when there is no active account', async () => {
@@ -101,5 +223,10 @@ describe('resolveActiveToken', () => {
   it('returns null when the session cannot mint a token', async () => {
     mockGetAccessToken.mockResolvedValueOnce(null);
     expect(await deviceSessionService.resolveActiveToken(STATE as never)).toBeNull();
+  });
+  it('returns null without minting a token when validateSessionById rejects the session (e.g. revoked act_as membership)', async () => {
+    mockValidateSessionById.mockResolvedValueOnce(null);
+    expect(await deviceSessionService.resolveActiveToken(STATE as never)).toBeNull();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -33,6 +33,10 @@ function lowestFreeAuthuser(accounts: IDeviceSessionAccount[]): number {
   return i;
 }
 
+export type SwitchActiveResult =
+  | { ok: true; state: DeviceSessionState }
+  | { ok: false; reason: 'not_found' | 'unauthorized' };
+
 class DeviceSessionService {
   private async load(deviceId: string): Promise<IDeviceSession | null> {
     return DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
@@ -40,13 +44,40 @@ class DeviceSessionService {
 
   async getState(deviceId: string): Promise<DeviceSessionState> {
     const existing = await this.load(deviceId);
-    if (existing) return projectState(existing);
+    if (existing) return this.healActiveAccount(existing);
     const created = await DeviceSession.findOneAndUpdate(
       { deviceId },
       { $setOnInsert: { deviceId, accounts: [], activeAccountId: null, revision: 0 } },
       { new: true, upsert: true },
     ).lean<IDeviceSession>();
     return projectState(created as IDeviceSession);
+  }
+
+  // Self-heals a device's active account when it is a managed (act_as)
+  // account whose operator membership has since been revoked.
+  // `resolveActiveToken` already refuses to mint a token for such an account,
+  // but without this the dead account keeps sitting in `accounts`/
+  // `activeAccountId` forever — the client would durably render "logged in
+  // as <org>" while holding the previous account's bearer. One pass only:
+  // drop the revoked account via the existing signout cascade and return the
+  // healed state; a newly-elected active account is left for the *next*
+  // getState call to re-validate rather than re-checked recursively here.
+  // Non-managed (personal) active accounts are never touched by this path —
+  // a personal account with a transiently-unresolvable access token must not
+  // be dropped, only a managed account whose act_as membership check failed.
+  private async healActiveAccount(doc: IDeviceSession): Promise<DeviceSessionState> {
+    const activeId = idToString(doc.activeAccountId);
+    if (!activeId) return projectState(doc);
+    const active = (doc.accounts ?? []).find((a) => idToString(a.accountId) === activeId);
+    const operatedBy = active ? idToString(active.operatedByUserId ?? null) : null;
+    if (!active || !operatedBy) return projectState(doc);
+    const validated = await sessionService.validateSessionById(active.sessionId, false);
+    if (validated) return projectState(doc);
+    logger.info('deviceSession.getState: dropping revoked managed active account', {
+      deviceId: doc.deviceId,
+      accountId: activeId,
+    });
+    return this.signout(doc.deviceId, { accountId: activeId });
   }
 
   async addAccount(
@@ -85,16 +116,27 @@ class DeviceSessionService {
     return projectState(updated as IDeviceSession);
   }
 
-  async switchActive(deviceId: string, accountId: string): Promise<DeviceSessionState | null> {
+  async switchActive(deviceId: string, accountId: string): Promise<SwitchActiveResult> {
     const current = await this.load(deviceId);
-    if (!current || !(current.accounts ?? []).some((a) => idToString(a.accountId) === accountId)) return null;
+    const target = (current?.accounts ?? []).find((a) => idToString(a.accountId) === accountId);
+    if (!current || !target) return { ok: false, reason: 'not_found' };
+
+    // Re-validate the target account's session BEFORE committing the switch.
+    // For a managed account this re-checks the operator's act_as membership
+    // (ensureManagedSessionAuthorized) and rejects the switch instead of
+    // durably pointing the device at an account the caller no longer has
+    // authority over (see resolveActiveToken, which does the same check on
+    // read but can't undo an already-committed activeAccountId).
+    const validated = await sessionService.validateSessionById(target.sessionId, false);
+    if (!validated) return { ok: false, reason: 'unauthorized' };
+
     const updated = await DeviceSession.findOneAndUpdate(
       { deviceId },
       { $set: { activeAccountId: accountId }, $inc: { revision: 1 } },
       { new: true },
     ).lean<IDeviceSession>();
-    if (!updated) return null;
-    return projectState(updated);
+    if (!updated) return { ok: false, reason: 'not_found' };
+    return { ok: true, state: projectState(updated) };
   }
 
   async resolveActiveToken(state: DeviceSessionState): Promise<{ accessToken: string; expiresAt: string } | null> {

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -54,7 +54,18 @@ class DeviceSessionService {
     input: { accountId: string; sessionId: string; operatedByUserId?: string },
   ): Promise<DeviceSessionState> {
     const current = await this.load(deviceId);
+    const existing = (current?.accounts ?? []).find((a) => idToString(a.accountId) === input.accountId);
     const others = (current?.accounts ?? []).filter((a) => idToString(a.accountId) !== input.accountId);
+    // Replacing an account's session (re-add with a new sessionId) must deactivate
+    // the session it displaces — otherwise a live, server-side session is left
+    // dangling with no device-session entry referencing it.
+    if (existing && existing.sessionId !== input.sessionId) {
+      try {
+        await sessionService.deactivateSession(existing.sessionId);
+      } catch (error) {
+        logger.warn('deviceSession.addAccount: deactivate replaced session failed', { sessionId: existing.sessionId, error });
+      }
+    }
     const authuser = lowestFreeAuthuser(others);
     const account = {
       accountId: input.accountId,
@@ -90,6 +101,12 @@ class DeviceSessionService {
     if (!state.activeAccountId) return null;
     const account = state.accounts.find((a) => a.accountId === state.activeAccountId);
     if (!account) return null;
+    // Re-validate before minting a token: for a managed-account session this
+    // re-checks the operator's act_as membership (ensureManagedSessionAuthorized)
+    // and deactivates+rejects a revoked session instead of handing out a token
+    // for an account the caller no longer has authority over.
+    const validated = await sessionService.validateSessionById(account.sessionId, false);
+    if (!validated) return null;
     const token = await sessionService.getAccessToken(account.sessionId);
     if (!token) return null;
     return { accessToken: token.accessToken, expiresAt: token.expiresAt.toISOString() };
@@ -98,8 +115,26 @@ class DeviceSessionService {
   async signout(deviceId: string, target: { accountId: string } | { all: true }): Promise<DeviceSessionState> {
     const current = await this.load(deviceId);
     if (!current) return this.getState(deviceId);
-    const removing = 'all' in target ? current.accounts ?? [] : (current.accounts ?? []).filter((a) => idToString(a.accountId) === target.accountId);
-    if (!('all' in target) && removing.length === 0) return projectState(current);
+    const allAccounts = current.accounts ?? [];
+
+    let removingIds: Set<string>;
+    if ('all' in target) {
+      removingIds = new Set(allAccounts.map((a) => idToString(a.accountId) ?? ''));
+    } else {
+      const targetPresent = allAccounts.some((a) => idToString(a.accountId) === target.accountId);
+      if (!targetPresent) return projectState(current);
+      removingIds = new Set([target.accountId]);
+      // Cascade: signing out an operator's own account must also remove every
+      // managed/org account that operator switched into on this device (one
+      // level deep — operated accounts can't themselves operate others).
+      for (const a of allAccounts) {
+        if (idToString(a.operatedByUserId) === target.accountId) {
+          removingIds.add(idToString(a.accountId) ?? '');
+        }
+      }
+    }
+
+    const removing = allAccounts.filter((a) => removingIds.has(idToString(a.accountId) ?? ''));
     for (const a of removing) {
       try {
         await sessionService.deactivateSession(a.sessionId);
@@ -107,7 +142,7 @@ class DeviceSessionService {
         logger.warn('deviceSession.signout: deactivate failed', { sessionId: a.sessionId, error });
       }
     }
-    const remaining = 'all' in target ? [] : (current.accounts ?? []).filter((a) => idToString(a.accountId) !== target.accountId);
+    const remaining = allAccounts.filter((a) => !removingIds.has(idToString(a.accountId) ?? ''));
     const activeStillPresent = remaining.some((a) => idToString(a.accountId) === idToString(current.activeAccountId));
     const nextActive = activeStillPresent ? idToString(current.activeAccountId) : (remaining[0] ? idToString(remaining[0].accountId) : null);
     const updated = await DeviceSession.findOneAndUpdate(


### PR DESCRIPTION
Incremental server-side hardening for the device-session authority (the cross-domain session-sync foundation already live from #482/#483/#484). **Additive** — does not change the existing `/auth/*` or `oxy_rt` paths; only tightens the `/session/device/*` routes.

## Org/managed-account binding (was unbound)
- `POST /session/device/add` now captures `Session.operatedByUserId` into the device-account entry (fetched from the session doc — the bearer JWT doesn't carry it).
- `signout` cascades one level: signing out an operator's personal account also removes the org accounts that operator switched into (deactivates their sessions), and a cascaded account can never be elected next-active.
- `resolveActiveToken` re-validates membership via `validateSessionById` (→ `ensureManagedSessionAuthorized`) before minting — a revoked act_as membership yields no token.
- `addAccount` deactivates a displaced session when re-adding the same account with a new sessionId (no dangling live session).

## I2 — revoked-org switch/state
- `POST /session/device/switch` validates the target before committing: on-device but membership-revoked → **403** (no DB write, no broadcast); not-on-device → 404 (unchanged).
- `GET /session/device/state` self-heals: a managed active account whose membership was revoked is dropped + re-elected (personal accounts never dropped; distinguishes revoked-membership from a merely-expired-but-refreshable token).

## Tests
- `deviceSession.service.test.ts` + `sessionDevice.test.ts`: +new cases (operatedBy capture, signout cascade, resolveActiveToken validation, replaced-session deactivation, 403 reject, self-heal, personal-not-dropped).
- Full api suite green on the branch: **1288/1288**, tsc 0.

Part of the cross-domain session-sync rollout (staged: server first; the client cutover in `@oxyhq/services` follows separately after a real-browser gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)