### PR TITLE
fix(auth-sdk,console): automatic SSO probes once per tab — sign-in screen instead of infinite bounce

### DIFF
--- a/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.coldBoot.test.tsx
@@ -111,6 +111,7 @@ jest.mock('@oxyhq/core', () => {
     ssoAttemptedKey: actual.ssoAttemptedKey,
     ssoPriorSessionKey: actual.ssoPriorSessionKey,
     ssoSignedOutKey: actual.ssoSignedOutKey,
+    ssoOutcomeKey: actual.ssoOutcomeKey,
     silentRestoreSuppressed: actual.silentRestoreSuppressed,
     isCentralIdPOrigin: actual.isCentralIdPOrigin,
     guardActive: actual.guardActive,

--- a/packages/auth-sdk/__tests__/WebOxyProvider.sessionClientMutations.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.sessionClientMutations.test.tsx
@@ -81,6 +81,7 @@ jest.mock('@oxyhq/core', () => {
     ssoAttemptedKey: actual.ssoAttemptedKey,
     ssoPriorSessionKey: actual.ssoPriorSessionKey,
     ssoSignedOutKey: actual.ssoSignedOutKey,
+    ssoOutcomeKey: actual.ssoOutcomeKey,
     silentRestoreSuppressed: actual.silentRestoreSuppressed,
     isCentralIdPOrigin: actual.isCentralIdPOrigin,
     guardActive: actual.guardActive,

--- a/packages/auth-sdk/__tests__/WebOxyProvider.signInLoop.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.signInLoop.test.tsx
@@ -67,6 +67,7 @@ jest.mock('@oxyhq/core', () => {
     ssoAttemptedKey: actual.ssoAttemptedKey,
     ssoPriorSessionKey: actual.ssoPriorSessionKey,
     ssoSignedOutKey: actual.ssoSignedOutKey,
+    ssoOutcomeKey: actual.ssoOutcomeKey,
     silentRestoreSuppressed: actual.silentRestoreSuppressed,
     isCentralIdPOrigin: actual.isCentralIdPOrigin,
     guardActive: actual.guardActive,
@@ -139,8 +140,11 @@ jest.mock('@oxyhq/core', () => {
 });
 
 import { WebOxyProvider, useAuth } from '../src/WebOxyProvider';
+import { ssoOutcomeKey } from '@oxyhq/core';
 
 const ORIGIN = 'https://console.oxy.so';
+
+type AuthApi = ReturnType<typeof useAuth>;
 
 interface Snapshot {
   isReady: boolean;
@@ -242,5 +246,121 @@ describe('WebOxyProvider — console sign-in loop regression', () => {
       await captured.signIn?.();
     });
     expect(signInMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The definitive loop breaker for the console `AuthGuard`'s DIRECT interactive
+ * `signIn()` call (which bypasses the cold-boot bounce guard): once a prior
+ * AUTOMATIC probe this tab has come back `none`/`error`, an automatic
+ * `signIn({ interactive: false })` refuses to re-navigate, while a deliberate
+ * user-gesture `signIn()` always does. Backed by the per-tab
+ * `sessionStorage` outcome (core `ssoOutcomeKey`) so the refusal survives the
+ * callback → destination hard navigation and holds across the reload.
+ */
+describe('WebOxyProvider — automatic signIn loop guard (lastSsoOutcome)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    window.history.replaceState(null, '', `${ORIGIN}/`);
+    signInMock.mockClear();
+    silentSignInMock.mockClear();
+    signInMock.mockImplementation(async () => null);
+    silentSignInMock.mockImplementation(async () => null);
+  });
+
+  /** Renders the provider and captures the live `useAuth()` value. */
+  function renderCapture(): { current: AuthApi | null } {
+    const captured: { current: AuthApi | null } = { current: null };
+    function Capture() {
+      captured.current = useAuth();
+      return null;
+    }
+    render(
+      <WebOxyProvider baseURL="https://api.oxy.so">
+        <Capture />
+      </WebOxyProvider>,
+    );
+    return captured;
+  }
+
+  it('surfaces the persisted none outcome and refuses automatic signIn across two invocations', async () => {
+    // Simulate the destination load AFTER a prompt=none probe returned no
+    // session: the callback page persisted a `none` outcome (with reason) that
+    // survives the hard navigation back to the app root.
+    window.sessionStorage.setItem(
+      ssoOutcomeKey(ORIGIN),
+      JSON.stringify({ kind: 'none', reason: 'no_cookie' }),
+    );
+
+    const captured = renderCapture();
+    await waitFor(() => expect(captured.current).not.toBeNull());
+
+    // The provider exposes the outcome so an RP can render a branded sign-in
+    // screen instead of bouncing again.
+    expect(captured.current?.lastSsoOutcome).toBe('none');
+    expect(captured.current?.lastSsoOutcomeReason).toBe('no_cookie');
+
+    // Two automatic invocations (an auth-guard effect that re-fires) must NOT
+    // re-navigate — reverting the guard makes the count climb here.
+    await act(async () => {
+      await captured.current?.signIn({ interactive: false });
+    });
+    await act(async () => {
+      await captured.current?.signIn({ interactive: false });
+    });
+    expect(signInMock).not.toHaveBeenCalled();
+  });
+
+  it('allows the FIRST automatic signIn (no prior outcome) to navigate exactly once', async () => {
+    const captured = renderCapture();
+    await waitFor(() => expect(captured.current).not.toBeNull());
+    expect(captured.current?.lastSsoOutcome).toBeNull();
+
+    // First automatic probe is permitted (a truly fresh visit has no prior
+    // none/error). It initiates the redirect and resolves null.
+    await act(async () => {
+      await captured.current?.signIn({ interactive: false });
+    });
+    expect(signInMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a user-gesture signIn() always navigates after a none outcome and clears the persisted outcome', async () => {
+    window.sessionStorage.setItem(
+      ssoOutcomeKey(ORIGIN),
+      JSON.stringify({ kind: 'none', reason: 'no_cookie' }),
+    );
+
+    const captured = renderCapture();
+    await waitFor(() => expect(captured.current).not.toBeNull());
+    expect(captured.current?.lastSsoOutcome).toBe('none');
+
+    // A deliberate gesture (default interactive) ignores the prior outcome.
+    await act(async () => {
+      await captured.current?.signIn();
+    });
+    expect(signInMock).toHaveBeenCalledTimes(1);
+    // ...and it cleared the per-tab outcome so the sign-in screen no longer
+    // lingers and the guard re-arms.
+    expect(window.sessionStorage.getItem(ssoOutcomeKey(ORIGIN))).toBeNull();
+  });
+
+  it('a successful commit clears the persisted once-flag (guard re-arms)', async () => {
+    // A prior none outcome is present, then cold boot recovers a session via the
+    // silent-iframe step. The commit must supersede + clear the outcome.
+    window.sessionStorage.setItem(ssoOutcomeKey(ORIGIN), JSON.stringify({ kind: 'none' }));
+    silentSignInMock.mockImplementation(async () =>
+      ({
+        sessionId: 'sess-1',
+        user: { id: 'u1', username: 'u1' } as unknown as User,
+        accessToken: 'tok-1',
+      }) as SessionLoginResponse,
+    );
+
+    const captured = renderCapture();
+
+    await waitFor(() => expect(captured.current?.isAuthenticated).toBe(true));
+    expect(window.sessionStorage.getItem(ssoOutcomeKey(ORIGIN))).toBeNull();
+    expect(captured.current?.lastSsoOutcome).toBeNull();
   });
 });

--- a/packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.ssoCallbackIntercept.test.tsx
@@ -66,6 +66,7 @@ jest.mock('@oxyhq/core', () => {
     ssoGuardKey: actual.ssoGuardKey,
     ssoDestKey: actual.ssoDestKey,
     ssoAttemptedKey: actual.ssoAttemptedKey,
+    ssoOutcomeKey: actual.ssoOutcomeKey,
     isCentralIdPOrigin: actual.isCentralIdPOrigin,
     guardActive: actual.guardActive,
     buildSsoBounceUrl: actual.buildSsoBounceUrl,

--- a/packages/auth-sdk/__tests__/WebOxyProvider.tokenRefresh.test.tsx
+++ b/packages/auth-sdk/__tests__/WebOxyProvider.tokenRefresh.test.tsx
@@ -76,6 +76,7 @@ jest.mock('@oxyhq/core', () => {
     ssoAttemptedKey: actual.ssoAttemptedKey,
     ssoPriorSessionKey: actual.ssoPriorSessionKey,
     ssoSignedOutKey: actual.ssoSignedOutKey,
+    ssoOutcomeKey: actual.ssoOutcomeKey,
     silentRestoreSuppressed: actual.silentRestoreSuppressed,
     isCentralIdPOrigin: actual.isCentralIdPOrigin,
     guardActive: actual.guardActive,

--- a/packages/auth-sdk/__tests__/sessionClientWiring.test.tsx
+++ b/packages/auth-sdk/__tests__/sessionClientWiring.test.tsx
@@ -87,6 +87,7 @@ jest.mock('@oxyhq/core', () => {
     ssoAttemptedKey: actual.ssoAttemptedKey,
     ssoPriorSessionKey: actual.ssoPriorSessionKey,
     ssoSignedOutKey: actual.ssoSignedOutKey,
+    ssoOutcomeKey: actual.ssoOutcomeKey,
     silentRestoreSuppressed: actual.silentRestoreSuppressed,
     isCentralIdPOrigin: actual.isCentralIdPOrigin,
     guardActive: actual.guardActive,

--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -37,12 +37,14 @@ import {
   ssoAttemptedKey,
   ssoPriorSessionKey,
   ssoSignedOutKey,
+  ssoOutcomeKey,
   silentRestoreSuppressed,
   isCentralIdPOrigin,
   guardActive,
   allowSsoBounce,
   buildSsoBounceUrl,
   consumeSsoReturn,
+  parseSsoReturnFragment,
   createSessionClient,
   deviceStateToClientSessions,
   activeSessionIdOf,
@@ -57,6 +59,7 @@ import type {
   AuthManagerAccount,
   ColdBootStep,
   ColdBootOutcome,
+  SsoReturnKind,
 } from '@oxyhq/core';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { attachQueryPersistence, clearQueryCache, createQueryClient } from './hooks/queryClient';
@@ -96,6 +99,21 @@ export interface WebAuthState {
   accounts: AuthManagerAccount[];
   /** The active account's `authuser` slot, or `null` when no account is signed in. */
   activeAuthuser: number | null;
+  /**
+   * The outcome of the LAST cross-domain SSO return consumed this tab, or `null`
+   * when none has been (a fresh visit, or after a successful commit / explicit
+   * sign-in cleared it). `'none'` / `'error'` mean the central IdP had no
+   * session for a silent (`prompt=none`) probe — an RP can render a branded
+   * sign-in screen instead of letting an auth-guard re-bounce forever. Survives
+   * the callback → destination hard navigation via per-tab `sessionStorage`.
+   */
+  lastSsoOutcome: SsoReturnKind | null;
+  /**
+   * Machine-readable reason accompanying a `'none'` / `'error'`
+   * {@link lastSsoOutcome} when the IdP supplied one (e.g. `no_cookie`,
+   * `stale_session`, `no_grant`, `no_grant_establish`); `null` otherwise.
+   */
+  lastSsoOutcomeReason: string | null;
 }
 
 export interface WebAuthActions {
@@ -104,8 +122,17 @@ export interface WebAuthActions {
    * central IdP (`preferredAuthMethod="auto"` / `"redirect"`; both redirect).
    * FedCM is not part of the client sign-in path — see the removal note in
    * `CrossDomainAuth`'s doc comment in `@oxyhq/core`.
+   *
+   * `interactive` (default `true`) distinguishes a deliberate user gesture (a
+   * "Sign in" button) from an AUTOMATIC invocation by a caller's auth-guard
+   * effect. A user gesture ALWAYS (re)navigates and clears the per-tab
+   * last-outcome. An automatic invocation (`interactive: false`) refuses to
+   * re-navigate once a prior automatic probe this tab already returned
+   * `none`/`error` — the loop breaker for the `console.oxy.so` pattern
+   * `if (isReady && !isAuthenticated) signIn()`, whose direct call would
+   * otherwise bypass the cold-boot bounce guard and re-bounce every render.
    */
-  signIn: () => Promise<void>;
+  signIn: (opts?: { interactive?: boolean }) => Promise<void>;
   signInWithRedirect: () => void;
   /**
    * Sign out of this device entirely: revokes every account this device
@@ -380,6 +407,74 @@ function silentRestoreSuppressedWeb(): boolean {
   return silentRestoreSuppressed(storage, window.location.origin);
 }
 
+/**
+ * The parsed shape of the LAST consumed SSO-return outcome — the exposed
+ * `lastSsoOutcome` / `lastSsoOutcomeReason` context fields, and the signal the
+ * automatic-sign-in loop guard reads.
+ */
+interface SsoOutcomeSnapshot {
+  kind: SsoReturnKind;
+  reason: string | null;
+}
+
+/**
+ * Read the LAST consumed SSO-return outcome persisted for this origin (core
+ * {@link ssoOutcomeKey}). It survives the hard navigation `consumeSsoReturn`
+ * performs off the internal callback path back to the app destination, so the
+ * destination load can surface it. Returns `null` off-web, when nothing was
+ * recorded, or on any parse/storage error — fail safe toward "no prior outcome"
+ * so a first automatic probe is never wrongly suppressed.
+ */
+function readSsoOutcomeWeb(): SsoOutcomeSnapshot | null {
+  if (!isWebBrowser()) return null;
+  try {
+    const raw = window.sessionStorage.getItem(ssoOutcomeKey(window.location.origin));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { kind?: unknown; reason?: unknown };
+    if (parsed.kind !== 'ok' && parsed.kind !== 'none' && parsed.kind !== 'error') {
+      return null;
+    }
+    return {
+      kind: parsed.kind,
+      reason: typeof parsed.reason === 'string' ? parsed.reason : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the LAST consumed SSO-return outcome for this origin so it survives
+ * the callback → destination hard navigation. Best-effort; no-ops off-web and
+ * swallows storage errors.
+ */
+function persistSsoOutcomeWeb(kind: SsoReturnKind, reason: string | null): void {
+  if (!isWebBrowser()) return;
+  try {
+    window.sessionStorage.setItem(
+      ssoOutcomeKey(window.location.origin),
+      JSON.stringify(reason ? { kind, reason } : { kind }),
+    );
+  } catch {
+    // Best-effort; swallow QuotaExceededError / SecurityError (private mode).
+  }
+}
+
+/**
+ * Clear the persisted SSO-return outcome for this origin. Called on a successful
+ * session commit and on an explicit user-gesture sign-in / full sign-out, so a
+ * deliberate retry is never suppressed by a prior automatic none/error. No-ops
+ * off-web / on storage failure.
+ */
+function clearSsoOutcomeWeb(): void {
+  if (!isWebBrowser()) return;
+  try {
+    window.sessionStorage.removeItem(ssoOutcomeKey(window.location.origin));
+  } catch {
+    // Best-effort.
+  }
+}
+
 function isOnSsoCallbackPath(): boolean {
   return isWebBrowser() && window.location.pathname === SSO_CALLBACK_PATH;
 }
@@ -500,6 +595,14 @@ export function WebOxyProvider({
   const [accounts, setAccounts] = useState<AuthManagerAccount[]>([]);
   const [activeAuthuser, setActiveAuthuserState] = useState<number | null>(null);
 
+  // Last consumed SSO-return outcome (`lastSsoOutcome` / `lastSsoOutcomeReason`
+  // on the context). Lazily seeded from per-tab `sessionStorage` so a
+  // destination load AFTER the callback → destination hard navigation observes
+  // the outcome the callback page consumed (there is no fragment left to parse
+  // by then). Refreshed by `runSsoReturn` when a fragment is present, and
+  // cleared on a successful commit / explicit sign-in / sign-out.
+  const [ssoOutcome, setSsoOutcome] = useState<SsoOutcomeSnapshot | null>(() => readSsoOutcomeWeb());
+
   /**
    * Sessions projected from the `SessionClient`. `null` until `syncFromClient`
    * has applied a state at least once (before cold boot resolves); the public
@@ -574,6 +677,10 @@ export function WebOxyProvider({
     // still-live IdP session on the next reload. Cleared on any deliberate
     // sign-in.
     markSignedOutWeb();
+    // Drop any persisted SSO-return outcome so a fresh visit / next deliberate
+    // sign-in starts from a clean slate (no stale sign-in screen, guard re-armed).
+    clearSsoOutcomeWeb();
+    setSsoOutcome(null);
   }, [queryClient, sessionClientHost]);
 
   /**
@@ -712,6 +819,12 @@ export function WebOxyProvider({
     // flag, so when it is set that step never runs and never reaches here — this
     // clear is only hit on a genuine (re-)sign-in or when restore was permitted.
     clearSignedOutWeb();
+    // A successful commit supersedes any prior `none`/`error` SSO return: clear
+    // the persisted last-outcome so the automatic-sign-in loop guard re-arms
+    // (a later session drop may legitimately probe once again) and no stale
+    // sign-in screen lingers.
+    clearSsoOutcomeWeb();
+    setSsoOutcome(null);
 
     // Register this recovered account+session into the server-authoritative
     // device-session set (Fase 4 cutover — mirrors the services `OxyContext`
@@ -859,6 +972,22 @@ export function WebOxyProvider({
   const runSsoReturn = useCallback((): Promise<SsoReturnSession | null> => {
     if (inFlightSsoReturnRef.current) {
       return inFlightSsoReturnRef.current;
+    }
+    // Capture the return OUTCOME from the fragment BEFORE `consumeSsoReturn`
+    // strips it. `runSsoReturn` is the single funnel for every SSO return (eager
+    // callback interceptor, cold-boot `sso-return` step, bfcache pageshow), and
+    // the memo guard above ensures the body runs once per return — so this
+    // records the outcome exactly once. Persist it per-tab so it survives the
+    // hard navigation `consumeSsoReturn` performs off the callback path back to
+    // the app destination; the destination load reads it back to surface
+    // `lastSsoOutcome` and to gate automatic sign-in.
+    if (isWebBrowser()) {
+      const parsed = parseSsoReturnFragment(window.location.hash);
+      if (parsed) {
+        const reason = parsed.reason ?? null;
+        persistSsoOutcomeWeb(parsed.kind, reason);
+        setSsoOutcome({ kind: parsed.kind, reason });
+      }
     }
     const inFlight = consumeSsoReturn(oxyServices, {
       isWeb: isWebBrowser,
@@ -1334,9 +1463,36 @@ export function WebOxyProvider({
    * re-invoked `signIn()` is a no-op (short-circuited by the mutex) until the
    * real navigation lands and tears the whole page down.
    */
-  const signIn = useCallback(async () => {
+  const signIn = useCallback(async (opts?: { interactive?: boolean }) => {
+    // Default to interactive: existing call sites (buttons) pass nothing and
+    // must keep their always-navigate behaviour. Only guard/effect callers that
+    // explicitly pass `interactive: false` opt into the loop breaker.
+    const interactive = opts?.interactive !== false;
+
     if (signingInRef.current) {
       return;
+    }
+
+    if (interactive) {
+      // Deliberate user gesture: always (re)navigate. Clear the per-tab
+      // last-outcome so a prior automatic `none`/`error` never suppresses a
+      // deliberate retry, and so an RP's sign-in screen does not linger after
+      // the user pressed "Sign in".
+      clearSsoOutcomeWeb();
+      setSsoOutcome(null);
+    } else {
+      // AUTOMATIC (guard/effect) invocation: refuse to re-navigate when a prior
+      // automatic probe THIS TAB already came back `none`/`error`. This is the
+      // loop breaker for the `console.oxy.so` pattern — an auth-guard effect
+      // `if (isReady && !isAuthenticated) signIn()` whose direct call would
+      // otherwise bypass the cold-boot bounce guard and re-bounce to the IdP
+      // every time the `prompt=none` probe returns no session. Read the DURABLE
+      // per-tab outcome (survives the callback → destination hard navigation),
+      // not React state, so the refusal holds across that reload.
+      const prior = readSsoOutcomeWeb();
+      if (prior && (prior.kind === 'none' || prior.kind === 'error')) {
+        return;
+      }
     }
 
     signingInRef.current = true;
@@ -1516,6 +1672,8 @@ export function WebOxyProvider({
     sessions,
     accounts,
     activeAuthuser,
+    lastSsoOutcome: ssoOutcome?.kind ?? null,
+    lastSsoOutcomeReason: ssoOutcome?.reason ?? null,
     oxyServices,
     crossDomainAuth,
     signIn,
@@ -1529,7 +1687,7 @@ export function WebOxyProvider({
     commitClaimedSession,
   }), [
     user, isAuthenticated, isLoading, error, clientId, activeSessionId, sessions,
-    accounts, activeAuthuser,
+    accounts, activeAuthuser, ssoOutcome,
     oxyServices, crossDomainAuth,
     signIn, signInWithRedirect,
     signOut, switchSession,
@@ -1608,6 +1766,8 @@ export function useAuth() {
     sessions: ctx.sessions,
     accounts: ctx.accounts,
     activeAuthuser: ctx.activeAuthuser,
+    lastSsoOutcome: ctx.lastSsoOutcome,
+    lastSsoOutcomeReason: ctx.lastSsoOutcomeReason,
     signIn: ctx.signIn,
     signInWithRedirect: ctx.signInWithRedirect,
     signOut: ctx.signOut,

--- a/packages/console/src/components/sign-in-screen.tsx
+++ b/packages/console/src/components/sign-in-screen.tsx
@@ -1,0 +1,47 @@
+/**
+ * Branded, logged-out sign-in screen.
+ *
+ * Shown by the `AuthGuard` when the app is READY, the user is unauthenticated,
+ * AND the central IdP returned no session for the silent (`prompt=none`) SSO
+ * probe (`lastSsoOutcome` is `none`/`error`). Rendering this instead of
+ * re-bouncing is what breaks the console redirect loop: the automatic probe
+ * runs at most once per tab, and from here the user drives an explicit sign-in
+ * gesture (`signIn()` — which clears the last-outcome and re-bounces).
+ *
+ * Mirrors `SplashScreen`'s macOS-boot styling (centered Oxy logo + app name)
+ * so the hand-off from the boot splash to this screen has no visual jump.
+ */
+import { Button } from '@/components/ui/button';
+
+export function SignInScreen({
+  onSignIn,
+  isError = false,
+}: {
+  onSignIn: () => void;
+  isError?: boolean;
+}) {
+  return (
+    <div className="flex h-screen w-full flex-col items-center justify-center gap-6 bg-background px-6 text-center">
+      <img
+        src="/icon-192.png"
+        alt="Oxy"
+        width={80}
+        height={80}
+        className="h-20 w-20 rounded-[22px]"
+        draggable={false}
+      />
+      <div className="flex flex-col gap-1.5">
+        {/* App name comes from public/manifest.json via Vite, like SplashScreen. */}
+        <p className="text-lg font-semibold text-foreground">{__APP_NAME__}</p>
+        <p className="max-w-xs text-sm text-muted-foreground">
+          {isError
+            ? 'We couldn’t complete sign-in. Please try again.'
+            : 'Sign in with your Oxy account to continue.'}
+        </p>
+      </div>
+      <Button size="lg" className="min-w-48" onClick={onSignIn}>
+        Sign in with Oxy
+      </Button>
+    </div>
+  );
+}

--- a/packages/console/src/routes/_layout.tsx
+++ b/packages/console/src/routes/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { useAuth } from '@oxyhq/auth';
 import { SidebarProvider, SidebarInset, SidebarTrigger } from '@/components/ui/sidebar';
@@ -6,19 +6,43 @@ import { AppSidebar } from '@/components/layout/app-sidebar';
 import { Separator } from '@/components/ui/separator';
 import { CommandMenuTrigger } from '@/components/command-menu';
 import { SplashScreen } from '@/components/splash-screen';
+import { SignInScreen } from '@/components/sign-in-screen';
 
 export const Route = createFileRoute('/_layout')({
   component: LayoutComponent,
 });
 
 function AuthGuard({ children }: { children: React.ReactNode }) {
-  const { isAuthenticated, isReady, signIn } = useAuth();
+  const { isAuthenticated, isReady, signIn, lastSsoOutcome } = useAuth();
+  const autoSignInTriedRef = useRef(false);
 
+  // The central IdP had no session for the silent (prompt=none) SSO probe. The
+  // RP must NOT re-bounce automatically — it defers to a user gesture below.
+  const idpHadNoSession = lastSsoOutcome === 'none' || lastSsoOutcome === 'error';
+
+  // Attempt automatic SSO exactly ONCE per tab: a single silent bounce to the
+  // central IdP. `signIn({ interactive: false })` is itself loop-proof (it
+  // refuses to re-navigate once a prior automatic probe this tab came back
+  // none/error), so this ref is a belt-and-suspenders guard against redundant
+  // calls within a mount. When the probe returns no session the branded
+  // sign-in screen below takes over instead of the old infinite re-bounce.
   useEffect(() => {
-    if (isReady && !isAuthenticated) {
-      signIn();
+    if (isReady && !isAuthenticated && !idpHadNoSession && !autoSignInTriedRef.current) {
+      autoSignInTriedRef.current = true;
+      void signIn({ interactive: false });
     }
-  }, [isReady, isAuthenticated, signIn]);
+  }, [isReady, isAuthenticated, idpHadNoSession, signIn]);
+
+  if (isReady && !isAuthenticated && idpHadNoSession) {
+    // A deliberate gesture: `signIn()` (default interactive) clears the
+    // last-outcome and re-bounces to the IdP.
+    return (
+      <SignInScreen
+        onSignIn={() => void signIn()}
+        isError={lastSsoOutcome === 'error'}
+      />
+    );
+  }
 
   if (!isReady || !isAuthenticated) {
     return <SplashScreen />;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -545,6 +545,7 @@ export {
     ssoAttemptedKey,
     ssoPriorSessionKey,
     ssoSignedOutKey,
+    ssoOutcomeKey,
     ssoCallbackBootstrapKey,
     ssoNavigate,
     getSsoCallbackBootstrapScript,

--- a/packages/core/src/utils/__tests__/ssoReturn.test.ts
+++ b/packages/core/src/utils/__tests__/ssoReturn.test.ts
@@ -70,6 +70,13 @@ describe('parseSsoReturnFragment', () => {
 
       expect(result).toEqual({ kind: 'ok', code: 'a+b/c', state: 's t' });
     });
+
+    it('ignores a stray reason on an ok outcome', () => {
+      const result = parseSsoReturnFragment('#oxy_sso=ok&code=abc123&state=xyz&reason=no_cookie');
+
+      expect(result).toEqual({ kind: 'ok', code: 'abc123', state: 'xyz' });
+      expect(result?.reason).toBeUndefined();
+    });
   });
 
   describe('none', () => {
@@ -85,6 +92,18 @@ describe('parseSsoReturnFragment', () => {
       expect(result).toEqual({ kind: 'none', state: 'xyz' });
       expect(result?.code).toBeUndefined();
     });
+
+    it('carries a machine-readable reason on a none outcome', () => {
+      const result = parseSsoReturnFragment('#oxy_sso=none&reason=no_cookie&state=xyz');
+
+      expect(result).toEqual({ kind: 'none', state: 'xyz', reason: 'no_cookie' });
+    });
+
+    it('omits reason when the none outcome carries none', () => {
+      const result = parseSsoReturnFragment('#oxy_sso=none&state=xyz');
+
+      expect(result?.reason).toBeUndefined();
+    });
   });
 
   describe('error', () => {
@@ -99,6 +118,12 @@ describe('parseSsoReturnFragment', () => {
 
       expect(result).toEqual({ kind: 'error' });
       expect(result?.code).toBeUndefined();
+    });
+
+    it('carries a machine-readable reason on an error outcome', () => {
+      const result = parseSsoReturnFragment('#oxy_sso=error&reason=no_grant_establish');
+
+      expect(result).toEqual({ kind: 'error', reason: 'no_grant_establish' });
     });
   });
 

--- a/packages/core/src/utils/ssoBounce.ts
+++ b/packages/core/src/utils/ssoBounce.ts
@@ -70,6 +70,7 @@ const ATTEMPTED_KEY_PREFIX = 'oxy_sso_attempted:';
 const CALLBACK_BOOTSTRAP_KEY_PREFIX = 'oxy_sso_callback_bootstrap:';
 const PRIOR_SESSION_KEY_PREFIX = 'oxy_sso_prior_session:';
 const SIGNED_OUT_KEY_PREFIX = 'oxy_signed_out:';
+const OUTCOME_KEY_PREFIX = 'oxy_sso_outcome:';
 
 /** Per-origin CSRF state key (matched on return to defeat fragment forgery). */
 export function ssoStateKey(origin: string): string {
@@ -155,6 +156,27 @@ export function ssoPriorSessionKey(origin: string): string {
  */
 export function ssoSignedOutKey(origin: string): string {
   return `${SIGNED_OUT_KEY_PREFIX}${origin}`;
+}
+
+/**
+ * Per-origin key holding the LAST consumed SSO-return outcome (`ok` | `none` |
+ * `error`, plus an optional machine-readable `reason` on the non-`ok` outcomes).
+ *
+ * Lives in per-tab `sessionStorage` like the other loop-breaker keys, and for
+ * the same reason: a `none`/`error` return HARD-navigates the RP off the
+ * internal callback path back to its real destination (a fresh document load),
+ * so the outcome an RP wants to render ("the central IdP had no session — show a
+ * branded sign-in screen instead of bouncing again") must survive that
+ * round-trip. The RP reads it on the destination load to decide whether an
+ * AUTOMATIC (guard-driven) sign-in should re-bounce or defer to a user gesture.
+ *
+ * Written as a small JSON blob (`{kind, reason?}`). Set whenever a return is
+ * consumed; cleared on a successful session commit and on an explicit
+ * user-gesture sign-in / full sign-out (so a deliberate retry is never
+ * suppressed by a prior automatic none/error).
+ */
+export function ssoOutcomeKey(origin: string): string {
+  return `${OUTCOME_KEY_PREFIX}${origin}`;
 }
 
 /**

--- a/packages/core/src/utils/ssoReturn.ts
+++ b/packages/core/src/utils/ssoReturn.ts
@@ -41,12 +41,22 @@ export type SsoReturnKind = 'ok' | 'none' | 'error';
  * The parsed result of an SSO return fragment.
  *
  * `code` is present only for `kind: 'ok'`. `state` echoes the CSRF state the RP
- * generated for the bounce (when the IdP round-tripped it).
+ * generated for the bounce (when the IdP round-tripped it). `reason` is present
+ * only for a NON-`ok` outcome when the IdP supplied one.
  */
 export interface SsoReturnResult {
   kind: SsoReturnKind;
   code?: string;
   state?: string;
+  /**
+   * Machine-readable reason accompanying a NON-`ok` outcome, when the central
+   * IdP supplies one (e.g. `no_cookie` | `stale_session` | `no_grant` |
+   * `no_grant_establish` on a `none` bounce). Purely informational: it lets a
+   * Relying Party surface WHY a silent probe returned no session (e.g. to brand
+   * a "sign in" screen) without re-deriving it. Absent on `ok`, and whenever the
+   * IdP did not include a `reason` param.
+   */
+  reason?: string;
 }
 
 const VALID_KINDS: ReadonlySet<string> = new Set<SsoReturnKind>(['ok', 'none', 'error']);
@@ -98,6 +108,13 @@ export function parseSsoReturnFragment(hash: string | undefined | null): SsoRetu
     const code = params.get('code');
     if (code !== null && code.length > 0) {
       result.code = code;
+    }
+  } else {
+    // A machine-readable reason accompanies a NON-`ok` outcome when the IdP
+    // supplies one. Success carries no reason, so it is only read here.
+    const reason = params.get('reason');
+    if (reason !== null && reason.length > 0) {
+      result.reason = reason;
     }
   }
 


### PR DESCRIPTION
P0 client loop (minimal repro: incognito): console's AuthGuard auto-fired interactive signIn() on every unauthenticated resolution; an oxy_sso=none return re-fired it → infinite top-level bounce for any visitor without a central session (burned per-IP API budgets into 429s, user-reported). The SSO return funnel now persists the per-tab outcome ({kind,reason} in sessionStorage, surviving the callback hard-nav) and exposes lastSsoOutcome/lastSsoOutcomeReason via useAuth(); signIn({interactive:false}) refuses to re-navigate after a none/error probe (user gesture always navigates; commit/sign-out re-arm); console renders a branded Sign-in-with-Oxy screen instead of looping. Core parses the &reason= param (producer: #506) + per-tab ssoOutcomeKey. Verification: core 789, auth-sdk 100 (4 new loop-guard tests failing-first), tsc 0, core/auth/console builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)