### PR TITLE
feat(auth): direct IdP sign-in joins the browser's central device session

### DIFF
--- a/packages/api/src/controllers/__tests__/sessionAccess.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/sessionAccess.controller.test.ts
@@ -107,6 +107,18 @@ jest.mock('../../services/signature.service', () => ({
   default: {},
 }));
 
+// session.controller imports deviceSession.service for the central device-join
+// path; mock it (and the socket broadcast helper) so the DeviceSession model —
+// which touches the mocked Mongoose Schema.Types — is never loaded here.
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: { addAccount: jest.fn() },
+}));
+
+jest.mock('../../utils/socket', () => ({
+  broadcastDeviceState: jest.fn(),
+}));
+
 jest.mock('../../utils/deviceUtils', () => ({
   getDeviceActiveSessions: jest.fn(),
   logoutAllDeviceSessions: jest.fn(),

--- a/packages/api/src/controllers/__tests__/signIn.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/signIn.controller.test.ts
@@ -16,6 +16,9 @@ const mockVerifyPassword = jest.fn();
 const mockHashPassword = jest.fn();
 const mockValidatePasswordStrength = jest.fn();
 const mockCreateSession = jest.fn();
+const mockGetSession = jest.fn();
+const mockAddAccount = jest.fn();
+const mockBroadcastDeviceState = jest.fn();
 const mockCheckForAnomalies = jest.fn().mockResolvedValue({ hasAnomalies: false });
 const mockIsLockedOut = jest.fn();
 const mockRecordFailure = jest.fn();
@@ -57,7 +60,16 @@ jest.mock('../../utils/password', () => ({
 
 jest.mock('../../services/session.service', () => ({
   __esModule: true,
-  default: { createSession: mockCreateSession },
+  default: { createSession: mockCreateSession, getSession: mockGetSession },
+}));
+
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: { addAccount: mockAddAccount },
+}));
+
+jest.mock('../../utils/socket', () => ({
+  broadcastDeviceState: mockBroadcastDeviceState,
 }));
 
 jest.mock('../../services/anomalyDetection.service', () => ({
@@ -217,6 +229,119 @@ describe('SessionController.signIn (H5)', () => {
     expect(mockClearFailures).toHaveBeenCalledWith({ scope: 'login', identifier: 'alice' });
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ sessionId: 's1', accessToken: 'tok' })
+    );
+  });
+});
+
+describe('SessionController.signIn — central device join (priorSessionId)', () => {
+  const activeUser = {
+    _id: { toString: () => 'user-1' },
+    password: 'real-hash',
+    username: 'alice',
+    twoFactorAuth: { enabled: false },
+  };
+  const createdSession = {
+    sessionId: 'new-sess',
+    deviceId: 'device-A',
+    expiresAt: new Date(Date.now() + 60_000),
+    accessToken: 'tok',
+    deviceInfo: { deviceName: 'x', deviceType: 'desktop', platform: 'web' },
+  };
+
+  beforeEach(() => {
+    mockVerifyPassword.mockResolvedValue(true);
+    mockCreateSession.mockResolvedValue(createdSession);
+    mockAddAccount.mockResolvedValue({ state: { deviceId: 'device-A' }, changed: true });
+  });
+
+  it('inherits the prior ACTIVE session deviceId, registers the account, and broadcasts', async () => {
+    mockUserFindOne.mockReturnValueOnce(makeQuery(activeUser));
+    // getSession only returns ACTIVE, unexpired sessions.
+    mockGetSession.mockResolvedValueOnce({ sessionId: 'prior-sess', deviceId: 'device-A' });
+
+    const res = createMockRes();
+    await SessionController.signIn(
+      createReq({ identifier: 'alice', password: 'right', priorSessionId: 'prior-sess' }),
+      res
+    );
+
+    // The prior sessionId is re-validated server-side (never a client deviceId).
+    expect(mockGetSession).toHaveBeenCalledWith('prior-sess', true);
+    // createSession inherits the prior device's central deviceId verbatim.
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      'user-1',
+      expect.anything(),
+      expect.objectContaining({ deviceId: 'device-A' })
+    );
+    // The freshly-authenticated account is registered into the device authority.
+    expect(mockAddAccount).toHaveBeenCalledWith(
+      'device-A',
+      expect.objectContaining({ accountId: 'user-1', sessionId: 'new-sess' })
+    );
+    // A changed device state is broadcast to the device room.
+    expect(mockBroadcastDeviceState).toHaveBeenCalledTimes(1);
+    // Response shape is unchanged (still the session auth response).
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'new-sess', accessToken: 'tok' })
+    );
+  });
+
+  it('does not broadcast when addAccount reports no change (idempotent re-register)', async () => {
+    mockUserFindOne.mockReturnValueOnce(makeQuery(activeUser));
+    mockGetSession.mockResolvedValueOnce({ sessionId: 'prior-sess', deviceId: 'device-A' });
+    mockAddAccount.mockResolvedValueOnce({ state: { deviceId: 'device-A' }, changed: false });
+
+    const res = createMockRes();
+    await SessionController.signIn(
+      createReq({ identifier: 'alice', password: 'right', priorSessionId: 'prior-sess' }),
+      res
+    );
+
+    expect(mockAddAccount).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastDeviceState).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'new-sess' })
+    );
+  });
+
+  it('ignores an INACTIVE prior session — no device join, no error', async () => {
+    mockUserFindOne.mockReturnValueOnce(makeQuery(activeUser));
+    // getSession returns null for a signed-out / expired session.
+    mockGetSession.mockResolvedValueOnce(null);
+
+    const res = createMockRes();
+    await SessionController.signIn(
+      createReq({ identifier: 'alice', password: 'right', priorSessionId: 'dead-sess' }),
+      res
+    );
+
+    expect(mockGetSession).toHaveBeenCalledWith('dead-sess', true);
+    // No inherited deviceId is threaded into createSession.
+    const createOptions = mockCreateSession.mock.calls[0][2];
+    expect(createOptions.deviceId).toBeUndefined();
+    expect(mockAddAccount).not.toHaveBeenCalled();
+    expect(mockBroadcastDeviceState).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'new-sess' })
+    );
+  });
+
+  it('is a no-op device-wise when no priorSessionId is supplied (today\'s behavior)', async () => {
+    mockUserFindOne.mockReturnValueOnce(makeQuery(activeUser));
+
+    const res = createMockRes();
+    await SessionController.signIn(
+      createReq({ identifier: 'alice', password: 'right' }),
+      res
+    );
+
+    expect(mockGetSession).not.toHaveBeenCalled();
+    const createOptions = mockCreateSession.mock.calls[0][2];
+    expect(createOptions.deviceId).toBeUndefined();
+    expect(mockAddAccount).not.toHaveBeenCalled();
+    expect(mockBroadcastDeviceState).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'new-sess' })
     );
   });
 });

