### PR TITLE
fix(api): idempotent /session/device/add — reload no longer flips the active account back

### DIFF
--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -142,8 +142,8 @@ describe('POST /session/device/signout', () => {
 });
 
 describe('POST /session/device/add', () => {
-  it('adds an account and broadcasts', async () => {
-    mockAddAccount.mockResolvedValueOnce(STATE);
+  it('adds an account and broadcasts when the state changed', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: STATE, changed: true });
     const res = await requestJson(server, 'POST', '/session/device/add', {});
     expect(res.status).toBe(200);
     expect(mockGetSession).toHaveBeenCalledWith('s1', true);
@@ -153,9 +153,18 @@ describe('POST /session/device/add', () => {
     expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
   });
 
+  it('does NOT broadcast on an idempotent re-register (changed=false) but still returns the current state', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: STATE, changed: false });
+    const res = await requestJson(server, 'POST', '/session/device/add', {});
+    expect(res.status).toBe(200);
+    expect(mockBroadcast).not.toHaveBeenCalled();
+    expect(res.body.data.state).toEqual(STATE);
+    expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
+  });
+
   it('passes the operator id through to addAccount for a managed-account session', async () => {
     mockGetSession.mockResolvedValueOnce({ operatedByUserId: { toString: () => 'op1' } });
-    mockAddAccount.mockResolvedValueOnce(STATE);
+    mockAddAccount.mockResolvedValueOnce({ state: STATE, changed: true });
     const res = await requestJson(server, 'POST', '/session/device/add', {});
     expect(res.status).toBe(200);
     expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1', operatedByUserId: 'op1' });
@@ -163,7 +172,7 @@ describe('POST /session/device/add', () => {
 
   it('does not forward operatedByUserId for an ordinary first-party session', async () => {
     mockGetSession.mockResolvedValueOnce({ operatedByUserId: null });
-    mockAddAccount.mockResolvedValueOnce(STATE);
+    mockAddAccount.mockResolvedValueOnce({ state: STATE, changed: true });
     await requestJson(server, 'POST', '/session/device/add', {});
     expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
   });

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -49,12 +49,13 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
   // deactivated) — such a session must NOT be re-added to the device set.
   if (!sessionDoc) { res.status(401).json({ error: 'Invalid session' }); return; }
   const operatedByUserId = sessionDoc.operatedByUserId ? sessionDoc.operatedByUserId.toString() : undefined;
-  const state = await deviceSessionService.addAccount(session.deviceId, {
+  const { state, changed } = await deviceSessionService.addAccount(session.deviceId, {
     accountId,
     sessionId: session.sessionId,
     ...(operatedByUserId ? { operatedByUserId } : {}),
   });
-  broadcastDeviceState(state);
+  // An idempotent re-register (reload handoff) changes nothing — do not broadcast.
+  if (changed) broadcastDeviceState(state);
   res.json({ data: await withActiveToken(state) });
 }));
 

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -50,7 +50,7 @@ describe('projectState', () => {
 });
 
 describe('addAccount', () => {
-  it('adds a new account at authuser 0, sets it active, bumps revision', async () => {
+  it('adds a new account at authuser 0, sets it active, bumps revision (changed)', async () => {
     mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
     mockFindOneAndUpdate.mockReturnValueOnce(lean({
       deviceId: 'd1',
@@ -59,7 +59,8 @@ describe('addAccount', () => {
       revision: 1,
       updatedAt: new Date(1720000000000),
     }));
-    const state = await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's1' });
+    const { state, changed } = await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's1' });
+    expect(changed).toBe(true);
     expect(state.activeAccountId).toBe('a1');
     expect(state.accounts[0].authuser).toBe(0);
     expect(state.revision).toBe(1);
@@ -74,7 +75,8 @@ describe('addAccount', () => {
       revision: 1,
       updatedAt: new Date(1720000000000),
     }));
-    const state = await deviceSessionService.addAccount('d1', { accountId: 'org1', sessionId: 's-org', operatedByUserId: 'op1' });
+    const { state, changed } = await deviceSessionService.addAccount('d1', { accountId: 'org1', sessionId: 's-org', operatedByUserId: 'op1' });
+    expect(changed).toBe(true);
     expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
       { deviceId: 'd1' },
       expect.objectContaining({
@@ -87,41 +89,69 @@ describe('addAccount', () => {
     expect(state.accounts[0].operatedByUserId).toBe('op1');
   });
 
-  it('deactivates the replaced session when re-adding the same account with a different sessionId', async () => {
+  it('re-adding the same account with a DIFFERENT sessionId replaces the session, sets active, bumps revision, deactivates the displaced session (changed)', async () => {
     mockFindOne.mockReturnValueOnce(lean({
       deviceId: 'd1',
-      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's-old', authuser: 0, operatedByUserId: null }],
-      activeAccountId: { toString: () => 'a1' },
-      revision: 1,
+      accounts: [
+        { accountId: { toString: () => 'a1' }, sessionId: 's-old', authuser: 0, operatedByUserId: null },
+        { accountId: { toString: () => 'b1' }, sessionId: 's-b', authuser: 1, operatedByUserId: null },
+      ],
+      activeAccountId: { toString: () => 'b1' },
+      revision: 5,
     }));
     mockDeactivate.mockResolvedValueOnce(true);
     mockFindOneAndUpdate.mockReturnValueOnce(lean({
       deviceId: 'd1',
-      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's-new', authuser: 0, operatedByUserId: null }],
+      accounts: [
+        { accountId: { toString: () => 'b1' }, sessionId: 's-b', authuser: 1, operatedByUserId: null },
+        { accountId: { toString: () => 'a1' }, sessionId: 's-new', authuser: 0, operatedByUserId: null },
+      ],
       activeAccountId: { toString: () => 'a1' },
-      revision: 2,
+      revision: 6,
       updatedAt: new Date(1720000000000),
     }));
-    await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's-new' });
+    const { state, changed } = await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's-new' });
     expect(mockDeactivate).toHaveBeenCalledWith('s-old');
+    expect(changed).toBe(true);
+    expect(state.activeAccountId).toBe('a1');
+    expect(state.revision).toBe(6);
   });
 
-  it('does not deactivate anything when re-adding the same account with the same sessionId', async () => {
+  it('idempotent re-register: re-adding the same account with the SAME sessionId is a pure no-op (no deactivate, no write, no revision bump, changed=false)', async () => {
     mockFindOne.mockReturnValueOnce(lean({
       deviceId: 'd1',
       accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
       activeAccountId: { toString: () => 'a1' },
       revision: 1,
-    }));
-    mockFindOneAndUpdate.mockReturnValueOnce(lean({
-      deviceId: 'd1',
-      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0, operatedByUserId: null }],
-      activeAccountId: { toString: () => 'a1' },
-      revision: 2,
       updatedAt: new Date(1720000000000),
     }));
-    await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's1' });
+    const { state, changed } = await deviceSessionService.addAccount('d1', { accountId: 'a1', sessionId: 's1' });
+    expect(changed).toBe(false);
     expect(mockDeactivate).not.toHaveBeenCalled();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(state.activeAccountId).toBe('a1');
+    expect(state.revision).toBe(1);
+  });
+
+  it('REGRESSION: an idempotent re-register of a NON-active account never steals active from the current active account (the reload-handoff bug)', async () => {
+    // Device: A (active session s-A) was switched away from — B is now active.
+    // The cold-boot handoff re-registers the still-restored A session on reload.
+    // A must NOT become active again; the switch to B must survive.
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [
+        { accountId: { toString: () => 'A' }, sessionId: 's-A', authuser: 0, operatedByUserId: null },
+        { accountId: { toString: () => 'B' }, sessionId: 's-B', authuser: 1, operatedByUserId: null },
+      ],
+      activeAccountId: { toString: () => 'B' },
+      revision: 77,
+      updatedAt: new Date(1720000000000),
+    }));
+    const { state, changed } = await deviceSessionService.addAccount('d1', { accountId: 'A', sessionId: 's-A' });
+    expect(changed).toBe(false);
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(state.activeAccountId).toBe('B');
+    expect(state.revision).toBe(77);
   });
 });
 

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -38,6 +38,11 @@ export type SwitchActiveResult =
   | { ok: false; reason: 'not_found' }
   | { ok: false; reason: 'unauthorized'; state: DeviceSessionState };
 
