### PR TITLE
fix(ci): Node 22.x in all workflows — deploy-frontends was still on Node 20

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -48,7 +48,7 @@ jobs:
           bun-version: 1.3.14
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
       # lock (non-deterministic configVersion churn), failing deploys. Lockfile
       # sync is already gated pre-push (test-build) and in PR CI, so the deploy
@@ -109,7 +109,7 @@ jobs:
           bun-version: 1.3.14
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
       # lock (non-deterministic configVersion churn), failing deploys. Lockfile
       # sync is already gated pre-push (test-build) and in PR CI, so the deploy
@@ -135,7 +135,7 @@ jobs:
           bun-version: 1.3.14
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
       # lock (non-deterministic configVersion churn), failing deploys. Lockfile
       # sync is already gated pre-push (test-build) and in PR CI, so the deploy
@@ -161,7 +161,7 @@ jobs:
           bun-version: 1.3.14
       - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       # bun 1.3.14 `--frozen-lockfile` false-positives on a perfectly-synced
       # lock (non-deterministic configVersion churn), failing deploys. Lockfile
       # sync is already gated pre-push (test-build) and in PR CI, so the deploy


### PR DESCRIPTION
Completes #510: the node-gyp@latest/undici breakage also hit deploy-frontends.yml's bun install (all four CF deploys failed on #509's push). Bump every setup-node to 22.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)