### PR TITLE
feat(api): device-first auth surface — /auth/device/* bootstrap, deviceToken, rotating refresh, signout family revoke

### DIFF
--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -26,6 +26,7 @@ import {
   revokeAllUserFamilies,
   clearAllRefreshCookies,
 } from '../services/refreshToken.service';
+import { resolveLoginDeviceId, finalizeDeviceLogin } from '../services/deviceLogin.service';
 import type { AuthRequest } from '../middleware/auth';
 import { exactCaseInsensitiveUsernameRegex } from '../utils/resolveUserIdentifier';
 
@@ -331,7 +332,7 @@ export class SessionController {
    */
   static async signUp(req: Request, res: Response) {
     try {
-      const { email, username, password, name, deviceName, deviceFingerprint } = req.body;
+      const { email, username, password, name, deviceName, deviceFingerprint, deviceToken } = req.body;
 
       if (
         !email ||
@@ -412,15 +413,32 @@ export class SessionController {
         });
       }
 
+      // Device-first attribution (oxy_device cookie > deviceToken > none),
+      // resolved before mint so the session carries the central deviceId.
+      const signupDeviceId = await resolveLoginDeviceId(req, deviceToken);
+
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        { deviceName, deviceFingerprint, ...(signupDeviceId ? { deviceId: signupDeviceId } : {}) }
       );
 
