### PR TITLE
fix(api): IdP mint reuses the device-registered session — one session per account per device

### DIFF
--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -443,3 +443,84 @@ describe('detachMigratedAccount', () => {
     expect(mockUpdateOne).not.toHaveBeenCalled();
   });
 });
+
+describe('resolveRegisteredSession', () => {
+  it('reuses the session REGISTERED for the account on the device — validated + freshly-minted token', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'central-device',
+      accounts: [
+        { accountId: { toString: () => 'other' }, sessionId: 's-other', authuser: 0 },
+        { accountId: { toString: () => 'acct-1' }, sessionId: 'registered-sess', authuser: 1 },
+      ],
+      activeAccountId: { toString: () => 'other' },
+      revision: 4,
+    }));
+    // The registered session validates (managed act_as re-check passes) and
+    // reports its own stored deviceId — the central device it was minted on.
+    mockValidateSessionById.mockResolvedValueOnce({ session: { deviceId: 'central-device' } });
+    const expiresAt = new Date(Date.now() + 60_000);
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'fresh-token', expiresAt });
+
+    const result = await deviceSessionService.resolveRegisteredSession('central-device', 'acct-1');
+
+    expect(result).toEqual({
+      sessionId: 'registered-sess',
+      deviceId: 'central-device',
+      accessToken: 'fresh-token',
+      expiresAt,
+    });
+    // Validated + minted against the REGISTERED session id, not the active one.
+    expect(mockValidateSessionById).toHaveBeenCalledWith('registered-sess', false);
+    expect(mockGetAccessToken).toHaveBeenCalledWith('registered-sess');
+  });
+
+  it('returns null when the device doc is absent (first sign-in on the device)', async () => {
+    mockFindOne.mockReturnValueOnce(lean(null));
+    const result = await deviceSessionService.resolveRegisteredSession('unknown-device', 'acct-1');
+    expect(result).toBeNull();
+    expect(mockValidateSessionById).not.toHaveBeenCalled();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the account is not registered on the device', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'central-device',
+      accounts: [{ accountId: { toString: () => 'other' }, sessionId: 's-other', authuser: 0 }],
+      activeAccountId: { toString: () => 'other' },
+      revision: 1,
+    }));
+    const result = await deviceSessionService.resolveRegisteredSession('central-device', 'acct-1');
+    expect(result).toBeNull();
+    expect(mockValidateSessionById).not.toHaveBeenCalled();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('returns null WITHOUT minting a token when the registered session is no longer valid (never resurrect a dead session)', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'central-device',
+      accounts: [{ accountId: { toString: () => 'acct-1' }, sessionId: 'dead-sess', authuser: 0 }],
+      activeAccountId: { toString: () => 'acct-1' },
+      revision: 1,
+    }));
+    mockValidateSessionById.mockResolvedValueOnce(null);
+
+    const result = await deviceSessionService.resolveRegisteredSession('central-device', 'acct-1');
+
+    expect(result).toBeNull();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the token machinery cannot mint an access token', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'central-device',
+      accounts: [{ accountId: { toString: () => 'acct-1' }, sessionId: 'registered-sess', authuser: 0 }],
+      activeAccountId: { toString: () => 'acct-1' },
+      revision: 1,
+    }));
+    mockValidateSessionById.mockResolvedValueOnce({ session: { deviceId: 'central-device' } });
+    mockGetAccessToken.mockResolvedValueOnce(null);
+
+    const result = await deviceSessionService.resolveRegisteredSession('central-device', 'acct-1');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/api/src/services/__tests__/fedcm.service.test.ts
+++ b/packages/api/src/services/__tests__/fedcm.service.test.ts
@@ -22,6 +22,7 @@ const mockClientFindOneAndUpdate = jest.fn();
 const mockAppFind = jest.fn();
 const mockUserFindById = jest.fn();
 const mockCreateSession = jest.fn();
+const mockResolveRegisteredSession = jest.fn();
 const mockGrantFindOneAndUpdate = jest.fn();
 const mockGrantFind = jest.fn();
 const mockCacheInvalidate = jest.fn();