--- a/packages/api/src/controllers/__tests__/twoFactorDeviceJoin.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/twoFactorDeviceJoin.controller.test.ts
@@ -1,0 +1,148 @@
+/**
+ * verify2FALogin — central device join (priorSessionId)
+ *
+ * A 2FA-completed login must behave like the password sign-in path: when the
+ * browser already has an account signed in (the IdP threads its active device
+ * session as `priorSessionId`), the finalized session inherits that device's
+ * central deviceId and the account is registered into the device authority.
+ *
+ * The real helper behavior (server-side sessionId re-validation + addAccount +
+ * broadcast) is covered end-to-end by signIn.controller.test.ts. Here we mock
+ * the shared helpers to assert `verify2FALogin` threads through them correctly.
+ */
+
+const mockJwtVerify = jest.fn();
+const mockFindById = jest.fn();
+const mockVerifyToken = jest.fn();
+const mockCreateSession = jest.fn();
+const mockResolvePriorDeviceId = jest.fn();
+const mockJoinDeviceAfterSignIn = jest.fn();
+const mockBuildSessionAuthResponse = jest.fn();
+const mockIsLockedOut = jest.fn();
+const mockRecordFailure = jest.fn();
+const mockClearFailures = jest.fn();
+
+jest.mock('jsonwebtoken', () => ({
+  __esModule: true,
+  default: { verify: mockJwtVerify, sign: jest.fn() },
+  verify: mockJwtVerify,
+  sign: jest.fn(),
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: { findById: mockFindById },
+}));
+
+jest.mock('../../services/twoFactor.service', () => ({
+  __esModule: true,
+  default: { verifyToken: mockVerifyToken, verifyBackupCode: jest.fn() },
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: mockCreateSession },
+}));
+
+jest.mock('../session.controller', () => ({
+  __esModule: true,
+  buildSessionAuthResponse: mockBuildSessionAuthResponse,
+  resolvePriorDeviceId: mockResolvePriorDeviceId,
+  joinDeviceAfterSignIn: mockJoinDeviceAfterSignIn,
+}));
+
+jest.mock('../../services/securityActivityService', () => ({
+  __esModule: true,
+  default: { logSignIn: jest.fn(), logSecurityEvent: jest.fn() },
+}));
+
+jest.mock('../../services/loginLockout.service', () => ({
+  isLockedOut: mockIsLockedOut,
+  recordFailure: mockRecordFailure,
+  clearFailures: mockClearFailures,
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import { Request, Response } from 'express';
+import { verify2FALogin } from '../twoFactor.controller';
+
+function createMockRes(): Response {
+  const res = {} as Partial<Response>;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+function createReq(body: Record<string, unknown>): Request {
+  return { body, headers: {}, ip: '127.0.0.1' } as unknown as Request;
+}
+
+const finalizedSession = {
+  sessionId: 'new-sess',
+  deviceId: 'device-A',
+  expiresAt: new Date(Date.now() + 60_000),
+  accessToken: 'tok',
+  deviceInfo: { deviceName: 'x', deviceType: 'desktop', platform: 'web' },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.ACCESS_TOKEN_SECRET = 'test-secret';
+  mockJwtVerify.mockReturnValue({ userId: 'user-1', purpose: '2fa_challenge' });
+  mockIsLockedOut.mockResolvedValue({ locked: false });
+  mockClearFailures.mockResolvedValue(undefined);
+  mockVerifyToken.mockReturnValue(true);
+  mockFindById.mockReturnValue({
+    select: jest.fn().mockResolvedValue({
+      _id: { toString: () => 'user-1' },
+      twoFactorAuth: { enabled: true, secret: 'totp-secret' },
+      save: jest.fn().mockResolvedValue(undefined),
+    }),
+  });
+  mockCreateSession.mockResolvedValue(finalizedSession);
+  mockBuildSessionAuthResponse.mockReturnValue({ sessionId: 'new-sess', accessToken: 'tok' });
+});
+
+describe('verify2FALogin — central device join', () => {
+  it('inherits the prior device and registers the account when priorSessionId resolves', async () => {
+    mockResolvePriorDeviceId.mockResolvedValueOnce('device-A');
+
+    const res = createMockRes();
+    await verify2FALogin(
+      createReq({ loginToken: 'lt', token: '123456', priorSessionId: 'prior-sess' }),
+      res
+    );
+
+    expect(mockResolvePriorDeviceId).toHaveBeenCalledWith('prior-sess');
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      'user-1',
+      expect.anything(),
+      expect.objectContaining({ deviceId: 'device-A' })
+    );
+    expect(mockJoinDeviceAfterSignIn).toHaveBeenCalledWith('device-A', 'user-1', 'new-sess');
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'new-sess' })
+    );
+  });
+
+  it('does not join the device when priorSessionId is absent/inactive', async () => {
+    mockResolvePriorDeviceId.mockResolvedValueOnce(null);
+
+    const res = createMockRes();
+    await verify2FALogin(
+      createReq({ loginToken: 'lt', token: '123456' }),
+      res
+    );
+
+    const createOptions = mockCreateSession.mock.calls[0][2];
+    expect(createOptions.deviceId).toBeUndefined();
+    expect(mockJoinDeviceAfterSignIn).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'new-sess' })
+    );
+  });
+});