-      const response = buildSessionAuthResponse(session, user);
-      if (!response) {
+      const baseSignupResponse = buildSessionAuthResponse(session, user);
+      if (!baseSignupResponse) {
         return res.status(500).json({ message: 'Failed to format user data' });
+      }
+      const response: typeof baseSignupResponse & { refreshToken?: string } = baseSignupResponse;
+
+      // Register into the device set (add-only) + broadcast, and additively
+      // attach a rotating refresh token when the lane allows it. Best-effort.
+      const signupDeviceExtras = await finalizeDeviceLogin({
+        req,
+        deviceId: signupDeviceId,
+        session,
+        userId: user._id.toString(),
+      });
+      if (signupDeviceExtras.refreshToken) {
+        response.refreshToken = signupDeviceExtras.refreshToken;
       }
 
       try {
@@ -526,11 +544,11 @@ export class SessionController {
    */
   static async verifyChallenge(req: Request, res: Response) {
     try {
-      const { publicKey, challenge, signature, timestamp, deviceName, deviceFingerprint } = req.body;
+      const { publicKey, challenge, signature, timestamp, deviceName, deviceFingerprint, deviceToken } = req.body;
 
       if (!publicKey || !challenge || !signature || !timestamp) {
-        return res.status(400).json({ 
-          message: 'Public key, challenge, signature, and timestamp are required' 
+        return res.status(400).json({
+          message: 'Public key, challenge, signature, and timestamp are required'
         });
       }
 
@@ -573,11 +591,15 @@ export class SessionController {
         return res.status(404).json({ message: 'User not found' });
       }
 
+      // Device-first attribution (oxy_device cookie > deviceToken > none),
+      // resolved before mint so the session carries the central deviceId.
+      const verifyDeviceId = await resolveLoginDeviceId(req, deviceToken);
+
       // Create session
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        { deviceName, deviceFingerprint, ...(verifyDeviceId ? { deviceId: verifyDeviceId } : {}) }
       );
       const sessionAfterCreate = Date.now();
 
@@ -623,7 +645,7 @@ export class SessionController {
         return res.status(500).json({ message: 'Failed to format user data' });
       }
 
-      const response: SessionAuthResponse = {
+      const response: SessionAuthResponse & { refreshToken?: string } = {
         sessionId: session.sessionId,
         deviceId: session.deviceId,
         expiresAt: session.expiresAt.toISOString(),
@@ -634,6 +656,18 @@ export class SessionController {
           avatar: userData.avatar
         }
       };
+
+      // Register into the device set (add-only) + broadcast, and additively
+      // attach a rotating refresh token when the lane allows it. Best-effort.
+      const verifyDeviceExtras = await finalizeDeviceLogin({
+        req,
+        deviceId: verifyDeviceId,
+        session,
+        userId: user._id.toString(),
+      });
+      if (verifyDeviceExtras.refreshToken) {
+        response.refreshToken = verifyDeviceExtras.refreshToken;
+      }
 
       res.json(response);
     } catch (error) {
@@ -660,7 +694,7 @@ export class SessionController {
    */
   static async signIn(req: Request, res: Response) {
     try {
-      const { identifier, email, username, password, deviceName, deviceFingerprint } = req.body;
+      const { identifier, email, username, password, deviceName, deviceFingerprint, deviceToken } = req.body;
       const loginIdentifier = identifier || email || username;
 
       if (!loginIdentifier || !password || typeof password !== 'string') {
@@ -741,10 +775,16 @@ export class SessionController {
         req
       );
 
+      // Resolve the device this sign-in attaches to (oxy_device cookie >
+      // deviceToken > none) BEFORE minting the session so its central deviceId
+      // is stamped onto the session's token claims. Additive — null keeps the
+      // pre-existing device attribution (UA/IP/random).
+      const loginDeviceId = await resolveLoginDeviceId(req, deviceToken);
+
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        { deviceName, deviceFingerprint, ...(loginDeviceId ? { deviceId: loginDeviceId } : {}) }
       );
 
       const baseResponse = buildSessionAuthResponse(session, user);
@@ -754,12 +794,28 @@ export class SessionController {
       }
 
       // Include anomaly information in response if detected
-      const response: SessionAuthResponse & { securityAlert?: { message: string; anomalies: Array<{ type: string; reason: string; details?: string }> } } = baseResponse;
+      const response: SessionAuthResponse & {
+        securityAlert?: { message: string; anomalies: Array<{ type: string; reason: string; details?: string }> };
+        refreshToken?: string;
+      } = baseResponse;
       if (anomalyCheck.hasAnomalies) {
         response.securityAlert = {
           message: 'Unusual activity detected on your account',
           anomalies: anomalyCheck.anomalies,
         };
+      }
+
+      // Device-first lane: register the session into the resolved device set
+      // (add-only, never flips active) + broadcast, and additively attach a
+      // rotating refresh token when the lane allows it. Best-effort.
+      const deviceExtras = await finalizeDeviceLogin({
+        req,
+        deviceId: loginDeviceId,
+        session,
+        userId: user._id.toString(),
+      });
+      if (deviceExtras.refreshToken) {
+        response.refreshToken = deviceExtras.refreshToken;
       }
 
       try {

--- a/packages/api/src/controllers/sso.controller.ts
+++ b/packages/api/src/controllers/sso.controller.ts
@@ -26,6 +26,7 @@ import type { AuthRequest } from '../middleware/auth';
 import { ssoEstablishTokenSchema } from '../schemas/sso.schemas';
 import { logger } from '../utils/logger';
 import { normaliseOrigin } from '../utils/origin';
+import { hasValidInternalSecret } from '../utils/internalSecret';
 
 /**
  * Establish-token claim contract — MUST match the IdP `/sso/establish` verifier
@@ -49,25 +50,6 @@ function timingSafeStringEqual(a: string, b: string): boolean {
     return false;
   }
   return crypto.timingSafeEqual(aBuf, bBuf);
-}
-
-/**
- * Validate the internal shared-secret header. Returns true only when
- * `SSO_INTERNAL_SECRET` is configured AND the `X-Oxy-Internal` header matches it
- * in constant time. When the env var is unset we fail closed (the route is
- * effectively disabled) — we never accept an empty/absent secret.
- */
-function hasValidInternalSecret(req: Request): boolean {
-  const expected = process.env.SSO_INTERNAL_SECRET;
-  if (typeof expected !== 'string' || expected.length === 0) {
-    logger.error('POST /sso/code called but SSO_INTERNAL_SECRET is not configured');
-    return false;
-  }
-  const provided = req.headers['x-oxy-internal'];
-  if (typeof provided !== 'string' || provided.length === 0) {
-    return false;
-  }
-  return timingSafeStringEqual(provided, expected);
 }
 
 /**

--- a/packages/api/src/controllers/twoFactor.controller.ts
+++ b/packages/api/src/controllers/twoFactor.controller.ts
@@ -5,6 +5,7 @@ import twoFactorService from '../services/twoFactor.service';
 import { logger } from '../utils/logger';
 import securityActivityService from '../services/securityActivityService';
 import sessionService from '../services/session.service';
+import { resolveLoginDeviceId, finalizeDeviceLogin } from '../services/deviceLogin.service';
 import { buildSessionAuthResponse } from './session.controller';
 import { AuthRequest } from '../middleware/auth';
 import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
@@ -294,7 +295,7 @@ export async function verify2FAToken(req: Request, res: Response) {
  */
 export async function verify2FALogin(req: Request, res: Response) {
   try {
-    const { loginToken, token, backupCode, deviceName, deviceFingerprint } = req.body;
+    const { loginToken, token, backupCode, deviceName, deviceFingerprint, deviceToken } = req.body;
 
     if (!loginToken) {
       return res.status(400).json({ message: 'Login token is required' });
@@ -394,16 +395,33 @@ export async function verify2FALogin(req: Request, res: Response) {
     user.twoFactorAuth.verifiedAt = new Date();
     await user.save();
 
+    // Device-first attribution (oxy_device cookie > deviceToken > none),
+    // resolved before mint so the session carries the central deviceId.
+    const twoFactorDeviceId = await resolveLoginDeviceId(req, deviceToken);
+
     // Create session (same as signIn would)
     const session = await sessionService.createSession(
       user._id.toString(),
       req,
-      { deviceName, deviceFingerprint }
+      { deviceName, deviceFingerprint, ...(twoFactorDeviceId ? { deviceId: twoFactorDeviceId } : {}) }
     );
 
-    const response = buildSessionAuthResponse(session, user);
-    if (!response) {
+    const baseTwoFactorResponse = buildSessionAuthResponse(session, user);
+    if (!baseTwoFactorResponse) {
       return res.status(500).json({ message: 'Failed to format user data' });
+    }
+    const response: typeof baseTwoFactorResponse & { refreshToken?: string } = baseTwoFactorResponse;
+
+    // Register into the device set (add-only) + broadcast, and additively attach
+    // a rotating refresh token when the lane allows it. Best-effort.
+    const twoFactorDeviceExtras = await finalizeDeviceLogin({
+      req,
+      deviceId: twoFactorDeviceId,
+      session,
+      userId: user._id.toString(),
+    });
+    if (twoFactorDeviceExtras.refreshToken) {
+      response.refreshToken = twoFactorDeviceExtras.refreshToken;
     }
 
     try {

--- a/packages/api/src/models/AuthSession.ts
+++ b/packages/api/src/models/AuthSession.ts
@@ -53,6 +53,15 @@ export interface IAuthSession extends Document {
   /** Random nonce embedded in the QR payload (audit only; not a binding check). */
   challengeNonce?: string;
   applicationId: mongoose.Types.ObjectId; // Canonical, required reference to a registered Application
+  /**
+   * Central deviceId of the browser/device that STARTED this cross-app auth
+   * session (device-flow QR attribution), resolved from an optional `deviceToken`
+   * at create time. When present, the authorize paths mint the resulting session
+   * onto this device so a cross-device QR sign-in converges on the originating
+   * device's `DeviceSession` set instead of sprawling a fresh device. Optional —
+   * native/legacy callers that pass no `deviceToken` leave it unset.
+   */
+  deviceId?: string;
   status: AuthSessionStatus;
   authorizedBy?: string;     // Public key of the user who authorized
   authorizedUserId?: mongoose.Types.ObjectId; // MongoDB user ID of the authorizing user

--- a/packages/api/src/models/DeviceSession.ts
+++ b/packages/api/src/models/DeviceSession.ts
@@ -12,6 +12,14 @@ export interface IDeviceSession extends Document {
   deviceId: string;
   accounts: IDeviceSessionAccount[];
   activeAccountId: mongoose.Types.ObjectId | null;
+  /**
+   * SHA-256 hex of the random 256-bit `oxy_device` cookie secret bound to this
+   * device. The cookie value itself is NEVER the deviceId — it is an opaque
+   * secret, and only its hash is stored, so a Mongo dump cannot forge the cookie
+   * and possessing the cookie reveals nothing about the deviceId. Sparse-unique:
+   * legacy device docs predate it and carry none.
+   */
+  cookieKeyHash?: string;
   revision: number;
   createdAt: Date;
   updatedAt: Date;
@@ -33,11 +41,16 @@ const DeviceSessionSchema = new Schema<IDeviceSession>(
     deviceId: { type: String, required: true },
     accounts: { type: [AccountSchema], default: [] },
     activeAccountId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+    // Sparse-unique: only device docs bound to an `oxy_device` cookie carry a
+    // hash. Never `default: null`, or sparse uniqueness would collide across
+    // legacy docs.
+    cookieKeyHash: { type: String, default: undefined },
     revision: { type: Number, default: 0 },
   },
   { timestamps: true },
 );
 
 DeviceSessionSchema.index({ deviceId: 1 }, { unique: true });
+DeviceSessionSchema.index({ cookieKeyHash: 1 }, { unique: true, sparse: true });
 
 export default mongoose.model<IDeviceSession>('DeviceSession', DeviceSessionSchema);

--- a/packages/api/src/models/DeviceToken.ts
+++ b/packages/api/src/models/DeviceToken.ts
@@ -1,0 +1,99 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+/**
+ * DeviceToken Model
+ *
+ * Backs the opaque **device token** — the add-only attribution credential that
+ * lets a first-party sign-in performed over a cookieless cross-site fetch (e.g.
+ * an in-app modal on `mention.earth` hitting `api.oxy.so`) land in the SAME
+ * browser/device `DeviceSession` the user already has. It is NOT a session
+ * credential: it never reads session state and never flips the device's active
+ * account — it only ATTRIBUTES a freshly-credentialed new session to a device
+ * set (see `deviceSession.service.addAccount({ activate: 'if-empty' })`).
+ *
+ * Security model (mirrors `RefreshToken`):
+ * - Hash-only storage: the raw token is a bearer-equivalent, so we persist only
+ *   its SHA-256 hash (`tokenHash`, unique). A dump of this collection cannot be
+ *   replayed because the attacker never sees a raw token.
+ * - Bound to `(deviceId, origin, channel)`: `channel: 'web'` binds the token to
+ *   an exact https `origin` (the resolver requires `req.headers.origin ===
+ *   origin`); `channel: 'native'` requires the Origin header to be ABSENT.
+ * - One live token per `(deviceId, origin)`: issuing a new token revokes the
+ *   previous one for the same pair, so a rotated-away token cannot be reused.
+ * - Sliding 400-day expiry (`expiresAt`), bumped on use (`lastUsedAt`), so an
+ *   actively-used device keeps its attribution while an abandoned one lapses.
+ *
+ * The raw token is never logged.
+ */
+export type DeviceTokenChannel = 'web' | 'native';
+
+export interface IDeviceToken extends Document {
+  /** SHA-256 hex digest of the raw device token (never the raw value). */
+  tokenHash: string;
+  /** The central deviceId this token attributes new sessions to. */
+  deviceId: string;
+  /** Transport channel — `web` (origin-bound) or `native` (no Origin header). */
+  channel: DeviceTokenChannel;
+  /** For `web`: the exact https origin. For `native`: the literal `'native'`. */
+  origin: string;
+  /** Set when the token is revoked (rotation or explicit device revoke). */
+  revokedAt?: Date | null;
+  /** Sliding 400-day expiry, bumped on each successful resolve. */
+  expiresAt: Date;
+  /** Last time the token successfully resolved (attribution use). */
+  lastUsedAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DeviceTokenSchema: Schema = new Schema(
+  {
+    tokenHash: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    deviceId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    channel: {
+      type: String,
+      enum: ['web', 'native'],
+      required: true,
+    },
+    origin: {
+      type: String,
+      required: true,
+    },
+    revokedAt: {
+      type: Date,
+      default: null,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+    lastUsedAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// TTL — Mongo prunes after expiry. A 5-minute pad (mirroring RefreshToken /
+// AuthCode) keeps a just-expired token detectable during the grace window.
+DeviceTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 300 });
+
+// One live token per (deviceId, origin) is a service-layer invariant (issue
+// revokes the previous), not a DB unique — a revoked row lingers until the TTL
+// sweep, so a unique index would reject the replacement.
+DeviceTokenSchema.index({ deviceId: 1, origin: 1 });
+
+export const DeviceToken = mongoose.model<IDeviceToken>('DeviceToken', DeviceTokenSchema);
+export default DeviceToken;

--- a/packages/api/src/routes/__tests__/accountsSwitch.test.ts
+++ b/packages/api/src/routes/__tests__/accountsSwitch.test.ts
@@ -48,6 +48,22 @@ jest.mock('../../services/session.service', () => ({
   default: { createSession: (...args: unknown[]) => mockCreateSession(...args) },
 }));
 
+// The switch now registers the managed session into the operator's device set.
+// This suite uses REAL mongoose (no DB), so mock the device-set write + socket
+// broadcast to avoid a buffered query hanging the request.
+const mockAddAccount = jest.fn(async () => ({
+  state: { deviceId: 'op-device', accounts: [], activeAccountId: null, revision: 1, updatedAt: Date.now() },
+  changed: false,
+}));
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: { addAccount: (...args: unknown[]) => mockAddAccount(...args) },
+}));
+const mockBroadcastDeviceState = jest.fn();
+jest.mock('../../utils/socket', () => ({
+  broadcastDeviceState: (...args: unknown[]) => mockBroadcastDeviceState(...args),
+}));
+
 const mockAuthMiddleware = jest.fn();
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
@@ -200,6 +216,13 @@ describe('POST /accounts/:id/switch', () => {
       operatedByUserId: OPERATOR_ID,
       deviceId: 'dev-op',
     });
+    // The managed session is registered into the operator's device set
+    // server-side (a switch is a deliberate activation → activate: 'always').
+    expect(mockAddAccount).toHaveBeenCalledWith(
+      'dev-1',
+      { accountId: ORG_ID, sessionId: 'sess-1', operatedByUserId: OPERATOR_ID },
+      { activate: 'always' },
+    );
   });
 
   it('falls back to a fresh device when the bearer has no resolvable deviceId', async () => {

--- a/packages/api/src/routes/__tests__/deviceAuth.test.ts
+++ b/packages/api/src/routes/__tests__/deviceAuth.test.ts
@@ -303,6 +303,23 @@ describe('POST /auth/device/web-session', () => {
     });
     expect(res.status).toBe(403);
   });
+
+  it('allows a single-label host only on EXACT host equality (no registrable apex)', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'd1', activeAccountId: null, accounts: [] });
+    const res = await request('POST', '/auth/device/web-session', {
+      body: {},
+      headers: { host: 'internal-host', origin: 'https://internal-host', cookie: 'oxy_device=known' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('403s when single-label hosts differ (exact-equality fallback)', async () => {
+    const res = await request('POST', '/auth/device/web-session', {
+      body: {},
+      headers: { host: 'host-a', origin: 'https://host-b' },
+    });
+    expect(res.status).toBe(403);
+  });
 });
 
 describe('POST /auth/device/exchange', () => {
@@ -432,5 +449,32 @@ describe('POST /auth/device/resolve', () => {
     expect(accounts).toHaveLength(1);
     expect(accounts[0]).toMatchObject({ sessionId: 's1', accessToken: 'acc' });
     expect((accounts[0].user as Record<string, unknown>).id).toBe('u1');
+  });
+
+  it('SKIPS a corrupt/dead account (does not 500 the whole feed)', async () => {
+    internalOk = true;
+    mockGetStateByCookieKey.mockResolvedValueOnce({
+      deviceId: 'd1',
+      activeAccountId: 'u2',
+      accounts: [
+        { accountId: 'u1', sessionId: 's-bad' },
+        { accountId: 'u2', sessionId: 's-good' },
+      ],
+    });
+    // First account throws mid-resolve; second resolves cleanly.
+    mockValidateSessionById.mockRejectedValueOnce(new Error('corrupt session'));
+    mockValidateSessionById.mockResolvedValueOnce({ session: {}, user: { _id: 'u2', username: 'good' } });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc2', expiresAt: new Date(Date.now() + 60_000) });
+
+    const res = await request('POST', '/auth/device/resolve', {
+      body: { deviceKey: 'somedevicesecretvalue' },
+      headers: { 'x-oxy-internal': 'secret' },
+    });
+
+    expect(res.status).toBe(200);
+    const accounts = res.body.accounts as Array<Record<string, unknown>>;
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]).toMatchObject({ sessionId: 's-good', accessToken: 'acc2' });
+    expect(res.body.activeAccountId).toBe('u2');
   });
 });

--- a/packages/api/src/routes/__tests__/deviceAuth.test.ts
+++ b/packages/api/src/routes/__tests__/deviceAuth.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Device-first auth router tests (`/auth/device/*` + `/auth/refresh-token`).
+ *
+ * Covers:
+ *  - bootstrap: 303 redirect + `oxy_device` Set-Cookie + `#oxy_boot=` fragment
+ *    (reason:'session' with a code) for a trusted return_to; 400 for an
+ *    untrusted / invalid return_to.
+ *  - web-session: same-site happy (session bundle) + no_session shape; 403 for a
+ *    non-trusted caller.
+ *  - exchange: burn happy → bundle; Origin mismatch → 403; replay/expired → 410.
+ *  - refresh-token: rotate happy; failure → 401.
+ *  - device/token: bearer → deviceToken; missing device binding → 400.
+ *  - resolve: X-Oxy-Internal gate (404 without) + device-set feed with it.
+ *
+ * Every service is mocked; `deviceCookie` + `origin` + contracts schemas +
+ * `registrableApex` run for real.
+ */
+
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../middleware/originGuard', () => ({
+  requireSameSiteOrigin: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const mockDecodeToken = jest.fn();
+jest.mock('../../middleware/authUtils', () => ({
+  extractTokenFromRequest: () => 'tok',
+  decodeToken: (...a: unknown[]) => mockDecodeToken(...a),
+}));
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+const mockIsTrustedOrigin = jest.fn(() => true);
+jest.mock('../../config/dynamicOriginRegistry', () => ({
+  isTrustedOrigin: (...a: unknown[]) => mockIsTrustedOrigin(...a),
+}));
+
+let internalOk = false;
+jest.mock('../../utils/internalSecret', () => ({
+  hasValidInternalSecret: () => internalOk,
+}));
+
+const mockGetStateByCookieKey = jest.fn();
+const mockEnsureDeviceForCookie = jest.fn();
+const mockAddAccount = jest.fn();
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: {
+    getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a),
+    ensureDeviceForCookie: (...a: unknown[]) => mockEnsureDeviceForCookie(...a),
+    addAccount: (...a: unknown[]) => mockAddAccount(...a),
+  },
+}));
+
+const mockValidateSessionById = jest.fn();
+const mockGetAccessToken = jest.fn();
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: {
+    validateSessionById: (...a: unknown[]) => mockValidateSessionById(...a),
+    getAccessToken: (...a: unknown[]) => mockGetAccessToken(...a),
+  },
+}));
+
+const mockIssueDeviceToken = jest.fn(async () => 'device-token-abcdefghijklmnopqrst');
+jest.mock('../../services/deviceToken.service', () => ({
+  issueDeviceToken: (...a: unknown[]) => mockIssueDeviceToken(...a),
+  NATIVE_ORIGIN: 'native',
+}));
+
+const mockMintBootCode = jest.fn();
+const mockRedeemBootCode = jest.fn();
+jest.mock('../../services/deviceBootCode.service', () => ({
+  mintBootCode: (...a: unknown[]) => mockMintBootCode(...a),
+  redeemBootCode: (...a: unknown[]) => mockRedeemBootCode(...a),
+}));
+
+const mockIssueRefreshToken = jest.fn(async () => ({
+  token: 'refresh-token-abcdefghijklmnopqrst',
+  family: 'fam',
+  expiresAt: new Date(Date.now() + 60_000),
+}));
+const mockRotateRefreshToken = jest.fn();
+jest.mock('../../services/refreshToken.service', () => ({
+  issueRefreshToken: (...a: unknown[]) => mockIssueRefreshToken(...a),
+  rotateRefreshToken: (...a: unknown[]) => mockRotateRefreshToken(...a),
+}));
+
+jest.mock('../../utils/userTransform', () => ({
+  formatUserResponse: (u: { _id?: string; id?: string; username?: string } | null) =>
+    u ? { id: u._id ?? u.id ?? 'uid', username: u.username ?? 'bob', name: {} } : null,
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import deviceAuthRouter from '../deviceAuth';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface Res {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: Record<string, unknown>;
+}
+
+let server: http.Server;
+
+async function request(
+  method: string,
+  path: string,
+  opts: { body?: unknown; headers?: Record<string, string> } = {},
+): Promise<Res> {
+  const address = server.address() as AddressInfo;
+  const payload = opts.body !== undefined ? JSON.stringify(opts.body) : undefined;
+  const headers: Record<string, string | number> = { ...(opts.headers ?? {}) };
+  if (payload) {
+    headers['content-type'] = 'application/json';
+    headers['content-length'] = Buffer.byteLength(payload);
+  }
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method, host: '127.0.0.1', port: address.port, path, headers },
+      (res) => {
+        let raw = '';
+        res.on('data', (c) => { raw += c; });
+        res.on('end', () => {
+          let parsed: Record<string, unknown> = {};
+          try {
+            parsed = raw.length > 0 ? JSON.parse(raw) : {};
+          } catch {
+            parsed = { _raw: raw };
+          }
+          resolve({ status: res.statusCode ?? 0, headers: res.headers, body: parsed });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function decodeFragment(location: string): Record<string, unknown> {
+  const marker = '#oxy_boot=';
+  const idx = location.indexOf(marker);
+  const b64 = location.slice(idx + marker.length);
+  return JSON.parse(Buffer.from(b64, 'base64url').toString('utf8'));
+}
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/auth', deviceAuthRouter);
+  app.use(errorHandler);
+  server = app.listen(0, done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  // resetAllMocks (not clearAllMocks) so queued `mockResolvedValueOnce`
+  // implementations never leak between tests; re-establish the always-on
+  // defaults afterwards.
+  jest.resetAllMocks();
+  internalOk = false;
+  mockIsTrustedOrigin.mockReturnValue(true);
+  mockIssueDeviceToken.mockResolvedValue('device-token-abcdefghijklmnopqrst');
+  mockIssueRefreshToken.mockResolvedValue({
+    token: 'refresh-token-abcdefghijklmnopqrst',
+    family: 'fam',
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+});
+
+describe('GET /auth/device/bootstrap', () => {
+  it('303s with an oxy_device cookie and a session fragment (code) for a known device + active session', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({
+      deviceId: 'd1',
+      activeAccountId: 'u1',
+      accounts: [{ accountId: 'u1', sessionId: 's1' }],
+    });
+    mockValidateSessionById.mockResolvedValueOnce({ session: {} });
+    mockMintBootCode.mockResolvedValueOnce({ code: 'boot-code-abcdefghijklmnopqrst', expiresInSeconds: 60 });
+
+    const res = await request(
+      'GET',
+      '/auth/device/bootstrap?return_to=' + encodeURIComponent('https://accounts.oxy.so/app') + '&state=st123',
+      { headers: { cookie: 'oxy_device=cookiesecret' } },
+    );
+
+    expect(res.status).toBe(303);
+    const setCookie = (res.headers['set-cookie'] ?? []).join(';');
+    expect(setCookie).toMatch(/oxy_device=/);
+    const location = res.headers.location as string;
+    expect(location.startsWith('https://accounts.oxy.so/app#oxy_boot=')).toBe(true);
+    const frag = decodeFragment(location);
+    expect(frag).toMatchObject({ v: 1, state: 'st123', reason: 'session' });
+    expect(typeof frag.code).toBe('string');
+    expect(typeof frag.deviceToken).toBe('string');
+    expect(res.headers['cache-control']).toContain('no-store');
+    expect(res.headers['referrer-policy']).toBe('no-referrer');
+  });
+
+  it('mints a new device and returns reason:new_device (no code) when no cookie is present', async () => {
+    mockEnsureDeviceForCookie.mockResolvedValueOnce({ deviceId: 'd2', rawCookieKey: 'freshsecretvalue' });
+
+    const res = await request(
+      'GET',
+      '/auth/device/bootstrap?return_to=' + encodeURIComponent('https://accounts.oxy.so/app') + '&state=st123',
+    );
+
+    expect(res.status).toBe(303);
+    const frag = decodeFragment(res.headers.location as string);
+    expect(frag.reason).toBe('new_device');
+    expect(frag.code).toBeUndefined();
+    expect(mockMintBootCode).not.toHaveBeenCalled();
+  });
+
+  it('400s for an untrusted return_to origin', async () => {
+    mockIsTrustedOrigin.mockReturnValue(false);
+    const res = await request(
+      'GET',
+      '/auth/device/bootstrap?return_to=' + encodeURIComponent('https://evil.example/app') + '&state=st123',
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('400s for a non-loopback http return_to', async () => {
+    const res = await request(
+      'GET',
+      '/auth/device/bootstrap?return_to=' + encodeURIComponent('http://accounts.oxy.so/app') + '&state=st123',
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('400s when state is missing', async () => {
+    const res = await request(
+      'GET',
+      '/auth/device/bootstrap?return_to=' + encodeURIComponent('https://accounts.oxy.so/app'),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /auth/device/web-session', () => {
+  const sameSite = { host: 'api.oxy.so', origin: 'https://accounts.oxy.so' };
+
+  it('returns a token bundle for a same-site caller with an active session', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({
+      deviceId: 'd1',
+      activeAccountId: 'u1',
+      accounts: [{ accountId: 'u1', sessionId: 's1' }],
+    });
+    // resolveActiveSessionRef validate + buildTokenBundle (getAccessToken +
+    // validateSessionById(true) for the user).
+    mockValidateSessionById.mockResolvedValueOnce({ session: {} }); // resolveActiveSessionRef
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc', expiresAt: new Date(Date.now() + 60_000) });
+    mockValidateSessionById.mockResolvedValueOnce({ session: {}, user: { _id: 'u1', username: 'bob' } });
+
+    const res = await request('POST', '/auth/device/web-session', {
+      body: {},
+      headers: { ...sameSite, cookie: 'oxy_device=known' },
+    });
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.reason).toBe('session');
+    expect(data.deviceToken).toBeDefined();
+    const session = data.session as Record<string, unknown>;
+    expect(session).toMatchObject({ sessionId: 's1', accessToken: 'acc' });
+    expect(typeof session.refreshToken).toBe('string');
+  });
+
+  it('returns reason:no_session when the device has no active session', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'd1', activeAccountId: null, accounts: [] });
+
+    const res = await request('POST', '/auth/device/web-session', {
+      body: {},
+      headers: { ...sameSite, cookie: 'oxy_device=known' },
+    });
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.reason).toBe('no_session');
+    expect(data.deviceToken).toBeDefined();
+    expect(data.session).toBeUndefined();
+  });
+
+  it('403s a non-trusted origin', async () => {
+    mockIsTrustedOrigin.mockReturnValue(false);
+    const res = await request('POST', '/auth/device/web-session', {
+      body: {},
+      headers: { host: 'api.oxy.so', origin: 'https://evil.example' },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /auth/device/exchange', () => {
+  it('burns the code and returns a token bundle when the Origin matches', async () => {
+    mockRedeemBootCode.mockResolvedValueOnce({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc', expiresAt: new Date(Date.now() + 60_000) });
+    mockValidateSessionById.mockResolvedValueOnce({ session: {}, user: { _id: 'u1', username: 'bob' } });
+
+    const res = await request('POST', '/auth/device/exchange', {
+      body: { code: 'boot-code-abcdefghijklmnopqrst' },
+      headers: { origin: 'https://mention.earth' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ sessionId: 's1', accessToken: 'acc' });
+    expect(typeof res.body.refreshToken).toBe('string');
+  });
+
+  it('403s on an Origin mismatch', async () => {
+    mockRedeemBootCode.mockResolvedValueOnce({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+    const res = await request('POST', '/auth/device/exchange', {
+      body: { code: 'boot-code-abcdefghijklmnopqrst' },
+      headers: { origin: 'https://evil.example' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('410s a replayed/expired code', async () => {
+    mockRedeemBootCode.mockResolvedValueOnce(null);
+    const res = await request('POST', '/auth/device/exchange', {
+      body: { code: 'boot-code-abcdefghijklmnopqrst' },
+      headers: { origin: 'https://mention.earth' },
+    });
+    expect(res.status).toBe(410);
+  });
+});
+
+describe('POST /auth/refresh-token', () => {
+  it('rotates the family and returns fresh tokens', async () => {
+    mockRotateRefreshToken.mockResolvedValueOnce({ ok: true, token: 'next-refresh-abcdefghijklmnop', sessionId: 's1' });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc', expiresAt: new Date(Date.now() + 60_000) });
+
+    const res = await request('POST', '/auth/refresh-token', {
+      body: { refreshToken: 'current-refresh-abcdefghijklmnop' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      accessToken: 'acc',
+      refreshToken: 'next-refresh-abcdefghijklmnop',
+      sessionId: 's1',
+    });
+  });
+
+  it('401s uniformly on a rotation failure (reuse/expired/not_found)', async () => {
+    mockRotateRefreshToken.mockResolvedValueOnce({ ok: false, reason: 'reuse_detected' });
+    const res = await request('POST', '/auth/refresh-token', {
+      body: { refreshToken: 'stale-refresh-abcdefghijklmnop' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('401s on a malformed body (no token leakage of the reason)', async () => {
+    const res = await request('POST', '/auth/refresh-token', { body: { refreshToken: 'short' } });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /auth/device/token', () => {
+  it('issues a native device token from the bearer deviceId claim', async () => {
+    mockDecodeToken.mockReturnValueOnce({ deviceId: 'd1', sessionId: 's1' });
+    const res = await request('POST', '/auth/device/token', {
+      body: {},
+      headers: { authorization: 'Bearer tok' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.deviceToken).toBeDefined();
+    expect(mockIssueDeviceToken).toHaveBeenCalledWith({ deviceId: 'd1', origin: 'native', channel: 'native' });
+  });
+
+  it('400s when the bearer has no device binding', async () => {
+    mockDecodeToken.mockReturnValueOnce({ sessionId: 's1' });
+    const res = await request('POST', '/auth/device/token', {
+      body: {},
+      headers: { authorization: 'Bearer tok' },
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /auth/device/resolve', () => {
+  it('404s without a valid X-Oxy-Internal secret', async () => {
+    internalOk = false;
+    const res = await request('POST', '/auth/device/resolve', { body: { deviceKey: 'somedevicesecretvalue' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the empty feed for an unknown device', async () => {
+    internalOk = true;
+    mockGetStateByCookieKey.mockResolvedValueOnce(null);
+    const res = await request('POST', '/auth/device/resolve', {
+      body: { deviceKey: 'somedevicesecretvalue' },
+      headers: { 'x-oxy-internal': 'secret' },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ activeAccountId: null, accounts: [] });
+  });
+
+  it('returns the device account feed with minted access tokens', async () => {
+    internalOk = true;
+    mockGetStateByCookieKey.mockResolvedValueOnce({
+      deviceId: 'd1',
+      activeAccountId: 'u1',
+      accounts: [{ accountId: 'u1', sessionId: 's1' }],
+    });
+    mockValidateSessionById.mockResolvedValueOnce({ session: {}, user: { _id: 'u1', username: 'bob' } });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc', expiresAt: new Date(Date.now() + 60_000) });
+
+    const res = await request('POST', '/auth/device/resolve', {
+      body: { deviceKey: 'somedevicesecretvalue' },
+      headers: { 'x-oxy-internal': 'secret' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.activeAccountId).toBe('u1');
+    const accounts = res.body.accounts as Array<Record<string, unknown>>;
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]).toMatchObject({ sessionId: 's1', accessToken: 'acc' });
+    expect((accounts[0].user as Record<string, unknown>).id).toBe('u1');
+  });
+});

--- a/packages/api/src/routes/__tests__/sessionClaim.test.ts
+++ b/packages/api/src/routes/__tests__/sessionClaim.test.ts
@@ -58,11 +58,19 @@ jest.mock('../../services/session.service', () => ({
   },
 }));
 
-jest.mock('../../services/oauthCode.service', () => ({
-  issueAuthCode: jest.fn(),
-  exchangeAuthCode: jest.fn(),
-  AUTH_CODE_TTL_MS: 60_000,
-}));
+jest.mock('../../services/oauthCode.service', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeCrypto = require('crypto');
+  return {
+    issueAuthCode: jest.fn(),
+    exchangeAuthCode: jest.fn(),
+    AUTH_CODE_TTL_MS: 60_000,
+    // The claim handler now mints a rotating refresh-family token via
+    // `issueRefreshToken`, which pulls these hashing helpers from here.
+    sha256Hex: (value: string) => nodeCrypto.createHash('sha256').update(value).digest('hex'),
+    base64UrlEncode: (buf: Buffer) => buf.toString('base64url'),
+  };
+});
 
 jest.mock('../../services/signature.service', () => ({
   __esModule: true,
@@ -323,17 +331,22 @@ describe('POST /auth/session/claim', () => {
     });
 
     expect(res.status).toBe(200);
-    // sendSuccess wraps the body in { data: ... }
+    // sendSuccess wraps the body in { data: ... }. The claim now returns a fresh
+    // ROTATING refresh-family token (minted via issueRefreshToken), NOT the
+    // legacy Session-embedded JWT, so we assert its presence as a non-empty
+    // string rather than a fixed value.
     expect(res.body).toEqual({
       data: {
         accessToken: 'access-jwt',
-        refreshToken: 'refresh-jwt',
+        refreshToken: expect.any(String),
         sessionId,
         deviceId: 'dev-1',
         expiresAt: expiresAt.toISOString(),
         user: { id: userId, username: 'alice' },
       },
     });
+    expect(res.body.data.refreshToken).not.toBe('refresh-jwt');
+    expect(res.body.data.refreshToken.length).toBeGreaterThan(0);
     expect(mockGetAccessToken).toHaveBeenCalledWith(sessionId);
   });
 

--- a/packages/api/src/routes/__tests__/sessionClaim.test.ts
+++ b/packages/api/src/routes/__tests__/sessionClaim.test.ts
@@ -59,8 +59,7 @@ jest.mock('../../services/session.service', () => ({
 }));
 
 jest.mock('../../services/oauthCode.service', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const nodeCrypto = require('crypto');
+  const nodeCrypto = jest.requireActual<typeof import('crypto')>('crypto');
   return {
     issueAuthCode: jest.fn(),
     exchangeAuthCode: jest.fn(),

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -12,6 +12,8 @@ import { User, IUser } from '../models/User';
 import { IAccountMember } from '../models/AccountMember';
 import { IAccountCredential } from '../models/AccountCredential';
 import sessionService from '../services/session.service';
+import deviceSessionService from '../services/deviceSession.service';
+import { broadcastDeviceState } from '../utils/socket';
 import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
 import { logger } from '../utils/logger';
 import type { SessionAuthResponse } from '../types/session';
@@ -358,6 +360,34 @@ router.post(
       operatedByUserId: operatorId,
       ...(callerDeviceId ? { deviceId: callerDeviceId } : {}),
     });
+
+    // Register the managed session into the operator's device set server-side so
+    // it survives reload and syncs cross-domain via the socket room — a switch is
+    // a deliberate activation, so `activate: 'always'`. This replaces the client
+    // establishing the slot separately. Best-effort: never fail the switch on a
+    // device-set write. Only when the operator's device is known.
+    if (callerDeviceId) {
+      try {
+        const { state, changed } = await deviceSessionService.addAccount(
+          session.deviceId,
+          {
+            accountId: account._id.toString(),
+            sessionId: session.sessionId,
+            operatedByUserId: operatorId,
+          },
+          { activate: 'always' },
+        );
+        if (changed) broadcastDeviceState(state);
+      } catch (error) {
+        logger.warn('[accounts] switch: device-set registration failed', {
+          component: 'accounts',
+          method: 'switch',
+          operatorId,
+          targetAccountId: id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     const userData = formatUserResponse(account);
     if (!userData) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -36,6 +36,7 @@ import { claimAuthSession, authorizeSessionWithSignedChallenge } from '../servic
 import Session from '../models/Session';
 import {
   rotateRefreshToken,
+  issueRefreshToken,
   issueAndSetRefreshCookie,
   revokeFamilyByRawToken,
   revokeFamily,
@@ -47,6 +48,7 @@ import {
   selectActiveCandidate,
   MAX_DEVICE_ACCOUNTS,
 } from '../services/refreshToken.service';
+import { resolveLoginDeviceId } from '../services/deviceLogin.service';
 import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils';
 import {
   signupSchema,
@@ -1131,6 +1133,15 @@ router.post('/logout', refreshLimiter, requireSameSiteOrigin, asyncHandler(async
   // always proceeds to clear and returns 200.
   const authuser = parseAuthuserParam(req);
 
+  // Persisted-refresh lane (ADDITIVE): a client that holds a rotating refresh
+  // token in storage (web localStorage / native) passes it in the body so its
+  // family is revoked alongside the cookie families. Idempotent on unknown
+  // tokens; never affects the legacy cookie path below.
+  const bodyRefreshToken = (req.body as { refreshToken?: unknown } | undefined)?.refreshToken;
+  if (typeof bodyRefreshToken === 'string' && bodyRefreshToken.length > 0) {
+    await revokeFamilyByRawToken(bodyRefreshToken);
+  }
+
   if (authuser !== null) {
     const buckets = parseAllRefreshCookies(req.headers.cookie);
     const rawList = buckets.get(authuser) ?? [];
@@ -1440,11 +1451,12 @@ import AuthSession from '../models/AuthSession';
  *         description: Application is not available (suspended/deleted/pending review).
  */
 router.post('/session/create', validate({ body: authSessionCreateSchema }), asyncHandler(async (req, res) => {
-  const { sessionToken, expiresAt, clientId, applicationId } = req.body as {
+  const { sessionToken, expiresAt, clientId, applicationId, deviceToken } = req.body as {
     sessionToken: string;
     clientId?: string;
     applicationId?: string;
     expiresAt?: string | number;
+    deviceToken?: string;
   };
 
   if (!sessionToken) {
@@ -1534,6 +1546,12 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
   const authorizeCode = crypto.randomBytes(16).toString('hex');
   const qrNonce = crypto.randomBytes(8).toString('hex');
 
+  // Device-first attribution: when the QR was started from a device that already
+  // holds a session (oxy_device cookie) or presented an add-only deviceToken,
+  // persist that central deviceId so the authorize paths mint the resulting
+  // session onto the SAME device set instead of sprawling a fresh device.
+  const attributionDeviceId = await resolveLoginDeviceId(req, deviceToken);
+
   // Create new auth session
   const authSession = await AuthSession.create({
     sessionToken,
@@ -1544,6 +1562,7 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
     challengeNonce: qrNonce,
     expiresAt: expiresAtDate,
     status: 'pending',
+    ...(attributionDeviceId ? { deviceId: attributionDeviceId } : {}),
   });
 
   // Deep-link / universal-link payload for the QR. Commons parses ONLY `code`
@@ -1807,11 +1826,17 @@ router.post('/session/authorize/:sessionToken', authMiddleware, validate({ param
   const appLabel = app ? app.name : 'App';
 
   // Create a new session for the third-party app, owned by the
-  // authenticated user identified via the bearer token.
+  // authenticated user identified via the bearer token. When the flow was
+  // started with a device binding (`deviceId` persisted at create time), pass it
+  // as the explicit deviceId so the session lands on the originating device.
   const newSession = await sessionService.createSession(
     authenticatedUserId,
     req,
-    { deviceName: deviceName || `${appLabel} App`, deviceFingerprint }
+    {
+      deviceName: deviceName || `${appLabel} App`,
+      deviceFingerprint,
+      ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
+    }
   );
 
   // Update auth session
@@ -1979,11 +2004,9 @@ router.post(
       throw new UnauthorizedError('invalid_grant');
     }
 
-    // Pull the refreshToken + deviceId from the underlying Session so
-    // the client can persist them and continue using the normal token
-    // refresh flow afterwards.
+    // Pull the deviceId from the underlying Session for the response.
     const session = await Session.findOne({ sessionId: authSession.authorizedSessionId })
-      .select('refreshToken deviceId expiresAt')
+      .select('deviceId expiresAt')
       .lean();
 
     if (!session) {
@@ -1992,6 +2015,15 @@ router.post(
       });
       throw new UnauthorizedError('invalid_grant');
     }
+
+    // Return a fresh ROTATING refresh-family token (the persisted-refresh lane),
+    // NOT the legacy Session-embedded JWT. The client persists this and rotates
+    // it via `POST /auth/refresh-token`. (The OAuth `/auth/oauth/token` flow is
+    // deliberately untouched.)
+    const refresh = await issueRefreshToken({
+      sessionId: authSession.authorizedSessionId,
+      userId: authSession.authorizedUserId.toString(),
+    });
 
     const userData = formatUserResponse(user);
 
@@ -2004,7 +2036,7 @@ router.post(
 
     sendSuccess(res, {
       accessToken: tokenResult.accessToken,
-      refreshToken: session.refreshToken,
+      refreshToken: refresh.token,
       sessionId: authSession.authorizedSessionId,
       deviceId: session.deviceId,
       expiresAt: tokenResult.expiresAt.toISOString(),

--- a/packages/api/src/routes/deviceAuth.ts
+++ b/packages/api/src/routes/deviceAuth.ts
@@ -262,18 +262,27 @@ function assertSameSiteApex(req: Request): { ok: true; origin: string } | { ok: 
 
   if (isLoopbackOrigin(origin)) return { ok: true, origin };
 
-  const hostRaw = req.headers.host;
-  if (typeof hostRaw !== 'string' || hostRaw.length === 0) return { ok: false };
+  // Use Express's `req.hostname` — it strips the port and handles IPv6 literals
+  // (`[::1]:3000` → `[::1]`) correctly, unlike a naive `host.split(':')` which
+  // shreds an IPv6 address.
+  const apiHost = req.hostname;
+  if (typeof apiHost !== 'string' || apiHost.length === 0) return { ok: false };
   let originHost: string;
   try {
     originHost = new URL(origin).hostname;
   } catch {
     return { ok: false };
   }
-  const apiApex = registrableApex(hostRaw.split(':')[0]);
+
+  const apiApex = registrableApex(apiHost);
   const originApex = registrableApex(originHost);
-  if (!apiApex || !originApex || apiApex !== originApex) return { ok: false };
-  return { ok: true, origin };
+  if (apiApex && originApex) {
+    // Registrable-domain match (the `*.oxy.so` sibling case).
+    return apiApex === originApex ? { ok: true, origin } : { ok: false };
+  }
+  // No registrable apex (IP literal / single-label host): same-site ONLY on an
+  // exact host match — never treat two different bare hosts as same-site.
+  return originHost.toLowerCase() === apiHost.toLowerCase() ? { ok: true, origin } : { ok: false };
 }
 
 router.post(
@@ -473,26 +482,40 @@ router.post(
       return;
     }
 
-    const accounts: Array<{
+    type ResolvedAccount = {
       user: SerializedUser;
       sessionId: string;
       accessToken: string;
       expiresAt: string;
-    }> = [];
-    for (const account of state.accounts) {
-      const validated = await sessionService.validateSessionById(account.sessionId, true);
-      if (!validated) continue;
-      const tokenResult = await sessionService.getAccessToken(account.sessionId);
-      if (!tokenResult) continue;
-      const user = validated.user ? formatUserResponse(validated.user) : null;
-      if (!user) continue;
-      accounts.push({
-        user,
-        sessionId: account.sessionId,
-        accessToken: tokenResult.accessToken,
-        expiresAt: tokenResult.expiresAt.toISOString(),
-      });
-    }
+    };
+    // Resolve every account in PARALLEL, each isolated in its own try/catch so a
+    // single dead/corrupt session is SKIPPED (returns null) rather than 500-ing
+    // the whole chooser feed.
+    const resolved = await Promise.all(
+      state.accounts.map(async (account): Promise<ResolvedAccount | null> => {
+        try {
+          const validated = await sessionService.validateSessionById(account.sessionId, true);
+          if (!validated) return null;
+          const tokenResult = await sessionService.getAccessToken(account.sessionId);
+          if (!tokenResult) return null;
+          const user = validated.user ? formatUserResponse(validated.user) : null;
+          if (!user) return null;
+          return {
+            user,
+            sessionId: account.sessionId,
+            accessToken: tokenResult.accessToken,
+            expiresAt: tokenResult.expiresAt.toISOString(),
+          };
+        } catch (error) {
+          logger.warn('device resolve: skipping unresolvable account', {
+            sessionId: account.sessionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return null;
+        }
+      }),
+    );
+    const accounts = resolved.filter((a): a is ResolvedAccount => a !== null);
 
     // The active account survives only if it minted a live token above.
     const activeAlive =

--- a/packages/api/src/routes/deviceAuth.ts
+++ b/packages/api/src/routes/deviceAuth.ts
@@ -1,0 +1,507 @@
+/**
+ * Device-first auth surface — ADDITIVE (auth centralization, wave 1).
+ *
+ * A single router mounted at `/auth` BEFORE the generic `/auth` mount, housing
+ * the new device-first bootstrap + persisted-refresh endpoints:
+ *
+ *   GET  /auth/device/bootstrap   — top-level cross-apex hop: (re-)plants the
+ *                                   `oxy_device` cookie, resolves the active
+ *                                   session, and hands back a single-use boot
+ *                                   `code` in the `#oxy_boot=…` fragment.
+ *   POST /auth/device/web-session — same-site (`*.oxy.so`) fast path: exchanges
+ *                                   the `oxy_device` cookie directly for a token
+ *                                   bundle, no redirect.
+ *   POST /auth/device/exchange    — burn a boot code (origin-bound) for tokens.
+ *   POST /auth/refresh-token      — ONE rotating refresh implementation (web +
+ *                                   native).
+ *   POST /auth/device/token       — issue the native-channel device token.
+ *   POST /auth/device/resolve     — X-Oxy-Internal device-set feed for the IdP
+ *                                   chooser.
+ *
+ * The legacy `/sso*`, `/fedcm/*`, `/auth/refresh`, `/auth/refresh-all`,
+ * `/auth/session`, and `oxy_rt` cookie machinery are BYTE-UNTOUCHED — everything
+ * here is new surface. NO token or deviceId is ever placed in a URL/query/
+ * fragment/response-body of these endpoints (the cookie secret ≠ deviceId, the
+ * boot code is opaque, and the deviceToken is opaque).
+ */
+
+import { Router, Request, Response } from 'express';
+import { registrableApex } from '@oxyhq/core/server';
+import type { DeviceBootFragment, DeviceBootReason } from '@oxyhq/contracts';
+import { deviceBootFragmentSchema } from '@oxyhq/contracts';
+import { authMiddleware } from '../middleware/auth';
+import { requireSameSiteOrigin } from '../middleware/originGuard';
+import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils';
+import { rateLimit } from '../middleware/rateLimiter';
+import { asyncHandler } from '../utils/asyncHandler';
+import { logger } from '../utils/logger';
+import { normaliseOrigin, isLoopbackOrigin } from '../utils/origin';
+import { isTrustedOrigin } from '../config/dynamicOriginRegistry';
+import { hasValidInternalSecret } from '../utils/internalSecret';
+import { readDeviceCookie, setDeviceCookie } from '../utils/deviceCookie';
+import deviceSessionService from '../services/deviceSession.service';
+import sessionService from '../services/session.service';
+import { issueDeviceToken, NATIVE_ORIGIN } from '../services/deviceToken.service';
+import { mintBootCode, redeemBootCode } from '../services/deviceBootCode.service';
+import { issueRefreshToken, rotateRefreshToken } from '../services/refreshToken.service';
+import { formatUserResponse } from '../utils/userTransform';
+import {
+  deviceBootstrapQuerySchema,
+  deviceExchangeRequestSchema,
+  tokenRefreshRequestSchema,
+  deviceResolveRequestSchema,
+} from '../schemas/deviceAuth.schemas';
+
+const router = Router();
+
+/**
+ * The canonical serialized user shape (`formatUserResponse` output). Used
+ * locally so response objects carry a precise type without asserting against the
+ * contract `UserResponse` (which the serializer's passthrough fields do not
+ * cleanly satisfy at the type level); the wire shape matches the contract and is
+ * validated by every SDK consumer on input.
+ */
+type SerializedUser = NonNullable<ReturnType<typeof formatUserResponse>>;
+
+/**
+ * The trusted CREDENTIALED lane: first-party / internal / system / official app
+ * origins, plus http loopback dev origins (which `isTrustedOrigin` deliberately
+ * excludes but the credentialed CORS lane always trusts). Third-party app
+ * origins never pass — they can never begin a device-first bootstrap.
+ */
+function isTrustedLaneOrigin(origin: string): boolean {
+  return isTrustedOrigin(origin) || isLoopbackOrigin(origin);
+}
+
+/** base64url-encode a JSON-serialisable value (URL-safe, no padding). */
+function encodeFragment(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+/**
+ * Validate + normalise a bootstrap `return_to`: parseable URL, https (http only
+ * for loopback), no embedded credentials, and its origin on the trusted lane.
+ * Returns the normalised origin, or null when the target is not eligible.
+ */
+function resolveReturnTo(returnTo: string): { url: URL; origin: string } | null {
+  let url: URL;
+  try {
+    url = new URL(returnTo);
+  } catch {
+    return null;
+  }
+  // Never honour a URL that smuggles credentials.
+  if (url.username || url.password) return null;
+
+  const loopback = url.protocol === 'http:' && isLoopbackOrigin(url.origin);
+  if (url.protocol !== 'https:' && !loopback) return null;
+
+  const origin = normaliseOrigin(url.origin);
+  if (!origin) return null;
+  if (!isTrustedLaneOrigin(origin)) return null;
+
+  return { url, origin };
+}
+
+/**
+ * Resolve the device's active session (validated) into `{ sessionId, userId }`,
+ * or null when there is no active account or its session is dead. Shared by
+ * bootstrap + web-session.
+ */
+async function resolveActiveSessionRef(
+  state: { activeAccountId: string | null; accounts: { accountId: string; sessionId: string }[] } | null,
+): Promise<{ sessionId: string; userId: string } | null> {
+  if (!state || !state.activeAccountId) return null;
+  const active = state.accounts.find((a) => a.accountId === state.activeAccountId);
+  if (!active) return null;
+  const validated = await sessionService.validateSessionById(active.sessionId, false);
+  if (!validated) return null;
+  return { sessionId: active.sessionId, userId: state.activeAccountId };
+}
+
+/**
+ * Build the full token bundle (matches the contract `AuthTokenBundle` wire
+ * shape) for a validated session: fresh access token, a NEW rotating
+ * refresh-family head, expiry, and the canonical user. Returns null when the
+ * session can no longer mint a token or the user is gone.
+ */
+async function buildTokenBundle(
+  sessionId: string,
+  userId: string,
+): Promise<{
+  sessionId: string;
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+  user: SerializedUser;
+} | null> {
+  const tokenResult = await sessionService.getAccessToken(sessionId);
+  if (!tokenResult) return null;
+
+  const resolved = await sessionService.validateSessionById(sessionId, true);
+  const user = resolved?.user ? formatUserResponse(resolved.user) : null;
+  if (!user) return null;
+
+  const refresh = await issueRefreshToken({ sessionId, userId });
+
+  return {
+    sessionId,
+    accessToken: tokenResult.accessToken,
+    refreshToken: refresh.token,
+    expiresAt: tokenResult.expiresAt.toISOString(),
+    user,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  GET /auth/device/bootstrap                                                */
+/* -------------------------------------------------------------------------- */
+
+const bootstrapLimiter = rateLimit({
+  prefix: 'rl:auth:device:bootstrap:',
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+});
+
+router.get(
+  '/device/bootstrap',
+  bootstrapLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = deviceBootstrapQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ message: 'return_to and state are required' });
+      return;
+    }
+    const { return_to: returnTo, state } = parsed.data;
+
+    const target = resolveReturnTo(returnTo);
+    if (!target) {
+      res.status(400).json({ message: 'return_to is not an allowed target' });
+      return;
+    }
+    const returnToOrigin = target.origin;
+
+    // Resolve (or mint) the device bound to the `oxy_device` cookie.
+    const rawCookie = readDeviceCookie(req);
+    const existingState = rawCookie ? await deviceSessionService.getStateByCookieKey(rawCookie) : null;
+
+    let deviceId: string;
+    let rawCookieKey: string;
+    let freshDevice = false;
+    if (existingState && rawCookie) {
+      deviceId = existingState.deviceId;
+      rawCookieKey = rawCookie;
+    } else {
+      const ensured = await deviceSessionService.ensureDeviceForCookie();
+      deviceId = ensured.deviceId;
+      rawCookieKey = ensured.rawCookieKey;
+      freshDevice = true;
+    }
+
+    // Resolve the active session and mint a single-use, origin-bound boot code.
+    let reason: DeviceBootReason = freshDevice ? 'new_device' : 'no_session';
+    let code: string | undefined;
+    const activeRef = await resolveActiveSessionRef(existingState);
+    if (activeRef) {
+      const minted = await mintBootCode({
+        sessionId: activeRef.sessionId,
+        userId: activeRef.userId,
+        clientOrigin: returnToOrigin,
+      });
+      code = minted.code;
+      reason = 'session';
+    }
+
+    // Rotate a fresh web deviceToken on EVERY hop, bound to the return_to origin.
+    const deviceToken = await issueDeviceToken({ deviceId, origin: returnToOrigin, channel: 'web' });
+
+    const fragment: DeviceBootFragment = {
+      v: 1,
+      state,
+      reason,
+      ...(code ? { code } : {}),
+      deviceToken,
+    };
+    // Guard: never emit a fragment the consumer cannot parse.
+    const validFragment = deviceBootFragmentSchema.safeParse(fragment);
+    if (!validFragment.success) {
+      logger.error('device bootstrap built an invalid fragment', new Error('invalid fragment'));
+      res.status(500).json({ message: 'Internal server error' });
+      return;
+    }
+
+    setDeviceCookie(res, rawCookieKey);
+    res.set('Cache-Control', 'no-store');
+    res.set('Referrer-Policy', 'no-referrer');
+
+    target.url.hash = `oxy_boot=${encodeFragment(fragment)}`;
+    res.redirect(303, target.url.toString());
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  POST /auth/device/web-session                                             */
+/* -------------------------------------------------------------------------- */
+
+const webSessionLimiter = rateLimit({
+  prefix: 'rl:auth:device:websession:',
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+});
+
+/**
+ * Same-site fast path. The Origin MUST be present, on the trusted lane, AND
+ * share the API host's registrable apex (a true `*.oxy.so` sibling) — loopback
+ * dev origins are exempted from the apex check. Rejects otherwise.
+ */
+function assertSameSiteApex(req: Request): { ok: true; origin: string } | { ok: false } {
+  const originRaw = req.headers.origin;
+  if (typeof originRaw !== 'string' || originRaw.length === 0) return { ok: false };
+  const origin = normaliseOrigin(originRaw);
+  if (!origin || !isTrustedLaneOrigin(origin)) return { ok: false };
+
+  if (isLoopbackOrigin(origin)) return { ok: true, origin };
+
+  const hostRaw = req.headers.host;
+  if (typeof hostRaw !== 'string' || hostRaw.length === 0) return { ok: false };
+  let originHost: string;
+  try {
+    originHost = new URL(origin).hostname;
+  } catch {
+    return { ok: false };
+  }
+  const apiApex = registrableApex(hostRaw.split(':')[0]);
+  const originApex = registrableApex(originHost);
+  if (!apiApex || !originApex || apiApex !== originApex) return { ok: false };
+  return { ok: true, origin };
+}
+
+router.post(
+  '/device/web-session',
+  webSessionLimiter,
+  requireSameSiteOrigin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const site = assertSameSiteApex(req);
+    if (!site.ok) {
+      res.status(403).json({ message: 'Origin is not an allowed same-site caller' });
+      return;
+    }
+
+    const rawCookie = readDeviceCookie(req);
+    const existingState = rawCookie ? await deviceSessionService.getStateByCookieKey(rawCookie) : null;
+
+    let deviceId: string;
+    let rawCookieKey: string;
+    let freshDevice = false;
+    if (existingState && rawCookie) {
+      deviceId = existingState.deviceId;
+      rawCookieKey = rawCookie;
+    } else {
+      const ensured = await deviceSessionService.ensureDeviceForCookie();
+      deviceId = ensured.deviceId;
+      rawCookieKey = ensured.rawCookieKey;
+      freshDevice = true;
+    }
+
+    // Always (re-)plant the cookie with a fresh sliding expiry and issue a fresh
+    // web deviceToken bound to the caller origin.
+    setDeviceCookie(res, rawCookieKey);
+    const deviceToken = await issueDeviceToken({ deviceId, origin: site.origin, channel: 'web' });
+
+    const activeRef = await resolveActiveSessionRef(existingState);
+    if (activeRef) {
+      const bundle = await buildTokenBundle(activeRef.sessionId, activeRef.userId);
+      if (bundle) {
+        res.json({ data: { reason: 'session' as const, session: bundle, deviceToken } });
+        return;
+      }
+    }
+
+    const reason: DeviceBootReason = freshDevice ? 'new_device' : 'no_session';
+    res.json({ data: { reason, deviceToken } });
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  POST /auth/device/exchange                                                */
+/* -------------------------------------------------------------------------- */
+
+const exchangeLimiter = rateLimit({
+  prefix: 'rl:auth:device:exchange:',
+  windowMs: 60 * 1000,
+  max: 10,
+});
+
+router.post(
+  '/device/exchange',
+  exchangeLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = deviceExchangeRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ message: 'code is required' });
+      return;
+    }
+
+    // Atomic single-use burn. Missing / replayed / expired → 410.
+    const record = await redeemBootCode(parsed.data.code);
+    if (!record) {
+      res.status(410).json({ message: 'Code is invalid, expired, or already used' });
+      return;
+    }
+
+    // Bind redemption to the RP that the code was minted for.
+    const originRaw = req.headers.origin;
+    const origin = typeof originRaw === 'string' ? normaliseOrigin(originRaw) : null;
+    if (!origin || origin !== record.clientOrigin) {
+      logger.warn('device exchange Origin does not match code clientOrigin');
+      res.status(403).json({ message: 'Origin mismatch' });
+      return;
+    }
+
+    const bundle = await buildTokenBundle(record.sessionId, record.userId);
+    if (!bundle) {
+      // The session died between mint and exchange — treat as a spent code.
+      res.status(410).json({ message: 'Code is invalid, expired, or already used' });
+      return;
+    }
+
+    res.json(bundle);
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  POST /auth/refresh-token                                                  */
+/* -------------------------------------------------------------------------- */
+
+const refreshTokenLimiter = rateLimit({
+  prefix: 'rl:auth:refresh-token:',
+  windowMs: 60 * 1000,
+  max: 60,
+});
+
+router.post(
+  '/refresh-token',
+  refreshTokenLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = tokenRefreshRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(401).json({ message: 'Invalid refresh token' });
+      return;
+    }
+
+    // Rotate (single-use claim + reuse-detection family revoke). All failures →
+    // uniform 401 so a caller cannot distinguish not_found/expired/reuse.
+    const outcome = await rotateRefreshToken(parsed.data.refreshToken);
+    if (!outcome.ok) {
+      res.status(401).json({ message: 'Invalid refresh token' });
+      return;
+    }
+
+    const tokenResult = await sessionService.getAccessToken(outcome.sessionId);
+    if (!tokenResult) {
+      res.status(401).json({ message: 'Invalid refresh token' });
+      return;
+    }
+
+    res.json({
+      accessToken: tokenResult.accessToken,
+      refreshToken: outcome.token,
+      expiresAt: tokenResult.expiresAt.toISOString(),
+      sessionId: outcome.sessionId,
+    });
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  POST /auth/device/token                                                   */
+/* -------------------------------------------------------------------------- */
+
+const deviceTokenLimiter = rateLimit({
+  prefix: 'rl:auth:device:token:',
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+});
+
+router.post(
+  '/device/token',
+  deviceTokenLimiter,
+  authMiddleware,
+  asyncHandler(async (req: Request, res: Response) => {
+    // Derive the deviceId from the caller's validated bearer — never the body.
+    const token = extractTokenFromRequest(req);
+    const decoded = token ? decodeToken(token) : null;
+    const deviceId = decoded?.deviceId;
+    if (typeof deviceId !== 'string' || deviceId.length === 0) {
+      res.status(400).json({ message: 'Bearer token has no device binding' });
+      return;
+    }
+
+    const deviceToken = await issueDeviceToken({ deviceId, origin: NATIVE_ORIGIN, channel: 'native' });
+    res.json({ deviceToken });
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  POST /auth/device/resolve  (X-Oxy-Internal — IdP chooser feed)            */
+/* -------------------------------------------------------------------------- */
+
+const deviceResolveLimiter = rateLimit({
+  prefix: 'rl:auth:device:resolve:',
+  windowMs: 60 * 1000,
+  max: 120,
+});
+
+router.post(
+  '/device/resolve',
+  deviceResolveLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    // Gate FIRST — 404 (not 401) so the route's existence is not revealed.
+    if (!hasValidInternalSecret(req)) {
+      res.status(404).json({ message: 'Not found' });
+      return;
+    }
+
+    const parsed = deviceResolveRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ message: 'deviceKey is required' });
+      return;
+    }
+
+    const state = await deviceSessionService.getStateByCookieKey(parsed.data.deviceKey);
+    if (!state) {
+      res.json({ activeAccountId: null, accounts: [] });
+      return;
+    }
+
+    const accounts: Array<{
+      user: SerializedUser;
+      sessionId: string;
+      accessToken: string;
+      expiresAt: string;
+    }> = [];
+    for (const account of state.accounts) {
+      const validated = await sessionService.validateSessionById(account.sessionId, true);
+      if (!validated) continue;
+      const tokenResult = await sessionService.getAccessToken(account.sessionId);
+      if (!tokenResult) continue;
+      const user = validated.user ? formatUserResponse(validated.user) : null;
+      if (!user) continue;
+      accounts.push({
+        user,
+        sessionId: account.sessionId,
+        accessToken: tokenResult.accessToken,
+        expiresAt: tokenResult.expiresAt.toISOString(),
+      });
+    }
+
+    // The active account survives only if it minted a live token above.
+    const activeAlive =
+      state.activeAccountId && accounts.some((a) => a.user.id === state.activeAccountId)
+        ? state.activeAccountId
+        : null;
+
+    res.json({ activeAccountId: activeAlive, accounts });
+  }),
+);
+
+export default router;

--- a/packages/api/src/schemas/auth.schemas.ts
+++ b/packages/api/src/schemas/auth.schemas.ts
@@ -14,6 +14,9 @@ export const signupSchema = z.object({
   }).optional(),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  // Opaque add-only device attribution token (device-first auth). Optional;
+  // absent for the legacy path. Never a session credential.
+  deviceToken: z.string().trim().max(512).optional(),
 }).superRefine((data, ctx) => {
   // Native users must supply a clean display name (letters/spaces/apostrophe
   // only). Federated names are stripped silently elsewhere; native names are
@@ -42,6 +45,7 @@ export const loginSchema = z.object({
   password: z.string().min(1),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  deviceToken: z.string().trim().max(512).optional(),
 });
 
 // POST /auth/register (public key)
@@ -66,6 +70,7 @@ export const verifyChallengeSchema = z.object({
   timestamp: z.number(),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  deviceToken: z.string().trim().max(512).optional(),
 });
 
 // POST /auth/recover/request
@@ -120,6 +125,9 @@ export const authSessionCreateSchema = z.object({
   clientId: z.string().trim().min(1).optional(),
   applicationId: z.string().trim().min(1).optional(),
   expiresAt: z.union([z.string(), z.number()]).optional(),
+  // Optional add-only device attribution (device-flow QR started from a device
+  // that already holds a session). Persisted onto the AuthSession as `deviceId`.
+  deviceToken: z.string().trim().max(512).optional(),
 }).refine(
   (data) => Boolean(data.clientId) || Boolean(data.applicationId),
   { message: 'Either clientId or applicationId is required' }

--- a/packages/api/src/schemas/deviceAuth.schemas.ts
+++ b/packages/api/src/schemas/deviceAuth.schemas.ts
@@ -1,0 +1,35 @@
+/**
+ * Zod schemas for the device-first auth surface (`/auth/device/*` +
+ * `/auth/refresh-token`).
+ *
+ * The wire CONTRACTS (request + response) live in `@oxyhq/contracts`
+ * (`deviceBoot.ts`) — the single source of truth shared with the SDK. This file
+ * imports the request schemas for route-body validation and adds the one
+ * server-only input the contract does not model: the bootstrap query string
+ * (`return_to` + CSRF `state`), which the handler additionally validates for
+ * https/loopback + trusted-origin + size.
+ */
+
+import { z } from 'zod';
+
+export {
+  deviceExchangeRequestSchema,
+  tokenRefreshRequestSchema,
+  deviceResolveRequestSchema,
+} from '@oxyhq/contracts';
+
+/**
+ * `GET /auth/device/bootstrap?return_to=<url>&state=<opaque≤256>`.
+ *
+ * `return_to` is size-capped here (2KB) and further validated in the handler
+ * (parseable https URL, no embedded credentials, origin on the trusted lane, or
+ * an http loopback dev origin). `state` is an opaque CSRF echo the client stored
+ * in its tab's sessionStorage and re-verifies on return; it is bounded to 256
+ * chars to match `deviceBootFragmentSchema`.
+ */
+export const deviceBootstrapQuerySchema = z.object({
+  return_to: z.string().min(1).max(2048),
+  state: z.string().min(1).max(256),
+});
+
+export type DeviceBootstrapQuery = z.infer<typeof deviceBootstrapQuerySchema>;

--- a/packages/api/src/schemas/security.schemas.ts
+++ b/packages/api/src/schemas/security.schemas.ts
@@ -35,4 +35,5 @@ export const verify2FALoginSchema = z.object({
   backupCode: z.string().trim().optional(),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  deviceToken: z.string().trim().max(512).optional(),
 });

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -21,6 +21,7 @@ import linkMetadataRoutes from './routes/linkMetadata';
 import linksRoutes from './routes/links';
 import locationSearchRoutes from './routes/locationSearch';
 import authRoutes from './routes/auth';
+import deviceAuthRoutes from './routes/deviceAuth';
 import assetRoutes from './routes/assets';
 import cdnRoutes from './routes/cdn';
 import storageRoutes from './routes/storage';
@@ -507,6 +508,11 @@ app.use(bruteForceProtection);
 app.get('/csrf-token', getCsrfToken);
 
 // API Routes
+// Device-first auth surface (ADDITIVE). Mounted BEFORE the generic `/auth` so
+// `/auth/device/*` and `/auth/refresh-token` are owned by this router; it brings
+// its own per-endpoint rate limiters (NOT the broad `authRateLimiter`, avoiding
+// double-counting). Unmatched paths fall through to the generic `/auth` router.
+app.use("/auth", deviceAuthRoutes);
 // Apply stricter rate limiting to auth routes
 app.use("/auth", authRateLimiter, authRoutes);
 app.use("/auth", userRateLimiter, csrfProtection, authLinkingRoutes); // Auth linking (requires auth)

--- a/packages/api/src/services/__tests__/deviceBootCode.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceBootCode.service.test.ts
@@ -1,0 +1,119 @@
+/**
+ * deviceBootCode.service unit tests.
+ *
+ * Mirrors the ssoCode.service test shape: an in-memory Valkey double honouring
+ * atomic GETDEL exercises the real single-use burn logic.
+ *
+ * Covers:
+ *  - mint stores sha256(code) (never the raw code) with a 60s TTL; returns raw.
+ *  - redeem happy path returns the payload.
+ *  - double redeem (single-use burn) → null.
+ *  - malformed stored record → null.
+ *  - fail-closed: mint throws / redeem returns null when Redis is absent.
+ */
+
+import * as crypto from 'crypto';
+
+const store = new Map<string, string>();
+const mockRedis = {
+  set: jest.fn(async (key: string, value: string, _ex: string, _ttl: number) => {
+    store.set(key, value);
+    return 'OK';
+  }),
+  getdel: jest.fn(async (key: string) => {
+    const value = store.get(key);
+    if (value === undefined) return null;
+    store.delete(key);
+    return value;
+  }),
+};
+
+let redisClient: unknown = mockRedis;
+jest.mock('../../config/redis', () => ({
+  getRedisClient: () => redisClient,
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import {
+  mintBootCode,
+  redeemBootCode,
+  DEVICE_BOOT_CODE_TTL_SECONDS,
+} from '../deviceBootCode.service';
+
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+beforeEach(() => {
+  store.clear();
+  jest.clearAllMocks();
+  redisClient = mockRedis;
+});
+
+describe('mintBootCode', () => {
+  it('stores sha256(code) with a 60s TTL and returns the raw code (no token in the record)', async () => {
+    const { code, expiresInSeconds } = await mintBootCode({
+      sessionId: 's1',
+      userId: 'u1',
+      clientOrigin: 'https://mention.earth',
+    });
+
+    expect(typeof code).toBe('string');
+    expect(code.length).toBeGreaterThan(20);
+    expect(expiresInSeconds).toBe(DEVICE_BOOT_CODE_TTL_SECONDS);
+
+    // Key is the HASH of the code, under the device:boot: namespace.
+    expect(mockRedis.set).toHaveBeenCalledWith(
+      `device:boot:${sha256Hex(code)}`,
+      expect.any(String),
+      'EX',
+      DEVICE_BOOT_CODE_TTL_SECONDS,
+    );
+
+    const record = JSON.parse(mockRedis.set.mock.calls[0][1] as string);
+    expect(record).toMatchObject({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+    // The record NEVER carries a token.
+    expect(record.accessToken).toBeUndefined();
+    expect(record.refreshToken).toBeUndefined();
+  });
+
+  it('fails closed: throws when Redis is unavailable', async () => {
+    redisClient = null;
+    await expect(
+      mintBootCode({ sessionId: 's', userId: 'u', clientOrigin: 'https://mention.earth' }),
+    ).rejects.toThrow(/unavailable/i);
+  });
+});
+
+describe('redeemBootCode', () => {
+  it('redeems once and returns the payload', async () => {
+    const { code } = await mintBootCode({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+    const record = await redeemBootCode(code);
+    expect(record).toMatchObject({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+  });
+
+  it('is single-use: a second redeem of the same code returns null (atomic GETDEL burn)', async () => {
+    const { code } = await mintBootCode({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+    expect(await redeemBootCode(code)).not.toBeNull();
+    expect(await redeemBootCode(code)).toBeNull();
+  });
+
+  it('returns null for an unknown / expired code', async () => {
+    expect(await redeemBootCode('never-minted')).toBeNull();
+  });
+
+  it('returns null for a malformed stored record', async () => {
+    // Plant a record missing the required fields under a known code hash.
+    const code = 'deadbeefdeadbeefdeadbeef';
+    store.set(`device:boot:${sha256Hex(code)}`, JSON.stringify({ nope: true }));
+    expect(await redeemBootCode(code)).toBeNull();
+  });
+
+  it('fails closed: returns null when Redis is unavailable', async () => {
+    redisClient = null;
+    expect(await redeemBootCode('x')).toBeNull();
+  });
+});

--- a/packages/api/src/services/__tests__/deviceLogin.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceLogin.service.test.ts
@@ -1,0 +1,173 @@
+/**
+ * deviceLogin.service unit tests — the shared device-first login attribution.
+ *
+ * Covers:
+ *  - resolveLoginDeviceId precedence: oxy_device cookie > deviceToken > none.
+ *  - finalizeDeviceLogin is ADD-ONLY: registers with `activate: 'if-empty'`
+ *    (never steals the active account) and broadcasts only when the set changed.
+ *  - refresh-token lane: attached when a device binding resolved OR the Origin is
+ *    trusted-lane / absent; withheld for a third-party-lane browser Origin.
+ */
+
+import type { Request } from 'express';
+
+const mockGetStateByCookieKey = jest.fn();
+const mockAddAccount = jest.fn();
+jest.mock('../deviceSession.service', () => {
+  const svc = {
+    getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a),
+    addAccount: (...a: unknown[]) => mockAddAccount(...a),
+  };
+  // deviceLogin.service dynamically imports the NAMED `deviceSessionService`.
+  return { __esModule: true, default: svc, deviceSessionService: svc };
+});
+
+const mockResolveDeviceToken = jest.fn();
+jest.mock('../deviceToken.service', () => ({
+  resolveDeviceToken: (...a: unknown[]) => mockResolveDeviceToken(...a),
+}));
+
+const mockIssueRefreshToken = jest.fn(async () => ({ token: 'rt', family: 'f', expiresAt: new Date() }));
+jest.mock('../refreshToken.service', () => ({
+  issueRefreshToken: (...a: unknown[]) => mockIssueRefreshToken(...a),
+}));
+
+const mockBroadcast = jest.fn();
+jest.mock('../../utils/socket', () => ({
+  broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a),
+}));
+
+const mockIsTrustedOrigin = jest.fn(() => false);
+jest.mock('../../config/dynamicOriginRegistry', () => ({
+  isTrustedOrigin: (...a: unknown[]) => mockIsTrustedOrigin(...a),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import { resolveLoginDeviceId, finalizeDeviceLogin } from '../deviceLogin.service';
+
+function req(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  mockIssueRefreshToken.mockResolvedValue({ token: 'rt', family: 'f', expiresAt: new Date() });
+  mockIsTrustedOrigin.mockReturnValue(false);
+});
+
+describe('resolveLoginDeviceId', () => {
+  it('returns null and consults nothing when neither cookie nor deviceToken is present', async () => {
+    const result = await resolveLoginDeviceId(req(), undefined);
+    expect(result).toBeNull();
+    expect(mockGetStateByCookieKey).not.toHaveBeenCalled();
+    expect(mockResolveDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('resolves via the oxy_device cookie (winning over a deviceToken)', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'cookie-device' });
+    const result = await resolveLoginDeviceId(req({ cookie: 'oxy_device=secret' }), 'a-device-token');
+    expect(result).toBe('cookie-device');
+    // Cookie wins — the deviceToken is never consulted.
+    expect(mockResolveDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the deviceToken when no cookie maps to a device', async () => {
+    mockResolveDeviceToken.mockResolvedValueOnce({ deviceId: 'token-device' });
+    const result = await resolveLoginDeviceId(req(), 'a-device-token');
+    expect(result).toBe('token-device');
+    expect(mockResolveDeviceToken).toHaveBeenCalled();
+  });
+
+  it('returns null when the deviceToken does not resolve', async () => {
+    mockResolveDeviceToken.mockResolvedValueOnce(null);
+    expect(await resolveLoginDeviceId(req(), 'bad-token')).toBeNull();
+  });
+});
+
+describe('finalizeDeviceLogin — device registration (add-only)', () => {
+  it('registers with activate:if-empty and broadcasts when the set changed', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: { deviceId: 'd1' }, changed: true });
+
+    const extras = await finalizeDeviceLogin({
+      req: req(),
+      deviceId: 'd1',
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+
+    expect(mockAddAccount).toHaveBeenCalledWith(
+      'd1',
+      { accountId: 'u1', sessionId: 's1' },
+      { activate: 'if-empty' },
+    );
+    expect(mockBroadcast).toHaveBeenCalledTimes(1);
+    // Device binding present → refresh token attached.
+    expect(extras.refreshToken).toBe('rt');
+  });
+
+  it('does NOT broadcast when the registration was an idempotent no-op', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: { deviceId: 'd1' }, changed: false });
+    await finalizeDeviceLogin({
+      req: req(),
+      deviceId: 'd1',
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+    expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('threads operatedByUserId into the registration', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: {}, changed: false });
+    await finalizeDeviceLogin({
+      req: req(),
+      deviceId: 'd1',
+      session: { sessionId: 's-org', deviceId: 'd1' },
+      userId: 'org1',
+      operatedByUserId: 'op1',
+    });
+    expect(mockAddAccount).toHaveBeenCalledWith(
+      'd1',
+      { accountId: 'org1', sessionId: 's-org', operatedByUserId: 'op1' },
+      { activate: 'if-empty' },
+    );
+  });
+});
+
+describe('finalizeDeviceLogin — refresh-token lane', () => {
+  it('attaches a refresh token when the Origin is absent (native/first-party)', async () => {
+    const extras = await finalizeDeviceLogin({
+      req: req(),
+      deviceId: null,
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+    expect(mockAddAccount).not.toHaveBeenCalled();
+    expect(extras.refreshToken).toBe('rt');
+  });
+
+  it('attaches a refresh token for a trusted-lane Origin', async () => {
+    mockIsTrustedOrigin.mockReturnValue(true);
+    const extras = await finalizeDeviceLogin({
+      req: req({ origin: 'https://accounts.oxy.so' }),
+      deviceId: null,
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+    expect(extras.refreshToken).toBe('rt');
+  });
+
+  it('withholds the refresh token for a third-party-lane browser Origin', async () => {
+    mockIsTrustedOrigin.mockReturnValue(false);
+    const extras = await finalizeDeviceLogin({
+      req: req({ origin: 'https://third-party.example' }),
+      deviceId: null,
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+    expect(extras.refreshToken).toBeUndefined();
+    expect(mockIssueRefreshToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -1,6 +1,7 @@
 const mockFindOne = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
 const mockUpdateOne = jest.fn();
+const mockCreate = jest.fn();
 const mockDeactivate = jest.fn();
 const mockGetAccessToken = jest.fn();
 const mockValidateSessionById = jest.fn();
@@ -11,6 +12,7 @@ jest.mock('../../models/DeviceSession', () => ({
     findOne: (...a: unknown[]) => mockFindOne(...a),
     findOneAndUpdate: (...a: unknown[]) => mockFindOneAndUpdate(...a),
     updateOne: (...a: unknown[]) => mockUpdateOne(...a),
+    create: (...a: unknown[]) => mockCreate(...a),
   },
 }));
 jest.mock('../session.service', () => ({
@@ -22,6 +24,20 @@ jest.mock('../session.service', () => ({
   },
 }));
 jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+// deviceSession.service now additively imports these; mock them so the module
+// graph loads under the global mongoose mock (no real RefreshToken/AuthCode).
+const mockRevokeAllFamiliesBySession = jest.fn();
+jest.mock('../refreshToken.service', () => ({
+  revokeAllFamiliesBySession: (...a: unknown[]) => mockRevokeAllFamiliesBySession(...a),
+}));
+jest.mock('../oauthCode.service', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeCrypto = require('crypto');
+  return {
+    sha256Hex: (value: string) => nodeCrypto.createHash('sha256').update(value).digest('hex'),
+    base64UrlEncode: (buf: Buffer) => buf.toString('base64url'),
+  };
+});
 
 import deviceSessionService, { projectState } from '../deviceSession.service';
 
@@ -522,5 +538,119 @@ describe('resolveRegisteredSession', () => {
 
     const result = await deviceSessionService.resolveRegisteredSession('central-device', 'acct-1');
     expect(result).toBeNull();
+  });
+});
+
+describe('addAccount — activate option', () => {
+  it("'if-empty' does NOT flip the active account when one already exists", async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 3,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: { toString: () => 'a1' }, revision: 4,
+    }));
+
+    await deviceSessionService.addAccount('d1', { accountId: 'a2', sessionId: 's2' }, { activate: 'if-empty' });
+
+    const update = mockFindOneAndUpdate.mock.calls[0][1];
+    // Active stays a1 — the add-only lane never steals the active selection.
+    expect(update.$set.activeAccountId).toBe('a1');
+  });
+
+  it("'if-empty' DOES set active when the device has no active account", async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: { toString: () => 'a2' }, revision: 1,
+    }));
+
+    await deviceSessionService.addAccount('d1', { accountId: 'a2', sessionId: 's2' }, { activate: 'if-empty' });
+
+    const update = mockFindOneAndUpdate.mock.calls[0][1];
+    expect(update.$set.activeAccountId).toBe('a2');
+  });
+
+  it("default 'always' sets the new account active (existing callers unchanged)", async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 3,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: { toString: () => 'a2' }, revision: 4,
+    }));
+
+    await deviceSessionService.addAccount('d1', { accountId: 'a2', sessionId: 's2' });
+
+    const update = mockFindOneAndUpdate.mock.calls[0][1];
+    expect(update.$set.activeAccountId).toBe('a2');
+  });
+});
+
+describe('signout — refresh family cascade', () => {
+  it('revokes ALL refresh families for each signed-out session', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 3,
+    }));
+
+    await deviceSessionService.signout('d1', { accountId: 'a1' });
+
+    expect(mockDeactivate).toHaveBeenCalledWith('s1');
+    expect(mockRevokeAllFamiliesBySession).toHaveBeenCalledWith('s1');
+  });
+});
+
+describe('getStateByCookieKey', () => {
+  it('returns the projected state for a known cookie secret', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'dev-cookie',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 5,
+      updatedAt: new Date(1720000000000),
+    }));
+    const state = await deviceSessionService.getStateByCookieKey('raw-secret');
+    expect(state?.deviceId).toBe('dev-cookie');
+    // Looked up by the HASH of the secret, never the raw value.
+    const query = mockFindOne.mock.calls[0][0];
+    expect(query.cookieKeyHash).toBeDefined();
+    expect(query.cookieKeyHash).not.toBe('raw-secret');
+  });
+
+  it('returns null for an unknown cookie / empty key', async () => {
+    mockFindOne.mockReturnValueOnce(lean(null));
+    expect(await deviceSessionService.getStateByCookieKey('unknown')).toBeNull();
+    expect(await deviceSessionService.getStateByCookieKey('')).toBeNull();
+  });
+});
+
+describe('ensureDeviceForCookie', () => {
+  it('mints a new device + cookie secret and stores only the hash', async () => {
+    mockCreate.mockResolvedValueOnce({});
+    const { deviceId, rawCookieKey } = await deviceSessionService.ensureDeviceForCookie();
+
+    expect(typeof deviceId).toBe('string');
+    expect(deviceId.length).toBeGreaterThan(0);
+    expect(typeof rawCookieKey).toBe('string');
+    expect(rawCookieKey.length).toBeGreaterThan(20);
+
+    const created = mockCreate.mock.calls[0][0];
+    expect(created.deviceId).toBe(deviceId);
+    // The stored cookieKeyHash is the sha256 of the returned secret — not the secret.
+    expect(created.cookieKeyHash).toBe(
+      require('crypto').createHash('sha256').update(rawCookieKey).digest('hex'),
+    );
+    expect(created.cookieKeyHash).not.toBe(rawCookieKey);
   });
 });

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -32,6 +32,10 @@ const mockRevokeAllFamiliesBySession = jest.fn();
 jest.mock('../refreshToken.service', () => ({
   revokeAllFamiliesBySession: (...a: unknown[]) => mockRevokeAllFamiliesBySession(...a),
 }));
+const mockRevokeDeviceTokens = jest.fn();
+jest.mock('../deviceToken.service', () => ({
+  revokeDeviceTokens: (...a: unknown[]) => mockRevokeDeviceTokens(...a),
+}));
 jest.mock('../oauthCode.service', () => {
   const nodeCrypto = jest.requireActual<typeof import('crypto')>('crypto');
   return {
@@ -594,7 +598,7 @@ describe('addAccount — activate option', () => {
 });
 
 describe('signout — refresh family cascade', () => {
-  it('revokes ALL refresh families for each signed-out session', async () => {
+  it('revokes ALL refresh families for each signed-out session (single-account: deviceTokens untouched)', async () => {
     mockFindOne.mockReturnValueOnce(lean({
       deviceId: 'd1',
       accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
@@ -609,6 +613,30 @@ describe('signout — refresh family cascade', () => {
 
     expect(mockDeactivate).toHaveBeenCalledWith('s1');
     expect(mockRevokeAllFamiliesBySession).toHaveBeenCalledWith('s1');
+    // Single-account signout must NOT revoke device tokens — other apps/accounts
+    // on the same device still legitimately use theirs.
+    expect(mockRevokeDeviceTokens).not.toHaveBeenCalled();
+  });
+
+  it('signout-ALL revokes device tokens for the device (after the refresh-family revocation)', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [
+        { accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 },
+        { accountId: { toString: () => 'a2' }, sessionId: 's2', authuser: 1 },
+      ],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 4,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 5,
+    }));
+
+    await deviceSessionService.signout('d1', { all: true });
+
+    expect(mockRevokeAllFamiliesBySession).toHaveBeenCalledWith('s1');
+    expect(mockRevokeAllFamiliesBySession).toHaveBeenCalledWith('s2');
+    expect(mockRevokeDeviceTokens).toHaveBeenCalledWith('d1');
   });
 });
 

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -1,3 +1,5 @@
+import * as nodeCrypto from 'crypto';
+
 const mockFindOne = jest.fn();
 const mockFindOneAndUpdate = jest.fn();
 const mockUpdateOne = jest.fn();
@@ -31,8 +33,7 @@ jest.mock('../refreshToken.service', () => ({
   revokeAllFamiliesBySession: (...a: unknown[]) => mockRevokeAllFamiliesBySession(...a),
 }));
 jest.mock('../oauthCode.service', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const nodeCrypto = require('crypto');
+  const nodeCrypto = jest.requireActual<typeof import('crypto')>('crypto');
   return {
     sha256Hex: (value: string) => nodeCrypto.createHash('sha256').update(value).digest('hex'),
     base64UrlEncode: (buf: Buffer) => buf.toString('base64url'),
@@ -649,7 +650,7 @@ describe('ensureDeviceForCookie', () => {
     expect(created.deviceId).toBe(deviceId);
     // The stored cookieKeyHash is the sha256 of the returned secret — not the secret.
     expect(created.cookieKeyHash).toBe(
-      require('crypto').createHash('sha256').update(rawCookieKey).digest('hex'),
+      nodeCrypto.createHash('sha256').update(rawCookieKey).digest('hex'),
     );
     expect(created.cookieKeyHash).not.toBe(rawCookieKey);
   });

--- a/packages/api/src/services/__tests__/deviceToken.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceToken.service.test.ts
@@ -1,0 +1,186 @@
+/**
+ * deviceToken.service unit tests.
+ *
+ * Covers the opaque add-only device-attribution token:
+ *  - issue: revokes the previous live token for the same (deviceId, origin),
+ *    stores sha256(raw), returns the raw token.
+ *  - resolve: channel policy — `web` requires an EXACT Origin match; `native`
+ *    requires the Origin header to be ABSENT. Expired/revoked/unknown → null.
+ *  - revoke: revokes every live token for a device.
+ *
+ * The DeviceToken model is mocked; hashing uses the real crypto helpers from
+ * `oauthCode.service` (loaded under the global mongoose mock).
+ */
+
+import * as crypto from 'crypto';
+import type { Request } from 'express';
+
+const mockUpdateMany = jest.fn();
+const mockCreate = jest.fn();
+const mockFindOne = jest.fn();
+const mockUpdateOne = jest.fn();
+
+jest.mock('../../models/DeviceToken', () => ({
+  __esModule: true,
+  default: {
+    updateMany: (...a: unknown[]) => mockUpdateMany(...a),
+    create: (...a: unknown[]) => mockCreate(...a),
+    findOne: (...a: unknown[]) => mockFindOne(...a),
+    updateOne: (...a: unknown[]) => mockUpdateOne(...a),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+// Hashing helpers come from oauthCode.service; mock it so the AuthCode model
+// (Schema.Types.ObjectId) is not evaluated under the global mongoose mock.
+jest.mock('../oauthCode.service', () => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const nodeCrypto = require('crypto');
+  return {
+    sha256Hex: (value: string) => nodeCrypto.createHash('sha256').update(value).digest('hex'),
+    base64UrlEncode: (buf: Buffer) => buf.toString('base64url'),
+  };
+});
+
+import {
+  issueDeviceToken,
+  resolveDeviceToken,
+  revokeDeviceTokens,
+  NATIVE_ORIGIN,
+} from '../deviceToken.service';
+
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function reqWithOrigin(origin?: string): Request {
+  return { headers: origin ? { origin } : {} } as unknown as Request;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdateMany.mockResolvedValue({});
+  mockCreate.mockResolvedValue({});
+  mockUpdateOne.mockResolvedValue({});
+});
+
+describe('issueDeviceToken', () => {
+  it('revokes the previous live token for the same (deviceId, origin) then stores sha256(raw)', async () => {
+    const raw = await issueDeviceToken({ deviceId: 'd1', origin: 'https://accounts.oxy.so', channel: 'web' });
+
+    expect(typeof raw).toBe('string');
+    expect(raw.length).toBeGreaterThan(20);
+
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      { deviceId: 'd1', origin: 'https://accounts.oxy.so', revokedAt: null },
+      { $set: { revokedAt: expect.any(Date) } },
+    );
+
+    const created = mockCreate.mock.calls[0][0];
+    expect(created.deviceId).toBe('d1');
+    expect(created.origin).toBe('https://accounts.oxy.so');
+    expect(created.channel).toBe('web');
+    // Only the hash is persisted, never the raw token.
+    expect(created.tokenHash).toBe(sha256Hex(raw));
+    expect(created.expiresAt.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('stores the literal native origin for the native channel', async () => {
+    await issueDeviceToken({ deviceId: 'd2', origin: 'ignored', channel: 'native' });
+    const created = mockCreate.mock.calls[0][0];
+    expect(created.origin).toBe(NATIVE_ORIGIN);
+    expect(created.channel).toBe('native');
+  });
+});
+
+describe('resolveDeviceToken — web channel', () => {
+  const stored = {
+    _id: 'row1',
+    revokedAt: null,
+    expiresAt: new Date(Date.now() + 60_000),
+    channel: 'web',
+    origin: 'https://accounts.oxy.so',
+    deviceId: 'd1',
+  };
+
+  it('resolves + bumps when the Origin matches exactly', async () => {
+    mockFindOne.mockResolvedValueOnce(stored);
+    const result = await resolveDeviceToken('raw', reqWithOrigin('https://accounts.oxy.so'));
+    expect(result).toEqual({ deviceId: 'd1' });
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { _id: 'row1' },
+      { $set: { lastUsedAt: expect.any(Date), expiresAt: expect.any(Date) } },
+    );
+  });
+
+  it('returns null when the Origin does not match', async () => {
+    mockFindOne.mockResolvedValueOnce(stored);
+    expect(await resolveDeviceToken('raw', reqWithOrigin('https://evil.com'))).toBeNull();
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the Origin header is absent (web token)', async () => {
+    mockFindOne.mockResolvedValueOnce(stored);
+    expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toBeNull();
+  });
+});
+
+describe('resolveDeviceToken — native channel', () => {
+  const stored = {
+    _id: 'row2',
+    revokedAt: null,
+    expiresAt: new Date(Date.now() + 60_000),
+    channel: 'native',
+    origin: NATIVE_ORIGIN,
+    deviceId: 'd9',
+  };
+
+  it('resolves when the Origin header is ABSENT', async () => {
+    mockFindOne.mockResolvedValueOnce(stored);
+    expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toEqual({ deviceId: 'd9' });
+  });
+
+  it('returns null when a browser Origin is present (native token replayed from a browser)', async () => {
+    mockFindOne.mockResolvedValueOnce(stored);
+    expect(await resolveDeviceToken('raw', reqWithOrigin('https://accounts.oxy.so'))).toBeNull();
+  });
+});
+
+describe('resolveDeviceToken — lifecycle guards', () => {
+  it('returns null for an unknown token', async () => {
+    mockFindOne.mockResolvedValueOnce(null);
+    expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toBeNull();
+  });
+
+  it('returns null for a revoked token', async () => {
+    mockFindOne.mockResolvedValueOnce({
+      _id: 'r', revokedAt: new Date(), expiresAt: new Date(Date.now() + 60_000), channel: 'native', origin: NATIVE_ORIGIN, deviceId: 'd',
+    });
+    expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toBeNull();
+  });
+
+  it('returns null for an expired token', async () => {
+    mockFindOne.mockResolvedValueOnce({
+      _id: 'r', revokedAt: null, expiresAt: new Date(Date.now() - 1000), channel: 'native', origin: NATIVE_ORIGIN, deviceId: 'd',
+    });
+    expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toBeNull();
+  });
+
+  it('never throws — returns null on a DB error', async () => {
+    mockFindOne.mockRejectedValueOnce(new Error('db down'));
+    expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toBeNull();
+  });
+});
+
+describe('revokeDeviceTokens', () => {
+  it('revokes every live token for a device', async () => {
+    await revokeDeviceTokens('d1');
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      { deviceId: 'd1', revokedAt: null },
+      { $set: { revokedAt: expect.any(Date) } },
+    );
+  });
+});

--- a/packages/api/src/services/__tests__/deviceToken.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceToken.service.test.ts
@@ -174,6 +174,14 @@ describe('resolveDeviceToken — lifecycle guards', () => {
     mockFindOne.mockRejectedValueOnce(new Error('db down'));
     expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toBeNull();
   });
+
+  it('returns the valid deviceId even when the sliding-expiry bump write fails (best-effort, not the deny path)', async () => {
+    mockFindOne.mockResolvedValueOnce({
+      _id: 'r', revokedAt: null, expiresAt: new Date(Date.now() + 60_000), channel: 'native', origin: NATIVE_ORIGIN, deviceId: 'd-keep',
+    });
+    mockUpdateOne.mockRejectedValueOnce(new Error('transient write failure'));
+    expect(await resolveDeviceToken('raw', reqWithOrigin(undefined))).toEqual({ deviceId: 'd-keep' });
+  });
 });
 
 describe('revokeDeviceTokens', () => {

--- a/packages/api/src/services/__tests__/deviceToken.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceToken.service.test.ts
@@ -25,7 +25,9 @@ jest.mock('../../models/DeviceToken', () => ({
   default: {
     updateMany: (...a: unknown[]) => mockUpdateMany(...a),
     create: (...a: unknown[]) => mockCreate(...a),
-    findOne: (...a: unknown[]) => mockFindOne(...a),
+    // resolveDeviceToken reads via `.lean()`; the query returns a lean-shaped
+    // object whose `.lean()` yields whatever `mockFindOne` was staged with.
+    findOne: (...a: unknown[]) => ({ lean: () => mockFindOne(...a) }),
     updateOne: (...a: unknown[]) => mockUpdateOne(...a),
   },
 }));
@@ -37,8 +39,7 @@ jest.mock('../../utils/logger', () => ({
 // Hashing helpers come from oauthCode.service; mock it so the AuthCode model
 // (Schema.Types.ObjectId) is not evaluated under the global mongoose mock.
 jest.mock('../oauthCode.service', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const nodeCrypto = require('crypto');
+  const nodeCrypto = jest.requireActual<typeof import('crypto')>('crypto');
   return {
     sha256Hex: (value: string) => nodeCrypto.createHash('sha256').update(value).digest('hex'),
     base64UrlEncode: (buf: Buffer) => buf.toString('base64url'),

--- a/packages/api/src/services/authSession.service.ts
+++ b/packages/api/src/services/authSession.service.ts
@@ -174,12 +174,16 @@ export async function authorizeSessionWithSignedChallenge(
   }
   const userId = user._id.toString();
 
-  // 4. Mint the session for the originating app, owned by the signer.
+  // 4. Mint the session for the originating app, owned by the signer. When the
+  //    flow was started with a device binding (`deviceId` persisted at create
+  //    time), pass it as the explicit deviceId so the session lands on the
+  //    originating device set instead of sprawling a fresh device.
   const app = await Application.findById(authSession.applicationId);
   const appLabel = app ? app.name : 'App';
   const newSession = await sessionService.createSession(userId, req, {
     deviceName: deviceName || `${appLabel} App`,
     deviceFingerprint,
+    ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
   });
 
   // 5. Bind the result onto the session row.

--- a/packages/api/src/services/deviceBootCode.service.ts
+++ b/packages/api/src/services/deviceBootCode.service.ts
@@ -1,0 +1,136 @@
+/**
+ * Device-first bootstrap code store.
+ *
+ * Clones the security PATTERN of `ssoCode.service.ts` (opaque single-use code,
+ * sha256-hashed key, atomic GETDEL burn, fail-closed on Redis absence) for the
+ * device-first bootstrap hop. `GET /auth/device/bootstrap` resolves the active
+ * session from the `oxy_device` cookie and mints one of these codes; the raw
+ * code travels in the top-level `#oxy_boot=…` fragment, and the RP browser
+ * exchanges it at `POST /auth/device/exchange` for real tokens.
+ *
+ * DISTINCT from the SSO code store: a DIFFERENT Valkey key prefix
+ * (`device:boot:`), and the stored record carries NO tokens — only the
+ * `sessionId`/`userId`/`clientOrigin` needed to mint a fresh token bundle at
+ * exchange time. A leaked fragment therefore never exposes a token, only a
+ * single-use, origin-bound, ≤60s handle.
+ *
+ * Security properties:
+ *  - 256-bit CSPRNG opaque code; we persist `sha256(code)`, never the raw value.
+ *  - Redemption is single-use via atomic `GETDEL`.
+ *  - Bound to `clientOrigin`; exchange is only honoured when the RP's `Origin`
+ *    matches.
+ *  - 60s TTL — one top-level redirect round-trip.
+ *  - Fails closed: mint throws / redeem returns null when Redis is unavailable,
+ *    so the flow degrades safely instead of minting un-burnable codes.
+ */
+
+import * as crypto from 'crypto';
+import { getRedisClient } from '../config/redis';
+import { logger } from '../utils/logger';
+
+/** Opaque-code entropy in bytes (256 bits). */
+const CODE_BYTES = 32;
+
+/** Time-to-live of a minted boot code, in seconds. */
+export const DEVICE_BOOT_CODE_TTL_SECONDS = 60;
+
+/** Valkey key namespace for device boot codes (distinct from `sso:code:`). */
+const KEY_PREFIX = 'device:boot:';
+
+/** What is persisted under `device:boot:<sha256(code)>` — NEVER any token. */
+export interface DeviceBootCodePayload {
+  sessionId: string;
+  userId: string;
+  clientOrigin: string;
+  createdAt: number;
+}
+
+/** SHA-256 hex digest — never persist or look up by the raw code. */
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function keyFor(code: string): string {
+  return `${KEY_PREFIX}${sha256Hex(code)}`;
+}
+
+/**
+ * Mint a single-use device boot code wrapping `{ sessionId, userId,
+ * clientOrigin }`. Returns the RAW opaque code for the fragment.
+ *
+ * Fails closed: throws if the Valkey client is unavailable so the caller never
+ * hands back a code that cannot later be burned.
+ */
+export async function mintBootCode(input: {
+  sessionId: string;
+  userId: string;
+  clientOrigin: string;
+}): Promise<{ code: string; expiresInSeconds: number }> {
+  const redis = getRedisClient();
+  if (!redis) {
+    throw new Error('Device boot code store unavailable: Redis/Valkey is not configured');
+  }
+
+  const code = crypto.randomBytes(CODE_BYTES).toString('base64url');
+  const record: DeviceBootCodePayload = {
+    sessionId: input.sessionId,
+    userId: input.userId,
+    clientOrigin: input.clientOrigin,
+    createdAt: Date.now(),
+  };
+
+  await redis.set(keyFor(code), JSON.stringify(record), 'EX', DEVICE_BOOT_CODE_TTL_SECONDS);
+
+  return { code, expiresInSeconds: DEVICE_BOOT_CODE_TTL_SECONDS };
+}
+
+/**
+ * Atomically redeem (single-use burn) a device boot code via `GETDEL`. Returns
+ * `null` when the code is missing, already redeemed, or expired (the caller maps
+ * this to `410 Gone`), or on a Valkey outage (fail closed).
+ */
+export async function redeemBootCode(code: string): Promise<DeviceBootCodePayload | null> {
+  const redis = getRedisClient();
+  if (!redis) {
+    logger.error('Device boot code redemption attempted with no Redis/Valkey client');
+    return null;
+  }
+
+  let raw: string | null;
+  try {
+    raw = await redis.getdel(keyFor(code));
+  } catch (error) {
+    logger.error(
+      'Device boot code GETDEL failed',
+      error instanceof Error ? error : new Error(String(error))
+    );
+    return null;
+  }
+
+  if (raw === null) {
+    return null;
+  }
+
+  let parsed: DeviceBootCodePayload;
+  try {
+    parsed = JSON.parse(raw) as DeviceBootCodePayload;
+  } catch (error) {
+    logger.error(
+      'Device boot code store contained unparseable record',
+      error instanceof Error ? error : new Error(String(error))
+    );
+    return null;
+  }
+
+  if (
+    !parsed ||
+    typeof parsed.sessionId !== 'string' ||
+    typeof parsed.userId !== 'string' ||
+    typeof parsed.clientOrigin !== 'string'
+  ) {
+    logger.error('Device boot code store contained malformed record');
+    return null;
+  }
+
+  return parsed;
+}

--- a/packages/api/src/services/deviceLogin.service.ts
+++ b/packages/api/src/services/deviceLogin.service.ts
@@ -1,0 +1,127 @@
+/**
+ * Device-first login attribution — shared across the first-party auth flows
+ * (`/auth/login`, `/auth/signup`, `/auth/verify`, `/security/2fa/verify-login`).
+ *
+ * ADD-ONLY: this never reads or overrides an existing active account. It only
+ *  - resolves WHICH device a fresh sign-in belongs to (cookie > deviceToken),
+ *  - registers the freshly-credentialed session into that device's set WITHOUT
+ *    stealing the active account (`activate: 'if-empty'`), and
+ *  - decides whether the response may carry a persisted rotating refresh token.
+ *
+ * A stolen deviceToken can therefore only ADD an already-authenticated session
+ * to a device set (a detectable set-pollution), never flip the active account or
+ * read state.
+ *
+ * `deviceSession.service` / `deviceToken.service` are imported LAZILY (only when
+ * a cookie/deviceToken/deviceId is actually present) so that merely importing
+ * this helper — which the hot auth controllers do at module load — never forces
+ * the `DeviceSession`/`DeviceToken` Mongoose models to evaluate. This matches the
+ * existing `session.service` lazy-`import('./account.service.js')` convention and
+ * keeps unit tests that mock only the models they touch working unchanged.
+ */
+
+import type { Request } from 'express';
+import { readDeviceCookie } from '../utils/deviceCookie';
+import { normaliseOrigin, isLoopbackOrigin } from '../utils/origin';
+import { isTrustedOrigin } from '../config/dynamicOriginRegistry';
+import { issueRefreshToken } from './refreshToken.service';
+import { broadcastDeviceState } from '../utils/socket';
+import { logger } from '../utils/logger';
+
+/**
+ * Resolve the device a fresh sign-in should attach to. Precedence:
+ *   1. the `oxy_device` cookie when it maps to a known device,
+ *   2. an add-only `deviceToken` (channel-policy verified against the request),
+ *   3. none.
+ * Returns the deviceId or null. Never throws.
+ */
+export async function resolveLoginDeviceId(
+  req: Request,
+  deviceToken: unknown,
+): Promise<string | null> {
+  try {
+    const rawCookie = readDeviceCookie(req);
+    const hasDeviceToken = typeof deviceToken === 'string' && deviceToken.length > 0;
+    if (!rawCookie && !hasDeviceToken) {
+      return null;
+    }
+
+    const { deviceSessionService } = await import('./deviceSession.service.js');
+    if (rawCookie) {
+      const state = await deviceSessionService.getStateByCookieKey(rawCookie);
+      if (state) return state.deviceId;
+    }
+    if (hasDeviceToken) {
+      const { resolveDeviceToken } = await import('./deviceToken.service.js');
+      const resolved = await resolveDeviceToken(deviceToken as string, req);
+      if (resolved) return resolved.deviceId;
+    }
+  } catch (error) {
+    logger.warn('resolveLoginDeviceId failed', { error });
+  }
+  return null;
+}
+
+/**
+ * Whether the response may carry a persisted rotating refresh token: yes when a
+ * device binding resolved, OR the request Origin is on the trusted lane
+ * (first-party/internal/official/loopback) or ABSENT (native / non-browser).
+ * Third-party-lane browser origins get today's response shape exactly (no
+ * refreshToken), so a third-party page can never obtain a long-lived refresh
+ * token from a first-party login.
+ */
+function shouldReturnRotatingRefresh(req: Request, hasDeviceBinding: boolean): boolean {
+  if (hasDeviceBinding) return true;
+  const originRaw = req.headers.origin;
+  if (typeof originRaw !== 'string' || originRaw.length === 0) return true;
+  const normalized = normaliseOrigin(originRaw);
+  if (!normalized) return false;
+  if (isLoopbackOrigin(normalized)) return true;
+  return isTrustedOrigin(normalized);
+}
+
+/**
+ * Finalize a fresh sign-in for the device-first lane: register the session into
+ * the resolved device's set (add-only, never flips active) + broadcast, and mint
+ * a rotating refresh token for the response when the lane allows it. Everything
+ * is best-effort — a failure here never breaks the sign-in.
+ *
+ * Returns `{ refreshToken? }` to be merged additively into the auth response.
+ */
+export async function finalizeDeviceLogin(opts: {
+  req: Request;
+  deviceId: string | null;
+  session: { sessionId: string; deviceId: string };
+  userId: string;
+  operatedByUserId?: string;
+}): Promise<{ refreshToken?: string }> {
+  const { req, deviceId, session, userId, operatedByUserId } = opts;
+
+  if (deviceId) {
+    try {
+      const { deviceSessionService } = await import('./deviceSession.service.js');
+      const { state, changed } = await deviceSessionService.addAccount(
+        session.deviceId,
+        {
+          accountId: userId,
+          sessionId: session.sessionId,
+          ...(operatedByUserId ? { operatedByUserId } : {}),
+        },
+        { activate: 'if-empty' },
+      );
+      if (changed) broadcastDeviceState(state);
+    } catch (error) {
+      logger.warn('finalizeDeviceLogin: device registration failed', { userId, error });
+    }
+  }
+
+  if (shouldReturnRotatingRefresh(req, !!deviceId)) {
+    try {
+      const refresh = await issueRefreshToken({ sessionId: session.sessionId, userId });
+      return { refreshToken: refresh.token };
+    } catch (error) {
+      logger.warn('finalizeDeviceLogin: refresh mint failed', { userId, error });
+    }
+  }
+  return {};
+}

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -1,6 +1,9 @@
+import * as crypto from 'crypto';
 import type { DeviceSessionState, SessionAccount } from '@oxyhq/contracts';
 import DeviceSession, { IDeviceSession, IDeviceSessionAccount } from '../models/DeviceSession';
 import sessionService from './session.service';
+import { revokeAllFamiliesBySession } from './refreshToken.service';
+import { sha256Hex, base64UrlEncode } from './oauthCode.service';
 import { logger } from '../utils/logger';
 
 function idToString(value: unknown): string | null {
@@ -101,7 +104,14 @@ class DeviceSessionService {
   async addAccount(
     deviceId: string,
     input: { accountId: string; sessionId: string; operatedByUserId?: string },
+    opts?: { activate?: 'always' | 'if-empty' },
   ): Promise<AddAccountResult> {
+    // `activate` default 'always' keeps every existing caller (device
+    // add/switch, cold-boot handoff) byte-identical. 'if-empty' is the ADD-ONLY
+    // attribution semantic used by the device-first login lanes: register the
+    // new account into the set but NEVER steal the device's current active
+    // selection — it only becomes active when nothing else is.
+    const activate = opts?.activate ?? 'always';
     const current = await this.load(deviceId);
     const existing = (current?.accounts ?? []).find((a) => idToString(a.accountId) === input.accountId);
 
@@ -109,6 +119,12 @@ class DeviceSessionService {
     if (current && existing && existing.sessionId === input.sessionId) {
       return { state: projectState(current), changed: false };
     }
+
+    const currentActiveId = idToString(current?.activeAccountId ?? null);
+    // 'if-empty' preserves an existing active account; only claims active when
+    // the device currently has none.
+    const nextActiveAccountId =
+      activate === 'always' || !currentActiveId ? input.accountId : currentActiveId;
 
     const others = (current?.accounts ?? []).filter((a) => idToString(a.accountId) !== input.accountId);
     // Case 2 — replacing an account's session (re-add with a new sessionId) must
@@ -132,7 +148,7 @@ class DeviceSessionService {
     const updated = await DeviceSession.findOneAndUpdate(
       { deviceId },
       {
-        $set: { accounts: [...others, account], activeAccountId: input.accountId },
+        $set: { accounts: [...others, account], activeAccountId: nextActiveAccountId },
         $inc: { revision: 1 },
       },
       { new: true, upsert: true },
@@ -214,6 +230,15 @@ class DeviceSessionService {
         await sessionService.deactivateSession(a.sessionId);
       } catch (error) {
         logger.warn('deviceSession.signout: deactivate failed', { sessionId: a.sessionId, error });
+      }
+      // Cascade the signout to the persisted rotating refresh families:
+      // deactivateSession alone leaves a stored refresh token able to mint fresh
+      // access tokens, so revoke EVERY family bound to the session. Best-effort —
+      // a revoke failure must never block the signout.
+      try {
+        await revokeAllFamiliesBySession(a.sessionId);
+      } catch (error) {
+        logger.warn('deviceSession.signout: refresh family revoke failed', { sessionId: a.sessionId, error });
       }
     }
     const remaining = allAccounts.filter((a) => !removingIds.has(idToString(a.accountId) ?? ''));
@@ -307,7 +332,49 @@ class DeviceSessionService {
       { $set: { accounts: remaining, activeAccountId: nextActive }, $inc: { revision: 1 } },
     );
   }
+
+  /**
+   * Resolve the `DeviceSessionState` bound to an `oxy_device` cookie SECRET.
+   * The cookie value is hashed and looked up against `cookieKeyHash` — the raw
+   * secret is never stored, and the deviceId is never derivable from the cookie.
+   * Returns null when the cookie maps to no device (unknown / pruned / never
+   * planted).
+   */
+  async getStateByCookieKey(rawCookieKey: string): Promise<DeviceSessionState | null> {
+    if (typeof rawCookieKey !== 'string' || rawCookieKey.length === 0) return null;
+    const cookieKeyHash = sha256Hex(rawCookieKey);
+    const doc = await DeviceSession.findOne({ cookieKeyHash }).lean<IDeviceSession>();
+    if (!doc) return null;
+    return projectState(doc);
+  }
+
+  /**
+   * Ensure a device exists for a fresh `oxy_device` cookie. Mints a NEW random
+   * deviceId AND a NEW random 256-bit cookie secret, persists a device doc bound
+   * to `sha256(secret)`, and returns both. Called by the bootstrap hop when the
+   * request carries no (or an unknown) device cookie — the caller then plants the
+   * returned `rawCookieKey` as the `oxy_device` cookie. The deviceId is server-
+   * minted and never leaves the server; only the opaque cookie secret does.
+   */
+  async ensureDeviceForCookie(): Promise<{ deviceId: string; rawCookieKey: string }> {
+    const deviceId = crypto.randomUUID();
+    const rawCookieKey = base64UrlEncode(crypto.randomBytes(32));
+    const cookieKeyHash = sha256Hex(rawCookieKey);
+    await DeviceSession.create({
+      deviceId,
+      accounts: [],
+      activeAccountId: null,
+      revision: 0,
+      cookieKeyHash,
+    });
+    return { deviceId, rawCookieKey };
+  }
 }
 
-const deviceSessionService = new DeviceSessionService();
+// Exported BOTH as the default (existing static `import deviceSessionService`
+// call sites) AND as a named export so dynamic `await import(...)` consumers can
+// destructure it cleanly under NodeNext CJS interop (a default-only export
+// resolves to the namespace object there — same reason `account.service`
+// exports `accountService` by name).
+export const deviceSessionService = new DeviceSessionService();
 export default deviceSessionService;

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -3,6 +3,7 @@ import type { DeviceSessionState, SessionAccount } from '@oxyhq/contracts';
 import DeviceSession, { IDeviceSession, IDeviceSessionAccount } from '../models/DeviceSession';
 import sessionService from './session.service';
 import { revokeAllFamiliesBySession } from './refreshToken.service';
+import { revokeDeviceTokens } from './deviceToken.service';
 import { sha256Hex, base64UrlEncode } from './oauthCode.service';
 import { logger } from '../utils/logger';
 
@@ -241,6 +242,28 @@ class DeviceSessionService {
         logger.warn('deviceSession.signout: refresh family revoke failed', { sessionId: a.sessionId, error });
       }
     }
+
+    // Signout-ALL also severs the device's ATTRIBUTION bindings: revoke every
+    // deviceToken issued for this device so a retained token (400-day sliding
+    // TTL) can never later attach a fresh sign-in as active into the now-empty
+    // set. Only on the {all} path — a single-account signout deliberately leaves
+    // deviceTokens alone, since other apps/accounts on the SAME device still
+    // legitimately use theirs to attribute their own sign-ins. Best-effort — a
+    // revoke failure must never block signout.
+    //
+    // We deliberately do NOT clear the `oxy_device` cookie here: device identity
+    // is not an account credential (an empty device set grants NOTHING via
+    // bootstrap — reason resolves to `no_session`), and clearing a cookie via
+    // Set-Cookie on a cross-apex fetch response is 3rd-party-cookie-blocked
+    // anyway. The next bootstrap simply re-uses the same empty device.
+    if ('all' in target) {
+      try {
+        await revokeDeviceTokens(deviceId);
+      } catch (error) {
+        logger.warn('deviceSession.signout: device token revoke failed', { deviceId, error });
+      }
+    }
+
     const remaining = allAccounts.filter((a) => !removingIds.has(idToString(a.accountId) ?? ''));
     const activeStillPresent = remaining.some((a) => idToString(a.accountId) === idToString(current.activeAccountId));
     const nextActive = activeStillPresent ? idToString(current.activeAccountId) : (remaining[0] ? idToString(remaining[0].accountId) : null);

--- a/packages/api/src/services/deviceToken.service.ts
+++ b/packages/api/src/services/deviceToken.service.ts
@@ -1,0 +1,138 @@
+/**
+ * Device Token Service
+ *
+ * The opaque **device token** is the add-only attribution credential (see the
+ * `DeviceToken` model). It lets a first-party sign-in performed over a
+ * cookieless cross-site fetch land in the SAME browser/device `DeviceSession`
+ * the user already has — WITHOUT ever reading state or flipping the active
+ * account.
+ *
+ * Security primitives (mirror `refreshToken.service`):
+ *  - 256-bit CSPRNG raw token, base64url; ONLY its sha256 is stored.
+ *  - `issueDeviceToken` revokes the previous live token for the same
+ *    `(deviceId, origin)` so a rotated-away token can never be reused.
+ *  - `resolveDeviceToken` enforces the CHANNEL policy: a `web` token only
+ *    resolves when the request `Origin` header EXACTLY matches the bound origin;
+ *    a `native` token only resolves when the `Origin` header is ABSENT (native
+ *    apps attach no browser Origin). It never throws — a null return means "no
+ *    attribution", and the caller proceeds without a device binding.
+ *  - Sliding 400-day expiry, bumped (`lastUsedAt` + `expiresAt`) on each resolve.
+ *
+ * The raw token is a bearer-equivalent — never logged.
+ */
+
+import * as crypto from 'crypto';
+import type { Request } from 'express';
+import DeviceToken, { DeviceTokenChannel } from '../models/DeviceToken';
+import { sha256Hex, base64UrlEncode } from './oauthCode.service';
+import { normaliseOrigin } from '../utils/origin';
+import { logger } from '../utils/logger';
+
+/** Raw device-token entropy in bytes (256 bits). */
+const DEVICE_TOKEN_BYTES = 32;
+
+/** Sliding lifetime of a device token (400 days). */
+export const DEVICE_TOKEN_TTL_MS = 400 * 24 * 60 * 60 * 1000;
+
+/** Literal `origin` value for the native channel (no browser origin exists). */
+export const NATIVE_ORIGIN = 'native';
+
+export interface IssueDeviceTokenInput {
+  deviceId: string;
+  /** An https origin for the `web` channel, or the literal `'native'`. */
+  origin: string;
+  channel: DeviceTokenChannel;
+}
+
+/**
+ * Mint a device token bound to `(deviceId, origin, channel)`. Revokes the
+ * previous live token for the same `(deviceId, origin)` first (one live token
+ * per pair). Returns the RAW token — the only place it exists in plaintext.
+ */
+export async function issueDeviceToken(input: IssueDeviceTokenInput): Promise<string> {
+  const { deviceId, channel } = input;
+  // `web` tokens store the NORMALISED origin so the resolve-time comparison
+  // (`normaliseOrigin(Origin) === stored.origin`) is exact. `native` keeps the
+  // literal marker.
+  const origin =
+    channel === 'web' ? normaliseOrigin(input.origin) ?? input.origin : NATIVE_ORIGIN;
+
+  await DeviceToken.updateMany(
+    { deviceId, origin, revokedAt: null },
+    { $set: { revokedAt: new Date() } }
+  );
+
+  const rawToken = base64UrlEncode(crypto.randomBytes(DEVICE_TOKEN_BYTES));
+  const tokenHash = sha256Hex(rawToken);
+  await DeviceToken.create({
+    tokenHash,
+    deviceId,
+    origin,
+    channel,
+    expiresAt: new Date(Date.now() + DEVICE_TOKEN_TTL_MS),
+  });
+
+  return rawToken;
+}
+
+/**
+ * Resolve a presented raw device token to its deviceId, enforcing the channel
+ * policy against the request. Never throws — returns `null` for any
+ * missing/expired/revoked token or channel-policy mismatch, so the caller
+ * proceeds without a device binding.
+ */
+export async function resolveDeviceToken(
+  rawToken: string,
+  req: Request
+): Promise<{ deviceId: string } | null> {
+  try {
+    if (typeof rawToken !== 'string' || rawToken.length === 0) {
+      return null;
+    }
+    const tokenHash = sha256Hex(rawToken);
+    const stored = await DeviceToken.findOne({ tokenHash });
+    if (!stored) return null;
+    if (stored.revokedAt) return null;
+    if (stored.expiresAt < new Date()) return null;
+
+    const originHeaderRaw = req.headers.origin;
+    const originHeader = typeof originHeaderRaw === 'string' ? originHeaderRaw : undefined;
+
+    if (stored.channel === 'web') {
+      // A web token is bound to an exact origin — the request MUST carry that
+      // Origin header. This is what keeps a stolen web token from riding a
+      // different site's request.
+      if (!originHeader || originHeader.length === 0) return null;
+      const normalised = normaliseOrigin(originHeader);
+      if (!normalised || normalised !== stored.origin) return null;
+    } else {
+      // A native token must NOT carry a browser Origin (native apps attach
+      // none). A present Origin means the token is being replayed from a
+      // browser context — refuse.
+      if (originHeader && originHeader.length > 0) return null;
+    }
+
+    // Slide the expiry and record use. Best-effort — a write failure must not
+    // deny an otherwise-valid attribution.
+    await DeviceToken.updateOne(
+      { _id: stored._id },
+      { $set: { lastUsedAt: new Date(), expiresAt: new Date(Date.now() + DEVICE_TOKEN_TTL_MS) } }
+    );
+
+    return { deviceId: stored.deviceId };
+  } catch (error) {
+    logger.error(
+      'resolveDeviceToken failed',
+      error instanceof Error ? error : new Error(String(error))
+    );
+    return null;
+  }
+}
+
+/** Revoke every live device token for a device (signout / device removal). */
+export async function revokeDeviceTokens(deviceId: string): Promise<void> {
+  await DeviceToken.updateMany(
+    { deviceId, revokedAt: null },
+    { $set: { revokedAt: new Date() } }
+  );
+}

--- a/packages/api/src/services/deviceToken.service.ts
+++ b/packages/api/src/services/deviceToken.service.ts
@@ -23,7 +23,7 @@
 
 import * as crypto from 'crypto';
 import type { Request } from 'express';
-import DeviceToken, { DeviceTokenChannel } from '../models/DeviceToken';
+import DeviceToken, { DeviceTokenChannel, IDeviceToken } from '../models/DeviceToken';
 import { sha256Hex, base64UrlEncode } from './oauthCode.service';
 import { normaliseOrigin } from '../utils/origin';
 import { logger } from '../utils/logger';
@@ -90,7 +90,9 @@ export async function resolveDeviceToken(
       return null;
     }
     const tokenHash = sha256Hex(rawToken);
-    const stored = await DeviceToken.findOne({ tokenHash });
+    // `.lean()` — the row is only READ (its `_id` is reused for the bump write),
+    // never mutated as a document, so skip the Mongoose hydration overhead.
+    const stored = await DeviceToken.findOne({ tokenHash }).lean<IDeviceToken>();
     if (!stored) return null;
     if (stored.revokedAt) return null;
     if (stored.expiresAt < new Date()) return null;

--- a/packages/api/src/services/deviceToken.service.ts
+++ b/packages/api/src/services/deviceToken.service.ts
@@ -114,12 +114,19 @@ export async function resolveDeviceToken(
       if (originHeader && originHeader.length > 0) return null;
     }
 
-    // Slide the expiry and record use. Best-effort — a write failure must not
-    // deny an otherwise-valid attribution.
-    await DeviceToken.updateOne(
-      { _id: stored._id },
-      { $set: { lastUsedAt: new Date(), expiresAt: new Date(Date.now() + DEVICE_TOKEN_TTL_MS) } }
-    );
+    // Slide the expiry and record use. Best-effort in its OWN try/catch — the
+    // token has already validated, so a transient write failure must NOT fall to
+    // the deny path and return null for an otherwise-valid attribution.
+    try {
+      await DeviceToken.updateOne(
+        { _id: stored._id },
+        { $set: { lastUsedAt: new Date(), expiresAt: new Date(Date.now() + DEVICE_TOKEN_TTL_MS) } }
+      );
+    } catch (bumpError) {
+      logger.warn('resolveDeviceToken: sliding-expiry bump failed (non-fatal)', {
+        error: bumpError instanceof Error ? bumpError.message : String(bumpError),
+      });
+    }
 
     return { deviceId: stored.deviceId };
   } catch (error) {

--- a/packages/api/src/services/refreshToken.service.ts
+++ b/packages/api/src/services/refreshToken.service.ts
@@ -162,6 +162,21 @@ export async function revokeAllUserFamilies(userId: string): Promise<void> {
 }
 
 /**
+ * Revoke EVERY un-revoked refresh token bound to a session — ALL rotation
+ * families, not just the latest. Used by the device signout cascade: when a
+ * device signs an account out, `deactivateSession` alone leaves the persisted
+ * rotating refresh family live, so a stored token could still mint fresh access
+ * tokens. This closes that gap. Does NOT deactivate the session (the caller
+ * already did) and never mints/rotates — pure revoke, idempotent.
+ */
+export async function revokeAllFamiliesBySession(sessionId: string): Promise<void> {
+  await RefreshToken.updateMany(
+    { sessionId, revokedAt: null },
+    { $set: { revokedAt: new Date() } }
+  );
+}
+
+/**
  * Revoke the rotation family for a presented RAW refresh token (logout via the
  * httpOnly cookie). Hashes the raw token, looks up the stored row by its
  * `tokenHash`, and — if found — revokes the whole family AND deactivates the

--- a/packages/api/src/utils/deviceCookie.ts
+++ b/packages/api/src/utils/deviceCookie.ts
@@ -65,6 +65,16 @@ export function buildDeviceCookieOptions(): DeviceCookieOptions {
 
 /**
  * (Re-)set the device cookie on the response with the fresh sliding expiry.
+ *
+ * SECURITY NOTE (re: CodeQL "clear text storage of sensitive information"):
+ * `secret` is a random 256-bit, opaque, bearer-equivalent token — NOT user PII.
+ * The cookie IS its transport, hardened via `buildDeviceCookieOptions()`
+ * (HttpOnly so JS can never read it, Secure so it only rides HTTPS, SameSite=Lax).
+ * Server-side it is persisted ONLY as its SHA-256 (`DeviceSession.cookieKeyHash`)
+ * — the raw value is never written to any document, cache, or log, and possessing
+ * the cookie reveals nothing about the deviceId. This is the identical posture as
+ * the first-party `oxy_rt` refresh cookie (`setRefreshCookie`). There is no
+ * cleartext-at-rest to encrypt: the value is already the credential.
  */
 export function setDeviceCookie(res: Response, secret: string): void {
   res.cookie(DEVICE_COOKIE_NAME, secret, buildDeviceCookieOptions());

--- a/packages/api/src/utils/deviceCookie.ts
+++ b/packages/api/src/utils/deviceCookie.ts
@@ -1,0 +1,99 @@
+/**
+ * `oxy_device` cookie spec — ONE authoritative definition.
+ *
+ * The device cookie carries a random 256-bit secret (base64url) that maps to a
+ * `DeviceSession` via its SHA-256 (`DeviceSession.cookieKeyHash`). It is the
+ * first-party anchor for device-first session bootstrap:
+ *  - `Domain=.oxy.so` so every `*.oxy.so` first-party surface (api, auth, apps)
+ *    shares one device identity, and the auth.oxy.so IdP chooser can read it
+ *    first-party.
+ *  - `SameSite=Lax` so it rides top-level navigations (the cross-apex bootstrap
+ *    hop) and same-site fetches (the `*.oxy.so` web-session fast path), but not
+ *    cross-site sub-requests.
+ *  - `HttpOnly` + `Secure` so it is never readable from JS (XSS-proof) and only
+ *    travels over HTTPS.
+ *  - 400-day sliding `Max-Age`, re-set on every bootstrap hop.
+ *
+ * The secret is NEVER the deviceId — possessing the cookie reveals nothing about
+ * the device set, and only its hash is stored server-side.
+ *
+ * Localhost dev: `Domain` and `Secure` are omitted (http host-only) so a local
+ * dev server can exercise the flow without TLS and without a `.oxy.so` domain.
+ */
+
+import type { Request, Response } from 'express';
+import { isProduction } from '../config/env';
+
+/** Cookie name. */
+export const DEVICE_COOKIE_NAME = 'oxy_device';
+
+/** Default parent domain — every `*.oxy.so` surface shares one device identity. */
+export const DEFAULT_DEVICE_COOKIE_DOMAIN = '.oxy.so';
+
+/** 400-day sliding lifetime in seconds (matches the Max-Age header value). */
+export const DEVICE_COOKIE_MAX_AGE_SECONDS = 400 * 24 * 60 * 60;
+
+/** Same lifetime in milliseconds (express `res.cookie` takes `maxAge` in ms). */
+export const DEVICE_COOKIE_MAX_AGE_MS = DEVICE_COOKIE_MAX_AGE_SECONDS * 1000;
+
+export interface DeviceCookieOptions {
+  httpOnly: true;
+  secure: boolean;
+  sameSite: 'lax';
+  domain?: string;
+  path: string;
+  maxAge: number;
+}
+
+/**
+ * Build the `oxy_device` cookie attributes. Production: `Secure` + parent-domain
+ * `Domain` (env `DEVICE_COOKIE_DOMAIN` override, default `.oxy.so`). Dev/local:
+ * host-only, no `Secure`, so http loopback works.
+ */
+export function buildDeviceCookieOptions(): DeviceCookieOptions {
+  const prod = isProduction();
+  const domain = process.env.DEVICE_COOKIE_DOMAIN || DEFAULT_DEVICE_COOKIE_DOMAIN;
+  return {
+    httpOnly: true,
+    secure: prod,
+    sameSite: 'lax',
+    ...(prod ? { domain } : {}),
+    path: '/',
+    maxAge: DEVICE_COOKIE_MAX_AGE_MS,
+  };
+}
+
+/**
+ * (Re-)set the device cookie on the response with the fresh sliding expiry.
+ */
+export function setDeviceCookie(res: Response, secret: string): void {
+  res.cookie(DEVICE_COOKIE_NAME, secret, buildDeviceCookieOptions());
+}
+
+/**
+ * Read the raw `oxy_device` cookie secret from a request. Prefers `req.cookies`
+ * (cookie-parser) and falls back to parsing the raw `Cookie` header so the
+ * helper works in unit tests that mount a bare router. Returns `undefined` when
+ * absent/empty.
+ */
+export function readDeviceCookie(req: Request): string | undefined {
+  const parsed = (req as Request & { cookies?: Record<string, unknown> }).cookies;
+  const fromParser = parsed?.[DEVICE_COOKIE_NAME];
+  if (typeof fromParser === 'string' && fromParser.length > 0) {
+    return fromParser;
+  }
+
+  const header = req.headers.cookie;
+  if (typeof header !== 'string' || header.length === 0) {
+    return undefined;
+  }
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (name !== DEVICE_COOKIE_NAME) continue;
+    const value = part.slice(eq + 1).trim();
+    return value.length > 0 ? value : undefined;
+  }
+  return undefined;
+}

--- a/packages/api/src/utils/internalSecret.ts
+++ b/packages/api/src/utils/internalSecret.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal shared-secret gate for server-to-server endpoints.
+ *
+ * Extracted from `sso.controller.ts` (pure move, no behaviour change) so BOTH
+ * the central SSO `POST /sso/code` endpoint AND the new device-first
+ * `POST /auth/device/resolve` endpoint reuse ONE authoritative gate. Both are
+ * called only by first-party internal callers (the auth.oxy.so worker / IdP
+ * chooser) and must never be reachable by the public.
+ *
+ * Fails closed: when `SSO_INTERNAL_SECRET` is unset the route is effectively
+ * disabled (an empty/absent configured secret is never accepted), and the
+ * `X-Oxy-Internal` header must match it in constant time.
+ */
+
+import * as crypto from 'crypto';
+import type { Request } from 'express';
+import { logger } from './logger';
+
+/** Constant-time string equality (length-tolerant; no early-exit leak). */
+function timingSafeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) {
+    // Compare against self to keep the comparison cost data-independent, then
+    // return false. Length is not itself a secret here.
+    crypto.timingSafeEqual(aBuf, aBuf);
+    return false;
+  }
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+/**
+ * Validate the internal shared-secret header. Returns true only when
+ * `SSO_INTERNAL_SECRET` is configured AND the `X-Oxy-Internal` header matches it
+ * in constant time. When the env var is unset we fail closed (the route is
+ * effectively disabled) — we never accept an empty/absent secret.
+ */
+export function hasValidInternalSecret(req: Request): boolean {
+  const expected = process.env.SSO_INTERNAL_SECRET;
+  if (typeof expected !== 'string' || expected.length === 0) {
+    logger.error('Internal-secret-gated route called but SSO_INTERNAL_SECRET is not configured');
+    return false;
+  }
+  const provided = req.headers['x-oxy-internal'];
+  if (typeof provided !== 'string' || provided.length === 0) {
+    return false;
+  }
+  return timingSafeStringEqual(provided, expected);
+}


### PR DESCRIPTION
## Phase F2 — SERVER ADDITIVE (auth centralization, wave 1)

**Additive only.** The legacy surface (`/sso*`, `/fedcm/*`, `/auth/refresh`, `/auth/refresh-all`, `POST /auth/session`, and the `oxy_rt` cookie machinery in `refreshToken.service`) is **byte-untouched**. Everything here is new files or additive edits. The api Jest suite is the regression fence: **152 suites / 1492 tests green** (`tsc --noEmit` clean, `eslint` clean, no dependency/lockfile change).

### New endpoints (`src/routes/deviceAuth.ts`, mounted at `/auth` before the generic `/auth`)

| Endpoint | Auth | Function |
|---|---|---|
| `GET /auth/device/bootstrap?return_to&state` | `oxy_device` cookie | Top-level hop: (re-)plants cookie, resolves the active session, mints a single-use origin-bound boot code, 303s back with `#oxy_boot=<fragment>` (no token / no deviceId in the URL). `return_to` is https-only (http loopback exempt), credential-free, ≤2KB, origin must pass `isTrustedOrigin` (third-party never). `Cache-Control: no-store` + `Referrer-Policy: no-referrer`. |
| `POST /auth/device/web-session` | cookie (same-site) | Fast path for `*.oxy.so`: `requireSameSiteOrigin` + trusted-lane + shared registrable apex → exchanges the cookie for a token bundle, no redirect. |
| `POST /auth/device/exchange` | boot code (GETDEL burn, origin-bound) | Atomic single-use burn → `AuthTokenBundle`. 403 on Origin mismatch, 410 on replay/expired. |
| `POST /auth/refresh-token` | body `refreshToken` | ONE rotating refresh (`rotateRefreshToken`) for web + native. 401 uniform on any failure. |
| `POST /auth/device/token` | bearer | Issues the native-channel device token (deviceId from JWT claims). |
| `POST /auth/device/resolve` | `X-Oxy-Internal` | Device-set feed for the IdP chooser. 404 without the secret; no CORS exposure. |

### New models / services

- **`models/DeviceToken`** — hash-only, bound to `(deviceId, origin, channel)`, 400d sliding expiry.
- **`DeviceSession.cookieKeyHash`** (sparse-unique) + **`AuthSession.deviceId`**.
- **`deviceToken.service`** — issue/resolve/revoke + channel policy (`web` requires an exact `Origin`; `native` requires the `Origin` header ABSENT; never throws).
- **`deviceBootCode.service`** — `ssoCode` pattern, `device:boot:` prefix, 60s TTL, atomic GETDEL, fail-closed, **no token in the stored record**.
- **`deviceLogin.service`** — shared add-only login attribution (lazy-imports the model-heavy services so importing it never forces model eval).
- **`deviceSession.service`** — `addAccount` gains `{activate:'always'|'if-empty'}` (default `always`, existing callers unchanged); `getStateByCookieKey` / `ensureDeviceForCookie`; **signout now cascades `revokeAllFamiliesBySession`** to kill persisted refresh families.
- **`utils/internalSecret`** (`hasValidInternalSecret` extracted from `sso.controller`, pure move) + **`utils/deviceCookie`** (one authoritative `oxy_device` cookie spec).

### Additive login-flow edits

`/auth/login`, `/auth/signup`, `/auth/verify`, `/security/2fa/verify-login`, `/auth/session/create+claim`, `/accounts/:id/switch` accept an optional `deviceToken`; attribution precedence is **oxy_device cookie > deviceToken > none**; the resolved deviceId is threaded into `createSession`; the new session is registered **add-only** (`activate:'if-empty'`, never flips the active account) + broadcast; the response **additively** gains `refreshToken` only on the trusted lane (device binding, trusted-lane Origin, or absent Origin) — third-party-lane origins keep today's shape. `/auth/session/claim` now returns a fresh **rotating** refresh token (not the legacy Session JWT); `/accounts/:id/switch` registers the managed session (`activate:'always'`).

### Security notes

- `deviceToken` is **add-only attribution**: it never reads state and never flips the active account.
- The cookie secret is **not** the deviceId (only `sha256` stored); possessing the cookie reveals nothing.
- Constant-time internal-secret comparison; single-use origin-bound boot codes; no `new Model(req.body)` / `req.body` spread; owner ids resolved server-side.

### Existing tests legitimately extended (justified in the commit)

- `sessionClaim.test` — claim now returns a rotating refresh token; assertion relaxed to any non-empty string + the `oauthCode` mock supplies the hashing helpers now used.
- `deviceSession.service.test` / `accountsSwitch.test` — mock the newly-imported services and assert the new device-set registration.

**Do not merge** — merge = prod deploy; the lead coordinates the merge-train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)