### PR TITLE
fix(api): trust http://localhost:* (any port) for credentialed CORS in all envs

### DIFF
--- a/packages/api/src/config/__tests__/dynamicOriginRegistry.test.ts
+++ b/packages/api/src/config/__tests__/dynamicOriginRegistry.test.ts
@@ -40,6 +40,7 @@ import {
   getExtraAllowedOrigins,
   BOOTSTRAP_CORE_ORIGINS,
 } from '../dynamicOriginRegistry';
+import { isLoopbackOrigin } from '../../utils/origin';
 
 interface AppRow {
   redirectUris?: string[];
@@ -205,6 +206,49 @@ describe('OXY_EXTRA_ALLOWED_ORIGINS', () => {
       allow: true,
       credentials: true,
     });
+  });
+});
+
+describe('loopback (local dev) origins — always credentialed', () => {
+  it.each([
+    'http://localhost:8081',
+    'http://localhost',
+    'http://localhost:54321',
+    'http://127.0.0.1:3000',
+    'http://127.0.0.1',
+    'http://[::1]:19006',
+    'http://[::1]',
+  ])('grants the credentialed lane to %s', (origin) => {
+    expect(getCorsDecision(origin)).toEqual({ allow: true, credentials: true });
+  });
+
+  it('lets a loopback origin win even when it is also in the third-party snapshot', () => {
+    setOriginSnapshotForTests([], ['http://localhost:8081']);
+    expect(getCorsDecision('http://localhost:8081')).toEqual({
+      allow: true,
+      credentials: true,
+    });
+  });
+
+  it('does not treat https loopback as a loopback origin (falls through to deny)', () => {
+    expect(isLoopbackOrigin('https://localhost:8081')).toBe(false);
+    expect(getCorsDecision('https://localhost:8081')).toEqual({
+      allow: false,
+      credentials: false,
+    });
+  });
+
+  it('rejects loopback lookalikes', () => {
+    expect(isLoopbackOrigin('http://localhost.evil.com')).toBe(false);
+    expect(isLoopbackOrigin('http://localhost.evil.com:3000')).toBe(false);
+    expect(isLoopbackOrigin('http://127.0.0.1.evil.com')).toBe(false);
+    expect(isLoopbackOrigin('not a url')).toBe(false);
+    expect(isLoopbackOrigin('')).toBe(false);
+  });
+
+  it('normalises scheme/host casing and trailing path before matching', () => {
+    expect(isLoopbackOrigin('HTTP://LOCALHOST:3000')).toBe(true);
+    expect(isLoopbackOrigin('http://localhost:3000/callback?x=1')).toBe(true);
   });
 });
 

--- a/packages/api/src/config/allowedOrigins.ts
+++ b/packages/api/src/config/allowedOrigins.ts
@@ -13,8 +13,10 @@
  *  - active first-party / internal / system / official Applications'
  *    `redirectUris` origins (auto-authorized by registering the app in Console),
  *  - validated `OXY_EXTRA_ALLOWED_ORIGINS` (emergency escape hatch),
- * with `http://localhost[:port]` / `http://127.0.0.1[:port]` ONLY outside
- * production.
+ * with `http://localhost[:port]` / `http://127.0.0.1[:port]` / `http://[::1][:port]`
+ * trusted UNCONDITIONALLY in ALL environments (including production) — an
+ * approved posture so a developer's loopback dev server can make credentialed /
+ * state-changing requests against prod (owner-approved).
  *
  * Registering a NEW first-party frontend now authorizes its origin
  * automatically via the Application registry — no code edit here. The bootstrap
@@ -25,8 +27,7 @@
  */
 
 import { isTrustedOrigin, getExtraAllowedOrigins } from './dynamicOriginRegistry';
