### PR TITLE
fix(services,api): link-title crash guard + display-name whitespace probe \p{Zs}

### DIFF
--- a/packages/api/src/utils/__tests__/displayNameSanitize.test.ts
+++ b/packages/api/src/utils/__tests__/displayNameSanitize.test.ts
@@ -145,6 +145,18 @@ describe('displayNameSanitize', () => {
     it('collapses internal whitespace and trims the ends', () => {
       expect(cleanDisplayName('  Ada   Lovelace  ')).toBe('Ada Lovelace');
     });
+
+    it.each([
+      ['Ada\tLovelace', 'tab'],
+      ['Ada\nLovelace', 'newline'],
+      ['Ada\rLovelace', 'carriage return'],
+      ['Ada\n\tLovelace', 'mixed control whitespace'],
+    ])('collapses control whitespace (%s) to a single space', (input) => {
+      // `\p{Zs}` no longer admits tab/newline/CR, so they are replaced with a
+      // space in the char-strip step and then collapsed by the whitespace pass —
+      // the net output is identical to a plain-space input.
+      expect(cleanDisplayName(input)).toBe('Ada Lovelace');
+    });
   });
 
   describe('cleanDisplayName — normalization', () => {
@@ -223,6 +235,25 @@ describe('displayNameSanitize', () => {
     it('returns false for hyphens and dots', () => {
       expect(isValidDisplayName('Jean-Luc')).toBe(false);
       expect(isValidDisplayName('J.R.')).toBe(false);
+    });
+
+    it.each([
+      ['Ada\tLovelace', 'tab'],
+      ['Ada\nLovelace', 'newline'],
+      ['Ada\rLovelace', 'carriage return'],
+      ['Line break', 'line separator U+2028'],
+    ])('returns false for control whitespace (%s)', (name) => {
+      // Regression: `\s` used to admit these, so a layout-breaking / multi-line
+      // spoofing name passed the native 400-gate. `\p{Zs}` rejects them.
+      expect(isValidDisplayName(name)).toBe(false);
+    });
+
+    it.each([
+      ['Ada Lovelace', 'ASCII space'],
+      ['Ada Lovelace', 'non-breaking space'],
+      ['山田　太郎', 'ideographic space'],
+    ])('returns true for space separators (%s)', (name) => {
+      expect(isValidDisplayName(name)).toBe(true);
     });
   });
 });

--- a/packages/api/src/utils/displayNameSanitize.ts
+++ b/packages/api/src/utils/displayNameSanitize.ts
@@ -5,15 +5,18 @@
  *   - letters of any script (`\p{L}`),
  *   - combining marks / accents (`\p{M}`, e.g. the acute accent in a decomposed
  *     "é"),
- *   - whitespace (`\s`),
+ *   - Unicode space separators (`\p{Zs}`: the ASCII space, NBSP, ideographic
+ *     space, …) — but NOT control whitespace such as tab, newline, or carriage
+ *     return, which would break layout or enable multi-line spoofing,
  *   - the straight apostrophe (`'`, e.g. "O'Brien").
  *
  * Everything else is removed: emoji (🐧), symbols (⁂ ⏚), `:emoji:` shortcodes,
- * digits, hyphens, dots, and any other punctuation.
+ * digits, hyphens, dots, control whitespace (tab/newline/CR), and any other
+ * punctuation.
  *
  * XSS reasoning
  * -------------
- * The allowed set `\p{L}\p{M}\s'` explicitly EXCLUDES `<`, `>`, `&`, and `"`,
+ * The allowed set `\p{L}\p{M}\p{Zs}'` explicitly EXCLUDES `<`, `>`, `&`, and `"`,
  * so the output of {@link cleanDisplayName} can never contain an HTML/XSS
  * vector — there is simply no character in the output that can open a tag, an
  * entity, or an attribute. The only special character that survives is the
@@ -30,11 +33,16 @@ export const MAX_DISPLAY_NAME_LENGTH = 80;
 /** Matches a `:shortcode:` emoji token (e.g. `:bongoCat:`, `:+1:`). */
 const SHORTCODE_PATTERN = /:[A-Za-z0-9_+-]+:/g;
 
