### PR TITLE
fix(api): allow loopback dev origins to start QR sign-in for trusted apps

### DIFF
--- a/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionAppIdentity.test.ts
@@ -578,6 +578,87 @@ describe('POST /auth/session/create — application resolution (#214)', () => {
   });
 });
 
+describe('POST /auth/session/create — loopback dev origins (Sign in with Oxy QR)', () => {
+  // A loopback dev server (e.g. Allo web on http://localhost:8081) is NOT one of
+  // a trusted app's registered redirect origins, but it must still be able to
+  // START the QR sign-in flow. The guard lets loopback through; originVerified
+  // stays false so Commons still shows its anti-phishing warning.
+  it('allows a trusted/official app to start the flow from an unregistered loopback origin, but leaves originVerified=false', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
+    mockApplicationFindById.mockResolvedValueOnce(officialApp());
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/session/create',
+      { sessionToken: 'tok-create-loopback', clientId: 'oxy_dk_client' },
+      { origin: 'http://localhost:8081' },
+    );
+
+    expect(res.status).toBe(200);
+    const created = mockAuthSessionCreate.mock.calls[0][0] as {
+      applicationId: { toString: () => string };
+      boundOrigin?: string;
+      originVerified?: boolean;
+    };
+    expect(created.applicationId.toString()).toBe(OFFICIAL_APP_ID);
+    expect(created.boundOrigin).toBe('http://localhost:8081');
+    // Loopback is allowed to START the flow but is NOT a verified official origin.
+    expect(created.originVerified).toBe(false);
+  });
+
+  it('allows a trusted/official app from its OWN registered redirect origin with originVerified=true (regression guard — unchanged behavior)', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
+    mockApplicationFindById.mockResolvedValueOnce(officialApp());
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/session/create',
+      { sessionToken: 'tok-create-registered-origin', clientId: 'oxy_dk_client' },
+      { origin: 'https://accounts.oxy.so' },
+    );
+
+    expect(res.status).toBe(200);
+    const created = mockAuthSessionCreate.mock.calls[0][0] as { originVerified?: boolean };
+    expect(created.originVerified).toBe(true);
+  });
+
+  it('still rejects a trusted app from a non-loopback, non-registered browser origin', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
+    mockApplicationFindById.mockResolvedValueOnce(officialApp());
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/session/create',
+      { sessionToken: 'tok-create-foreign-origin', clientId: 'oxy_dk_client' },
+      { origin: 'https://evil.example' },
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toBe('Application origin is not allowed');
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT treat https://localhost as loopback — an unregistered https loopback origin is still rejected', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential(OFFICIAL_APP_ID));
+    mockApplicationFindById.mockResolvedValueOnce(officialApp());
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/session/create',
+      { sessionToken: 'tok-create-https-loopback', clientId: 'oxy_dk_client' },
+      { origin: 'https://localhost:8081' },
+    );
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toBe('Application origin is not allowed');
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+});
+
 describe('POST /auth/session/authorize-signed/:authorizeCode — route mapping (C2)', () => {
   it('maps an ok outcome to 200 and notifies the originator over the socket', async () => {
     mockAuthorizeSigned.mockResolvedValueOnce({

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -76,7 +76,7 @@ import {
 } from '../schemas/auth.schemas';
 import { AppGrant } from '../models/AppGrant';
 import { FedCMGrant } from '../models/FedCMGrant';
-import { normaliseOrigin } from '../utils/origin';
+import { normaliseOrigin, isLoopbackOrigin } from '../utils/origin';
 import { serializePublicApplication } from '../utils/serializeApplication';
 import { isValidObjectId } from '../utils/validation';
 import { formatUserNameResponse } from '../utils/displayName';
@@ -1497,7 +1497,13 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
   // accepted as-is — the device-flow consent screen still authorises every
   // session interactively.
   if (isTrustedApplication(resolvedApp) && hasBrowserContext(req)) {
-    if (!boundOrigin || !applicationAllowsOrigin(resolvedApp, boundOrigin)) {
+    // Loopback dev origins (http://localhost, 127.0.0.1, [::1] on any port) are
+    // allowed to START the QR flow for a trusted app even though they are not
+    // registered redirect origins — otherwise no local dev server could sign in.
+    // This is only a gate to begin the flow; `originVerified` below stays false
+    // for loopback (it keys off applicationAllowsOrigin ONLY), so the Commons
+    // approval UI still shows its anti-phishing warning for an unverified origin.
+    if (!boundOrigin || (!applicationAllowsOrigin(resolvedApp, boundOrigin) && !isLoopbackOrigin(boundOrigin))) {
       throw new ForbiddenError('Application origin is not allowed');
     }
   }


### PR DESCRIPTION
## Summary
- `POST /auth/session/create` rejected a trusted/official app's browser caller with 403 when the `Origin` was a loopback dev server (e.g. `http://localhost:8081`), because loopback is not a registered redirect origin for the app.
- Allow `isLoopbackOrigin` bound origins through the guard so local dev servers can start the "Sign in with Oxy" QR flow.
- `originVerified` stays keyed off `applicationAllowsOrigin` only (unchanged) — loopback origins are let through the gate but are NOT marked verified, so the Commons approval UI still shows its anti-phishing warning for an unregistered/unverified origin. Remote sites cannot forge a `localhost` `Origin` header, so this does not weaken the trust boundary.

## Test plan
- [x] `bun run build` — tsc, zero errors
- [x] `bun run test` — full suite green (148 suites / 1436 tests passed on this branch base)
- [x] New regression tests in `authSessionAppIdentity.test.ts`:
  - trusted app starts flow from unregistered `http://localhost:8081` → 200, `originVerified: false`
  - trusted app from its own registered redirect origin → 200, `originVerified: true` (unchanged behavior)
  - trusted app from a non-loopback, non-registered origin → still 403
  - `https://localhost:8081` (https, not http) → still 403 (loopback match is scheme-strict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)