### PR TITLE
fix(core): device-session sync discarded on every call — SessionClient read the {data} envelope twice

### DIFF
--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -91,7 +91,19 @@ export class SessionClient {
   private applySync(raw: unknown): void {
     const sync = safeParseContract(deviceSessionSyncSchema, raw);
     if (!sync) {
-      logger.warn('[SessionClient] discarded invalid session sync');
+      const parsed = deviceSessionSyncSchema.safeParse(raw);
+      // Log field-level type diagnostics ONLY — never values. The payload carries tokens and
+      // session ids; issue.path/code and the invalid_type expected/received TYPE names are safe,
+      // but zod messages can embed offending values for other codes, so they are omitted.
+      const issues = parsed.success
+        ? []
+        : parsed.error.issues.map((issue) =>
+            issue.code === 'invalid_type'
+              ? { path: issue.path.join('.'), code: issue.code, expected: issue.expected, received: issue.received }
+              : { path: issue.path.join('.'), code: issue.code },
+          );
+      const keys = raw && typeof raw === 'object' ? Object.keys(raw) : [];
+      logger.warn('[SessionClient] discarded invalid session sync', { component: 'SessionClient', issues, keys });
       return;
     }
     this.applyState(sync.state);

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -113,23 +113,23 @@ export class SessionClient {
   }
 
   async bootstrap(): Promise<void> {
-    const res = await this.host.makeRequest<{ data?: unknown }>('GET', '/session/device/state', undefined, { cache: false });
-    this.applySync(res?.data);
+    const res = await this.host.makeRequest<unknown>('GET', '/session/device/state', undefined, { cache: false });
+    this.applySync(res);
   }
 
   async switchAccount(accountId: string): Promise<void> {
-    const res = await this.host.makeRequest<{ data?: unknown }>('POST', '/session/device/switch', { accountId }, { cache: false });
-    this.applySync(res?.data);
+    const res = await this.host.makeRequest<unknown>('POST', '/session/device/switch', { accountId }, { cache: false });
+    this.applySync(res);
   }
 
   async signOut(target: { accountId: string } | { all: true }): Promise<void> {
-    const res = await this.host.makeRequest<{ data?: unknown }>('POST', '/session/device/signout', target, { cache: false });
-    this.applySync(res?.data);
+    const res = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
+    this.applySync(res);
   }
 
   async addCurrentAccount(): Promise<void> {
-    const res = await this.host.makeRequest<{ data?: unknown }>('POST', '/session/device/add', undefined, { cache: false });
-    this.applySync(res?.data);
+    const res = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
+    this.applySync(res);
   }
 
   async start(): Promise<void> {

--- a/packages/core/src/session/__tests__/SessionClient.diagnostics.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.diagnostics.test.ts
@@ -1,0 +1,89 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+import { logger } from '../../utils/loggerUtils';
+
+const STATE = (rev: number): DeviceSessionState => ({
+  deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000,
+});
+
+function makeHost(makeRequest: jest.Mock): SessionClientHost {
+  return {
+    makeRequest,
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 't',
+    onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => null,
+  };
+}
+
+describe('SessionClient sync diagnostics', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('logs the failing zod issue path + code when a nested field is the wrong type', async () => {
+    // authuser must be a non-negative integer; a string trips invalid_type at accounts[0].authuser.
+    const badAuthuser = { accountId: 'a1', sessionId: 's1', authuser: 'not-a-number' };
+    const state = { ...STATE(3), accounts: [badAuthuser] };
+    const makeRequest = jest.fn().mockResolvedValueOnce({ data: { state, activeToken: null } });
+    const c = new SessionClient(makeHost(makeRequest));
+
+    await c.bootstrap();
+
+    expect(c.getState()).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[SessionClient] discarded invalid session sync',
+      expect.objectContaining({ component: 'SessionClient' }),
+    );
+    const context = warnSpy.mock.calls[0][1];
+    expect(context.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'state.accounts.0.authuser', code: 'invalid_type' }),
+      ]),
+    );
+    // invalid_type issues carry TYPE names (safe), not values.
+    const authuserIssue = context.issues.find((i: { path: string }) => i.path === 'state.accounts.0.authuser');
+    expect(authuserIssue.received).toBe('string');
+    expect(authuserIssue.expected).toBe('number');
+    // Top-level envelope keys are summarized to catch drift.
+    expect(context.keys).toEqual(['state', 'activeToken']);
+  });
+
+  it('never leaks token-like values into the logged diagnostics', async () => {
+    // A valid-looking accessToken alongside an otherwise-invalid state must not surface in the log.
+    const secretToken = 'jwt-SUPER-SECRET-ACCESS-TOKEN-abc123';
+    const makeRequest = jest.fn().mockResolvedValueOnce({
+      data: { state: { deviceId: 'd1' /* missing required fields */ }, activeToken: { accessToken: secretToken, expiresAt: 'x' } },
+    });
+    const c = new SessionClient(makeHost(makeRequest));
+
+    await c.bootstrap();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const serialized = JSON.stringify(warnSpy.mock.calls[0]);
+    expect(serialized).not.toContain(secretToken);
+    expect(serialized).not.toContain('SUPER-SECRET');
+  });
+
+  it('reports envelope drift via keys and a top-level invalid_type when raw is undefined', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce({ notData: true });
+    const c = new SessionClient(makeHost(makeRequest));
+
+    await c.bootstrap();
+
+    const context = warnSpy.mock.calls[0][1];
+    expect(context.keys).toEqual([]);
+    expect(context.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: '', code: 'invalid_type', expected: 'object', received: 'undefined' }),
+      ]),
+    );
+  });
+});

