### PR TITLE
fix(session): statically inject the socket.io factory — realtime sync independent of bundler dynamic-import support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -154,7 +154,6 @@
         "@types/gridfs-stream": "^0.5.39",
         "@types/http-errors": "^2.0.4",
         "@types/mongodb": "^4.0.7",
-        "@types/socket.io-client": "^1.4.36",
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
         "eslint": "^9.0.0",
@@ -2171,8 +2170,6 @@
     "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, ""],
 
     "@types/smtp-server": ["@types/smtp-server@3.5.13", "", { "dependencies": { "@types/node": "*", "@types/nodemailer": "*" } }, "sha512-S3rGl2KbViH+98/CgHipPIWgtAFnjxLsppxIRbgJHNuZL7Y+py+7kZjT7xS+wOmCxYTn4O7IqLqkvekg99MDVQ=="],
-
-    "@types/socket.io-client": ["@types/socket.io-client@1.4.36", "", {}, ""],
 
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, ""],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -108,7 +108,6 @@
     "@types/gridfs-stream": "^0.5.39",
     "@types/http-errors": "^2.0.4",
     "@types/mongodb": "^4.0.7",
-    "@types/socket.io-client": "^1.4.36",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "eslint": "^9.0.0",

--- a/packages/auth-sdk/__tests__/sessionClientWiring.test.tsx
+++ b/packages/auth-sdk/__tests__/sessionClientWiring.test.tsx
@@ -278,4 +278,26 @@ describe('SessionClient wiring into WebOxyProvider (Task 1 — additive, inert u
     expect(latest.userId).toBeNull();
     expect(stubs.getUsersByIds).not.toHaveBeenCalled();
   });
+
+  it('injects the statically-imported socket.io factory as the third createSessionClient argument', async () => {
+    // Realtime sync must not rely on core's lazy dynamic import of a bare
+    // specifier under Vite: WebOxyProvider statically imports `io` from
+    // socket.io-client (a real @oxyhq/auth dependency) and passes it through as
+    // the SessionClient socketFactory.
+    const fake = buildFakeClient(null);
+    mockedCreateSessionClient.mockReturnValue({
+      client: fake.fakeClient as never,
+      host: { setCurrentAccountId: jest.fn() } as never,
+    });
+
+    let latest: ProbeState = { isAuthenticated: false, userId: null, sessionsLength: 0, activeSessionId: null };
+    renderProvider((s) => { latest = s; });
+    await waitFor(() => expect(latest.isAuthenticated).toBe(false));
+
+    expect(mockedCreateSessionClient).toHaveBeenCalledTimes(1);
+    const args = mockedCreateSessionClient.mock.calls[0];
+    expect(args).toHaveLength(3);
+    // The third positional arg is the injected socket.io `io` factory.
+    expect(typeof args[2]).toBe('function');
+  });
 });

--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -61,6 +61,7 @@ import type {
   ColdBootOutcome,
   SsoReturnKind,
 } from '@oxyhq/core';
+import { io } from 'socket.io-client';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { attachQueryPersistence, clearQueryCache, createQueryClient } from './hooks/queryClient';
 import { isWebBrowser } from './hooks/useWebSSO';
