### PR TITLE
fix(sso): trusted first-party apps skip the per-user FedCM grant gate on silent IdP paths

### DIFF
--- a/packages/api/src/controllers/__tests__/fedcm.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/fedcm.controller.test.ts
@@ -13,7 +13,7 @@ import type { Request, Response } from 'express';
 const mockMintNonce = jest.fn();
 const mockExchangeIdToken = jest.fn();
 const mockGetUserGrantedOrigins = jest.fn();
-const mockGetApprovedClientOrigins = jest.fn();
+const mockGetApprovedClientData = jest.fn();
 const mockAddApprovedClient = jest.fn();
 const mockRemoveApprovedClient = jest.fn();
 const mockGetUserAuthorizedApps = jest.fn();
@@ -25,7 +25,7 @@ jest.mock('../../services/fedcm.service', () => ({
     mintNonce: mockMintNonce,
     exchangeIdToken: mockExchangeIdToken,
     getUserGrantedOrigins: mockGetUserGrantedOrigins,
-    getApprovedClientOrigins: mockGetApprovedClientOrigins,
+    getApprovedClientData: mockGetApprovedClientData,
     addApprovedClient: mockAddApprovedClient,
     removeApprovedClient: mockRemoveApprovedClient,
     getUserAuthorizedApps: mockGetUserAuthorizedApps,
@@ -229,16 +229,23 @@ describe('getUserGrants', () => {
 });
 
 describe('getApprovedClients', () => {
-  it('returns the approved origins on success', async () => {
-    mockGetApprovedClientOrigins.mockResolvedValueOnce(['https://mention.earth']);
+  it('returns clients (full allow-list) + trusted (consent-skip subset) on success', async () => {
+    mockGetApprovedClientData.mockResolvedValueOnce({
+      origins: ['https://mention.earth', 'https://console.oxy.so'],
+      trusted: ['https://console.oxy.so'],
+    });
     const res = createRes();
     await getApprovedClients(createReq(), res as unknown as Response);
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ success: true, clients: ['https://mention.earth'] });
+    expect(res.body).toEqual({
+      success: true,
+      clients: ['https://mention.earth', 'https://console.oxy.so'],
+      trusted: ['https://console.oxy.so'],
+    });
   });
 
   it('returns 500 when the service throws', async () => {
-    mockGetApprovedClientOrigins.mockRejectedValueOnce(new Error('db down'));
+    mockGetApprovedClientData.mockRejectedValueOnce(new Error('db down'));
     const res = createRes();
     await getApprovedClients(createReq(), res as unknown as Response);
     expect(res.statusCode).toBe(500);

--- a/packages/api/src/controllers/fedcm.controller.ts
+++ b/packages/api/src/controllers/fedcm.controller.ts
@@ -155,11 +155,15 @@ export async function getUserGrants(req: Request, res: Response) {
  */
 export async function getApprovedClients(req: Request, res: Response) {
   try {
-    const origins = await fedcmService.getApprovedClientOrigins();
+    const { origins, trusted } = await fedcmService.getApprovedClientData();
 
+    // `clients` is the full approved-clients allow-list (unchanged, back-compat).
+    // `trusted` is the additive subset of first-party/official origins the IdP
+    // worker may silently restore WITHOUT a per-user FedCM grant.
     return res.json({
       success: true,
       clients: origins,
+      trusted,
     });
   } catch (error) {
     logger.error('Get approved FedCM clients error:', error);

--- a/packages/api/src/services/__tests__/fedcm.service.test.ts
+++ b/packages/api/src/services/__tests__/fedcm.service.test.ts
@@ -68,11 +68,11 @@ jest.mock('../../models/Application', () => ({
 // Pass-through cache for non-authoritative list reads (the uncached Mongo read
 // driven by the Application/FedCMClient mocks above). Authorization decisions
 // (`isClientApproved`) bypass this cache and read the canonical registry
-// directly; only `getApprovedOrigins` (list reads) and `invalidate` are needed.
+// directly; only `getApprovedData` (snapshot reads) and `invalidate` are needed.
 jest.mock('../../utils/approvedClientsCache', () => ({
   __esModule: true,
   default: {
-    getApprovedOrigins: (loader: () => Promise<string[]>) => loader(),
+    getApprovedData: (loader: () => Promise<unknown>) => loader(),
     invalidate: mockCacheInvalidate,
   },
 }));
@@ -696,6 +696,83 @@ describe('FedCM approved-origins derivation (trusted Application registry + manu
     for (const dev of DEV_NATIVE) {
       expect(origins).toContain(dev);
     }
+  });
+});
+
+/**
+ * Trusted (consent-skip) subset — `getApprovedClientData().trusted`.
+ *
+ * The IdP worker skips its per-user FedCM grant gate for these origins so
+ * first-party / official apps (e.g. console.oxy.so, which never records a grant)
+ * restore silently. The trusted set is derived ONLY from Applications the shared
+ * `isTrustedApplication` predicate marks first-party/internal/system/official —
+ * the SAME classifier the OAuth consent auto-approve path uses. Dev/native
+ * origins and manual escape-hatch rows are approved (in `clients`) but NOT
+ * trusted (never in `trusted`).
+ */
+describe('FedCM trusted-client derivation (consent-skip subset)', () => {
+  const DEV_NATIVE = ['http://localhost:3000', 'http://localhost:8081', 'astro://auth'];
+
+  it('includes official / first-party / internal / system app origins in trusted', async () => {
+    mockAppFind.mockReturnValueOnce(
+      leanQuery([
+        { name: 'Oxy Console', type: 'first_party', redirectUris: ['https://console.oxy.so/__oxy/sso-callback'] },
+        { name: 'Oxy Website', isOfficial: true, redirectUris: ['https://oxy.so/__oxy/sso-callback'] },
+        { name: 'Internal Svc', isInternal: true, redirectUris: ['https://internal.oxy.so/__oxy/sso-callback'] },
+        { name: 'Oxy Auth', type: 'system', redirectUris: ['https://auth.oxy.so/__oxy/sso-callback'] },
+      ])
+    );
+
+    const { trusted } = await fedcmService.getApprovedClientData();
+
+    for (const expected of [
+      'https://console.oxy.so',
+      'https://oxy.so',
+      'https://internal.oxy.so',
+      'https://auth.oxy.so',
+    ]) {
+      expect(trusted).toContain(expected);
+    }
+  });
+
+  it('trusted is a strict subset of clients (every trusted origin is also approved)', async () => {
+    mockAppFind.mockReturnValueOnce(
+      leanQuery([
+        { name: 'Oxy Console', type: 'first_party', redirectUris: ['https://console.oxy.so/__oxy/sso-callback'] },
+      ])
+    );
+
+    const { origins, trusted } = await fedcmService.getApprovedClientData();
+    for (const t of trusted) {
+      expect(origins).toContain(t);
+    }
+    expect(trusted).toContain('https://console.oxy.so');
+    expect(origins).toContain('https://console.oxy.so');
+  });
+
+  it('does NOT mark dev/native origins as trusted (approved, but no consent-skip)', async () => {
+    mockAppFind.mockReturnValueOnce(leanQuery([])); // no apps
+    const { origins, trusted } = await fedcmService.getApprovedClientData();
+    for (const dev of DEV_NATIVE) {
+      expect(origins).toContain(dev); // approved
+      expect(trusted).not.toContain(dev); // but never trusted for consent-skip
+    }
+  });
+
+  it('does NOT mark manual FedCMClient escape-hatch origins as trusted', async () => {
+    mockAppFind.mockReturnValueOnce(leanQuery([]));
+    mockClientFind.mockReturnValueOnce(leanQuery([{ origin: 'https://manual.example' }]));
+    const { origins, trusted } = await fedcmService.getApprovedClientData();
+    expect(origins).toContain('https://manual.example'); // approved via escape hatch
+    expect(trusted).not.toContain('https://manual.example'); // never a consent-skip
+  });
+
+  it('yields an empty trusted set (fail-closed) when the registry read throws', async () => {
+    mockAppFind.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({ lean: jest.fn().mockRejectedValue(new Error('db down')) }),
+    });
+    const { trusted } = await fedcmService.getApprovedClientData();
+    expect(trusted).toEqual([]);
   });
 });
 

--- a/packages/api/src/services/fedcm.service.ts
+++ b/packages/api/src/services/fedcm.service.ts
@@ -5,7 +5,8 @@ import { Application } from '../models/Application';
 import { User } from '../models/User';
 import { logger } from '../utils/logger';
 import { normaliseOrigin } from '../utils/origin';
-import approvedClientsCache from '../utils/approvedClientsCache';
+import approvedClientsCache, { type ApprovedClientsData } from '../utils/approvedClientsCache';
+import { isTrustedApplication } from '../utils/trustedApplication';
 import sessionService from './session.service';
 import deviceSessionService from './deviceSession.service';
 import { Request } from 'express';
@@ -19,7 +20,7 @@ import { formatUserNameResponse } from '../utils/displayName';
  * a registered {@link Application} — local dev servers and the native app
  * callback scheme. These are intentionally a small, explicit constant: every
  * trusted PRODUCTION RP origin is derived from staff-approved Application
- * metadata instead (see `fetchApprovedClientOrigins`), so user-created
+ * metadata instead (see `fetchApprovedClientData`), so user-created
  * third-party apps cannot self-approve SSO origins.
  */
 const DEV_NATIVE_APPROVED_ORIGINS = [
@@ -201,15 +202,15 @@ function verifyIdToken(token: string): FedcmTokenPayload {
  */
 class FedCMService {
   /**
-   * Uncached read of all approved client origins straight from Mongo.
+   * Uncached read of the approved-clients snapshot straight from Mongo:
+   * `{ origins, trusted }`.
    *
-   * Single source of truth for production first-party RP origins: derive origins
-   * from the canonical {@link Application} registry, but only for active apps
-   * whose staff-controlled trust fields mark them as platform-approved. Normal
-   * user-created third-party apps are active too, so `status: 'active'` alone is
-   * not a trust boundary for FedCM/SSO session minting.
-   *
-   * Unioned with:
+   * `origins` — the FULL approved-clients allow-list. Single source of truth for
+   * production first-party RP origins: derive origins from the canonical
+   * {@link Application} registry, but only for active apps whose staff-controlled
+   * trust fields mark them as platform-approved. Normal user-created third-party
+   * apps are active too, so `status: 'active'` alone is not a trust boundary for
+   * FedCM/SSO session minting. Unioned with:
    *  - {@link DEV_NATIVE_APPROVED_ORIGINS} (localhost dev + native scheme — not
    *    modelled as Applications);
    *  - any explicitly `approved` {@link FedCMClient} rows — the admin escape
@@ -217,14 +218,26 @@ class FedCMService {
    *    (yet) have an Application. `seedApprovedClients` only ever seeds the
    *    dev/native entries here.
    *
-   * Fail-soft: returns the dev/native fallback on error so callers (and the
-   * cache loader) never throw on a transient DB hiccup; the FedCM exchange
-   * remains fail-closed for everything else (an unknown origin is rejected).
+   * `trusted` — the strict subset of `origins` derived from Applications the
+   * platform classifies as first-party / internal / system / official via the
+   * shared {@link isTrustedApplication} predicate (the SAME classifier the
+   * `/auth/oauth/consent` auto-approve path uses — `packages/api/src/routes/auth.ts`
+   * line 2596). These NEVER require per-user FedCM consent, so the IdP worker
+   * short-circuits its per-user grant gate for them. Dev/native origins and
+   * manual escape-hatch rows are deliberately NOT trusted: only staff-controlled
+   * Application trust fields grant the consent-skip.
+   *
+   * Fail-soft: returns the dev/native fallback (with an empty `trusted`) on error
+   * so callers (and the cache loader) never throw on a transient DB hiccup; the
+   * FedCM exchange remains fail-closed for everything else (an unknown origin is
+   * rejected).
    */
-  private async fetchApprovedClientOrigins(): Promise<string[]> {
+  private async fetchApprovedClientData(): Promise<ApprovedClientsData> {
     const origins = new Set<string>();
+    const trusted = new Set<string>();
 
-    // Dev/native origins are always approved (a small, explicit constant).
+    // Dev/native origins are always approved (a small, explicit constant) — but
+    // NOT trusted for the consent-skip; only registered Applications are.
     for (const dev of DEV_NATIVE_APPROVED_ORIGINS) {
       const normalised = normaliseOrigin(dev);
       if (normalised) origins.add(normalised);
@@ -232,15 +245,24 @@ class FedCMService {
 
     try {
       const [apps, manualClients] = await Promise.all([
-        Application.find(TRUSTED_APPLICATION_FEDCM_FILTER).select('redirectUris').lean(),
+        Application.find(TRUSTED_APPLICATION_FEDCM_FILTER)
+          .select('isOfficial isInternal type redirectUris')
+          .lean(),
         // Manual/admin-approved escape-hatch entries (not Applications).
         FedCMClient.find({ approved: true }).select('origin').lean(),
       ]);
 
       for (const app of apps) {
+        // `TRUSTED_APPLICATION_FEDCM_FILTER` already restricts the query to the
+        // trusted set; re-applying the shared predicate makes the trust
+        // classification explicit in code (single source of truth with the
+        // OAuth consent auto-approve path) and robust to any future query drift.
+        const appIsTrusted = isTrustedApplication(app);
         for (const uri of app.redirectUris ?? []) {
           const normalised = normaliseOrigin(uri);
-          if (normalised) origins.add(normalised);
+          if (!normalised) continue;
+          origins.add(normalised);
+          if (appIsTrusted) trusted.add(normalised);
         }
       }
 
@@ -254,7 +276,7 @@ class FedCMService {
       // the cache loader, still fail-closed for any origin not in the set.
     }
 
-    return Array.from(origins);
+    return { origins: Array.from(origins), trusted: Array.from(trusted) };
   }
 
   /**
@@ -292,10 +314,19 @@ class FedCMService {
   }
 
   /**
+   * Get the approved-clients snapshot `{ origins, trusted }` (short-TTL cached —
+   * see approvedClientsCache). ONE Mongo read serves both the full allow-list and
+   * the trusted (consent-skip) subset.
+   */
+  async getApprovedClientData(): Promise<ApprovedClientsData> {
+    return approvedClientsCache.getApprovedData(() => this.fetchApprovedClientData());
+  }
+
+  /**
    * Get all approved client origins (short-TTL cached — see approvedClientsCache).
    */
   async getApprovedClientOrigins(): Promise<string[]> {
-    return approvedClientsCache.getApprovedOrigins(() => this.fetchApprovedClientOrigins());
+    return (await this.getApprovedClientData()).origins;
   }
 
   /**
@@ -316,7 +347,7 @@ class FedCMService {
    */
   async isClientApproved(origin: string): Promise<boolean> {
     try {
-      const origins = await this.fetchApprovedClientOrigins();
+      const { origins } = await this.fetchApprovedClientData();
       return origins.includes(origin);
     } catch (error) {
       logger.error('Error checking FedCM client approval:', error);
@@ -329,7 +360,7 @@ class FedCMService {
    *
    * PRODUCTION RP origins are NOT seeded here: trusted first-party/internal
    * origins are derived live from the {@link Application} registry by
-   * {@link fetchApprovedClientOrigins}. This
+   * {@link fetchApprovedClientData}. This
    * function only persists the small {@link DEV_NATIVE_APPROVED_ORIGINS} set
    * (localhost + native scheme) as {@link FedCMClient} rows so they survive in
    * the admin-visible collection and the `getUserAuthorizedApps` catalog.

--- a/packages/api/src/utils/approvedClientsCache.ts
+++ b/packages/api/src/utils/approvedClientsCache.ts
@@ -10,6 +10,20 @@ const LOCAL_KEY = 'approved:origins';
 const LOG_COMPONENT = 'ApprovedClientsCache';
 
 /**
+ * Cached approved-clients snapshot. `origins` is the full approved-clients
+ * allow-list (dev/native + trusted-Application origins + manual escape-hatch
+ * rows); `trusted` is the strict subset of first-party/official/internal
+ * origins the API classifies as never requiring per-user FedCM consent (see
+ * `isTrustedApplication`). Both derive from ONE Mongo read and are cached
+ * together so the IdP worker can consume both from a single `/fedcm/clients/approved`
+ * fetch.
+ */
+export interface ApprovedClientsData {
+  origins: string[];
+  trusted: string[];
+}
+
+/**
  * In-process cache for NON-AUTHORITATIVE FedCM approved-client list reads.
  *
  * Collapses the redundant `FedCMClient`/`Application` reads per SSO/FedCM
@@ -31,7 +45,7 @@ const LOG_COMPONENT = 'ApprovedClientsCache';
  * further when Valkey is reachable.
  */
 class ApprovedClientsCache {
-  private local: Map<string, { origins: string[]; timestamp: number; ttl: number }> = new Map();
+  private local: Map<string, { data: ApprovedClientsData; timestamp: number; ttl: number }> = new Map();
   private cleanupTimer: NodeJS.Timeout;
 
   constructor() {
@@ -40,18 +54,18 @@ class ApprovedClientsCache {
   }
 
   /**
-   * Return the cached approved-origins list when a fresh local entry exists,
-   * otherwise invoke `loader()` (the uncached Mongo read), store the result,
-   * and return it. The loader is fail-soft (returns `[]` on Mongo error) so a
-   * cache miss never throws here.
+   * Return the cached approved-clients snapshot (`{ origins, trusted }`) when a
+   * fresh local entry exists, otherwise invoke `loader()` (the uncached Mongo
+   * read), store the result, and return it. The loader is fail-soft (returns the
+   * dev/native fallback on Mongo error) so a cache miss never throws here.
    */
-  async getApprovedOrigins(loader: () => Promise<string[]>): Promise<string[]> {
+  async getApprovedData(loader: () => Promise<ApprovedClientsData>): Promise<ApprovedClientsData> {
     const local = this.getLocal();
     if (local) return local;
 
-    const origins = await loader();
-    this.setLocal(origins);
-    return origins;
+    const data = await loader();
+    this.setLocal(data);
+    return data;
   }
 
   /**
@@ -75,19 +89,19 @@ class ApprovedClientsCache {
 
   // --- Local cache helpers ---
 
-  private getLocal(): string[] | null {
+  private getLocal(): ApprovedClientsData | null {
     const cached = this.local.get(LOCAL_KEY);
     if (!cached) return null;
     if (Date.now() - cached.timestamp > cached.ttl) {
       this.local.delete(LOCAL_KEY);
       return null;
     }
-    return cached.origins;
+    return cached.data;
   }
 
-  private setLocal(origins: string[]): void {
+  private setLocal(data: ApprovedClientsData): void {
     this.local.set(LOCAL_KEY, {
-      origins,
+      data,
       timestamp: Date.now(),
       ttl: DEFAULT_TTL,
     });
@@ -95,7 +109,7 @@ class ApprovedClientsCache {
     const redis = getRedisClient();
     if (redis && redis.status === 'ready') {
       const ttlSec = Math.ceil(DEFAULT_TTL / 1000);
-      redis.setex(REDIS_KEY, ttlSec, JSON.stringify(origins)).catch((err) => {
+      redis.setex(REDIS_KEY, ttlSec, JSON.stringify(data)).catch((err) => {
         logger.warn('approvedClientsCache: Redis setex failed', {
           component: LOG_COMPONENT,
           err: err instanceof Error ? err.message : String(err),

--- a/packages/auth/server/__tests__/ssoCache.idp.test.ts
+++ b/packages/auth/server/__tests__/ssoCache.idp.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, setSy
 
 const RP_ORIGIN = 'https://accounts.oxy.so';
 const OTHER_ORIGIN = 'https://console.oxy.so';
+const THIRD_PARTY_ORIGIN = 'https://third-party.example';
 const API_BASE = 'https://api.oxy.so';
 const USER_A = '507f1f77bcf86cd799439011';
 const USER_B = '507f1f77bcf86cd799439012';
@@ -56,6 +57,9 @@ type StubMode = 'ok' | 'fail' | 'empty';
 let approvedFetchCount = 0;
 let approvedMode: StubMode = 'ok';
 let approvedList: string[] = [RP_ORIGIN];
+// The trusted (consent-skip) subset returned alongside `clients`. Empty by
+// default so the existing cache/resolve tests keep the full grant gate.
+let trustedList: string[] = [];
 let grantsFetchCount = 0;
 let grantsMode: StubMode = 'ok';
 let grantsList: string[] = [RP_ORIGIN];
@@ -82,7 +86,7 @@ function installStub(): void {
         return new Response('err', { status: 500 });
       }
       const clients = approvedMode === 'empty' ? [] : approvedList;
-      return new Response(JSON.stringify({ success: true, clients }), {
+      return new Response(JSON.stringify({ success: true, clients, trusted: trustedList }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       });
@@ -113,6 +117,12 @@ let fetchApprovedClients: (
   userId: string,
   forceRefresh?: boolean
 ) => Promise<string[]>;
+let userHasGrantedClient: (
+  config: typeof CONFIG,
+  userId: string,
+  clientOrigin: string,
+  forceRefresh?: boolean
+) => Promise<boolean>;
 let resetSsoCaches: () => void = () => {};
 
 beforeAll(async () => {
@@ -120,6 +130,7 @@ beforeAll(async () => {
   const mod = await import('../index');
   resolveApprovedClientOrigin = mod.resolveApprovedClientOrigin;
   fetchApprovedClients = mod.fetchApprovedClients;
+  userHasGrantedClient = mod.userHasGrantedClient;
   resetSsoCaches = mod.__resetSsoCachesForTests;
 });
 
@@ -133,6 +144,7 @@ beforeEach(() => {
   approvedFetchCount = 0;
   approvedMode = 'ok';
   approvedList = [RP_ORIGIN];
+  trustedList = [];
   grantsFetchCount = 0;
   grantsMode = 'ok';
   grantsList = [RP_ORIGIN];
@@ -329,5 +341,84 @@ describe('grants cache (30s TTL, NO stale-on-failure)', () => {
     const liveRead = await fetchApprovedClients(CONFIG, USER_A, true);
     expect(liveRead).toEqual([RP_ORIGIN]); // revocation observed
     expect(grantsFetchCount).toBe(2);
+  });
+});
+
+/**
+ * Trusted-origin short-circuit in `userHasGrantedClient`.
+ *
+ * A first-party / official RP the API marks `trusted` NEVER requires a per-user
+ * FedCM grant — official ecosystem apps sign in with zero consent friction. Such
+ * an origin (e.g. console.oxy.so, which has no flow that records a grant and
+ * would otherwise be stuck on `no_grant`) resolves TRUE without ANY per-user
+ * grant fetch. Third-party origins keep the full grant gate; a missing/absent
+ * `trusted` array (older API) fails closed to that gate.
+ */
+describe('userHasGrantedClient — trusted-origin short-circuit', () => {
+  it('returns true for a trusted origin WITHOUT any per-user grant fetch', async () => {
+    // console.oxy.so is an official app: approved AND trusted, but the user has
+    // NEVER granted it (grants list is empty).
+    approvedList = [RP_ORIGIN, OTHER_ORIGIN];
+    trustedList = [OTHER_ORIGIN];
+    grantsMode = 'empty';
+
+    const granted = await userHasGrantedClient(CONFIG, USER_A, OTHER_ORIGIN);
+    expect(granted).toBe(true);
+    // The grant endpoint was NEVER hit — the trusted list alone authorised it.
+    expect(grantsFetchCount).toBe(0);
+  });
+
+  it('applies the trusted short-circuit even with forceRefresh (the /sso/establish re-check)', async () => {
+    approvedList = [RP_ORIGIN, OTHER_ORIGIN];
+    trustedList = [OTHER_ORIGIN];
+    grantsMode = 'empty';
+
+    const granted = await userHasGrantedClient(CONFIG, USER_A, OTHER_ORIGIN, true);
+    expect(granted).toBe(true);
+    expect(grantsFetchCount).toBe(0); // trusted origins carry no grant to re-check
+  });
+
+  it('still fetches the per-user grant for a NON-trusted (third-party) approved origin', async () => {
+    // Third-party origin: approved (may start SSO) but NOT trusted → the grant
+    // gate applies. With a matching grant it passes, but the grant WAS fetched.
+    approvedList = [RP_ORIGIN, THIRD_PARTY_ORIGIN];
+    trustedList = [OTHER_ORIGIN]; // does NOT include the third-party origin
+    grantsList = [THIRD_PARTY_ORIGIN];
+
+    const granted = await userHasGrantedClient(CONFIG, USER_A, THIRD_PARTY_ORIGIN);
+    expect(granted).toBe(true);
+    expect(grantsFetchCount).toBe(1); // grant gate enforced (fetch happened)
+  });
+
+  it('denies a NON-trusted approved origin the user has not granted', async () => {
+    approvedList = [RP_ORIGIN, THIRD_PARTY_ORIGIN];
+    trustedList = [OTHER_ORIGIN];
+    grantsMode = 'empty'; // user has granted nothing
+
+    const granted = await userHasGrantedClient(CONFIG, USER_A, THIRD_PARTY_ORIGIN);
+    expect(granted).toBe(false);
+    expect(grantsFetchCount).toBe(1); // full gate ran and denied
+  });
+
+  it('fails closed to the grant gate when the API omits a trusted array (older API)', async () => {
+    // trustedList stays [] → even an official origin falls through to the grant
+    // gate. Today's behaviour: without a trust signal, no consent-skip.
+    approvedList = [RP_ORIGIN, OTHER_ORIGIN];
+    trustedList = [];
+    grantsMode = 'empty';
+
+    const granted = await userHasGrantedClient(CONFIG, USER_A, OTHER_ORIGIN);
+    expect(granted).toBe(false);
+    expect(grantsFetchCount).toBe(1); // grant gate enforced (fail closed)
+  });
+
+  it('fails closed to the grant gate when the approved/trusted snapshot cannot be fetched', async () => {
+    // No prior cache AND the approved-clients fetch fails → isTrustedClientOrigin
+    // returns false → the grant gate runs (which also fails closed to empty).
+    approvedMode = 'fail';
+    grantsMode = 'fail';
+
+    const granted = await userHasGrantedClient(CONFIG, USER_A, OTHER_ORIGIN);
+    expect(granted).toBe(false);
   });
 });

--- a/packages/auth/server/index.ts
+++ b/packages/auth/server/index.ts
@@ -516,13 +516,22 @@ async function fetchApprovedClients(
  * already consented to. First-time RPs get a no-session outcome so the RP falls
  * back to an interactive sign-in/consent flow.
  *
+ * TRUSTED-ORIGIN SHORT-CIRCUIT: a first-party / official RP the API classifies
+ * as trusted (`isTrustedApplication`) NEVER requires per-user consent — official
+ * ecosystem apps must sign in with zero consent friction. Such origins (e.g.
+ * console.oxy.so, which has no flow that records a FedCM grant and would
+ * otherwise be permanently stuck on `no_grant`) return `true` here BEFORE any
+ * per-user grant fetch. Only origins the API marks trusted qualify; a
+ * missing/absent trusted array fails closed to the full grant gate below.
+ *
  * Fails CLOSED: any failure in the per-user grant lookup yields an empty list
  * (treated as "no grant"), so a transient API error blocks silent restore
  * rather than handing a session to an un-consented RP.
  *
  * `forceRefresh` is threaded through to {@link fetchApprovedClients} for the
  * `/sso/establish` re-check, which must observe a grant revoked between hops
- * rather than the value the central `/sso` hop just cached.
+ * rather than the value the central `/sso` hop just cached. (Trusted origins
+ * carry no per-user grant to revoke, so the short-circuit is unaffected by it.)
  */
 async function userHasGrantedClient(
   config: ResolvedConfig,
@@ -530,6 +539,11 @@ async function userHasGrantedClient(
   clientOrigin: string,
   forceRefresh = false
 ): Promise<boolean> {
+  // First-party/official origins skip the per-user grant gate entirely — the
+  // API is the sole trust authority (worker never hardcodes an origin).
+  if (await isTrustedClientOrigin(config.apiBaseUrl, clientOrigin)) {
+    return true;
+  }
   const grantedOrigins = await fetchApprovedClients(config, userId, forceRefresh);
   return grantedOrigins.some((origin) => normaliseOrigin(origin) === clientOrigin);
 }
@@ -656,30 +670,46 @@ const APPROVED_CLIENTS_TTL_MS = 60_000;
  */
 const APPROVED_CLIENTS_STALE_CAP_MS = 10 * 60_000;
 
+/**
+ * The approved-clients snapshot served by `GET /fedcm/clients/approved`:
+ *   - `clients` — the FULL approved-clients allow-list (what `resolveApprovedClientOrigin`
+ *     validates a candidate RP `client_id` against).
+ *   - `trusted` — the strict subset of first-party/official origins the API
+ *     classifies (via `isTrustedApplication`) as NEVER requiring per-user FedCM
+ *     consent. `userHasGrantedClient` short-circuits its grant gate for these.
+ *
+ * `trusted` is ADDITIVE: an older API that omits it yields `[]`, which reinstates
+ * the full per-user grant gate for every origin (today's behaviour, fails closed).
+ */
+interface ApprovedClientsData {
+  clients: string[];
+  trusted: string[];
+}
+
 interface ApprovedClientsCache {
-  list: string[];
+  data: ApprovedClientsData;
   fetchedAt: number;
 }
 
 /**
- * Module-level cache of the approved-clients allow-list. POSITIVE, non-empty
- * results only — a failed fetch (`null`) or an empty list (`[]`, never the real
- * production state and far more likely a transient API glitch) is treated as
- * non-authoritative and never stored as truth.
+ * Module-level cache of the approved-clients snapshot. POSITIVE, non-empty
+ * allow-lists only — a failed fetch (`null`) or an empty `clients` list (`[]`,
+ * never the real production state and far more likely a transient API glitch) is
+ * treated as non-authoritative and never stored as truth.
  */
 let approvedClientsCache: ApprovedClientsCache | null = null;
 
 /** In-flight approved-clients fetch de-dup — concurrent callers share one round-trip. */
-let approvedClientsInFlight: Promise<string[] | null> | null = null;
+let approvedClientsInFlight: Promise<ApprovedClientsData | null> | null = null;
 
 /**
- * Raw approved-clients fetch. Returns the parsed origin list on a successful,
- * well-formed response (possibly empty), or `null` on ANY failure (non-2xx,
- * malformed body, network/timeout). The `null` vs `[]` distinction lets the
- * caller keep serving a prior good list on failure while never caching an empty
- * fetch as truth.
+ * Raw approved-clients fetch. Returns the parsed `{ clients, trusted }` snapshot
+ * on a successful, well-formed response (possibly with an empty `clients` list),
+ * or `null` on ANY failure (non-2xx, malformed body, network/timeout). The `null`
+ * vs empty distinction lets the caller keep serving a prior good list on failure
+ * while never caching an empty fetch as truth.
  */
-async function fetchApprovedClientsList(apiBaseUrl: string): Promise<string[] | null> {
+async function fetchApprovedClientsList(apiBaseUrl: string): Promise<ApprovedClientsData | null> {
   try {
     const res = await fetch(`${apiBaseUrl}/fedcm/clients/approved`, {
       headers: { Accept: 'application/json' },
@@ -687,29 +717,40 @@ async function fetchApprovedClientsList(apiBaseUrl: string): Promise<string[] | 
     });
     if (!res.ok) return null;
     const data = (await res.json()) as Record<string, unknown>;
-    // The controller responds `{ success, clients: string[] }`; tolerate an
-    // `origins` alias defensively in case the shape ever changes.
-    const list = (Array.isArray(data.clients) ? data.clients : data.origins) as unknown;
-    if (!Array.isArray(list)) return null;
-    return list.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+    // The controller responds `{ success, clients: string[], trusted: string[] }`;
+    // tolerate an `origins` alias for `clients` defensively in case the shape ever changes.
+    const rawClients = (Array.isArray(data.clients) ? data.clients : data.origins) as unknown;
+    if (!Array.isArray(rawClients)) return null;
+    const clients = rawClients.filter(
+      (entry): entry is string => typeof entry === 'string' && entry.length > 0
+    );
+    // `trusted` is additive/optional — an API that predates it yields `[]`, which
+    // keeps the full per-user grant gate for EVERY origin (fails closed). We never
+    // synthesize trust the API did not assert (no worker-side hardcode).
+    const trusted = Array.isArray(data.trusted)
+      ? (data.trusted as unknown[]).filter(
+          (entry): entry is string => typeof entry === 'string' && entry.length > 0
+        )
+      : [];
+    return { clients, trusted };
   } catch {
     return null;
   }
 }
 
 /**
- * Resolve the approved-clients allow-list through the module cache:
+ * Resolve the approved-clients snapshot through the module cache:
  *   1. FRESH cache (age < {@link APPROVED_CLIENTS_TTL_MS}) → return it, no fetch.
  *   2. Otherwise fetch (concurrent callers share ONE in-flight round-trip).
- *      - a non-empty list → refresh the cache and return it.
- *      - a failed/empty fetch → serve the prior list if it is within
+ *      - a non-empty `clients` list → refresh the cache and return it.
+ *      - a failed/empty fetch → serve the prior snapshot if it is within
  *        {@link APPROVED_CLIENTS_STALE_CAP_MS} (bounded staleness), else return
  *        the fetched value (null/empty) so the caller fails closed.
  */
-async function getApprovedClientOrigins(apiBaseUrl: string): Promise<string[] | null> {
+async function getApprovedClientData(apiBaseUrl: string): Promise<ApprovedClientsData | null> {
   const now = Date.now();
   if (approvedClientsCache && now - approvedClientsCache.fetchedAt < APPROVED_CLIENTS_TTL_MS) {
-    return approvedClientsCache.list;
+    return approvedClientsCache.data;
   }
 
   if (!approvedClientsInFlight) {
@@ -719,18 +760,18 @@ async function getApprovedClientOrigins(apiBaseUrl: string): Promise<string[] | 
   }
   const fetched = await approvedClientsInFlight;
 
-  if (fetched && fetched.length > 0) {
-    approvedClientsCache = { list: fetched, fetchedAt: Date.now() };
+  if (fetched && fetched.clients.length > 0) {
+    approvedClientsCache = { data: fetched, fetchedAt: Date.now() };
     return fetched;
   }
 
   // Non-authoritative outcome (failed or empty): prefer a bounded-stale prior
-  // list over the fails-closed collapse. Only within the stale cap.
+  // snapshot over the fails-closed collapse. Only within the stale cap.
   if (
     approvedClientsCache &&
     Date.now() - approvedClientsCache.fetchedAt < APPROVED_CLIENTS_STALE_CAP_MS
   ) {
-    return approvedClientsCache.list;
+    return approvedClientsCache.data;
   }
   return fetched;
 }
@@ -738,7 +779,7 @@ async function getApprovedClientOrigins(apiBaseUrl: string): Promise<string[] | 
 /**
  * Validate a candidate RP `client_id` against the authoritative approved-
  * clients allow-list served by the Oxy API (`GET /fedcm/clients/approved`),
- * sourced through the module cache ({@link getApprovedClientOrigins}). This is
+ * sourced through the module cache ({@link getApprovedClientData}). This is
  * the SAME list `/fedcm/exchange` enforces via `isClientApproved`, so the silent
  * path cannot deliver a token to any origin the FedCM path would itself reject.
  * Returns the normalised, approved origin or `null`.
@@ -756,12 +797,31 @@ async function resolveApprovedClientOrigin(
   const candidate = normaliseOrigin(clientId);
   if (!candidate) return null;
 
-  const list = await getApprovedClientOrigins(apiBaseUrl);
-  if (!list) return null;
-  for (const entry of list) {
+  const data = await getApprovedClientData(apiBaseUrl);
+  if (!data) return null;
+  for (const entry of data.clients) {
     if (normaliseOrigin(entry) === candidate) return candidate;
   }
   return null;
+}
+
+/**
+ * Whether `clientOrigin` is a TRUSTED (first-party / official / internal /
+ * system) RP origin the API classifies as never requiring per-user FedCM
+ * consent. Sourced from the SAME cached `/fedcm/clients/approved` snapshot
+ * `resolveApprovedClientOrigin` reads (the API is the sole trust authority — the
+ * worker never hardcodes an origin here).
+ *
+ * Fails CLOSED: with no usable snapshot (network/parse error) or an absent
+ * `trusted` array (older API), this returns `false`, so the caller falls through
+ * to the full per-user grant gate — today's behaviour. `clientOrigin` is already
+ * a normalised, approved origin at every call site; we still normalise each
+ * trusted entry for the comparison.
+ */
+async function isTrustedClientOrigin(apiBaseUrl: string, clientOrigin: string): Promise<boolean> {
+  const data = await getApprovedClientData(apiBaseUrl);
+  if (!data) return false;
+  return data.trusted.some((entry) => normaliseOrigin(entry) === clientOrigin);
 }
 
 /**
@@ -2300,11 +2360,12 @@ export type { WorkerEnv };
 
 // Cache internals exported for unit tests only. `resolveApprovedClientOrigin`
 // and `fetchApprovedClients` are exercised directly to assert TTL/stale/single-
-// flight behaviour; `__resetSsoCachesForTests` clears the module-level caches
-// between cases (the caches are process-global, so every test file that touches
-// the SSO endpoints must reset them in `beforeEach` for isolation — mirrors the
-// `__resetBloomCSSForTests` pattern).
-export { resolveApprovedClientOrigin, fetchApprovedClients };
+// flight behaviour; `userHasGrantedClient` is exercised to assert the trusted
+// short-circuit skips the per-user grant fetch; `__resetSsoCachesForTests`
+// clears the module-level caches between cases (the caches are process-global,
+// so every test file that touches the SSO endpoints must reset them in
+// `beforeEach` for isolation — mirrors the `__resetBloomCSSForTests` pattern).
+export { resolveApprovedClientOrigin, fetchApprovedClients, userHasGrantedClient };
 
 export function __resetSsoCachesForTests(): void {
   approvedClientsCache = null;


### PR DESCRIPTION
Official apps must never require consent (standing requirement), but the IdP silent paths enforced the per-user FedCMGrant registry for every origin — first-party apps with no grant-recording flow (console.oxy.so) could never silently restore (live fragment evidence: reason=no_grant → stuck on the sign-in screen). The approved-clients payload now carries the trusted subset (same isTrustedApplication predicate as the OAuth consent auto-approve; dev/native + manual rows never trusted); the worker short-circuits userHasGrantedClient for trusted origins (incl. the establish forceRefresh re-check); third-party keeps the full gate; absent/unfetchable trusted set fails closed. api 1403 · worker 150 · tsc 0 · worker builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)