### PR TITLE
feat(core): device-first session machinery — authStateStore, unified refresh, coldBootV2, deviceBoot mixin (additive)

### DIFF
--- a/packages/core/src/HttpService.ts
+++ b/packages/core/src/HttpService.ts
@@ -70,6 +70,19 @@ export interface RequestOptions {
   signal?: AbortSignal;
   headers?: Record<string, string>;
   responseType?: 'blob';
+  /**
+   * Skip BOTH the bearer auth header (and its near-expiry preflight refresh)
+   * AND the 401-driven auto-refresh/retry for this request.
+   *
+   * Required for the body-authenticated refresh endpoint (`POST
+   * /auth/refresh-token`): it does not need a bearer, and — critically — it is
+   * itself invoked from inside the registered `AuthRefreshHandler`. If it went
+   * through the normal preflight, `getAuthHeader` would call
+   * `refreshAccessToken` while the handler-owning `tokenRefreshPromise` is
+   * still in flight and await ITSELF (deadlock). Skipping auth makes the
+   * refresh call fully independent of the current (near-expired) bearer.
+   */
+  skipAuth?: boolean;
 }
 
 interface RequestConfig extends RequestOptions {
@@ -403,8 +416,11 @@ export class HttpService {
         // Build URL with params
         const fullUrl = this.buildURL(url, params);
         
-        // Get auth token (with auto-refresh)
-        const authHeader = await this.getAuthHeader();
+        // Get auth token (with auto-refresh). `skipAuth` requests (the
+        // body-authenticated refresh endpoint) send NO bearer and skip the
+        // near-expiry preflight — see RequestOptions.skipAuth for the deadlock
+        // this avoids.
+        const authHeader = config.skipAuth ? null : await this.getAuthHeader();
 
         // CSRF protects cookie-authenticated browser writes. Bearer-authenticated
         // SDK clients are not vulnerable to ambient-cookie CSRF, and linked app
@@ -514,7 +530,7 @@ export class HttpService {
           // On 401, delegate refresh to AuthManager and retry once before
           // giving up. HttpService deliberately does not know any session
           // routes; the AuthManager is the single session authority.
-          if (response.status === 401 && !config._isAuthRetry) {
+          if (response.status === 401 && !config._isAuthRetry && !config.skipAuth) {
             const refreshed = await this.refreshAccessToken('response-401');
             if (refreshed) {
               // `deduplicate: false` is REQUIRED on the retry (mirrors the 403

--- a/packages/core/src/boot/__tests__/coldBootV2.test.ts
+++ b/packages/core/src/boot/__tests__/coldBootV2.test.ts
@@ -1,0 +1,299 @@
+import type { OxyServices } from '../../OxyServices';
+import type { AuthTokenBundle, TokenRefreshResponse } from '@oxyhq/contracts';
+import type { SessionLoginResponse } from '../../models/session';
+import type { WebSessionResult } from '../../mixins/OxyServices.deviceBoot';
+import {
+  runSessionColdBoot,
+  createBrowserColdBootDom,
+  isSameApex,
+  BOOT_ATTEMPTED_KEY,
+  type ColdBootDom,
+} from '../coldBootV2';
+import { BOOT_STATE_SESSION_KEY } from '../deviceBootReturn';
+import { createMemoryAuthStateStore, type AuthStateStore } from '../../session/authStateStore';
+import { KeyManager } from '../../crypto/keyManager';
+
+const BUNDLE: AuthTokenBundle = {
+  sessionId: 'sess-boot',
+  accessToken: 'access-boot',
+  refreshToken: 'refresh-boot-abcdefghij',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  user: { id: 'user-boot', name: {} } as AuthTokenBundle['user'],
+};
+
+const ROTATED: TokenRefreshResponse = {
+  accessToken: 'access-rot',
+  refreshToken: 'refresh-rot-abcdefghij',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  sessionId: 'sess-rot',
+};
+
+interface OxyOverrides {
+  baseURL?: string;
+  exchangeBootCode?: OxyServices['exchangeBootCode'];
+  refreshWithToken?: OxyServices['refreshWithToken'];
+  signInWithSharedIdentity?: OxyServices['signInWithSharedIdentity'];
+  issueNativeDeviceToken?: OxyServices['issueNativeDeviceToken'];
+  requestWebSession?: OxyServices['requestWebSession'];
+}
+
+function makeOxy(overrides: OxyOverrides = {}): { oxy: OxyServices; setTokens: jest.Mock } {
+  const setTokens = jest.fn();
+  const oxy = {
+    getBaseURL: () => overrides.baseURL ?? 'https://api.oxy.so',
+    setTokens,
+    exchangeBootCode: overrides.exchangeBootCode ?? (async () => BUNDLE),
+    refreshWithToken: overrides.refreshWithToken ?? (async () => ROTATED),
+    signInWithSharedIdentity: overrides.signInWithSharedIdentity ?? (async () => null),
+    issueNativeDeviceToken: overrides.issueNativeDeviceToken ?? (async () => 'native-device-token'),
+    requestWebSession:
+      overrides.requestWebSession
+      ?? (async () => ({ reason: 'no_session', deviceToken: 'dt-web' }) as WebSessionResult),
+    buildBootstrapUrl: (returnTo: string, state: string) =>
+      `https://api.oxy.so/auth/device/bootstrap?return_to=${encodeURIComponent(returnTo)}&state=${state}`,
+  } as unknown as OxyServices;
+  return { oxy, setTokens };
+}
+
+interface DomHandle {
+  dom: ColdBootDom;
+  navigate: jest.Mock;
+  strip: jest.Mock;
+  session: Map<string, string>;
+  local: Map<string, string>;
+}
+
+function makeDom(opts: { hash?: string; hostname?: string; sessionState?: string; attempted?: boolean } = {}): DomHandle {
+  const session = new Map<string, string>();
+  const local = new Map<string, string>();
+  if (opts.sessionState !== undefined) session.set(BOOT_STATE_SESSION_KEY, opts.sessionState);
+  if (opts.attempted) local.set(BOOT_ATTEMPTED_KEY, '1');
+  const navigate = jest.fn();
+  const strip = jest.fn();
+  const dom: ColdBootDom = {
+    getHash: () => opts.hash ?? '',
+    stripFragment: strip,
+    getSessionItem: (k) => session.get(k) ?? null,
+    setSessionItem: (k, v) => {
+      session.set(k, v);
+    },
+    removeSessionItem: (k) => {
+      session.delete(k);
+    },
+    getLocalItem: (k) => local.get(k) ?? null,
+    setLocalItem: (k, v) => {
+      local.set(k, v);
+    },
+    getLocationHostname: () => opts.hostname ?? 'accounts.oxy.so',
+    getReturnToHref: () => 'https://accounts.oxy.so/home',
+    navigate,
+    randomState: () => 'state-fixed-1234',
+  };
+  return { dom, navigate, strip, session, local };
+}
+
+const WEB = { isWeb: true, isNative: false };
+const NATIVE = { isWeb: false, isNative: true };
+
+describe('isSameApex', () => {
+  it('groups by registrable domain', () => {
+    expect(isSameApex('accounts.oxy.so', 'api.oxy.so')).toBe(true);
+    expect(isSameApex('oxy.so', 'api.oxy.so')).toBe(true);
+    expect(isSameApex('app.mention.earth', 'api.oxy.so')).toBe(false);
+    expect(isSameApex('homiio.com', 'api.oxy.so')).toBe(false);
+  });
+});
+
+describe('runSessionColdBoot — step ordering', () => {
+  it('stored-tokens warm-plants a still-valid access token before any hop', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save({
+      sessionId: 'sess-warm',
+      refreshToken: 'r-abcdefghij',
+      userId: 'user-warm',
+      accessToken: 'warm-token',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    const { oxy, setTokens } = makeOxy();
+    const requestWebSession = jest.spyOn(oxy, 'requestWebSession');
+    const onSession = jest.fn();
+
+    const outcome = await runSessionColdBoot({
+      oxy, store, platform: WEB, dom: makeDom().dom, onSession,
+    });
+
+    expect(outcome).toEqual({ kind: 'session', via: 'stored-tokens', session: expect.any(Object) });
+    expect(setTokens).toHaveBeenCalledWith('warm-token');
+    expect(onSession).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-warm', via: 'stored-tokens' }));
+    expect(requestWebSession).not.toHaveBeenCalled();
+  });
+
+  it('stored-tokens rotates when the warm token is absent/expired', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save({ sessionId: 'sess-old', refreshToken: 'r-abcdefghij', userId: 'user-1' });
+    const { oxy, setTokens } = makeOxy();
+
+    const outcome = await runSessionColdBoot({ oxy, store, platform: WEB, dom: makeDom().dom });
+
+    expect(outcome.kind).toBe('session');
+    expect(setTokens).toHaveBeenCalledWith('access-rot');
+    expect(await store.load()).toMatchObject({ sessionId: 'sess-rot', refreshToken: 'refresh-rot-abcdefghij' });
+  });
+
+  it('bootstrap-return wins over later steps when a valid fragment is present', async () => {
+    const store = createMemoryAuthStateStore();
+    // A base64url fragment carrying reason:session + matching state.
+    const frag = {
+      v: 1,
+      state: 'state-match',
+      reason: 'session',
+      code: 'c'.repeat(24),
+      deviceToken: 'd'.repeat(24),
+    };
+    const b64 = Buffer.from(JSON.stringify(frag), 'utf-8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const domHandle = makeDom({ hash: `#oxy_boot=${b64}`, sessionState: 'state-match' });
+    const { oxy, setTokens } = makeOxy();
+    const onSession = jest.fn();
+
+    const outcome = await runSessionColdBoot({
+      oxy, store, platform: WEB, dom: domHandle.dom, onSession,
+    });
+
+    expect(outcome).toEqual({ kind: 'session', via: 'bootstrap-return', session: expect.any(Object) });
+    expect(domHandle.strip).toHaveBeenCalled();
+    expect(setTokens).toHaveBeenCalledWith('access-boot');
+    expect(onSession).toHaveBeenCalledWith(expect.objectContaining({ via: 'bootstrap-return' }));
+  });
+});
+
+describe('runSessionColdBoot — bootstrap-hop (web)', () => {
+  it('same-apex: resolves a session via the inline web-session fetch (no navigation)', async () => {
+    const store = createMemoryAuthStateStore();
+    const requestWebSession = jest.fn(async () => BUNDLE as WebSessionResult);
+    const { oxy, setTokens } = makeOxy({ requestWebSession });
+    const domHandle = makeDom({ hostname: 'accounts.oxy.so' });
+
+    const outcome = await runSessionColdBoot({ oxy, store, platform: WEB, dom: domHandle.dom });
+
+    expect(outcome).toEqual({ kind: 'session', via: 'bootstrap-hop', session: expect.any(Object) });
+    expect(requestWebSession).toHaveBeenCalledTimes(1);
+    expect(setTokens).toHaveBeenCalledWith('access-boot');
+    expect(domHandle.navigate).not.toHaveBeenCalled();
+    expect(await store.load()).toMatchObject({ sessionId: 'sess-boot' });
+  });
+
+  it('same-apex: signed-out device persists the deviceToken and reports signed out', async () => {
+    const store = createMemoryAuthStateStore();
+    const requestWebSession = jest.fn(async () => ({ reason: 'no_session', deviceToken: 'dt-web' }) as WebSessionResult);
+    const { oxy } = makeOxy({ requestWebSession });
+    const domHandle = makeDom({ hostname: 'accounts.oxy.so' });
+    const onSignedOut = jest.fn();
+
+    const outcome = await runSessionColdBoot({ oxy, store, platform: WEB, dom: domHandle.dom, onSignedOut });
+
+    expect(outcome).toEqual({ kind: 'unauthenticated' });
+    expect(onSignedOut).toHaveBeenCalledWith('no_session');
+    expect(await store.loadDeviceToken()).toBe('dt-web');
+    expect(domHandle.navigate).not.toHaveBeenCalled();
+  });
+
+  it('cross-apex: navigates ONCE, stashing state + the attempted flag', async () => {
+    const store = createMemoryAuthStateStore();
+    const { oxy } = makeOxy();
+    const domHandle = makeDom({ hostname: 'app.mention.earth' });
+    const onSignedOut = jest.fn();
+    const onSession = jest.fn();
+
+    await runSessionColdBoot({ oxy, store, platform: WEB, dom: domHandle.dom, onSignedOut, onSession });
+
+    expect(domHandle.navigate).toHaveBeenCalledTimes(1);
+    expect(domHandle.navigate).toHaveBeenCalledWith(expect.stringContaining('/auth/device/bootstrap?return_to='));
+    expect(domHandle.session.get(BOOT_STATE_SESSION_KEY)).toBe('state-fixed-1234');
+    expect(domHandle.local.get(BOOT_ATTEMPTED_KEY)).toBe('1');
+    // Navigating away — neither callback fires (no signed-out flash).
+    expect(onSignedOut).not.toHaveBeenCalled();
+    expect(onSession).not.toHaveBeenCalled();
+  });
+
+  it('cross-apex: NEVER navigates a second time once the attempted flag is set', async () => {
+    const store = createMemoryAuthStateStore();
+    const { oxy } = makeOxy();
+    const domHandle = makeDom({ hostname: 'app.mention.earth', attempted: true });
+    const onSignedOut = jest.fn();
+
+    const outcome = await runSessionColdBoot({ oxy, store, platform: WEB, dom: domHandle.dom, onSignedOut });
+
+    expect(domHandle.navigate).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ kind: 'unauthenticated' });
+    expect(onSignedOut).toHaveBeenCalledWith('no_session');
+  });
+});
+
+describe('runSessionColdBoot — native shared-key', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('re-mints via shared identity and issues + mirrors a deviceToken the first time', async () => {
+    const store = createMemoryAuthStateStore();
+    const sharedSession: SessionLoginResponse = {
+      sessionId: 'sess-shared',
+      deviceId: 'dev-1',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+      user: { id: 'user-shared', username: 'u', name: {}, avatar: undefined },
+      accessToken: 'access-shared',
+    };
+    const issueNativeDeviceToken = jest.fn(async () => 'fresh-device-token');
+    const { oxy } = makeOxy({
+      signInWithSharedIdentity: async () => sharedSession,
+      issueNativeDeviceToken,
+    });
+    const getShared = jest.spyOn(KeyManager, 'getSharedDeviceToken').mockResolvedValue(null);
+    const setShared = jest.spyOn(KeyManager, 'setSharedDeviceToken').mockResolvedValue(undefined);
+    const requestWebSession = jest.spyOn(oxy, 'requestWebSession');
+
+    const outcome = await runSessionColdBoot({ oxy, store, platform: NATIVE, dom: makeDom().dom });
+
+    expect(outcome).toEqual({ kind: 'session', via: 'shared-key-signin', session: expect.any(Object) });
+    expect(getShared).toHaveBeenCalled();
+    expect(issueNativeDeviceToken).toHaveBeenCalled();
+    expect(setShared).toHaveBeenCalledWith('fresh-device-token');
+    expect(await store.loadDeviceToken()).toBe('fresh-device-token');
+    // bootstrap-hop is web-only — never runs on native.
+    expect(requestWebSession).not.toHaveBeenCalled();
+  });
+
+  it('skips device-token issuance when the shared token already exists', async () => {
+    const store = createMemoryAuthStateStore();
+    const issueNativeDeviceToken = jest.fn(async () => 'unused');
+    const { oxy } = makeOxy({
+      signInWithSharedIdentity: async () => ({
+        sessionId: 'sess-shared',
+        deviceId: 'dev-1',
+        expiresAt: '2030-01-01T00:00:00.000Z',
+        user: { id: 'user-shared', username: 'u', name: {}, avatar: undefined },
+        accessToken: 'access-shared',
+      }),
+      issueNativeDeviceToken,
+    });
+    jest.spyOn(KeyManager, 'getSharedDeviceToken').mockResolvedValue('already-there');
+
+    await runSessionColdBoot({ oxy, store, platform: NATIVE, dom: makeDom().dom });
+
+    expect(issueNativeDeviceToken).not.toHaveBeenCalled();
+  });
+});
+
+describe('createBrowserColdBootDom', () => {
+  it('returns neutral values under the jest node environment (no window)', () => {
+    const dom = createBrowserColdBootDom();
+    expect(dom.getHash()).toBe('');
+    expect(dom.getLocationHostname()).toBeNull();
+    expect(dom.getSessionItem('x')).toBeNull();
+    expect(() => dom.stripFragment()).not.toThrow();
+    expect(() => dom.navigate('https://x')).not.toThrow();
+    expect(dom.randomState()).toMatch(/^[0-9a-f]+$/);
+  });
+});

--- a/packages/core/src/boot/__tests__/deviceBootReturn.test.ts
+++ b/packages/core/src/boot/__tests__/deviceBootReturn.test.ts
@@ -1,0 +1,151 @@
+import type { AuthTokenBundle, DeviceBootFragment } from '@oxyhq/contracts';
+import {
+  parseDeviceBootFragment,
+  hashHasBootFragment,
+  consumeDeviceBootReturn,
+  type ConsumeDeviceBootReturnDeps,
+} from '../deviceBootReturn';
+import { createMemoryAuthStateStore } from '../../session/authStateStore';
+
+const STATE = 'st-1234567890';
+const CODE = 'c'.repeat(24);
+const DEVICE_TOKEN = 'd'.repeat(24);
+
+function fragmentObject(overrides: Partial<DeviceBootFragment> = {}): DeviceBootFragment {
+  return { v: 1, state: STATE, reason: 'session', code: CODE, deviceToken: DEVICE_TOKEN, ...overrides };
+}
+
+function encodeHash(obj: unknown): string {
+  const b64 = Buffer.from(JSON.stringify(obj), 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `#oxy_boot=${b64}`;
+}
+
+const BUNDLE: AuthTokenBundle = {
+  sessionId: 'sess-1',
+  accessToken: 'access-jwt',
+  refreshToken: 'refresh-abcdefghijklmnop',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  user: { id: 'user-1', name: {} } as AuthTokenBundle['user'],
+};
+
+/** Build the injectable deps around a memory store, recording call order. */
+function makeDeps(
+  hash: string,
+  overrides: Partial<ConsumeDeviceBootReturnDeps> & { expectedState?: string | null } = {},
+): { deps: ConsumeDeviceBootReturnDeps; calls: string[]; store: ReturnType<typeof createMemoryAuthStateStore> } {
+  const calls: string[] = [];
+  const store = createMemoryAuthStateStore();
+  const deps: ConsumeDeviceBootReturnDeps = {
+    hash,
+    stripFragment: () => calls.push('strip'),
+    readExpectedState: () => (overrides.expectedState !== undefined ? overrides.expectedState : STATE),
+    clearExpectedState: () => calls.push('clearState'),
+    store,
+    exchangeBootCode: overrides.exchangeBootCode
+      ?? (async () => {
+        calls.push('exchange');
+        return BUNDLE;
+      }),
+    plantAccessToken: overrides.plantAccessToken ?? ((token) => calls.push(`plant:${token}`)),
+  };
+  return { deps, calls, store };
+}
+
+describe('parseDeviceBootFragment', () => {
+  it('parses a valid base64url fragment', () => {
+    expect(parseDeviceBootFragment(encodeHash(fragmentObject()))).toEqual(fragmentObject());
+  });
+
+  it('returns null when the parameter is absent', () => {
+    expect(parseDeviceBootFragment('#something=else')).toBeNull();
+    expect(parseDeviceBootFragment('')).toBeNull();
+  });
+
+  it('returns null for malformed base64 / non-JSON / wrong shape', () => {
+    expect(parseDeviceBootFragment('#oxy_boot=!!!not-base64!!!')).toBeNull();
+    expect(parseDeviceBootFragment(encodeHash({ nope: true }))).toBeNull();
+    // v must be the literal 1
+    expect(parseDeviceBootFragment(encodeHash(fragmentObject({ v: 2 as 1 })))).toBeNull();
+  });
+});
+
+describe('hashHasBootFragment', () => {
+  it('detects the fragment regardless of position', () => {
+    expect(hashHasBootFragment('#oxy_boot=abc')).toBe(true);
+    expect(hashHasBootFragment('#x=1&oxy_boot=abc')).toBe(true);
+    expect(hashHasBootFragment('#other=1')).toBe(false);
+    expect(hashHasBootFragment('')).toBe(false);
+  });
+});
+
+describe('consumeDeviceBootReturn', () => {
+  it('returns none and does not touch the URL when no fragment is present', async () => {
+    const { deps, calls } = makeDeps('#unrelated=1');
+    expect(await consumeDeviceBootReturn(deps)).toEqual({ kind: 'none' });
+    expect(calls).not.toContain('strip');
+  });
+
+  it('strips the fragment BEFORE exchanging the code', async () => {
+    const { deps, calls } = makeDeps(encodeHash(fragmentObject()));
+    const outcome = await consumeDeviceBootReturn(deps);
+    expect(outcome.kind).toBe('session');
+    expect(calls.indexOf('strip')).toBeLessThan(calls.indexOf('exchange'));
+  });
+
+  it('resolves a session, persists it, and plants the token', async () => {
+    const { deps, store } = makeDeps(encodeHash(fragmentObject()));
+    const outcome = await consumeDeviceBootReturn(deps);
+    expect(outcome).toEqual({
+      kind: 'session',
+      session: { sessionId: 'sess-1', userId: 'user-1', accessToken: 'access-jwt' },
+    });
+    expect(await store.load()).toMatchObject({
+      sessionId: 'sess-1',
+      refreshToken: 'refresh-abcdefghijklmnop',
+      userId: 'user-1',
+      deviceToken: DEVICE_TOKEN,
+    });
+    expect(await store.loadDeviceToken()).toBe(DEVICE_TOKEN);
+  });
+
+  it('rejects a state mismatch without persisting or exchanging', async () => {
+    const { deps, calls, store } = makeDeps(encodeHash(fragmentObject()), { expectedState: 'WRONG' });
+    expect(await consumeDeviceBootReturn(deps)).toEqual({ kind: 'state-mismatch' });
+    expect(calls).toContain('strip');
+    expect(calls).not.toContain('exchange');
+    expect(await store.loadDeviceToken()).toBeNull();
+  });
+
+  it('rejects when there is no expected state stashed at all', async () => {
+    const { deps } = makeDeps(encodeHash(fragmentObject()), { expectedState: null });
+    expect(await consumeDeviceBootReturn(deps)).toEqual({ kind: 'state-mismatch' });
+  });
+
+  it('persists the deviceToken but returns no-session for a signed-out device', async () => {
+    const { deps, store, calls } = makeDeps(
+      encodeHash(fragmentObject({ reason: 'new_device', code: undefined })),
+    );
+    expect(await consumeDeviceBootReturn(deps)).toEqual({ kind: 'no-session', reason: 'new_device' });
+    expect(calls).not.toContain('exchange');
+    expect(await store.loadDeviceToken()).toBe(DEVICE_TOKEN);
+  });
+
+  it('returns no-session when the code exchange fails (burned/expired code)', async () => {
+    const { deps } = makeDeps(encodeHash(fragmentObject()), {
+      exchangeBootCode: async () => {
+        throw new Error('code already burned');
+      },
+    });
+    expect(await consumeDeviceBootReturn(deps)).toEqual({ kind: 'no-session', reason: 'no_session' });
+  });
+
+  it('strips even a malformed fragment and returns none', async () => {
+    const { deps, calls } = makeDeps('#oxy_boot=!!!malformed!!!');
+    expect(await consumeDeviceBootReturn(deps)).toEqual({ kind: 'none' });
+    expect(calls).toContain('strip');
+  });
+});

--- a/packages/core/src/boot/coldBootV2.ts
+++ b/packages/core/src/boot/coldBootV2.ts
@@ -1,0 +1,397 @@
+/**
+ * coldBootV2 — one device-first cold boot for every consumer.
+ *
+ * On a fresh page load / app launch this resolves the device's session in a
+ * deterministic order, built on the pure `runColdBoot` primitive. It NEVER
+ * redirects to a login page: an unresolved boot ends in a signed-out state that
+ * the app renders with a "Sign in with Oxy" button.
+ *
+ * Ordered steps (first to yield a session wins):
+ *   1. `bootstrap-return` (web) — consume a `#oxy_boot` return fragment from a
+ *      just-completed cross-apex hop: strip it, verify state, persist the
+ *      deviceToken, exchange the code.
+ *   2. `stored-tokens` — the persisted per-origin refresh family: warm-plant a
+ *      still-valid access token, else rotate via `/auth/refresh-token`.
+ *   3. `shared-key-signin` (native) — re-mint from the shared-keychain identity,
+ *      issuing + mirroring a shared deviceToken the first time.
+ *   4. `bootstrap-hop` (web) — same-apex: an inline credentialed
+ *      `/auth/device/web-session` fetch (no redirect); cross-apex: ONE top-level
+ *      navigation to `/auth/device/bootstrap`, guarded once-ever per origin.
+ *   5. Signed out.
+ *
+ * All mutable guard state lives in STORAGE (localStorage `oxy.boot.attempted` +
+ * sessionStorage `oxy.boot.state`), never in module scope, so the guard holds
+ * under Metro/bundler re-evaluation.
+ *
+ * ESM-safe (no `require()`); no react/react-native/expo imports.
+ */
+import { resolveUserId } from '@oxyhq/contracts';
+import { runColdBoot, type ColdBootOutcome, type ColdBootStep } from '../utils/coldBoot';
+import { isWeb as detectWeb, isNative as detectNative } from '../utils/platform';
+import { KeyManager } from '../crypto/keyManager';
+import { logger } from '../utils/loggerUtils';
+import type { OxyServices } from '../OxyServices';
+import type { AuthStateStore, PersistedAuthState } from '../session/authStateStore';
+import { refreshPersistedSession } from '../session/refresh';
+import { isAuthTokenBundle } from '../mixins/OxyServices.deviceBoot';
+import {
+  consumeDeviceBootReturn,
+  hashHasBootFragment,
+  BOOT_STATE_SESSION_KEY,
+  type DeviceBootSession,
+} from './deviceBootReturn';
+
+/**
+ * localStorage flag marking that the cross-apex bootstrap navigation has fired
+ * once for this origin. Persistent (not session) so the visible redirect
+ * happens AT MOST ONCE EVER per browser+origin — a signed-out user is never
+ * bounced again; they sign in explicitly.
+ */
+export const BOOT_ATTEMPTED_KEY = 'oxy.boot.attempted';
+
+/**
+ * Do not warm-plant a stored access token with less than this remaining — it
+ * would need an immediate refresh anyway, so fall through to the rotate path.
+ * Matches the refresh lead window.
+ */
+const WARM_MIN_REMAINING_MS = 60_000;
+
+/** Why a cold boot ended without a session. */
+export type SignedOutReason =
+  | 'no_session'
+  | 'new_device'
+  | 'state-mismatch'
+  | 'error';
+
+/**
+ * The DOM/storage seam. All access is injected so the boot is unit-testable
+ * under the jest `node` environment; {@link createBrowserColdBootDom} provides
+ * the guarded real-globals implementation used in production.
+ */
+export interface ColdBootDom {
+  getHash(): string;
+  stripFragment(): void;
+  getSessionItem(key: string): string | null;
+  setSessionItem(key: string, value: string): void;
+  removeSessionItem(key: string): void;
+  getLocalItem(key: string): string | null;
+  setLocalItem(key: string, value: string): void;
+  getLocationHostname(): string | null;
+  /** Current href WITHOUT its hash fragment (the bootstrap `return_to`). */
+  getReturnToHref(): string | null;
+  navigate(url: string): void;
+  /** A fresh high-entropy CSRF state token. */
+  randomState(): string;
+}
+
+export interface RunSessionColdBootOptions {
+  oxy: OxyServices;
+  store: AuthStateStore;
+  /** Platform hints; default derived from `@oxyhq/core`'s platform detection. */
+  platform?: { isWeb?: boolean; isNative?: boolean };
+  /**
+   * The RP return URL for the cross-apex hop. Defaults to the current href
+   * (sans fragment) via the DOM seam.
+   */
+  returnTo?: string;
+  /** Invoked with the winning session (token already planted). */
+  onSession?: (session: DeviceBootSession & { via: string }) => void | Promise<void>;
+  /** Invoked when the boot ended signed out (not while navigating away). */
+  onSignedOut?: (reason: SignedOutReason) => void | Promise<void>;
+  onStepError?: (id: string, error: unknown) => void;
+  /** DOM/storage seam; defaults to the guarded browser implementation. */
+  dom?: ColdBootDom;
+}
+
+/**
+ * Generate a 128-bit hex CSRF state token. Prefers Web Crypto
+ * (`crypto.getRandomValues`, present in browsers and modern Node); falls back
+ * to a time+`Math.random` mix only when no CSPRNG is reachable (this token
+ * gates a single-use CSRF echo, not a long-lived secret).
+ */
+function generateStateToken(): string {
+  const cryptoObj = (globalThis as { crypto?: Crypto }).crypto;
+  if (cryptoObj?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    cryptoObj.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  }
+  return `${Date.now().toString(16)}${Math.random().toString(16).slice(2, 18)}`;
+}
+
+/**
+ * The guarded real-globals {@link ColdBootDom}. Every accessor tolerates a
+ * missing/throwing global (SSR, sandboxed iframe) by returning a neutral value
+ * or no-op, so the boot degrades to signed-out rather than crashing.
+ */
+export function createBrowserColdBootDom(): ColdBootDom {
+  const safe = <T>(fn: () => T, fallback: T): T => {
+    try {
+      return fn();
+    } catch {
+      return fallback;
+    }
+  };
+  return {
+    getHash: () => safe(() => (typeof window !== 'undefined' ? window.location.hash : ''), ''),
+    stripFragment: () =>
+      safe(() => {
+        if (typeof window !== 'undefined' && window.history?.replaceState) {
+          const { pathname, search } = window.location;
+          window.history.replaceState(null, '', `${pathname}${search}`);
+        }
+      }, undefined),
+    getSessionItem: (key) =>
+      safe(() => (typeof sessionStorage !== 'undefined' ? sessionStorage.getItem(key) : null), null),
+    setSessionItem: (key, value) =>
+      safe(() => {
+        if (typeof sessionStorage !== 'undefined') sessionStorage.setItem(key, value);
+      }, undefined),
+    removeSessionItem: (key) =>
+      safe(() => {
+        if (typeof sessionStorage !== 'undefined') sessionStorage.removeItem(key);
+      }, undefined),
+    getLocalItem: (key) =>
+      safe(() => (typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null), null),
+    setLocalItem: (key, value) =>
+      safe(() => {
+        if (typeof localStorage !== 'undefined') localStorage.setItem(key, value);
+      }, undefined),
+    getLocationHostname: () =>
+      safe(() => (typeof window !== 'undefined' ? window.location.hostname : null), null),
+    getReturnToHref: () =>
+      safe(() => {
+        if (typeof window === 'undefined') return null;
+        const { origin, pathname, search } = window.location;
+        return `${origin}${pathname}${search}`;
+      }, null),
+    navigate: (url) =>
+      safe(() => {
+        if (typeof window !== 'undefined') window.location.assign(url);
+      }, undefined),
+    randomState: generateStateToken,
+  };
+}
+
+/**
+ * Registrable domain = the last two labels of a host. A deliberately SMALL
+ * local helper (the plan forbids coupling the boot to `fapiAutoDetect`/`tldts`).
+ * Correct for every Oxy apex (all two-label domains: `oxy.so`, `mention.earth`,
+ * `alia.onl`, `homiio.com`); the only imprecision — a multi-part public suffix
+ * such as `co.uk` — never arises here because the compared API host is always
+ * `api.oxy.so`, so a page under a different registrable domain still classifies
+ * as cross-apex.
+ */
+function registrableDomain(host: string): string {
+  const labels = host.toLowerCase().split('.').filter(Boolean);
+  return labels.length <= 2 ? labels.join('.') : labels.slice(-2).join('.');
+}
+
+/** True when both hosts share a registrable domain (same-site / same-apex). */
+export function isSameApex(pageHost: string, apiHost: string): boolean {
+  const a = registrableDomain(pageHost);
+  const b = registrableDomain(apiHost);
+  return a !== '' && a === b;
+}
+
+/** Build a `DeviceBootSession` from a persisted state (post-refresh/warm-plant). */
+function sessionFromPersisted(state: PersistedAuthState, accessToken: string): DeviceBootSession {
+  return { sessionId: state.sessionId, userId: state.userId, accessToken };
+}
+
+/**
+ * Run the device-first cold boot. Resolves to the `runColdBoot` outcome and, as
+ * a side effect, invokes `onSession` (winning session, token already planted)
+ * or `onSignedOut` (no session — unless the boot is navigating away for the
+ * cross-apex hop, in which case neither fires).
+ */
+export async function runSessionColdBoot(
+  opts: RunSessionColdBootOptions,
+): Promise<ColdBootOutcome<DeviceBootSession>> {
+  const { oxy, store } = opts;
+  const dom = opts.dom ?? createBrowserColdBootDom();
+  const isWeb = opts.platform?.isWeb ?? detectWeb();
+  const isNative = opts.platform?.isNative ?? detectNative();
+
+  // Signed-out reason + navigating flag are boot-local (not module-level), so
+  // they cannot leak across boots or break under bundler re-evaluation.
+  let signedOutReason: SignedOutReason = 'no_session';
+  let navigating = false;
+
+  const steps: Array<ColdBootStep<DeviceBootSession>> = [];
+
+  // 1. bootstrap-return (web) — consume a #oxy_boot fragment.
+  steps.push({
+    id: 'bootstrap-return',
+    enabled: () => isWeb && hashHasBootFragment(dom.getHash()),
+    run: async () => {
+      const outcome = await consumeDeviceBootReturn({
+        hash: dom.getHash(),
+        stripFragment: () => dom.stripFragment(),
+        readExpectedState: () => dom.getSessionItem(BOOT_STATE_SESSION_KEY),
+        clearExpectedState: () => dom.removeSessionItem(BOOT_STATE_SESSION_KEY),
+        store,
+        exchangeBootCode: (code) => oxy.exchangeBootCode(code),
+        plantAccessToken: (accessToken) => oxy.setTokens(accessToken),
+      });
+      if (outcome.kind === 'session') {
+        return { kind: 'session', session: outcome.session };
+      }
+      if (outcome.kind === 'state-mismatch') {
+        signedOutReason = 'state-mismatch';
+      } else if (outcome.kind === 'no-session') {
+        // `DeviceBootReason` also carries 'session'; a no-session outcome with
+        // that reason (a `session` reason but no code) is still signed out.
+        signedOutReason = outcome.reason === 'new_device' ? 'new_device' : 'no_session';
+      }
+      // Fall through: a stored refresh family (a prior same-origin session) may
+      // still recover below. The once-ever flag blocks a second hop.
+      return { kind: 'skip' };
+    },
+  });
+
+  // 2. stored-tokens — warm-plant or rotate the persisted refresh family.
+  steps.push({
+    id: 'stored-tokens',
+    run: async () => {
+      const persisted = await store.load();
+      if (!persisted) {
+        return { kind: 'skip' };
+      }
+      // Warm path: a still-valid access token → plant immediately (no network).
+      if (
+        persisted.accessToken &&
+        persisted.expiresAt &&
+        Date.parse(persisted.expiresAt) - Date.now() > WARM_MIN_REMAINING_MS
+      ) {
+        oxy.setTokens(persisted.accessToken);
+        return { kind: 'session', session: sessionFromPersisted(persisted, persisted.accessToken) };
+      }
+      // Rotate path: refreshPersistedSession plants + persists, and clears the
+      // store on a family-revoked error.
+      const token = await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: isNative });
+      if (!token) {
+        return { kind: 'skip' };
+      }
+      const after = await store.load();
+      const base = after ?? persisted;
+      return { kind: 'session', session: sessionFromPersisted(base, token) };
+    },
+  });
+
+  // 3. shared-key-signin (native) — re-mint from the shared identity.
+  steps.push({
+    id: 'shared-key-signin',
+    enabled: () => isNative,
+    run: async () => {
+      const session = await oxy.signInWithSharedIdentity();
+      if (!session?.accessToken) {
+        return { kind: 'skip' };
+      }
+      // First shared-key sign-in on this device: issue + persist + mirror a
+      // shared deviceToken so every native Oxy app joins one DeviceSession.
+      // Best-effort — never fail the sign-in over device-token issuance.
+      try {
+        const existing = await KeyManager.getSharedDeviceToken();
+        if (!existing) {
+          const deviceToken = await oxy.issueNativeDeviceToken();
+          await store.saveDeviceToken(deviceToken);
+          await KeyManager.setSharedDeviceToken(deviceToken);
+        }
+      } catch (error) {
+        logger.debug(
+          'Native deviceToken issuance skipped',
+          { component: 'coldBootV2', method: 'shared-key-signin' },
+          error,
+        );
+      }
+      return {
+        kind: 'session',
+        session: {
+          sessionId: session.sessionId,
+          userId: session.user.id,
+          accessToken: session.accessToken,
+        },
+      };
+    },
+  });
+
+  // 4. bootstrap-hop (web, terminal) — same-apex inline fetch OR cross-apex nav.
+  steps.push({
+    id: 'bootstrap-hop',
+    enabled: () => isWeb,
+    run: async () => {
+      const pageHost = dom.getLocationHostname();
+      let apiHost: string | null = null;
+      try {
+        apiHost = new URL(oxy.getBaseURL()).hostname;
+      } catch {
+        apiHost = null;
+      }
+      if (!pageHost || !apiHost) {
+        return { kind: 'skip' };
+      }
+
+      // Same-apex: inline credentialed fetch, no redirect, runs every boot.
+      if (isSameApex(pageHost, apiHost)) {
+        const result = await oxy.requestWebSession();
+        if (isAuthTokenBundle(result)) {
+          const userId = resolveUserId(result.user);
+          if (!userId) {
+            return { kind: 'skip' };
+          }
+          const next: PersistedAuthState = {
+            sessionId: result.sessionId,
+            refreshToken: result.refreshToken,
+            userId,
+            deviceToken: (await store.loadDeviceToken()) ?? undefined,
+            accessToken: result.accessToken,
+            expiresAt: result.expiresAt,
+          };
+          await store.save(next);
+          oxy.setTokens(result.accessToken);
+          return { kind: 'session', session: sessionFromPersisted(next, result.accessToken) };
+        }
+        // Known device, signed out.
+        await store.saveDeviceToken(result.deviceToken);
+        signedOutReason = result.reason;
+        return { kind: 'skip' };
+      }
+
+      // Cross-apex: ONE visible top-level navigation, once-ever per origin.
+      if (dom.getLocalItem(BOOT_ATTEMPTED_KEY)) {
+        return { kind: 'skip' };
+      }
+      const returnTo = opts.returnTo ?? dom.getReturnToHref();
+      if (!returnTo) {
+        return { kind: 'skip' };
+      }
+      const state = dom.randomState();
+      dom.setSessionItem(BOOT_STATE_SESSION_KEY, state);
+      dom.setLocalItem(BOOT_ATTEMPTED_KEY, '1');
+      navigating = true;
+      dom.navigate(oxy.buildBootstrapUrl(returnTo, state));
+      return { kind: 'skip' };
+    },
+  });
+
+  const outcome = await runColdBoot<DeviceBootSession>({
+    steps,
+    onStepError: (id, error) => {
+      signedOutReason = 'error';
+      opts.onStepError?.(id, error);
+    },
+  });
+
+  if (outcome.kind === 'session') {
+    await opts.onSession?.({ ...outcome.session, via: outcome.via });
+    return outcome;
+  }
+
+  // Navigating away for the cross-apex hop: the page is unloading, so do not
+  // flash a signed-out state.
+  if (!navigating) {
+    await opts.onSignedOut?.(signedOutReason);
+  }
+  return outcome;
+}

--- a/packages/core/src/boot/deviceBootReturn.ts
+++ b/packages/core/src/boot/deviceBootReturn.ts
@@ -1,0 +1,192 @@
+/**
+ * Device-boot return-fragment consumption (web cross-apex hop).
+ *
+ * After the top-level `GET /auth/device/bootstrap` hop, the API 303s back to the
+ * RP with a `#oxy_boot=<base64url(JSON)>` fragment. This module parses and
+ * consumes it: it strips the fragment from the URL FIRST (so the opaque
+ * deviceToken / code never linger in history or a `Referer`), verifies the
+ * echoed CSRF `state` against the value the initiator stashed in
+ * `sessionStorage`, persists the deviceToken, and — when a session resolved —
+ * exchanges the single-use `code` for a token bundle.
+ *
+ * Pure/injectable: all DOM access (hash, `history.replaceState`,
+ * `sessionStorage`) is passed in as callbacks so the logic is unit-testable
+ * under the jest `node` environment and reusable by `coldBootV2`.
+ *
+ * ESM-safe (no `require()`).
+ */
+import {
+  deviceBootFragmentSchema,
+  resolveUserId,
+  safeParseContract,
+  type AuthTokenBundle,
+  type DeviceBootFragment,
+  type DeviceBootReason,
+} from '@oxyhq/contracts';
+import type { AuthStateStore, PersistedAuthState } from '../session/authStateStore';
+
+/** The `#oxy_boot=` fragment parameter name the API appends on the return hop. */
+export const BOOT_FRAGMENT_PARAM = 'oxy_boot';
+
+/**
+ * `sessionStorage` key under which the bootstrap-hop initiator stashes the
+ * 128-bit CSRF `state` before navigating, and which the return step reads back
+ * (single-use).
+ */
+export const BOOT_STATE_SESSION_KEY = 'oxy.boot.state';
+
+/**
+ * Decode a base64url string to UTF-8 text, or `null` on any malformed input.
+ * Handles both web (`atob` + `TextDecoder`) and Node (`Buffer`) without a
+ * `require()` — the ESM build stays clean.
+ */
+function base64UrlDecode(input: string): string | null {
+  try {
+    let b64 = input.replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4 !== 0) {
+      b64 += '=';
+    }
+    if (typeof atob === 'function') {
+      const binary = atob(b64);
+      const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+      if (typeof TextDecoder !== 'undefined') {
+        return new TextDecoder().decode(bytes);
+      }
+      return binary;
+    }
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(b64, 'base64').toString('utf-8');
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when a location hash carries the `oxy_boot` return fragment. */
+export function hashHasBootFragment(hash: string): boolean {
+  return new RegExp(`(^|[#&])${BOOT_FRAGMENT_PARAM}=`).test(hash);
+}
+
+/**
+ * Extract + decode + validate the `oxy_boot` fragment from a location hash.
+ * Returns the parsed {@link DeviceBootFragment}, or `null` when the parameter
+ * is absent, not valid base64url, not JSON, or fails the contract schema.
+ */
+export function parseDeviceBootFragment(hash: string): DeviceBootFragment | null {
+  const withoutHash = hash.startsWith('#') ? hash.slice(1) : hash;
+  const params = new URLSearchParams(withoutHash);
+  const raw = params.get(BOOT_FRAGMENT_PARAM);
+  if (!raw) {
+    return null;
+  }
+  const json = base64UrlDecode(raw);
+  if (!json) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  return safeParseContract(deviceBootFragmentSchema, parsed);
+}
+
+/** The winning session shape a cold-boot step reports. */
+export interface DeviceBootSession {
+  sessionId: string;
+  userId: string;
+  accessToken: string;
+}
+
+/** Outcome of {@link consumeDeviceBootReturn}. */
+export type DeviceBootReturnOutcome =
+  | { kind: 'none' }
+  | { kind: 'state-mismatch' }
+  | { kind: 'session'; session: DeviceBootSession }
+  | { kind: 'no-session'; reason: DeviceBootReason };
+
+export interface ConsumeDeviceBootReturnDeps {
+  /** The current location hash (e.g. `window.location.hash`). */
+  hash: string;
+  /** Strip the fragment from the URL (e.g. `history.replaceState`). */
+  stripFragment: () => void;
+  /** Read the expected CSRF state (e.g. `sessionStorage.getItem(BOOT_STATE_SESSION_KEY)`). */
+  readExpectedState: () => string | null;
+  /** Clear the expected CSRF state (single-use). */
+  clearExpectedState: () => void;
+  store: AuthStateStore;
+  /** Exchange the single-use boot code for a token bundle (`oxy.exchangeBootCode`). */
+  exchangeBootCode: (code: string) => Promise<AuthTokenBundle>;
+  /** Plant the freshly-minted access token on the owner client (`oxy.setTokens`). */
+  plantAccessToken: (accessToken: string) => void;
+}
+
+/**
+ * Consume the device-boot return fragment.
+ *
+ * Order is load-bearing:
+ *   1. If no fragment is present, return `none` (no URL mutation).
+ *   2. STRIP the fragment from the URL immediately — before validation or any
+ *      network — so the deviceToken/code never persist in history/referrer.
+ *   3. Verify the echoed `state` against the stashed (single-use) value; a
+ *      mismatch returns `state-mismatch` without persisting or exchanging.
+ *   4. Persist the deviceToken (survives sign-out).
+ *   5. If a session resolved (`reason:'session'` + `code`), exchange the code,
+ *      persist the rotated session, plant the token, and return `session`.
+ *      Otherwise return `no-session` with the reason.
+ */
+export async function consumeDeviceBootReturn(
+  deps: ConsumeDeviceBootReturnDeps,
+): Promise<DeviceBootReturnOutcome> {
+  if (!hashHasBootFragment(deps.hash)) {
+    return { kind: 'none' };
+  }
+
+  // Strip FIRST — even a forged/malformed fragment must not linger in the URL.
+  deps.stripFragment();
+
+  const fragment = parseDeviceBootFragment(deps.hash);
+  if (!fragment) {
+    return { kind: 'none' };
+  }
+
+  const expected = deps.readExpectedState();
+  deps.clearExpectedState();
+  if (!expected || expected !== fragment.state) {
+    return { kind: 'state-mismatch' };
+  }
+
+  await deps.store.saveDeviceToken(fragment.deviceToken);
+
+  if (fragment.reason === 'session' && fragment.code) {
+    try {
+      const bundle = await deps.exchangeBootCode(fragment.code);
+      const userId = resolveUserId(bundle.user);
+      if (!userId) {
+        return { kind: 'no-session', reason: 'no_session' };
+      }
+      const next: PersistedAuthState = {
+        sessionId: bundle.sessionId,
+        refreshToken: bundle.refreshToken,
+        userId,
+        deviceToken: fragment.deviceToken,
+        accessToken: bundle.accessToken,
+        expiresAt: bundle.expiresAt,
+      };
+      await deps.store.save(next);
+      deps.plantAccessToken(bundle.accessToken);
+      return {
+        kind: 'session',
+        session: { sessionId: bundle.sessionId, userId, accessToken: bundle.accessToken },
+      };
+    } catch {
+      // The code burned/expired between hop and exchange — resolve signed-out
+      // rather than throwing (the once-ever hop already fired; do not retry).
+      return { kind: 'no-session', reason: 'no_session' };
+    }
+  }
+
+  return { kind: 'no-session', reason: fragment.reason };
+}

--- a/packages/core/src/crypto/__tests__/sharedDeviceToken.test.ts
+++ b/packages/core/src/crypto/__tests__/sharedDeviceToken.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared device-token contract on web. Under the jest `node` environment
+ * `getPlatformOS()` resolves to `'web'`, so the shared-keychain device-token
+ * methods are no-ops (web persists its deviceToken in the per-origin
+ * AuthStateStore instead of a keychain). The native keychain plumbing is
+ * exercised via spies in the coldBootV2 suite.
+ */
+import { KeyManager } from '../keyManager';
+
+describe('KeyManager shared device token (web)', () => {
+  it('getSharedDeviceToken returns null on web', async () => {
+    expect(await KeyManager.getSharedDeviceToken()).toBeNull();
+  });
+
+  it('setSharedDeviceToken is a no-op that does not throw on web', async () => {
+    await expect(KeyManager.setSharedDeviceToken('dt-web')).resolves.toBeUndefined();
+    // Still null — nothing was persisted on web.
+    expect(await KeyManager.getSharedDeviceToken()).toBeNull();
+  });
+
+  it('clearSharedDeviceToken is a no-op that does not throw on web', async () => {
+    await expect(KeyManager.clearSharedDeviceToken()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/crypto/keyManager.ts
+++ b/packages/core/src/crypto/keyManager.ts
@@ -91,6 +91,11 @@ const STORAGE_KEYS = {
   SHARED_PUBLIC_KEY: 'oxy_shared_identity_public_key',
   SHARED_SESSION_TOKEN: 'oxy_shared_session_token',
   SHARED_SESSION_ID: 'oxy_shared_session_id',
+  // Opaque device-attribution token, shared across all Oxy apps on one device
+  // so they all resolve to a SINGLE server-side DeviceSession (device-first
+  // session model). Add-only: it never carries session state, only attributes
+  // a newly-credentialed session to the shared device set.
+  SHARED_DEVICE_TOKEN: 'oxy_shared_device_token',
 } as const;
 
 /**
@@ -640,6 +645,102 @@ export class KeyManager {
         logger.error('Failed to migrate to shared identity', error, { component: 'KeyManager' });
       }
       return false;
+    }
+  }
+
+  /**
+   * Store the opaque device-attribution token in the SHARED keychain so every
+   * Oxy app on this device reads the SAME token and therefore resolves to one
+   * server-side DeviceSession.
+   *
+   * Mirrors the shared-session storage options exactly (iOS keychain access
+   * group `group.so.oxy.shared`; Android shared secure store). Native-only —
+   * a no-op on web (the shared keychain does not exist there; web persists its
+   * deviceToken in the per-origin {@link AuthStateStore} instead).
+   */
+  static async setSharedDeviceToken(deviceToken: string): Promise<void> {
+    if (isWebPlatform()) {
+      return; // Not supported on web
+    }
+
+    try {
+      const store = await initSecureStore();
+
+      if (isIOS()) {
+        const opts: OxySecureStoreOptions = {
+          keychainAccessible: store.WHEN_UNLOCKED,
+          keychainAccessGroup: IOS_KEYCHAIN_GROUP,
+        };
+        await store.setItemAsync(STORAGE_KEYS.SHARED_DEVICE_TOKEN, deviceToken, opts);
+      } else if (isAndroid()) {
+        await store.setItemAsync(STORAGE_KEYS.SHARED_DEVICE_TOKEN, deviceToken);
+      }
+
+      if (isDev()) {
+        logger.debug('Shared device token stored successfully', { component: 'KeyManager' });
+      }
+    } catch (error) {
+      if (isDev()) {
+        logger.error('Failed to store shared device token', error, { component: 'KeyManager' });
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Read the shared device-attribution token, or `null` when none is set (or
+   * on web). Mirrors {@link getSharedSession}'s keychain-access-group read.
+   */
+  static async getSharedDeviceToken(): Promise<string | null> {
+    if (isWebPlatform()) {
+      return null;
+    }
+
+    try {
+      const store = await initSecureStore();
+
+      if (isIOS()) {
+        const opts: OxySecureStoreOptions = { keychainAccessGroup: IOS_KEYCHAIN_GROUP };
+        return await store.getItemAsync(STORAGE_KEYS.SHARED_DEVICE_TOKEN, opts);
+      }
+      if (isAndroid()) {
+        return await store.getItemAsync(STORAGE_KEYS.SHARED_DEVICE_TOKEN);
+      }
+      return null;
+    } catch (error) {
+      if (isDev()) {
+        logger.warn('Failed to get shared device token', { component: 'KeyManager' }, error);
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Delete the shared device-attribution token (device signout-all). Best-effort:
+   * a keychain failure is logged, not thrown, so it cannot block a sign-out.
+   */
+  static async clearSharedDeviceToken(): Promise<void> {
+    if (isWebPlatform()) {
+      return;
+    }
+
+    try {
+      const store = await initSecureStore();
+
+      if (isIOS()) {
+        const opts: OxySecureStoreOptions = { keychainAccessGroup: IOS_KEYCHAIN_GROUP };
+        await store.deleteItemAsync(STORAGE_KEYS.SHARED_DEVICE_TOKEN, opts);
+      } else if (isAndroid()) {
+        await store.deleteItemAsync(STORAGE_KEYS.SHARED_DEVICE_TOKEN);
+      }
+
+      if (isDev()) {
+        logger.debug('Shared device token cleared successfully', { component: 'KeyManager' });
+      }
+    } catch (error) {
+      if (isDev()) {
+        logger.error('Failed to clear shared device token', error, { component: 'KeyManager' });
+      }
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -591,6 +591,63 @@ export {
     accountIdsOf,
 } from './session/projectSessionState';
 
+// ---------------------------------------------------------------------------
+// Device-first session machinery (auth centralization, wave 1) — additive.
+// Persisted auth-state store, the unified refresh handler + scheduler, the
+// cold-boot v2 runner, and the device-boot return-fragment consumer. Built ON
+// the existing `runColdBoot` primitive + `SessionClient`; the legacy
+// FedCM/SSO/CrossDomainAuth surface is untouched (cutover happens in F4).
+// ---------------------------------------------------------------------------
+export {
+    createWebAuthStateStore,
+    createNativeAuthStateStore,
+    createMemoryAuthStateStore,
+    AUTH_STATE_STORAGE_KEY,
+    DEVICE_TOKEN_STORAGE_KEY,
+} from './session/authStateStore';
+export type {
+    PersistedAuthState,
+    AuthStateStore,
+    NativeKeyValueStorage,
+} from './session/authStateStore';
+
+export {
+    refreshPersistedSession,
+    createAuthRefreshHandler,
+    installAuthRefreshHandler,
+    startTokenRefreshScheduler,
+    TOKEN_REFRESH_LEAD_MS,
+} from './session/refresh';
+export type { RefreshDeps, TokenRefreshSchedulerHandle } from './session/refresh';
+
+export {
+    runSessionColdBoot,
+    createBrowserColdBootDom,
+    isSameApex,
+    BOOT_ATTEMPTED_KEY,
+} from './boot/coldBootV2';
+export type {
+    RunSessionColdBootOptions,
+    ColdBootDom,
+    SignedOutReason,
+} from './boot/coldBootV2';
+
+export {
+    consumeDeviceBootReturn,
+    parseDeviceBootFragment,
+    hashHasBootFragment,
+    BOOT_FRAGMENT_PARAM,
+    BOOT_STATE_SESSION_KEY,
+} from './boot/deviceBootReturn';
+export type {
+    DeviceBootSession,
+    DeviceBootReturnOutcome,
+    ConsumeDeviceBootReturnDeps,
+} from './boot/deviceBootReturn';
+
+export { isAuthTokenBundle } from './mixins/OxyServices.deviceBoot';
+export type { WebSessionResult, WebSessionNoSession } from './mixins/OxyServices.deviceBoot';
+
 // API response contracts (request/response Zod schemas + inferred types) live in
 // `@oxyhq/contracts` — the single source of truth shared by the backend and every
 // client SDK. Import them directly from `@oxyhq/contracts`; `@oxyhq/core` does NOT

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -9,7 +9,8 @@ import type {
   RefreshAllAccount,
   RefreshCookieResponse,
 } from '../models/interfaces';
-import type { UserNameResponse } from '@oxyhq/contracts';
+import type { UserNameResponse, LoginResult, LoginSessionResult } from '@oxyhq/contracts';
+import { loginResultSchema, safeParseContract } from '@oxyhq/contracts';
 import type { SessionLoginResponse } from '../models/session';
 import type { OxyServicesBase } from '../OxyServices.base';
 import type { PublicApplication } from './OxyServices.connectedApps';
@@ -1368,6 +1369,81 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
       deviceFingerprint?: any
     ): Promise<SessionLoginResponse> {
       return this.signIn(email, password, deviceName, deviceFingerprint);
+    }
+
+    /**
+     * Device-first password sign-in. Unlike the legacy {@link signIn} (which
+     * assumes a one-step session and is kept intact for existing callers until
+     * the F4 cutover), this returns the FULL `POST /auth/login` contract — the
+     * discriminated {@link LoginResult}: either a 2FA challenge
+     * (`{ twoFactorRequired, loginToken }`) to complete via
+     * {@link completeTwoFactorSignIn}, or a session arm.
+     *
+     * `options.deviceToken` attributes the new session to the caller's existing
+     * device set (so an in-app login from a cross-apex, cookie-less web app
+     * still joins the same DeviceSession). On the session arm, a returned access
+     * token is planted immediately (mirroring {@link verifyChallenge}), so the
+     * caller has an authenticated client without a second round-trip.
+     */
+    async passwordSignIn(
+      identifier: string,
+      password: string,
+      options: { deviceToken?: string; deviceName?: string; deviceFingerprint?: string } = {},
+    ): Promise<LoginResult> {
+      try {
+        const res = await this.makeRequest<unknown>('POST', '/auth/login', {
+          identifier,
+          password,
+          deviceName: options.deviceName,
+          deviceFingerprint: options.deviceFingerprint,
+          deviceToken: options.deviceToken,
+        }, { cache: false });
+        const parsed = safeParseContract(loginResultSchema, res);
+        if (!parsed) {
+          throw new Error('auth/login returned an unexpected response shape');
+        }
+        if (!('twoFactorRequired' in parsed) && parsed.accessToken) {
+          this.setTokens(parsed.accessToken);
+        }
+        return parsed;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Complete a 2FA-gated sign-in started by {@link passwordSignIn}. Presents
+     * the short-lived `loginToken` with either a TOTP `token` or a `backupCode`
+     * to `POST /security/2fa/verify-login`, which must resolve to the session
+     * arm of {@link LoginResult} (a second 2FA challenge here is a protocol
+     * error). A returned access token is planted immediately.
+     */
+    async completeTwoFactorSignIn(params: {
+      loginToken: string;
+      token?: string;
+      backupCode?: string;
+      deviceToken?: string;
+      deviceName?: string;
+    }): Promise<LoginSessionResult> {
+      try {
+        const res = await this.makeRequest<unknown>('POST', '/security/2fa/verify-login', {
+          loginToken: params.loginToken,
+          token: params.token,
+          backupCode: params.backupCode,
+          deviceToken: params.deviceToken,
+          deviceName: params.deviceName,
+        }, { cache: false });
+        const parsed = safeParseContract(loginResultSchema, res);
+        if (!parsed || 'twoFactorRequired' in parsed) {
+          throw new Error('security/2fa/verify-login returned an unexpected response shape');
+        }
+        if (parsed.accessToken) {
+          this.setTokens(parsed.accessToken);
+        }
+        return parsed;
+      } catch (error) {
+        throw this.handleError(error);
+      }
     }
   };
 }

--- a/packages/core/src/mixins/OxyServices.deviceBoot.ts
+++ b/packages/core/src/mixins/OxyServices.deviceBoot.ts
@@ -1,0 +1,175 @@
+/**
+ * Device-first bootstrap mixin (auth centralization, wave 1).
+ *
+ * The client half of the new device-first session bootstrap: the four network
+ * calls the cold boot (`coldBootV2`) and the unified refresh handler
+ * (`refresh.ts`) make, plus the URL builder for the cross-apex bootstrap hop.
+ * Every response is validated against the `@oxyhq/contracts` `deviceBoot`
+ * schemas via `safeParseContract`, so producer (oxy-api) and consumer cannot
+ * drift — an unexpected shape throws here rather than silently corrupting the
+ * persisted store.
+ *
+ * These methods are ADDITIVE and carry NO persistence or token-planting side
+ * effects of their own (except the bearer-authenticated calls that naturally
+ * flow through `HttpService`). The cold boot / refresh handler own persistence
+ * and `setTokens`, so the same network primitive can be reused from either
+ * without double-planting.
+ */
+import { z } from 'zod';
+import {
+  authTokenBundleSchema,
+  tokenRefreshResponseSchema,
+  deviceTokenIssueResponseSchema,
+  safeParseContract,
+  type AuthTokenBundle,
+  type TokenRefreshResponse,
+} from '@oxyhq/contracts';
+import type { OxyServicesBase } from '../OxyServices.base';
+
+/**
+ * The "known device, no active session" arm of `POST /auth/device/web-session`
+ * — the fast-path returns EITHER a full {@link AuthTokenBundle} (a session was
+ * resolved from the same-site device cookie) OR this shape (the device is known
+ * / just planted but signed out). It carries the rotated `deviceToken` to
+ * persist, never any session tokens.
+ */
+export interface WebSessionNoSession {
+  reason: 'no_session' | 'new_device';
+  deviceToken: string;
+}
+
+/** The discriminated outcome of `POST /auth/device/web-session`. */
+export type WebSessionResult = AuthTokenBundle | WebSessionNoSession;
+
+const webSessionNoSessionSchema: z.ZodType<WebSessionNoSession> = z.object({
+  reason: z.enum(['no_session', 'new_device']),
+  deviceToken: z.string().min(1),
+});
+
+const webSessionResultSchema: z.ZodType<WebSessionResult> = z.union([
+  authTokenBundleSchema,
+  webSessionNoSessionSchema,
+]);
+
+/** Type guard: did the web-session fast-path resolve a full token bundle? */
+export function isAuthTokenBundle(result: WebSessionResult): result is AuthTokenBundle {
+  return 'accessToken' in result;
+}
+
+export function OxyServicesDeviceBootMixin<T extends typeof OxyServicesBase>(Base: T) {
+  return class extends Base {
+    /**
+     * Exchange a single-use boot `code` (from the `#oxy_boot` return fragment)
+     * for a token bundle. Origin-bound + GETDEL-burned server-side.
+     *
+     * @throws if the response does not match {@link authTokenBundleSchema}.
+     */
+    async exchangeBootCode(code: string): Promise<AuthTokenBundle> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          '/auth/device/exchange',
+          { code },
+          { cache: false },
+        );
+        const parsed = safeParseContract(authTokenBundleSchema, res);
+        if (!parsed) {
+          throw new Error('device/exchange returned an unexpected response shape');
+        }
+        return parsed;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Same-site fast path (`*.oxy.so` apps). Reads the first-party `oxy_device`
+     * cookie via a credentialed same-origin fetch and either resolves a full
+     * session bundle or reports the device is known-but-signed-out. Never
+     * redirects.
+     *
+     * @throws if the response matches neither arm of {@link webSessionResultSchema}.
+     */
+    async requestWebSession(): Promise<WebSessionResult> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          '/auth/device/web-session',
+          undefined,
+          { cache: false },
+        );
+        const parsed = safeParseContract(webSessionResultSchema, res);
+        if (!parsed) {
+          throw new Error('device/web-session returned an unexpected response shape');
+        }
+        return parsed;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Rotate the persisted refresh-token family (web + native, one call). The
+     * caller (refresh handler / cold boot) plants + persists the rotated pair.
+     *
+     * @throws if the response does not match {@link tokenRefreshResponseSchema}.
+     */
+    async refreshWithToken(refreshToken: string): Promise<TokenRefreshResponse> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          '/auth/refresh-token',
+          { refreshToken },
+          // `skipAuth`: refresh-token is body-authenticated and is called from
+          // inside the refresh handler — sending the near-expired bearer through
+          // the preflight would deadlock. See RequestOptions.skipAuth.
+          { cache: false, skipAuth: true },
+        );
+        const parsed = safeParseContract(tokenRefreshResponseSchema, res);
+        if (!parsed) {
+          throw new Error('auth/refresh-token returned an unexpected response shape');
+        }
+        return parsed;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Issue (or rotate) the native channel's opaque device token. Bearer-gated —
+     * the server derives the deviceId from the JWT. Native apps mirror the
+     * returned token into the shared keychain via
+     * `KeyManager.setSharedDeviceToken`.
+     *
+     * @throws if the response does not match {@link deviceTokenIssueResponseSchema}.
+     */
+    async issueNativeDeviceToken(): Promise<string> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          '/auth/device/token',
+          undefined,
+          { cache: false },
+        );
+        const parsed = safeParseContract(deviceTokenIssueResponseSchema, res);
+        if (!parsed) {
+          throw new Error('auth/device/token returned an unexpected response shape');
+        }
+        return parsed.deviceToken;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Build the top-level `GET /auth/device/bootstrap` URL for the cross-apex
+     * hop. The server validates `return_to` against the trusted-origin lane and
+     * echoes `state` back in the return fragment for CSRF verification.
+     */
+    buildBootstrapUrl(returnTo: string, state: string): string {
+      const base = this.getBaseURL().replace(/\/+$/, '');
+      const params = new URLSearchParams({ return_to: returnTo, state });
+      return `${base}/auth/device/bootstrap?${params.toString()}`;
+    }
+  };
+}

--- a/packages/core/src/mixins/__tests__/OxyServices.deviceBoot.test.ts
+++ b/packages/core/src/mixins/__tests__/OxyServices.deviceBoot.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Device-boot mixin tests. Stubs `makeRequest` so the tests run with no network
+ * and asserts each method's route/shape, contract validation, and the
+ * `skipAuth` flag on the refresh call.
+ */
+import type { AuthTokenBundle, TokenRefreshResponse } from '@oxyhq/contracts';
+import { OxyServices } from '../../OxyServices';
+import { isAuthTokenBundle, type WebSessionResult } from '../OxyServices.deviceBoot';
+
+const BUNDLE: AuthTokenBundle = {
+  sessionId: 'sess-1',
+  accessToken: 'access-1',
+  refreshToken: 'refresh-abcdefghijkl',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  user: { id: 'user-1', name: {} } as AuthTokenBundle['user'],
+};
+
+const ROTATED: TokenRefreshResponse = {
+  accessToken: 'access-2',
+  refreshToken: 'refresh-mnopqrstuvwx',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  sessionId: 'sess-1',
+};
+
+describe('OxyServices.deviceBoot', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequest = jest.spyOn(oxy, 'makeRequest');
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('exchangeBootCode', () => {
+    it('POSTs the code and returns the validated bundle', async () => {
+      makeRequest.mockResolvedValueOnce(BUNDLE);
+      const result = await oxy.exchangeBootCode('code-123');
+      expect(result).toEqual(BUNDLE);
+      expect(makeRequest).toHaveBeenCalledWith('POST', '/auth/device/exchange', { code: 'code-123' }, { cache: false });
+    });
+
+    it('throws on an unexpected response shape', async () => {
+      makeRequest.mockResolvedValueOnce({ nope: true });
+      await expect(oxy.exchangeBootCode('code-123')).rejects.toThrow();
+    });
+  });
+
+  describe('requestWebSession', () => {
+    it('returns the token-bundle arm', async () => {
+      makeRequest.mockResolvedValueOnce(BUNDLE);
+      const result = await oxy.requestWebSession();
+      expect(isAuthTokenBundle(result)).toBe(true);
+      expect(makeRequest).toHaveBeenCalledWith('POST', '/auth/device/web-session', undefined, { cache: false });
+    });
+
+    it('returns the no-session arm', async () => {
+      const noSession: WebSessionResult = { reason: 'no_session', deviceToken: 'device-abcdefghij' };
+      makeRequest.mockResolvedValueOnce(noSession);
+      const result = await oxy.requestWebSession();
+      expect(isAuthTokenBundle(result)).toBe(false);
+      expect(result).toEqual(noSession);
+    });
+
+    it('throws when the response matches neither arm', async () => {
+      makeRequest.mockResolvedValueOnce({ reason: 'weird' });
+      await expect(oxy.requestWebSession()).rejects.toThrow();
+    });
+  });
+
+  describe('refreshWithToken', () => {
+    it('POSTs with skipAuth and returns the rotated pair', async () => {
+      makeRequest.mockResolvedValueOnce(ROTATED);
+      const result = await oxy.refreshWithToken('refresh-abcdefghijkl');
+      expect(result).toEqual(ROTATED);
+      expect(makeRequest).toHaveBeenCalledWith(
+        'POST',
+        '/auth/refresh-token',
+        { refreshToken: 'refresh-abcdefghijkl' },
+        { cache: false, skipAuth: true },
+      );
+    });
+  });
+
+  describe('issueNativeDeviceToken', () => {
+    it('POSTs and returns just the token string', async () => {
+      makeRequest.mockResolvedValueOnce({ deviceToken: 'native-dt' });
+      expect(await oxy.issueNativeDeviceToken()).toBe('native-dt');
+      expect(makeRequest).toHaveBeenCalledWith('POST', '/auth/device/token', undefined, { cache: false });
+    });
+  });
+
+  describe('buildBootstrapUrl', () => {
+    it('builds the bootstrap URL with encoded params', () => {
+      const url = oxy.buildBootstrapUrl('https://accounts.oxy.so/home', 'st-1');
+      expect(url).toContain('http://test.invalid/auth/device/bootstrap?');
+      expect(url).toContain('return_to=https%3A%2F%2Faccounts.oxy.so%2Fhome');
+      expect(url).toContain('state=st-1');
+    });
+  });
+});

--- a/packages/core/src/mixins/__tests__/passwordSignIn.test.ts
+++ b/packages/core/src/mixins/__tests__/passwordSignIn.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Device-first password sign-in (`passwordSignIn` + `completeTwoFactorSignIn`).
+ * Stubs `makeRequest` and asserts the login-result contract handling: the 2FA
+ * arm passes through un-planted, the session arm plants its access token, the
+ * deviceToken is threaded into the request, and a 2FA arm from verify-login is
+ * a protocol error.
+ */
+import type { LoginResult } from '@oxyhq/contracts';
+import { OxyServices } from '../../OxyServices';
+
+const SESSION_ARM: LoginResult = {
+  sessionId: 'sess-1',
+  deviceId: 'dev-1',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  accessToken: 'access-1',
+  refreshToken: 'refresh-1',
+  user: { id: 'user-1', username: 'u' },
+};
+
+const TWO_FACTOR_ARM: LoginResult = { twoFactorRequired: true, loginToken: 'login-token-1' };
+
+describe('passwordSignIn', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+  let setTokens: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequest = jest.spyOn(oxy, 'makeRequest');
+    setTokens = jest.spyOn(oxy, 'setTokens').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('returns the 2FA arm without planting a token', async () => {
+    makeRequest.mockResolvedValueOnce(TWO_FACTOR_ARM);
+    const result = await oxy.passwordSignIn('alice', 'pw');
+    expect(result).toEqual(TWO_FACTOR_ARM);
+    expect(setTokens).not.toHaveBeenCalled();
+  });
+
+  it('plants the access token on the session arm and threads the deviceToken', async () => {
+    makeRequest.mockResolvedValueOnce(SESSION_ARM);
+    const result = await oxy.passwordSignIn('alice', 'pw', { deviceToken: 'dt-1', deviceName: 'Phone' });
+    expect(result).toEqual(SESSION_ARM);
+    expect(setTokens).toHaveBeenCalledWith('access-1');
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/login',
+      { identifier: 'alice', password: 'pw', deviceName: 'Phone', deviceFingerprint: undefined, deviceToken: 'dt-1' },
+      { cache: false },
+    );
+  });
+
+  it('throws on an unexpected response shape', async () => {
+    makeRequest.mockResolvedValueOnce({ nope: true });
+    await expect(oxy.passwordSignIn('alice', 'pw')).rejects.toThrow();
+  });
+});
+
+describe('completeTwoFactorSignIn', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+  let setTokens: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequest = jest.spyOn(oxy, 'makeRequest');
+    setTokens = jest.spyOn(oxy, 'setTokens').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('verifies the login token, plants the session, and POSTs to /security/2fa/verify-login', async () => {
+    makeRequest.mockResolvedValueOnce(SESSION_ARM);
+    const result = await oxy.completeTwoFactorSignIn({ loginToken: 'lt', token: '123456', deviceToken: 'dt-1' });
+    expect(result).toEqual(SESSION_ARM);
+    expect(setTokens).toHaveBeenCalledWith('access-1');
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/security/2fa/verify-login',
+      { loginToken: 'lt', token: '123456', backupCode: undefined, deviceToken: 'dt-1', deviceName: undefined },
+      { cache: false },
+    );
+  });
+
+  it('throws when verify-login unexpectedly returns another 2FA challenge', async () => {
+    makeRequest.mockResolvedValueOnce(TWO_FACTOR_ARM);
+    await expect(oxy.completeTwoFactorSignIn({ loginToken: 'lt', token: '123456' })).rejects.toThrow();
+  });
+});

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -32,6 +32,7 @@ import { OxyServicesAppDataMixin } from './OxyServices.appData';
 import { OxyServicesCivicMixin } from './OxyServices.civic';
 import { OxyServicesNodesMixin } from './OxyServices.nodes';
 import { OxyServicesLinksMixin } from './OxyServices.links';
+import { OxyServicesDeviceBootMixin } from './OxyServices.deviceBoot';
 
 /**
  * Instance shape of every mixin in the pipeline, intersected. The runtime
@@ -68,6 +69,7 @@ type AllMixinInstances =
   & InstanceType<ReturnType<typeof OxyServicesCivicMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesNodesMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesLinksMixin<typeof OxyServicesBase>>>
+  & InstanceType<ReturnType<typeof OxyServicesDeviceBootMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesUtilityMixin<typeof OxyServicesBase>>>;
 
 /**
@@ -146,6 +148,11 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     // Link previews / unfurls: SDK-owned link-metadata resolution via oxy-api,
     // so apps stop scraping link metadata locally.
     OxyServicesLinksMixin,
+
+    // Device-first session bootstrap: the client half of the new
+    // /auth/device/* + /auth/refresh-token surface (exchange, web-session,
+    // refresh, native device-token, bootstrap-url builder).
+    OxyServicesDeviceBootMixin,
 
     // Utility (last, can use all above)
     OxyServicesUtilityMixin,

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -25,6 +25,16 @@ export interface SessionClientHost {
 export interface SessionClientOptions {
   transport?: TokenTransport;
   /**
+   * Invoked when an APPLIED state has zero accounts — i.e. a device
+   * signout-all removed the last account from this device set. Providers use
+   * this to clear the persisted {@link AuthStateStore} so a reload does not
+   * try to restore a session that no longer exists on the device.
+   *
+   * Only fires when a state is actually applied (revision advanced), never on
+   * a stale/rejected push. Exceptions thrown by the callback are isolated.
+   */
+  onUnauthenticated?: () => void;
+  /**
    * Statically-injected `socket.io-client` factory (its `io` export).
    * `@oxyhq/services` and `@oxyhq/auth` list `socket.io-client` as a real
    * dependency and pass `io` in directly, so realtime session sync never
@@ -90,6 +100,15 @@ export class SessionClient {
         logger.warn('[SessionClient] ensureActiveToken failed', { component: 'SessionClient' }, error);
       });
     }
+    // A device signout-all leaves zero accounts — tell the provider to clear
+    // the persisted store so a reload does not try to restore a dead session.
+    if (next.accounts.length === 0 && this.options.onUnauthenticated) {
+      try {
+        this.options.onUnauthenticated();
+      } catch (error) {
+        logger.error('[SessionClient] onUnauthenticated threw', error);
+      }
+    }
     return true;
   }
 
@@ -142,6 +161,28 @@ export class SessionClient {
   async addCurrentAccount(): Promise<void> {
     const res = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
     this.applySync(res);
+  }
+
+  /**
+   * Register the just-signed-in account into the device set AND make it the
+   * ACTIVE account — the explicit user-intent activation a sign-in UI performs.
+   *
+   * `addCurrentAccount` alone honors the server's `activate:'if-empty'` policy
+   * (a new account does NOT steal focus from an already-active one), which is
+   * correct for a background/silent add but wrong right after a deliberate
+   * sign-in. This adds, then switches to the target so the UI lands on the
+   * account the user just authenticated.
+   *
+   * @param accountId - The signed-in account id (e.g. `session.user.id`). When
+   *   omitted, falls back to the host's current-account ref. If neither
+   *   resolves, the add still applies and no switch is performed.
+   */
+  async registerAndActivate(accountId?: string): Promise<void> {
+    await this.addCurrentAccount();
+    const target = accountId ?? this.host.getCurrentAccountId();
+    if (target && this.state?.activeAccountId !== target) {
+      await this.switchAccount(target);
+    }
   }
 
   async start(): Promise<void> {

--- a/packages/core/src/session/__tests__/SessionClient.additive.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.additive.test.ts
@@ -1,0 +1,92 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+
+const stateWith = (rev: number, active: string | null, accountIds: string[]): DeviceSessionState => ({
+  deviceId: 'd1',
+  accounts: accountIds.map((id, i) => ({ accountId: id, sessionId: `s-${id}`, authuser: i })),
+  activeAccountId: active,
+  revision: rev,
+  updatedAt: 1720000000000,
+});
+
+const sync = (state: DeviceSessionState) => ({ state, activeToken: { accessToken: `jwt-${state.revision}`, expiresAt: 'x' } });
+
+function makeHost(makeRequest: jest.Mock, currentAccountId: string | null = null): SessionClientHost {
+  return {
+    makeRequest,
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 't',
+    onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => currentAccountId,
+  };
+}
+
+class TestClient extends SessionClient {
+  public apply(raw: unknown): boolean {
+    return this.applyState(raw);
+  }
+}
+
+describe('SessionClient.registerAndActivate', () => {
+  it('adds then switches to the explicit target when it is not already active', async () => {
+    const makeRequest = jest
+      .fn()
+      // add → device set has a1 active, a2 present but not active
+      .mockResolvedValueOnce(sync(stateWith(1, 'a1', ['a1', 'a2'])))
+      // switch → a2 becomes active
+      .mockResolvedValueOnce(sync(stateWith(2, 'a2', ['a1', 'a2'])));
+    const c = new SessionClient(makeHost(makeRequest));
+
+    await c.registerAndActivate('a2');
+
+    expect(makeRequest).toHaveBeenNthCalledWith(1, 'POST', '/session/device/add', undefined, { cache: false });
+    expect(makeRequest).toHaveBeenNthCalledWith(2, 'POST', '/session/device/switch', { accountId: 'a2' }, { cache: false });
+    expect(c.getState()?.activeAccountId).toBe('a2');
+  });
+
+  it('falls back to the host current-account ref when no target is passed', async () => {
+    const makeRequest = jest
+      .fn()
+      .mockResolvedValueOnce(sync(stateWith(1, 'a1', ['a1', 'a2'])))
+      .mockResolvedValueOnce(sync(stateWith(2, 'a2', ['a1', 'a2'])));
+    const c = new SessionClient(makeHost(makeRequest, 'a2'));
+
+    await c.registerAndActivate();
+
+    expect(makeRequest).toHaveBeenNthCalledWith(2, 'POST', '/session/device/switch', { accountId: 'a2' }, { cache: false });
+  });
+
+  it('does NOT switch when the added account is already active', async () => {
+    const makeRequest = jest.fn().mockResolvedValueOnce(sync(stateWith(1, 'a1', ['a1'])));
+    const c = new SessionClient(makeHost(makeRequest));
+
+    await c.registerAndActivate('a1');
+
+    expect(makeRequest).toHaveBeenCalledTimes(1);
+    expect(makeRequest).toHaveBeenCalledWith('POST', '/session/device/add', undefined, { cache: false });
+  });
+});
+
+describe('SessionClient onUnauthenticated', () => {
+  it('fires when an applied state has zero accounts (device signout-all)', () => {
+    const onUnauthenticated = jest.fn();
+    const c = new TestClient(makeHost(jest.fn()), { onUnauthenticated });
+
+    c.apply(stateWith(1, 'a1', ['a1']));
+    expect(onUnauthenticated).not.toHaveBeenCalled();
+
+    c.apply(stateWith(2, null, []));
+    expect(onUnauthenticated).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire for a stale (non-applied) empty state', () => {
+    const onUnauthenticated = jest.fn();
+    const c = new TestClient(makeHost(jest.fn()), { onUnauthenticated });
+
+    c.apply(stateWith(5, 'a1', ['a1']));
+    // revision 4 <= 5 → rejected, so onUnauthenticated must NOT fire.
+    c.apply(stateWith(4, null, []));
+    expect(onUnauthenticated).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/session/__tests__/authStateStore.test.ts
+++ b/packages/core/src/session/__tests__/authStateStore.test.ts
@@ -1,0 +1,185 @@
+import {
+  createWebAuthStateStore,
+  createNativeAuthStateStore,
+  createMemoryAuthStateStore,
+  AUTH_STATE_STORAGE_KEY,
+  DEVICE_TOKEN_STORAGE_KEY,
+  type PersistedAuthState,
+  type NativeKeyValueStorage,
+} from '../authStateStore';
+
+const SAMPLE: PersistedAuthState = {
+  sessionId: 's-1',
+  refreshToken: 'r-abcdefghijklmnop',
+  userId: 'u-1',
+  deviceToken: 'd-1234567890',
+  accessToken: 'a-jwt',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+};
+
+/** A minimal in-map Storage; setItem can be made to throw (quota simulation). */
+function makeFakeStorage(opts: { throwOnSet?: boolean } = {}): Storage {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => {
+      if (opts.throwOnSet) {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      }
+      map.set(k, v);
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
+    },
+    clear: () => map.clear(),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    get length() {
+      return map.size;
+    },
+  } as Storage;
+}
+
+function installLocalStorage(storage: Storage): void {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  // Remove whatever localStorage the test installed (value or throwing getter).
+  if (Object.getOwnPropertyDescriptor(globalThis, 'localStorage')) {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+  }
+});
+
+describe('createWebAuthStateStore', () => {
+  it('round-trips a PersistedAuthState under the versioned key', async () => {
+    const storage = makeFakeStorage();
+    installLocalStorage(storage);
+    const store = createWebAuthStateStore();
+
+    await store.save(SAMPLE);
+    expect(storage.getItem(AUTH_STATE_STORAGE_KEY)).toBeTruthy();
+    expect(await store.load()).toEqual(SAMPLE);
+  });
+
+  it('clear() wipes the session but the deviceToken survives', async () => {
+    installLocalStorage(makeFakeStorage());
+    const store = createWebAuthStateStore();
+
+    await store.save(SAMPLE);
+    await store.saveDeviceToken('device-token-xyz');
+    await store.clear();
+
+    expect(await store.load()).toBeNull();
+    expect(await store.loadDeviceToken()).toBe('device-token-xyz');
+  });
+
+  it('persists the deviceToken under a separate long-lived key', async () => {
+    const storage = makeFakeStorage();
+    installLocalStorage(storage);
+    const store = createWebAuthStateStore();
+
+    await store.saveDeviceToken('dt');
+    expect(storage.getItem(DEVICE_TOKEN_STORAGE_KEY)).toBe('dt');
+    await store.clearDeviceToken();
+    expect(await store.loadDeviceToken()).toBeNull();
+  });
+
+  it('returns null for a malformed or incomplete blob', async () => {
+    const storage = makeFakeStorage();
+    installLocalStorage(storage);
+    const store = createWebAuthStateStore();
+
+    storage.setItem(AUTH_STATE_STORAGE_KEY, 'not-json');
+    expect(await store.load()).toBeNull();
+
+    storage.setItem(AUTH_STATE_STORAGE_KEY, JSON.stringify({ sessionId: 's', userId: 'u' }));
+    expect(await store.load()).toBeNull();
+  });
+
+  it('degrades to in-memory when accessing localStorage throws (sandboxed iframe SecurityError)', async () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+
+    // Construction must not throw, and the store must still function (in-memory).
+    const store = createWebAuthStateStore();
+    await expect(store.save(SAMPLE)).resolves.toBeUndefined();
+    expect(await store.load()).toEqual(SAMPLE);
+  });
+
+  it('swallows a write that throws (quota / private mode) without rejecting', async () => {
+    installLocalStorage(makeFakeStorage({ throwOnSet: true }));
+    const store = createWebAuthStateStore();
+
+    await expect(store.save(SAMPLE)).resolves.toBeUndefined();
+    // The failed write means nothing was persisted.
+    expect(await store.load()).toBeNull();
+  });
+});
+
+describe('createNativeAuthStateStore', () => {
+  function makeNativeStorage(): NativeKeyValueStorage & { map: Map<string, string> } {
+    const map = new Map<string, string>();
+    return {
+      map,
+      getItem: async (k) => (map.has(k) ? (map.get(k) as string) : null),
+      setItem: async (k, v) => {
+        map.set(k, v);
+      },
+      removeItem: async (k) => {
+        map.delete(k);
+      },
+    };
+  }
+
+  it('round-trips through the injected async storage', async () => {
+    const storage = makeNativeStorage();
+    const store = createNativeAuthStateStore(storage);
+
+    await store.save(SAMPLE);
+    expect(storage.map.get(AUTH_STATE_STORAGE_KEY)).toBeTruthy();
+    expect(await store.load()).toEqual(SAMPLE);
+  });
+
+  it('deviceToken survives a session clear', async () => {
+    const store = createNativeAuthStateStore(makeNativeStorage());
+    await store.save(SAMPLE);
+    await store.saveDeviceToken('dt-native');
+    await store.clear();
+    expect(await store.load()).toBeNull();
+    expect(await store.loadDeviceToken()).toBe('dt-native');
+  });
+
+  it('degrades gracefully when the injected storage throws', async () => {
+    const store = createNativeAuthStateStore({
+      getItem: async () => {
+        throw new Error('secure store locked');
+      },
+      setItem: async () => {
+        throw new Error('secure store locked');
+      },
+      removeItem: async () => {
+        throw new Error('secure store locked');
+      },
+    });
+    await expect(store.save(SAMPLE)).resolves.toBeUndefined();
+    expect(await store.load()).toBeNull();
+  });
+});
+
+describe('createMemoryAuthStateStore', () => {
+  it('round-trips and clears in process memory', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save(SAMPLE);
+    expect(await store.load()).toEqual(SAMPLE);
+    await store.clear();
+    expect(await store.load()).toBeNull();
+  });
+});

--- a/packages/core/src/session/__tests__/refresh.test.ts
+++ b/packages/core/src/session/__tests__/refresh.test.ts
@@ -1,0 +1,205 @@
+import type { OxyServices } from '../../OxyServices';
+import type { TokenRefreshResponse } from '@oxyhq/contracts';
+import type { SessionLoginResponse } from '../../models/session';
+import { refreshPersistedSession, startTokenRefreshScheduler } from '../refresh';
+import { createMemoryAuthStateStore, type PersistedAuthState } from '../authStateStore';
+
+const STORED: PersistedAuthState = {
+  sessionId: 'sess-old',
+  refreshToken: 'refresh-old-abcdefghij',
+  userId: 'user-1',
+  deviceToken: 'device-abcdefghij',
+};
+
+const ROTATED: TokenRefreshResponse = {
+  accessToken: 'access-new',
+  refreshToken: 'refresh-new-abcdefghij',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  sessionId: 'sess-new',
+};
+
+interface RefreshMockOverrides {
+  refreshWithToken?: OxyServices['refreshWithToken'];
+  signInWithSharedIdentity?: OxyServices['signInWithSharedIdentity'];
+}
+
+function makeOxy(overrides: RefreshMockOverrides = {}): { oxy: OxyServices; setTokens: jest.Mock } {
+  const setTokens = jest.fn();
+  const oxy = {
+    setTokens,
+    refreshWithToken: overrides.refreshWithToken ?? (async () => ROTATED),
+    signInWithSharedIdentity: overrides.signInWithSharedIdentity ?? (async () => null),
+  } as unknown as OxyServices;
+  return { oxy, setTokens };
+}
+
+describe('refreshPersistedSession — arm 1 (refresh-token rotation)', () => {
+  it('rotates, plants, persists the new family head, and returns the new token', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save(STORED);
+    const { oxy, setTokens } = makeOxy();
+
+    const token = await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: false });
+
+    expect(token).toBe('access-new');
+    expect(setTokens).toHaveBeenCalledWith('access-new');
+    expect(await store.load()).toEqual({
+      sessionId: 'sess-new',
+      refreshToken: 'refresh-new-abcdefghij',
+      userId: 'user-1',
+      deviceToken: 'device-abcdefghij',
+      accessToken: 'access-new',
+      expiresAt: '2030-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('clears the store on a family-revoked (401) error', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save(STORED);
+    const { oxy } = makeOxy({
+      refreshWithToken: async () => {
+        throw Object.assign(new Error('revoked'), { status: 401 });
+      },
+    });
+
+    const token = await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: false });
+
+    expect(token).toBeNull();
+    expect(await store.load()).toBeNull();
+  });
+
+  it('clears the store on an invalid_grant code', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save(STORED);
+    const { oxy } = makeOxy({
+      refreshWithToken: async () => {
+        throw Object.assign(new Error('bad'), { code: 'invalid_grant' });
+      },
+    });
+
+    expect(await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: false })).toBeNull();
+    expect(await store.load()).toBeNull();
+  });
+
+  it('KEEPS the store on a transient (500 / network) error', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save(STORED);
+    const { oxy } = makeOxy({
+      refreshWithToken: async () => {
+        throw Object.assign(new Error('server'), { status: 500 });
+      },
+    });
+
+    expect(await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: false })).toBeNull();
+    expect(await store.load()).toEqual(STORED);
+  });
+});
+
+describe('refreshPersistedSession — arm 2 (native shared-key fallback)', () => {
+  const SHARED_SESSION: SessionLoginResponse = {
+    sessionId: 'sess-shared',
+    deviceId: 'dev-1',
+    expiresAt: '2030-01-01T00:00:00.000Z',
+    user: { id: 'user-1', username: 'u', name: {}, avatar: undefined },
+    accessToken: 'access-shared',
+  };
+
+  it('re-mints via shared identity when there is no refresh token', async () => {
+    const store = createMemoryAuthStateStore(); // no stored refresh token
+    const signInWithSharedIdentity = jest.fn(async () => SHARED_SESSION);
+    const { oxy } = makeOxy({ signInWithSharedIdentity });
+
+    const token = await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: true });
+
+    expect(token).toBe('access-shared');
+    expect(signInWithSharedIdentity).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to shared-key after a revoked refresh token', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save(STORED);
+    const signInWithSharedIdentity = jest.fn(async () => SHARED_SESSION);
+    const { oxy } = makeOxy({
+      refreshWithToken: async () => {
+        throw Object.assign(new Error('revoked'), { status: 403 });
+      },
+      signInWithSharedIdentity,
+    });
+
+    const token = await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: true });
+
+    expect(token).toBe('access-shared');
+    expect(await store.load()).toBeNull(); // revoked family was cleared
+    expect(signInWithSharedIdentity).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT try shared-key when the fallback is disabled (web)', async () => {
+    const store = createMemoryAuthStateStore();
+    const signInWithSharedIdentity = jest.fn(async () => SHARED_SESSION);
+    const { oxy } = makeOxy({ signInWithSharedIdentity });
+
+    expect(await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: false })).toBeNull();
+    expect(signInWithSharedIdentity).not.toHaveBeenCalled();
+  });
+});
+
+describe('startTokenRefreshScheduler', () => {
+  function makeSchedulerOxy(expiresInSeconds: number | null): {
+    oxy: OxyServices;
+    refreshAccessToken: jest.Mock;
+  } {
+    let cleared = false;
+    const refreshAccessToken = jest.fn(async () => {
+      cleared = true; // stop the reschedule loop after the first fire
+      return null;
+    });
+    const nowSec = Math.floor(Date.now() / 1000);
+    const oxy = {
+      getAccessToken: () => (cleared ? null : 'tok'),
+      getAccessTokenExpiry: () => (expiresInSeconds === null ? null : nowSec + expiresInSeconds),
+      onTokensChanged: () => () => undefined,
+      httpService: { refreshAccessToken },
+    } as unknown as OxyServices;
+    return { oxy, refreshAccessToken };
+  }
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fires a refresh ~60s before expiry', async () => {
+    jest.useFakeTimers();
+    const { oxy, refreshAccessToken } = makeSchedulerOxy(120);
+    const handle = startTokenRefreshScheduler(oxy);
+
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(refreshAccessToken).toHaveBeenCalledWith('preflight');
+
+    handle.dispose();
+  });
+
+  it('no-ops cleanly for an opaque token with no exp', () => {
+    jest.useFakeTimers();
+    const { oxy, refreshAccessToken } = makeSchedulerOxy(null);
+    const handle = startTokenRefreshScheduler(oxy);
+    jest.advanceTimersByTime(10 * 60_000);
+    expect(refreshAccessToken).not.toHaveBeenCalled();
+    handle.dispose();
+  });
+
+  it('calls unref() on its timer so it never holds the event loop', () => {
+    const unref = jest.fn();
+    const setTimeoutSpy = jest
+      .spyOn(global, 'setTimeout')
+      .mockReturnValue({ unref } as unknown as ReturnType<typeof setTimeout>);
+    const { oxy } = makeSchedulerOxy(120);
+
+    const handle = startTokenRefreshScheduler(oxy);
+    expect(setTimeoutSpy).toHaveBeenCalled();
+    expect(unref).toHaveBeenCalled();
+
+    handle.dispose();
+    setTimeoutSpy.mockRestore();
+  });
+});

