### PR TITLE
fix(api): establish-token CORS must allow credentials for approved origins

### DIFF
--- a/packages/api/src/routes/__tests__/ssoEstablishToken.test.ts
+++ b/packages/api/src/routes/__tests__/ssoEstablishToken.test.ts
@@ -53,7 +53,7 @@ jest.mock('../../middleware/auth', () => ({
   },
 }));
 
-const APPROVED = new Set(['https://accounts.oxy.so', 'https://mention.earth']);
+const APPROVED = new Set(['https://accounts.oxy.so', 'https://mention.earth', 'http://localhost:8081']);
 const recordGrant = jest.fn(async (_userId: string, _origin: string) => {});
 jest.mock('../../services/fedcm.service', () => ({
   __esModule: true,
@@ -310,8 +310,38 @@ describe('POST /sso/establish-token', () => {
     });
     expect(result.status).toBe(204);
     expect(result.headers['access-control-allow-origin']).toBe('https://accounts.oxy.so');
-    expect(result.headers['access-control-allow-credentials']).toBe('false');
+    // Bearer-only endpoint, but the shared @oxyhq/core HTTP client sends
+    // credentials:'include' for same-baseURL calls, so the preflight MUST allow
+    // credentials for approved origins (ambient cookies are ignored server-side).
+    expect(result.headers['access-control-allow-credentials']).toBe('true');
     expect(String(result.headers['access-control-allow-headers'])).toContain('Authorization');
+  });
+
+  it('echoes an approved dev-localhost origin with credentials allowed on the OPTIONS preflight', async () => {
+    // The bug was confirmed against http://localhost:8081 in prod: the shared
+    // SDK HTTP client sends credentials:'include' for same-baseURL calls, so a
+    // dev localhost RP must also receive ACAC:true (it is an approved origin).
+    const address = server.address() as AddressInfo;
+    const result = await new Promise<{ status: number; headers: http.IncomingHttpHeaders }>((resolve, reject) => {
+      const req = http.request(
+        {
+          method: 'OPTIONS',
+          host: '127.0.0.1',
+          port: address.port,
+          path: '/sso/establish-token',
+          headers: { origin: 'http://localhost:8081' },
+        },
+        (res) => {
+          res.on('data', () => {});
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+        },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(result.status).toBe(204);
+    expect(result.headers['access-control-allow-origin']).toBe('http://localhost:8081');
+    expect(result.headers['access-control-allow-credentials']).toBe('true');
   });
 
   it('does not echo an unapproved origin on the OPTIONS preflight', async () => {
@@ -334,6 +364,9 @@ describe('POST /sso/establish-token', () => {
       req.end();
     });
     expect(result.status).toBe(204);
+    // An unapproved origin gets NEITHER Access-Control-Allow-Origin NOR
+    // Access-Control-Allow-Credentials — the approved-clients gate is not weakened.
     expect(result.headers['access-control-allow-origin']).toBeUndefined();
+    expect(result.headers['access-control-allow-credentials']).toBeUndefined();
   });
 });

--- a/packages/api/src/routes/sso.ts
+++ b/packages/api/src/routes/sso.ts
@@ -50,14 +50,28 @@ export async function ssoExchangeCors(req: Request, res: Response, next: NextFun
  * Dedicated CORS handler for `POST /sso/establish-token`.
  *
  * Mounted BEFORE the global CORS middleware (see server.ts) so it fully owns the
- * response for this path. Unlike `/sso/exchange` this endpoint is
- * BEARER-authenticated (the token rides in the `Authorization` header, not a
- * cookie), so it echoes the validated approved origin with
- * `Access-Control-Allow-Credentials: false` and additionally allows the
- * `Authorization` request header. Cross-apex RP origins (`mention.earth`, …) are
- * NOT covered by the apex-scoped global policy, which is exactly why this
- * dedicated handler — echoing any origin on the FedCM approved-clients allow-list
- * — is required. The OPTIONS preflight is answered here (204).
+ * response for this path. This endpoint is BEARER-authenticated (the token rides
+ * in the `Authorization` header; `authMiddleware` requires it and has no cookie
+ * fallback, and the controller reads the user id SOLELY from the bearer's
+ * claims). It nonetheless MUST echo `Access-Control-Allow-Credentials: true`
+ * because the `@oxyhq/core` shared HTTP client sends `credentials:'include'` for
+ * same-baseURL calls (the RP targets `api.oxy.so`, which equals the SDK
+ * baseURL) — answering `false` makes the browser block every include-mode
+ * request, breaking establish-token for every cross-origin RP. Echoing `true`
+ * is safe: any ambient cookies the browser attaches are ignored server-side, and
+ * the Origin is echoed ONLY for FedCM-approved clients — never a wildcard.
+ * Cross-apex RP origins (`mention.earth`, …) are not covered by the apex-scoped
+ * global policy, which is exactly why this dedicated handler — echoing any origin
+ * on the FedCM approved-clients allow-list — is required. It additionally allows
+ * the `Authorization` request header. The OPTIONS preflight is answered here (204).
+ *
+ * Because `Access-Control-Allow-Credentials` is `true`, the value written to
+ * `Access-Control-Allow-Origin` is the NORMALISED allow-list value, tested inline
+ * against `getApprovedClientOrigins()` — never the raw request header. Echoing a
+ * validated allow-list member (instead of reflecting untrusted request bytes) is
+ * the correct credentialed-CORS pattern: a real browser's canonical Origin already
+ * equals its normalised form, so approved clients see no behavioural change, while
+ * an unapproved or malformed Origin receives no CORS header at all.
  */
 export async function ssoEstablishTokenCors(req: Request, res: Response, next: NextFunction): Promise<void> {
   const originHeader = req.headers.origin;
@@ -65,9 +79,10 @@ export async function ssoEstablishTokenCors(req: Request, res: Response, next: N
 
   if (typeof originHeader === 'string' && originHeader.length > 0) {
     const normalised = normaliseOrigin(originHeader);
-    if (normalised && (await fedcmService.isClientApproved(normalised))) {
-      res.setHeader('Access-Control-Allow-Origin', originHeader);
-      res.setHeader('Access-Control-Allow-Credentials', 'false');
+    const approvedOrigins = await fedcmService.getApprovedClientOrigins();
+    if (normalised && approvedOrigins.includes(normalised)) {
+      res.setHeader('Access-Control-Allow-Origin', normalised);
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
       res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
       res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, Accept');
       res.setHeader('Access-Control-Max-Age', '600');


### PR DESCRIPTION
## Bug

`POST /sso/establish-token` broke for **every** cross-origin RP. Confirmed against prod via curl: both `http://localhost:8081` (dev) and `https://mention.earth` preflights returned `Access-Control-Allow-Credentials: false`.

The `@oxyhq/core` shared HTTP client sends `credentials:'include'` for **same-baseURL** calls — and the RP targets `api.oxy.so`, which equals the SDK baseURL. A browser blocks an include-mode request whenever the CORS response answers `Access-Control-Allow-Credentials: false`, so the establish-token mint failed on every RP (durable cross-domain session restore after a "Sign in with Oxy" QR claim never planted its `fedcm_session` cookie).

## Fix

In `ssoEstablishTokenCors` (only — `ssoExchangeCors` stays `ACAC:false`; its client uses `credentials:'omit'`), echo `Access-Control-Allow-Credentials: true` for FedCM-approved origins.

## Why this is safe (bearer-only)

The endpoint is bearer-only: `authMiddleware` requires an `Authorization: Bearer` header with **no cookie fallback**, and the controller (`issueEstablishToken`) reads the user id **solely from the bearer's claims**. Any ambient cookies the browser attaches under include-mode are therefore ignored server-side. The Origin is echoed **only** for origins on the FedCM approved-clients allow-list — never a wildcard — so the approved-origin gate is not weakened.

## Tests

`packages/api/src/routes/__tests__/ssoEstablishToken.test.ts`: flipped the preflight/response ACAC assertion to `true`, added an approved dev-localhost (`http://localhost:8081`) preflight case asserting `ACAC:true`, and strengthened the unapproved-origin case to assert **no** `Access-Control-Allow-Origin` **and no** `Access-Control-Allow-Credentials` header. Full `packages/api` suite green: 148 suites / 1437 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)