### PR TITLE
fix(session): error-isolation + revoked-account healing from review findings (#493)

### DIFF
--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -75,7 +75,9 @@ afterAll((done) => { server.close(done); });
 beforeEach(() => {
   jest.clearAllMocks();
   mockResolveActiveToken.mockResolvedValue({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' });
-  mockGetSession.mockResolvedValue(null);
+  // Default to an active first-party session; individual tests override this
+  // to exercise managed sessions or the expired/revoked (null) 401 path.
+  mockGetSession.mockResolvedValue({ operatedByUserId: null });
 });
 
 describe('GET /session/device/state', () => {
@@ -107,12 +109,15 @@ describe('POST /session/device/switch', () => {
     expect(mockBroadcast).not.toHaveBeenCalled();
   });
 
-  it('403 when the target account session is not authorized (e.g. revoked act_as membership)', async () => {
-    mockSwitchActive.mockResolvedValueOnce({ ok: false, reason: 'unauthorized' });
+  it('403 and broadcasts the healed state when the target session is revoked (act_as membership pulled)', async () => {
+    const healed = { ...STATE, accounts: [], activeAccountId: null, revision: 2 };
+    mockSwitchActive.mockResolvedValueOnce({ ok: false, reason: 'unauthorized', state: healed });
     const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'org1' });
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('Account not authorized');
-    expect(mockBroadcast).not.toHaveBeenCalled();
+    // switchActive healed the device set (dropped the revoked account); the
+    // route broadcasts that healed state so the device's other tabs converge.
+    expect(mockBroadcast).toHaveBeenCalledWith(healed);
   });
 });
 
@@ -161,5 +166,14 @@ describe('POST /session/device/add', () => {
     mockAddAccount.mockResolvedValueOnce(STATE);
     await requestJson(server, 'POST', '/session/device/add', {});
     expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
+  });
+
+  it('401s and never adds the account when the session is expired/revoked (getSession returns null)', async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await requestJson(server, 'POST', '/session/device/add', {});
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid session');
+    expect(mockAddAccount).not.toHaveBeenCalled();
+    expect(mockBroadcast).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -44,7 +44,11 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
   // so a managed-account sign-in must be resolved from the session record
   // itself to bind the device-session entry to its operator.
   const sessionDoc = await sessionService.getSession(session.sessionId, true);
-  const operatedByUserId = sessionDoc?.operatedByUserId ? sessionDoc.operatedByUserId.toString() : undefined;
+  // The session record must still be active. `getSession` returns null for an
+  // expired/revoked session (JWT not yet expired but the session doc
+  // deactivated) — such a session must NOT be re-added to the device set.
+  if (!sessionDoc) { res.status(401).json({ error: 'Invalid session' }); return; }
+  const operatedByUserId = sessionDoc.operatedByUserId ? sessionDoc.operatedByUserId.toString() : undefined;
   const state = await deviceSessionService.addAccount(session.deviceId, {
     accountId,
     sessionId: session.sessionId,
@@ -61,7 +65,14 @@ router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
   if (!accountId) { res.status(400).json({ error: 'accountId required' }); return; }
   const outcome = await deviceSessionService.switchActive(deviceId, accountId);
   if (!outcome.ok) {
-    if (outcome.reason === 'unauthorized') { res.status(403).json({ error: 'Account not authorized' }); return; }
+    if (outcome.reason === 'unauthorized') {
+      // The target session was revoked; `switchActive` healed the device set by
+      // removing the dead account. Broadcast the healed state so the device's
+      // other tabs drop it too, then reject the switch.
+      broadcastDeviceState(outcome.state);
+      res.status(403).json({ error: 'Account not authorized' });
+      return;
+    }
     res.status(404).json({ error: 'Account not on this device' });
     return;
   }

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -228,8 +228,8 @@ describe('switchActive', () => {
     expect(result).toEqual({ ok: true, state: expect.objectContaining({ activeAccountId: 'a1', revision: 2 }) });
   });
 
-  it('returns unauthorized and does not commit the switch when validateSessionById rejects the target session (e.g. revoked act_as membership)', async () => {
-    mockFindOne.mockReturnValueOnce(lean({
+  it('heals a revoked target: removes the account from the device set and returns the healed state (does NOT commit the switch)', async () => {
+    const doc = {
       deviceId: 'd1',
       accounts: [
         { accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null },
@@ -237,12 +237,32 @@ describe('switchActive', () => {
       ],
       activeAccountId: { toString: () => 'op1' },
       revision: 1,
+    };
+    mockFindOne.mockReturnValueOnce(lean(doc)); // switchActive's initial load
+    mockValidateSessionById.mockResolvedValueOnce(null); // target session revoked
+    mockFindOne.mockReturnValueOnce(lean(doc)); // signout()'s own reload
+    mockDeactivate.mockResolvedValueOnce(true);
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'op1' }, sessionId: 's-op', authuser: 0, operatedByUserId: null }],
+      activeAccountId: { toString: () => 'op1' },
+      revision: 2,
+      updatedAt: new Date(1720000000000),
     }));
-    mockValidateSessionById.mockResolvedValueOnce(null);
     const result = await deviceSessionService.switchActive('d1', 'org1');
     expect(mockValidateSessionById).toHaveBeenCalledWith('s-org', false);
-    expect(result).toEqual({ ok: false, reason: 'unauthorized' });
-    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    // The revoked account's session is deactivated and the account dropped from
+    // the set; the healed state is returned so the route can broadcast it. The
+    // switch itself is NOT committed (activeAccountId stays on op1).
+    expect(mockDeactivate).toHaveBeenCalledWith('s-org');
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unauthorized',
+      state: expect.objectContaining({
+        accounts: [expect.objectContaining({ accountId: 'op1' })],
+        activeAccountId: 'op1',
+      }),
+    });
   });
 });
 

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -35,7 +35,8 @@ function lowestFreeAuthuser(accounts: IDeviceSessionAccount[]): number {
 
 export type SwitchActiveResult =
   | { ok: true; state: DeviceSessionState }
-  | { ok: false; reason: 'not_found' | 'unauthorized' };
+  | { ok: false; reason: 'not_found' }
+  | { ok: false; reason: 'unauthorized'; state: DeviceSessionState };
 
 class DeviceSessionService {
   private async load(deviceId: string): Promise<IDeviceSession | null> {
@@ -128,7 +129,15 @@ class DeviceSessionService {
     // authority over (see resolveActiveToken, which does the same check on
     // read but can't undo an already-committed activeAccountId).
     const validated = await sessionService.validateSessionById(target.sessionId, false);
-    if (!validated) return { ok: false, reason: 'unauthorized' };
+    if (!validated) {
+      // The target session is revoked (e.g. the operator's act_as membership
+      // was pulled). Leaving it in the device set strands a dead account the
+      // device can never switch into. Heal by removing it through the SAME
+      // signout cascade a normal removal uses, and return the healed state so
+      // the route can broadcast it to the device's other tabs/connections.
+      const state = await this.signout(deviceId, { accountId });
+      return { ok: false, reason: 'unauthorized', state };
+    }
 
     const updated = await DeviceSession.findOneAndUpdate(
       { deviceId },

--- a/packages/auth-sdk/__tests__/session/tokenRefresh.test.ts
+++ b/packages/auth-sdk/__tests__/session/tokenRefresh.test.ts
@@ -245,6 +245,27 @@ describe('startTokenRefreshScheduler', () => {
     handle.dispose();
   });
 
+  it('clamps an over-int32 delay so a long-TTL token does not fire immediately (int32 overflow → tight refresh loop)', () => {
+    const fake = buildFakeOxyServices();
+    fake.setTokens('tok-long');
+    // Expiry ~30 days out: fireInMs (minus the 60s lead) exceeds the 2^31-1 ms
+    // setTimeout ceiling. Without clamping, that overflows the int32 timer field
+    // and the timer fires immediately — a busy refresh loop.
+    fake.setExpirySeconds(Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60);
+    const handle = startTokenRefreshScheduler(fake as unknown as OxyServices);
+
+    // A short advance must NOT fire: proof the delay was clamped to the ceiling
+    // rather than overflowing to an immediate fire.
+    jest.advanceTimersByTime(TOKEN_REFRESH_LEAD_MS);
+    expect(fake.httpService.refreshAccessToken).not.toHaveBeenCalled();
+
+    // It fires once the clamped ceiling delay (2^31 - 1 ms) elapses.
+    jest.advanceTimersByTime(2_147_483_647);
+    expect(fake.httpService.refreshAccessToken).toHaveBeenCalledWith('preflight');
+
+    handle.dispose();
+  });
+
   it('dispose() tears down the timer — no refresh fires after disposal', () => {
     const fake = buildFakeOxyServices();
     fake.setTokens('tok-1');

--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -619,22 +619,46 @@ export function WebOxyProvider({
       await clearSessionState();
       return;
     }
+    // LAST-WRITE-WINS GUARD: `syncFromClient` runs concurrently — once per
+    // socket `notify()` push AND once per direct post-mutation call — and each
+    // invocation captures `state` before the async profile fetch. Capture the
+    // revision this fetch is FOR, then re-read the client's current state after
+    // the await and bail if it has moved on, so a SLOWER, OLDER fetch cannot
+    // clobber `user`/`sessions`/`accounts` back to an outdated projection.
+    const capturedRevision = state.revision;
     const ids = accountIdsOf(state);
-    const users = ids.length > 0 ? await oxyServices.getUsersByIds(ids) : [];
+    let users: User[] = [];
+    try {
+      users = ids.length > 0 ? await oxyServices.getUsersByIds(ids) : [];
+    } catch (fetchError) {
+      // Fire-and-forget from the `sessionClient.subscribe` callback, so a
+      // rejected fetch would surface as an unhandled rejection. Log and bail;
+      // the next `notify()`/mutation re-projects the current truth.
+      logger.warn(
+        'syncFromClient: failed to resolve account profiles',
+        { component: 'WebOxyProvider', method: 'syncFromClient' },
+        fetchError as unknown,
+      );
+      return;
+    }
+    const latest = sessionClient.getState();
+    if (!latest || latest.revision !== capturedRevision) {
+      return;
+    }
     const usersById = new Map(users.map((resolvedUser) => [resolvedUser.id, resolvedUser]));
-    setClientProjectedSessions(deviceStateToClientSessions(state, usersById));
-    setActiveSessionId(activeSessionIdOf(state));
-    const activeUser = activeUserOf(state, usersById);
+    setClientProjectedSessions(deviceStateToClientSessions(latest, usersById));
+    setActiveSessionId(activeSessionIdOf(latest));
+    const activeUser = activeUserOf(latest, usersById);
     if (activeUser) {
       setUser(activeUser);
     }
     const expSeconds = oxyServices.getAccessTokenExpiry();
-    setAccounts(projectAuthManagerAccounts(state, usersById, {
+    setAccounts(projectAuthManagerAccounts(latest, usersById, {
       accessToken: oxyServices.getAccessToken(),
       expiresAt: expSeconds !== null ? new Date(expSeconds * 1000).toISOString() : null,
     }));
-    setActiveAuthuserState(activeAuthuserOf(state));
-    sessionClientHost.setCurrentAccountId(state.activeAccountId);
+    setActiveAuthuserState(activeAuthuserOf(latest));
+    sessionClientHost.setCurrentAccountId(latest.activeAccountId);
   }, [oxyServices, sessionClient, sessionClientHost, clearSessionState]);
 
   useEffect(() => {

--- a/packages/auth-sdk/src/session/tokenRefresh.ts
+++ b/packages/auth-sdk/src/session/tokenRefresh.ts
@@ -80,6 +80,14 @@ const SILENT_IFRAME_REFRESH_TIMEOUT = 4000;
  */
 export const TOKEN_REFRESH_LEAD_MS = 60_000;
 
+/**
+ * Max `setTimeout` delay (2^31 − 1 ms, ~24.8 days). A larger delay overflows
+ * the browser/Node int32 timer field and fires IMMEDIATELY — with a long-TTL
+ * token that turns the reschedule-on-finish loop into a tight busy refresh.
+ * Clamp the computed delay to this ceiling.
+ */
+const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+
 /** A single refresh arm: mints a session, or resolves to `null` to fall through to the next arm. */
 type RefreshArm = () => Promise<SessionLoginResponse | null>;
 
@@ -215,7 +223,7 @@ export function startTokenRefreshScheduler(oxyServices: OxyServices): TokenRefre
       return;
     }
     const fireInMs = expSeconds * 1000 - Date.now() - TOKEN_REFRESH_LEAD_MS;
-    timer = setTimeout(runRefresh, Math.max(fireInMs, 0));
+    timer = setTimeout(runRefresh, Math.min(Math.max(fireInMs, 0), MAX_TIMEOUT_DELAY_MS));
   };
 
   const onFocus = (): void => {

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -818,7 +818,16 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     // fresher call has already applied (or will apply) the current truth.
     const capturedRevision = state.revision;
     const ids = accountIdsOf(state);
-    const users = ids.length > 0 ? await oxyServices.getUsersByIds(ids) : [];
+    let users: User[] = [];
+    try {
+      users = ids.length > 0 ? await oxyServices.getUsersByIds(ids) : [];
+    } catch (fetchError) {
+      // Invoked fire-and-forget from the socket `notify()` subscription, so a
+      // rejected profile fetch would surface as an unhandled rejection. Log and
+      // bail; the next `notify()`/mutation will re-project the current truth.
+      logger('Failed to resolve account profiles during syncFromClient', fetchError);
+      return;
+    }
     const latest = sessionClient.getState();
     if (!latest || latest.revision !== capturedRevision) {
       return;
@@ -1627,7 +1636,19 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
         const handoff = (async () => {
           try {
             if (!registeredDuringBootRef.current) {
-              await sessionClient.addCurrentAccount();
+              // Nested guard: registering this account into the device set is
+              // best-effort. If it throws, `start()` must STILL run so the
+              // realtime socket connects and state projects — cold boot
+              // re-registers the account into the device set on the next load.
+              try {
+                await sessionClient.addCurrentAccount();
+              } catch (addAccountErr) {
+                loggerUtil.warn(
+                  'cold-boot: addCurrentAccount failed; continuing to start()',
+                  { component: 'OxyContext', method: 'restoreSessionsFromStorage' },
+                  addAccountErr as unknown,
+                );
+              }
             }
             await sessionClient.start();
             await syncFromClient();
@@ -2200,9 +2221,21 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     // `oxyServices.switchToAccount` already planted above) and reproject
     // state, so the switch persists across reload / other tabs / devices
     // instead of only living in this provider's local session-management
-    // state.
-    await sessionClient.addCurrentAccount();
-    await syncFromClient();
+    // state. Best-effort: the token for the new account is already planted, so
+    // a transient failure here must NEVER reject the switch — fall through to
+    // `loginSuccess`/`onAuthStateChange` so the UI reflects the switched-to
+    // account (cold boot re-registers into the device set on next load).
+    // Mirrors the same guard in `handleWebSSOSession`.
+    try {
+      await sessionClient.addCurrentAccount();
+      await syncFromClient();
+    } catch (registrationError) {
+      loggerUtil.warn(
+        'switchToAccount: failed to register account into device set',
+        { component: 'OxyContext', method: 'switchToAccount' },
+        registrationError as unknown,
+      );
+    }
 
     // Fetch the canonical User for the new account (the switch result carries
     // only MinimalUserData); fall back to that minimal shape if the profile

--- a/packages/services/src/ui/utils/activeAuthuser.ts
+++ b/packages/services/src/ui/utils/activeAuthuser.ts
@@ -110,7 +110,10 @@ export function clearSignedOut(): void {
  * `silent-iframe` cold-boot step.
  */
 export function isSilentRestoreSuppressed(): boolean {
-  if (!hasLocalStorage()) return false;
+  // Unlike its try/catch-wrapped siblings this reads `window.location.origin`
+  // directly, so guard it: an RN polyfill can expose `localStorage` without a
+  // `location`, which would throw here. Fail safe toward normal restore.
+  if (!hasLocalStorage() || typeof window.location === 'undefined') return false;
   return silentRestoreSuppressed(window.localStorage, window.location.origin);
 }
 


### PR DESCRIPTION
Minimal-diff fixes for the auth/session bot-review findings verified live on `main` (#493). Each is the smallest correct change at the reported site so the eventual `impl/session-sync-p1` rebase stays trivial.

## Findings addressed

1. **HIGH** `packages/auth-sdk/src/WebOxyProvider.tsx` — `syncFromClient` now captures `state.revision` before the `getUsersByIds` await, re-reads the client state after, and bails if a fresher revision landed (last-write-wins guard, mirroring its `OxyContext` twin); the fetch is wrapped in try/catch so a fire-and-forget rejection warns instead of becoming an unhandled rejection.
2. **HIGH** `packages/services/src/ui/context/OxyContext.tsx` — `switchToAccount` wraps `addCurrentAccount()` + `syncFromClient()` in a best-effort try/catch (mirrors `handleWebSSOSession`); a transient failure after the token is planted no longer rejects the whole switch and wedges the UI on the old account.
3. **HIGH** `packages/api/src/services/deviceSession.service.ts` + `packages/api/src/routes/sessionDevice.ts` — `switchActive` now removes a revoked target account from the device set (via the existing `signout` cascade) and returns the healed `state`; the `/switch` route broadcasts that healed state so other tabs converge. `SwitchActiveResult` gains the healed-state variant.
4. **MED-HIGH** `packages/services/src/ui/context/OxyContext.tsx` — cold-boot handoff gives `addCurrentAccount()` its own nested try/catch so a failure there no longer prevents `start()` (realtime socket) from running.
5. **SEC** `packages/api/src/routes/sessionDevice.ts` — `/session/device/add` rejects with 401 when the session record is expired/inactive (`getSession` returns null) instead of letting the optional-chain add the account anyway.
6. **MED** `packages/services/src/ui/utils/activeAuthuser.ts` — `isSilentRestoreSuppressed` now guards `typeof window.location !== 'undefined'` (RN polyfill with localStorage but no location would otherwise throw). The localStorage SecurityError guard was already fixed on main (75f0c806); only the `window.location` access needed hardening.
7. **MED** `packages/services/src/ui/context/OxyContext.tsx` — the revision-guarded `syncFromClient` (socket `notify()` path) wraps its `getUsersByIds` fetch in try/catch (warn) to avoid a fire-and-forget unhandled rejection.
8. **LOW** `packages/auth-sdk/src/session/tokenRefresh.ts` — clamps the `setTimeout` delay to `2^31 − 1` ms so a long-TTL token can't overflow the int32 timer field and fire immediately in a tight refresh loop.

## Tests
- `packages/api`: updated `switchActive` unauthorized test to assert healing + broadcast; added a `/session/device/add` 401-on-expired-session test. `deviceSession.service.test.ts` + `sessionDevice.test.ts` — 28 passing.
- `packages/auth-sdk`: added a `startTokenRefreshScheduler` clamp regression test (over-int32 delay does not fire immediately). Full suite — 94 passing.
- `packages/services`: full suite — 245 passing.
- `bunx tsc --noEmit` clean for api, services, auth-sdk. Lint clean on touched files (no new biome/eslint violations).

Minimal-diff fixes; `impl/session-sync-p1` should verify these guards survive its rewrite when rebasing. Closes #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)