### PR TITLE
fix(api): session reuse migrates onto the caller's central deviceId — kills split-brain device docs

### DIFF
--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -1,5 +1,6 @@
 const mockFindOne = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
+const mockUpdateOne = jest.fn();
 const mockDeactivate = jest.fn();
 const mockGetAccessToken = jest.fn();
 const mockValidateSessionById = jest.fn();
@@ -9,6 +10,7 @@ jest.mock('../../models/DeviceSession', () => ({
   default: {
     findOne: (...a: unknown[]) => mockFindOne(...a),
     findOneAndUpdate: (...a: unknown[]) => mockFindOneAndUpdate(...a),
+    updateOne: (...a: unknown[]) => mockUpdateOne(...a),
   },
 }));
 jest.mock('../session.service', () => ({
@@ -374,5 +376,70 @@ describe('resolveActiveToken', () => {
     mockValidateSessionById.mockResolvedValueOnce(null);
     expect(await deviceSessionService.resolveActiveToken(STATE as never)).toBeNull();
     expect(mockGetAccessToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('detachMigratedAccount', () => {
+  it('drops the account entry WITHOUT deactivating the migrated (preserved) session', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'oldDevice',
+      accounts: [
+        { accountId: { toString: () => 'a1' }, sessionId: 'migrated-sess', authuser: 0 },
+        { accountId: { toString: () => 'a2' }, sessionId: 's2', authuser: 1 },
+      ],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 3,
+    }));
+
+    await deviceSessionService.detachMigratedAccount('oldDevice', 'a1', 'migrated-sess');
+
+    // The migrated session lives on its new device — never deactivated here.
+    expect(mockDeactivate).not.toHaveBeenCalled();
+    // The account entry is pulled and active reassigned to the remaining one.
+    expect(mockUpdateOne).toHaveBeenCalledTimes(1);
+    const [filter, update] = mockUpdateOne.mock.calls[0] as [
+      Record<string, unknown>,
+      { $set: { accounts: Array<{ sessionId: string }>; activeAccountId: string | null }; $inc: { revision: number } },
+    ];
+    expect(filter).toEqual({ deviceId: 'oldDevice' });
+    expect(update.$set.accounts.map((a) => a.sessionId)).toEqual(['s2']);
+    expect(update.$set.activeAccountId).toBe('a2');
+    expect(update.$inc).toEqual({ revision: 1 });
+  });
+
+  it('deactivates a DIFFERENT stale session the old doc referenced for that account', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'oldDevice',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 'stale-sess', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+    }));
+
+    await deviceSessionService.detachMigratedAccount('oldDevice', 'a1', 'migrated-sess');
+
+    expect(mockDeactivate).toHaveBeenCalledWith('stale-sess');
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { deviceId: 'oldDevice' },
+      { $set: { accounts: [], activeAccountId: null }, $inc: { revision: 1 } },
+    );
+  });
+
+  it('is a no-op when the device doc is absent', async () => {
+    mockFindOne.mockReturnValueOnce(lean(null));
+    await deviceSessionService.detachMigratedAccount('oldDevice', 'a1', 'migrated-sess');
+    expect(mockDeactivate).not.toHaveBeenCalled();
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the account is not listed on the doc', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'oldDevice',
+      accounts: [{ accountId: { toString: () => 'other' }, sessionId: 's-other', authuser: 0 }],
+      activeAccountId: { toString: () => 'other' },
+      revision: 1,
+    }));
+    await deviceSessionService.detachMigratedAccount('oldDevice', 'a1', 'migrated-sess');
+    expect(mockDeactivate).not.toHaveBeenCalled();
+    expect(mockUpdateOne).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -8,6 +8,7 @@ const mockSave = jest.fn();
 const mockUpdateOne = jest.fn();
 const mockUpdateMany = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