+// `changed` is false only for an idempotent re-register (same account, same
+// session) — the cold-boot reload handoff. The route uses it to skip the
+// device-state broadcast when nothing actually changed.
+export type AddAccountResult = { state: DeviceSessionState; changed: boolean };
+
 class DeviceSessionService {
   private async load(deviceId: string): Promise<IDeviceSession | null> {
     return DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
@@ -81,16 +86,34 @@ class DeviceSessionService {
     return this.signout(doc.deviceId, { accountId: activeId });
   }
 
+  // Registering a session into the device set. Reload ≠ sign-in: the client
+  // cold-boot handoff calls this on EVERY reload with the RESTORED session to
+  // re-register it, so this must be idempotent and must NOT steal the device's
+  // active account. Three cases:
+  //   1. Same account + SAME session already present  → pure no-op: return the
+  //      current state untouched (no active flip, no revision bump, no write).
+  //      This is the reload handoff; flipping active here silently reverted a
+  //      prior account switch on the next reload.
+  //   2. Same account + DIFFERENT session (deliberate re-auth of that account)
+  //      → replace the session (deactivating the displaced one), set active,
+  //      bump revision.
+  //   3. New account (fresh sign-in / first-entry mint) → add, set active, bump.
   async addAccount(
     deviceId: string,
     input: { accountId: string; sessionId: string; operatedByUserId?: string },
-  ): Promise<DeviceSessionState> {
+  ): Promise<AddAccountResult> {
     const current = await this.load(deviceId);
     const existing = (current?.accounts ?? []).find((a) => idToString(a.accountId) === input.accountId);
+
+    // Case 1 — idempotent re-register (the cold-boot reload handoff).
+    if (current && existing && existing.sessionId === input.sessionId) {
+      return { state: projectState(current), changed: false };
+    }
+
     const others = (current?.accounts ?? []).filter((a) => idToString(a.accountId) !== input.accountId);
-    // Replacing an account's session (re-add with a new sessionId) must deactivate
-    // the session it displaces — otherwise a live, server-side session is left
-    // dangling with no device-session entry referencing it.
+    // Case 2 — replacing an account's session (re-add with a new sessionId) must
+    // deactivate the session it displaces — otherwise a live, server-side session
+    // is left dangling with no device-session entry referencing it.
     if (existing && existing.sessionId !== input.sessionId) {
       try {
         await sessionService.deactivateSession(existing.sessionId);
@@ -114,7 +137,7 @@ class DeviceSessionService {
       },
       { new: true, upsert: true },
     ).lean<IDeviceSession>();
-    return projectState(updated as IDeviceSession);
+    return { state: projectState(updated as IDeviceSession), changed: true };
   }
 
   async switchActive(deviceId: string, accountId: string): Promise<SwitchActiveResult> {


### PR DESCRIPTION
## Summary

**P0** — the last link in "switch doesn't survive reload" (with #499): `addAccount` always set `activeAccountId` to the added account, and the client cold-boot handoff re-registers the restored session on EVERY reload — so a deliberate switch to account B was flipped back to A on the next load (live device doc at revision 77 from the churn). Reload is not sign-in.

`addAccount` now branches: same account + same sessionId (reload handoff) → **pure read** (no flip, no revision bump, no broadcast); same account + new sessionId (re-auth) → replace session + set active + bump (unchanged); new account → add + set active + bump (unchanged). Route broadcasts only when state changed. Returns `{state, changed}` mirroring `SwitchActiveResult`.

TDD failing-first proven (regression test: active=B, re-register A same-session → still B, revision unchanged). Audit: mint (`verifyActingAs`) and heal/validate (`ensureManagedSessionAuthorized`) use the identical permission source — no second bug there.

Conflict note: merged with #495's expired-session 401 guard on /add (both kept).

## Verification (this branch)
api 1329/1329, tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)