### PR TITLE
fix(scopes): durably include signals:write in application scopes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -607,7 +607,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "14.0.0",
+      "version": "14.0.1",
       "dependencies": {
         "@oxyhq/contracts": "0.8.0",
       },

--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -37,7 +37,10 @@ import AccountMember from '../src/models/AccountMember';
 import { User } from '../src/models/User';
 import { permissionsForAccountRole } from '../src/utils/accountRoles';
 import { logger } from '../src/utils/logger';
-import type { ApplicationScope } from '../src/utils/applicationScopes';
+import {
+  unionValidScopes,
+  type ApplicationScope,
+} from '../src/utils/applicationScopes';
 
 // ── Mirror routes/applications.ts credential generation EXACTLY ──────────────
 const CREDENTIAL_PUBLIC_KEY_PREFIX = 'oxy_dk_';
@@ -128,8 +131,12 @@ const SEED_APPS: SeedAppSpec[] = [
     // resolves federated users. The mint intersects credential scopes with these
     // app scopes, so the app MUST carry federation:write for the credential's
     // federation:write to survive. files:write is needed for federated-media S3
-    // caching (POST /assets/service/cache).
-    scopes: ['user:read', 'files:write', 'federation:write'],
+    // caching (POST /assets/service/cache); files:read for reading cached assets
+    // back (GET /assets/service/*). signals:write lets Mention push cross-app
+    // recommendation signals (interest + interaction-affinity edges) — the
+    // credential already carries it, so the app MUST declare it or the mint's
+    // intersection drops it.
+    scopes: ['user:read', 'files:read', 'files:write', 'federation:write', 'signals:write'],
   },
   {
     name: 'Homiio',
@@ -405,7 +412,9 @@ async function seed(): Promise<void> {
       application.isInternal = desiredAppFields.isInternal;
       application.capabilities = desiredAppFields.capabilities;
       application.redirectUris = desiredAppFields.redirectUris;
-      application.scopes = desiredAppFields.scopes;
+      // Additive union: keep any valid already-granted scope so a re-run never
+      // silently revokes an out-of-band grant (e.g. Mention's signals:write).
+      application.scopes = unionValidScopes(desiredAppFields.scopes, application.scopes);
       application.ownerAccountId = desiredAppFields.ownerAccountId;
       if (application.isModified()) {
         await application.save();

--- a/packages/api/src/routes/__tests__/applications.test.ts
+++ b/packages/api/src/routes/__tests__/applications.test.ts
@@ -507,6 +507,83 @@ describe('GET/PATCH/DELETE /applications/:appId — account-derived RBAC', () =>
 });
 
 // ---------------------------------------------------------------------------
+// PATCH scopes — privileged-scope reconciliation
+//
+// Regression coverage for the root cause of Mention losing its granted, in-use
+// `signals:write` scope: `PATCH /:appId` replaces `application.scopes` with the
+// submitted array, so a non-staff caller submitting a stale/partial scope list
+// (e.g. a console scope-picker whose canonical options omit a newly-added
+// privileged scope) MUST NOT silently revoke an already-granted privileged
+// scope. Non-staff callers can neither add nor drop privileged scopes.
+// ---------------------------------------------------------------------------
+
+describe('PATCH /applications/:appId — privileged scope reconciliation', () => {
+  it('preserves an already-granted privileged scope a non-staff owner omits', async () => {
+    const app = seedApp({ scopes: ['user:read', 'files:write', 'signals:write'] });
+
+    // Simulates the console form re-submitting a canonical list that includes a
+    // newly-added non-privileged scope (files:read) but drops signals:write.
+    const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
+      scopes: ['user:read', 'files:write', 'files:read'],
+    });
+
+    expect(res.status).toBe(200);
+    expect(app.scopes).toContain('signals:write');
+    expect(app.scopes).toEqual(
+      expect.arrayContaining(['user:read', 'files:write', 'files:read', 'signals:write'])
+    );
+    expect(res.body.application?.scopes).toContain('signals:write');
+  });
+
+  it('preserves multiple already-granted privileged scopes on a scope edit', async () => {
+    const app = seedApp({ scopes: ['user:read', 'signals:write', 'federation:write'] });
+
+    const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
+      scopes: ['user:read'],
+    });
+
+    expect(res.status).toBe(200);
+    expect(app.scopes).toEqual(
+      expect.arrayContaining(['user:read', 'signals:write', 'federation:write'])
+    );
+  });
+
+  it('still rejects a non-staff caller adding a new privileged scope', async () => {
+    seedApp({ scopes: ['user:read'] });
+
+    const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
+      scopes: ['user:read', 'signals:write'],
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('lets a STAFF caller intentionally revoke a privileged scope', async () => {
+    actAs(OWNER_ID, true);
+    const app = seedApp({ scopes: ['user:read', 'signals:write'] });
+
+    const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
+      scopes: ['user:read'],
+    });
+
+    expect(res.status).toBe(200);
+    expect(app.scopes).not.toContain('signals:write');
+    expect(app.scopes).toEqual(['user:read']);
+  });
+
+  it('does not duplicate a privileged scope the non-staff caller kept', async () => {
+    const app = seedApp({ scopes: ['user:read', 'signals:write'] });
+
+    const res = await requestJson(server, 'PATCH', `/applications/${APP_ID}`, {
+      scopes: ['user:read', 'signals:write'],
+    });
+
+    expect(res.status).toBe(200);
+    expect(app.scopes.filter((s: string) => s === 'signals:write')).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // List
 // ---------------------------------------------------------------------------
 

--- a/packages/api/src/routes/applications.ts
+++ b/packages/api/src/routes/applications.ts
@@ -160,10 +160,34 @@ function resolveRedirectUris(input: { redirectUris?: string[] }): string[] | und
  * Enforce the staff-only privileged-scope gate when an actor sets an
  * application's scopes.
  *
- * Privileged scopes ({@link isPrivilegedScope}, e.g. `federation:write`) confer
- * act-on-behalf authority and are NOT self-grantable. A NON-STAFF caller is
- * REJECTED with 403 if the scope set they submit adds a privileged scope that
- * was not already present on the application. Returns the validated scope list.
+ * Privileged scopes ({@link isPrivilegedScope}, e.g. `federation:write`,
+ * `signals:write`) confer act-on-behalf authority and are ENTIRELY
+ * staff-controlled: a non-staff caller may neither grant NOR revoke them. Only
+ * platform staff may change an application's privileged-scope set.
+ *
+ * Because `PATCH /:appId` (and create) replace `application.scopes` wholesale
+ * with the submitted array, a naive "reject on newly-added privileged scope"
+ * check would still let a non-staff caller SILENTLY DROP an already-granted
+ * privileged scope simply by omitting it from the payload — e.g. a console
+ * scope-picker form whose canonical option list predates a newly-added
+ * privileged scope submits a set that no longer contains it, and the
+ * authoritative replace revokes it. That is exactly how Mention's granted,
+ * in-use `signals:write` was being wiped on routine app edits, breaking
+ * recommendation signal pushes at the next service-token mint (the mint
+ * intersects credential scopes with app scopes, so losing it on the app loses
+ * it for every credential).
+ *
+ * The gate is therefore symmetric for non-staff callers:
+ * - Adding a privileged scope not already present → 403 (unchanged).
+ * - Omitting an already-granted privileged scope → the scope is PRESERVED
+ *   (re-added to the result), never silently revoked. Removing a privileged
+ *   scope requires staff.
+ *
+ * `previousScopes` supplies the currently-granted set to reconcile against; it
+ * is empty on create (nothing to preserve) and the stored scopes on update.
+ * Staff callers get an authoritative replace of exactly what they submit,
+ * including intentional privileged-scope removal. Returns the validated,
+ * deduplicated scope list.
  */
 function authorizeRequestedScopes(
   req: AuthRequest,
@@ -177,6 +201,8 @@ function authorizeRequestedScopes(
   }
 
   const previouslyGranted = new Set(previousScopes);
+  const requested = new Set(deduped);
+
   const newlyAddedPrivileged = deduped.filter(
     (scope) => isPrivilegedScope(scope) && !previouslyGranted.has(scope)
   );
@@ -191,7 +217,20 @@ function authorizeRequestedScopes(
     );
   }
 
-  return deduped;
+  // Preserve already-granted privileged scopes a non-staff caller omitted:
+  // revoking a privileged scope is a staff-only mutation, so an omission is
+  // treated as "leave it untouched" rather than a silent revoke.
+  const preservedPrivileged = Array.from(previouslyGranted).filter(
+    (scope) => isPrivilegedScope(scope) && !requested.has(scope)
+  );
+  if (preservedPrivileged.length > 0) {
+    logger.warn('Preserving already-granted privileged application scope omitted by non-staff actor', {
+      userId: requireUserId(req),
+      scopes: preservedPrivileged,
+    });
+  }
+
+  return [...deduped, ...preservedPrivileged];
 }
 
 /**

--- a/packages/api/src/utils/__tests__/applicationScopes.test.ts
+++ b/packages/api/src/utils/__tests__/applicationScopes.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for the dependency-free application-scope authority
+ * (`utils/applicationScopes.ts`).
+ *
+ * The two pure reconcilers under test are the single source of truth for how an
+ * application's granted scopes flow into a service token:
+ *
+ *   - `intersectScopes` — effective credential scopes = credential ∩ app scopes.
+ *     A credential can never exceed its app's grant.
+ *   - `unionValidScopes` — additive rebuild of an app's scopes from a canonical
+ *     (declarative) list. Guards the ROOT CAUSE that dropped Mention's granted,
+ *     in-use `signals:write`: a destructive `application.scopes = seedScopes`
+ *     rebuild silently revoked an out-of-band grant, and because the mint
+ *     intersects credential ∩ app scopes, the credential lost it too.
+ */
+
+import {
+  intersectScopes,
+  unionValidScopes,
+  isPrivilegedScope,
+  isValidApplicationScope,
+} from '../applicationScopes';
+
+describe('intersectScopes (credential ∩ app grant)', () => {
+  it('keeps only scopes present on both sides, preserving credential order', () => {
+    expect(
+      intersectScopes(['signals:write', 'user:read'], ['user:read', 'files:write', 'signals:write'])
+    ).toEqual(['signals:write', 'user:read']);
+  });
+
+  it('drops a credential scope the app no longer grants', () => {
+    // Exactly the failure mode: the app lost signals:write, so the mint drops it.
+    expect(intersectScopes(['signals:write', 'user:read'], ['user:read', 'files:write'])).toEqual([
+      'user:read',
+    ]);
+  });
+
+  it('drops unknown scopes and de-duplicates', () => {
+    expect(
+      intersectScopes(['user:read', 'user:read', 'bogus:scope'], ['user:read', 'bogus:scope'])
+    ).toEqual(['user:read']);
+  });
+});
+
+describe('unionValidScopes (additive canonical rebuild)', () => {
+  it('preserves an already-granted scope the canonical list omits', () => {
+    // The seed's canonical Mention list historically omitted signals:write; the
+    // union must NOT revoke the already-granted, in-use scope.
+    expect(
+      unionValidScopes(
+        ['user:read', 'files:write', 'federation:write'],
+        ['user:read', 'files:write', 'federation:write', 'signals:write']
+      )
+    ).toEqual(['user:read', 'files:write', 'federation:write', 'signals:write']);
+  });
+
+  it('adds scopes newly declared in the canonical list', () => {
+    expect(unionValidScopes(['user:read', 'files:read'], ['user:read'])).toEqual([
+      'user:read',
+      'files:read',
+    ]);
+  });
+
+  it('orders canonical scopes first, then extra granted scopes, de-duplicated', () => {
+    expect(
+      unionValidScopes(['user:read', 'files:write'], ['signals:write', 'user:read'])
+    ).toEqual(['user:read', 'files:write', 'signals:write']);
+  });
+
+  it('drops unknown/legacy stored scopes that can never survive a mint', () => {
+    expect(unionValidScopes(['user:read'], ['user:read', 'legacy:scope'])).toEqual(['user:read']);
+  });
+
+  it('returns the canonical set when there is nothing extra granted', () => {
+    expect(unionValidScopes(['user:read', 'files:write'], [])).toEqual(['user:read', 'files:write']);
+  });
+
+  it('is a no-op fixed point once the canonical list already contains the grant', () => {
+    const canonical = ['user:read', 'files:read', 'files:write', 'federation:write', 'signals:write'];
+    expect(unionValidScopes(canonical, canonical)).toEqual(canonical);
+  });
+});
+
+describe('scope classification helpers', () => {
+  it('recognises signals:write as a valid privileged scope', () => {
+    expect(isValidApplicationScope('signals:write')).toBe(true);
+    expect(isPrivilegedScope('signals:write')).toBe(true);
+  });
+
+  it('treats a plain read scope as valid but not privileged', () => {
+    expect(isValidApplicationScope('files:read')).toBe(true);
+    expect(isPrivilegedScope('files:read')).toBe(false);
+  });
+
+  it('rejects an unknown scope', () => {
+    expect(isValidApplicationScope('bogus:scope')).toBe(false);
+    expect(isPrivilegedScope('bogus:scope')).toBe(false);
+  });
+});

--- a/packages/api/src/utils/applicationScopes.ts
+++ b/packages/api/src/utils/applicationScopes.ts
@@ -114,3 +114,34 @@ export function intersectScopes(
   }
   return result;
 }
