### PR TITLE
feat(api,core): viewer mutual-ids endpoint + getMutualUserIds for Mention Mutuals feed

### DIFF
--- a/packages/api/src/routes/__tests__/usersMutualIds.test.ts
+++ b/packages/api/src/routes/__tests__/usersMutualIds.test.ts
@@ -1,0 +1,213 @@
+/**
+ * GET /users/mutual-ids route tests.
+ *
+ * Focus: the SECURITY wiring and response contract of the route (the mutual-set
+ * LOGIC outcomes are covered by
+ * `services/__tests__/user.service.getMutualUserIds.test.ts`).
+ *
+ *  - the viewer is taken from `resolveViewerId(req)` (server-derived from the
+ *    auth token) and passed to the service — there is no `:userId` param and a
+ *    client-supplied `?viewerId=` query is IGNORED (anti-IDOR / anti-impersonation)
+ *  - an anonymous caller (resolveViewerId → undefined) is NOT rejected: the
+ *    service is still invoked (with `undefined`) and an empty `{ data: [] }` is
+ *    returned
+ *  - the response is the lean `{ data: string[] }` envelope (bare ids to SEED a
+ *    feed) — NOT the paginated `{ data, pagination }` of `/users/:userId/mutuals`
+ *  - an over-cap `?limit=` clamps to MAX_MUTUAL_IDS before hitting the service
+ *
+ * The router is mounted on a minimal Express app and exercised via `node:http`
+ * round-trips so we hit the real route + middleware chain. Only the data source
+ * (`userService.getMutualUserIds`) and the auth/resolution shims are stubbed.
+ */
+
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+import { MAX_MUTUAL_IDS } from '../../utils/recommendationWeights';
+
+const mockGetMutualUserIds = jest.fn();
+
+// Mutable viewer the stubbed `resolveViewerId` returns — set per test to model
+// an authenticated viewer vs. an anonymous caller.
+let currentViewerId: string | undefined;
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  serviceAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// Optional dual-auth is a pass-through here; the viewer is resolved by the
+// stubbed `resolveViewerId` (server-side derivation), never from the request
+// query/body.
+jest.mock('../../middleware/optionalAuth', () => ({
+  optionalUserOrServiceAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  resolveViewerId: () => currentViewerId,
+}));
+
+jest.mock('../../services/email.service', () => ({
+  emailService: { deleteAllUserData: jest.fn() },
+}));
+jest.mock('../../services/federation.service', () => ({
+  federationService: { scheduleAvatarRefresh: jest.fn() },
+  isOwnFederationDomain: jest.fn(),
+}));
+jest.mock('../../services/assetServiceSingleton', () => ({
+  assetService: { ensureOwnedAssetPublic: jest.fn().mockResolvedValue(undefined) },
+  s3Service: {},
+}));
+jest.mock('../../services/user.service', () => ({
+  userService: {
+    getMutualUserIds: mockGetMutualUserIds,
+  },
+}));
+jest.mock('../../services/identityExport.service', () => ({
+  buildExportBundle: jest.fn(),
+}));
+jest.mock('../../services/signature.service', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../controllers/users.controller', () => ({
+  UsersController: class {
+    searchUsers = jest.fn();
+  },
+}));
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: jest.fn() },
+}));
+jest.mock('../../utils/validation', () => ({
+  resolveUserIdToObjectId: jest.fn(async (id: string) => id),
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import usersRouter from '../users';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: {
+    error?: string;
+    message?: string;
+    data?: unknown;
+    pagination?: unknown;
+  };
+}
+
+async function getJson(server: http.Server, path: string): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method: 'GET', host: '127.0.0.1', port: address.port, path },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            const parsed = raw.length > 0 ? JSON.parse(raw) : {};
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/users', usersRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentViewerId = undefined;
+  mockGetMutualUserIds.mockReset();
+});
+
+describe('GET /users/mutual-ids', () => {
+  const VIEWER = '5f000000000000000000000b';
+
+  it('passes the server-derived viewer to the service and returns the lean ids envelope', async () => {
+    currentViewerId = VIEWER;
+    mockGetMutualUserIds.mockResolvedValueOnce(['m1', 'm2']);
+
+    const res = await getJson(server, '/users/mutual-ids');
+
+    expect(res.status).toBe(200);
+    expect(mockGetMutualUserIds).toHaveBeenCalledTimes(1);
+    expect(mockGetMutualUserIds).toHaveBeenCalledWith(VIEWER, { limit: MAX_MUTUAL_IDS });
+    // Lean ids-only shape — no pagination envelope.
+    expect(res.body.data).toEqual(['m1', 'm2']);
+    expect(res.body.pagination).toBeUndefined();
+  });
+
+  it('IGNORES a client-supplied viewerId query (anti-impersonation)', async () => {
+    currentViewerId = VIEWER;
+    mockGetMutualUserIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(server, '/users/mutual-ids?viewerId=5f000000000000000000000a');
+
+    expect(res.status).toBe(200);
+    // The viewer is the server-derived one, NOT the attacker-supplied query.
+    expect(mockGetMutualUserIds).toHaveBeenCalledWith(VIEWER, { limit: MAX_MUTUAL_IDS });
+  });
+
+  it('does not 401 for an anonymous caller — still invokes the service with undefined', async () => {
+    currentViewerId = undefined;
+    mockGetMutualUserIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(server, '/users/mutual-ids');
+
+    expect(res.status).toBe(200);
+    expect(mockGetMutualUserIds).toHaveBeenCalledWith(undefined, { limit: MAX_MUTUAL_IDS });
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('clamps an over-cap limit to MAX_MUTUAL_IDS before calling the service', async () => {
+    currentViewerId = VIEWER;
+    mockGetMutualUserIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(server, `/users/mutual-ids?limit=${MAX_MUTUAL_IDS * 100}`);
+
+    expect(res.status).toBe(200);
+    expect(mockGetMutualUserIds).toHaveBeenCalledWith(VIEWER, { limit: MAX_MUTUAL_IDS });
+  });
+
+  it('forwards a valid in-range limit unchanged', async () => {
+    currentViewerId = VIEWER;
+    mockGetMutualUserIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(server, '/users/mutual-ids?limit=100');
+
+    expect(res.status).toBe(200);
+    expect(mockGetMutualUserIds).toHaveBeenCalledWith(VIEWER, { limit: 100 });
+  });
+
+  it('rejects a negative limit with 400 (validatePagination)', async () => {
+    currentViewerId = VIEWER;
+
+    const res = await getJson(server, '/users/mutual-ids?limit=-5');
+
+    expect(res.status).toBe(400);
+    expect(mockGetMutualUserIds).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -74,6 +74,7 @@ const getUserIdsFromRequestBody = (body: unknown): unknown => {
 };
 
 import { PAGINATION } from '../utils/constants';
+import { MAX_MUTUAL_IDS } from '../utils/recommendationWeights';
 import { federationService, isOwnFederationDomain } from '../services/federation.service';
 
 // Initialize router and controller
@@ -539,6 +540,52 @@ router.post(
 
     logger.debug('POST /users/by-ids', { requested: ids.length, resolved: users.length });
     sendSuccess(res, users);
+  })
+);
+
+/**
+ * GET /users/mutual-ids
+ *
+ * The authenticated VIEWER's OWN mutual-follow user ids — the accounts the viewer
+ * follows that ALSO follow the viewer back. Lean, ids-only, bounded payload built
+ * to SEED Mention's "Mutuals" feed (which then hydrates and ranks the posts
+ * itself), so it returns bare ids rather than the hydrated DTOs of
+ * `GET /users/:userId/mutuals` ("followers you know" about ANOTHER profile).
+ *
+ * The viewer is derived SERVER-SIDE from the auth token via `resolveViewerId`
+ * (the same dual-auth as `/mutuals` and `/by-ids`) — never a client-supplied id,
+ * and there is no `:userId` param to spoof (anti-IDOR). OPTIONAL semantics: an
+ * anonymous caller (or a service token with no user context) has no "you follow"
+ * set → `{ data: [] }`.
+ *
+ * Registered BEFORE the `/:userId` param routes so Express never treats
+ * `mutual-ids` as a `:userId` value.
+ *
+ * @query {number} limit - Max ids to return (capped at MAX_MUTUAL_IDS).
+ * @returns {{ data: string[] }} The viewer's mutual-follow user ids.
+ */
+router.get(
+  '/mutual-ids',
+  optionalUserOrServiceAuth,
+  validatePagination,
+  asyncHandler(async (req: OptionalUserOrServiceRequest, res: Response) => {
+    // Viewer is always the authenticated principal — never a client param.
+    const viewerId = resolveViewerId(req);
+    const { limit } = req.query as PaginationQuery;
+
+    const parsedLimit = limit
+      ? Math.min(parseInt(limit, 10), MAX_MUTUAL_IDS)
+      : MAX_MUTUAL_IDS;
+
+    const ids = await userService.getMutualUserIds(viewerId, { limit: parsedLimit });
+
+    logger.debug('GET /users/mutual-ids', {
+      viewerId,
+      limit: parsedLimit,
+      count: ids.length,
+    });
+
+    sendSuccess(res, ids);
   })
 );
 

--- a/packages/api/src/services/__tests__/user.service.getMutualUserIds.test.ts
+++ b/packages/api/src/services/__tests__/user.service.getMutualUserIds.test.ts
@@ -1,0 +1,180 @@
+/**
+ * UserService.getMutualUserIds — the viewer's OWN mutual-follow ids.
+ *
+ * Mutual ids = the accounts the VIEWER follows that ALSO follow the viewer back
+ * (the SELF intersection `following(viewer) ∩ followers(viewer)`). This powers
+ * Mention's "Mutuals" feed, so the method is lean and ids-only (no hydrated DTOs,
+ * no `countDocuments`, no `User` lookup). The viewer id is ALWAYS server-derived
+ * (the route resolves it from the auth token via `resolveViewerId`); these tests
+ * cover the logic outcomes the route relies on:
+ *   - viewer with a mutual → the mutual's id, from the two-step Follow query
+ *   - no viewer (anonymous / service token w/o user) → [], zero DB queries
+ *   - viewer follows nobody → [] (short-circuits before the second query)
+ *   - viewer shares no follow-back with anyone they follow → [] (empty page 2)
+ *   - an over-cap limit clamps to MAX_MUTUAL_IDS on the returned page
+ *
+ * Mirrors the `user.service.getUserMutuals` harness: restore the real `mongoose`
+ * (the global setup mocks it wholesale, stripping `Types`) and mock the models as
+ * chainable query builders.
+ */
+
+// The global jest.setup.cjs mocks `mongoose` wholesale, which strips `Types`
+// (and therefore `Types.ObjectId`). This suite only needs the real `Types`
+// helper — the models themselves are mocked below — so restore the actual
+// mongoose module.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import { Types } from 'mongoose';
+import { MAX_MUTUAL_IDS } from '../../utils/recommendationWeights';
+
+// Chainable Follow query builder: select/limit/skip/sort return the builder,
+// lean() is the terminal awaited result (sequenced per find() call).
+const mockFollowLean = jest.fn();
+const followQuery = {
+  select: jest.fn(() => followQuery),
+  limit: jest.fn(() => followQuery),
+  skip: jest.fn(() => followQuery),
+  sort: jest.fn(() => followQuery),
+  lean: mockFollowLean,
+};
+const mockFollowFind = jest.fn(() => followQuery);
+const mockFollowCountDocuments = jest.fn();
+
+const mockUserFind = jest.fn();
+
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  default: {
+    find: mockFollowFind,
+    countDocuments: mockFollowCountDocuments,
+  },
+  FollowType: {
+    USER: 'user',
+    HASHTAG: 'hashtag',
+    TOPIC: 'topic',
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    find: mockUserFind,
+  },
+}));
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../securityActivityService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { UserService } from '../user.service';
+
+describe('UserService.getMutualUserIds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the ids of accounts the viewer follows that follow back', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+
+    // V = the people the viewer follows.
+    const v1 = new Types.ObjectId();
+    const v2 = new Types.ObjectId();
+    // v1 follows the viewer back (mutual); v2 does not.
+
+    mockFollowLean
+      // 1) viewer's following set
+      .mockResolvedValueOnce([{ followedId: v1 }, { followedId: v2 }])
+      // 2) of those, the ones who follow the viewer back
+      .mockResolvedValueOnce([{ followerUserId: v1 }]);
+
+    const result = await new UserService().getMutualUserIds(viewerId, { limit: 50 });
+
+    // Two-step Follow query, self-directed (target === viewer), ids only.
+    expect(mockFollowFind).toHaveBeenCalledTimes(2);
+    expect(mockFollowFind).toHaveBeenNthCalledWith(1, {
+      followerUserId: viewerId,
+      followType: 'user',
+    });
+    expect(mockFollowFind).toHaveBeenNthCalledWith(2, {
+      followedId: viewerId,
+      followType: 'user',
+      followerUserId: { $in: [v1, v2] },
+    });
+
+    // Lean, ids-only: no hydration and no count query.
+    expect(mockFollowCountDocuments).not.toHaveBeenCalled();
+    expect(mockUserFind).not.toHaveBeenCalled();
+
+    expect(result).toEqual([v1.toString()]);
+  });
+
+  it('returns empty for an anonymous viewer without querying the database', async () => {
+    const result = await new UserService().getMutualUserIds(undefined, { limit: 50 });
+
+    expect(result).toEqual([]);
+    expect(mockFollowFind).not.toHaveBeenCalled();
+  });
+
+  it('returns empty when the viewer follows nobody (short-circuits before the second query)', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+
+    mockFollowLean.mockResolvedValueOnce([]);
+
+    const result = await new UserService().getMutualUserIds(viewerId, { limit: 50 });
+
+    expect(result).toEqual([]);
+    expect(mockFollowFind).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty when none of the viewer\'s followed accounts follow back', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+    const v1 = new Types.ObjectId();
+
+    mockFollowLean
+      .mockResolvedValueOnce([{ followedId: v1 }])
+      .mockResolvedValueOnce([]);
+
+    const result = await new UserService().getMutualUserIds(viewerId, { limit: 50 });
+
+    expect(result).toEqual([]);
+    expect(mockFollowFind).toHaveBeenCalledTimes(2);
+  });
+
+  it('clamps an over-cap limit to MAX_MUTUAL_IDS on the returned page', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+    const v1 = new Types.ObjectId();
+
+    mockFollowLean
+      .mockResolvedValueOnce([{ followedId: v1 }])
+      .mockResolvedValueOnce([{ followerUserId: v1 }]);
+
+    await new UserService().getMutualUserIds(viewerId, { limit: MAX_MUTUAL_IDS * 10 });
+
+    // Page 1 bounds the following scan to MAX_MUTUAL_IDS; page 2 caps the
+    // returned ids to the clamped limit (also MAX_MUTUAL_IDS here).
+    expect(followQuery.limit.mock.calls).toEqual([[MAX_MUTUAL_IDS], [MAX_MUTUAL_IDS]]);
+  });
+});

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -29,7 +29,7 @@ import { formatUserNameResponse, type NameParts } from '../utils/displayName';
 
 // Constants
 import { PAGINATION } from '../utils/constants';