--- a/packages/core/src/session/authStateStore.ts
+++ b/packages/core/src/session/authStateStore.ts
@@ -1,0 +1,305 @@
+/**
+ * Persisted auth state — ONE shape, web + native.
+ *
+ * The device-first session model (auth-centralization wave 1) persists the
+ * rotating refresh-token family head per ORIGIN so a reload restores the
+ * session locally without a redirect. This module is the storage seam: a tiny
+ * `load / save / clear` interface plus platform factories, so the cold boot
+ * (`coldBootV2`) and the unified refresh handler (`refresh.ts`) never touch a
+ * platform storage API directly.
+ *
+ * Platform-agnostic — the native factory takes an INJECTED key/value store
+ * (`@oxyhq/services` passes a SecureStore-backed adapter) so `@oxyhq/core`
+ * never imports `expo-secure-store`. The web factory is self-contained
+ * (`localStorage`) and degrades to in-memory when storage is unavailable
+ * (sandboxed iframe `SecurityError`, private-mode quota, SSR).
+ *
+ * ESM-safe (no `require()`).
+ */
+
+/**
+ * The persisted session credential set for a single origin.
+ *
+ * `refreshToken` is the rotating single-use family head; `sessionId` + `userId`
+ * identify the owning device session and account. `deviceToken` is the opaque,
+ * add-only device attribution token (mirrored to the shared keychain on native
+ * so every Oxy app on one phone shares one DeviceSession).
+ *
+ * `accessToken` + `expiresAt` are OPTIONAL warm-boot fields. Persisting them
+ * lets the cold boot plant a still-valid access token on the very first paint
+ * WITHOUT a blocking `/auth/refresh-token` round-trip — the proactive scheduler
+ * then rotates it in the background. They are a strict optimization: the store
+ * is fully functional (via `refreshToken`) when they are absent or stale, and
+ * the access token is short-lived, so persisting it adds no exposure the
+ * already-persisted refresh token does not (see the plan's XSS risk note — the
+ * refresh token is the dominant secret either way).
+ */
+export interface PersistedAuthState {
+  sessionId: string;
+  refreshToken: string;
+  userId: string;
+  deviceToken?: string;
+  /** Optional warm-boot access token (short-lived; see interface docs). */
+  accessToken?: string;
+  /** Optional warm-boot access-token expiry, ISO-8601. */
+  expiresAt?: string;
+}
+
+/**
+ * The storage seam consumed by the cold boot and the refresh handler. Async
+ * throughout so one interface fits both synchronous web `localStorage` and
+ * asynchronous native SecureStore/AsyncStorage.
+ *
+ * Two lifetimes:
+ *  - The SESSION credential blob (`load`/`save`/`clear`) is per-sign-in and is
+ *    wiped on `clear()` (sign-out).
+ *  - The DEVICE token (`loadDeviceToken`/`saveDeviceToken`/`clearDeviceToken`)
+ *    is long-lived device attribution that SURVIVES `clear()`: a signed-out
+ *    browser is still the same device, and a later in-app (cross-apex,
+ *    cookie-less) login sends this token so the new session joins the SAME
+ *    server-side DeviceSession. Only an explicit device signout-all
+ *    (`clearDeviceToken`) removes it.
+ */
+export interface AuthStateStore {
+  load(): Promise<PersistedAuthState | null>;
+  save(state: PersistedAuthState): Promise<void>;
+  clear(): Promise<void>;
+  loadDeviceToken(): Promise<string | null>;
+  saveDeviceToken(token: string): Promise<void>;
+  clearDeviceToken(): Promise<void>;
+}
+
+/**
+ * The minimal async key/value surface a native store must provide. Matches
+ * both `expo-secure-store` (wrapped) and `@react-native-async-storage`.
+ */
+export interface NativeKeyValueStorage {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+}
+
+/**
+ * Versioned storage key. The `.v1` suffix lets a future shape change ship a
+ * `.v2` key without reading a stale/incompatible `.v1` blob. Distinct from the
+ * `oxy_shared_*` keychain keys in `KeyManager`, so it never collides.
+ */
+export const AUTH_STATE_STORAGE_KEY = 'oxy.auth.v1';
+
+/**
+ * Storage key for the long-lived device-attribution token. Separate from
+ * {@link AUTH_STATE_STORAGE_KEY} because it must OUTLIVE a session `clear()`
+ * (sign-out) — the device is unchanged across sign-ins.
+ */
+export const DEVICE_TOKEN_STORAGE_KEY = 'oxy.device.v1';
+
+/**
+ * Parse + shape-validate a stored blob. Returns `null` for anything that is
+ * not a well-formed {@link PersistedAuthState} (absent, malformed JSON, wrong
+ * types) so a corrupt entry degrades to "signed out" rather than throwing.
+ */
+function deserialize(raw: string | null): PersistedAuthState | null {
+  if (!raw) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return null;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (
+    typeof candidate.sessionId !== 'string' ||
+    typeof candidate.refreshToken !== 'string' ||
+    typeof candidate.userId !== 'string' ||
+    candidate.sessionId.length === 0 ||
+    candidate.refreshToken.length === 0 ||
+    candidate.userId.length === 0
+  ) {
+    return null;
+  }
+  const state: PersistedAuthState = {
+    sessionId: candidate.sessionId,
+    refreshToken: candidate.refreshToken,
+    userId: candidate.userId,
+  };
+  if (typeof candidate.deviceToken === 'string' && candidate.deviceToken.length > 0) {
+    state.deviceToken = candidate.deviceToken;
+  }
+  if (typeof candidate.accessToken === 'string' && candidate.accessToken.length > 0) {
+    state.accessToken = candidate.accessToken;
+  }
+  if (typeof candidate.expiresAt === 'string' && candidate.expiresAt.length > 0) {
+    state.expiresAt = candidate.expiresAt;
+  }
+  return state;
+}
+
+/**
+ * A process-lifetime, in-memory {@link AuthStateStore}. Used directly for
+ * tests/SSR and as the degraded fallback of the web store when `localStorage`
+ * is unreachable. Not durable across reloads — that is acceptable for the
+ * fallback because the alternative (throwing) would break cold boot entirely.
+ */
+export function createMemoryAuthStateStore(): AuthStateStore {
+  let current: PersistedAuthState | null = null;
+  let deviceToken: string | null = null;
+  return {
+    load: async () => current,
+    save: async (state) => {
+      current = state;
+    },
+    clear: async () => {
+      current = null;
+    },
+    loadDeviceToken: async () => deviceToken,
+    saveDeviceToken: async (token) => {
+      deviceToken = token;
+    },
+    clearDeviceToken: async () => {
+      deviceToken = null;
+    },
+  };
+}
+
+/**
+ * Read the ambient `localStorage`, tolerating the case where merely ACCESSING
+ * `window.localStorage` throws. In a sandboxed / cross-origin iframe the getter
+ * itself raises `SecurityError` (not the method calls), so the access must be
+ * inside the try. Returns `null` when storage is unavailable.
+ */
+function safeGetLocalStorage(): Storage | null {
+  try {
+    if (typeof globalThis === 'undefined') {
+      return null;
+    }
+    const store = (globalThis as { localStorage?: Storage }).localStorage;
+    return store ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A `localStorage`-backed {@link AuthStateStore} under the versioned
+ * {@link AUTH_STATE_STORAGE_KEY}.
+ *
+ * Resilience:
+ *  - If `localStorage` is unreachable (sandboxed-iframe `SecurityError`, SSR),
+ *    the whole store degrades to an in-memory {@link createMemoryAuthStateStore}
+ *    for this page's lifetime — never throws on construction.
+ *  - Individual `getItem`/`setItem`/`removeItem` are each wrapped: a read that
+ *    throws yields `null`; a write that throws (quota, private mode) is
+ *    swallowed. The persisted-refresh lane treats a failed persist as "no
+ *    durable state" (falls back to the bootstrap hop) rather than crashing.
+ */
+export function createWebAuthStateStore(): AuthStateStore {
+  const storage = safeGetLocalStorage();
+  if (!storage) {
+    return createMemoryAuthStateStore();
+  }
+  return {
+    load: async () => {
+      try {
+        return deserialize(storage.getItem(AUTH_STATE_STORAGE_KEY));
+      } catch {
+        return null;
+      }
+    },
+    save: async (state) => {
+      try {
+        storage.setItem(AUTH_STATE_STORAGE_KEY, JSON.stringify(state));
+      } catch {
+        // Quota / private-mode / disabled storage — non-fatal. The session
+        // stays live in memory; only reload durability is lost.
+      }
+    },
+    clear: async () => {
+      try {
+        storage.removeItem(AUTH_STATE_STORAGE_KEY);
+      } catch {
+        // Non-fatal — see save().
+      }
+    },
+    loadDeviceToken: async () => {
+      try {
+        return storage.getItem(DEVICE_TOKEN_STORAGE_KEY);
+      } catch {
+        return null;
+      }
+    },
+    saveDeviceToken: async (token) => {
+      try {
+        storage.setItem(DEVICE_TOKEN_STORAGE_KEY, token);
+      } catch {
+        // Non-fatal — see save().
+      }
+    },
+    clearDeviceToken: async () => {
+      try {
+        storage.removeItem(DEVICE_TOKEN_STORAGE_KEY);
+      } catch {
+        // Non-fatal — see save().
+      }
+    },
+  };
+}
+
+/**
+ * A native {@link AuthStateStore} over an injected async key/value store.
+ *
+ * `@oxyhq/core` never imports `expo-secure-store`; `@oxyhq/services` constructs
+ * the SecureStore-backed adapter and passes it here. Every operation is wrapped
+ * so a storage exception degrades gracefully (read → `null`, write → swallowed)
+ * exactly like the web store.
+ */
+export function createNativeAuthStateStore(storage: NativeKeyValueStorage): AuthStateStore {
+  return {
+    load: async () => {
+      try {
+        return deserialize(await storage.getItem(AUTH_STATE_STORAGE_KEY));
+      } catch {
+        return null;
+      }
+    },
+    save: async (state) => {
+      try {
+        await storage.setItem(AUTH_STATE_STORAGE_KEY, JSON.stringify(state));
+      } catch {
+        // Non-fatal — session stays live in memory.
+      }
+    },
+    clear: async () => {
+      try {
+        await storage.removeItem(AUTH_STATE_STORAGE_KEY);
+      } catch {
+        // Non-fatal.
+      }
+    },
+    loadDeviceToken: async () => {
+      try {
+        return await storage.getItem(DEVICE_TOKEN_STORAGE_KEY);
+      } catch {
+        return null;
+      }
+    },
+    saveDeviceToken: async (token) => {
+      try {
+        await storage.setItem(DEVICE_TOKEN_STORAGE_KEY, token);
+      } catch {
+        // Non-fatal.
+      }
+    },
+    clearDeviceToken: async () => {
+      try {
+        await storage.removeItem(DEVICE_TOKEN_STORAGE_KEY);
+      } catch {
+        // Non-fatal.
+      }
+    },
+  };
+}

--- a/packages/core/src/session/refresh.ts
+++ b/packages/core/src/session/refresh.ts
@@ -1,0 +1,284 @@
+/**
+ * Unified token refresh — THE single refresh implementation for web + native.
+ *
+ * Before device-first, refresh was duplicated: `@oxyhq/auth`'s
+ * `session/tokenRefresh.ts` (per-apex `/auth/silent` iframe) and
+ * `@oxyhq/services`'s `inSessionTokenRefresh.ts` (native shared-key). This
+ * module replaces both with ONE persisted-refresh-token rotation shared by
+ * every consumer:
+ *
+ *  - `refreshPersistedSession` — arm 1 rotates the stored refresh-token family
+ *    (`POST /auth/refresh-token`), planting + persisting the rotated pair; arm 2
+ *    (native only) re-mints via the shared-keychain identity when there is no
+ *    live refresh token. It is used BOTH reactively (wrapped as the
+ *    `AuthRefreshHandler` installed on `HttpService`) AND proactively (the
+ *    cold-boot `stored-tokens` step calls it directly).
+ *  - `createAuthRefreshHandler` / `installAuthRefreshHandler` wire arm 1+2 into
+ *    `HttpService.setAuthRefreshHandler`, keeping that layer's single-flight
+ *    dedup + cooldown (this module does NOT reimplement them).
+ *  - `startTokenRefreshScheduler` — a proactive scheduler (lifted from the
+ *    better of the two prior duplicates, `@oxyhq/auth`'s `tokenRefresh.ts`),
+ *    decoupled from any React / auth-sdk type: refreshes ~60s before `exp`,
+ *    re-arms on token change + web tab-focus, `.unref?.()`s its timer in Node.
+ *
+ * Framework-free; no module-level mutable state.
+ */
+import type { OxyServices } from '../OxyServices';
+import type { AuthRefreshHandler, AuthRefreshReason } from '../HttpService';
+import type { AuthStateStore, PersistedAuthState } from './authStateStore';
+import { isNative } from '../utils/platform';
+import { logger } from '../utils/loggerUtils';
+
+/**
+ * Lead time (ms) before access-token expiry at which the proactive scheduler
+ * refreshes. Mirrors `HttpService`'s per-request `TOKEN_REFRESH_LEAD_SECONDS`
+ * (60s) so the scheduled refresh and the request-time preflight refresh use
+ * the same window — the scheduler just fires it during idle/background.
+ */
+export const TOKEN_REFRESH_LEAD_MS = 60_000;
+
+/**
+ * Max `setTimeout` delay (2^31 − 1 ms, ~24.8 days). A larger delay overflows
+ * the int32 timer field and fires IMMEDIATELY — with a long-TTL token that
+ * turns the reschedule-on-finish loop into a tight busy refresh. Clamp to it.
+ */
+const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+
+/**
+ * Error codes (in addition to HTTP 401/403) that mean the stored refresh token
+ * is permanently unusable — the family was revoked or a reuse was detected. On
+ * any of these the persisted store is CLEARED (the session is truly over);
+ * transient failures (network, 5xx) leave the store intact so a later attempt
+ * can still succeed.
+ */
+const REVOKED_REFRESH_CODES = new Set([
+  'invalid_grant',
+  'refresh_token_revoked',
+  'refresh_token_reuse',
+  'token_reuse',
+  'invalid_token',
+]);
+
+interface HttpishError {
+  status?: number;
+  code?: string;
+}
+
+/** Does this error mean the refresh token is permanently dead (vs. transient)? */
+function isRevokedRefreshError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const e = error as HttpishError;
+  if (e.status === 401 || e.status === 403) {
+    return true;
+  }
+  return typeof e.code === 'string' && REVOKED_REFRESH_CODES.has(e.code);
+}
+
+export interface RefreshDeps {
+  oxy: OxyServices;
+  store: AuthStateStore;
+  /**
+   * Whether to fall back to the native shared-keychain re-mint (arm 2) when
+   * there is no live refresh token / arm 1 is revoked. Defaults to `isNative()`
+   * — web has no shared keychain. Exposed for tests.
+   */
+  allowSharedKeyFallback?: boolean;
+}
+
+/**
+ * Rotate the persisted session and return the fresh access token, or `null`
+ * when no arm could produce one.
+ *
+ * Arm 1 (`POST /auth/refresh-token`): if the store holds a refresh token, rotate
+ * it — on success plant + persist the rotated pair; on a REVOKED error clear the
+ * store; on a transient error leave the store and return `null`.
+ *
+ * Arm 2 (native shared-keychain): when there is no refresh token or arm 1 was
+ * revoked, re-mint via `signInWithSharedIdentity` (which plants tokens). The
+ * shared keychain — not the per-origin store — is the durable native credential,
+ * so this arm does not write the store.
+ */
+export async function refreshPersistedSession(deps: RefreshDeps): Promise<string | null> {
+  const { oxy, store } = deps;
+  const allowSharedKeyFallback = deps.allowSharedKeyFallback ?? isNative();
+
+  const persisted = await store.load();
+
+  if (persisted?.refreshToken) {
+    try {
+      const rotated = await oxy.refreshWithToken(persisted.refreshToken);
+      oxy.setTokens(rotated.accessToken);
+      const next: PersistedAuthState = {
+        sessionId: rotated.sessionId,
+        refreshToken: rotated.refreshToken,
+        userId: persisted.userId,
+        accessToken: rotated.accessToken,
+        expiresAt: rotated.expiresAt,
+      };
+      if (persisted.deviceToken) {
+        next.deviceToken = persisted.deviceToken;
+      }
+      await store.save(next);
+      return rotated.accessToken;
+    } catch (error) {
+      if (isRevokedRefreshError(error)) {
+        await store.clear();
+        // Fall through to the native shared-key arm below — on a shared-key
+        // device the refresh family being revoked does not end the session.
+      } else {
+        logger.debug(
+          'Persisted refresh failed (transient) — keeping store',
+          { component: 'refresh', method: 'refreshPersistedSession' },
+          error,
+        );
+        return null;
+      }
+    }
+  }
+
+  if (allowSharedKeyFallback) {
+    try {
+      const session = await oxy.signInWithSharedIdentity();
+      if (session?.accessToken) {
+        return session.accessToken;
+      }
+    } catch (error) {
+      logger.debug(
+        'Shared-key refresh fallback failed',
+        { component: 'refresh', method: 'refreshPersistedSession' },
+        error,
+      );
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build the reactive `AuthRefreshHandler` (arm 1 + arm 2). Install it via
+ * {@link installAuthRefreshHandler} or directly on
+ * `oxy.httpService.setAuthRefreshHandler`. `HttpService` owns single-flight
+ * dedup + cooldown, so the timer, the request-time preflight, and a 401 all
+ * collapse to one network attempt.
+ */
+export function createAuthRefreshHandler(deps: RefreshDeps): AuthRefreshHandler {
+  return async (_reason: AuthRefreshReason): Promise<string | null> => {
+    return refreshPersistedSession(deps);
+  };
+}
+
+/**
+ * Install the unified refresh handler on the owner client's `HttpService`.
+ * Returns a disposer that removes it.
+ */
+export function installAuthRefreshHandler(deps: RefreshDeps): () => void {
+  deps.oxy.httpService.setAuthRefreshHandler(createAuthRefreshHandler(deps));
+  return () => {
+    deps.oxy.httpService.setAuthRefreshHandler(null);
+  };
+}
+
+/** Handle returned by {@link startTokenRefreshScheduler}; `dispose()` tears it down. */
+export interface TokenRefreshSchedulerHandle {
+  dispose(): void;
+}
+
+/**
+ * Start the proactive refresh scheduler against `oxy`.
+ *
+ * Schedules a single timer to fire {@link TOKEN_REFRESH_LEAD_MS} before the
+ * current access token's `exp`, calling
+ * `oxy.httpService.refreshAccessToken('preflight')` (which runs the installed
+ * handler; deduped + cooldown-guarded). After every attempt it reschedules
+ * from the possibly-rotated token. It also reschedules whenever the token
+ * changes (a sign-out that clears the token cancels the timer) and, on web
+ * tab-focus, refreshes immediately if already inside the lead window (a
+ * long-hidden tab throttles timers, so the token can be expired on return).
+ *
+ * No-ops cleanly when there is no token or an opaque/no-`exp` token — the
+ * reactive 401 path stays the only refresh trigger in that case. The timer is
+ * `.unref?.()`-ed so it never keeps a Node/Jest event loop alive.
+ */
+export function startTokenRefreshScheduler(oxy: OxyServices): TokenRefreshSchedulerHandle {
+  let disposed = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTimer = (): void => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const runRefresh = (): void => {
+    void oxy.httpService.refreshAccessToken('preflight')
+      .catch(() => null)
+      .finally(() => {
+        if (!disposed) {
+          schedule();
+        }
+      });
+  };
+
+  const schedule = (): void => {
+    clearTimer();
+    if (disposed || !oxy.getAccessToken()) {
+      return;
+    }
+    const expSeconds = oxy.getAccessTokenExpiry();
+    if (expSeconds === null) {
+      return;
+    }
+    const fireInMs = expSeconds * 1000 - Date.now() - TOKEN_REFRESH_LEAD_MS;
+    timer = setTimeout(runRefresh, Math.min(Math.max(fireInMs, 0), MAX_TIMEOUT_DELAY_MS));
+    // Never keep a Node/Jest event loop alive for a background refresh timer.
+    timer.unref?.();
+  };
+
+  const onFocus = (): void => {
+    if (disposed || !oxy.getAccessToken()) {
+      return;
+    }
+    const expSeconds = oxy.getAccessTokenExpiry();
+    if (expSeconds === null) {
+      return;
+    }
+    const remainingMs = expSeconds * 1000 - Date.now();
+    if (remainingMs <= TOKEN_REFRESH_LEAD_MS) {
+      runRefresh();
+    } else {
+      schedule();
+    }
+  };
+
+  const unsubscribeTokens = oxy.onTokensChanged(() => {
+    if (!disposed) {
+      schedule();
+    }
+  });
+
+  let removeFocusListener: (() => void) | null = null;
+  if (typeof document !== 'undefined') {
+    const handler = (): void => {
+      if (document.visibilityState === 'visible') {
+        onFocus();
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    removeFocusListener = () => document.removeEventListener('visibilitychange', handler);
+  }
+
+  schedule();
+
+  return {
+    dispose(): void {
+      disposed = true;
+      clearTimer();
+      unsubscribeTokens();
+      removeFocusListener?.();
+      removeFocusListener = null;
+    },
+  };
+}


### PR DESCRIPTION
## F3 — core client, strictly additive

The client half of the auth-centralization wave 1. **Additive only** — no cold-boot / SSO / FedCM / CrossDomainAuth code is deleted or modified (auth-sdk still imports it). The cutover + deletions happen in F4. Publishable as an optional minor; the 6.0.0 major ships in F5.

The server surface (`/auth/device/*`, `/auth/refresh-token`, `/security/2fa/verify-login`) is built in parallel (F2); this code is a client of it, validated against the `@oxyhq/contracts` `deviceBoot` schemas and covered by mocked-HTTP tests.

### New modules (`packages/core`)
- **`session/authStateStore.ts`** — one persisted-auth-state shape for web + native. `createWebAuthStateStore` (localStorage `oxy.auth.v1`, SecurityError-safe: degrades to in-memory when the `localStorage` getter itself throws), `createNativeAuthStateStore` (injected async KV store), `createMemoryAuthStateStore`. The deviceToken lives under a **separate** long-lived key (`oxy.device.v1`) that survives session `clear()`.
- **`crypto/keyManager.ts`** — `setSharedDeviceToken` / `getSharedDeviceToken` / `clearSharedDeviceToken` over the `group.so.oxy.shared` keychain (mirrors the shared-session storage options exactly), so every native Oxy app shares one DeviceSession.
- **`session/refresh.ts`** — THE single refresh: `refreshPersistedSession` (arm 1 `/auth/refresh-token` rotation + persist; arm 2 native shared-key re-mint), `createAuthRefreshHandler` / `installAuthRefreshHandler` (wired via `HttpService.setAuthRefreshHandler`, keeping its dedup/cooldown), and `startTokenRefreshScheduler` (lifted from auth-sdk's `tokenRefresh.ts`, framework-free, `.unref?.()`-ed).
- **`boot/coldBootV2.ts` + `boot/deviceBootReturn.ts`** — `runSessionColdBoot` built on the existing pure `runColdBoot`: ordered steps `bootstrap-return → stored-tokens → shared-key-signin (native) → bootstrap-hop (web)`. Same-apex = inline credentialed `/auth/device/web-session` fetch; cross-apex = ONE top-level navigation, **once-ever per origin** (localStorage `oxy.boot.attempted` + sessionStorage state). **Never navigates to a login page and never runs twice.** All guard state lives in storage, not module scope (Metro-safe).
- **`mixins/OxyServices.deviceBoot.ts`** — `exchangeBootCode`, `requestWebSession`, `refreshWithToken`, `issueNativeDeviceToken`, `buildBootstrapUrl` (registered in `MIXIN_PIPELINE`, all `safeParseContract`-validated).

### Additive touches
- **`HttpService`** — new `skipAuth` request option: the body-authenticated `/auth/refresh-token` call runs from *inside* the refresh handler, so sending the near-expired bearer through the preflight would deadlock (self-await the in-flight `tokenRefreshPromise`). `skipAuth` sends no bearer and skips the 401 auto-refresh for that one request.
- **`OxyServices.auth.ts`** — `passwordSignIn` (returns the full `LoginResult` union: 2FA arm vs session arm) + `completeTwoFactorSignIn`. Legacy `signIn` is left untouched (see deviation note).
- **`SessionClient`** — `registerAndActivate(accountId?)` (add + explicit switch for sign-in UIs) and an `onUnauthenticated` option (fires when an applied state has zero accounts → providers clear the persisted store).

### Deviation
The brief said to *extend* the password sign-in to return the `LoginResult` union while keeping existing signatures working. Since the legacy `signIn` returns `SessionLoginResponse` and callers (services/auth-sdk) still depend on that shape in this additive phase, changing its return type would be a breaking change. I added a **new** `passwordSignIn` method (the device-first entry the F4 modal uses) and left `signIn` intact — satisfying both "return the union" and "keep existing signatures working." The clean-cut retirement of `signIn` happens in F4.

### Verification
- Full `@oxyhq/core` jest suite green: **855 tests / 74 suites** (+32 new).
- New suites: authStateStore (quota/SecurityError degrade, native injected, versioned key, deviceToken-survives-clear), deviceBootReturn (parse / state-mismatch / strip-first), refresh (rotation-persist, family-revoked-clears, transient-keeps, shared-key fallback, scheduler timing + unref), coldBootV2 (step ordering, once-ever hop guard, same-apex-fetch vs cross-apex-navigate, never-navigates-when-attempted), deviceBoot mixin (contract validation + skipAuth), passwordSignIn/2FA, SessionClient registerAndActivate/onUnauthenticated.
- `bun run core:build` passes; ESM output verified `require()`-free.

### Do NOT merge
A `packages/core` merge redeploys all four Pages apps — the lead coordinates the merge train (F4/F5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)