### PR TITLE
fix: stop the IdP↔api rate-limit collapse — service-lane limiter + worker-side caching (console bounce loop)

### DIFF
--- a/packages/api/src/middleware/__tests__/idpServiceRateLimit.test.ts
+++ b/packages/api/src/middleware/__tests__/idpServiceRateLimit.test.ts
@@ -1,0 +1,153 @@
+/**
+ * IdP worker server-to-server rate-limit exemption.
+ *
+ * The auth.oxy.so Cloudflare worker calls a small set of oxy-api endpoints
+ * server-to-server for EVERY user's FedCM / SSO / silent-restore flow, from a
+ * shared pool of egress IPs:
+ *
+ *   - GET  /fedcm/clients/approved   (resolveApprovedClientOrigin)
+ *   - GET  /fedcm/grants/:userId     (fetchApprovedClients, X-Oxy-Internal)
+ *   - GET  /session/validate/:id     (fetchUserFromAPI / validateSession)
+ *   - POST /sso/code                 (mint SSO code, X-Oxy-Internal)
+ *
+ * These MUST NOT share the per-IP browser budget (`rl:general`, 1000/15min):
+ * one worker IP fans many users through them, so browser-scale traffic would
+ * exhaust the budget → 429 → the IdP fails closed → RP guards re-bounce and
+ * amplify. This suite proves the exported general limiter SKIPS these paths and
+ * that they instead carry the dedicated high-ceiling `idpServiceLimiter`.
+ *
+ * MOUNT-ORDER INVARIANT (documented, enforced by these tests): every path
+ * matched by `isIdpServiceToServicePath` is excluded from `rl:general`, so it
+ * MUST carry its own route-level limiter (reads → `idpServiceLimiter`;
+ * /sso/code → its secret-gated `rl:sso:code:` codeLimiter). `isIdpServiceToServicePath`
+ * and the route wiring must be kept in sync.
+ */
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+import {
+  rateLimiter,
+  idpServiceLimiter,
+  isIdpServiceToServicePath,
+} from '../security';
+
+interface Probe {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+}
+
+function get(server: http.Server, path: string): Promise<Probe> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method: 'GET', host: '127.0.0.1', port: address.port, path },
+      (res) => {
+        res.on('data', () => undefined);
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function hasRateLimitHeaders(headers: http.IncomingHttpHeaders): boolean {
+  return Object.keys(headers).some((h) => h.toLowerCase().startsWith('ratelimit'));
+}
+
+function listen(app: express.Express): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('isIdpServiceToServicePath', () => {
+  it('matches the exact worker READ + mint paths', () => {
+    expect(isIdpServiceToServicePath('/fedcm/clients/approved')).toBe(true);
+    expect(isIdpServiceToServicePath('/fedcm/grants/64f7c2a1b8e9d3f4a1c2b3d4')).toBe(true);
+    expect(isIdpServiceToServicePath('/session/validate/sess-abc')).toBe(true);
+    expect(isIdpServiceToServicePath('/sso/code')).toBe(true);
+  });
+
+  it('does NOT match browser-reachable neighbours that must stay under the general budget', () => {
+    // Bearer-cross-checked, browser-reachable — MUST NOT be exempted.
+    expect(isIdpServiceToServicePath('/session/validate-header/sess-abc')).toBe(false);
+    // Browser-facing FedCM endpoints (their own limiters / general budget apply).
+    expect(isIdpServiceToServicePath('/fedcm/nonce')).toBe(false);
+    expect(isIdpServiceToServicePath('/fedcm/exchange')).toBe(false);
+    // Public SSO redemption is browser-driven.
+    expect(isIdpServiceToServicePath('/sso/exchange')).toBe(false);
+    // Ordinary user/session traffic.
+    expect(isIdpServiceToServicePath('/session/user/64f7c2a1b8e9d3f4a1c2b3d4')).toBe(false);
+    expect(isIdpServiceToServicePath('/users/me')).toBe(false);
+    expect(isIdpServiceToServicePath('/')).toBe(false);
+  });
+});
+
+describe('general limiter (rl:general) exempts IdP service paths', () => {
+  let server: http.Server;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(rateLimiter);
+    app.all('*', (_req, res) => res.json({ ok: true }));
+    server = await listen(app);
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it('does not consume / emit the general budget on exempt paths', async () => {
+    for (const path of [
+      '/fedcm/clients/approved',
+      '/fedcm/grants/64f7c2a1b8e9d3f4a1c2b3d4',
+      '/session/validate/sess-abc',
+      '/sso/code',
+    ]) {
+      const res = await get(server, path);
+      expect(res.status).toBe(200);
+      // A skipped request never touches the store and emits NO RateLimit
+      // headers — proof it does not draw down the per-IP browser budget.
+      expect(hasRateLimitHeaders(res.headers)).toBe(false);
+    }
+  });
+
+  it('still enforces the general budget on browser-facing paths', async () => {
+    const res = await get(server, '/session/validate-header/sess-abc');
+    expect(res.status).toBe(200);
+    expect(hasRateLimitHeaders(res.headers)).toBe(true);
+    // NODE_ENV is not "development" under jest → production ceiling of 1000.
+    expect(res.headers['ratelimit-limit']).toBe('1000');
+  });
+});
+
+describe('idpServiceLimiter (rl:fedcm:service) is the dedicated high-cap limiter', () => {
+  let server: http.Server;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(idpServiceLimiter);
+    app.all('*', (_req, res) => res.json({ ok: true }));
+    server = await listen(app);
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it('enforces a ceiling far above the general per-IP budget', async () => {
+    const res = await get(server, '/fedcm/clients/approved');
+    expect(res.status).toBe(200);
+    expect(hasRateLimitHeaders(res.headers)).toBe(true);
+    // 20x the general 1000 ceiling — sized for shared-egress worker fan-out, a
+    // distinct instance from rl:general (different limit proves distinctness).
+    expect(res.headers['ratelimit-limit']).toBe('20000');
+    expect(res.headers['ratelimit-limit']).not.toBe('1000');
+  });
+});

--- a/packages/api/src/middleware/__tests__/idpServiceRateLimitPrefix.test.ts
+++ b/packages/api/src/middleware/__tests__/idpServiceRateLimitPrefix.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Every Redis-backed limiter in `security.ts` MUST register a UNIQUE key
+ * prefix. Two limiters sharing a prefix increment the same counter when a
+ * request flows through both (express-rate-limit throws ERR_ERL_DOUBLE_COUNT
+ * and the effective per-IP budget is silently halved). This suite captures the
+ * prefix each limiter hands to `rate-limit-redis` at construction time and
+ * asserts the new `rl:fedcm:service:` limiter is present and distinct from the
+ * general/auth/user limiters.
+ */
+
+const capturedPrefixes: string[] = [];
+
+jest.mock('rate-limit-redis', () => ({
+  RedisStore: jest.fn().mockImplementation((opts: { prefix?: string }) => {
+    if (typeof opts?.prefix === 'string') capturedPrefixes.push(opts.prefix);
+    return {
+      init: jest.fn(),
+      increment: jest.fn(async () => ({ totalHits: 1, resetTime: new Date() })),
+      decrement: jest.fn(),
+      resetKey: jest.fn(),
+      resetAll: jest.fn(),
+    };
+  }),
+}));
+
+// Force the Redis branch of `makeStore` so a RedisStore (with its prefix) is
+// actually constructed for each limiter.
+jest.mock('../../config/redis', () => ({
+  getRedisClient: () => ({ call: jest.fn() }),
+}));
+
+// Importing the module builds every limiter at load time, populating
+// `capturedPrefixes` via the mocked RedisStore constructor.
+import '../security';
+
+describe('security.ts limiter prefixes are unique', () => {
+  it('registers the dedicated IdP service limiter with rl:fedcm:service:', () => {
+    expect(capturedPrefixes).toContain('rl:fedcm:service:');
+  });
+
+  it('keeps every limiter prefix distinct (no ERR_ERL_DOUBLE_COUNT)', () => {
+    // The four Redis-backed limiters defined in security.ts. slowDown's
+    // bruteForceProtection uses an in-memory store (no prefix), so it is absent.
+    const securityPrefixes = ['rl:general:', 'rl:fedcm:service:', 'rl:auth:', 'rl:user:'];
+
+    for (const prefix of securityPrefixes) {
+      // Present, and registered EXACTLY once — a duplicate would double-count.
+      expect(capturedPrefixes.filter((p) => p === prefix)).toHaveLength(1);
+    }
+    // The four are mutually distinct.
+    expect(new Set(securityPrefixes).size).toBe(securityPrefixes.length);
+    // The dedicated service limiter is not the general per-IP browser budget.
+    expect('rl:fedcm:service:').not.toBe('rl:general:');
+  });
+});

--- a/packages/api/src/middleware/security.ts
+++ b/packages/api/src/middleware/security.ts
@@ -26,17 +26,70 @@ function makeStore(prefix: string) {
   };
 }
 