-import { MAX_FOLLOWING_FOR_MUTUALS } from '../utils/recommendationWeights';
+import { MAX_FOLLOWING_FOR_MUTUALS, MAX_MUTUAL_IDS } from '../utils/recommendationWeights';
 
 interface UserWithCount {
   _count?: {
@@ -604,6 +604,75 @@ export class UserService {
       limit,
       offset,
     };
+  }
+
+  /**
+   * Get the VIEWER's OWN mutual-follow user ids — the accounts the viewer follows
+   * that ALSO follow the viewer back (a bidirectional follow edge). This is the
+   * SELF intersection `following(viewer) ∩ followers(viewer)`.
+   *
+   * Distinct from {@link getUserMutuals} ("followers you know" about ANOTHER
+   * profile, which returns hydrated DTOs and is empty for a self-target). This
+   * method is lean and ids-only on purpose: it SEEDS Mention's "Mutuals" feed,
+   * which then hydrates and ranks the mutuals' posts itself, so shipping bare ids
+   * (not profile DTOs) keeps the payload small.
+   *
+   * The viewer id is ALWAYS derived server-side by the route (`resolveViewerId`),
+   * never a client param. An anonymous caller (or a service token with no user
+   * context) has no "you follow" set ⇒ empty. A viewer who follows nobody
+   * short-circuits before the second query.
+   *
+   * Bounded by `MAX_MUTUAL_IDS`: both the following window scanned AND the number
+   * of ids returned are capped, so the `$in` and the payload stay small. When the
+   * viewer has more mutuals than the cap, the most-recently-established mutuals
+   * are returned first (`createdAt` desc).
+   */
+  async getMutualUserIds(
+    viewerId: string | undefined,
+    params: { limit?: number } = {}
+  ): Promise<string[]> {
+    if (!viewerId) {
+      return [];
+    }
+
+    const limit = Math.min(
+      params.limit && params.limit > 0 ? params.limit : MAX_MUTUAL_IDS,
+      MAX_MUTUAL_IDS
+    );
+
+    // 1. The viewer's following set (bounded so the `$in` below stays small).
+    const viewerFollowing = await Follow.find({
+      followerUserId: viewerId,
+      followType: FollowType.USER,
+    })
+      .select('followedId')
+      .limit(MAX_MUTUAL_IDS)
+      .lean();
+
+    const followingIds = viewerFollowing
+      .map((follow) => follow.followedId)
+      .filter((id): id is Types.ObjectId => id instanceof Types.ObjectId);
+
+    if (followingIds.length === 0) {
+      return [];
+    }
+
+    // 2. Of those, the accounts that follow the viewer BACK — the bidirectional
+    //    edges — most-recently-established first.
+    const mutualFollows = await Follow.find({
+      followedId: viewerId,
+      followType: FollowType.USER,
+      followerUserId: { $in: followingIds },
+    })
+      .select('followerUserId')
+      .limit(limit)
+      .sort({ createdAt: -1 })
+      .lean();
+
+    return mutualFollows
+      .map((follow) => follow.followerUserId)
+      .filter((id): id is Types.ObjectId => id instanceof Types.ObjectId)
+      .map((id) => id.toString());
   }
 
   /**

--- a/packages/api/src/utils/recommendationWeights.ts
+++ b/packages/api/src/utils/recommendationWeights.ts
@@ -62,6 +62,14 @@ export const MUTUAL_COUNT_WINDOW = 300;
 /** Max followed accounts to feed the mutual-overlap aggregation. */
 export const MAX_FOLLOWING_FOR_MUTUALS = 2000;
 
+/**
+ * Hard cap on the viewer's own mutual-follow id set (`getMutualUserIds`, which
+ * powers Mention's "Mutuals" feed). Bounds BOTH the following window scanned and
+ * the number of ids returned, so the `$in` query and the response payload stay
+ * small regardless of how many accounts the viewer follows.
+ */
+export const MAX_MUTUAL_IDS = 5000;
+
 /** Max app-signal candidates pulled into the candidate union per request. */
 export const MAX_APP_SIGNAL_CANDIDATES = 500;
 

--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -797,6 +797,32 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
     }
 
     /**
+     * Get the authenticated VIEWER's OWN mutual-follow user ids — the accounts the
+     * viewer follows that ALSO follow the viewer back (a bidirectional follow
+     * edge). The viewer is derived server-side from the SDK's auth token (never a
+     * param), so there is no target id to pass.
+     *
+     * Returns a bounded, lean list of ids meant to SEED a "Mutuals" feed (the
+     * consumer hydrates/ranks the posts itself) — distinct from
+     * {@link getUserMutuals}, which returns hydrated "followers you know" DTOs
+     * about ANOTHER profile. An anonymous caller resolves to an empty array.
+     */
+    async getMutualUserIds(
+      params?: { limit?: number }
+    ): Promise<string[]> {
+      try {
+        const query = buildPaginationParams(params || {});
+        const response = await this.makeRequest<{ data: string[] }>('GET', '/users/mutual-ids', query, {
+          cache: true,
+          cacheTTL: 2 * 60 * 1000, // 2 minutes cache
+        });
+        return response.data || [];
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
      * Get notifications
      */
     async getNotifications(): Promise<Notification[]> {


### PR DESCRIPTION
## Summary
- `GET /users/mutual-ids` (oxy-api) — a lean, ids-only source of the VIEWER's own mutual-follow user ids (accounts the viewer follows that ALSO follow the viewer back), returned as `{ data: string[] }`. Viewer is derived server-side via `resolveViewerId` (dual user/service auth) — never a client param, no `:userId` to spoof. Registered before the `/:userId` param routes.
- `userService.getMutualUserIds(viewerId, { limit })` — two-step Follow (`followType: USER`) aggregation, ids-only (no `countDocuments`, no `User` hydration). Anonymous → `[]`; follows nobody → `[]` (short-circuits). Bounded by `MAX_MUTUAL_IDS` (5000) on both the following scan and returned ids; most-recently-established mutuals first.
- `@oxyhq/core`: `getMutualUserIds({ limit }?): Promise<string[]>` — new user-mixin method calling `GET /users/mutual-ids`, mirroring the caching posture of `getUserMutuals`.

Distinct from the existing target-relative `GET /users/:userId/mutuals` / `getUserMutuals` (DTO-shaped, empty for a self-target) — this seeds Mention's "Mutuals" feed with the bidirectional self-intersection `following(viewer) ∩ followers(viewer)` as bare ids.

No new `@oxyhq/contracts` symbol — purely additive to `api` and `core`.

## Test plan
- [x] `git merge-base HEAD origin/main` == `origin/main` after rebase (clean, no conflicts)
- [x] `bun run build:all` — 12/12 tasks successful (contracts → protocol → core → auth → services → rest)
- [x] `packages/api`: `bun run test` — 141 suites / 1327 tests passed (includes 11 new: 5 in `user.service.getMutualUserIds.test.ts`, 6 in `usersMutualIds.test.ts`)
- [x] `packages/core`: `bun run test` — 62 suites / 776 tests passed
- [x] `bun install --frozen-lockfile` — clean, no lockfile drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)