### PR TITLE
feat(api,core): follows-of-follows ids endpoint + getFollowsOfFollowsIds for Mention friends-of-friends feed

### DIFF
--- a/packages/api/src/routes/__tests__/usersFollowsOfFollowsIds.test.ts
+++ b/packages/api/src/routes/__tests__/usersFollowsOfFollowsIds.test.ts
@@ -1,0 +1,229 @@
+/**
+ * GET /users/follows-of-follows-ids route tests.
+ *
+ * Focus: the SECURITY wiring and response contract of the route (the two-hop
+ * follows-of-follows LOGIC outcomes are covered by
+ * `services/__tests__/user.service.getFollowsOfFollowsIds.test.ts`).
+ *
+ *  - the viewer is taken from `resolveViewerId(req)` (server-derived from the
+ *    auth token) and passed to the service — there is no `:userId` param and a
+ *    client-supplied `?viewerId=` query is IGNORED (anti-IDOR / anti-impersonation)
+ *  - an anonymous caller (resolveViewerId → undefined) is NOT rejected: the
+ *    service is still invoked (with `undefined`) and an empty `{ data: [] }` is
+ *    returned
+ *  - the response is the lean `{ data: string[] }` envelope (bare ids to SEED a
+ *    feed) — NOT a paginated envelope
+ *  - an over-cap `?limit=` clamps to MAX_FOLLOWS_OF_FOLLOWS_IDS before hitting
+ *    the service
+ *
+ * The router is mounted on a minimal Express app and exercised via `node:http`
+ * round-trips so we hit the real route + middleware chain. Only the data source
+ * (`userService.getFollowsOfFollowsIds`) and the auth/resolution shims are
+ * stubbed.
+ */
+
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+import { MAX_FOLLOWS_OF_FOLLOWS_IDS } from '../../utils/recommendationWeights';
+
+const mockGetFollowsOfFollowsIds = jest.fn();
+
+// Mutable viewer the stubbed `resolveViewerId` returns — set per test to model
+// an authenticated viewer vs. an anonymous caller.
+let currentViewerId: string | undefined;
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  serviceAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// Optional dual-auth is a pass-through here; the viewer is resolved by the
+// stubbed `resolveViewerId` (server-side derivation), never from the request
+// query/body.
+jest.mock('../../middleware/optionalAuth', () => ({
+  optionalUserOrServiceAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  resolveViewerId: () => currentViewerId,
+}));
+
+jest.mock('../../services/email.service', () => ({
+  emailService: { deleteAllUserData: jest.fn() },
+}));
+jest.mock('../../services/federation.service', () => ({
+  federationService: { scheduleAvatarRefresh: jest.fn() },
+  isOwnFederationDomain: jest.fn(),
+}));
+jest.mock('../../services/assetServiceSingleton', () => ({
+  assetService: { ensureOwnedAssetPublic: jest.fn().mockResolvedValue(undefined) },
+  s3Service: {},
+}));
+jest.mock('../../services/user.service', () => ({
+  userService: {
+    getFollowsOfFollowsIds: mockGetFollowsOfFollowsIds,
+  },
+}));
+jest.mock('../../services/identityExport.service', () => ({
+  buildExportBundle: jest.fn(),
+}));
+jest.mock('../../services/signature.service', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../controllers/users.controller', () => ({
+  UsersController: class {
+    searchUsers = jest.fn();
+  },
+}));
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: jest.fn() },
+}));
+jest.mock('../../utils/validation', () => ({
+  resolveUserIdToObjectId: jest.fn(async (id: string) => id),
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import usersRouter from '../users';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: {
+    error?: string;
+    message?: string;
+    data?: unknown;
+    pagination?: unknown;
+  };
+}
+
+async function getJson(server: http.Server, path: string): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method: 'GET', host: '127.0.0.1', port: address.port, path },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            const parsed = raw.length > 0 ? JSON.parse(raw) : {};
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/users', usersRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentViewerId = undefined;
+  mockGetFollowsOfFollowsIds.mockReset();
+});
+
+describe('GET /users/follows-of-follows-ids', () => {
+  const VIEWER = '5f000000000000000000000b';
+
+  it('passes the server-derived viewer to the service and returns the lean ids envelope', async () => {
+    currentViewerId = VIEWER;
+    mockGetFollowsOfFollowsIds.mockResolvedValueOnce(['f1', 'f2']);
+
+    const res = await getJson(server, '/users/follows-of-follows-ids');
+
+    expect(res.status).toBe(200);
+    expect(mockGetFollowsOfFollowsIds).toHaveBeenCalledTimes(1);
+    expect(mockGetFollowsOfFollowsIds).toHaveBeenCalledWith(VIEWER, {
+      limit: MAX_FOLLOWS_OF_FOLLOWS_IDS,
+    });
+    // Lean ids-only shape — no pagination envelope.
+    expect(res.body.data).toEqual(['f1', 'f2']);
+    expect(res.body.pagination).toBeUndefined();
+  });
+
+  it('IGNORES a client-supplied viewerId query (anti-impersonation)', async () => {
+    currentViewerId = VIEWER;
+    mockGetFollowsOfFollowsIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(
+      server,
+      '/users/follows-of-follows-ids?viewerId=5f000000000000000000000a',
+    );
+
+    expect(res.status).toBe(200);
+    // The viewer is the server-derived one, NOT the attacker-supplied query.
+    expect(mockGetFollowsOfFollowsIds).toHaveBeenCalledWith(VIEWER, {
+      limit: MAX_FOLLOWS_OF_FOLLOWS_IDS,
+    });
+  });
+
+  it('does not 401 for an anonymous caller — still invokes the service with undefined', async () => {
+    currentViewerId = undefined;
+    mockGetFollowsOfFollowsIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(server, '/users/follows-of-follows-ids');
+
+    expect(res.status).toBe(200);
+    expect(mockGetFollowsOfFollowsIds).toHaveBeenCalledWith(undefined, {
+      limit: MAX_FOLLOWS_OF_FOLLOWS_IDS,
+    });
+    expect(res.body.data).toEqual([]);
+  });
+
+  it('clamps an over-cap limit to MAX_FOLLOWS_OF_FOLLOWS_IDS before calling the service', async () => {
+    currentViewerId = VIEWER;
+    mockGetFollowsOfFollowsIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(
+      server,
+      `/users/follows-of-follows-ids?limit=${MAX_FOLLOWS_OF_FOLLOWS_IDS * 100}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetFollowsOfFollowsIds).toHaveBeenCalledWith(VIEWER, {
+      limit: MAX_FOLLOWS_OF_FOLLOWS_IDS,
+    });
+  });
+
+  it('forwards a valid in-range limit unchanged', async () => {
+    currentViewerId = VIEWER;
+    mockGetFollowsOfFollowsIds.mockResolvedValueOnce([]);
+
+    const res = await getJson(server, '/users/follows-of-follows-ids?limit=100');
+
+    expect(res.status).toBe(200);
+    expect(mockGetFollowsOfFollowsIds).toHaveBeenCalledWith(VIEWER, { limit: 100 });
+  });
+
+  it('rejects a negative limit with 400 (validatePagination)', async () => {
+    currentViewerId = VIEWER;
+
+    const res = await getJson(server, '/users/follows-of-follows-ids?limit=-5');
+
+    expect(res.status).toBe(400);
+    expect(mockGetFollowsOfFollowsIds).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -74,7 +74,7 @@ const getUserIdsFromRequestBody = (body: unknown): unknown => {
 };
 
 import { PAGINATION } from '../utils/constants';
-import { MAX_MUTUAL_IDS } from '../utils/recommendationWeights';
+import { MAX_MUTUAL_IDS, MAX_FOLLOWS_OF_FOLLOWS_IDS } from '../utils/recommendationWeights';
 import { federationService, isOwnFederationDomain } from '../services/federation.service';
 
 // Initialize router and controller
@@ -580,6 +580,54 @@ router.get(
     const ids = await userService.getMutualUserIds(viewerId, { limit: parsedLimit });
 
     logger.debug('GET /users/mutual-ids', {
+      viewerId,
+      limit: parsedLimit,
+      count: ids.length,
+    });
+
+    sendSuccess(res, ids);
+  })
+);
+
+/**
+ * GET /users/follows-of-follows-ids
+ *
+ * The authenticated VIEWER's bounded "follows-of-follows" user ids — the union
+ * of the accounts followed by the accounts the viewer follows (a two-hop walk of
+ * the follow graph), MINUS the viewer's own follows and the viewer themselves.
+ * Lean, ids-only, bounded payload built to SEED Mention's friends-of-friends
+ * feed (which then hydrates and ranks the posts itself), so it returns bare ids
+ * rather than hydrated DTOs. Candidates are ordered by frequency (accounts
+ * followed by more of the viewer's follows first), then recency.
+ *
+ * The viewer is derived SERVER-SIDE from the auth token via `resolveViewerId`
+ * (the same dual-auth as `/mutual-ids` and `/by-ids`) — never a client-supplied
+ * id, and there is no `:userId` param to spoof (anti-IDOR). OPTIONAL semantics:
+ * an anonymous caller (or a service token with no user context) has no "you
+ * follow" set → `{ data: [] }`.
+ *
+ * Registered BEFORE the `/:userId` param routes so Express never treats
+ * `follows-of-follows-ids` as a `:userId` value.
+ *
+ * @query {number} limit - Max ids to return (capped at MAX_FOLLOWS_OF_FOLLOWS_IDS).
+ * @returns {{ data: string[] }} The viewer's follows-of-follows user ids.
+ */
+router.get(
+  '/follows-of-follows-ids',
+  optionalUserOrServiceAuth,
+  validatePagination,
+  asyncHandler(async (req: OptionalUserOrServiceRequest, res: Response) => {
+    // Viewer is always the authenticated principal — never a client param.
+    const viewerId = resolveViewerId(req);
+    const { limit } = req.query as PaginationQuery;
+
+    const parsedLimit = limit
+      ? Math.min(parseInt(limit, 10), MAX_FOLLOWS_OF_FOLLOWS_IDS)
+      : MAX_FOLLOWS_OF_FOLLOWS_IDS;
+
+    const ids = await userService.getFollowsOfFollowsIds(viewerId, { limit: parsedLimit });
+
+    logger.debug('GET /users/follows-of-follows-ids', {
       viewerId,
       limit: parsedLimit,
       count: ids.length,

--- a/packages/api/src/services/__tests__/user.service.getFollowsOfFollowsIds.test.ts
+++ b/packages/api/src/services/__tests__/user.service.getFollowsOfFollowsIds.test.ts
@@ -1,0 +1,222 @@
+/**
+ * UserService.getFollowsOfFollowsIds — the viewer's bounded follows-of-follows ids.
+ *
+ * Follows-of-follows = the union of the accounts followed by the accounts the
+ * VIEWER follows (a two-hop walk of the follow graph), MINUS the viewer's own
+ * follows and the viewer themselves. This SEEDS Mention's friends-of-friends
+ * feed, so the method is lean and ids-only (no hydrated DTOs, no `countDocuments`,
+ * no `User` lookup). The viewer id is ALWAYS server-derived (the route resolves
+ * it from the auth token via `resolveViewerId`); these tests cover the logic
+ * outcomes the route relies on:
+ *   - viewer with follows-of-follows → the candidate ids, excluding own
+ *     follows/self, ranked by frequency then recency (as the aggregation returns)
+ *   - no viewer (anonymous / service token w/o user) → [], zero DB queries
+ *   - viewer follows nobody → [] (short-circuits before the aggregation)
+ *   - the second hop is seeded by only the MAX_FOF_FIRST_HOP most-recent follows
+ *   - an over-cap limit clamps to MAX_FOLLOWS_OF_FOLLOWS_IDS on the returned page
+ *
+ * Mirrors the `user.service.getMutualUserIds` harness: restore the real
+ * `mongoose` (the global setup mocks it wholesale, stripping `Types`) and mock
+ * the models as chainable query builders.
+ */
+
+// The global jest.setup.cjs mocks `mongoose` wholesale, which strips `Types`
+// (and therefore `Types.ObjectId`). This suite only needs the real `Types`
+// helper — the models themselves are mocked below — so restore the actual
+// mongoose module.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import { Types } from 'mongoose';
+import {
+  MAX_FOLLOWS_OF_FOLLOWS_IDS,
+  MAX_FOF_FIRST_HOP,
+} from '../../utils/recommendationWeights';
+
+// Chainable Follow query builder: select/limit/skip/sort return the builder,
+// lean() is the terminal awaited result (sequenced per find() call).
+const mockFollowLean = jest.fn();
+const followQuery = {
+  select: jest.fn(() => followQuery),
+  limit: jest.fn(() => followQuery),
+  skip: jest.fn(() => followQuery),
+  sort: jest.fn(() => followQuery),
+  lean: mockFollowLean,
+};
+const mockFollowFind = jest.fn(() => followQuery);
+const mockFollowAggregate = jest.fn();
+const mockFollowCountDocuments = jest.fn();
+
+const mockUserFind = jest.fn();
+
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  default: {
+    find: mockFollowFind,
+    aggregate: mockFollowAggregate,
+    countDocuments: mockFollowCountDocuments,
+  },
+  FollowType: {
+    USER: 'user',
+    HASHTAG: 'hashtag',
+    TOPIC: 'topic',
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    find: mockUserFind,
+  },
+}));
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../securityActivityService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { UserService } from '../user.service';
+
+interface AggregatePipelineStage {
+  $match?: {
+    followerUserId?: { $in?: Types.ObjectId[] };
+    followType?: string;
+    followedId?: { $nin?: Types.ObjectId[] };
+  };
+  $limit?: number;
+}
+
+describe('UserService.getFollowsOfFollowsIds', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the union of follows-of-follows, excluding own follows and self', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+
+    // The people the viewer follows (first hop).
+    const v1 = new Types.ObjectId();
+    const v2 = new Types.ObjectId();
+
+    // Two candidates surfaced by the second-hop aggregation (already filtered by
+    // the pipeline: v1/v2/self are $nin-excluded server-side by Mongo).
+    const fof1 = new Types.ObjectId();
+    const fof2 = new Types.ObjectId();
+
+    mockFollowLean.mockResolvedValueOnce([{ followedId: v1 }, { followedId: v2 }]);
+    mockFollowAggregate.mockResolvedValueOnce([
+      { _id: fof1, followerCount: 2, lastFollowedAt: new Date() },
+      { _id: fof2, followerCount: 1, lastFollowedAt: new Date() },
+    ]);
+
+    const result = await new UserService().getFollowsOfFollowsIds(viewerId, { limit: 50 });
+
+    // One find (the viewer's following) + one aggregate (the second hop).
+    expect(mockFollowFind).toHaveBeenCalledTimes(1);
+    expect(mockFollowFind).toHaveBeenCalledWith({
+      followerUserId: viewerId,
+      followType: 'user',
+    });
+    expect(followQuery.sort).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(mockFollowAggregate).toHaveBeenCalledTimes(1);
+
+    // Lean, ids-only: no hydration and no count query.
+    expect(mockFollowCountDocuments).not.toHaveBeenCalled();
+    expect(mockUserFind).not.toHaveBeenCalled();
+
+    // The aggregation seeds the second hop with the viewer's follows and excludes
+    // the viewer + everything the viewer already follows.
+    const pipeline = mockFollowAggregate.mock.calls[0][0] as AggregatePipelineStage[];
+    const matchStage = pipeline[0].$match;
+    expect(matchStage?.followerUserId?.$in).toEqual([v1, v2]);
+    expect(matchStage?.followType).toBe('user');
+    const ninIds = (matchStage?.followedId?.$nin ?? []).map((id) => id.toString());
+    expect(ninIds).toContain(viewerId);
+    expect(ninIds).toContain(v1.toString());
+    expect(ninIds).toContain(v2.toString());
+
+    // Frequency-then-recency order preserved from the aggregation output.
+    expect(result).toEqual([fof1.toString(), fof2.toString()]);
+  });
+
+  it('returns empty for an anonymous viewer without querying the database', async () => {
+    const result = await new UserService().getFollowsOfFollowsIds(undefined, { limit: 50 });
+
+    expect(result).toEqual([]);
+    expect(mockFollowFind).not.toHaveBeenCalled();
+    expect(mockFollowAggregate).not.toHaveBeenCalled();
+  });
+
+  it('returns empty when the viewer follows nobody (short-circuits before the aggregation)', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+
+    mockFollowLean.mockResolvedValueOnce([]);
+
+    const result = await new UserService().getFollowsOfFollowsIds(viewerId, { limit: 50 });
+
+    expect(result).toEqual([]);
+    expect(mockFollowFind).toHaveBeenCalledTimes(1);
+    expect(mockFollowAggregate).not.toHaveBeenCalled();
+  });
+
+  it('seeds the second hop with only the MAX_FOF_FIRST_HOP most-recent follows', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+
+    // Viewer follows more accounts than the first-hop cap.
+    const following = Array.from({ length: MAX_FOF_FIRST_HOP + 25 }, () => ({
+      followedId: new Types.ObjectId(),
+    }));
+
+    mockFollowLean.mockResolvedValueOnce(following);
+    mockFollowAggregate.mockResolvedValueOnce([]);
+
+    await new UserService().getFollowsOfFollowsIds(viewerId, { limit: 50 });
+
+    // The following scan is bounded to the following cap...
+    expect(followQuery.limit).toHaveBeenCalledWith(MAX_FOLLOWS_OF_FOLLOWS_IDS);
+
+    // ...and only the most-recent MAX_FOF_FIRST_HOP of them seed the second hop.
+    const pipeline = mockFollowAggregate.mock.calls[0][0] as AggregatePipelineStage[];
+    expect(pipeline[0].$match?.followerUserId?.$in).toHaveLength(MAX_FOF_FIRST_HOP);
+    // The exclusion set is the FULL (bounded) following set, not just the sample.
+    expect(pipeline[0].$match?.followedId?.$nin).toHaveLength(following.length + 1);
+  });
+
+  it('clamps an over-cap limit to MAX_FOLLOWS_OF_FOLLOWS_IDS on the returned page', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+    const v1 = new Types.ObjectId();
+
+    mockFollowLean.mockResolvedValueOnce([{ followedId: v1 }]);
+    mockFollowAggregate.mockResolvedValueOnce([]);
+
+    await new UserService().getFollowsOfFollowsIds(viewerId, {
+      limit: MAX_FOLLOWS_OF_FOLLOWS_IDS * 10,
+    });
+
+    // The aggregation's $limit stage caps the returned page to the clamped limit.
+    const pipeline = mockFollowAggregate.mock.calls[0][0] as AggregatePipelineStage[];
+    const limitStage = pipeline.find((stage) => stage.$limit !== undefined);
+    expect(limitStage?.$limit).toBe(MAX_FOLLOWS_OF_FOLLOWS_IDS);
+  });
+});

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -29,7 +29,12 @@ import { formatUserNameResponse, type NameParts } from '../utils/displayName';
 
 // Constants
 import { PAGINATION } from '../utils/constants';
-import { MAX_FOLLOWING_FOR_MUTUALS, MAX_MUTUAL_IDS } from '../utils/recommendationWeights';
+import {
+  MAX_FOLLOWING_FOR_MUTUALS,
+  MAX_MUTUAL_IDS,
+  MAX_FOLLOWS_OF_FOLLOWS_IDS,
+  MAX_FOF_FIRST_HOP,
+} from '../utils/recommendationWeights';
 
 interface UserWithCount {
   _count?: {
@@ -45,6 +50,17 @@ interface UserWithCount {
 interface FollowCountRow {
   _id: Types.ObjectId;
   count: number;
+}
+
+/**
+ * One row of the follows-of-follows aggregation: a candidate user id, how many
+ * of the viewer's follows follow that candidate (frequency), and the most-recent
+ * time any of them did so (the recency tiebreak).
+ */
+interface FollowsOfFollowsRow {
+  _id: Types.ObjectId;
+  followerCount: number;
+  lastFollowedAt: Date;
 }
 
 /**
@@ -671,6 +687,97 @@ export class UserService {
 
     return mutualFollows
       .map((follow) => follow.followerUserId)
+      .filter((id): id is Types.ObjectId => id instanceof Types.ObjectId)
+      .map((id) => id.toString());
+  }
+
+  /**
+   * Get the VIEWER's bounded "follows-of-follows" user ids — the union of the
+   * accounts followed by the accounts the viewer follows (a two-hop walk of the
+   * follow graph), MINUS the viewer's own follows and the viewer themselves.
+   * This SEEDS Mention's friends-of-friends feed, which hydrates and ranks the
+   * posts itself, so the payload is lean and ids-only (no hydrated DTOs, no
+   * `User` lookup) — mirroring {@link getMutualUserIds}.
+   *
+   * The viewer id is ALWAYS derived server-side by the route (`resolveViewerId`),
+   * never a client param. An anonymous caller (or a service token with no user
+   * context) has no "you follow" set ⇒ empty. A viewer who follows nobody
+   * short-circuits before the aggregation.
+   *
+   * Bounded so the fan-out cannot blow up:
+   *  - the viewer's following set (used for exclusion) is scanned most-recent
+   *    first and capped at `MAX_FOLLOWS_OF_FOLLOWS_IDS`;
+   *  - only the `MAX_FOF_FIRST_HOP` most-recent of those follows seed the second
+   *    hop, so the `$in` over the Follow collection stays small no matter how
+   *    many accounts the viewer follows;
+   *  - the returned set is capped at `MAX_FOLLOWS_OF_FOLLOWS_IDS`.
+   *
+   * Ordering: candidates are ranked by how many of the viewer's sampled follows
+   * follow each one (frequency — the strongest friends-of-friends signal), with
+   * the most-recently-established edge breaking ties (recency).
+   */
+  async getFollowsOfFollowsIds(
+    viewerId: string | undefined,
+    params: { limit?: number } = {}
+  ): Promise<string[]> {
+    if (!viewerId) {
+      return [];
+    }
+
+    const limit = Math.min(
+      params.limit && params.limit > 0 ? params.limit : MAX_FOLLOWS_OF_FOLLOWS_IDS,
+      MAX_FOLLOWS_OF_FOLLOWS_IDS
+    );
+
+    // 1. The viewer's following set, most-recent first. Bounded so both the
+    //    exclusion set and the first-hop seed stay small.
+    const viewerFollowing = await Follow.find({
+      followerUserId: viewerId,
+      followType: FollowType.USER,
+    })
+      .select('followedId')
+      .sort({ createdAt: -1 })
+      .limit(MAX_FOLLOWS_OF_FOLLOWS_IDS)
+      .lean();
+
+    const followingIds = viewerFollowing
+      .map((follow) => follow.followedId)
+      .filter((id): id is Types.ObjectId => id instanceof Types.ObjectId);
+
+    if (followingIds.length === 0) {
+      return [];
+    }
+
+    // 2. Seed the second hop with only the most-recent follows to cap the
+    //    fan-out. Everything the viewer already follows, plus the viewer, is
+    //    excluded from the result — a follow-of-follow the viewer already
+    //    follows is not a recommendation.
+    const firstHopIds = followingIds.slice(0, MAX_FOF_FIRST_HOP);
+    const excludeIds = [new Types.ObjectId(viewerId), ...followingIds];
+
+    // 3. Union of the accounts THOSE follows follow, ranked by how many of the
+    //    viewer's follows follow each candidate (frequency), then recency.
+    const rows = await Follow.aggregate<FollowsOfFollowsRow>([
+      {
+        $match: {
+          followerUserId: { $in: firstHopIds },
+          followType: FollowType.USER,
+          followedId: { $nin: excludeIds },
+        },
+      },
+      {
+        $group: {
+          _id: '$followedId',
+          followerCount: { $sum: 1 },
+          lastFollowedAt: { $max: '$createdAt' },
+        },
+      },
+      { $sort: { followerCount: -1, lastFollowedAt: -1 } },
+      { $limit: limit },
+    ]);
+
+    return rows
+      .map((row) => row._id)
       .filter((id): id is Types.ObjectId => id instanceof Types.ObjectId)
       .map((id) => id.toString());
   }

--- a/packages/api/src/utils/recommendationWeights.ts
+++ b/packages/api/src/utils/recommendationWeights.ts
@@ -70,6 +70,24 @@ export const MAX_FOLLOWING_FOR_MUTUALS = 2000;
  */
 export const MAX_MUTUAL_IDS = 5000;
 
+/**
+ * Hard cap on the viewer's "follows-of-follows" id set (`getFollowsOfFollowsIds`,
+ * which SEEDS Mention's friends-of-friends feed). Bounds BOTH the viewer's own
+ * following set scanned for exclusion AND the number of ids returned, so the
+ * `$nin`/`$in` clauses and the response payload stay small regardless of how many
+ * accounts the viewer follows.
+ */
+export const MAX_FOLLOWS_OF_FOLLOWS_IDS = 5000;
+
+/**
+ * Max first-hop follows sampled (most-recent first) as the seed set for the
+ * second hop of `getFollowsOfFollowsIds`. Caps the fan-out: without it a viewer
+ * who follows tens of thousands of accounts would scan every one of their
+ * follows' following edges. The sample is the viewer's most-recent follows, so
+ * the recommendation tracks their current interests.
+ */
+export const MAX_FOF_FIRST_HOP = 500;
+
 /** Max app-signal candidates pulled into the candidate union per request. */
 export const MAX_APP_SIGNAL_CANDIDATES = 500;
 

--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -823,6 +823,34 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
     }
 
     /**
+     * Get the authenticated VIEWER's bounded "follows-of-follows" user ids — the
+     * union of the accounts followed by the accounts the viewer follows (a
+     * two-hop walk of the follow graph), MINUS the viewer's own follows and the
+     * viewer themselves. The viewer is derived server-side from the SDK's auth
+     * token (never a param), so there is no target id to pass.
+     *
+     * Returns a bounded, lean list of ids meant to SEED a friends-of-friends
+     * feed (the consumer hydrates/ranks the posts itself), ordered by frequency
+     * (accounts followed by more of the viewer's follows first), then recency.
+     * An anonymous caller resolves to an empty array. Mirrors
+     * {@link getMutualUserIds}'s caching posture.
+     */
+    async getFollowsOfFollowsIds(
+      params?: { limit?: number }
+    ): Promise<string[]> {
+      try {
+        const query = buildPaginationParams(params || {});
+        const response = await this.makeRequest<{ data: string[] }>('GET', '/users/follows-of-follows-ids', query, {
+          cache: true,
+          cacheTTL: 2 * 60 * 1000, // 2 minutes cache
+        });
+        return response.data || [];
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
      * Get notifications
      */
     async getNotifications(): Promise<Notification[]> {


### PR DESCRIPTION
## Summary
- Additive `GET /users/follows-of-follows-ids → { data: string[] }` on oxy-api — viewer is derived server-side from the auth token (same dual user+service auth with `X-Oxy-User-Id` delegation as `/users/mutual-ids`); anonymous callers get `{ data: [] }`.
- Bounded two-hop fan-out over the Follow collection: viewer's following set (most-recent first) → union of those accounts' following sets, aggregated by frequency then recency. Capped at `MAX_FOLLOWS_OF_FOLLOWS_IDS` (5000), seeded from only the `MAX_FOF_FIRST_HOP` (500) most-recent first-hop follows.
- `@oxyhq/core` `getFollowsOfFollowsIds` mixin mirrors `getMutualUserIds`'s caching posture (2m TTL).
- No new `@oxyhq/contracts` symbol — bare id array response shape, matching the mutual-ids precedent.
- Seeds Mention's friends-of-friends feed.

## Test plan
- [x] `bun run build:all` — all 12 workspace build tasks green
- [x] `packages/api` jest suite — 143/143 suites, 1338/1338 tests
- [x] `packages/core` jest suite — 64/64 suites, 780/780 tests
- [x] New route + service tests (mutual + fof) — 22/22
- [x] `tsc --noEmit` clean on both `core` and `api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>