### PR TITLE
fix(ci,node): pin node-gyp so better-sqlite3 builds don't fetch broken node-gyp@latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,16 @@ jobs:
         with:
           node-version: '22.x'
 
+      # Pin node-gyp so bun does not fetch the volatile `bunx node-gyp@latest`
+      # when compiling better-sqlite3's native addon (packages/node). node-gyp@13's
+      # bundled undici calls `webidl.util.markAsUncloneable`, which broke the
+      # install. A pinned node-gyp on PATH + npm_config_node_gyp is Node-version
+      # independent and removes that volatility.
+      - name: Pin node-gyp for native addon builds
+        run: |
+          npm install -g node-gyp@11.5.0
+          echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: bun install
 
@@ -111,6 +121,16 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '22.x'
+
+      # Pin node-gyp so bun does not fetch the volatile `bunx node-gyp@latest`
+      # when compiling better-sqlite3's native addon (packages/node). node-gyp@13's
+      # bundled undici calls `webidl.util.markAsUncloneable`, which broke the
+      # install. A pinned node-gyp on PATH + npm_config_node_gyp is Node-version
+      # independent and removes that volatility.
+      - name: Pin node-gyp for native addon builds
+        run: |
+          npm install -g node-gyp@11.5.0
+          echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: bun install

--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -29,6 +29,15 @@ FROM node:20-alpine AS builder
 RUN apk add --no-cache python3 make g++
 RUN npm install -g bun
 
+# Pin node-gyp to a known-good version. better-sqlite3 has no prebuilt binary for
+# this Node/musl target, so it compiles from source. Bun's default addon build
+# fetches `bunx node-gyp@latest` — currently node-gyp@13, whose bundled undici
+# calls `webidl.util.markAsUncloneable`, which throws on Node 20 and fails the
+# install. Installing node-gyp globally puts a known-good `node-gyp` on PATH, and
+# `npm_config_node_gyp` makes bun use it directly instead of the volatile @latest.
+RUN npm install -g node-gyp@11.5.0
+ENV npm_config_node_gyp=/usr/local/lib/node_modules/node-gyp/bin/node-gyp.js
+
 WORKDIR /app
 
 # Narrow the workspaces to the lean subset this image needs, then drop the
@@ -63,6 +72,12 @@ FROM node:20-alpine
 
 RUN apk add --no-cache python3 make g++ curl
 RUN npm install -g bun
+
+# better-sqlite3 (a runtime dependency) compiles from source in the production
+# install too; pin node-gyp so bun does not fetch the broken `node-gyp@latest`.
+# See the builder stage above for the full rationale.
+RUN npm install -g node-gyp@11.5.0
+ENV npm_config_node_gyp=/usr/local/lib/node_modules/node-gyp/bin/node-gyp.js
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem

`bun install` began failing globally (~2026-07-03 00:00) — CI (`API Build`/`API Tests`) and the `packages/node` Docker image. Root cause verified from PR #511 CI (run 28630785115):

```
prebuild-install warn install No prebuilt binaries found (target=20.20.2 runtime=node arch=x64 libc= platform=linux)
gyp info using node-gyp@13.0.1
gyp ERR! stack TypeError: webidl.util.markAsUncloneable is not a function
   at new CacheStorage (/tmp/bunx-1001-node-gyp@latest/node_modules/undici/lib/web/cache/cachestorage.js:20:17)
```

`better-sqlite3@^12.11.1` (added recently in `packages/node`) has no prebuilt binary for our Node/musl targets, so bun compiles its native addon from source. Bun's default addon build fetches `bunx node-gyp@latest` → **node-gyp@13.0.1**, whose bundled undici calls `webidl.util.markAsUncloneable`, which throws on Node 20 → install fails.

## Fix

Pin `node-gyp` to a known-good version so bun never fetches the volatile `@latest`:
- Install `node-gyp@11.5.0` globally (puts a known-good `node-gyp` on PATH).
- Set `npm_config_node_gyp` so bun's addon-build shim (`if [ "x$npm_config_node_gyp" = "x" ]; then bun x --silent node-gyp; else "$npm_config_node_gyp"; fi`) uses it directly instead of `bunx node-gyp@latest`.

This is **Node-version independent** — a durable root-cause fix, not a bet on node-gyp@latest's undici happening to work on a given Node (which is what the earlier `#510` Node-22 bump relies on). It complements #510 without depending on it.

Applied identically to:
- Both api CI jobs (`api-test`, `api-build`) in `.github/workflows/ci.yml`
- Both stages of `packages/node/Dockerfile` (still `node:20-alpine`, which #510 did not touch — it would hit the exact same failure on build)

The oxy-api root `Dockerfile` and `deploy-aws.yml` are unaffected: they narrow workspaces to exclude `packages/node`, so they never compile better-sqlite3.

## Validation

Reproduced the failure and verified the fix locally on the exact broken environment (`node:20-alpine` + bun 1.3.14):
- **Broken baseline** (default `bunx node-gyp@latest`): `webidl.util.markAsUncloneable is not a function`, node-gyp@13.0.1, target 20.20.2 — identical to CI.
- **Fixed** (pinned node-gyp@11.5.0 + `npm_config_node_gyp`): better-sqlite3 compiles from source and loads — `better-sqlite3 OK row { x: 7 }`.

No `package.json`/`bun.lock` change (node-gyp is installed globally, not as a repo dependency), so the frozen-lockfile gate is unaffected.

**This PR's own green CI is the proof the global breakage is fixed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)