### PR TITLE
fix(console): bundle socket.io-client — realtime session sync was REST-only

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -353,6 +353,7 @@
         "react-resizable-panels": "^4.12.0",
         "shadcn": "^3.7.0",
         "shiki": "^3.21.0",
+        "socket.io-client": "^4.8.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.0.6",
@@ -607,7 +608,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "14.0.0",
+      "version": "14.0.1",
       "dependencies": {
         "@oxyhq/contracts": "0.8.0",
       },

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -38,6 +38,7 @@
     "react-resizable-panels": "^4.12.0",
     "shadcn": "^3.7.0",
     "shiki": "^3.21.0",
+    "socket.io-client": "^4.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.0.6",


### PR DESCRIPTION
SessionClient's lazy import of socket.io-client failed in console's Vite bundle (only app missing the dep) → '[SessionClient] no socket.io-client; running REST-only' (user-reported) → no instant cross-app sync in console. Dep added; built bundle verified to contain the socket client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)