### PR TITLE
fix(api): org switch inherits the operator's deviceId — switches finally survive reloads

### DIFF
--- a/packages/api/src/routes/__tests__/accountsSwitch.test.ts
+++ b/packages/api/src/routes/__tests__/accountsSwitch.test.ts
@@ -53,6 +53,12 @@ jest.mock('../../middleware/auth', () => ({
   authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
 }));
 
+const mockDecodeToken = jest.fn();
+jest.mock('../../middleware/authUtils', () => ({
+  decodeToken: (...args: unknown[]) => mockDecodeToken(...args),
+  extractTokenFromRequest: () => 'tkn',
+}));
+
 jest.mock('../../middleware/rateLimiter', () => ({
   rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
@@ -132,6 +138,10 @@ beforeEach(() => {
   mockVerifyActingAs.mockReset();
   mockFindById.mockReset();
   mockCreateSession.mockReset();
+  // Default: the operator's bearer decodes to a device id — the switch must
+  // inherit it so the org session lands on the SAME device doc as the operator.
+  mockDecodeToken.mockReset();
+  mockDecodeToken.mockReturnValue({ sessionId: 'op-sess', deviceId: 'dev-op' });
 });
 
 describe('POST /accounts/:id/switch', () => {
@@ -183,7 +193,37 @@ describe('POST /accounts/:id/switch', () => {
     expect(res.body.user?.username).toBe('acme-org');
     expect(res.body.sessionId).toBe('sess-1');
     expect(res.body.accessToken).toBe('acc-1');
-    // Operator recorded on the minted session.
+    // Operator recorded on the minted session, AND the operator's deviceId is
+    // inherited so the org session joins the operator's existing device doc
+    // (not a fresh device the browser never restores from on reload).
+    expect(mockCreateSession).toHaveBeenCalledWith(ORG_ID, expect.anything(), {
+      operatedByUserId: OPERATOR_ID,
+      deviceId: 'dev-op',
+    });
+  });
+
+  it('falls back to a fresh device when the bearer has no resolvable deviceId', async () => {
+    // No decodable deviceId on the caller's bearer → keep today's behavior
+    // (let createSession derive/allocate a device) rather than passing undefined.
+    mockDecodeToken.mockReturnValue(null);
+    mockVerifyActingAs.mockResolvedValue('admin');
+    mockFindById.mockResolvedValue({
+      _id: new Types.ObjectId(ORG_ID),
+      username: 'acme-org',
+      kind: 'organization',
+      accountStatus: 'active',
+    });
+    mockCreateSession.mockResolvedValue({
+      sessionId: 'sess-1',
+      deviceId: 'dev-fresh',
+      expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+      accessToken: 'acc-1',
+    });
+
+    const res = await post(server, `/accounts/${ORG_ID}/switch`);
+
+    expect(res.status).toBe(200);
+    // No deviceId key threaded — the switch still mints a session.
     expect(mockCreateSession).toHaveBeenCalledWith(ORG_ID, expect.anything(), { operatedByUserId: OPERATOR_ID });
   });
 

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -12,6 +12,8 @@ import { User, IUser } from '../models/User';
 import { IAccountMember } from '../models/AccountMember';
 import { IAccountCredential } from '../models/AccountCredential';
 import sessionService from '../services/session.service';
+import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
+import { logger } from '../utils/logger';
 import type { SessionAuthResponse } from '../types/session';
 import { resolveUserByIdentifier } from '../utils/resolveUserIdentifier';
 import { isPrivilegedScope, type ApplicationScope } from '../utils/applicationScopes';
@@ -53,6 +55,17 @@ function requireUserId(req: AuthRequest): string {
     throw new UnauthorizedError('Authentication required');
   }
   return userId;
+}
+
+/**
+ * Resolve the caller's central deviceId from their verified bearer (the access
+ * token embeds a `deviceId` claim). Returns null when the token is absent or
+ * undecodable. Mirrors `resolveCallerDeviceId` in sessionDevice.ts.
+ */
+function resolveCallerDeviceId(req: AuthRequest): string | null {
+  const token = extractTokenFromRequest(req);
+  const decoded = token ? decodeToken(token) : null;
+  return decoded?.deviceId ?? null;
 }
 
 /** Per-user (or per-IP when anonymous) rate-limit key for a scope. */
@@ -325,8 +338,25 @@ router.post(
 
     // Mint a REAL session for the managed account, recording the operator so the
     // session's validity stays bound to their act_as membership.
+    //
+    // Inherit the OPERATOR's central deviceId so the org session joins the SAME
+    // device doc as the operator's own session. Without this the switch mints a
+    // fresh deviceId (UA/IP-derived), the org lands in a device doc the browser
+    // never restores from on reload (it restores via the operator's personal
+    // session), and the switch silently reverts. If the caller's bearer has no
+    // decodable deviceId, keep today's behavior (let createSession allocate one).
+    const callerDeviceId = resolveCallerDeviceId(req);
+    if (!callerDeviceId) {
+      logger.warn('[accounts] switch: no deviceId on operator bearer — org session gets a fresh device', {
+        component: 'accounts',
+        method: 'switch',
+        operatorId,
+        targetAccountId: id,
+      });
+    }
     const session = await sessionService.createSession(account._id.toString(), req, {
       operatedByUserId: operatorId,
+      ...(callerDeviceId ? { deviceId: callerDeviceId } : {}),
     });
 
     const userData = formatUserResponse(account);


### PR DESCRIPTION
## Summary

**P0, final link in the switch-persistence chain** (with #494/#499/#500). Prod Mongo evidence: one physical browser had its personal account on device `feb12fb6` while every org switch created a FRESH single-account device doc (`72124e01` rev 1, `a098af96`) — `POST /accounts/:id/switch` minted the managed session without a deviceId, so `/session/device/add` (which derives the device from the caller bearer) registered the org into the wrong `DeviceSession`. The browser's real device state never contained the org → reload always reverted.

The mint now threads the operator's `deviceId` claim (same `decodeToken` primitive the device routes use); a bearer without the claim keeps today's fresh-device behavior + a warn. Sweep of every `createSession` call site: FedCM exchange already threads the claim (#483); QR authorize / OAuth / password / 2FA / social legitimately mint fresh or cross-device sessions — this was the only site with the bug.

TDD failing-first (asserts `createSession` receives the operator's deviceId) + fallback test.

## Verification (this branch)
api 1302/1302, tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)