-
-const DEV_ORIGIN_PATTERN = /^http:\/\/(?:localhost|127\.0\.0\.1)(?::\d{1,5})?$/;
+import { isLoopbackOrigin } from '../utils/origin';
 
 /**
  * Strict TRUSTED Origin allowlist check. Comparison is case-sensitive on
@@ -35,16 +36,17 @@ const DEV_ORIGIN_PATTERN = /^http:\/\/(?:localhost|127\.0\.0\.1)(?::\d{1,5})?$/;
  * for our zones.
  *
  * Reads the trusted snapshot from {@link dynamicOriginRegistry}; also honours
- * dev-localhost (outside production) and the `OXY_EXTRA_ALLOWED_ORIGINS`
- * escape hatch synchronously, so an env change is reflected immediately rather
- * than only after the next background refresh.
+ * loopback dev origins (unconditionally, in ALL environments — owner-approved)
+ * and the `OXY_EXTRA_ALLOWED_ORIGINS` escape hatch synchronously, so an env
+ * change is reflected immediately rather than only after the next background
+ * refresh.
  */
 export function isAllowedOrigin(origin: string): boolean {
   if (isTrustedOrigin(origin)) {
     return true;
   }
 
-  if (process.env.NODE_ENV !== 'production' && DEV_ORIGIN_PATTERN.test(origin)) {
+  if (isLoopbackOrigin(origin)) {
     return true;
   }
 

--- a/packages/api/src/config/dynamicOriginRegistry.ts
+++ b/packages/api/src/config/dynamicOriginRegistry.ts
@@ -40,7 +40,7 @@
 import mongoose from 'mongoose';
 import type { ApplicationType } from '../models/Application';
 import { isTrustedApplication } from '../utils/trustedApplication';
-import { normaliseOrigin } from '../utils/origin';
+import { normaliseOrigin, isLoopbackOrigin } from '../utils/origin';
 import { isValidHostname } from './env';
 import { logger } from '../utils/logger';
 
@@ -251,7 +251,11 @@ class DynamicOriginRegistry {
   }
 
   getCorsDecision(origin: string): CorsDecision {
-    if (this.trustedOrigins.has(origin)) {
+    // Loopback dev origins ALWAYS get the credentialed lane, and win over the
+    // third-party lane below: a localhost origin that a third-party app happens
+    // to register as a redirectUri must still be able to send credentialed
+    // requests (SDK `credentials:'include'` fetch of `/csrf-token`).
+    if (this.trustedOrigins.has(origin) || isLoopbackOrigin(origin)) {
       return { allow: true, credentials: true };
     }
     if (this.thirdPartyOrigins.has(origin)) {

--- a/packages/api/src/middleware/__tests__/originGuard.test.ts
+++ b/packages/api/src/middleware/__tests__/originGuard.test.ts
@@ -2,9 +2,9 @@
  * Origin guard tests (MED-1 CSRF hardening, Phase A)
  *
  * `isAllowedOrigin`: strict allowlist — exact first-party app origins,
- * dev-only localhost, and validated
- * `OXY_EXTRA_ALLOWED_ORIGINS` entries. Suffix-spoofing, case tricks, and
- * homograph hosts must all fail.
+ * loopback localhost / 127.0.0.1 / [::1] (unconditional, all envs), and
+ * validated `OXY_EXTRA_ALLOWED_ORIGINS` entries. Suffix-spoofing, case tricks,
+ * and homograph hosts must all fail.
  *
  * `requireSameSiteOrigin`: blocks non-safe methods from non-allowlisted
  * browser contexts (Origin header, with Sec-Fetch-Site as fallback) and
@@ -108,17 +108,26 @@ describe('isAllowedOrigin', () => {
     expect(isAllowedOrigin(origin)).toBe(false);
   });
 
-  it('allows localhost / 127.0.0.1 outside production', () => {
+  it('allows localhost / 127.0.0.1 / [::1] outside production', () => {
     process.env.NODE_ENV = 'development';
     expect(isAllowedOrigin('http://localhost:3000')).toBe(true);
     expect(isAllowedOrigin('http://localhost')).toBe(true);
     expect(isAllowedOrigin('http://127.0.0.1:8081')).toBe(true);
+    expect(isAllowedOrigin('http://[::1]:19006')).toBe(true);
   });
 
-  it('rejects localhost / 127.0.0.1 in production', () => {
+  it('allows localhost / 127.0.0.1 / [::1] in production too (owner-approved)', () => {
     process.env.NODE_ENV = 'production';
-    expect(isAllowedOrigin('http://localhost:3000')).toBe(false);
-    expect(isAllowedOrigin('http://127.0.0.1:8081')).toBe(false);
+    expect(isAllowedOrigin('http://localhost:8081')).toBe(true);
+    expect(isAllowedOrigin('http://localhost')).toBe(true);
+    expect(isAllowedOrigin('http://localhost:54321')).toBe(true);
+    expect(isAllowedOrigin('http://127.0.0.1:3000')).toBe(true);
+    expect(isAllowedOrigin('http://[::1]:19006')).toBe(true);
+  });
+
+  it('rejects https loopback (loopback is http-only)', () => {
+    process.env.NODE_ENV = 'production';
+    expect(isAllowedOrigin('https://localhost:8081')).toBe(false);
   });
 
   it('rejects localhost lookalikes even in development', () => {
@@ -251,10 +260,10 @@ describe('requireSameSiteOrigin', () => {
     expect(res.status).toBe(200);
   });
 
-  it('rejects http localhost origins in production', async () => {
+  it('passes http localhost origins in production too (owner-approved)', async () => {
     process.env.NODE_ENV = 'production';
     const res = await request('POST', { origin: 'http://localhost:3000' });
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(200);
   });
 
   it.each(['PUT', 'DELETE'])('applies to %s requests', async (method) => {

--- a/packages/api/src/utils/origin.ts
+++ b/packages/api/src/utils/origin.ts
@@ -26,3 +26,31 @@ export function normaliseOrigin(value: string): string | null {
     return null;
   }
 }
+
+/**
+ * Loopback (local development) origin predicate. Matches `http://localhost`,
+ * `http://127.0.0.1`, and `http://[::1]` with an OPTIONAL `:<port>` (any 1–5
+ * digit port). HTTP only — loopback dev servers are served over http, so an
+ * `https://localhost` origin is deliberately NOT a loopback match.
+ *
+ * The input is normalised first (via {@link normaliseOrigin}), so scheme/host
+ * casing and trailing paths/queries never defeat the check, and only the
+ * `scheme://host[:port]` triple is tested. Fails closed: returns `false` for any
+ * unparseable input.
+ *
+ * @example
+ *   isLoopbackOrigin('http://localhost:8081')  // true
+ *   isLoopbackOrigin('http://127.0.0.1')       // true
+ *   isLoopbackOrigin('http://[::1]:19006')     // true
+ *   isLoopbackOrigin('https://localhost:8081') // false (https)
+ *   isLoopbackOrigin('http://localhost.evil.com') // false
+ */
+const LOOPBACK_ORIGIN_PATTERN = /^http:\/\/(?:localhost|127\.0\.0\.1|\[::1\])(?::\d{1,5})?$/;
+
+export function isLoopbackOrigin(origin: string): boolean {
+  const normalised = normaliseOrigin(origin);
+  if (normalised === null) {
+    return false;
+  }
+  return LOOPBACK_ORIGIN_PATTERN.test(normalised);
+}


### PR DESCRIPTION
## Summary
- Loopback dev servers need credentialed/state-changing requests against the prod API (`api.oxy.so`).
- Adds `isLoopbackOrigin()` (`packages/api/src/utils/origin.ts`) matching `http://localhost`/`127.0.0.1`/`[::1]` on any port, fails closed on anything else.
- Wires it into both trust definitions: `getCorsDecision` (loopback wins over the third-party non-credentialed lane) in `dynamicOriginRegistry.ts`, and `isAllowedOrigin` in `allowedOrigins.ts` (also gates the CSRF Origin guard + Socket.IO).
- Drops the previous `NODE_ENV !== 'production'` gate — the loopback allowance now applies in all environments.

**Owner-approved security posture:** only a process running on the developer's own machine (localhost) can present a matching `Origin` header and ride `oxy.so` cookies; a remote/attacker site cannot forge a `localhost` Origin from a browser context, so this does not widen the credentialed CORS surface to third parties.

## Test plan
- [x] `bun run build` (tsc via `packages/api` build chain: contracts → protocol → core → tsc) — exits 0, zero errors
- [x] `bun run test` in `packages/api` — 134 suites / 1307 tests passed (includes updated `dynamicOriginRegistry.test.ts` + `originGuard.test.ts` covering the new loopback behavior)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)