+const mockDetachMigratedAccount = jest.fn();
 
 /**
  * Creates a chainable mock that supports .select().lean() and .lean() patterns.
@@ -128,11 +129,22 @@ jest.mock('../securityActivityService', () => ({
   },
 }));
 
+// The reused-session deviceId migration best-effort detaches the account from
+// the OLD device doc via deviceSessionService — mock it to observe the call
+// without touching the DeviceSession model.
+jest.mock('../deviceSession.service', () => ({
+  __esModule: true,
+  default: {
+    detachMigratedAccount: mockDetachMigratedAccount,
+  },
+}));
+
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import sessionService from '../session.service';
 import Session from '../../models/Session';
 import sessionCache from '../../utils/sessionCache';
-import { validateAccessToken } from '../../utils/sessionUtils';
+import { generateSessionTokens, validateAccessToken } from '../../utils/sessionUtils';
+import { deriveServiceDeviceId } from '../../utils/deviceUtils';
 import { Request } from 'express';
 
 function createMockSession(overrides: Record<string, unknown> = {}) {
@@ -173,6 +185,7 @@ describe('Session Service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockFindOneResults.length = 0;
+    mockDetachMigratedAccount.mockResolvedValue(undefined);
     const cache = (sessionCache as unknown as { _cache: Map<string, unknown> })._cache;
     cache.clear();
   });
@@ -425,6 +438,118 @@ describe('Session Service', () => {
       expect(second.sessionId).toBe(first.sessionId);
       expect(second.accessToken).toBe('refreshed-access-token');
       expect(mockSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /**
+   * Reused-session deviceId migration.
+   *
+   * When a caller supplies an explicit central deviceId (e.g. the FedCM/SSO
+   * exchange threading a real device from the id_token) but the reused session
+   * sits on a DIFFERENT legacy per-origin device, the session must HOP onto the
+   * caller's device: its stored deviceId is updated, the re-minted access token
+   * carries the new deviceId, and the account is detached from the old device
+   * doc so the graveyard doc stops advertising a live-looking account. No hop
+   * when no explicit deviceId is given, or when it already matches.
+   */
+  describe('createSession deviceId migration on reuse', () => {
+    const SAVED_SALT = process.env.DEVICE_ID_SALT;
+    const RP = 'https://console.oxy.so';
+    const CENTRAL = 'central-device-real';
+
+    beforeEach(() => {
+      process.env.DEVICE_ID_SALT = 'x'.repeat(48);
+    });
+
+    afterEach(() => {
+      if (SAVED_SALT === undefined) {
+        delete process.env.DEVICE_ID_SALT;
+      } else {
+        process.env.DEVICE_ID_SALT = SAVED_SALT;
+      }
+    });
+
+    it('migrates a reused legacy per-origin session onto the caller central device', async () => {
+      const originDeviceId = deriveServiceDeviceId('user-123', RP);
+      expect(originDeviceId).not.toBe(CENTRAL);
+
+      // isNewDevice check (keyed on the central target) → none.
+      mockFindOneResults.push(null);
+      // PRIMARY reuse lookup (central target) → none: nothing on the real device yet.
+      mockFindOneResults.push(null);
+      // SECONDARY legacy lookup (origin-derived device) → HIT: the pre-unification session.
+      mockFindOneResults.push(
+        createMockSession({ sessionId: 'legacy-sess', deviceId: originDeviceId })
+      );
+      const migrated = createMockSession({
+        sessionId: 'legacy-sess',
+        deviceId: CENTRAL,
+        accessToken: 'migrated-access-token',
+      });
+      mockFindOneAndUpdate.mockResolvedValueOnce(migrated);
+
+      const result = await sessionService.createSession('user-123', createMockRequest(), {
+        deviceName: 'FedCM Sign-In',
+        stableDeviceKey: RP,
+        deviceId: CENTRAL,
+      });
+
+      // Same session row reused (no new row minted), now on the central device.
+      expect(mockSave).not.toHaveBeenCalled();
+      expect(result.sessionId).toBe('legacy-sess');
+      expect(result.deviceId).toBe(CENTRAL);
+
+      // The reuse update $set migrated the stored deviceId to the central id.
+      const updateArg = mockFindOneAndUpdate.mock.calls[0][1] as { $set: Record<string, unknown> };
+      expect(updateArg.$set.deviceId).toBe(CENTRAL);
+
+      // The re-minted JWT embeds the NEW deviceId (3rd generateSessionTokens arg).
+      const tokenCalls = (generateSessionTokens as jest.Mock).mock.calls;
+      expect(tokenCalls[tokenCalls.length - 1][2]).toBe(CENTRAL);
+
+      // The old device doc's entry for this account is detached; the migrated
+      // session id is preserved (never deactivated).
+      expect(mockDetachMigratedAccount).toHaveBeenCalledWith(originDeviceId, 'user-123', 'legacy-sess');
+    });
+
+    it('does NOT migrate on reuse when no explicit deviceId is supplied', async () => {
+      // Pure stableDeviceKey path: the reuse lookup keys on the origin-derived
+      // device and any UA/IP mismatch must NOT move the session.
+      mockFindOneResults.push({ _id: 'mongo-id-123' }); // isNewDevice: seen
+      mockFindOneResults.push(
+        createMockSession({ sessionId: 'sess-x', deviceId: 'device-old' })
+      ); // PRIMARY reuse lookup: HIT
+      mockFindOneAndUpdate.mockResolvedValueOnce(
+        createMockSession({ sessionId: 'sess-x', deviceId: 'device-old' })
+      );
+
+      await sessionService.createSession('user-123', createMockRequest(), {
+        deviceName: 'FedCM Sign-In',
+        stableDeviceKey: RP,
+      });
+
+      const updateArg = mockFindOneAndUpdate.mock.calls[0][1] as { $set: Record<string, unknown> };
+      expect(updateArg.$set.deviceId).toBeUndefined();
+      expect(mockDetachMigratedAccount).not.toHaveBeenCalled();
+    });
+
+    it('performs NO migration side-effects when the explicit deviceId already matches', async () => {
+      mockFindOneResults.push({ _id: 'mongo-id-123' }); // isNewDevice: seen
+      mockFindOneResults.push(
+        createMockSession({ sessionId: 'sess-y', deviceId: CENTRAL })
+      ); // PRIMARY reuse lookup: HIT, already on the central device
+      mockFindOneAndUpdate.mockResolvedValueOnce(
+        createMockSession({ sessionId: 'sess-y', deviceId: CENTRAL })
+      );
+
+      await sessionService.createSession('user-123', createMockRequest(), {
+        deviceName: 'FedCM Sign-In',
+        deviceId: CENTRAL,
+      });
+
+      const updateArg = mockFindOneAndUpdate.mock.calls[0][1] as { $set: Record<string, unknown> };
+      expect(updateArg.$set.deviceId).toBeUndefined();
+      expect(mockDetachMigratedAccount).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -226,6 +226,44 @@ class DeviceSessionService {
     ).lean<IDeviceSession>();
     return projectState(updated as IDeviceSession);
   }
+
+  /**
+   * Detach an account from a device doc after its session MIGRATED to another
+   * device (see the deviceId migration in `sessionService.createSession`).
+   * Removes the account's entry from THIS device's `accounts[]` so the stale
+   * (graveyard) doc stops advertising a live-looking account, and deactivates
+   * the session the doc referenced — UNLESS it is `preserveSessionId`, the
+   * session that just moved (which stays active on its new device). Best-effort
+   * cleanup: a no-op when the doc is absent or the account is not listed. Never
+   * throws for a missing account so callers can fire it without guarding.
+   */
+  async detachMigratedAccount(deviceId: string, accountId: string, preserveSessionId: string): Promise<void> {
+    const current = await this.load(deviceId);
+    if (!current) return;
+    const accounts = current.accounts ?? [];
+    const entry = accounts.find((a) => idToString(a.accountId) === accountId);
+    if (!entry) return;
+
+    // Deactivate a DIFFERENT (genuinely stale) session the doc referenced —
+    // never the one that just migrated and is now live on the caller's device.
+    if (entry.sessionId && entry.sessionId !== preserveSessionId) {
+      try {
+        await sessionService.deactivateSession(entry.sessionId);
+      } catch (error) {
+        logger.warn('deviceSession.detachMigratedAccount: deactivate failed', { sessionId: entry.sessionId, error });
+      }
+    }
+
+    const remaining = accounts.filter((a) => idToString(a.accountId) !== accountId);
+    const activeStillPresent = remaining.some((a) => idToString(a.accountId) === idToString(current.activeAccountId));
+    const nextActive = activeStillPresent
+      ? idToString(current.activeAccountId)
+      : (remaining[0] ? idToString(remaining[0].accountId) : null);
+    await DeviceSession.updateOne(
+      { deviceId },
+      { $set: { accounts: remaining, activeAccountId: nextActive }, $inc: { revision: 1 } },
+    );
+  }
 }
 
 const deviceSessionService = new DeviceSessionService();

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -13,6 +13,7 @@ import {
   DeviceFingerprint
 } from '../utils/deviceUtils';
 import { generateSessionTokens, validateAccessToken, validateRefreshToken } from '../utils/sessionUtils';
+import deviceSessionService from './deviceSession.service';
 import { Request } from 'express';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
@@ -417,9 +418,15 @@ class SessionService {
       // explicit `deviceId` (e.g. threaded from a FedCM id_token claim) wins
       // over the derived stable id, letting the caller stamp a unified central
       // device id verbatim. Precedence: deviceId > stableDeviceKey > UA/IP > random.
-      const stableId = explicitDeviceId ?? (stableDeviceKey
+      // The origin-derived stable id (per (user, RP)). Kept SEPARATELY from the
+      // attribution id below so we can still locate a LEGACY per-origin session
+      // — one minted before deviceId unification, pinned to this synthetic
+      // origin device — and MIGRATE it onto the caller's central device instead
+      // of orphaning it (which sprawled one graveyard doc per historical mint).
+      const originDeviceId = stableDeviceKey
         ? deriveServiceDeviceId(userId, stableDeviceKey)
-        : undefined);
+        : undefined;
+      const stableId = explicitDeviceId ?? originDeviceId;
       // Pass userId so the derived deviceId is scoped per-user — two users
       // behind the same NAT on the same Chrome no longer collide on the same
       // device-id (security review H1).
@@ -456,18 +463,48 @@ class SessionService {
         deviceId: deviceInfo.deviceId,
       }).select('_id').lean());
 
-      const existingSession = await Session.findOne({
+      // Reuse an existing active session. Prefer one already attributed to the
+      // caller's (central) device; fall back to a LEGACY per-origin session so a
+      // pre-unification session HOPS onto the central device (below) instead of
+      // orphaning. Once migrated it's found by the primary lookup on subsequent
+      // mints — the fallback can't re-sprawl.
+      let existingSession = await Session.findOne({
         userId,
         deviceId: deviceInfo.deviceId,
         isActive: true,
         expiresAt: { $gt: new Date() }
-      }).select('_id sessionId deviceInfo').lean();
+      }).select('_id sessionId deviceId deviceInfo').lean();
+
+      if (!existingSession && originDeviceId && originDeviceId !== deviceInfo.deviceId) {
+        existingSession = await Session.findOne({
+          userId,
+          deviceId: originDeviceId,
+          isActive: true,
+          expiresAt: { $gt: new Date() }
+        }).select('_id sessionId deviceId deviceInfo').lean();
+      }
 
       if (existingSession) {
         const sessionId = existingSession.sessionId;
         const expiresAt = new Date(Date.now() + SESSION_EXPIRES_IN);
         const now = new Date();
+        // Tokens are re-minted with the ATTRIBUTION deviceId (the explicit
+        // central id when supplied), so the reused access token's `deviceId`
+        // claim addresses the caller's real device — the room the client's
+        // SessionClient joins and where cross-domain broadcasts land.
         const { accessToken, refreshToken } = generateSessionTokens(userId, sessionId, deviceInfo.deviceId);
+
+        // Migrate a reused session onto the caller's central device when an
+        // explicit deviceId was supplied and the reused session still sits on a
+        // different (legacy per-origin) device. Without this the session — and
+        // thus the RP's socket room + DeviceSession doc — stays pinned to a
+        // stale synthetic device and never receives the real device's
+        // cross-domain broadcasts. No explicit deviceId ⇒ no hop (UA/IP/random
+        // fallbacks must never move a session).
+        const previousDeviceId = existingSession.deviceId;
+        const migrateToDeviceId = explicitDeviceId && previousDeviceId !== explicitDeviceId
+          ? explicitDeviceId
+          : null;
 
         const updated = await Session.findOneAndUpdate(
           { _id: existingSession._id },
@@ -477,6 +514,7 @@ class SessionService {
               refreshToken,
               expiresAt,
               lastRefresh: now,
+              ...(migrateToDeviceId ? { deviceId: migrateToDeviceId } : {}),
               'deviceInfo.lastActive': now,
               'deviceInfo.deviceName': deviceName || existingSession.deviceInfo?.deviceName,
               'deviceInfo.ipAddress': deviceInfo.ipAddress,
@@ -493,6 +531,32 @@ class SessionService {
 
         if (updated) {
           sessionCache.set(sessionId, updated as ISession);
+          if (migrateToDeviceId) {
+            logger.info('[SessionService] Migrated reused session onto caller device', {
+              component: 'SessionService',
+              method: 'createSession',
+              userId,
+              sessionId: sessionId.substring(0, 8),
+              fromDeviceId: previousDeviceId.substring(0, 8),
+              toDeviceId: migrateToDeviceId.substring(0, 8),
+            });
+            // Best-effort: drop this account's entry from the OLD device doc so
+            // the graveyard doc stops advertising a live-looking account. The
+            // migrated session is preserved (it now lives on the caller's
+            // device); detach only deactivates a DIFFERENT stale session the old
+            // doc referenced. Never fail the mint on cleanup errors.
+            try {
+              await deviceSessionService.detachMigratedAccount(previousDeviceId, userId, sessionId);
+            } catch (error) {
+              logger.warn('[SessionService] Failed to detach migrated account from old device doc', {
+                component: 'SessionService',
+                method: 'createSession',
+                userId,
+                fromDeviceId: previousDeviceId.substring(0, 8),
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          }
           return updated as ISession;
         }
       }


### PR DESCRIPTION
## Summary

**P0, bug #5 in the session-sync chain** (prod Mongo evidence): `createSession`'s stable-session reuse kept the OLD session's `deviceId` forever, even when the caller threaded the central deviceId claim. console.oxy.so eternally reused a pre-unification session anchored to ghost device `7ce7082d` while the real browser device was `feb12fb6` → console bootstrapped a stale `DeviceSession`, joined the wrong socket room (never receiving real broadcasts — same mechanism behind mention.earth not seeing switches), and bounce-looped against the stale doc.

- Reuse lookup: primary by central deviceId, one-shot legacy fallback by the origin-derived id; on reuse with an explicit differing deviceId the session **migrates** (doc + re-minted JWT claims carry the new id, verified at `generateSessionTokens`).
- Cleanup via new `detachMigratedAccount()` — removes the account from the OLD device doc and deactivates its referenced session **only when it is not the migrated one** (a signout-based cleanup would have deactivated the live session itself). Best-effort; never fails the mint.
- No explicit deviceId ⇒ fully inert (UA/IP/random attribution never moves a session). Caller audit: fedcm exchange (migration path) + accounts switch (already central via #503); all other mint sites unaffected.

TDD failing-first: migration, no-explicit inert, same-id no-op, detach preserves migrated session.

## Verification (this branch)
api 1358/1358, tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)