-/** Matches any character NOT allowed in a display name (global, Unicode). */
-const DISALLOWED_PATTERN = /[^\p{L}\p{M}\s']/gu;
+/**
+ * Matches any character NOT allowed in a display name (global, Unicode). The
+ * whitespace class is `\p{Zs}` (space separators only), NOT `\s` — the latter
+ * would admit tab/newline/carriage return, which break layout and enable
+ * multi-line spoofing.
+ */
+const DISALLOWED_PATTERN = /[^\p{L}\p{M}\p{Zs}']/gu;
 
 /** Single test for the presence of a disallowed character (non-global). */
-const DISALLOWED_PROBE = /[^\p{L}\p{M}\s']/u;
+const DISALLOWED_PROBE = /[^\p{L}\p{M}\p{Zs}']/u;
 
 /**
  * Matches a run of combining marks (`\p{M}`) that is NOT attached to a base

--- a/packages/services/src/ui/screens/EditProfileFieldScreen.tsx
+++ b/packages/services/src/ui/screens/EditProfileFieldScreen.tsx
@@ -22,6 +22,7 @@ import { useOxy } from '../context/OxyContext';
 import { useProfileEditing } from '../hooks/useProfileEditing';
 import { toast } from '@oxyhq/bloom';
 import { EMAIL_REGEX } from '@oxyhq/core';
+import { getLinkTitle, getLinkDescription, linksToListItems } from './linkFormat';
 
 /**
  * Field types supported by EditProfileFieldScreen
@@ -70,9 +71,6 @@ type EditableListItem = {
     image?: string;
     coordinates?: { lat: number; lon: number };
 };
-
-const getLinkTitle = (url: string) => url.replace(/^https?:\/\//, '').replace(/\/$/, '');
-const getLinkDescription = (url: string) => `Link to ${url}`;
 
 /**
  * EditProfileFieldScreen - A dedicated screen for editing profile fields
@@ -293,14 +291,7 @@ const EditProfileFieldScreen: React.FC<EditProfileFieldScreenProps> = ({
                         description: String(link.description || getLinkDescription(String(link.url || ''))),
                     })));
                 } else {
-                    setListItems(links.map((item, i) => {
-                        return {
-                            id: `link-${i}`,
-                            url: item,
-                            title: getLinkTitle(item),
-                            description: getLinkDescription(item),
-                        };
-                    }));
+                    setListItems(linksToListItems(links));
                 }
             }
         } else {

--- a/packages/services/src/ui/screens/__tests__/linkFormat.test.ts
+++ b/packages/services/src/ui/screens/__tests__/linkFormat.test.ts
@@ -1,0 +1,73 @@
+import {
+    getLinkTitle,
+    getLinkDescription,
+    linksToListItems,
+} from '../linkFormat';
+
+describe('linkFormat', () => {
+    describe('getLinkTitle', () => {
+        it.each([
+            ['https://example.com', 'example.com'],
+            ['http://example.com/', 'example.com'],
+            ['https://example.com/path/', 'example.com/path'],
+            ['example.com', 'example.com'],
+        ])('strips protocol and trailing slash: %p → %p', (input, expected) => {
+            expect(getLinkTitle(input)).toBe(expected);
+        });
+    });
+
+    describe('getLinkDescription', () => {
+        it('prefixes the url with "Link to "', () => {
+            expect(getLinkDescription('https://example.com')).toBe('Link to https://example.com');
+        });
+    });
+
+    describe('linksToListItems', () => {
+        it('maps a normal string array, preserving valid-link rendering', () => {
+            const result = linksToListItems(['https://example.com/', 'http://oxy.so']);
+            expect(result).toEqual([
+                {
+                    id: 'link-0',
+                    url: 'https://example.com/',
+                    title: 'example.com',
+                    description: 'Link to https://example.com/',
+                },
+                {
+                    id: 'link-1',
+                    url: 'http://oxy.so',
+                    title: 'oxy.so',
+                    description: 'Link to http://oxy.so',
+                },
+            ]);
+        });
+
+        it.each([
+            [null, 'null'],
+            [undefined, 'undefined'],
+            [42, 'a number'],
+            [{ href: 'x' }, 'an object'],
+            [['nested'], 'an array'],
+        ])('does not throw on a non-string element (%s)', (bad) => {
+            // Regression: `links.map(getLinkTitle)` called `.replace` on a
+            // non-string element and crashed the editor. The coercion guard must
+            // yield a string url/title/description instead.
+            const run = () => linksToListItems([bad]);
+            expect(run).not.toThrow();
+            const [item] = run();
+            expect(typeof item.url).toBe('string');
+            expect(typeof item.title).toBe('string');
+            expect(typeof item.description).toBe('string');
+        });
+
+        it('coerces null / undefined to an empty-string url', () => {
+            const result = linksToListItems([null, undefined]);
+            expect(result[0].url).toBe('');
+            expect(result[0].title).toBe('');
+            expect(result[1].url).toBe('');
+        });
+
+        it('returns an empty array for an empty input', () => {
+            expect(linksToListItems([])).toEqual([]);
+        });
+    });
+});

--- a/packages/services/src/ui/screens/linkFormat.ts
+++ b/packages/services/src/ui/screens/linkFormat.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure link-display helpers for the profile "links" editor. Kept out of the
+ * screen component so the string-coercion guard can be unit-tested without
+ * rendering the whole React Native screen.
+ */
+
+/** Strip the protocol and any trailing slash from a link URL for display. */
+export const getLinkTitle = (url: string): string =>
+    url.replace(/^https?:\/\//, '').replace(/\/$/, '');
+
+/** Human-readable description for a link URL. */
+export const getLinkDescription = (url: string): string => `Link to ${url}`;
+
+export interface LinkListItem {
+    id: string;
+    url: string;
+    title: string;
+    description: string;
+}
+
+/**
+ * Build editable list items from a raw links array. The array can come from
+ * legacy or untrusted profile data whose elements are not guaranteed to be
+ * strings, so each entry is coerced with `String(item ?? '')` before formatting
+ * — a non-string element must never crash the editor.
+ */
+export function linksToListItems(links: readonly unknown[]): LinkListItem[] {
+    return links.map((item, i) => {
+        const url = String(item ?? '');
+        return {
+            id: `link-${i}`,
+            url,
+            title: getLinkTitle(url),
+            description: getLinkDescription(url),
+        };
+    });
+}


### PR DESCRIPTION
Two standalone bug fixes that are present on `main` today. They were surfaced as Gemini review findings on PR #530, but #530 was merged into `design/cross-domain-session-sync` (not `main`), so most of its findings don't apply to `main`. These two are the exceptions — real bugs that exist on `main` independent of #530.

## 1. services — link-title crash guard (was finding #5)
`EditProfileFieldScreen` built its editable list by mapping a raw `links` array straight into `getLinkTitle(item)`, which calls `String.prototype.replace`. When `userData.links` contained a non-string element (legacy / untrusted profile data), `.replace` threw `TypeError: item.replace is not a function` and crashed the profile editor.

- Extracted the pure link-format helpers (`getLinkTitle`, `getLinkDescription`) plus a new `linksToListItems(links)` into `packages/services/src/ui/screens/linkFormat.ts`, so the guard is unit-testable without rendering the RN screen.
- `linksToListItems` coerces every entry with `String(item ?? '')` before formatting — valid links render exactly as before; a non-string element yields an empty/coerced string instead of crashing.
- Added `linkFormat.test.ts` (13 tests) covering valid links and null/undefined/number/object/array elements.

## 2. api — display-name whitespace probe `\s` → `\p{Zs}` (was finding #4)
The display-name character policy in `packages/api/src/utils/displayNameSanitize.ts` used `\s` in `DISALLOWED_PATTERN` / `DISALLOWED_PROBE`. `\s` admits tab / newline / carriage-return, so a layout-breaking or multi-line spoofing display name passed the native 400-gate (`isValidDisplayName`).

- Switched both patterns to `\p{Zs}` (Unicode space separators only); both already carry the `u` flag.
- `cleanDisplayName` output is unchanged: control whitespace is replaced by a space in the char-strip step and still collapsed by the untouched `/\s+/` pass.
- `isValidDisplayName` now correctly **rejects** `\n` / `\r` / `\t` / U+2028 while still accepting ordinary and Unicode space separators (space, NBSP, ideographic space).
- Extended the sanitizer tests (control-whitespace collapse in `cleanDisplayName`, rejection in `isValidDisplayName`, space-separator acceptance).

The finding originally pointed at `packages/core/src/utils/validationUtils.ts`, but that shared `isValidDisplayName` helper only exists on the #530 branch. The equivalent, pre-existing `\s` bug on `main` lives in the api sanitizer, which is fixed here.

## Gates
- api: `displayNameSanitize` 62/62, all displayName-related suites 87/87.
- services: full suite 28 suites / 198 tests (includes the new `linkFormat` suite).
- tsc: services typecheck baseline unchanged (this change actually removes 2 pre-existing implicit-`any` errors; remaining errors are pre-existing `@oxyhq/core` resolution + untouched maps).
- lint: biome clean on the diff (2 `noForEach` findings in `EditProfileFieldScreen` are pre-existing in untouched code); eslint clean on the api files.

Scope note: this PR does **not** touch or re-land the #530 branch content — that belongs to its owning session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)