+/**
+ * Paths hit ONLY by the first-party IdP worker (auth.oxy.so) server-to-server,
+ * never by a browser directly:
+ *   - GET /fedcm/clients/approved   (worker: resolveApprovedClientOrigin)
+ *   - GET /fedcm/grants/:userId     (worker: fetchApprovedClients, X-Oxy-Internal)
+ *   - GET /session/validate/:id     (worker: fetchUserFromAPI / validateSession)
+ *   - POST /sso/code                (worker: mint SSO code, X-Oxy-Internal)
+ *
+ * The IdP worker fans EVERY user's /sso, /sso/establish, /auth/silent and FedCM
+ * flow through these, from a small pool of shared Cloudflare egress IPs.
+ * Subjecting them to the per-IP browser budget (rl:general 1000/15min) lets
+ * normal multi-user traffic exhaust the budget on one worker IP → 429 → the IdP
+ * fails closed (invalid_request on /sso, silent restore fails) → RP auth guards
+ * re-bounce and amplify the load. These are trusted infrastructure calls, NOT
+ * browser traffic, so they are excluded from the general per-IP limiter and
+ * capped instead by their own dedicated limiters (idpServiceLimiter below for
+ * the reads; the route-local secret-gated codeLimiter for POST /sso/code).
+ *
+ * MOUNT-ORDER INVARIANT: the general `rateLimiter` skips these paths, so any
+ * path listed here MUST carry its OWN dedicated limiter at its route (reads →
+ * `idpServiceLimiter`; /sso/code → its `rl:sso:code:` codeLimiter). Adding a
+ * path here without a route-level limiter would leave it entirely unthrottled.
+ * `/session/validate-header/` is intentionally NOT matched — it is bearer-cross-
+ * checked and browser-reachable, so it stays under the general budget.
+ */
+export function isIdpServiceToServicePath(path: string): boolean {
+  return (
+    path === '/fedcm/clients/approved' ||
+    path.startsWith('/fedcm/grants/') ||
+    path.startsWith('/session/validate/') ||
+    path === '/sso/code'
+  );
+}
+
 // General rate limiting middleware (exclude file uploads). The previous
 // ceiling of 150/15min was below what a single signed-in user generates
 // against the API in normal usage (feed scrolling, profile loads, sockets'
 // REST fallback, FedCM exchanges), which surfaced as misleading 429s on
 // unrelated endpoints. The userRateLimiter below still caps per-account