--- a/packages/core/src/session/__tests__/SessionClient.diagnostics.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.diagnostics.test.ts
@@ -32,7 +32,7 @@ describe('SessionClient sync diagnostics', () => {
     // authuser must be a non-negative integer; a string trips invalid_type at accounts[0].authuser.
     const badAuthuser = { accountId: 'a1', sessionId: 's1', authuser: 'not-a-number' };
     const state = { ...STATE(3), accounts: [badAuthuser] };
-    const makeRequest = jest.fn().mockResolvedValueOnce({ data: { state, activeToken: null } });
+    const makeRequest = jest.fn().mockResolvedValueOnce({ state, activeToken: null });
     const c = new SessionClient(makeHost(makeRequest));
 
     await c.bootstrap();
@@ -60,7 +60,8 @@ describe('SessionClient sync diagnostics', () => {
     // A valid-looking accessToken alongside an otherwise-invalid state must not surface in the log.
     const secretToken = 'jwt-SUPER-SECRET-ACCESS-TOKEN-abc123';
     const makeRequest = jest.fn().mockResolvedValueOnce({
-      data: { state: { deviceId: 'd1' /* missing required fields */ }, activeToken: { accessToken: secretToken, expiresAt: 'x' } },
+      state: { deviceId: 'd1' /* missing required fields */ },
+      activeToken: { accessToken: secretToken, expiresAt: 'x' },
     });
     const c = new SessionClient(makeHost(makeRequest));
 
@@ -73,7 +74,7 @@ describe('SessionClient sync diagnostics', () => {
   });
 
   it('reports envelope drift via keys and a top-level invalid_type when raw is undefined', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce({ notData: true });
+    const makeRequest = jest.fn().mockResolvedValueOnce(undefined);
     const c = new SessionClient(makeHost(makeRequest));
 
     await c.bootstrap();

--- a/packages/core/src/session/__tests__/SessionClient.httpIntegration.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.httpIntegration.test.ts
@@ -1,0 +1,65 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { OxyServices } from '../../OxyServices';
+import { SessionClient } from '../SessionClient';
+import { createSessionClientHost } from '../sessionClientHost';
+
+/**
+ * Real-stack integration test: a genuine `HttpService` (via `OxyServices`) →
+ * `createSessionClientHost` → `SessionClient`, with `global.fetch` stubbed to
+ * return the EXACT wire body the server sends for `GET /session/device/state`:
+ * `{ data: { state, activeToken } }`.
+ *
+ * This is the test that would have caught the P0: `HttpService.unwrapResponse`
+ * strips the outer `{ data }` envelope, so `makeRequest` already returns
+ * `{ state, activeToken }`. If `SessionClient` reads `.data` a SECOND time (or
+ * if `HttpService` stops unwrapping), the sync silently discards and neither
+ * the state nor the token reach the client — exactly the prod symptom.
+ */
+const WIRE_STATE: DeviceSessionState = {
+  deviceId: 'device-real',
+  accounts: [{ accountId: 'acct-1', sessionId: 'sess-1', authuser: 0 }],
+  activeAccountId: 'acct-1',
+  revision: 42,
+  updatedAt: 1720000000000,
+};
+
+const ROUTE_BODY = {
+  data: {
+    state: WIRE_STATE,
+    activeToken: { accessToken: 'planted-access-token', expiresAt: '2026-01-01T00:00:00.000Z' },
+  },
+};
+
+describe('SessionClient over a real HttpService (unwrap contract)', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('bootstrap() applies the server state and plants the active token through the real unwrap path', async () => {
+    const fetchMock = jest.fn(async () =>
+      new Response(JSON.stringify(ROUTE_BODY), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const oxy = new OxyServices({ baseURL: 'http://api.test.invalid' });
+    const host = createSessionClientHost(oxy);
+    const client = new SessionClient(host);
+
+    await client.bootstrap();
+
+    // The exact URL the server route serves.
+    const calledUrl = String((fetchMock.mock.calls[0] ?? [])[0]);
+    expect(calledUrl).toContain('/session/device/state');
+
+    // State reached the client (would be null if `.data` were read twice).
+    expect(client.getState()).toEqual(WIRE_STATE);
+
+    // Active token planted host-side (would be absent on a discarded sync).
+    expect(oxy.getAccessToken()).toBe('planted-access-token');
+  });
+});

--- a/packages/core/src/session/__tests__/SessionClient.rest.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.rest.test.ts
@@ -16,8 +16,9 @@ function makeHost(makeRequest: jest.Mock): SessionClientHost {
   };
 }
 
-// The server wraps the sync payload in a REST `{ data }` envelope; makeRequest does NOT unwrap it.
-const SYNC = (rev: number) => ({ data: { state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } } });
+// `makeRequest` (HttpService) already strips the server's outer `{ data }` envelope, so it
+// returns the unwrapped sync body directly — that is exactly what SessionClient consumes.
+const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
 
 describe('SessionClient REST', () => {
   it('bootstrap GETs /session/device/state and applies it', async () => {
@@ -69,7 +70,7 @@ describe('SessionClient REST', () => {
   });
 
   it('applies state but does not plant a token when activeToken is null', async () => {
-    const makeRequest = jest.fn().mockResolvedValueOnce({ data: { state: STATE(7), activeToken: null } });
+    const makeRequest = jest.fn().mockResolvedValueOnce({ state: STATE(7), activeToken: null });
     const host = makeHost(makeRequest);
     const c = new SessionClient(host);
     await c.bootstrap();

--- a/packages/core/src/session/__tests__/SessionClient.socket.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.socket.test.ts
@@ -21,8 +21,9 @@ jest.mock('socket.io-client', () => ({ __esModule: true, io: (...args: unknown[]
 import { SessionClient, type SessionClientHost } from '../SessionClient';
 
 const STATE = (rev: number): DeviceSessionState => ({ deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000 });
-// The server wraps the sync payload in a REST `{ data }` envelope; makeRequest does NOT unwrap it.
-const SYNC = (rev: number) => ({ data: { state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } } });
+// `makeRequest` (HttpService) already strips the server's outer `{ data }` envelope, so it
+// returns the unwrapped sync body directly — that is exactly what SessionClient consumes.
+const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
 
 function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
   return {

--- a/packages/core/src/session/__tests__/sessionIntegration.test.ts
+++ b/packages/core/src/session/__tests__/sessionIntegration.test.ts
@@ -191,7 +191,7 @@ describe('createSessionClient', () => {
 
   test('uses the injected transport (not a hard-coded one) when the client bootstraps', async () => {
     const oxy = fakeOxy();
-    oxy.makeRequest.mockResolvedValue({ data: { state, activeToken: null } });
+    oxy.makeRequest.mockResolvedValue({ state, activeToken: null });
     const transport = fakeTransport();
 
     const { client } = createSessionClient(oxy as never, transport);

--- a/packages/services/src/ui/session/__tests__/createSessionClient.test.ts
+++ b/packages/services/src/ui/session/__tests__/createSessionClient.test.ts
@@ -4,7 +4,7 @@ import { createSessionClient } from '../createSessionClient';
 function fakeOxy() {
   const listeners = new Set<(t: string | null) => void>();
   return {
-    makeRequest: jest.fn().mockResolvedValue({ data: undefined }),
+    makeRequest: jest.fn().mockResolvedValue(undefined),
     getBaseURL: jest.fn().mockReturnValue('https://api.oxy.so'),
     getAccessToken: jest.fn().mockReturnValue(null),
     setTokens: jest.fn(),


### PR DESCRIPTION
## Summary

**P0 live bug, root-caused with prod evidence** (accounts.oxy.so console: `[SessionClient] discarded invalid session sync` on every bootstrap/add/switch).

`HttpService.unwrapResponse` already strips the server's outer `{data}` envelope, so `makeRequest` returns `{state, activeToken}` unwrapped — but `SessionClient` read `res?.data` a second time, passing `undefined` to the contract parse. Every `/session/device/*` sync was discarded: server device state never reached the client, **account switches didn't survive reloads**, and instant cross-tab sync had no base state. Unit suites stayed green because every host mock fed the wrapped shape the real transport never produces.

- One unwrap authority (HttpService); SessionClient's four call sites consume the body directly (clean cut, no dual-shape shim).
- **New integration test over the real stack** — real `OxyServices` → real `HttpService.request` (real `unwrapResponse`) → real host adapter → real `SessionClient`, with `fetch` stubbed to the exact route-shaped `{data:{state,activeToken}}` body. Verified failing pre-fix, green post-fix; catches any future double-read or unwrap-authority move.
- All host-mock fixtures updated to the unwrapped shape.
- Plus: field-level discard diagnostics (zod issue paths/codes + envelope keys, never values) so any future contract drift is identifiable from one console line.

## Verification (this branch)
core 780/780 (incl. new integration test) · services 253/253 · tsc 0 · core+services builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)