+
+/**
+ * Reconcile a canonical (declarative) scope set with the scopes already granted
+ * on a stored application ADDITIVELY: the result is the UNION of both, in a
+ * stable order (canonical first, then any additional already-granted scope),
+ * de-duplicated, with unknown/legacy scopes dropped.
+ *
+ * This is the single authority for any "rebuild an application's scopes from a
+ * canonical list" path (the official-app seed today; any future ensure/rebuild
+ * routine). A destructive replace of `application.scopes` with only the
+ * canonical list silently REVOKES a legitimately-granted, in-use scope that was
+ * added out-of-band — and because {@link intersectScopes} intersects credential
+ * scopes with app scopes at every service-token mint, the credential loses the
+ * scope too. Using a union makes it IMPOSSIBLE for a granted, valid scope to
+ * vanish on the next rebuild. Intentionally REMOVING a scope is therefore an
+ * explicit operation on the app record, never a side effect of a rebuild.
+ */
+export function unionValidScopes(
+  canonicalScopes: readonly string[],
+  existingScopes: readonly string[]
+): ApplicationScope[] {
+  const result: ApplicationScope[] = [];
+  const seen = new Set<string>();
+  for (const scope of [...canonicalScopes, ...existingScopes]) {
+    if (seen.has(scope)) continue;
+    if (!isValidApplicationScope(scope)) continue;
+    seen.add(scope);
+    result.push(scope);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `seed-oxy-applications.ts` was destructively overwriting `application.scopes` on each seed run, silently dropping any scopes (like `signals:write`) that were granted outside the seed definition. Now uses `unionValidScopes()` to additively reconcile scopes — never drops a valid already-granted scope.
- **Scope preservation in `authorizeRequestedScopes`:** Non-staff callers can no longer silently drop privileged scopes by omitting them from the update payload; already-granted privileged scopes are preserved unless explicitly removed by staff.
- **New `unionValidScopes` helper:** Pure additive reconciliation utility in `packages/api/src/utils/applicationScopes.ts`, with 12 unit tests covering all edge cases.
- **Mention canonical scope spec updated:** `signals:write` + `files:read` are now declared in the seed so the Mention application always has them after any re-seed.

## Test plan

- [x] `bun run --filter @oxyhq/contracts build` — exit 0
- [x] `bun run --filter @oxyhq/api build` — exit 0
- [x] `bun run --cwd packages/api lint` — 0 errors (222 pre-existing warnings, none in changed files)
- [x] `cd packages/api && bunx jest` — 148 suites / 1420 tests all pass
- [x] `bun install --frozen-lockfile` — passes (1-line lockfile reconciliation for pre-existing `@oxyhq/services` 14.0.0→14.0.1 drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)