@@ -629,7 +630,12 @@ export function WebOxyProvider({
   // fall back to or go stale against.
   const sessionClientPairRef = useRef<ReturnType<typeof createSessionClient> | null>(null);
   if (!sessionClientPairRef.current) {
-    sessionClientPairRef.current = createSessionClient(oxyServices, createWebTokenTransport(oxyServices));
+    // `io` (socket.io-client, a real @oxyhq/auth dependency) is STATICALLY
+    // imported and injected as the SessionClient socketFactory so realtime
+    // session sync survives Vite/Rolldown bundling of the published core dist —
+    // core's lazy dynamic `import('socket.io-client')` of a bare specifier does
+    // not resolve reliably there.
+    sessionClientPairRef.current = createSessionClient(oxyServices, createWebTokenTransport(oxyServices), io);
   }
   const { client: sessionClient, host: sessionClientHost } = sessionClientPairRef.current;
 

--- a/packages/auth-sdk/tsconfig.json
+++ b/packages/auth-sdk/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM"],
+    "typeRoots": ["./node_modules/@types"],
     "declaration": true,
     "strict": true,
     "esModuleInterop": true,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -572,6 +572,10 @@ export type {
 // ---------------------------------------------------------------------------
 export { SessionClient } from './session/SessionClient';
 export type { TokenTransport, SessionClientHost, SessionClientOptions } from './session/SessionClient';
+// The injectable socket factory type: consumers that bundle socket.io-client
+// (services/auth-sdk) pass its `io` export as `socketFactory` so realtime sync
+// never relies on core's lazy dynamic import of a bare specifier.
+export type { SocketIOFactory, MinimalSocket } from './session/socketLoader';
 
 // Shared SessionClient integration layer: the host adapter, the pure
 // DeviceSessionState projection helpers, and the client factory are defined

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -6,7 +6,7 @@ import {
 } from '@oxyhq/contracts';
 import { logger } from '../utils/loggerUtils';
 import { getSocketIO } from './socketLoader';
-import type { MinimalSocket } from './socketLoader';
+import type { MinimalSocket, SocketIOFactory } from './socketLoader';
 
 export interface TokenTransport {
   /** Ensure this app holds a per-domain access token for state.activeAccountId (mint via FedCM/silent/sso/keychain). Best-effort. */
@@ -24,6 +24,18 @@ export interface SessionClientHost {
 
 export interface SessionClientOptions {
   transport?: TokenTransport;
+  /**
+   * Statically-injected `socket.io-client` factory (its `io` export).
+   * `@oxyhq/services` and `@oxyhq/auth` list `socket.io-client` as a real
+   * dependency and pass `io` in directly, so realtime session sync never
+   * depends on a runtime dynamic `import('socket.io-client')` of a bare
+   * specifier — which is bundler-fragile in Metro/Expo-web and Vite when
+   * `@oxyhq/core` is consumed as its published dist (the import resolves to
+   * nothing → `connectSocket` warns and falls back to REST-only). When this is
+   * provided, `connectSocket` uses it and never touches the lazy loader; when
+   * absent it falls back to `getSocketIO()`.
+   */
+  socketFactory?: SocketIOFactory;
 }
 
 type StateListener = (state: DeviceSessionState | null) => void;
@@ -157,7 +169,10 @@ export class SessionClient {
   }
 
   private async connectSocket(): Promise<void> {
-    const io = await getSocketIO();
+    // Prefer a statically-injected factory (services/auth-sdk bundle
+    // socket.io-client as a real dep); fall back to the lazy loader — and warn
+    // if THAT yields nothing — only when no factory was injected.
+    const io = this.options.socketFactory ?? (await getSocketIO());
     if (!io) {
       logger.warn('[SessionClient] no socket.io-client; running REST-only (no realtime sync)', { component: 'SessionClient' });
       return;

--- a/packages/core/src/session/__tests__/SessionClient.socketFactory.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.socketFactory.test.ts
@@ -1,0 +1,79 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import * as socketLoader from '../socketLoader';
+import type { MinimalSocket, SocketIOFactory } from '../socketLoader';
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+
+/**
+ * P0 (bundler-fragility): SessionClient must NOT depend on a runtime dynamic
+ * `import('socket.io-client')` when a consumer (services/auth-sdk) injects the
+ * `io` factory statically. These tests pin the two branches of `connectSocket`:
+ *
+ *  1. `socketFactory` injected  → the injected factory is used and the lazy
+ *     loader (`getSocketIO`) is NEVER invoked (the exact call that fails in the
+ *     Metro/Expo-web + Vite published-dist consumers).
+ *  2. no `socketFactory`        → the lazy loader IS invoked (fallback).
+ */
+
+type Handler = (...args: unknown[]) => void;
+class FakeSocket implements MinimalSocket {
+  connected = false;
+  handlers = new Map<string, Handler[]>();
+  on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
+  off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+  connect() { this.connected = true; }
+  disconnect() { this.connected = false; }
+}
+
+const STATE = (rev: number): DeviceSessionState => ({ deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000 });
+const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
+
+function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
+  return {
+    makeRequest: jest.fn().mockResolvedValue(SYNC(1)),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 'tok',
+    onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => 'a1',
+    ...over,
+  };
+}
+
+describe('SessionClient injected socketFactory', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses the injected factory and NEVER invokes the lazy loader', async () => {
+    const loaderSpy = jest.spyOn(socketLoader, 'getSocketIO');
+    let created: FakeSocket | null = null;
+    const factory: SocketIOFactory = jest.fn((_uri: string) => {
+      created = new FakeSocket();
+      created.connected = true;
+      return created;
+    });
+
+    const client = new SessionClient(makeHost(), { socketFactory: factory });
+    await client.start();
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith('http://test.invalid', expect.objectContaining({ transports: ['websocket'] }));
+    expect(loaderSpy).not.toHaveBeenCalled();
+    expect(created).not.toBeNull();
+    client.stop();
+  });
+
+  it('falls back to the lazy loader when no factory is injected', async () => {
+    const fake = new FakeSocket();
+    fake.connected = true;
+    const lazyFactory: SocketIOFactory = jest.fn(() => fake);
+    const loaderSpy = jest.spyOn(socketLoader, 'getSocketIO').mockResolvedValue(lazyFactory);
+
+    const client = new SessionClient(makeHost());
+    await client.start();
+
+    expect(loaderSpy).toHaveBeenCalledTimes(1);
+    expect(lazyFactory).toHaveBeenCalledWith('http://test.invalid', expect.objectContaining({ transports: ['websocket'] }));
+    client.stop();
+  });
+});

--- a/packages/core/src/session/createSessionClient.ts
+++ b/packages/core/src/session/createSessionClient.ts
@@ -1,5 +1,6 @@
 import type { OxyServices } from '../OxyServices';
 import { SessionClient, type TokenTransport } from './SessionClient';
+import type { SocketIOFactory } from './socketLoader';
 import { createSessionClientHost } from './sessionClientHost';
 
 /**
@@ -17,15 +18,22 @@ import { createSessionClientHost } from './sessionClientHost';
  * The host is returned alongside the client (not just the client) so the
  * caller can call `host.setCurrentAccountId(...)` as the active account
  * changes.
+ *
+ * `socketFactory` is the statically-injected `socket.io-client` `io` export.
+ * Consumers that bundle socket.io-client as a real dependency pass it so
+ * realtime sync never depends on core's lazy dynamic import of a bare
+ * specifier (bundler-fragile in Metro/Expo-web and Vite against the published
+ * dist). When omitted, the client falls back to the lazy loader.
  */
 export function createSessionClient(
   oxyServices: OxyServices,
   transport: TokenTransport,
+  socketFactory?: SocketIOFactory,
 ): {
   client: SessionClient;
   host: ReturnType<typeof createSessionClientHost>;
 } {
   const host = createSessionClientHost(oxyServices);
-  const client = new SessionClient(host, { transport });
+  const client = new SessionClient(host, { transport, socketFactory });
   return { client, host };
 }

--- a/packages/services/src/ui/session/__tests__/createSessionClient.test.ts
+++ b/packages/services/src/ui/session/__tests__/createSessionClient.test.ts
@@ -1,4 +1,19 @@
 import { SessionClient } from '@oxyhq/core';
+
+type Handler = (...args: unknown[]) => void;
+class FakeSocket {
+  connected = false;
+  on(_event: string, _cb: Handler) {}
+  off(_event: string, _cb?: Handler) {}
+  connect() { this.connected = true; }
+  disconnect() { this.connected = false; }
+}
+const ioMock = jest.fn((_uri: string, _opts?: Record<string, unknown>) => new FakeSocket());
+// `createSessionClient` STATICALLY imports `io` from socket.io-client and injects it as
+// the SessionClient `socketFactory`; this mock stands in for that real dependency so the
+// wiring test can assert the factory reaches — and is invoked by — the client.
+jest.mock('socket.io-client', () => ({ __esModule: true, io: (...args: unknown[]) => ioMock(...(args as [string, Record<string, unknown>?])) }));
+
 import { createSessionClient } from '../createSessionClient';
 
 function fakeOxy() {
@@ -37,5 +52,18 @@ describe('createSessionClient', () => {
     expect(host.getCurrentAccountId()).toBeNull();
     host.setCurrentAccountId('u1');
     expect(host.getCurrentAccountId()).toBe('u1');
+  });
+
+  test('injects the statically-imported socket.io factory — start() opens a socket without the lazy loader', async () => {
+    ioMock.mockClear();
+    const oxy = fakeOxy();
+
+    const { client } = createSessionClient(oxy as never);
+    await client.start();
+
+    // The injected `io` was used to open the session socket at the base URL.
+    expect(ioMock).toHaveBeenCalledTimes(1);
+    expect(ioMock).toHaveBeenCalledWith('https://api.oxy.so', expect.objectContaining({ transports: ['websocket'] }));
+    client.stop();
   });
 });

--- a/packages/services/src/ui/session/createSessionClient.ts
+++ b/packages/services/src/ui/session/createSessionClient.ts
@@ -1,5 +1,6 @@
 import type { OxyServices } from '@oxyhq/core';
 import { SessionClient } from '@oxyhq/core';
+import { io } from 'socket.io-client';
 import { createSessionClientHost } from './sessionClientHost';
 import { createTokenTransport } from './tokenTransport';
 
@@ -9,6 +10,13 @@ import { createTokenTransport } from './tokenTransport';
  * `OxyServices` instance, and returns both the client and the host — the host
  * is returned (not just the client) so `OxyContext` (Fase 3-B) can call
  * `host.setCurrentAccountId(...)` as the active account changes.
+ *
+ * `socket.io-client`'s `io` is STATICALLY imported and injected as the
+ * `SessionClient` `socketFactory` (socket.io-client is a real dependency of
+ * `@oxyhq/services`). This is what keeps realtime session sync working in the
+ * Metro/Expo-web bundle: core's lazy dynamic `import('socket.io-client')` of a
+ * bare specifier does not resolve reliably against the published core dist, so
+ * the app-bundled static import is the reliable source of the factory.
  */
 export function createSessionClient(oxyServices: OxyServices): {
   client: SessionClient;
@@ -16,6 +24,6 @@ export function createSessionClient(oxyServices: OxyServices): {
 } {
   const host = createSessionClientHost(oxyServices);
   const transport = createTokenTransport(oxyServices);
-  const client = new SessionClient(host, { transport });
+  const client = new SessionClient(host, { transport, socketFactory: io });
   return { client, host };
 }


### PR DESCRIPTION
## Problem

`SessionClient` loaded `socket.io-client` via a lazy bare-specifier dynamic `import('socket.io-client')` inside `@oxyhq/core`'s **published dist**. That is bundler-fragile by class: when core is consumed as its compiled dist, Metro/Expo-web (mention.earth) and Vite (console) do not reliably resolve the bare specifier — the import yields nothing, `connectSocket` warns and silently falls back to **REST-only, no realtime session sync**. mention.earth's Metro web export hit exactly this; console's Vite build needed an app-level `socket.io-client` dep as a workaround.

## Fix — statically inject the factory

`SessionClient`/`createSessionClient` now accept an optional `socketFactory` (`SocketIOFactory`). `@oxyhq/services` and `@oxyhq/auth` — both of which declare `socket.io-client` as a **real dependency** and are always bundled from `lib`/source by the consuming app — `import { io }` statically and inject it at every construction site.

- `connectSocket` prefers the injected factory and never touches the lazy loader when one is provided.
- The lazy `getSocketIO()` loader remains **only** as a no-factory fallback (unchanged behavior when nobody injects).
- New public exports from `@oxyhq/core`: `SocketIOFactory`, `MinimalSocket` types.

Realtime sync is now independent of bundler dynamic-import support.

## Also in this commit

- Removes the phantom `@types/socket.io-client@1.4.36` dev-dep from `@oxyhq/api` (dead dep — the API is a socket.io **server**; the DefinitelyTyped v1 types shadowed socket.io v4's own bundled types monorepo-wide). Lockfile regenerated in the same commit.
- Scopes `@oxyhq/auth`'s tsconfig `typeRoots` to `./node_modules/@types` (mirrors `@oxyhq/services`) so the removed v1 DT types no longer leak in.

## Verification (local, this branch on top of main)

- `bun install --frozen-lockfile` — clean, no drift
- contracts build, `core:build` — clean
- core `bun run test` — **791 passed** (includes new `SessionClient.socketFactory.test.ts` + `createSessionClient` wiring test)
- services `bun run test` — **254 passed**; services `tsc --noEmit` — clean
- auth-sdk `bun run test` — **101 passed**; auth-sdk `tsc --noEmit` — clean
- `auth:build` + `services:build` — clean
- api `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
