### PR TITLE
fix(services): device-flow sign-in commits via handleWebSession (fixes 'failed to complete sign in')

### DIFF
--- a/packages/services/src/ui/components/SignInModal.tsx
+++ b/packages/services/src/ui/components/SignInModal.tsx
@@ -62,7 +62,7 @@ const SignInModal: React.FC = () => {
 
     const insets = useSafeAreaInsets();
     const theme = useTheme();
-    const { oxyServices, switchSession, clientId } = useOxy();
+    const { oxyServices, handleWebSession, clientId } = useOxy();
 
     // Register the imperative visibility callback.
     useEffect(() => {
@@ -83,7 +83,7 @@ const SignInModal: React.FC = () => {
             theme={theme}
             insets={insets}
             oxyServices={oxyServices}
-            switchSession={switchSession}
+            handleWebSession={handleWebSession}
             clientId={clientId}
         />
     );
@@ -93,7 +93,7 @@ interface SignInModalContentProps {
     theme: ReturnType<typeof useTheme>;
     insets: ReturnType<typeof useSafeAreaInsets>;
     oxyServices: ReturnType<typeof useOxy>['oxyServices'];
-    switchSession: ReturnType<typeof useOxy>['switchSession'];
+    handleWebSession: ReturnType<typeof useOxy>['handleWebSession'];
     clientId: ReturnType<typeof useOxy>['clientId'];
 }
 
@@ -101,13 +101,13 @@ const SignInModalContent: React.FC<SignInModalContentProps> = ({
     theme,
     insets,
     oxyServices,
-    switchSession,
+    handleWebSession,
     clientId,
 }) => {
     const { qrData, qrPayload, isLoading, error, isWaiting, openAuthApproval, openSameDeviceApproval, retry } = useOxyAuthSession(
         oxyServices,
         clientId,
-        switchSession,
+        handleWebSession,
         { onSignedIn: hideSignInModal },
     );
 

--- a/packages/services/src/ui/hooks/useOxyAuthSession.ts
+++ b/packages/services/src/ui/hooks/useOxyAuthSession.ts
@@ -23,7 +23,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Linking, Platform } from 'react-native';
 import io, { type Socket } from 'socket.io-client';
-import type { OxyServices, User } from '@oxyhq/core';
+import type { OxyServices, SessionLoginResponse, User } from '@oxyhq/core';
 import { createDebugLogger } from '@oxyhq/core';
 import { completeDeviceFlowSignIn } from '../../utils/deviceFlowSignIn';
 
@@ -232,7 +232,7 @@ function generateSessionToken(): string {
 export function useOxyAuthSession(
   oxyServices: OxyServices,
   clientId: string | null,
-  switchSession: ((sessionId: string) => Promise<User>) | undefined,
+  commitSession: ((session: SessionLoginResponse) => Promise<void>) | undefined,
   options: UseOxyAuthSessionOptions = {},
 ): UseOxyAuthSessionResult {
   const { onSignedIn } = options;
@@ -284,8 +284,12 @@ export function useOxyAuthSession(
   // Without that exchange the SDK has no bearer token — the session is
   // authorized server-side but the app never becomes authenticated and the UI
   // sits "Waiting for authorization..." forever. Once `claimSessionByToken`
-  // plants the tokens in the HttpService, the rest of the session wiring flows
-  // through the normal `switchSession` path. Shared with both containers via
+  // plants the tokens in the HttpService, the claimed session is committed via
+  // `commitSession` (`useOxy().handleWebSession`) — the SAME path a fresh
+  // password/FedCM sign-in uses to register the account into the device's
+  // server-authoritative session set. It is NOT yet a member of that set, so
+  // `switchSession` (an account-SWITCH between accounts already on the
+  // device) is the wrong primitive here. Shared with both containers via
   // `completeDeviceFlowSignIn` so the two paths cannot drift.
   const handleAuthSuccess = useCallback(
     async (sessionId: string, sessionToken: string) => {
@@ -293,14 +297,14 @@ export function useOxyAuthSession(
       isProcessingRef.current = true;
 
       try {
-        if (!switchSession) {
-          throw new Error('Session management unavailable');
+        if (!commitSession) {
+          throw new Error('Session commit unavailable');
         }
         const user = await completeDeviceFlowSignIn({
           oxyServices,
           sessionId,
           sessionToken,
-          switchSession,
+          commitSession,
         });
         onSignedInRef.current?.(user);
       } catch (err) {
@@ -309,7 +313,7 @@ export function useOxyAuthSession(
         isProcessingRef.current = false;
       }
     },
-    [oxyServices, switchSession],
+    [oxyServices, commitSession],
   );
 
   // Start polling for authorization.

--- a/packages/services/src/ui/screens/OxyAuthScreen.tsx
+++ b/packages/services/src/ui/screens/OxyAuthScreen.tsx
@@ -33,12 +33,12 @@ import { isCrossApexWeb } from '../../utils/crossApex';
 
 const OxyAuthScreen: React.FC<BaseScreenProps> = ({ goBack, onAuthenticated }) => {
   const bloomTheme = useTheme();
-  const { oxyServices, switchSession, clientId } = useOxy();
+  const { oxyServices, handleWebSession, clientId } = useOxy();
 
   const { qrData, qrPayload, isLoading, error, isWaiting, openAuthApproval, openSameDeviceApproval, retry } = useOxyAuthSession(
     oxyServices,
     clientId,
-    switchSession,
+    handleWebSession,
     { onSignedIn: onAuthenticated },
   );
 

--- a/packages/services/src/utils/__tests__/deviceFlowSignIn.test.ts
+++ b/packages/services/src/utils/__tests__/deviceFlowSignIn.test.ts
@@ -1,23 +1,33 @@
 /**
  * @jest-environment node
  *
- * Regression coverage for the NATIVE device-flow sign-in bug:
+ * Regression coverage for the device-flow sign-in bugs:
  *
- *   On native, tapping "Sign In with Oxy" opens `OxyAuthScreen`, which creates
- *   a device-flow AuthSession and opens auth.oxy.so/authorize. The user signs
- *   in successfully, the API authorizes the session and notifies the client via
- *   the auth-session socket — but the screen then called `switchSession`
- *   DIRECTLY without first claiming the bearer with the secret `sessionToken`.
- *   The session was authorized server-side but the app never became
- *   authenticated ("nothing happens").
+ *   BUG 1 (native): tapping "Sign In with Oxy" opens `OxyAuthScreen`, which
+ *   creates a device-flow AuthSession and opens auth.oxy.so/authorize. The
+ *   user signs in successfully, the API authorizes the session and notifies
+ *   the client via the auth-session socket — but the screen then called
+ *   `switchSession` DIRECTLY without first claiming the bearer with the
+ *   secret `sessionToken`. The session was authorized server-side but the app
+ *   never became authenticated ("nothing happens").
  *
- *   The web `SignInModal` already claimed first; the native screen did not.
- *   `completeDeviceFlowSignIn` consolidates the claim->switch sequence so both
- *   paths are identical. These tests pin the ORDER (claim before switch) and the
- *   fail-fast behaviour.
+ *   BUG 2 (session-sync cutover regression): once claiming was fixed,
+ *   `completeDeviceFlowSignIn` still committed the claimed session through
+ *   `switchSession`. After the session-sync cutover, `switchSession` became an
+ *   account-SWITCH between accounts already registered on the device and
+ *   throws `No device account found for session "..."` for a freshly-claimed
+ *   session that was never registered — surfacing as "Authorization
+ *   successful but failed to complete sign in." The fix commits the claimed
+ *   session through `commitSession` (`useOxy().handleWebSession`) instead —
+ *   the same path a fresh password/FedCM sign-in uses to register the account
+ *   into the device's session set.
+ *
+ *   These tests pin the order (claim before commit), the fail-fast behaviour
+ *   on a claim that returns no usable session, and propagation of a
+ *   `commitSession` failure.
  */
 
-import type { User } from '@oxyhq/core';
+import type { SessionLoginResponse, User } from '@oxyhq/core';
 import {
   completeDeviceFlowSignIn,
   type DeviceFlowClient,
@@ -25,67 +35,153 @@ import {
 
 const SESSION_ID = 'session-id-123';
 const SESSION_TOKEN = 'a'.repeat(32);
-const USER = { id: 'user-1', username: 'nate', privacySettings: {} } as User;
+const ACCESS_TOKEN = 'access-token-abc';
+const USER = {
+  id: 'user-1',
+  username: 'nate',
+  name: { displayName: 'Nate' },
+  privacySettings: {},
+} as User;
+// The session carries only the minimal shape (`id`/`username`/`name`/`avatar`)
+// — this is what `commitSession` receives, not the full claimed `User`.
+const MINIMAL_USER = { id: USER.id, username: USER.username, name: USER.name, avatar: undefined };
 
 describe('completeDeviceFlowSignIn', () => {
-  it('claims the sessionToken BEFORE switching the session', async () => {
+  it('claims the sessionToken BEFORE committing the session', async () => {
     const order: string[] = [];
 
     const oxyServices: DeviceFlowClient = {
       claimSessionByToken: jest.fn(async (token: string) => {
         expect(token).toBe(SESSION_TOKEN);
         order.push('claim');
+        return {
+          accessToken: ACCESS_TOKEN,
+          sessionId: SESSION_ID,
+          deviceId: 'device-1',
+          expiresAt: '2026-01-01T00:00:00.000Z',
+          user: USER,
+        };
       }),
     };
-    const switchSession = jest.fn(async (sessionId: string): Promise<User> => {
-      expect(sessionId).toBe(SESSION_ID);
-      order.push('switch');
-      return USER;
+    const commitSession = jest.fn(async (session: SessionLoginResponse): Promise<void> => {
+      expect(session).toEqual({
+        sessionId: SESSION_ID,
+        deviceId: 'device-1',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+        user: MINIMAL_USER,
+        accessToken: ACCESS_TOKEN,
+      });
+      order.push('commit');
     });
 
     const user = await completeDeviceFlowSignIn({
       oxyServices,
       sessionId: SESSION_ID,
       sessionToken: SESSION_TOKEN,
-      switchSession,
+      commitSession,
     });
 
-    expect(order).toEqual(['claim', 'switch']);
+    expect(order).toEqual(['claim', 'commit']);
     expect(oxyServices.claimSessionByToken).toHaveBeenCalledWith(SESSION_TOKEN);
-    expect(switchSession).toHaveBeenCalledWith(SESSION_ID);
+    expect(commitSession).toHaveBeenCalledTimes(1);
     expect(user).toBe(USER);
   });
 
-  it('does NOT switch the session when the claim fails (the native regression)', async () => {
+  it('falls back to the delivered sessionId/deviceId/expiresAt when the claim omits them', async () => {
+    const oxyServices: DeviceFlowClient = {
+      claimSessionByToken: jest.fn(async () => ({
+        accessToken: ACCESS_TOKEN,
+        user: USER,
+      })),
+    };
+    const commitSession = jest.fn(async (): Promise<void> => {});
+
+    await completeDeviceFlowSignIn({
+      oxyServices,
+      sessionId: SESSION_ID,
+      sessionToken: SESSION_TOKEN,
+      commitSession,
+    });
+
+    expect(commitSession).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      deviceId: '',
+      expiresAt: '',
+      user: MINIMAL_USER,
+      accessToken: ACCESS_TOKEN,
+    });
+  });
+
+  it('does NOT commit the session when the claim fails (the original native regression)', async () => {
     const claimError = new Error('claim failed (401)');
     const oxyServices: DeviceFlowClient = {
       claimSessionByToken: jest.fn(async () => {
         throw claimError;
       }),
     };
-    const switchSession = jest.fn(async (): Promise<User> => USER);
+    const commitSession = jest.fn(async (): Promise<void> => {});
 
     await expect(
       completeDeviceFlowSignIn({
         oxyServices,
         sessionId: SESSION_ID,
         sessionToken: SESSION_TOKEN,
-        switchSession,
+        commitSession,
       }),
     ).rejects.toThrow('claim failed (401)');
 
     // The bearer was never planted, so we must not attempt the bearer-protected
-    // switch — surfacing the failure to the caller instead.
-    expect(switchSession).not.toHaveBeenCalled();
+    // commit — surfacing the failure to the caller instead.
+    expect(commitSession).not.toHaveBeenCalled();
   });
 
-  it('propagates a switchSession failure after a successful claim', async () => {
-    const switchError = new Error('session invalid');
+  it('throws when the claim returns no accessToken (the session-sync regression guard)', async () => {
     const oxyServices: DeviceFlowClient = {
-      claimSessionByToken: jest.fn(async () => undefined),
+      claimSessionByToken: jest.fn(async () => ({ sessionId: SESSION_ID, user: USER })),
     };
-    const switchSession = jest.fn(async (): Promise<User> => {
-      throw switchError;
+    const commitSession = jest.fn(async (): Promise<void> => {});
+
+    await expect(
+      completeDeviceFlowSignIn({
+        oxyServices,
+        sessionId: SESSION_ID,
+        sessionToken: SESSION_TOKEN,
+        commitSession,
+      }),
+    ).rejects.toThrow('Device-flow claim did not return a usable session');
+
+    expect(commitSession).not.toHaveBeenCalled();
+  });
+
+  it('throws when the claim returns no user', async () => {
+    const oxyServices: DeviceFlowClient = {
+      claimSessionByToken: jest.fn(async () => ({ accessToken: ACCESS_TOKEN, sessionId: SESSION_ID })),
+    };
+    const commitSession = jest.fn(async (): Promise<void> => {});
+
+    await expect(
+      completeDeviceFlowSignIn({
+        oxyServices,
+        sessionId: SESSION_ID,
+        sessionToken: SESSION_TOKEN,
+        commitSession,
+      }),
+    ).rejects.toThrow('Device-flow claim did not return a usable session');
+
+    expect(commitSession).not.toHaveBeenCalled();
+  });
+
+  it('propagates a commitSession failure after a successful claim', async () => {
+    const commitError = new Error('session invalid');
+    const oxyServices: DeviceFlowClient = {
+      claimSessionByToken: jest.fn(async () => ({
+        accessToken: ACCESS_TOKEN,
+        sessionId: SESSION_ID,
+        user: USER,
+      })),
+    };
+    const commitSession = jest.fn(async (): Promise<void> => {
+      throw commitError;
     });
 
     await expect(
@@ -93,11 +189,11 @@ describe('completeDeviceFlowSignIn', () => {
         oxyServices,
         sessionId: SESSION_ID,
         sessionToken: SESSION_TOKEN,
-        switchSession,
+        commitSession,
       }),
     ).rejects.toThrow('session invalid');
 
     expect(oxyServices.claimSessionByToken).toHaveBeenCalledTimes(1);
-    expect(switchSession).toHaveBeenCalledTimes(1);
+    expect(commitSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/services/src/utils/deviceFlowSignIn.ts
+++ b/packages/services/src/utils/deviceFlowSignIn.ts
@@ -2,25 +2,43 @@
  * Shared, pure orchestration for completing the cross-app device-flow sign-in
  * (the QR-code / "Open Oxy Auth" path used on native and web).
  *
- * THE BUG THIS FIXES (native): once another authenticated device approves the
- * pending AuthSession, the originating client is notified (socket / poll /
- * deep-link) with the authorized `sessionId`. Before any session-management
- * code can use it, the client MUST exchange the secret 128-bit `sessionToken`
- * (held only by this client, generated for THIS flow) for the first access
- * token via `claimSessionByToken` — the device-flow equivalent of OAuth's
- * code-for-token exchange (RFC 8628 §3.4).
+ * THE FIRST BUG THIS FIXES (native): once another authenticated device
+ * approves the pending AuthSession, the originating client is notified
+ * (socket / poll / deep-link) with the authorized `sessionId`. Before any
+ * session-management code can use it, the client MUST exchange the secret
+ * 128-bit `sessionToken` (held only by this client, generated for THIS flow)
+ * for the first access token via `claimSessionByToken` — the device-flow
+ * equivalent of OAuth's code-for-token exchange (RFC 8628 §3.4).
+ *
+ * THE SECOND BUG THIS FIXES (session-sync cutover regression): the
+ * freshly-claimed session is NOT yet registered in the device's
+ * server-authoritative session set — nothing has run
+ * `sessionClient.addCurrentAccount()` for it — so it must NOT be committed
+ * through `switchSession`. That path is now an account-SWITCH between
+ * accounts already registered on this device (`OxyContext`'s
+ * `switchSessionForContext`), and throws `No device account found for
+ * session "..."` for anything else, surfacing as "Authorization successful
+ * but failed to complete sign in." Instead the claimed session must be
+ * committed through the SAME path a fresh password/FedCM sign-in uses —
+ * `useOxy().handleWebSession` (`OxyContext`'s `handleWebSSOSession`) — which
+ * registers the account into the device set, persists it durably, and
+ * hydrates the full user profile.
  *
  * Skipping the claim leaves the SDK with NO bearer token: the session is
  * authorized server-side but the app never becomes authenticated and the UI
- * sits "Waiting for authorization..." forever. Consolidating the claim→switch
- * sequence here keeps native and web identical and unit-testable.
+ * sits "Waiting for authorization..." forever. Consolidating the
+ * claim->commit sequence here keeps native and web identical and
+ * unit-testable.
  */
 
-import { KeyManager, type User } from '@oxyhq/core';
+import { KeyManager, type MinimalUserData, type SessionLoginResponse, type User } from '@oxyhq/core';
 
 interface DeviceFlowClaimResult {
   accessToken?: string;
   sessionId?: string;
+  deviceId?: string;
+  expiresAt?: string;
+  user?: User;
 }
 
 /**
@@ -49,25 +67,29 @@ export interface CompleteDeviceFlowSignInOptions {
    */
   sessionToken: string;
   /**
-   * The session-management `switchSession` from `useOxy()`. Hydrates the
-   * activated session (validates, fetches the user, persists, updates state).
-   * Runs AFTER the bearer is planted so its bearer-protected calls succeed.
+   * `useOxy().handleWebSession` — commits the freshly-claimed session into
+   * context state through the SAME path a password/FedCM sign-in uses:
+   * registers the account into the device's server-authoritative session set,
+   * persists it durably, and hydrates the full user profile. Runs AFTER the
+   * bearer is planted so its bearer-protected calls succeed.
    */
-  switchSession: (sessionId: string) => Promise<User>;
+  commitSession: (session: SessionLoginResponse) => Promise<void>;
 }
 
 /**
  * Complete a device-flow sign-in: claim the first access token with the secret
- * `sessionToken` (planting the bearer), then hydrate the session via
- * `switchSession`. Returns the authenticated user.
+ * `sessionToken` (planting the bearer), then commit the resulting session via
+ * `commitSession` (registers it into the device's server-authoritative session
+ * set and hydrates the full user). Returns the authenticated user.
  *
- * Throws if either the claim or the switch fails; callers surface a retry UI.
+ * Throws if the claim did not return a usable session, or if either the claim
+ * or the commit fails; callers surface a retry UI.
  */
 export async function completeDeviceFlowSignIn({
   oxyServices,
   sessionId,
   sessionToken,
-  switchSession,
+  commitSession,
 }: CompleteDeviceFlowSignInOptions): Promise<User> {
   // 1) Plant the bearer + refresh tokens. The claim response is also persisted
   //    to native shared secure storage so a later cold boot has a bearer before
@@ -77,6 +99,31 @@ export async function completeDeviceFlowSignIn({
     await KeyManager.storeSharedSession(claimed.sessionId || sessionId, claimed.accessToken);
   }
 
-  // 2) Bearer is now planted — hydrate the session through the normal path.
-  return switchSession(sessionId);
+  if (!claimed?.accessToken || !claimed.user) {
+    throw new Error('Device-flow claim did not return a usable session');
+  }
+
+  // `SessionLoginResponse.user` is the minimal session-carried shape (avatar
+  // is `string | undefined`); the claim response returns the full `User`
+  // (avatar is `string | null | undefined`). Normalize rather than widening
+  // `SessionLoginResponse.user` to accept `null`.
+  const minimalUser: MinimalUserData = {
+    id: claimed.user.id,
+    username: claimed.user.username,
+    name: claimed.user.name,
+    avatar: claimed.user.avatar ?? undefined,
+  };
+
+  // 2) Bearer is now planted — commit the session through the same path a
+  //    fresh sign-in uses so it is registered into the device's
+  //    server-authoritative session set instead of an account switch.
+  await commitSession({
+    sessionId: claimed.sessionId || sessionId,
+    deviceId: claimed.deviceId ?? '',
+    expiresAt: claimed.expiresAt ?? '',
+    user: minimalUser,
+    accessToken: claimed.accessToken,
+  });
+
+  return claimed.user;
 }


### PR DESCRIPTION
ROOT CAUSE (reproduced live on accounts.oxy.so): the session-sync cutover changed `switchSession` semantics to an account-switch that throws for sessions not already in the device set. `completeDeviceFlowSignIn` (the 'Sign in with Oxy' device-flow) called `switchSession(sessionId)` to hydrate a freshly-CLAIMED session — never registered → threw → 'Authorization successful but failed to complete sign in.' FIX: commit the claimed session via `handleWebSession` (= `handleWebSSOSession` → `addCurrentAccount` registers into the device set + persists), the same path password/FedCM use. `claimSessionByToken` returns the full session. services 247/247, tsc clean. Deploys accounts+inbox.