### PR TITLE
fix(ci): Node 22.x for api jobs — node-gyp@latest requires it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Install dependencies
         run: bun install
@@ -110,7 +110,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Install dependencies
         run: bun install
@@ -131,7 +131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
 
       - name: Run npm audit
         run: npm audit --audit-level=high || true


### PR DESCRIPTION
bunx node-gyp@latest (better-sqlite3 install) bundles an undici calling webidl.util.markAsUncloneable, absent on Node 20.20.2 — every PR's API Build/Tests fail deterministically since the release. Bump setup-node to 22.x in both api jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)