### PR TITLE
chore(release): @oxyhq/core@5.5.0 + @oxyhq/services@14.1.0 (injected socket factory)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -391,7 +391,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "5.4.3",
+      "version": "5.5.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:^",
         "@oxyhq/protocol": "workspace:^",
@@ -607,7 +607,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "14.0.1",
+      "version": "14.1.0",
       "dependencies": {
         "@oxyhq/contracts": "0.8.0",
       },
@@ -615,7 +615,7 @@
         "@biomejs/biome": "^1.9.4",
         "@commitlint/cli": "^17.6.5",
         "@commitlint/config-conventional": "^17.6.5",
-        "@oxyhq/core": "^5.4.2",
+        "@oxyhq/core": "^5.5.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@react-native/babel-preset": "^0.86.0",
@@ -656,7 +656,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.16.0",
-        "@oxyhq/core": "^5.4.2",
+        "@oxyhq/core": "^5.5.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@tanstack/query-async-storage-persister": "^5.101",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "5.4.3",
+  "version": "5.5.0",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "14.0.1",
+  "version": "14.1.0",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -109,7 +109,7 @@
     "@oxyhq/contracts": "0.8.0"
   },
   "devDependencies": {
-    "@oxyhq/core": "^5.4.2",
+    "@oxyhq/core": "^5.5.0",
     "nativewind": "5.0.0-preview.3",
     "react-native-css": "^3.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
@@ -153,7 +153,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.16.0",
-    "@oxyhq/core": "^5.4.2",
+    "@oxyhq/core": "^5.5.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@tanstack/query-async-storage-persister": "^5.101",


### PR DESCRIPTION
## Release

Version bumps for the socket-inject fix (already published to npm):

| Package | From | To | Bump |
|---------|------|----|----|
| `@oxyhq/core` | 5.4.3 | **5.5.0** | minor — new public `SocketIOFactory`/`MinimalSocket` exports + optional `socketFactory` param on `SessionClient`/`createSessionClient` |
| `@oxyhq/services` | 14.0.1 | **14.1.0** | minor — statically injects `socket.io-client`'s `io` as the `SessionClient` `socketFactory` |

### Why the core peer range bump

`@oxyhq/services` peer + dev `@oxyhq/core` range is raised `^5.4.2` → **`^5.5.0`**. The socket-factory handling lives in `connectSocket` (`socketFactory ?? getSocketIO()`) which only exists in core ≥ 5.5.0. Pinning the peer to `^5.5.0` guarantees a consumer of services 14.1.0 pulls a core that actually reads the injected factory — otherwise the old core silently ignores `socketFactory` and the realtime-sync bug persists.

### Verification

- `bun install` — lockfile regenerated, drift limited to the two `@oxyhq/core` range lines (committed in this same commit)
- contracts → core → services builds clean
- core `bun run test` — **791 passed**
- services `bun run test` — **254 passed**
- Published: `@oxyhq/core@5.5.0`, `@oxyhq/services@14.1.0` (`bun publish --access public`, tag `latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
