### PR TITLE
feat: durable web sessions for device-flow sign-ins (IdP establish hop) + visible ProfileMenu styling

### DIFF
--- a/packages/api/src/controllers/sso.controller.ts
+++ b/packages/api/src/controllers/sso.controller.ts
@@ -18,10 +18,25 @@
 
 import * as crypto from 'crypto';
 import { Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { registrableApex, SSO_CALLBACK_PATH } from '@oxyhq/core/server';
 import fedcmService from '../services/fedcm.service';
 import { mintSsoCode, redeemSsoCode, SsoSessionPayload } from '../services/ssoCode.service';
+import type { AuthRequest } from '../middleware/auth';
+import { ssoEstablishTokenSchema } from '../schemas/sso.schemas';
 import { logger } from '../utils/logger';
 import { normaliseOrigin } from '../utils/origin';
+
+/**
+ * Establish-token claim contract — MUST match the IdP `/sso/establish` verifier
+ * (`packages/auth/server/index.ts`: `ESTABLISH_TOKEN_PURPOSE` /
+ * `ESTABLISH_TOKEN_LIFETIME`). The IdP re-verifies the HS256 signature (same
+ * `FEDCM_TOKEN_SECRET`), that `purpose` is exactly this value, that it has not
+ * expired, and that the bound `host` equals the serving host. Never widen the
+ * lifetime or weaken these claims.
+ */
+const ESTABLISH_TOKEN_PURPOSE = 'sso-establish';
+const ESTABLISH_TOKEN_LIFETIME_SECONDS = 60;
 
 /** Constant-time string equality (length-tolerant; no early-exit leak). */
 function timingSafeStringEqual(a: string, b: string): boolean {
@@ -212,6 +227,144 @@ export async function exchangeSsoCode(req: Request, res: Response) {
     return res.json(response);
   } catch (error) {
     logger.error('SSO code exchange error', error instanceof Error ? error : new Error(String(error)));
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+}
+
+/**
+ * POST /sso/establish-token — mint a fully-formed `/sso/establish` URL for the
+ * caller's OWN session, bound to an approved RP origin.
+ *
+ * Bearer-authenticated (mounted behind `authMiddleware`). Closes the last
+ * durable-session gap on web: a device-flow ("Sign in with Oxy" QR) claim plants
+ * only in-memory tokens — no `fedcm_session` cookie is ever planted at the IdP,
+ * so a reload cannot re-mint a token. After such a claim the RP calls this to get
+ * a short-lived, host+audience-bound establish-token wrapped in the existing
+ * `/sso/establish` URL; navigating to it plants the durable first-party cookie.
+ *
+ * Security (fails CLOSED at every step):
+ *  - The session id ALWAYS comes from the caller's bearer (`sessionId` claim) —
+ *    NEVER from the body. A client can only establish for its own session.
+ *  - `origin` MUST be an approved client origin (same authoritative source as
+ *    `/fedcm/clients/approved`, cache-respecting) AND, when the request carries
+ *    an `Origin` header (it always does from a browser CORS call), MUST equal it.
+ *  - `apexAuthHost` is derived server-side from the origin's registrable apex
+ *    (`auth.<apex>`, `oxy.so` family → `auth.oxy.so`) — never taken from input.
+ *  - The FedCM grant for `(user, origin)` is recorded BEFORE responding: the
+ *    device-flow is an active sign-in to this RP, and `/sso/establish` re-checks
+ *    the per-user grant before planting the durable cookie. Without this the hop
+ *    would bounce `none` and never plant the cookie.
+ *  - When `FEDCM_TOKEN_SECRET` is unset the feature is disabled (501).
+ */
+export async function issueEstablishToken(req: AuthRequest, res: Response) {
+  const secret = process.env.FEDCM_TOKEN_SECRET;
+  if (typeof secret !== 'string' || secret.length === 0) {
+    logger.error('POST /sso/establish-token called but FEDCM_TOKEN_SECRET is not configured');
+    return res.status(501).json({ message: 'Not implemented' });
+  }
+
+  try {
+    // 1. Caller identity — user from the validated session, session id from the
+    //    bearer's `sessionId` claim. NEVER from the body. `authMiddleware` has
+    //    already verified the token (signature + live session) upstream, so we
+    //    decode the trusted bearer here only to read its `sessionId` claim.
+    const userId = req.user?.id;
+    if (typeof userId !== 'string' || userId.length === 0) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : undefined;
+    const decoded = token ? jwt.decode(token) : null;
+    const sessionId =
+      decoded && typeof decoded === 'object'
+        ? (decoded as { sessionId?: unknown }).sessionId
+        : undefined;
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+      return res.status(401).json({ message: 'Session-based token required' });
+    }
+
+    // 2. Validate the body (origin + opaque, length-capped state).
+    const parsed = ssoEstablishTokenSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ message: 'origin and state are required' });
+    }
+    const normalisedOrigin = normaliseOrigin(parsed.data.origin);
+    if (!normalisedOrigin) {
+      return res.status(400).json({ message: 'origin is not a valid origin' });
+    }
+
+    // 3. When present (always, for a browser CORS call) the Origin header MUST
+    //    match the target origin — a page can only establish for itself.
+    const originHeader = req.headers.origin;
+    if (typeof originHeader === 'string' && originHeader.length > 0) {
+      const normalisedHeader = normaliseOrigin(originHeader);
+      if (!normalisedHeader || normalisedHeader !== normalisedOrigin) {
+        logger.warn('SSO establish-token Origin header does not match target origin', {
+          originHeader,
+          target: normalisedOrigin,
+        });
+        return res.status(403).json({ message: 'Origin mismatch' });
+      }
+    }
+
+    // 4. Authoritative approved-clients allow-list (cache-respecting — same
+    //    source `/fedcm/clients/approved` serves). Fail closed → 403.
+    const approvedOrigins = await fedcmService.getApprovedClientOrigins();
+    const approvedSet = new Set(
+      approvedOrigins
+        .map((origin) => normaliseOrigin(origin))
+        .filter((origin): origin is string => origin !== null),
+    );
+    if (!approvedSet.has(normalisedOrigin)) {
+      logger.warn('SSO establish-token requested for unapproved origin', { origin: normalisedOrigin });
+      return res.status(403).json({ message: 'origin is not an approved client' });
+    }
+
+    // 5. Derive the per-apex IdP host server-side. Unlike the central `/sso`
+    //    hop (which skips this for `oxy.so` because auth.oxy.so already carries a
+    //    central cookie), a device-flow claim has NO cookie ANYWHERE — so even
+    //    `oxy.so` clients need the hop to `auth.oxy.so` to plant `fedcm_session`.
+    let hostname: string;
+    try {
+      hostname = new URL(normalisedOrigin).hostname.toLowerCase();
+    } catch {
+      return res.status(400).json({ message: 'origin is not a valid origin' });
+    }
+    const apex = registrableApex(hostname);
+    if (!apex) {
+      return res.status(400).json({ message: 'origin has no registrable apex' });
+    }
+    const apexAuthHost = `auth.${apex}`;
+
+    // 6. Record the FedCM grant for (user, origin) BEFORE responding: the
+    //    device-flow is an active sign-in to this approved RP, and
+    //    `/sso/establish` re-checks this grant before planting the durable
+    //    cookie. Awaited (not best-effort) so the grant is durable before the
+    //    client navigates to `/sso/establish`.
+    await fedcmService.recordGrant(userId, normalisedOrigin);
+
+    // 7. Mint the HS256 establish-token with the EXACT claim shape the IdP
+    //    verifies, exp = now + 60s. `jwt.sign` adds `iat` + `exp`.
+    const establishToken = jwt.sign(
+      {
+        sub: sessionId,
+        aud: normalisedOrigin,
+        host: apexAuthHost,
+        purpose: ESTABLISH_TOKEN_PURPOSE,
+      },
+      secret,
+      { algorithm: 'HS256', expiresIn: ESTABLISH_TOKEN_LIFETIME_SECONDS },
+    );
+
+    // 8. Build the fully-formed establish URL the client navigates to.
+    const establishUrl = new URL(`https://${apexAuthHost}/sso/establish`);
+    establishUrl.searchParams.set('et', establishToken);
+    establishUrl.searchParams.set('return_to', `${normalisedOrigin}${SSO_CALLBACK_PATH}`);
+    establishUrl.searchParams.set('state', parsed.data.state);
+
+    return res.json({ establishUrl: establishUrl.toString() });
+  } catch (error) {
+    logger.error('SSO establish-token error', error instanceof Error ? error : new Error(String(error)));
     return res.status(500).json({ message: 'Internal server error' });
   }
 }

--- a/packages/api/src/controllers/sso.controller.ts
+++ b/packages/api/src/controllers/sso.controller.ts
@@ -293,18 +293,25 @@ export async function issueEstablishToken(req: AuthRequest, res: Response) {
       return res.status(400).json({ message: 'origin is not a valid origin' });
     }
 
-    // 3. When present (always, for a browser CORS call) the Origin header MUST
-    //    match the target origin — a page can only establish for itself.
+    // 3. The Origin header MUST be present AND equal the target origin — a page
+    //    can only establish for itself. A missing/empty Origin means a
+    //    NON-browser caller (this endpoint is only ever reached via a browser
+    //    CORS request); treat it as hostile per lock-down-by-default (mirrors the
+    //    FedCM `/fedcm/exchange` missing-Origin guard). This check runs BEFORE
+    //    any grant write so a bearer-holding server-side caller can never record
+    //    a grant for an origin it is not actually running on (consent bypass).
     const originHeader = req.headers.origin;