@@ -93,6 +94,11 @@ jest.mock('../../models/User', () => ({
 jest.mock('../session.service', () => ({
   __esModule: true,
   default: { createSession: mockCreateSession },
+}));
+
+jest.mock('../deviceSession.service', () => ({
+  __esModule: true,
+  default: { resolveRegisteredSession: mockResolveRegisteredSession },
 }));
 
 jest.mock('../../utils/logger', () => ({
@@ -179,6 +185,9 @@ beforeEach(() => {
     expiresAt: new Date(Date.now() + 60_000),
     accessToken: 'token-xyz',
   });
+  // Default: the caller's device has NO registered session for this account, so
+  // the exchange falls through to the create/reuse path. Reuse tests override.
+  mockResolveRegisteredSession.mockResolvedValue(null);
   // Grant recording succeeds by default.
   mockGrantFindOneAndUpdate.mockResolvedValue({});
   // Grant lookup: no prior grants by default (overridden per-test).
@@ -405,6 +414,105 @@ describe('FedCM exchangeIdToken (H9)', () => {
 
     expect('error' in result).toBe(false);
     if ('error' in result) return;
+    expect(result.sessionId).toBe('sess-123');
+  });
+});
+
+/**
+ * ONE session per account per device (cross-domain session sync).
+ *
+ * When the id_token carries the caller's central deviceId AND that device
+ * already has a session REGISTERED for this account (via /session/device/add),
+ * the exchange REUSES that registered session verbatim instead of minting a
+ * separate per-origin `stableDeviceKey` session. Per-origin sessions can never
+ * converge onto the single sessionId the DeviceSession account entry holds, so
+ * each RP origin would join a DIFFERENT socket room and never receive the real
+ * device's cross-domain broadcasts. Only when the device has NO (valid) entry
+ * for the account does the exchange fall through to today's create/reuse path.
+ */
+describe('FedCM exchangeIdToken — device-registered session reuse', () => {
+  it('(a) reuses the DEVICE-REGISTERED session — no per-origin session minted', async () => {
+    mockResolveRegisteredSession.mockResolvedValueOnce({
+      sessionId: 'registered-sess',
+      deviceId: 'central-device-abc123',
+      accessToken: 'registered-token',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const token = mintToken({ deviceId: 'central-device-abc123' });
+    const result = await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    // The returned session IS the registered one on the central device.
+    expect(result.sessionId).toBe('registered-sess');
+    expect(result.deviceId).toBe('central-device-abc123');
+    expect(result.accessToken).toBe('registered-token');
+    // Looked up by the id_token's central deviceId + the token subject.
+    expect(mockResolveRegisteredSession).toHaveBeenCalledWith('central-device-abc123', 'user-123');
+    // The per-origin stable session was NEVER created/touched.
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    // Still emits the canonical structured session-user (a `name` object, never a
+    // bare string) so the SDK's `userResponseSchema` accepts it on reuse too.
+    expect(result.user.id).toBe('user-123');
+    expect(result.user.username).toBe('alice');
+    expect(typeof result.user.name).toBe('object');
+  });
+
+  it('(a) still records the grant when reusing a registered session', async () => {
+    mockResolveRegisteredSession.mockResolvedValueOnce({
+      sessionId: 'registered-sess',
+      deviceId: 'central-device-abc123',
+      accessToken: 'registered-token',
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    const token = mintToken({ deviceId: 'central-device-abc123' });
+    await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect(mockGrantFindOneAndUpdate).toHaveBeenCalled();
+  });
+
+  it('(b) falls through to createSession (threading the deviceId) when the device has NO registered entry', async () => {
+    mockResolveRegisteredSession.mockResolvedValueOnce(null);
+
+    const token = mintToken({ deviceId: 'central-device-abc123' });
+    const result = await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(mockResolveRegisteredSession).toHaveBeenCalledWith('central-device-abc123', 'user-123');
+    // First sign-in on the device → create the session, threading the deviceId so
+    // /session/device/add registers it under the central device.
+    expect(mockCreateSession).toHaveBeenCalledWith('user-123', expect.anything(), {
+      deviceName: 'FedCM Sign-In',
+      stableDeviceKey: APPROVED_ORIGIN,
+      deviceId: 'central-device-abc123',
+    });
+    expect(result.sessionId).toBe('sess-123');
+  });
+
+  it('(c) never consults the registry when the id_token carries no deviceId claim (fully unchanged)', async () => {
+    const token = mintToken();
+    await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect(mockResolveRegisteredSession).not.toHaveBeenCalled();
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    const optionsArg = mockCreateSession.mock.calls[0][2] as Record<string, unknown>;
+    expect(optionsArg).not.toHaveProperty('deviceId');
+  });
+
+  it('(d) falls through to create when the registered session is inactive (resolver returns null — never resurrect)', async () => {
+    // The resolver itself refuses to mint a token for a dead session and returns
+    // null; the exchange then mints a fresh session rather than failing.
+    mockResolveRegisteredSession.mockResolvedValueOnce(null);
+
+    const token = mintToken({ deviceId: 'central-device-abc123' });
+    const result = await fedcmService.exchangeIdToken(token, createReq(APPROVED_ORIGIN));
+
+    expect('error' in result).toBe(false);
+    if ('error' in result) return;
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
     expect(result.sessionId).toBe('sess-123');
   });
 });

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -228,6 +228,49 @@ class DeviceSessionService {
   }
 
   /**
+   * Resolve the session ALREADY REGISTERED for `accountId` on `deviceId` (added
+   * via `/session/device/add`) so an IdP mint can REUSE it instead of minting a
+   * separate per-origin session. This enforces the "ONE session per account per
+   * device" invariant: every RP origin that authenticates this account on this
+   * device converges on the SAME sessionId the DeviceSession entry holds — they
+   * join one socket room and see each other's cross-domain broadcasts. Without
+   * it each origin gets its own per-origin session, and the device doc (which
+   * stores ONE sessionId per account) can never make them converge.
+   *
+   * Returns null — the caller falls through to a fresh create — when the device
+   * has no entry for the account (true first sign-in on this device), the
+   * registered session is no longer valid (signed out, or a managed act_as
+   * membership was revoked), or the token machinery cannot mint. NEVER
+   * resurrects a dead session: validation runs BEFORE any token is minted. The
+   * access token is minted/rotated through the standard `getAccessToken` path,
+   * so it carries the registered session's central `deviceId` claim.
+   */
+  async resolveRegisteredSession(
+    deviceId: string,
+    accountId: string,
+  ): Promise<{ sessionId: string; deviceId: string; accessToken: string; expiresAt: Date } | null> {
+    const current = await this.load(deviceId);
+    if (!current) return null;
+    const entry = (current.accounts ?? []).find((a) => idToString(a.accountId) === accountId);
+    if (!entry) return null;
+
+    // Re-validate before minting: for a managed-account session this re-checks
+    // the operator's act_as membership and refuses a revoked session. A dead
+    // session yields null (fall through to create) — it is never resurrected.
+    const validated = await sessionService.validateSessionById(entry.sessionId, false);
+    if (!validated) return null;
+    const token = await sessionService.getAccessToken(entry.sessionId);
+    if (!token) return null;
+
+    return {
+      sessionId: entry.sessionId,
+      deviceId: validated.session.deviceId,
+      accessToken: token.accessToken,
+      expiresAt: token.expiresAt,
+    };
+  }
+
+  /**
    * Detach an account from a device doc after its session MIGRATED to another
    * device (see the deviceId migration in `sessionService.createSession`).
    * Removes the account's entry from THIS device's `accounts[]` so the stale

--- a/packages/api/src/services/fedcm.service.ts
+++ b/packages/api/src/services/fedcm.service.ts
@@ -7,6 +7,7 @@ import { logger } from '../utils/logger';
 import { normaliseOrigin } from '../utils/origin';
 import approvedClientsCache from '../utils/approvedClientsCache';
 import sessionService from './session.service';
+import deviceSessionService from './deviceSession.service';
 import { Request } from 'express';
 import * as crypto from 'crypto';
 import { fedcmTokenPayloadSchema, type FedcmTokenPayload, type UserNameResponse } from '@oxyhq/contracts';
@@ -699,26 +700,6 @@ class FedCMService {
         return { error: 'user_not_found' };
       }
 
-      // Create (or reuse) a session for this user. `req` here is the IdP
-      // Cloudflare Worker's server-to-server request (UA = 'unknown', egress
-      // IP varies per call), so we pass a `stableDeviceKey` of the RP origin:
-      // the deviceId is derived deterministically from (userId, clientOrigin)
-      // so a given (user, RP) reuses ONE session that just refreshes its
-      // tokens/expiry on each silent-auth / SSO bounce — instead of minting a
-      // brand-new "FedCM Sign-In" session every exchange.
-      const session = await sessionService.createSession(userId, req, {
-        deviceName: 'FedCM Sign-In',
-        stableDeviceKey: clientOrigin,
-        ...(tokenPayload.deviceId ? { deviceId: tokenPayload.deviceId } : {}),
-      });
-
-      // Record the grant: the user just actively authorized this RP origin via
-      // FedCM, so it belongs in `approved_clients` for future returning-account
-      // / silent-SSO flows. Best-effort — never blocks the issued session.
-      await this.recordGrant(userId, clientOrigin);
-
-      logger.info('FedCM: Session created via token exchange', { clientOrigin });
-
       const userDoc = user as {
         _id?: { toString(): string };
         id?: string;
@@ -739,18 +720,76 @@ class FedCMService {
         username: userDoc.username,
         publicKey: userDoc.publicKey,
       });
+      const sessionUser = {
+        id: idValue,
+        username: userDoc.username,
+        email: userDoc.email,
+        avatar: userDoc.avatar,
+        name,
+      };
+
+      // ONE session per account per device (cross-domain session sync). When the
+      // id_token carries the caller's CENTRAL deviceId AND that device already
+      // has a session REGISTERED for this account (added via
+      // `/session/device/add`), REUSE it verbatim — mint/rotate its access token
+      // and return it — instead of minting a separate per-origin `stableDeviceKey`
+      // session. Per-origin sessions can never converge onto the single sessionId
+      // the DeviceSession account entry holds, so each RP origin would join a
+      // DIFFERENT socket room and never receive the real device's cross-domain
+      // broadcasts. The reused access token carries the registered session's
+      // central deviceId claim, so the RP's SessionClient joins the real device
+      // room. A no-longer-valid registered session yields null (never resurrect a
+      // dead session) and falls through to the create path below.
+      if (tokenPayload.deviceId) {
+        const registered = await deviceSessionService.resolveRegisteredSession(
+          tokenPayload.deviceId,
+          userId,
+        );
+        if (registered) {
+          // The user actively authorized this RP via FedCM — record the grant for
+          // future returning-account / silent-SSO flows. Best-effort.
+          await this.recordGrant(userId, clientOrigin);
+          logger.info('FedCM: Reused device-registered session on exchange (no per-origin mint)', { clientOrigin });
+          return {
+            sessionId: registered.sessionId,
+            deviceId: registered.deviceId,
+            expiresAt: registered.expiresAt.toISOString(),
+            accessToken: registered.accessToken,
+            user: sessionUser,
+          };
+        }
+      }
+
+      // First sign-in for this account on this device (or no central deviceId
+      // claim). Create (or reuse) a session. `req` here is the IdP Cloudflare
+      // Worker's server-to-server request (UA = 'unknown', egress IP varies per
+      // call), so we pass a `stableDeviceKey` of the RP origin: the deviceId is
+      // derived deterministically from (userId, clientOrigin) so a given
+      // (user, RP) reuses ONE session that just refreshes its tokens/expiry on
+      // each silent-auth / SSO bounce — instead of minting a brand-new
+      // "FedCM Sign-In" session every exchange. When the central deviceId is
+      // threaded it wins over the derived id, so `/session/device/add` registers
+      // the session under the central device and the reuse path above catches it
+      // on subsequent exchanges.
+      const session = await sessionService.createSession(userId, req, {
+        deviceName: 'FedCM Sign-In',
+        stableDeviceKey: clientOrigin,
+        ...(tokenPayload.deviceId ? { deviceId: tokenPayload.deviceId } : {}),
+      });
+
+      // Record the grant: the user just actively authorized this RP origin via
+      // FedCM, so it belongs in `approved_clients` for future returning-account
+      // / silent-SSO flows. Best-effort — never blocks the issued session.
+      await this.recordGrant(userId, clientOrigin);
+
+      logger.info('FedCM: Session created via token exchange', { clientOrigin });
+
       return {
         sessionId: session.sessionId,
         deviceId: session.deviceId,
         expiresAt: session.expiresAt.toISOString(),
         accessToken: session.accessToken,
-        user: {
-          id: idValue,
-          username: userDoc.username,
-          email: userDoc.email,
-          avatar: userDoc.avatar,
-          name,
-        },
+        user: sessionUser,
       };
     } catch (error) {
       logger.error('FedCM: Token exchange failed', error);


### PR DESCRIPTION
## Summary

**Structural fix #6** in the session-sync chain: the /sso//fedcm exchange minted a stable session per ORIGIN, so each RP (console, mention) carried its own personal session anchored to ghost pre-unification deviceIds — never joining the real device's socket room (switches never propagated), and forced migration could only make apps displace each other's sessions (the DeviceSession entry holds ONE sessionId per account).

`exchangeIdToken` now consults `resolveRegisteredSession(deviceId, userId)` when the deviceId claim is present: validates the registered session (managed act_as re-check), rotates its token, and returns it — no per-origin session created or touched. No entry / inactive → existing create path (threads deviceId per #507); no claim → unchanged. Failing-first TDD (10 new cases across deviceSession + fedcm suites).

Trace (file:line in PR diff): the ONLY session-creating mint in the /sso pipeline is fedcm.service exchangeIdToken; /sso/code wraps an already-minted snapshot. The #507 migration couldn't fire for self-consistent ghost lineages (cookie-session ↔ stable session share the ghost id) — this reuse invariant replaces it as the convergence mechanism.

## Verification (this branch)
api 1326+/1326+ green (see CI), tsc 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)