--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -13,6 +13,8 @@ import { emitSessionUpdate } from '../server';
 import Notification from '../models/Notification';
 import SignatureService from '../services/signature.service';
 import sessionService from '../services/session.service';
+import deviceSessionService from '../services/deviceSession.service';
+import { broadcastDeviceState } from '../utils/socket';
 import sessionCache from '../utils/sessionCache';
 import { logger } from '../utils/logger';
 import { formatUserResponse, type UserLike } from '../utils/userTransform';
@@ -179,8 +181,49 @@ export function buildSessionAuthResponse(session: { sessionId: string; deviceId:
   };
 }
 
+/**
+ * Resolve the central deviceId of an ACTIVE prior session so a new sign-in on
+ * the same browser JOINS the browser's existing device instead of sprawling a
+ * fresh (UA/fingerprint-derived) one. The caller passes an OPTIONAL
+ * `priorSessionId` — the sessionId of an account already signed in on this
+ * device (the IdP threads the active device account's id from
+ * `useDeviceAccounts`). We NEVER trust a client-supplied deviceId: a deviceId is
+ * enumerable, but the sessionId is a bearer-equivalent secret that we
+ * re-validate server-side. `sessionService.getSession` only returns an ACTIVE,
+ * unexpired session, so a non-null result means the caller controls that
+ * session — we read ITS deviceId. Returns null when the id is absent, not a
+ * string, or the session is inactive/expired; the caller then falls through to
+ * today's device derivation with no join.
+ */
+export async function resolvePriorDeviceId(priorSessionId: unknown): Promise<string | null> {
+  if (typeof priorSessionId !== 'string' || priorSessionId.length === 0) return null;
+  const prior = await sessionService.getSession(priorSessionId, true);
+  return prior?.deviceId ?? null;
+}
+
+/**
+ * Register a deliberate sign-in into the central device authority — exactly what
+ * an app does via `POST /session/device/add`. The freshly-authenticated account
+ * is added to the device (becoming its active account, addAccount case-3
+ * semantics) and, when the device state actually changed, the new state is
+ * broadcast to the device room so every already-open app on this browser
+ * converges on the same account list. Only invoked once a sign-in has inherited
+ * a resolved prior device (`resolvePriorDeviceId`). Best-effort: a failure here
+ * must never break sign-in — the app re-registers on its next cold boot.
+ */
+export async function joinDeviceAfterSignIn(
+  deviceId: string,
+  accountId: string,
+  sessionId: string
+): Promise<void> {
+  const { state, changed } = await deviceSessionService.addAccount(deviceId, { accountId, sessionId });
+  // Mirror POST /session/device/add: an idempotent re-register changes nothing,
+  // so skip the broadcast.
+  if (changed) broadcastDeviceState(state);
+}
+
 export class SessionController {
-  
+
   /**
    * Register a new user with public key authentication
    * No passwords needed - identity is verified via signature
@@ -331,7 +374,7 @@ export class SessionController {
    */
   static async signUp(req: Request, res: Response) {
     try {
-      const { email, username, password, name, deviceName, deviceFingerprint } = req.body;
+      const { email, username, password, name, deviceName, deviceFingerprint, priorSessionId } = req.body;
 
       if (
         !email ||
@@ -412,15 +455,34 @@ export class SessionController {
         });
       }
 
+      // A signup performed while another account is already signed in on this
+      // browser (the IdP threads its active device session as `priorSessionId`)
+      // joins the SAME central device — same rule as sign-in. The id is
+      // re-validated server-side; a client-supplied deviceId is never trusted.
+      const priorDeviceId = await resolvePriorDeviceId(priorSessionId);
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        priorDeviceId
+          ? { deviceName, deviceId: priorDeviceId }
+          : { deviceName, deviceFingerprint }
       );
 
       const response = buildSessionAuthResponse(session, user);
       if (!response) {
         return res.status(500).json({ message: 'Failed to format user data' });
+      }
+
+      if (priorDeviceId) {
+        try {
+          await joinDeviceAfterSignIn(session.deviceId, user._id.toString(), session.sessionId);
+        } catch (error) {
+          logger.error('Failed to join device after signup', error instanceof Error ? error : new Error(String(error)), {
+            component: 'SessionController',
+            method: 'signUp',
+            userId: user._id.toString(),
+          });
+        }
       }
 
       try {
@@ -660,7 +722,7 @@ export class SessionController {
    */
   static async signIn(req: Request, res: Response) {
     try {
-      const { identifier, email, username, password, deviceName, deviceFingerprint } = req.body;
+      const { identifier, email, username, password, deviceName, deviceFingerprint, priorSessionId } = req.body;
       const loginIdentifier = identifier || email || username;
 
       if (!loginIdentifier || !password || typeof password !== 'string') {
@@ -741,10 +803,19 @@ export class SessionController {
         req
       );
 
+      // When this browser already has an account signed in (the IdP threads its
+      // active device session as `priorSessionId`), inherit that session's
+      // central deviceId so the new account joins the SAME device instead of
+      // sprawling a fresh one. The id is re-validated server-side; a
+      // client-supplied deviceId is never trusted. When a prior device is
+      // resolved, the explicit deviceId wins over any fingerprint hint.
+      const priorDeviceId = await resolvePriorDeviceId(priorSessionId);
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        priorDeviceId
+          ? { deviceName, deviceId: priorDeviceId }
+          : { deviceName, deviceFingerprint }
       );
 
       const baseResponse = buildSessionAuthResponse(session, user);
@@ -799,6 +870,23 @@ export class SessionController {
           method: 'signIn',
           userId: user._id.toString(),
         });
+      }
+
+      // Register the new account into the central device authority so every
+      // app already open on this browser converges on the same account list —
+      // exactly what an app does via POST /session/device/add. Only when the
+      // sign-in inherited a resolved prior device; best-effort (never breaks
+      // sign-in).
+      if (priorDeviceId) {
+        try {
+          await joinDeviceAfterSignIn(session.deviceId, user._id.toString(), session.sessionId);
+        } catch (error) {
+          logger.error('Failed to join device after sign-in', error instanceof Error ? error : new Error(String(error)), {
+            component: 'SessionController',
+            method: 'signIn',
+            userId: user._id.toString(),
+          });
+        }
       }
 
       const signinResponseWithAuthuser: typeof response & { authuser?: number } =

--- a/packages/api/src/controllers/twoFactor.controller.ts
+++ b/packages/api/src/controllers/twoFactor.controller.ts
@@ -5,7 +5,7 @@ import twoFactorService from '../services/twoFactor.service';
 import { logger } from '../utils/logger';
 import securityActivityService from '../services/securityActivityService';
 import sessionService from '../services/session.service';
-import { buildSessionAuthResponse } from './session.controller';
+import { buildSessionAuthResponse, resolvePriorDeviceId, joinDeviceAfterSignIn } from './session.controller';
 import { AuthRequest } from '../middleware/auth';
 import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
 
@@ -294,7 +294,7 @@ export async function verify2FAToken(req: Request, res: Response) {
  */
 export async function verify2FALogin(req: Request, res: Response) {
   try {
-    const { loginToken, token, backupCode, deviceName, deviceFingerprint } = req.body;
+    const { loginToken, token, backupCode, deviceName, deviceFingerprint, priorSessionId } = req.body;
 
     if (!loginToken) {
       return res.status(400).json({ message: 'Login token is required' });
@@ -394,16 +394,35 @@ export async function verify2FALogin(req: Request, res: Response) {
     user.twoFactorAuth.verifiedAt = new Date();
     await user.save();
 
-    // Create session (same as signIn would)
+    // Create session (same as signIn would). When the 2FA challenge completes a
+    // login on a browser that already has an account signed in (the IdP threads
+    // its active device session as `priorSessionId`), inherit that session's
+    // central deviceId so the account joins the SAME device. The id is
+    // re-validated server-side; a client-supplied deviceId is never trusted.
+    const priorDeviceId = await resolvePriorDeviceId(priorSessionId);
     const session = await sessionService.createSession(
       user._id.toString(),
       req,
-      { deviceName, deviceFingerprint }
+      priorDeviceId
+        ? { deviceName, deviceId: priorDeviceId }
+        : { deviceName, deviceFingerprint }
     );
 
     const response = buildSessionAuthResponse(session, user);
     if (!response) {
       return res.status(500).json({ message: 'Failed to format user data' });
+    }
+
+    if (priorDeviceId) {
+      try {
+        await joinDeviceAfterSignIn(session.deviceId, user._id.toString(), session.sessionId);
+      } catch (error) {
+        logger.error('Failed to join device after 2FA sign-in', error instanceof Error ? error : new Error(String(error)), {
+          component: 'TwoFactorController',
+          method: 'verify2FALogin',
+          userId: user._id.toString(),
+        });
+      }
     }
 
     try {

--- a/packages/auth/components/__tests__/login-form-prior-session.test.tsx
+++ b/packages/auth/components/__tests__/login-form-prior-session.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * The login form threads the browser's active device session as
+ * `priorSessionId` on the sign-in request, so the API joins the newly
+ * authenticated account to the SAME central device instead of sprawling a fresh
+ * one. The id is the value `useDeviceAccounts` already resolved from the
+ * device's refresh cookies; when no account is signed in, the field is omitted.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { BrowserRouter } from "react-router-dom"
+import * as coreActual from "@oxyhq/core"
+
+// The chooser is skipped and the form drives straight to the password step via
+// `loginHint`. `currentSessionId` is mutated per-test through this closure.
+let deviceAccountsState: {
+    isLoading: boolean
+    currentSessionId: string | null
+    accounts: unknown[]
+} = { isLoading: false, currentSessionId: null, accounts: [] }
+
+mock.module("@/lib/use-device-accounts", () => ({
+    useDeviceAccounts: () => deviceAccountsState,
+}))
+
+// A controllable username lookup so the identifier→password transition resolves
+// without touching the network. Spread the real module so co-running test files
+// keep the genuine core exports (bun's mock.module is process-global) — we only
+// override `OxyServices`.
+mock.module("@oxyhq/core", () => ({
+    ...coreActual,
+    OxyServices: class {
+        async lookupUsername() {
+            return { exists: true, username: "bob", name: { displayName: "Bob" }, avatar: null, color: null }
+        }
+    },
+}))
+
+mock.module("@/lib/device-fingerprint", () => ({
+    getOrCreateDeviceFingerprint: async () => "fp-1",
+}))
+
+const { LoginForm } = await import("@/components/login-form")
+
+let loginBody: Record<string, unknown> | null = null
+const originalFetch = globalThis.fetch
+
+beforeEach(() => {
+    loginBody = null
+    deviceAccountsState = { isLoading: false, currentSessionId: null, accounts: [] }
+    // Re-assert the mutable mocks each test (bun's mock.module is process-global).
+    mock.module("@/lib/use-device-accounts", () => ({
+        useDeviceAccounts: () => deviceAccountsState,
+    }))
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url.includes("/auth/login")) {
+            loginBody = JSON.parse(String(init?.body ?? "{}"))
+            // Return no sessionId so the form settles on the identifier/password
+            // step without entering the post-login redirect (which would need the
+            // real auth-utils / FedCM handoff). The request body — already
+            // captured above — is all this test asserts.
+            return Promise.resolve(
+                new Response(JSON.stringify({}), {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                }),
+            )
+        }
+        return Promise.resolve(new Response(JSON.stringify({}), { status: 200 }))
+    }) as typeof fetch
+})
+
+afterEach(() => {
+    globalThis.fetch = originalFetch
+})
+
+function renderForm(): { container: HTMLDivElement; root: Root } {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    act(() => {
+        root.render(
+            <BrowserRouter>
+                <LoginForm loginHint="bob" />
+            </BrowserRouter>,
+        )
+    })
+    return { container, root }
+}
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+}
+
+async function submitPassword(container: HTMLElement): Promise<void> {
+    // Advance from the auto-run lookup to the password step.
+    await flush()
+    const password = container.querySelector<HTMLInputElement>('input[name="password"]')
+    if (!password) throw new Error("password step did not render")
+    password.value = "correct horse"
+    const form = password.closest("form")
+    if (!form) throw new Error("password form not found")
+    await act(async () => {
+        form.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+    })
+    await flush()
+}
+
+describe("LoginForm — priorSessionId threading", () => {
+    test("includes priorSessionId when an account is signed in on the device", async () => {
+        deviceAccountsState = { isLoading: false, currentSessionId: "prior-session-xyz", accounts: [] }
+        const { container, root } = renderForm()
+
+        await submitPassword(container)
+
+        expect(loginBody).not.toBeNull()
+        expect(loginBody?.priorSessionId).toBe("prior-session-xyz")
+        expect(loginBody?.deviceFingerprint).toBe("fp-1")
+
+        act(() => root.unmount())
+        container.remove()
+    })
+
+    test("omits priorSessionId when no account is signed in", async () => {
+        deviceAccountsState = { isLoading: false, currentSessionId: null, accounts: [] }
+        const { container, root } = renderForm()
+
+        await submitPassword(container)
+
+        expect(loginBody).not.toBeNull()
+        expect(loginBody).not.toHaveProperty("priorSessionId")
+
+        act(() => root.unmount())
+        container.remove()
+    })
+})

--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -304,6 +304,16 @@ export function LoginForm({
             if (deviceFingerprint) {
                 body.deviceFingerprint = deviceFingerprint
             }
+            // When an account is already signed in on this browser, thread its
+            // active device session so the API joins the new account to the SAME
+            // central device (server-validated — never a raw deviceId). This is
+            // the id `useDeviceAccounts` already resolved from the device's
+            // refresh cookies; it is the same central device the `fedcm_session`
+            // cookie points at, so every open app converges via the socket
+            // broadcast instead of splitting into a fresh fingerprint device.
+            if (currentSessionId) {
+                body.priorSessionId = currentSessionId
+            }
             const response = await fetch(buildAuthUrl("/login"), {
                 method: "POST",
                 headers: await withCsrfHeader({ "content-type": "application/json" }),
@@ -355,6 +365,9 @@ export function LoginForm({
         const body: Record<string, string> = { loginToken }
         if (useBackupCode) body.backupCode = backupCode.trim()
         else body.token = otpValue
+        // Same central device-join as the password path: a 2FA-completed login on
+        // a browser that already has an account joins that account's device.
+        if (currentSessionId) body.priorSessionId = currentSessionId
 
         try {
             // Correct endpoint: /security/2fa/verify-login (creates session)


### PR DESCRIPTION
Signing in at auth.oxy.so with another account left it OFF the browser's DeviceSession → diverging account lists across apps (user-reproduced). Login/signup/2FA accept an optional priorSessionId (the SPA already holds it from the account chooser); the server re-validates it (active-only) and derives the deviceId — a raw client deviceId is never trusted (device-fixation guard) — then threads it into createSession and registers the account via the same addAccount+broadcast path as /session/device/add. Response shapes unchanged; missing/invalid prior = today's behavior. api 1337 · IdP 152 · tsc 0 · builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)