-// traffic.
+// traffic. IdP worker server-to-server paths are skipped (see
+// isIdpServiceToServicePath) so shared-egress traffic never exhausts this budget.
 const rateLimiter = rateLimit({
   ...makeStore('rl:general:'),
   windowMs: 15 * 60 * 1000,
   max: isProd ? 1000 : 2000,
   message: "Too many requests from this IP, please try again later.",
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req: Request) =>
+    req.path.startsWith('/files/upload') || isIdpServiceToServicePath(req.path),
+});
+
+// Dedicated high-ceiling limiter for the IdP worker's server-to-server READ
+// calls (see isIdpServiceToServicePath). Because those paths are skipped by
+// rl:general, this is their SOLE per-IP budget. The ceiling is deliberately
+// high: each hit is the shared Cloudflare Worker egress fanning MANY users'
+// FedCM/SSO flows through one IP, not a single browser — yet it still bounds a
+// runaway or compromised caller. Unique prefix (`rl:fedcm:service:`) keeps its
+// counter distinct from every other limiter (no ERR_ERL_DOUBLE_COUNT).
+const idpServiceLimiter = rateLimit({
+  ...makeStore('rl:fedcm:service:'),
+  windowMs: 15 * 60 * 1000,
+  max: isProd ? 20000 : 40000,
+  message: "Too many requests, please try again later.",
   standardHeaders: true,
   legacyHeaders: false,
   skip: (req: Request) => req.path.startsWith('/files/upload'),
@@ -75,12 +128,17 @@ const userRateLimiter = rateLimit({
   },
 });
 
-// Brute force protection middleware (exclude file uploads)
+// Brute force protection middleware (exclude file uploads). Also skips the IdP
+// worker's server-to-server paths (see isIdpServiceToServicePath): this is a
+// sibling per-IP budget mounted alongside the general limiter, and its low
+// delayAfter (100/15min) would otherwise add 500ms delays to the shared worker
+// egress IP — a latency-based version of the same fail-closed amplification.
 const bruteForceProtection = slowDown({
   windowMs: 15 * 60 * 1000,
   delayAfter: isProd ? 100 : 1000,
   delayMs: () => isProd ? 500 : 100,
-  skip: (req: Request) => req.path.startsWith('/files/upload'),
+  skip: (req: Request) =>
+    req.path.startsWith('/files/upload') || isIdpServiceToServicePath(req.path),
 });
 
 /**
@@ -131,4 +189,4 @@ const securityHeaders = helmet({
   // X-Permitted-Cross-Domain-Policies: Restrict Adobe Flash and PDF
 });
 
-export { rateLimiter, authRateLimiter, userRateLimiter, bruteForceProtection, securityHeaders };
+export { rateLimiter, idpServiceLimiter, authRateLimiter, userRateLimiter, bruteForceProtection, securityHeaders };

--- a/packages/api/src/routes/fedcm.ts
+++ b/packages/api/src/routes/fedcm.ts
@@ -10,6 +10,7 @@ import {
   revokeMyAuthorizedApp,
 } from '../controllers/fedcm.controller';
 import { rateLimit } from '../middleware/rateLimiter';
+import { idpServiceLimiter } from '../middleware/security';
 import { authMiddleware, serviceAuthMiddleware } from '../middleware/auth';
 
 const router = express.Router();
@@ -125,7 +126,9 @@ router.post('/exchange', exchangeIdToken);
  *                   items:
  *                     type: string
  */
-router.get('/clients/approved', getApprovedClients);
+// Excluded from rl:general (IdP worker server-to-server; see
+// isIdpServiceToServicePath). idpServiceLimiter is this route's sole per-IP cap.
+router.get('/clients/approved', idpServiceLimiter, getApprovedClients);
 
 /**
  * @openapi
@@ -174,7 +177,9 @@ router.get('/clients/approved', getApprovedClients);
  *       404:
  *         description: Internal shared secret missing or invalid.
  */
-router.get('/grants/:userId', getUserGrants);
+// Excluded from rl:general (IdP worker server-to-server, X-Oxy-Internal gated;
+// see isIdpServiceToServicePath). idpServiceLimiter is this route's sole per-IP cap.
+router.get('/grants/:userId', idpServiceLimiter, getUserGrants);
 
 /**
  * @openapi

--- a/packages/api/src/routes/session.ts
+++ b/packages/api/src/routes/session.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { SessionController } from '../controllers/session.controller';
 import { authMiddleware } from '../middleware/auth';
+import { idpServiceLimiter } from '../middleware/security';
 import { validate } from '../middleware/validate';
 import { sessionIdParams, updateDeviceNameSchema, batchUsersSchema } from '../schemas/session.schemas';
 
@@ -204,7 +205,9 @@ router.post('/logout-all/:sessionId', validate({ params: sessionIdParams }), Ses
  *       404:
  *         description: Session not found or expired.
  */
-router.get('/validate/:sessionId', validate({ params: sessionIdParams }), SessionController.validateSession);
+// Excluded from rl:general (IdP worker server-to-server session resolution; see
+// isIdpServiceToServicePath). idpServiceLimiter is this route's sole per-IP cap.
+router.get('/validate/:sessionId', idpServiceLimiter, validate({ params: sessionIdParams }), SessionController.validateSession);
 
 /**
  * @openapi

--- a/packages/auth/server/__tests__/deviceIdChain.idp.test.ts
+++ b/packages/auth/server/__tests__/deviceIdChain.idp.test.ts
@@ -108,11 +108,16 @@ function installApiStub(): void {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let app: { request: (path: string, init?: RequestInit) => Promise<Response> };
+// The worker's approved-clients + grants caches are process-global (shared with
+// every other test file that imports `../index`); reset before each case so a
+// cached list from another test can't suppress this file's stubbed API calls.
+let resetSsoCaches: () => void = () => {};
 
 beforeAll(async () => {
   installApiStub();
   const mod = await import('../index');
   app = mod.app as typeof app;
+  resetSsoCaches = mod.__resetSsoCachesForTests;
 });
 
 afterAll(() => {
@@ -120,6 +125,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  resetSsoCaches();
   stubbedDeviceId = 'dev-central-xyz';
   installApiStub();
 });

--- a/packages/auth/server/__tests__/fedcm.idp.test.ts
+++ b/packages/auth/server/__tests__/fedcm.idp.test.ts
@@ -188,11 +188,16 @@ function installApiStub(): void {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let app: { request: (path: string, init?: RequestInit) => Promise<Response> };
+// The worker's approved-clients + grants caches are process-global; reset them
+// before each case so a prior test's cached list can't leak into (or suppress
+// the API call of) the next. Mirrors the `__resetBloomCSSForTests` pattern.
+let resetSsoCaches: () => void = () => {};
 
 beforeAll(async () => {
   installApiStub();
   const mod = await import('../index');
   app = mod.app as typeof app;
+  resetSsoCaches = mod.__resetSsoCachesForTests;
 });
 
 afterAll(() => {
@@ -200,6 +205,7 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  resetSsoCaches();
   stubbedGrantedOrigins = [RP_ORIGIN];
   stubbedApprovedClients = [RP_ORIGIN];
   stubbedSsoCode = STUB_SSO_CODE;

--- a/packages/auth/server/__tests__/ssoCache.idp.test.ts
+++ b/packages/auth/server/__tests__/ssoCache.idp.test.ts
@@ -1,0 +1,333 @@
+/**
+ * IdP worker (auth.oxy.so) approved-clients + grants caching.
+ *
+ * The worker fetches `${apiBaseUrl}/fedcm/clients/approved` on EVERY /sso,
+ * /sso/establish, /auth/silent and /fedcm request, and per-user grants
+ * (`/fedcm/grants/:userId`) on the accounts + silent-consent paths. From shared
+ * Cloudflare egress IPs this hammered the API into 429s → the fails-closed
+ * `invalid_request` bounce loop we saw live. These tests pin the caching that
+ * fixes it, driving the exported cache functions directly with a counting fetch
+ * stub and a controllable system clock.
+ *
+ * Two DISTINCT policies are asserted:
+ *   - approved-clients (public allow-list): 60s fresh TTL, single-flight
+ *     de-dup, and BOUNDED-STALE serving (up to 10min) on failure — bounded
+ *     staleness beats a fails-closed collapse. Past the cap it fails closed.
+ *   - grants (per-user consent): 30s fresh TTL, single-flight de-dup, but NO
+ *     stale-on-failure — a stale grant must never gate consent, so a failed
+ *     lookup falls through to the fail-closed empty list.
+ *
+ * Run with `bun test`. The upstream API is stubbed via a global `fetch` mock;
+ * `setSystemTime` advances the clock to cross TTL / stale-cap boundaries without
+ * real waits.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, setSystemTime } from 'bun:test';
+
+const RP_ORIGIN = 'https://accounts.oxy.so';
+const OTHER_ORIGIN = 'https://console.oxy.so';
+const API_BASE = 'https://api.oxy.so';
+const USER_A = '507f1f77bcf86cd799439011';
+const USER_B = '507f1f77bcf86cd799439012';
+
+// The cache functions read `ssoInternalSecret` off the config for grants; the
+// other fields are unused by these two functions but keep the shape honest.
+const CONFIG = {
+  apiBaseUrl: API_BASE,
+  fedcmIssuer: 'https://auth.oxy.so',
+  fedcmTokenSecret: 'test-fedcm-secret',
+  ssoInternalSecret: 'test-sso-internal-secret-32-chars-long!!',
+};
+
+// Configure env BEFORE importing the server module (it reads env at load).
+process.env.FEDCM_TOKEN_SECRET = CONFIG.fedcmTokenSecret;
+process.env.FEDCM_ISSUER = CONFIG.fedcmIssuer;
+process.env.OXY_API_URL = API_BASE;
+process.env.SSO_INTERNAL_SECRET = CONFIG.ssoInternalSecret;
+process.env.NODE_ENV = 'test';
+
+// A fixed epoch base; individual tests advance the clock relative to it.
+const BASE = 1_700_000_000_000;
+
+const realFetch = globalThis.fetch;
+
+// ---- Stub state (reset in beforeEach) --------------------------------------
+type StubMode = 'ok' | 'fail' | 'empty';
+let approvedFetchCount = 0;
+let approvedMode: StubMode = 'ok';
+let approvedList: string[] = [RP_ORIGIN];
+let grantsFetchCount = 0;
+let grantsMode: StubMode = 'ok';
+let grantsList: string[] = [RP_ORIGIN];
+
+// When armed, the approved-clients handler blocks on this gate before
+// responding — lets a test fire concurrent callers while a single fetch is
+// still in flight, to prove single-flight de-dup.
+let approvedGate: Promise<void> | null = null;
+let openApprovedGate: (() => void) | null = null;
+function armApprovedGate(): void {
+  approvedGate = new Promise<void>((resolve) => {
+    openApprovedGate = () => resolve();
+  });
+}
+
+function installStub(): void {
+  globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.includes('/fedcm/clients/approved')) {
+      approvedFetchCount += 1;
+      if (approvedGate) await approvedGate;
+      if (approvedMode === 'fail') {
+        return new Response('err', { status: 500 });
+      }
+      const clients = approvedMode === 'empty' ? [] : approvedList;
+      return new Response(JSON.stringify({ success: true, clients }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    if (url.includes('/fedcm/grants/')) {
+      grantsFetchCount += 1;
+      if (grantsMode === 'fail') {
+        return new Response('err', { status: 500 });
+      }
+      const origins = grantsMode === 'empty' ? [] : grantsList;
+      return new Response(JSON.stringify({ origins }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+}
+
+let resolveApprovedClientOrigin: (
+  apiBaseUrl: string,
+  clientId: string | undefined
+) => Promise<string | null>;
+let fetchApprovedClients: (
+  config: typeof CONFIG,
+  userId: string,
+  forceRefresh?: boolean
+) => Promise<string[]>;
+let resetSsoCaches: () => void = () => {};
+
+beforeAll(async () => {
+  installStub();
+  const mod = await import('../index');
+  resolveApprovedClientOrigin = mod.resolveApprovedClientOrigin;
+  fetchApprovedClients = mod.fetchApprovedClients;
+  resetSsoCaches = mod.__resetSsoCachesForTests;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+  setSystemTime();
+});
+
+beforeEach(() => {
+  resetSsoCaches();
+  approvedFetchCount = 0;
+  approvedMode = 'ok';
+  approvedList = [RP_ORIGIN];
+  grantsFetchCount = 0;
+  grantsMode = 'ok';
+  grantsList = [RP_ORIGIN];
+  approvedGate = null;
+  openApprovedGate = null;
+  setSystemTime(new Date(BASE));
+  installStub();
+});
+
+afterEach(() => {
+  setSystemTime();
+});
+
+describe('approved-clients cache (60s TTL, bounded-stale)', () => {
+  it('serves the second call within TTL from cache without re-fetching', async () => {
+    const first = await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(first).toBe(RP_ORIGIN);
+    expect(approvedFetchCount).toBe(1);
+
+    // Advance just under the 60s TTL — still fresh.
+    setSystemTime(new Date(BASE + 59_000));
+    const second = await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(second).toBe(RP_ORIGIN);
+    expect(approvedFetchCount).toBe(1); // no second network round-trip
+
+    // A different-but-approved client resolves off the SAME cached list.
+    approvedList = [RP_ORIGIN, OTHER_ORIGIN]; // would only matter on a re-fetch
+    const other = await resolveApprovedClientOrigin(API_BASE, OTHER_ORIGIN);
+    expect(other).toBeNull(); // not in the cached list; still no re-fetch
+    expect(approvedFetchCount).toBe(1);
+  });
+
+  it('re-fetches once the TTL has elapsed', async () => {
+    await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(approvedFetchCount).toBe(1);
+
+    setSystemTime(new Date(BASE + 61_000)); // past the 60s TTL
+    await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(approvedFetchCount).toBe(2);
+  });
+
+  it('serves the stale list when a refresh fails within the stale cap', async () => {
+    // Prime the cache with a good list.
+    expect(await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN)).toBe(RP_ORIGIN);
+    expect(approvedFetchCount).toBe(1);
+
+    // TTL elapsed AND the refresh now fails — but we are still inside the 10min
+    // stale cap, so the prior good list must be served (bounded staleness).
+    approvedMode = 'fail';
+    setSystemTime(new Date(BASE + 5 * 60_000)); // 5min: past TTL, within 10min cap
+    const stale = await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(stale).toBe(RP_ORIGIN);
+    expect(approvedFetchCount).toBe(2); // it DID attempt a refresh (which failed)
+  });
+
+  it('fails closed once the stale cap is exceeded', async () => {
+    expect(await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN)).toBe(RP_ORIGIN);
+
+    approvedMode = 'fail';
+    setSystemTime(new Date(BASE + 11 * 60_000)); // 11min: beyond the 10min stale cap
+    const result = await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(result).toBeNull();
+  });
+
+  it('fails closed on the very first fetch failure (no prior cache to serve)', async () => {
+    approvedMode = 'fail';
+    const result = await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(result).toBeNull();
+    expect(approvedFetchCount).toBe(1);
+  });
+
+  it('never caches an empty list as truth (empty is non-authoritative)', async () => {
+    // A 200 with an empty `clients` array is treated as non-authoritative — it
+    // is NOT stored, so the next call re-fetches rather than honouring "nothing
+    // approved" for 60s.
+    approvedMode = 'empty';
+    expect(await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN)).toBeNull();
+    expect(approvedFetchCount).toBe(1);
+
+    approvedMode = 'ok';
+    const recovered = await resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    expect(recovered).toBe(RP_ORIGIN);
+    expect(approvedFetchCount).toBe(2); // re-fetched because empty was not cached
+  });
+
+  it('shares a single in-flight fetch across concurrent callers', async () => {
+    armApprovedGate();
+
+    // Fire two resolutions before the first fetch resolves.
+    const p1 = resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+    const p2 = resolveApprovedClientOrigin(API_BASE, RP_ORIGIN);
+
+    // Let the single in-flight fetch complete, then await both.
+    openApprovedGate?.();
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toBe(RP_ORIGIN);
+    expect(r2).toBe(RP_ORIGIN);
+    expect(approvedFetchCount).toBe(1); // de-duped onto ONE network round-trip
+  });
+});
+
+describe('grants cache (30s TTL, NO stale-on-failure)', () => {
+  it('serves the second lookup within TTL from cache without re-fetching', async () => {
+    const first = await fetchApprovedClients(CONFIG, USER_A);
+    expect(first).toEqual([RP_ORIGIN]);
+    expect(grantsFetchCount).toBe(1);
+
+    setSystemTime(new Date(BASE + 29_000)); // within 30s TTL
+    const second = await fetchApprovedClients(CONFIG, USER_A);
+    expect(second).toEqual([RP_ORIGIN]);
+    expect(grantsFetchCount).toBe(1);
+  });
+
+  it('re-fetches once the 30s TTL has elapsed', async () => {
+    await fetchApprovedClients(CONFIG, USER_A);
+    expect(grantsFetchCount).toBe(1);
+
+    setSystemTime(new Date(BASE + 31_000)); // past the 30s TTL
+    await fetchApprovedClients(CONFIG, USER_A);
+    expect(grantsFetchCount).toBe(2);
+  });
+
+  it('caches independently per userId', async () => {
+    await fetchApprovedClients(CONFIG, USER_A);
+    await fetchApprovedClients(CONFIG, USER_B);
+    expect(grantsFetchCount).toBe(2); // distinct users → distinct fetches
+
+    // Each is now cached on its own key.
+    await fetchApprovedClients(CONFIG, USER_A);
+    await fetchApprovedClients(CONFIG, USER_B);
+    expect(grantsFetchCount).toBe(2);
+  });
+
+  it('caches a legitimately-empty grant list (a real "no grants yet" state)', async () => {
+    grantsMode = 'empty';
+    expect(await fetchApprovedClients(CONFIG, USER_A)).toEqual([]);
+    expect(grantsFetchCount).toBe(1);
+
+    // Empty success IS authoritative for grants → cached, no re-fetch.
+    expect(await fetchApprovedClients(CONFIG, USER_A)).toEqual([]);
+    expect(grantsFetchCount).toBe(1);
+  });
+
+  it('fails closed on error and NEVER serves a stale grant list', async () => {
+    // Prime a good grant list.
+    expect(await fetchApprovedClients(CONFIG, USER_A)).toEqual([RP_ORIGIN]);
+    expect(grantsFetchCount).toBe(1);
+
+    // TTL elapsed AND the refresh fails: grants gate consent, so this must fail
+    // closed (empty list) — NOT serve the prior [RP_ORIGIN].
+    grantsMode = 'fail';
+    setSystemTime(new Date(BASE + 31_000));
+    const afterFailure = await fetchApprovedClients(CONFIG, USER_A);
+    expect(afterFailure).toEqual([]);
+    expect(grantsFetchCount).toBe(2); // it attempted a refresh
+
+    // The failure was not cached either — a subsequent success repopulates.
+    grantsMode = 'ok';
+    const recovered = await fetchApprovedClients(CONFIG, USER_A);
+    expect(recovered).toEqual([RP_ORIGIN]);
+  });
+
+  it('does not attempt a fetch when no internal secret is configured', async () => {
+    const noSecret = { ...CONFIG, ssoInternalSecret: '' };
+    const result = await fetchApprovedClients(noSecret, USER_A);
+    expect(result).toEqual([]);
+    expect(grantsFetchCount).toBe(0); // fails closed before any network call
+  });
+
+  it('shares a single in-flight lookup across concurrent callers for the same user', async () => {
+    // No gate needed: fire both before awaiting so they enqueue on one promise.
+    const p1 = fetchApprovedClients(CONFIG, USER_A);
+    const p2 = fetchApprovedClients(CONFIG, USER_A);
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual([RP_ORIGIN]);
+    expect(r2).toEqual([RP_ORIGIN]);
+    expect(grantsFetchCount).toBe(1);
+  });
+
+  it('forceRefresh bypasses a fresh cache (the /sso/establish between-hops re-check)', async () => {
+    // Prime the cache as the central /sso hop would, while the grant exists.
+    grantsList = [RP_ORIGIN, OTHER_ORIGIN];
+    expect(await fetchApprovedClients(CONFIG, USER_A)).toEqual([RP_ORIGIN, OTHER_ORIGIN]);
+    expect(grantsFetchCount).toBe(1);
+
+    // Grant revoked between hops. A cached read (within TTL) would still show it,
+    // but forceRefresh must read the LIVE, now-revoked list.
+    grantsList = [RP_ORIGIN];
+    const cachedRead = await fetchApprovedClients(CONFIG, USER_A);
+    expect(cachedRead).toEqual([RP_ORIGIN, OTHER_ORIGIN]); // stale cache still holds the grant
+    expect(grantsFetchCount).toBe(1);
+
+    const liveRead = await fetchApprovedClients(CONFIG, USER_A, true);
+    expect(liveRead).toEqual([RP_ORIGIN]); // revocation observed
+    expect(grantsFetchCount).toBe(2);
+  });
+});

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -400,20 +400,38 @@ async function fetchUserFromAPI(apiBaseUrl: string, sessionId: string): Promise<
 }
 
 /**
- * Fetch the RP origins this user has previously granted via FedCM. These
- * populate the spec's optional `approved_clients` array on the accounts
- * response so Chrome treats the account as a *returning* account for those RPs
- * — skipping the disclosure UI and (critically) allowing `mediation: 'silent'`
- * to resolve across apps. Without it every RP is treated as first-time and
- * cross-app silent SSO never completes.
- *
- * Best-effort: any failure yields an empty list (the account is still returned,
- * just without the returning-account optimization). The API endpoint is
- * cookie-less but returns private per-user RP grant metadata, so the IdP must
- * present the internal shared secret on this server-to-server call.
+ * TTL (ms) for the per-user grants cache. Grants change on an explicit user
+ * consent action, so the window is kept SHORT (30s) — long enough to absorb the
+ * burst of grant lookups a single SSO/silent flow fans out from shared egress
+ * IPs, short enough that a freshly-granted RP starts resolving silently within
+ * seconds. Deliberately much tighter than the 60s approved-clients TTL.
  */
-async function fetchApprovedClients(config: ResolvedConfig, userId: string): Promise<string[]> {
-  if (!config.ssoInternalSecret) return [];
+const GRANTS_TTL_MS = 30_000;
+
+interface GrantsCacheEntry {
+  origins: string[];
+  fetchedAt: number;
+}
+
+/**
+ * Per-user cache of granted RP origins, keyed by userId. POSITIVE results only
+ * (including a legitimately-empty grant list — an authenticated 200 with
+ * `origins: []` is a real "no grants yet" state). A FAILED lookup is NEVER
+ * cached and NEVER served stale: grants gate consent, so a transient error must
+ * fall through to the fail-closed empty list, exactly as before caching.
+ */
+const grantsCache = new Map<string, GrantsCacheEntry>();
+
+/** In-flight grants fetch de-dup, keyed by userId — concurrent lookups share one round-trip. */
+const grantsInFlight = new Map<string, Promise<string[] | null>>();
+
+/**
+ * Raw grants fetch. Returns the parsed origin list on a successful, well-formed
+ * response (possibly empty), or `null` on ANY failure (missing secret, non-2xx,
+ * malformed body, network/timeout). The `null` vs `[]` distinction is what lets
+ * the caller cache a genuine empty result while refusing to cache a failure.
+ */
+async function fetchGrantsFromApi(config: ResolvedConfig, userId: string): Promise<string[] | null> {
   try {
     const url = `${config.apiBaseUrl}/fedcm/grants/${encodeURIComponent(userId)}`;
     const res = await fetch(url, {
@@ -423,14 +441,70 @@ async function fetchApprovedClients(config: ResolvedConfig, userId: string): Pro
       },
       signal: AbortSignal.timeout(5000),
     });
-    if (!res.ok) return [];
+    if (!res.ok) return null;
     const data = await res.json() as Record<string, unknown>;
     const origins = data.origins;
-    if (!Array.isArray(origins)) return [];
+    if (!Array.isArray(origins)) return null;
     return origins.filter((o): o is string => typeof o === 'string' && o.length > 0);
   } catch {
-    return [];
+    return null;
   }
+}
+
+/**
+ * Fetch the RP origins this user has previously granted via FedCM. These
+ * populate the spec's optional `approved_clients` array on the accounts
+ * response so Chrome treats the account as a *returning* account for those RPs
+ * — skipping the disclosure UI and (critically) allowing `mediation: 'silent'`
+ * to resolve across apps. Without it every RP is treated as first-time and
+ * cross-app silent SSO never completes.
+ *
+ * Cached for {@link GRANTS_TTL_MS} per userId with single-flight de-dup so a
+ * burst of grant lookups (accounts + each silent-restore consent check) does
+ * not hammer the API from shared egress IPs. Best-effort: any failure yields an
+ * empty list (the account is still returned, just without the returning-account
+ * optimization) and is NOT cached — a stale grant must never gate consent, so
+ * failures always fail closed rather than serving a prior list. The API
+ * endpoint is cookie-less but returns private per-user RP grant metadata, so the
+ * IdP must present the internal shared secret on this server-to-server call.
+ *
+ * `forceRefresh` bypasses the fresh-cache short-circuit for the ONE security
+ * re-check whose entire purpose is to observe a state change: the `/sso/establish`
+ * grant re-check must catch a grant REVOKED between the central `/sso` hop and
+ * the per-apex establish hop, so it cannot be served the value the central hop
+ * just cached. It still refreshes the cache and shares any truly-concurrent
+ * in-flight fetch.
+ */
+async function fetchApprovedClients(
+  config: ResolvedConfig,
+  userId: string,
+  forceRefresh = false
+): Promise<string[]> {
+  if (!config.ssoInternalSecret) return [];
+
+  if (!forceRefresh) {
+    const cached = grantsCache.get(userId);
+    if (cached && Date.now() - cached.fetchedAt < GRANTS_TTL_MS) {
+      return cached.origins;
+    }
+  }
+
+  let inFlight = grantsInFlight.get(userId);
+  if (!inFlight) {
+    inFlight = fetchGrantsFromApi(config, userId).finally(() => {
+      grantsInFlight.delete(userId);
+    });
+    grantsInFlight.set(userId, inFlight);
+  }
+  const fetched = await inFlight;
+
+  // `[]` (empty array) is truthy → a successful empty grant list IS cached;
+  // only a `null` (failed) lookup is refused and falls through to fail-closed.
+  if (fetched) {
+    grantsCache.set(userId, { origins: fetched, fetchedAt: Date.now() });
+    return fetched;
+  }
+  return [];
 }
 
 /**
@@ -445,13 +519,18 @@ async function fetchApprovedClients(config: ResolvedConfig, userId: string): Pro
  * Fails CLOSED: any failure in the per-user grant lookup yields an empty list
  * (treated as "no grant"), so a transient API error blocks silent restore
  * rather than handing a session to an un-consented RP.
+ *
+ * `forceRefresh` is threaded through to {@link fetchApprovedClients} for the
+ * `/sso/establish` re-check, which must observe a grant revoked between hops
+ * rather than the value the central `/sso` hop just cached.
  */
 async function userHasGrantedClient(
   config: ResolvedConfig,
   userId: string,
-  clientOrigin: string
+  clientOrigin: string,
+  forceRefresh = false
 ): Promise<boolean> {
-  const grantedOrigins = await fetchApprovedClients(config, userId);
+  const grantedOrigins = await fetchApprovedClients(config, userId, forceRefresh);
   return grantedOrigins.some((origin) => normaliseOrigin(origin) === clientOrigin);
 }
 
@@ -557,24 +636,50 @@ function normaliseOrigin(value: string): string | null {
 }
 
 /**
- * Validate a candidate RP `client_id` against the authoritative approved-
- * clients allow-list served by the Oxy API (`GET /fedcm/clients/approved`).
- * This is the SAME list `/fedcm/exchange` enforces via `isClientApproved`, so
- * the silent path cannot deliver a token to any origin the FedCM path would
- * itself reject. Returns the normalised, approved origin or `null`.
- *
- * Fails CLOSED: any network/parse error yields `null` (no token issued). The
- * endpoint is cookie-less and the response carries only public approved
- * origins, so no auth token is needed for this server-to-server call.
+ * TTL (ms) for the FRESH approved-clients cache. Matches the API's own
+ * `approvedClientsCache` window (60s) so the worker never holds a view staler
+ * than the API would itself serve fresh. Within this window a repeated lookup
+ * (every /sso, /sso/establish, /auth/silent, /fedcm request) is served from
+ * memory with zero API round-trips.
  */
-async function resolveApprovedClientOrigin(
-  apiBaseUrl: string,
-  clientId: string | undefined
-): Promise<string | null> {
-  if (!clientId) return null;
-  const candidate = normaliseOrigin(clientId);
-  if (!candidate) return null;
+const APPROVED_CLIENTS_TTL_MS = 60_000;
 
+/**
+ * Hard cap (ms) on serving a STALE approved-clients list while the upstream
+ * fetch is failing. Bounded staleness (up to 10 min) beats the fails-closed
+ * collapse we saw live: when shared egress IPs get 429'd, a null list bounced
+ * every RP with `invalid_request` in a reload loop. Past this cap we fail closed
+ * again — a genuinely long API outage should not indefinitely honour a list that
+ * may no longer be authoritative. The API re-validates every client at
+ * `/sso/code` and `/fedcm/exchange`, so bounded-stale here can never approve a
+ * client the API itself would reject.
+ */
+const APPROVED_CLIENTS_STALE_CAP_MS = 10 * 60_000;
+
+interface ApprovedClientsCache {
+  list: string[];
+  fetchedAt: number;
+}
+
+/**
+ * Module-level cache of the approved-clients allow-list. POSITIVE, non-empty
+ * results only — a failed fetch (`null`) or an empty list (`[]`, never the real
+ * production state and far more likely a transient API glitch) is treated as
+ * non-authoritative and never stored as truth.
+ */
+let approvedClientsCache: ApprovedClientsCache | null = null;
+
+/** In-flight approved-clients fetch de-dup — concurrent callers share one round-trip. */
+let approvedClientsInFlight: Promise<string[] | null> | null = null;
+
+/**
+ * Raw approved-clients fetch. Returns the parsed origin list on a successful,
+ * well-formed response (possibly empty), or `null` on ANY failure (non-2xx,
+ * malformed body, network/timeout). The `null` vs `[]` distinction lets the
+ * caller keep serving a prior good list on failure while never caching an empty
+ * fetch as truth.
+ */
+async function fetchApprovedClientsList(apiBaseUrl: string): Promise<string[] | null> {
   try {
     const res = await fetch(`${apiBaseUrl}/fedcm/clients/approved`, {
       headers: { Accept: 'application/json' },
@@ -586,14 +691,77 @@ async function resolveApprovedClientOrigin(
     // `origins` alias defensively in case the shape ever changes.
     const list = (Array.isArray(data.clients) ? data.clients : data.origins) as unknown;
     if (!Array.isArray(list)) return null;
-    for (const entry of list) {
-      if (typeof entry !== 'string') continue;
-      if (normaliseOrigin(entry) === candidate) return candidate;
-    }
-    return null;
+    return list.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve the approved-clients allow-list through the module cache:
+ *   1. FRESH cache (age < {@link APPROVED_CLIENTS_TTL_MS}) → return it, no fetch.
+ *   2. Otherwise fetch (concurrent callers share ONE in-flight round-trip).
+ *      - a non-empty list → refresh the cache and return it.
+ *      - a failed/empty fetch → serve the prior list if it is within
+ *        {@link APPROVED_CLIENTS_STALE_CAP_MS} (bounded staleness), else return
+ *        the fetched value (null/empty) so the caller fails closed.
+ */
+async function getApprovedClientOrigins(apiBaseUrl: string): Promise<string[] | null> {
+  const now = Date.now();
+  if (approvedClientsCache && now - approvedClientsCache.fetchedAt < APPROVED_CLIENTS_TTL_MS) {
+    return approvedClientsCache.list;
+  }
+
+  if (!approvedClientsInFlight) {
+    approvedClientsInFlight = fetchApprovedClientsList(apiBaseUrl).finally(() => {
+      approvedClientsInFlight = null;
+    });
+  }
+  const fetched = await approvedClientsInFlight;
+
+  if (fetched && fetched.length > 0) {
+    approvedClientsCache = { list: fetched, fetchedAt: Date.now() };
+    return fetched;
+  }
+
+  // Non-authoritative outcome (failed or empty): prefer a bounded-stale prior
+  // list over the fails-closed collapse. Only within the stale cap.
+  if (
+    approvedClientsCache &&
+    Date.now() - approvedClientsCache.fetchedAt < APPROVED_CLIENTS_STALE_CAP_MS
+  ) {
+    return approvedClientsCache.list;
+  }
+  return fetched;
+}
+
+/**
+ * Validate a candidate RP `client_id` against the authoritative approved-
+ * clients allow-list served by the Oxy API (`GET /fedcm/clients/approved`),
+ * sourced through the module cache ({@link getApprovedClientOrigins}). This is
+ * the SAME list `/fedcm/exchange` enforces via `isClientApproved`, so the silent
+ * path cannot deliver a token to any origin the FedCM path would itself reject.
+ * Returns the normalised, approved origin or `null`.
+ *
+ * Fails CLOSED: with no usable (fresh or bounded-stale) list, any network/parse
+ * error yields `null` (no token issued). The endpoint is cookie-less and the
+ * response carries only public approved origins, so no auth token is needed for
+ * this server-to-server call.
+ */
+async function resolveApprovedClientOrigin(
+  apiBaseUrl: string,
+  clientId: string | undefined
+): Promise<string | null> {
+  if (!clientId) return null;
+  const candidate = normaliseOrigin(clientId);
+  if (!candidate) return null;
+
+  const list = await getApprovedClientOrigins(apiBaseUrl);
+  if (!list) return null;
+  for (const entry of list) {
+    if (normaliseOrigin(entry) === candidate) return candidate;
+  }
+  return null;
 }
 
 /**
@@ -2038,7 +2206,10 @@ app.get('/sso/establish', async (c) => {
   //    between the two hops. Re-check here BEFORE planting the durable
   //    first-party cookie or minting a session/code — an un-granted RP gets the
   //    same no-session outcome as a logged-out user and NO cookie is planted.
-  if (!(await userHasGrantedClient(config, user.id, approvedOrigin))) {
+  //    `forceRefresh: true` — this re-check's whole purpose is to observe a
+  //    between-hops revocation, so it MUST bypass the 30s grants cache the
+  //    central hop just populated and read the live grant.
+  if (!(await userHasGrantedClient(config, user.id, approvedOrigin, true))) {
     return redirectToCallback(c, returnTo, buildSsoFragment('none', state));
   }
 
@@ -2097,3 +2268,18 @@ app.get('/sso/establish', async (c) => {
 // (`server/worker.ts`) and the local Node entry (`server/node.ts`).
 export { app, readEnv };
 export type { WorkerEnv };
+
+// Cache internals exported for unit tests only. `resolveApprovedClientOrigin`
+// and `fetchApprovedClients` are exercised directly to assert TTL/stale/single-
+// flight behaviour; `__resetSsoCachesForTests` clears the module-level caches
+// between cases (the caches are process-global, so every test file that touches
+// the SSO endpoints must reset them in `beforeEach` for isolation — mirrors the
+// `__resetBloomCSSForTests` pattern).
+export { resolveApprovedClientOrigin, fetchApprovedClients };
+
+export function __resetSsoCachesForTests(): void {
+  approvedClientsCache = null;
+  approvedClientsInFlight = null;
+  grantsCache.clear();
+  grantsInFlight.clear();
+}


### PR DESCRIPTION
## Summary

**P0** — console.oxy.so (and any RP) intermittently bounce-looped: the IdP worker calls oxy-api server-to-server (`/fedcm/clients/approved`, `/fedcm/grants/:userId`, `/session/validate/:sessionId`, `/sso/code`) for EVERY `/sso`, `/sso/establish`, `/auth/silent` and FedCM flow of EVERY user, from a shared egress IP pool — all inside the per-IP browser budget (`rl:general` 1000/15min) AND the brute-force slow-down. Under normal traffic: 429s + 500ms penalties → IdP fails closed (`invalid_request`, dead silent restore) → RP auth guards re-bounce → self-amplifying loop (observed live twice today).

1. **api**: those exact paths skip the general limiter + slow-down and carry a dedicated `rl:fedcm:service:` limiter (20000/15min); `/sso/code` keeps its own secret-gated limiter as sole cap. Browser-facing limits and X-Oxy-Internal constant-time secret checks untouched. Mount-order invariant documented: every exempted path must carry its own route limiter.
2. **IdP worker**: approved-clients cached 60s (single-in-flight de-dup, positive-only, bounded stale-serving 10min then fail-closed); grants cached 30s per-user (never stale-served); the `/sso/establish` between-hops grant re-check passes `forceRefresh` so revocation between hops is still caught live (existing security test preserved). Session resolution uncached — revocation stays immediate.

## Verification (this branch)
api 1351/1351 (jest) + tsc 0 · auth IdP 144/144 (bun test) · worker `_worker.js` build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)