-    if (typeof originHeader === 'string' && originHeader.length > 0) {
-      const normalisedHeader = normaliseOrigin(originHeader);
-      if (!normalisedHeader || normalisedHeader !== normalisedOrigin) {
-        logger.warn('SSO establish-token Origin header does not match target origin', {
-          originHeader,
-          target: normalisedOrigin,
-        });
-        return res.status(403).json({ message: 'Origin mismatch' });
-      }
+    if (typeof originHeader !== 'string' || originHeader.length === 0) {
+      logger.warn('SSO establish-token missing Origin header');
+      return res.status(403).json({ message: 'Origin required' });
+    }
+    const normalisedHeader = normaliseOrigin(originHeader);
+    if (!normalisedHeader || normalisedHeader !== normalisedOrigin) {
+      logger.warn('SSO establish-token Origin header does not match target origin', {
+        originHeader,
+        target: normalisedOrigin,
+      });
+      return res.status(403).json({ message: 'Origin mismatch' });
     }
 
     // 4. Authoritative approved-clients allow-list (cache-respecting — same

--- a/packages/api/src/routes/__tests__/sso.test.ts
+++ b/packages/api/src/routes/__tests__/sso.test.ts
@@ -49,6 +49,15 @@ jest.mock('../../middleware/rateLimiter', () => ({
   rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// `sso.ts` imports `authMiddleware` (for the bearer-gated `/sso/establish-token`
+// route), which pulls the mongoose model chain the global mongoose mock cannot
+// load at import time. This suite exercises only the internal `/sso/code` +
+// public `/sso/exchange` routes, so stub the auth middleware to a no-op — it is
+// never mounted on the routes under test here.
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 // Approved-clients allow-list: only https://mention.earth is approved.
 const APPROVED = new Set(['https://mention.earth']);
 jest.mock('../../services/fedcm.service', () => ({

--- a/packages/api/src/routes/__tests__/ssoEstablishToken.test.ts
+++ b/packages/api/src/routes/__tests__/ssoEstablishToken.test.ts
@@ -1,0 +1,323 @@
+/**
+ * POST /sso/establish-token — bearer-authenticated durable-session establish
+ * mint (web device-flow / "Sign in with Oxy" QR).
+ *
+ * Coverage:
+ *  - missing bearer                                 -> 401 (auth gate)
+ *  - unapproved origin                              -> 403 (fail closed)
+ *  - Origin header != target origin                 -> 403
+ *  - FEDCM_TOKEN_SECRET unset                        -> 501 (feature disabled)
+ *  - happy path (oxy.so apex): host == auth.oxy.so, claim shape + exp correct,
+ *    grant recorded, establish URL fully formed
+ *  - cross-apex host derivation (mention.earth -> auth.mention.earth)
+ *  - OPTIONS preflight echoes an approved origin with Authorization allowed
+ *
+ * `authMiddleware` is stubbed (sets `req.user` for any bearer, 401 otherwise);
+ * the controller still decodes the REAL crafted JWT for the `sessionId` claim.
+ * `fedcm.service` is mocked so the approved-clients list + grant recording are
+ * asserted without a DB.
+ */
+
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+import jwt from 'jsonwebtoken';
+
+process.env.ACCESS_TOKEN_SECRET = 'test-access-token-secret-32-chars-long!!';
+process.env.FEDCM_TOKEN_SECRET = 'test-fedcm-token-secret-32-chars-long!!';
+
+// The global `jest.setup.cjs` stubs `jsonwebtoken` (fixed sign/verify, no
+// `decode`). This suite exercises the REAL establish-token crypto — the exact
+// HS256 claim shape + expiry the IdP verifies — so opt back into real
+// jsonwebtoken for this file only.
+jest.mock('jsonwebtoken', () => jest.requireActual('jsonwebtoken'));
+
+const TEST_USER_ID = '64f7c2a1b8e9d3f4a1c2b3d4';
+const TEST_SESSION_ID = 'session-abc-123';
+
+// Rate limiter is a pass-through in tests.
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// Stub the shared auth middleware: any Bearer token authenticates as TEST_USER;
+// the controller still decodes the real crafted token for the sessionId claim.
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const header = req.headers.authorization;
+    if (typeof header !== 'string' || !header.startsWith('Bearer ')) {
+      return res.status(401).json({ message: 'Authentication required' });
+    }
+    (req as unknown as { user?: { id: string } }).user = { id: TEST_USER_ID };
+    next();
+  },
+}));
+
+const APPROVED = new Set(['https://accounts.oxy.so', 'https://mention.earth']);
+const recordGrant = jest.fn(async (_userId: string, _origin: string) => {});
+jest.mock('../../services/fedcm.service', () => ({
+  __esModule: true,
+  default: {
+    getApprovedClientOrigins: jest.fn(async () => Array.from(APPROVED)),
+    isClientApproved: jest.fn(async (origin: string) => APPROVED.has(origin)),
+    recordGrant,
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import ssoRouter, { ssoEstablishTokenCors } from '../sso';
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function requestJson(
+  server: http.Server,
+  method: string,
+  path: string,
+  payload: unknown,
+  headers: Record<string, string> = {},
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload ?? {});
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+          ...headers,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            const parsed = raw.length > 0 ? JSON.parse(raw) : {};
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+/** A real session-based bearer the controller can decode for its sessionId. */
+function bearer(sessionId = TEST_SESSION_ID): string {
+  const token = jwt.sign(
+    { userId: TEST_USER_ID, sessionId },
+    process.env.ACCESS_TOKEN_SECRET as string,
+  );
+  return `Bearer ${token}`;
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use('/sso/establish-token', ssoEstablishTokenCors);
+  app.use(express.json());
+  app.use('/sso', ssoRouter);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.FEDCM_TOKEN_SECRET = 'test-fedcm-token-secret-32-chars-long!!';
+});
+
+describe('POST /sso/establish-token', () => {
+  it('returns 401 when the bearer is missing', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://accounts.oxy.so', state: 'state-xyz' },
+      { origin: 'https://accounts.oxy.so' },
+    );
+    expect(res.status).toBe(401);
+    expect(recordGrant).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 for an unapproved origin (fail closed)', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://evil.example', state: 'state-xyz' },
+      { authorization: bearer(), origin: 'https://evil.example' },
+    );
+    expect(res.status).toBe(403);
+    expect(recordGrant).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the Origin header does not match the target origin', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://accounts.oxy.so', state: 'state-xyz' },
+      { authorization: bearer(), origin: 'https://mention.earth' },
+    );
+    expect(res.status).toBe(403);
+    expect(recordGrant).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when origin or state is missing', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://accounts.oxy.so' },
+      { authorization: bearer(), origin: 'https://accounts.oxy.so' },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 501 when FEDCM_TOKEN_SECRET is not configured', async () => {
+    delete process.env.FEDCM_TOKEN_SECRET;
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://accounts.oxy.so', state: 'state-xyz' },
+      { authorization: bearer(), origin: 'https://accounts.oxy.so' },
+    );
+    expect(res.status).toBe(501);
+  });
+
+  it('mints an establish URL for an oxy.so RP (host auth.oxy.so, claim shape, grant recorded)', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://accounts.oxy.so', state: 'state-xyz' },
+      { authorization: bearer(), origin: 'https://accounts.oxy.so' },
+    );
+    expect(res.status).toBe(200);
+
+    const url = new URL(res.body.establishUrl as string);
+    expect(url.protocol).toBe('https:');
+    expect(url.host).toBe('auth.oxy.so');
+    expect(url.pathname).toBe('/sso/establish');
+    expect(url.searchParams.get('return_to')).toBe('https://accounts.oxy.so/__oxy/sso-callback');
+    expect(url.searchParams.get('state')).toBe('state-xyz');
+
+    // The grant MUST be recorded for (user, origin) so `/sso/establish` finds it.
+    expect(recordGrant).toHaveBeenCalledWith(TEST_USER_ID, 'https://accounts.oxy.so');
+
+    // The establish-token verifies against FEDCM_TOKEN_SECRET with the exact
+    // claim shape the IdP checks, sub == the bearer's session id, exp = iat + 60.
+    const et = url.searchParams.get('et') as string;
+    const claims = jwt.verify(et, process.env.FEDCM_TOKEN_SECRET as string) as Record<string, unknown>;
+    expect(claims.sub).toBe(TEST_SESSION_ID);
+    expect(claims.aud).toBe('https://accounts.oxy.so');
+    expect(claims.host).toBe('auth.oxy.so');
+    expect(claims.purpose).toBe('sso-establish');
+    expect(typeof claims.iat).toBe('number');
+    expect(claims.exp).toBe((claims.iat as number) + 60);
+  });
+
+  it('derives a cross-apex host (mention.earth -> auth.mention.earth)', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://mention.earth', state: 's2' },
+      { authorization: bearer(), origin: 'https://mention.earth' },
+    );
+    expect(res.status).toBe(200);
+
+    const url = new URL(res.body.establishUrl as string);
+    expect(url.host).toBe('auth.mention.earth');
+    expect(url.searchParams.get('return_to')).toBe('https://mention.earth/__oxy/sso-callback');
+
+    const claims = jwt.verify(
+      url.searchParams.get('et') as string,
+      process.env.FEDCM_TOKEN_SECRET as string,
+    ) as Record<string, unknown>;
+    expect(claims.host).toBe('auth.mention.earth');
+    expect(claims.aud).toBe('https://mention.earth');
+  });
+
+  it('never takes the session id from the body — only the bearer', async () => {
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      // A hostile body tries to smuggle a different session id.
+      { origin: 'https://accounts.oxy.so', state: 's', sub: 'attacker-session', sessionId: 'attacker-session' },
+      { authorization: bearer('real-session-999'), origin: 'https://accounts.oxy.so' },
+    );
+    expect(res.status).toBe(200);
+    const et = new URL(res.body.establishUrl as string).searchParams.get('et') as string;
+    const claims = jwt.verify(et, process.env.FEDCM_TOKEN_SECRET as string) as Record<string, unknown>;
+    expect(claims.sub).toBe('real-session-999');
+  });
+
+  it('echoes an approved origin with Authorization allowed on the OPTIONS preflight', async () => {
+    const address = server.address() as AddressInfo;
+    const result = await new Promise<{ status: number; headers: http.IncomingHttpHeaders }>((resolve, reject) => {
+      const req = http.request(
+        {
+          method: 'OPTIONS',
+          host: '127.0.0.1',
+          port: address.port,
+          path: '/sso/establish-token',
+          headers: { origin: 'https://accounts.oxy.so' },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(result.status).toBe(204);
+    expect(result.headers['access-control-allow-origin']).toBe('https://accounts.oxy.so');
+    expect(result.headers['access-control-allow-credentials']).toBe('false');
+    expect(String(result.headers['access-control-allow-headers'])).toContain('Authorization');
+  });
+
+  it('does not echo an unapproved origin on the OPTIONS preflight', async () => {
+    const address = server.address() as AddressInfo;
+    const result = await new Promise<{ status: number; headers: http.IncomingHttpHeaders }>((resolve, reject) => {
+      const req = http.request(
+        {
+          method: 'OPTIONS',
+          host: '127.0.0.1',
+          port: address.port,
+          path: '/sso/establish-token',
+          headers: { origin: 'https://evil.example' },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(result.status).toBe(204);
+    expect(result.headers['access-control-allow-origin']).toBeUndefined();
+  });
+});

--- a/packages/api/src/routes/__tests__/ssoEstablishToken.test.ts
+++ b/packages/api/src/routes/__tests__/ssoEstablishToken.test.ts
@@ -181,6 +181,22 @@ describe('POST /sso/establish-token', () => {
     expect(recordGrant).not.toHaveBeenCalled();
   });
 
+  it('returns 403 when the Origin header is absent (non-browser caller) and records NO grant', async () => {
+    // A missing Origin means a non-browser caller. Without this guard a
+    // bearer-holding server-side caller could record a FedCM grant for ANY
+    // approved origin in the body → silent /sso sign-in (consent bypass). The
+    // grant write MUST be skipped.
+    const res = await requestJson(
+      server,
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://accounts.oxy.so', state: 'state-xyz' },
+      { authorization: bearer() }, // no Origin header
+    );
+    expect(res.status).toBe(403);
+    expect(recordGrant).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when origin or state is missing', async () => {
     const res = await requestJson(
       server,

--- a/packages/api/src/routes/sso.ts
+++ b/packages/api/src/routes/sso.ts
@@ -1,7 +1,8 @@
 import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { rateLimit } from '../middleware/rateLimiter';
-import { issueSsoCode, exchangeSsoCode } from '../controllers/sso.controller';
+import { issueSsoCode, exchangeSsoCode, issueEstablishToken } from '../controllers/sso.controller';
+import { authMiddleware } from '../middleware/auth';
 import fedcmService from '../services/fedcm.service';
 import { normaliseOrigin } from '../utils/origin';
 
@@ -45,6 +46,42 @@ export async function ssoExchangeCors(req: Request, res: Response, next: NextFun
   next();
 }
 
+/**
+ * Dedicated CORS handler for `POST /sso/establish-token`.
+ *
+ * Mounted BEFORE the global CORS middleware (see server.ts) so it fully owns the
+ * response for this path. Unlike `/sso/exchange` this endpoint is
+ * BEARER-authenticated (the token rides in the `Authorization` header, not a
+ * cookie), so it echoes the validated approved origin with
+ * `Access-Control-Allow-Credentials: false` and additionally allows the
+ * `Authorization` request header. Cross-apex RP origins (`mention.earth`, …) are
+ * NOT covered by the apex-scoped global policy, which is exactly why this
+ * dedicated handler — echoing any origin on the FedCM approved-clients allow-list
+ * — is required. The OPTIONS preflight is answered here (204).
+ */
+export async function ssoEstablishTokenCors(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const originHeader = req.headers.origin;
+  res.setHeader('Vary', 'Origin');
+
+  if (typeof originHeader === 'string' && originHeader.length > 0) {
+    const normalised = normaliseOrigin(originHeader);
+    if (normalised && (await fedcmService.isClientApproved(normalised))) {
+      res.setHeader('Access-Control-Allow-Origin', originHeader);
+      res.setHeader('Access-Control-Allow-Credentials', 'false');
+      res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, Accept');
+      res.setHeader('Access-Control-Max-Age', '600');
+    }
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.status(204).end();
+    return;
+  }
+
+  next();
+}
+
 // Internal mint endpoint: cheap, but cap throughput so a leaked internal secret
 // cannot be used to flood the code store. Keyed per-IP via the default keyGen.
 const codeLimiter = rateLimit({
@@ -59,6 +96,14 @@ const exchangeLimiter = rateLimit({
   prefix: 'rl:sso:exchange:',
   windowMs: 60 * 1000,
   max: process.env.NODE_ENV === 'development' ? 600 : 120,
+});
+
+// Bearer-authenticated establish-token mint. Called once per web device-flow
+// sign-in, so a tight cap is fine — it blunts abuse of a leaked bearer.
+const establishTokenLimiter = rateLimit({
+  prefix: 'rl:sso:establish-token:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 600 : 60,
 });
 
 /**
@@ -178,5 +223,50 @@ router.post('/code', codeLimiter, issueSsoCode);
  *         description: Code is invalid, expired, or already used.
  */
 router.post('/exchange', exchangeLimiter, exchangeSsoCode);
+
+/**
+ * @openapi
+ * /sso/establish-token:
+ *   post:
+ *     tags:
+ *       - Federation
+ *     summary: Mint a durable-session establish URL for the caller's session (RP browser)
+ *     description: >
+ *       Bearer-authenticated. After a WEB device-flow ("Sign in with Oxy" QR)
+ *       claim — which plants only in-memory tokens and NO IdP cookie — the RP
+ *       calls this to plant a durable `fedcm_session` cookie so a reload can
+ *       re-mint a token. Returns a fully-formed `/sso/establish` URL bound to the
+ *       caller's OWN session (session id from the bearer, never the body), for an
+ *       approved origin that must also equal the request `Origin` header. 501 if
+ *       `FEDCM_TOKEN_SECRET` is unset.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [origin, state]
+ *             properties:
+ *               origin: { type: string, description: The approved RP origin to establish for. }
+ *               state: { type: string, description: Opaque CSRF state echoed into the callback fragment. }
+ *     responses:
+ *       200:
+ *         description: Establish URL issued.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 establishUrl: { type: string }
+ *       400:
+ *         description: Missing/invalid origin or state.
+ *       401:
+ *         description: Missing or invalid bearer session.
+ *       403:
+ *         description: Origin is unapproved or does not match the request Origin header.
+ *       501:
+ *         description: FEDCM_TOKEN_SECRET not configured (feature disabled).
+ */
+router.post('/establish-token', establishTokenLimiter, authMiddleware, issueEstablishToken);
 
 export default router;

--- a/packages/api/src/schemas/sso.schemas.ts
+++ b/packages/api/src/schemas/sso.schemas.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+/**
+ * `POST /sso/establish-token` request body.
+ *
+ * `origin` is the RP web origin the caller wants to establish a durable IdP
+ * session for (validated server-side against the approved-clients allow-list AND
+ * the request `Origin` header). `state` is the opaque CSRF value the RP persists
+ * under `ssoStateKey(origin)`; it is echoed verbatim into the `/sso/establish`
+ * callback fragment so the post-bounce `sso-return` step can validate it. Both
+ * are length-capped to bound abuse — a normal `state` is a UUID (~36 chars).
+ */
+export const ssoEstablishTokenSchema = z.object({
+  origin: z.string().min(1).max(2048),
+  state: z.string().min(1).max(512),
+});
+
+export type SsoEstablishTokenRequest = z.infer<typeof ssoEstablishTokenSchema>;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -30,7 +30,7 @@ import devicesRouter from './routes/devices';
 import securityRoutes from './routes/security';
 import subscriptionRoutes from './routes/subscription.routes';
 import fedcmRoutes from './routes/fedcm';
-import ssoRoutes, { ssoExchangeCors } from './routes/sso';
+import ssoRoutes, { ssoExchangeCors, ssoEstablishTokenCors } from './routes/sso';
 import authLinkingRoutes from './routes/authLinking';
 import fedcmService from './services/fedcm.service';
 import reputationService from './services/reputation.service';
@@ -196,6 +196,13 @@ app.use(performanceMiddleware);
 // the OPTIONS preflight itself. The global middleware below is credentialed and
 // apex-scoped, which is the wrong policy for this token-in-body endpoint.
 app.use('/sso/exchange', ssoExchangeCors);
+
+// Dedicated CORS for the bearer-authenticated establish-token mint — same
+// before-global-CORS rationale as `/sso/exchange`, but it additionally allows
+// the `Authorization` request header (credentials:false; the bearer is in the
+// header, not a cookie) and echoes any origin on the FedCM approved-clients
+// allow-list (cross-apex RPs the apex-scoped global policy would reject).
+app.use('/sso/establish-token', ssoEstablishTokenCors);
 
 // CORS middleware - reflects request origin with credentials
 app.use(createCorsMiddleware());

--- a/packages/auth-sdk/__tests__/hooks/useCommonsSignIn.test.tsx
+++ b/packages/auth-sdk/__tests__/hooks/useCommonsSignIn.test.tsx
@@ -9,10 +9,20 @@
 
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { OxyServices } from '@oxyhq/core';
+import { establishIdpSessionAfterClaim } from '@oxyhq/core';
 import {
   useCommonsSignIn,
   type CommonsClaimResult,
 } from '../../src/hooks/useCommonsSignIn';
+
+// The post-claim durable-session establish hop is the SHARED core primitive.
+// Mock it so the QR flow does not attempt a real top-level navigation, and so we
+// can assert it fires exactly once after a successful claim+commit.
+jest.mock('@oxyhq/core', () => ({
+  ...jest.requireActual('@oxyhq/core'),
+  establishIdpSessionAfterClaim: jest.fn(async () => true),
+}));
+const mockEstablish = establishIdpSessionAfterClaim as jest.Mock;
 
 // Stub `qrcode` so the hook renders a deterministic data URL without a canvas.
 jest.mock(
@@ -38,6 +48,7 @@ interface StubServices {
   startCommonsSignIn: jest.Mock;
   pollCommonsSignIn: jest.Mock;
   claimSessionByToken: jest.Mock;
+  requestSsoEstablishUrl: jest.Mock;
 }
 
 function makeServices(overrides: Partial<StubServices> = {}): StubServices {
@@ -51,6 +62,7 @@ function makeServices(overrides: Partial<StubServices> = {}): StubServices {
     })),
     pollCommonsSignIn: jest.fn(async () => ({ authorized: false, status: 'pending' })),
     claimSessionByToken: jest.fn(async () => claimResult),
+    requestSsoEstablishUrl: jest.fn(async () => ({ establishUrl: 'https://auth.oxy.so/sso/establish' })),
     ...overrides,
   };
 }
@@ -68,6 +80,10 @@ function renderCommons(services: StubServices, onAuthenticated?: jest.Mock, onEr
 }
 
 describe('useCommonsSignIn', () => {
+  beforeEach(() => {
+    mockEstablish.mockClear();
+  });
+
   it('starts a session, renders the QR, polls, claims, and commits', async () => {
     // Stay `pending` until we flip `approved`, so the transient `waiting` phase
     // is observable before approval drives the flow to completion.
@@ -99,6 +115,39 @@ describe('useCommonsSignIn', () => {
     expect(services.claimSessionByToken).toHaveBeenCalledWith('secret-token');
     expect(onAuthenticated).toHaveBeenCalledWith(claimResult);
     expect(result.current.isActive).toBe(false);
+  });
+
+  it('fires the shared durable-session establish hop once, after the claim commits', async () => {
+    let approved = false;
+    const services = makeServices({
+      pollCommonsSignIn: jest.fn(async () =>
+        approved ? { authorized: true, sessionId: 's1' } : { authorized: false, status: 'pending' },
+      ),
+    });
+    const order: string[] = [];
+    const onAuthenticated = jest.fn(async () => { order.push('commit'); });
+    mockEstablish.mockImplementation(async () => { order.push('establish'); return true; });
+
+    const { result } = renderCommons(services, onAuthenticated);
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.phase).toBe('waiting'));
+    act(() => { approved = true; });
+    await waitFor(() => expect(result.current.phase).toBe('authorized'));
+
+    // Hop fired exactly once, AFTER the commit, driven by the same client.
+    expect(mockEstablish).toHaveBeenCalledTimes(1);
+    expect(mockEstablish).toHaveBeenCalledWith(services, {});
+    expect(order).toEqual(['commit', 'establish']);
+  });
+
+  it('does not fire the establish hop when the flow expires before a claim', async () => {
+    const services = makeServices({
+      pollCommonsSignIn: jest.fn(async () => ({ authorized: false, status: 'expired' })),
+    });
+    const { result } = renderCommons(services);
+    act(() => result.current.start());
+    await waitFor(() => expect(result.current.phase).toBe('expired'));
+    expect(mockEstablish).not.toHaveBeenCalled();
   });
 
   it('moves to `expired` when the server reports the session expired', async () => {

--- a/packages/auth-sdk/src/hooks/useCommonsSignIn.ts
+++ b/packages/auth-sdk/src/hooks/useCommonsSignIn.ts
@@ -29,6 +29,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { OxyServices, User, CommonsSignInStatus } from '@oxyhq/core';
+import { establishIdpSessionAfterClaim } from '@oxyhq/core';
 import { renderQrDataUrl } from '../utils/qrCode';
 import { useWebOxyOptional } from '../WebOxyProvider';
 
@@ -188,6 +189,15 @@ export function useCommonsSignIn(
         if (runId !== runIdRef.current || !mountedRef.current) return;
         setPhase('authorized');
         await onAuthenticatedRef.current?.(result);
+        // WEB durable-session hop (shared core primitive — identical to the
+        // `@oxyhq/services` device-flow path). A QR claim plants only in-memory
+        // tokens: no IdP `fedcm_session` cookie, so a reload would lose the
+        // session. Now that the session is committed + durably persisted by
+        // `onAuthenticated`, plant the per-apex IdP cookie via ONE establish hop.
+        // Total (never throws) and no-op on the IdP origin; a single attempt that
+        // navigates away on success. Not fired for the SSO-return/silent paths —
+        // only this device-flow claim needs it.
+        await establishIdpSessionAfterClaim(svc, {});
       } catch (err) {
         fail(runId, err instanceof Error ? err.message : 'Failed to complete sign in.');
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -530,6 +530,10 @@ export { parseSsoReturnFragment, consumeSsoReturn } from './utils/ssoReturn';
 export type { SsoReturnKind, SsoReturnResult, ConsumeSsoReturnDeps } from './utils/ssoReturn';
 export { generateSsoState } from './mixins/OxyServices.sso';
 
+// Post-claim durable-session establish hop (web device-flow / QR sign-in).
+export { establishIdpSessionAfterClaim } from './utils/ssoEstablish';
+export type { SsoEstablishClient, EstablishAfterClaimDeps } from './utils/ssoEstablish';
+
 // SSO bounce — per-origin sessionStorage keys, bounce URL builder, predicates
 export {
     SSO_CALLBACK_PATH,

--- a/packages/core/src/mixins/OxyServices.sso.ts
+++ b/packages/core/src/mixins/OxyServices.sso.ts
@@ -49,6 +49,11 @@ interface SsoExchangeWireResponse {
   authuser?: number;
 }
 
+/** Wire shape of `POST /sso/establish-token`. */
+interface SsoEstablishTokenWireResponse {
+  establishUrl: string;
+}
+
 /**
  * Generate a cryptographically secure state value for the SSO bounce.
  *
@@ -201,6 +206,56 @@ export function OxyServicesSsoMixin<T extends typeof OxyServicesBase>(Base: T) {
       };
 
       return session;
+    }
+
+    /**
+     * Mint a server-formed `/sso/establish` URL for the caller's OWN session,
+     * bound to an approved RP `origin`.
+     *
+     * Bearer-authenticated (the session id is taken from the caller's own
+     * bearer, server-side — never from any argument). The server validates that
+     * `origin` is an approved client origin (and matches the request `Origin`),
+     * derives the per-apex IdP host (`auth.<apex>`), mints a short-lived HS256
+     * establish-token, and returns a fully-formed
+     * `https://<auth-host>/sso/establish?et=…&return_to=<origin>/__oxy/sso-callback&state=<state>`.
+     *
+     * Used AFTER a web device-flow claim to plant the durable first-party
+     * `fedcm_session` cookie so a reload can re-mint a token (see
+     * {@link establishIdpSessionAfterClaim}). Cache-free (a POST is never
+     * cached, but `cache: false` is explicit).
+     *
+     * @param origin - The RP origin (`window.location.origin`) to establish for.
+     * @param state - The CSRF state echoed back in the callback fragment; the
+     *   caller persists the SAME value under `ssoStateKey(origin)` so the
+     *   post-bounce `sso-return` step validates it.
+     */
+    public async requestSsoEstablishUrl(
+      origin: string,
+      state: string,
+    ): Promise<{ establishUrl: string }> {
+      if (typeof origin !== 'string' || origin.length === 0) {
+        throw this.handleError(new Error('requestSsoEstablishUrl requires a non-empty origin'));
+      }
+      if (typeof state !== 'string' || state.length === 0) {
+        throw this.handleError(new Error('requestSsoEstablishUrl requires a non-empty state'));
+      }
+
+      const response = await this.makeRequest<SsoEstablishTokenWireResponse>(
+        'POST',
+        '/sso/establish-token',
+        { origin, state },
+        { cache: false },
+      );
+
+      if (
+        !response ||
+        typeof response.establishUrl !== 'string' ||
+        response.establishUrl.length === 0
+      ) {
+        throw this.handleError(new Error('SSO establish-token returned no establishUrl'));
+      }
+
+      return { establishUrl: response.establishUrl };
     }
   };
 }

--- a/packages/core/src/mixins/__tests__/sso.test.ts
+++ b/packages/core/src/mixins/__tests__/sso.test.ts
@@ -166,6 +166,47 @@ describe('OxyServices.exchangeSsoCode', () => {
   });
 });
 
+describe('OxyServices.requestSsoEstablishUrl', () => {
+  const ESTABLISH_URL =
+    'https://auth.oxy.so/sso/establish?et=jwt&return_to=https%3A%2F%2Faccounts.oxy.so%2F__oxy%2Fsso-callback&state=s';
+
+  it('POSTs origin + state to /sso/establish-token (bearer, cache-free) and returns the URL', async () => {
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    const spy = jest
+      .spyOn(oxy, 'makeRequest')
+      .mockResolvedValue({ establishUrl: ESTABLISH_URL } as never);
+
+    const result = await oxy.requestSsoEstablishUrl('https://accounts.oxy.so', 's');
+
+    expect(result).toEqual({ establishUrl: ESTABLISH_URL });
+    expect(spy).toHaveBeenCalledWith(
+      'POST',
+      '/sso/establish-token',
+      { origin: 'https://accounts.oxy.so', state: 's' },
+      { cache: false },
+    );
+    spy.mockRestore();
+  });
+
+  it('rejects an empty origin or state without calling the API', async () => {
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    const spy = jest.spyOn(oxy, 'makeRequest');
+
+    await expect(oxy.requestSsoEstablishUrl('', 's')).rejects.toThrow();
+    await expect(oxy.requestSsoEstablishUrl('https://accounts.oxy.so', '')).rejects.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('throws when the server returns no establishUrl', async () => {
+    const oxy = new OxyServices({ baseURL: 'https://api.oxy.so' });
+    const spy = jest.spyOn(oxy, 'makeRequest').mockResolvedValue({} as never);
+
+    await expect(oxy.requestSsoEstablishUrl('https://accounts.oxy.so', 's')).rejects.toThrow();
+    spy.mockRestore();
+  });
+});
+
 describe('generateSsoState', () => {
   it('returns a non-empty unique string (module-level helper)', () => {
     const a = generateSsoState();

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -63,3 +63,15 @@ export type { OxyCorsOptions } from './cors';
 
 // Constant-time secret comparison.
 export { verifySecret } from './verifySecret';
+
+// Registrable-apex (eTLD+1) derivation via the Public Suffix List — the SINGLE
+// SOURCE OF TRUTH shared with the IdP worker and the client FAPI auto-detect.
+// Pure host handling (no browser deps), so it is safe on the server subpath and
+// lets `@oxyhq/api` derive `auth.<apex>` without duplicating PSL logic.
+export { registrableApex } from '../utils/fapiAutoDetect';
+
+// The single RP callback path the IdP redirects back to. A pure wire-contract
+// constant (no browser deps at module top level), re-used server-side so the
+// `/sso/establish-token` `return_to` cannot drift from what `/sso/establish`
+// validates.
+export { SSO_CALLBACK_PATH } from '../utils/ssoBounce';

--- a/packages/core/src/utils/__tests__/ssoEstablish.test.ts
+++ b/packages/core/src/utils/__tests__/ssoEstablish.test.ts
@@ -172,4 +172,33 @@ describe('establishIdpSessionAfterClaim', () => {
     expect(navigated).toEqual([]);
     expect(map.size).toBe(0);
   });
+
+  it.each([
+    ['unparseable', 'not a url'],
+    ['non-https (http)', 'http://auth.oxy.so/sso/establish?et=x&state=s'],
+    ['wrong path', 'https://auth.oxy.so/evil?et=x&state=s'],
+    ['non-auth host', 'https://evil.oxy.so/sso/establish?et=x&state=s'],
+  ])(
+    'aborts silently (no navigation, no state) for a %s establish URL',
+    async (_label, badUrl) => {
+      const { storage, map } = makeStorage();
+      const navigated: string[] = [];
+      const requestSsoEstablishUrl = jest.fn(async () => ({ establishUrl: badUrl }));
+
+      const result = await establishIdpSessionAfterClaim(
+        { requestSsoEstablishUrl },
+        {
+          isWeb: () => true,
+          storage,
+          location: { origin: RP_ORIGIN, href: RP_HREF },
+          navigate: (url) => navigated.push(url),
+          generateState: () => 'state-xyz',
+        },
+      );
+
+      expect(result).toBe(false);
+      expect(navigated).toEqual([]);
+      expect(map.size).toBe(0);
+    },
+  );
 });

--- a/packages/core/src/utils/__tests__/ssoEstablish.test.ts
+++ b/packages/core/src/utils/__tests__/ssoEstablish.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `establishIdpSessionAfterClaim` — the post-claim durable-session hop.
+ *
+ * After a WEB device-flow ("Sign in with Oxy" QR) claim commits, the app holds
+ * only in-memory tokens: no `fedcm_session` cookie was ever planted at the IdP,
+ * so a reload cannot re-mint a token. This primitive performs ONE top-level
+ * establish hop (via the RP-minted establish-URL) so the per-apex IdP cookie is
+ * planted and a reload restores via the existing `sso-return` / silent-iframe
+ * paths.
+ *
+ * Invariants pinned here:
+ *  - web only (no-op off-web / native);
+ *  - never fires while sitting on the central IdP origin (would loop);
+ *  - persists the SAME bounce state (`ssoStateKey`/`ssoGuardKey`/`ssoDestKey`)
+ *    the `buildSsoBounceUrl` machinery primes, so the post-bounce `sso-return`
+ *    step validates the state, exchanges the code, and restores the dest;
+ *  - persists ONLY after the establish-URL request succeeds (no stale state on
+ *    failure);
+ *  - navigates exactly once, to the server-returned establish URL;
+ *  - total: an establish-request failure leaves the committed in-memory session
+ *    untouched, does NOT navigate, and returns `false` (user no worse off).
+ */
+
+import { establishIdpSessionAfterClaim } from '../ssoEstablish';
+import {
+  ssoStateKey,
+  ssoGuardKey,
+  ssoDestKey,
+} from '../ssoBounce';
+import { CENTRAL_AUTH_URL } from '../authWebUrl';
+
+const RP_ORIGIN = 'https://accounts.oxy.so';
+const RP_HREF = 'https://accounts.oxy.so/settings';
+const ESTABLISH_URL =
+  'https://auth.oxy.so/sso/establish?et=jwt.abc.def&return_to=https%3A%2F%2Faccounts.oxy.so%2F__oxy%2Fsso-callback&state=state-xyz';
+
+function makeStorage(): {
+  storage: Pick<Storage, 'getItem' | 'setItem'>;
+  map: Map<string, string>;
+} {
+  const map = new Map<string, string>();
+  return {
+    map,
+    storage: {
+      getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+      setItem: (k: string, v: string) => {
+        map.set(k, v);
+      },
+    },
+  };
+}
+
+describe('establishIdpSessionAfterClaim', () => {
+  it('requests the establish URL with the RP origin + generated state and navigates once (web)', async () => {
+    const { storage, map } = makeStorage();
+    const navigated: string[] = [];
+    const requestSsoEstablishUrl = jest.fn(async (origin: string, state: string) => {
+      expect(origin).toBe(RP_ORIGIN);
+      expect(state).toBe('state-xyz');
+      return { establishUrl: ESTABLISH_URL };
+    });
+
+    const result = await establishIdpSessionAfterClaim(
+      { requestSsoEstablishUrl },
+      {
+        isWeb: () => true,
+        storage,
+        location: { origin: RP_ORIGIN, href: RP_HREF },
+        navigate: (url) => navigated.push(url),
+        generateState: () => 'state-xyz',
+        now: () => 1_700_000_000_000,
+      },
+    );
+
+    expect(result).toBe(true);
+    expect(requestSsoEstablishUrl).toHaveBeenCalledTimes(1);
+    expect(navigated).toEqual([ESTABLISH_URL]);
+
+    // Bounce state persisted so the post-bounce `sso-return` step validates it.
+    expect(map.get(ssoStateKey(RP_ORIGIN))).toBe('state-xyz');
+    expect(map.get(ssoGuardKey(RP_ORIGIN))).toBe(String(1_700_000_000_000));
+    expect(map.get(ssoDestKey(RP_ORIGIN))).toBe(RP_HREF);
+  });
+
+  it('is a no-op off-web (native): no request, no navigation, no state', async () => {
+    const { storage, map } = makeStorage();
+    const navigated: string[] = [];
+    const requestSsoEstablishUrl = jest.fn(async () => ({ establishUrl: ESTABLISH_URL }));
+
+    const result = await establishIdpSessionAfterClaim(
+      { requestSsoEstablishUrl },
+      {
+        isWeb: () => false,
+        storage,
+        location: { origin: RP_ORIGIN, href: RP_HREF },
+        navigate: (url) => navigated.push(url),
+      },
+    );
+
+    expect(result).toBe(false);
+    expect(requestSsoEstablishUrl).not.toHaveBeenCalled();
+    expect(navigated).toEqual([]);
+    expect(map.size).toBe(0);
+  });
+
+  it('never fires while sitting on the central IdP origin (loop guard)', async () => {
+    const { storage, map } = makeStorage();
+    const navigated: string[] = [];
+    const requestSsoEstablishUrl = jest.fn(async () => ({ establishUrl: ESTABLISH_URL }));
+
+    const result = await establishIdpSessionAfterClaim(
+      { requestSsoEstablishUrl },
+      {
+        isWeb: () => true,
+        storage,
+        location: { origin: new URL(CENTRAL_AUTH_URL).origin, href: `${CENTRAL_AUTH_URL}/` },
+        navigate: (url) => navigated.push(url),
+      },
+    );
+
+    expect(result).toBe(false);
+    expect(requestSsoEstablishUrl).not.toHaveBeenCalled();
+    expect(navigated).toEqual([]);
+    expect(map.size).toBe(0);
+  });
+
+  it('on an establish-request failure: no navigation, no persisted state, returns false (single attempt)', async () => {
+    const { storage, map } = makeStorage();
+    const navigated: string[] = [];
+    const onError = jest.fn();
+    const requestSsoEstablishUrl = jest.fn(async () => {
+      throw new Error('403 unapproved origin');
+    });
+
+    const result = await establishIdpSessionAfterClaim(
+      { requestSsoEstablishUrl },
+      {
+        isWeb: () => true,
+        storage,
+        location: { origin: RP_ORIGIN, href: RP_HREF },
+        navigate: (url) => navigated.push(url),
+        generateState: () => 'state-xyz',
+        onError,
+      },
+    );
+
+    expect(result).toBe(false);
+    expect(requestSsoEstablishUrl).toHaveBeenCalledTimes(1);
+    expect(navigated).toEqual([]);
+    // No stale bounce state left behind on failure.
+    expect(map.size).toBe(0);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not navigate when the server returns no establish URL', async () => {
+    const { storage, map } = makeStorage();
+    const navigated: string[] = [];
+    const requestSsoEstablishUrl = jest.fn(async () => ({ establishUrl: '' }));
+
+    const result = await establishIdpSessionAfterClaim(
+      { requestSsoEstablishUrl },
+      {
+        isWeb: () => true,
+        storage,
+        location: { origin: RP_ORIGIN, href: RP_HREF },
+        navigate: (url) => navigated.push(url),
+        generateState: () => 'state-xyz',
+      },
+    );
+
+    expect(result).toBe(false);
+    expect(navigated).toEqual([]);
+    expect(map.size).toBe(0);
+  });
+});

--- a/packages/core/src/utils/ssoEstablish.ts
+++ b/packages/core/src/utils/ssoEstablish.ts
@@ -137,9 +137,28 @@ export async function establishIdpSessionAfterClaim(
     }
     establishUrl = result.establishUrl;
 
-    // Persist the bounce state ONLY now that the request has succeeded and we
-    // WILL navigate — so a failed request never leaves stale state behind. This
-    // is the exact contract the terminal `/sso` bounce primes via
+    // Defense-in-depth before a TOP-LEVEL navigation: the establish URL is
+    // server-formed, but never follow anything that is not a well-formed https
+    // `/sso/establish` on an `auth.` host. A malformed or unexpected URL aborts
+    // silently (no navigation, no state persisted) — same total/no-throw
+    // contract — rather than navigating the document somewhere unintended.
+    let parsedEstablishUrl: URL;
+    try {
+      parsedEstablishUrl = new URL(establishUrl);
+    } catch {
+      return false;
+    }
+    if (
+      parsedEstablishUrl.protocol !== 'https:' ||
+      parsedEstablishUrl.pathname !== '/sso/establish' ||
+      !parsedEstablishUrl.hostname.toLowerCase().startsWith('auth.')
+    ) {
+      return false;
+    }
+
+    // Persist the bounce state ONLY now that the request has succeeded and the
+    // URL is validated — so a failed/rejected request never leaves stale state
+    // behind. This is the exact contract the terminal `/sso` bounce primes via
     // `buildSsoBounceUrl`, so the post-bounce `sso-return` step (`consumeSsoReturn`)
     // validates `state`, exchanges the returned code, and restores the dest.
     storage.setItem(ssoStateKey(origin), state);

--- a/packages/core/src/utils/ssoEstablish.ts
+++ b/packages/core/src/utils/ssoEstablish.ts
@@ -1,0 +1,155 @@
+/**
+ * Post-claim durable-session establish hop (web device-flow / "Sign in with
+ * Oxy" QR).
+ *
+ * A WEB device-flow claim (`claimSessionByToken`) plants only IN-MEMORY tokens:
+ * unlike a redirect/FedCM/silent sign-in, it never causes the IdP to plant a
+ * `fedcm_session` cookie. So a reload has nothing to restore from — the
+ * silent-iframe and `/sso` paths find no IdP session and the session is lost.
+ *
+ * This primitive closes that gap. AFTER the claim has committed and the session
+ * has been durably persisted, it performs ONE top-level establish hop through
+ * the RP's own per-apex IdP host (`auth.<rp-apex>`), reusing the EXISTING
+ * `/sso/establish` endpoint: the server mints a short-lived, host+audience-bound
+ * establish-token and returns a fully-formed establish URL; navigating to it
+ * plants the durable first-party `fedcm_session` cookie and bounces back to the
+ * RP callback with an opaque code the standard `sso-return` cold-boot step
+ * exchanges.
+ *
+ * It reuses the SAME per-origin `sessionStorage` bounce contract
+ * (`ssoStateKey` / `ssoGuardKey` / `ssoDestKey`) that {@link buildSsoBounceUrl}
+ * primes for the terminal `/sso` bounce, so the post-bounce `sso-return` step
+ * (`consumeSsoReturn`) validates the CSRF `state`, exchanges the code, and
+ * restores the user's real destination with no extra wiring.
+ *
+ * Contract:
+ *  - WEB only — off-web / native it is a no-op returning `false`.
+ *  - NEVER fires while sitting on the central IdP origin (that would loop the
+ *    IdP against itself).
+ *  - Bounce state is persisted ONLY after the establish-URL request succeeds, so
+ *    a failed request leaves no stale state behind.
+ *  - SINGLE attempt: the caller invokes this exactly once per successful claim.
+ *    On ANY failure it does NOT navigate and returns `false`, leaving the
+ *    committed in-memory session exactly as-is (the user is no worse off than
+ *    before this hop existed).
+ *  - Total: never throws. Failures are reported via {@link deps.onError} only.
+ */
+
+import {
+  ssoStateKey,
+  ssoGuardKey,
+  ssoDestKey,
+  ssoNavigate,
+  isCentralIdPOrigin,
+} from './ssoBounce';
+import { generateSsoState } from '../mixins/OxyServices.sso';
+
+/**
+ * The minimal SDK surface this hop needs: mint a server-formed establish URL
+ * bound to the caller's own session for an approved RP origin. Structural so the
+ * primitive is unit-testable with a stub and never imports the full client.
+ */
+export interface SsoEstablishClient {
+  requestSsoEstablishUrl(
+    origin: string,
+    state: string,
+  ): Promise<{ establishUrl: string }>;
+}
+
+/**
+ * Injectable web seams for {@link establishIdpSessionAfterClaim}. Every seam is
+ * overridable so the primitive is fully unit-testable with fakes and so native
+ * callers rely on the defaults (which resolve to `window.*` only when a browser
+ * is present). Defaults are evaluated lazily inside the function so importing
+ * this module never touches `window`.
+ */
+export interface EstablishAfterClaimDeps {
+  /** Per-tab SSO bounce store. Default: `window.sessionStorage`. */
+  storage?: Pick<Storage, 'getItem' | 'setItem'>;
+  /** The current location. Default: `window.location`. */
+  location?: Pick<Location, 'origin' | 'href'>;
+  /** Top-level navigation seam. Default: {@link ssoNavigate} (`location.assign`). */
+  navigate?: (url: string) => void;
+  /**
+   * Whether the current environment is a web browser with usable
+   * `sessionStorage`. Default: `typeof window !== 'undefined' && typeof
+   * window.sessionStorage !== 'undefined'`.
+   */
+  isWeb?: () => boolean;
+  /** CSRF state generator. Default: {@link generateSsoState}. */
+  generateState?: () => string;
+  /** Epoch-ms clock for the bounce guard. Default: `Date.now`. */
+  now?: () => number;
+  /**
+   * Optional debug hook invoked with the thrown error when the establish
+   * request (or state persistence) fails. NEVER rethrown. Default: no-op.
+   */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Perform the post-claim establish hop. Returns `true` when a navigation to the
+ * establish URL was initiated (the document is being torn down and replaced by
+ * the IdP), `false` on every no-op / failure path.
+ *
+ * @param client - The exchange surface (`oxyServices.requestSsoEstablishUrl`).
+ * @param deps - Injectable web seams; see {@link EstablishAfterClaimDeps}.
+ */
+export async function establishIdpSessionAfterClaim(
+  client: SsoEstablishClient,
+  deps: EstablishAfterClaimDeps = {},
+): Promise<boolean> {
+  const isWeb =
+    deps.isWeb ??
+    (() =>
+      typeof window !== 'undefined' &&
+      typeof window.sessionStorage !== 'undefined');
+
+  if (!isWeb()) {
+    return false;
+  }
+
+  const storage = deps.storage ?? window.sessionStorage;
+  const location = deps.location ?? window.location;
+  const navigate = deps.navigate ?? ssoNavigate;
+  const generateState = deps.generateState ?? generateSsoState;
+  const now = deps.now ?? (() => Date.now());
+
+  const origin = location.origin;
+
+  // Never establish while sitting on the central IdP itself — that would bounce
+  // the IdP against itself. (The device-flow claim can only happen on an RP.)
+  if (isCentralIdPOrigin(origin)) {
+    return false;
+  }
+
+  const state = generateState();
+
+  let establishUrl: string;
+  try {
+    const result = await client.requestSsoEstablishUrl(origin, state);
+    if (
+      !result ||
+      typeof result.establishUrl !== 'string' ||
+      result.establishUrl.length === 0
+    ) {
+      return false;
+    }
+    establishUrl = result.establishUrl;
+
+    // Persist the bounce state ONLY now that the request has succeeded and we
+    // WILL navigate — so a failed request never leaves stale state behind. This
+    // is the exact contract the terminal `/sso` bounce primes via
+    // `buildSsoBounceUrl`, so the post-bounce `sso-return` step (`consumeSsoReturn`)
+    // validates `state`, exchanges the returned code, and restores the dest.
+    storage.setItem(ssoStateKey(origin), state);
+    storage.setItem(ssoGuardKey(origin), String(now()));
+    storage.setItem(ssoDestKey(origin), location.href);
+  } catch (error) {
+    deps.onError?.(error);
+    return false;
+  }
+
+  navigate(establishUrl);
+  return true;
+}

--- a/packages/services/src/ui/components/ProfileMenu.tsx
+++ b/packages/services/src/ui/components/ProfileMenu.tsx
@@ -7,6 +7,7 @@ import {
     ScrollView,
     ActivityIndicator,
     Platform,
+    StyleSheet,
     type ViewStyle,
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
@@ -58,8 +59,10 @@ export interface ProfileMenuProps {
 }
 
 /**
- * Clean account switcher, written with NativeWind classNames + Bloom
- * primitives. Lists EVERY switchable account from {@link useSwitchableAccounts}
+ * Clean account switcher, written with react-native `StyleSheet` + Bloom
+ * theme colors (the package convention — no NativeWind, which is only an
+ * optional peer and absent in the primary `accounts` consumer). Lists EVERY
+ * switchable account from {@link useSwitchableAccounts}
  * — device sign-ins AND linked graph accounts (owned orgs + shared-with-you) —
  * and routes EVERY switch through the context's single
  * `switchToAccount(accountId)` dispatcher (there is no separate device-only
@@ -204,22 +207,20 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
             // Swallow taps inside the panel so they never reach the overlay's
             // outside-tap-to-close handler.
             onPress={() => undefined}
-            className={
-                isWeb
-                    ? 'overflow-hidden rounded-2xl border border-border bg-background'
-                    : 'overflow-hidden rounded-t-3xl bg-background pb-3'
-            }
             style={[
+                isWeb ? styles.panelWeb : styles.panelNative,
+                { backgroundColor: colors.background },
+                isWeb ? { borderColor: colors.border } : null,
                 panelAnchorStyle,
-                !isWeb ? { maxHeight: '85%' } : { maxHeight: '85%' },
+                styles.panelBounds,
                 styles.shadow,
             ]}
             accessibilityRole="menu"
             accessibilityLabel={t('accountMenu.label') || 'Account menu'}
         >
             <ScrollView
-                className="grow-0"
-                contentContainerClassName="py-1"
+                style={styles.scroll}
+                contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator={false}
             >
                 {/* 1) Every switchable account — device sign-ins AND linked graph
@@ -244,9 +245,12 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                             accessibilityState={{ selected: isActive }}
                             onPress={() => handleSwitch(account)}
                             disabled={isActive || isBusy || isSwitching}
-                            className={`flex-row items-center gap-3 px-4 py-2.5 ${isChild ? 'pl-10' : ''} ${
-                                isActive ? 'bg-secondary' : ''
-                            } ${isSwitching && !isActive ? 'opacity-40' : ''}`}
+                            style={[
+                                styles.accountRow,
+                                isChild && styles.childRow,
+                                isActive && { backgroundColor: colors.backgroundSecondary },
+                                isSwitching && !isActive && styles.rowDimmed,
+                            ]}
                         >
                             <Avatar
                                 source={account.user.avatar ?? undefined}
@@ -255,17 +259,21 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                                 name={account.displayName}
                                 size={isActive ? 40 : isChild ? 28 : 32}
                             />
-                            <View className="min-w-0 flex-1">
-                                <View className="flex-row items-center gap-2">
+                            <View style={styles.accountInfo}>
+                                <View style={styles.nameRow}>
                                     <Text
-                                        className={`shrink text-foreground ${isActive ? 'font-semibold' : 'font-medium'}`}
+                                        style={[
+                                            styles.accountName,
+                                            { color: colors.text },
+                                            isActive && styles.accountNameActive,
+                                        ]}
                                         numberOfLines={1}
                                     >
                                         {account.displayName}
                                     </Text>
                                     {role ? (
-                                        <View className="rounded-md bg-secondary px-1.5 py-0.5">
-                                            <Text className="text-[10px] font-semibold uppercase text-muted-foreground">
+                                        <View style={[styles.roleBadge, { backgroundColor: colors.card }]}>
+                                            <Text style={[styles.roleBadgeText, { color: colors.textSecondary }]}>
                                                 {t(`accounts.roles.${role}.label`) || role}
                                             </Text>
                                         </View>
@@ -273,7 +281,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                                 </View>
                                 {account.email ? (
                                     <Text
-                                        className="text-xs text-muted-foreground"
+                                        style={[styles.accountEmail, { color: colors.textSecondary }]}
                                         numberOfLines={1}
                                     >
                                         {account.email}
@@ -296,7 +304,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                                     onPress={() => handleRemove(sessionId)}
                                     disabled={actionDisabled}
                                     hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                                    className="h-7 w-7 items-center justify-center rounded-full opacity-60"
+                                    style={styles.rowSignOutButton}
                                 >
                                     <MaterialCommunityIcons
                                         name="logout"
@@ -311,9 +319,9 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
 
                 {/* 2) Switching indicator. */}
                 {isSwitching ? (
-                    <View className="flex-row items-center justify-center gap-2 py-2">
+                    <View style={styles.switchingRow}>
                         <ActivityIndicator color={colors.textSecondary} size="small" />
-                        <Text className="text-xs font-medium text-muted-foreground">
+                        <Text style={[styles.switchingText, { color: colors.textSecondary }]}>
                             {t('accountMenu.switching') || 'Switching account…'}
                         </Text>
                     </View>
@@ -325,6 +333,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                 <ActionRow
                     icon="account-plus-outline"
                     iconColor={colors.icon}
+                    textColor={colors.text}
                     label={t('accountMenu.addAnother') || 'Add another account'}
                     disabled={actionDisabled}
                     onPress={() => {
@@ -337,6 +346,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                 <ActionRow
                     icon="cog-outline"
                     iconColor={colors.icon}
+                    textColor={colors.text}
                     label={t('accountMenu.manage') || 'Manage your Oxy Account'}
                     disabled={actionDisabled}
                     onPress={() => {
@@ -350,6 +360,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                     <ActionRow
                         icon="account-outline"
                         iconColor={colors.icon}
+                        textColor={colors.text}
                         label={t('accountMenu.viewProfile') || 'View profile'}
                         disabled={actionDisabled}
                         onPress={() => {
@@ -366,14 +377,14 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                     accessibilityLabel={t('accountMenu.signOutAll') || 'Sign out of all accounts'}
                     onPress={() => signOutAllDialog.open()}
                     disabled={actionDisabled}
-                    className={`flex-row items-center gap-3 px-4 py-3 ${actionDisabled ? 'opacity-40' : ''}`}
+                    style={[styles.actionRow, actionDisabled && styles.rowDimmed]}
                 >
                     {signingOutAll ? (
                         <ActivityIndicator color={colors.error} size="small" />
                     ) : (
                         <MaterialCommunityIcons name="logout" size={18} color={colors.error} />
                     )}
-                    <Text className="font-medium" style={{ color: colors.error }}>
+                    <Text style={[styles.actionText, { color: colors.error }]}>
                         {t('accountMenu.signOutAll') || 'Sign out of all accounts'}
                     </Text>
                 </Pressable>
@@ -392,8 +403,7 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
                 accessibilityRole="button"
                 accessibilityLabel={t('common.actions.close') || 'Close'}
                 onPress={onClose}
-                className={isWeb ? 'flex-1 relative' : 'flex-1 justify-end'}
-                style={!isWeb ? styles.nativeScrim : undefined}
+                style={isWeb ? styles.webOverlay : styles.nativeOverlay}
             >
                 {content}
             </Pressable>
@@ -419,36 +429,136 @@ const ProfileMenu: React.FC<ProfileMenuProps> = ({
 const ActionRow: React.FC<{
     icon: React.ComponentProps<typeof MaterialCommunityIcons>['name'];
     iconColor: string;
+    textColor: string;
     label: string;
     disabled: boolean;
     onPress: () => void;
-}> = ({ icon, iconColor, label, disabled, onPress }) => (
+}> = ({ icon, iconColor, textColor, label, disabled, onPress }) => (
     <Pressable
         accessibilityRole="menuitem"
         accessibilityLabel={label}
         onPress={onPress}
         disabled={disabled}
-        className={`flex-row items-center gap-3 px-4 py-3 ${disabled ? 'opacity-40' : ''}`}
+        style={[styles.actionRow, disabled && styles.rowDimmed]}
     >
         <MaterialCommunityIcons name={icon} size={20} color={iconColor} />
-        <Text className="font-medium text-foreground">{label}</Text>
+        <Text style={[styles.actionText, { color: textColor }]}>{label}</Text>
     </Pressable>
 );
 
-// The panel's drop shadow and the native scrim are the only values with no
-// NativeWind class equivalent in this package (dynamic elevation + rgba scrim),
-// so they stay as small inline objects rather than raw class-replaceable styles.
-const styles = {
+const styles = StyleSheet.create({
+    // Overlay: web is a positioning context for the anchored panel; native dims
+    // the backdrop and docks the sheet to the bottom.
+    webOverlay: {
+        flex: 1,
+        position: 'relative',
+    },
+    nativeOverlay: {
+        flex: 1,
+        justifyContent: 'flex-end',
+        backgroundColor: 'rgba(0,0,0,0.32)',
+    },
+    // Panel shell — web popover / native bottom sheet.
+    panelWeb: {
+        overflow: 'hidden',
+        borderRadius: 16,
+        borderWidth: 1,
+    },
+    panelNative: {
+        overflow: 'hidden',
+        borderTopLeftRadius: 24,
+        borderTopRightRadius: 24,
+        paddingBottom: 12,
+    },
+    // Shared height cap applied to both panel variants.
+    panelBounds: {
+        maxHeight: '85%',
+    },
+    // The panel's drop shadow (dynamic elevation).
     shadow: {
         shadowColor: '#000',
         shadowOpacity: 0.18,
         shadowRadius: 24,
         shadowOffset: { width: 0, height: 8 },
         elevation: 12,
-    } satisfies ViewStyle,
-    nativeScrim: {
-        backgroundColor: 'rgba(0,0,0,0.32)',
-    } satisfies ViewStyle,
-};
+    },
+    scroll: {
+        flexGrow: 0,
+    },
+    scrollContent: {
+        paddingVertical: 4,
+    },
+    accountRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        paddingHorizontal: 16,
+        paddingVertical: 10,
+    },
+    childRow: {
+        paddingLeft: 40,
+    },
+    rowDimmed: {
+        opacity: 0.4,
+    },
+    accountInfo: {
+        flex: 1,
+        minWidth: 0,
+    },
+    nameRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+    },
+    accountName: {
+        fontWeight: '500',
+        flexShrink: 1,
+    },
+    accountNameActive: {
+        fontWeight: '600',
+    },
+    accountEmail: {
+        fontSize: 12,
+    },
+    roleBadge: {
+        paddingHorizontal: 6,
+        paddingVertical: 1,
+        borderRadius: 8,
+    },
+    roleBadgeText: {
+        fontSize: 10,
+        fontWeight: '600',
+        textTransform: 'capitalize',
+    },
+    rowSignOutButton: {
+        width: 28,
+        height: 28,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: 9999,
+        opacity: 0.6,
+    },
+    switchingRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        paddingVertical: 8,
+    },
+    switchingText: {
+        fontSize: 12,
+        fontWeight: '500',
+    },
+    actionRow: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        paddingHorizontal: 16,
+        paddingVertical: 12,
+    },
+    actionText: {
+        fontWeight: '500',
+    },
+});
 
 export default ProfileMenu;

--- a/packages/services/src/utils/__tests__/deviceFlowSignIn.test.ts
+++ b/packages/services/src/utils/__tests__/deviceFlowSignIn.test.ts
@@ -28,6 +28,7 @@
  */
 
 import type { SessionLoginResponse, User } from '@oxyhq/core';
+import { ssoStateKey, ssoGuardKey, ssoDestKey } from '@oxyhq/core';
 import {
   completeDeviceFlowSignIn,
   type DeviceFlowClient,
@@ -51,6 +52,7 @@ describe('completeDeviceFlowSignIn', () => {
     const order: string[] = [];
 
     const oxyServices: DeviceFlowClient = {
+      requestSsoEstablishUrl: jest.fn(async () => ({ establishUrl: 'https://auth.oxy.so/sso/establish' })),
       claimSessionByToken: jest.fn(async (token: string) => {
         expect(token).toBe(SESSION_TOKEN);
         order.push('claim');
@@ -89,6 +91,7 @@ describe('completeDeviceFlowSignIn', () => {
 
   it('falls back to the delivered sessionId/deviceId/expiresAt when the claim omits them', async () => {
     const oxyServices: DeviceFlowClient = {
+      requestSsoEstablishUrl: jest.fn(async () => ({ establishUrl: 'https://auth.oxy.so/sso/establish' })),
       claimSessionByToken: jest.fn(async () => ({
         accessToken: ACCESS_TOKEN,
         user: USER,
@@ -115,6 +118,7 @@ describe('completeDeviceFlowSignIn', () => {
   it('does NOT commit the session when the claim fails (the original native regression)', async () => {
     const claimError = new Error('claim failed (401)');
     const oxyServices: DeviceFlowClient = {
+      requestSsoEstablishUrl: jest.fn(async () => ({ establishUrl: 'https://auth.oxy.so/sso/establish' })),
       claimSessionByToken: jest.fn(async () => {
         throw claimError;
       }),
@@ -137,6 +141,7 @@ describe('completeDeviceFlowSignIn', () => {
 
   it('throws when the claim returns no accessToken (the session-sync regression guard)', async () => {
     const oxyServices: DeviceFlowClient = {
+      requestSsoEstablishUrl: jest.fn(async () => ({ establishUrl: 'https://auth.oxy.so/sso/establish' })),
       claimSessionByToken: jest.fn(async () => ({ sessionId: SESSION_ID, user: USER })),
     };
     const commitSession = jest.fn(async (): Promise<void> => {});
@@ -155,6 +160,7 @@ describe('completeDeviceFlowSignIn', () => {
 
   it('throws when the claim returns no user', async () => {
     const oxyServices: DeviceFlowClient = {
+      requestSsoEstablishUrl: jest.fn(async () => ({ establishUrl: 'https://auth.oxy.so/sso/establish' })),
       claimSessionByToken: jest.fn(async () => ({ accessToken: ACCESS_TOKEN, sessionId: SESSION_ID })),
     };
     const commitSession = jest.fn(async (): Promise<void> => {});
@@ -174,6 +180,7 @@ describe('completeDeviceFlowSignIn', () => {
   it('propagates a commitSession failure after a successful claim', async () => {
     const commitError = new Error('session invalid');
     const oxyServices: DeviceFlowClient = {
+      requestSsoEstablishUrl: jest.fn(async () => ({ establishUrl: 'https://auth.oxy.so/sso/establish' })),
       claimSessionByToken: jest.fn(async () => ({
         accessToken: ACCESS_TOKEN,
         sessionId: SESSION_ID,
@@ -195,5 +202,111 @@ describe('completeDeviceFlowSignIn', () => {
 
     expect(oxyServices.claimSessionByToken).toHaveBeenCalledTimes(1);
     expect(commitSession).toHaveBeenCalledTimes(1);
+  });
+
+  describe('web durable-session establish hop', () => {
+    const RP_ORIGIN = 'https://accounts.oxy.so';
+    const RP_HREF = 'https://accounts.oxy.so/settings';
+    const ESTABLISH_URL =
+      'https://auth.oxy.so/sso/establish?et=jwt&return_to=https%3A%2F%2Faccounts.oxy.so%2F__oxy%2Fsso-callback&state=state-1';
+
+    function webDeps(overrides: Record<string, unknown> = {}) {
+      const map = new Map<string, string>();
+      const navigated: string[] = [];
+      const deps = {
+        isWeb: () => true,
+        storage: {
+          getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+          setItem: (k: string, v: string) => { map.set(k, v); },
+        },
+        location: { origin: RP_ORIGIN, href: RP_HREF },
+        navigate: (url: string) => { navigated.push(url); },
+        generateState: () => 'state-1',
+        now: () => 1_700_000_000_000,
+        ...overrides,
+      };
+      return { deps, map, navigated };
+    }
+
+    function baseClient(
+      requestSsoEstablishUrl: DeviceFlowClient['requestSsoEstablishUrl'],
+    ): DeviceFlowClient {
+      return {
+        requestSsoEstablishUrl,
+        claimSessionByToken: jest.fn(async () => ({
+          accessToken: ACCESS_TOKEN,
+          sessionId: SESSION_ID,
+          deviceId: 'device-1',
+          expiresAt: '2026-01-01T00:00:00.000Z',
+          user: USER,
+        })),
+      };
+    }
+
+    it('fires the establish hop on web: requests the URL with the RP origin + state and navigates once', async () => {
+      const requestSsoEstablishUrl = jest.fn(async (origin: string, state: string) => {
+        expect(origin).toBe(RP_ORIGIN);
+        expect(state).toBe('state-1');
+        return { establishUrl: ESTABLISH_URL };
+      });
+      const oxyServices = baseClient(requestSsoEstablishUrl);
+      const { deps, map, navigated } = webDeps();
+
+      const user = await completeDeviceFlowSignIn({
+        oxyServices,
+        sessionId: SESSION_ID,
+        sessionToken: SESSION_TOKEN,
+        commitSession: jest.fn(async () => {}),
+        establishDeps: deps,
+      });
+
+      expect(user).toBe(USER);
+      expect(requestSsoEstablishUrl).toHaveBeenCalledTimes(1);
+      expect(navigated).toEqual([ESTABLISH_URL]);
+      // Bounce state persisted so the post-bounce `sso-return` step validates it.
+      expect(map.get(ssoStateKey(RP_ORIGIN))).toBe('state-1');
+      expect(map.get(ssoGuardKey(RP_ORIGIN))).toBe(String(1_700_000_000_000));
+      expect(map.get(ssoDestKey(RP_ORIGIN))).toBe(RP_HREF);
+    });
+
+    it('does NOT fire the hop on native (no request, no navigation)', async () => {
+      const requestSsoEstablishUrl = jest.fn(async () => ({ establishUrl: ESTABLISH_URL }));
+      const oxyServices = baseClient(requestSsoEstablishUrl);
+      const { deps, navigated } = webDeps({ isWeb: () => false });
+
+      await completeDeviceFlowSignIn({
+        oxyServices,
+        sessionId: SESSION_ID,
+        sessionToken: SESSION_TOKEN,
+        commitSession: jest.fn(async () => {}),
+        establishDeps: deps,
+      });
+
+      expect(requestSsoEstablishUrl).not.toHaveBeenCalled();
+      expect(navigated).toEqual([]);
+    });
+
+    it('completes sign-in even if the establish request fails — exactly one attempt, no navigation', async () => {
+      const requestSsoEstablishUrl = jest.fn(async () => {
+        throw new Error('403 unapproved');
+      });
+      const oxyServices = baseClient(requestSsoEstablishUrl);
+      const { deps, map, navigated } = webDeps();
+
+      const user = await completeDeviceFlowSignIn({
+        oxyServices,
+        sessionId: SESSION_ID,
+        sessionToken: SESSION_TOKEN,
+        commitSession: jest.fn(async () => {}),
+        establishDeps: deps,
+      });
+
+      // Sign-in still completed (the primitive is total — never throws).
+      expect(user).toBe(USER);
+      expect(requestSsoEstablishUrl).toHaveBeenCalledTimes(1);
+      expect(navigated).toEqual([]);
+      // No stale bounce state left behind on failure.
+      expect(map.size).toBe(0);
+    });
   });
 });

--- a/packages/services/src/utils/deviceFlowSignIn.ts
+++ b/packages/services/src/utils/deviceFlowSignIn.ts
@@ -31,7 +31,15 @@
  * unit-testable.
  */
 
-import { KeyManager, type MinimalUserData, type SessionLoginResponse, type User } from '@oxyhq/core';
+import {
+  KeyManager,
+  establishIdpSessionAfterClaim,
+  type EstablishAfterClaimDeps,
+  type MinimalUserData,
+  type SessionLoginResponse,
+  type SsoEstablishClient,
+  type User,
+} from '@oxyhq/core';
 
 interface DeviceFlowClaimResult {
   accessToken?: string;
@@ -46,8 +54,11 @@ interface DeviceFlowClaimResult {
  * structural type (rather than importing the full client) so the helper is
  * trivially unit-testable with a stub and never pulls the RN/Expo runtime into
  * a test bundle.
+ *
+ * Extends {@link SsoEstablishClient} (`requestSsoEstablishUrl`) so the WEB
+ * post-claim durable-session hop can be driven off the same client.
  */
-export interface DeviceFlowClient {
+export interface DeviceFlowClient extends SsoEstablishClient {
   /**
    * Exchange the device-flow `sessionToken` for the first access + refresh
    * token, planting them on the client. Single-use; replay is rejected by the
@@ -74,6 +85,13 @@ export interface CompleteDeviceFlowSignInOptions {
    * bearer is planted so its bearer-protected calls succeed.
    */
   commitSession: (session: SessionLoginResponse) => Promise<void>;
+  /**
+   * Injectable web seams for the post-claim durable-session establish hop
+   * ({@link establishIdpSessionAfterClaim}). Omit in production — the defaults
+   * resolve to `window.*` (and no-op off-web / on native). Tests inject fakes to
+   * drive the web path deterministically.
+   */
+  establishDeps?: EstablishAfterClaimDeps;
 }
 
 /**
@@ -90,6 +108,7 @@ export async function completeDeviceFlowSignIn({
   sessionId,
   sessionToken,
   commitSession,
+  establishDeps,
 }: CompleteDeviceFlowSignInOptions): Promise<User> {
   // 1) Plant the bearer + refresh tokens. The claim response is also persisted
   //    to native shared secure storage so a later cold boot has a bearer before
@@ -124,6 +143,17 @@ export async function completeDeviceFlowSignIn({
     user: minimalUser,
     accessToken: claimed.accessToken,
   });
+
+  // 3) WEB durable-session hop (no-op on native). A device-flow claim plants
+  //    ONLY in-memory tokens — no IdP `fedcm_session` cookie is ever planted, so
+  //    a reload cannot re-mint a token and the session is lost. Now that the
+  //    session is committed AND durably persisted (step 2), plant the per-apex
+  //    IdP cookie via ONE top-level establish hop. Single attempt; total (never
+  //    throws) — an establish failure leaves the committed session as-is. On web
+  //    success it navigates away, so it is the LAST step: the browser tears the
+  //    page down on the next tick, after `claimed.user` is returned to the
+  //    caller's `onSignedIn`.
+  await establishIdpSessionAfterClaim(oxyServices, establishDeps ?? {});
 
   return claimed.user;
 }


### PR DESCRIPTION
## Summary

1. **feat(sso): device-flow durable web sessions.** A QR "Sign in with Oxy" on web plants only in-memory tokens — no `fedcm_session` IdP cookie ever exists, so a reload has no re-mint path and the session is lost. New `POST /sso/establish-token` (bearer-auth, `rl:sso:establish-token:`) mints the same 60s HS256 establish-token the IdP `/sso` flow mints (sub = caller's own sessionId only; aud/host/purpose-bound; 501 fail-closed without `FEDCM_TOKEN_SECRET`) and records the FedCM grant that `/sso/establish` gates on (device-flow sign-ins never wrote one). `@oxyhq/core` gains `requestSsoEstablishUrl` + one shared web-only `establishIdpSessionAfterClaim` primitive; services `completeDeviceFlowSignIn` and auth-sdk `useCommonsSignIn` hop through it after the claim commits — the unchanged IdP `/sso/establish` re-validates the session, plants the per-apex cookie, and bounces back to `/__oxy/sso-callback`. Every later reload restores via the silent iframe; cross-app (accounts ↔ console) restores too.

2. **fix(sso): security hardening** (from security review): missing/empty `Origin` header now rejected 403 before any grant write (a bearer-holding server-side caller could otherwise record a grant for a different approved origin — consent bypass); client validates the establish URL shape (https, `/sso/establish`, `auth.` host) before the top-level navigation.

3. **fix(services): ProfileMenu visible without NativeWind.** The unified ProfileMenu styled itself with NativeWind classNames; nativewind is an optional peer absent in accounts.oxy.so, so the popover panel rendered with no background/colors (invisible, live regression from #494). Converted to StyleSheet + Bloom `useTheme` (the package convention). Behavior, dual-edge anchor, a11y, i18n unchanged.

## Verification (this branch)
core 776 · api 1316 · services 253 · auth-sdk 96 — all green; tsc 0 in all four; core/auth/services builds green. IdP (`packages/auth`) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)