### PR TITLE
fix(api): converge device docs onto the oxy_device cookie identity + mint cookie on same-site trusted login

### DIFF
--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -26,7 +26,8 @@ import {
   revokeAllUserFamilies,
   clearAllRefreshCookies,
 } from '../services/refreshToken.service';
-import { resolveLoginDeviceId, finalizeDeviceLogin } from '../services/deviceLogin.service';
+import { resolveLoginDevice, finalizeDeviceLogin } from '../services/deviceLogin.service';
+import { setDeviceCookie } from '../utils/deviceCookie';
 import type { AuthRequest } from '../middleware/auth';
 import { exactCaseInsensitiveUsernameRegex } from '../utils/resolveUserIdentifier';
 
@@ -413,15 +414,21 @@ export class SessionController {
         });
       }
 
-      // Device-first attribution (oxy_device cookie > deviceToken > none),
-      // resolved before mint so the session carries the central deviceId.
-      const signupDeviceId = await resolveLoginDeviceId(req, deviceToken);
+      // Device-first attribution (oxy_device cookie > deviceToken > same-site
+      // cookie mint > none), resolved before mint so the session carries the
+      // central deviceId.
+      const signupDevice = await resolveLoginDevice(req, deviceToken);
 
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint, ...(signupDeviceId ? { deviceId: signupDeviceId } : {}) }
+        { deviceName, deviceFingerprint, ...(signupDevice.deviceId ? { deviceId: signupDevice.deviceId } : {}) }
       );
+
+      // Plant the freshly-minted device cookie (same-site trusted signups only).
+      if (signupDevice.setCookieSecret) {
+        setDeviceCookie(res, signupDevice.setCookieSecret);
+      }
 
       const baseSignupResponse = buildSessionAuthResponse(session, user);
       if (!baseSignupResponse) {
@@ -433,7 +440,7 @@ export class SessionController {
       // attach a rotating refresh token when the lane allows it. Best-effort.
       const signupDeviceExtras = await finalizeDeviceLogin({
         req,
-        deviceId: signupDeviceId,
+        deviceId: signupDevice.deviceId,
         session,
         userId: user._id.toString(),
       });
@@ -591,17 +598,23 @@ export class SessionController {
         return res.status(404).json({ message: 'User not found' });
       }
 
-      // Device-first attribution (oxy_device cookie > deviceToken > none),
-      // resolved before mint so the session carries the central deviceId.
-      const verifyDeviceId = await resolveLoginDeviceId(req, deviceToken);
+      // Device-first attribution (oxy_device cookie > deviceToken > same-site
+      // cookie mint > none), resolved before mint so the session carries the
+      // central deviceId.
+      const verifyDevice = await resolveLoginDevice(req, deviceToken);
 
       // Create session
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint, ...(verifyDeviceId ? { deviceId: verifyDeviceId } : {}) }
+        { deviceName, deviceFingerprint, ...(verifyDevice.deviceId ? { deviceId: verifyDevice.deviceId } : {}) }
       );
       const sessionAfterCreate = Date.now();
+
+      // Plant the freshly-minted device cookie (same-site trusted logins only).
+      if (verifyDevice.setCookieSecret) {
+        setDeviceCookie(res, verifyDevice.setCookieSecret);
+      }
 
       // Log security event for sign-in only if this is a new session
       // More reliable detection: check if session was created during this request
@@ -661,7 +674,7 @@ export class SessionController {
       // attach a rotating refresh token when the lane allows it. Best-effort.
       const verifyDeviceExtras = await finalizeDeviceLogin({
         req,
-        deviceId: verifyDeviceId,
+        deviceId: verifyDevice.deviceId,
         session,
         userId: user._id.toString(),
       });
@@ -777,15 +790,21 @@ export class SessionController {
 
       // Resolve the device this sign-in attaches to (oxy_device cookie >
       // deviceToken > none) BEFORE minting the session so its central deviceId
-      // is stamped onto the session's token claims. Additive — null keeps the
-      // pre-existing device attribution (UA/IP/random).
-      const loginDeviceId = await resolveLoginDeviceId(req, deviceToken);
+      // is stamped onto the session's token claims. For a same-site trusted login
+      // with no existing binding, a device cookie is minted (planted below).
+      // Additive — null keeps the pre-existing device attribution (UA/IP/random).
+      const loginDevice = await resolveLoginDevice(req, deviceToken);
 
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint, ...(loginDeviceId ? { deviceId: loginDeviceId } : {}) }
+        { deviceName, deviceFingerprint, ...(loginDevice.deviceId ? { deviceId: loginDevice.deviceId } : {}) }
       );
+
+      // Plant the freshly-minted device cookie (same-site trusted logins only).
+      if (loginDevice.setCookieSecret) {
+        setDeviceCookie(res, loginDevice.setCookieSecret);
+      }
 
       const baseResponse = buildSessionAuthResponse(session, user);
 
@@ -810,7 +829,7 @@ export class SessionController {
       // rotating refresh token when the lane allows it. Best-effort.
       const deviceExtras = await finalizeDeviceLogin({
         req,
-        deviceId: loginDeviceId,
+        deviceId: loginDevice.deviceId,
         session,
         userId: user._id.toString(),
       });

--- a/packages/api/src/controllers/twoFactor.controller.ts
+++ b/packages/api/src/controllers/twoFactor.controller.ts
@@ -5,7 +5,8 @@ import twoFactorService from '../services/twoFactor.service';
 import { logger } from '../utils/logger';
 import securityActivityService from '../services/securityActivityService';
 import sessionService from '../services/session.service';
-import { resolveLoginDeviceId, finalizeDeviceLogin } from '../services/deviceLogin.service';
+import { resolveLoginDevice, finalizeDeviceLogin } from '../services/deviceLogin.service';
+import { setDeviceCookie } from '../utils/deviceCookie';
 import { buildSessionAuthResponse } from './session.controller';
 import { AuthRequest } from '../middleware/auth';
 import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
@@ -395,16 +396,22 @@ export async function verify2FALogin(req: Request, res: Response) {
     user.twoFactorAuth.verifiedAt = new Date();
     await user.save();
 
-    // Device-first attribution (oxy_device cookie > deviceToken > none),
-    // resolved before mint so the session carries the central deviceId.
-    const twoFactorDeviceId = await resolveLoginDeviceId(req, deviceToken);
+    // Device-first attribution (oxy_device cookie > deviceToken > same-site
+    // cookie mint > none), resolved before mint so the session carries the
+    // central deviceId.
+    const twoFactorDevice = await resolveLoginDevice(req, deviceToken);
 
     // Create session (same as signIn would)
     const session = await sessionService.createSession(
       user._id.toString(),
       req,
-      { deviceName, deviceFingerprint, ...(twoFactorDeviceId ? { deviceId: twoFactorDeviceId } : {}) }
+      { deviceName, deviceFingerprint, ...(twoFactorDevice.deviceId ? { deviceId: twoFactorDevice.deviceId } : {}) }
     );
+
+    // Plant the freshly-minted device cookie (same-site trusted logins only).
+    if (twoFactorDevice.setCookieSecret) {
+      setDeviceCookie(res, twoFactorDevice.setCookieSecret);
+    }
 
     const baseTwoFactorResponse = buildSessionAuthResponse(session, user);
     if (!baseTwoFactorResponse) {
@@ -416,7 +423,7 @@ export async function verify2FALogin(req: Request, res: Response) {
     // a rotating refresh token when the lane allows it. Best-effort.
     const twoFactorDeviceExtras = await finalizeDeviceLogin({
       req,
-      deviceId: twoFactorDeviceId,
+      deviceId: twoFactorDevice.deviceId,
       session,
       userId: user._id.toString(),
     });

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -11,6 +11,9 @@ const mockResolveActiveToken = jest.fn();
 const mockBroadcast = jest.fn();
 const mockDecodeToken = jest.fn();
 const mockGetSession = jest.fn();
+const mockGetStateByCookieKey = jest.fn();
+const mockConvergeAccountOntoDevice = jest.fn();
+const mockMigrateSessionToDevice = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (...a: unknown[]) => mockAuthMiddleware(...a),
@@ -31,12 +34,15 @@ jest.mock('../../services/deviceSession.service', () => ({
     switchActive: (...a: unknown[]) => mockSwitchActive(...a),
     signout: (...a: unknown[]) => mockSignout(...a),
     resolveActiveToken: (...a: unknown[]) => mockResolveActiveToken(...a),
+    getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a),
+    convergeAccountOntoDevice: (...a: unknown[]) => mockConvergeAccountOntoDevice(...a),
   },
 }));
 jest.mock('../../services/session.service', () => ({
   __esModule: true,
   default: {
     getSession: (...a: unknown[]) => mockGetSession(...a),
+    migrateSessionToDevice: (...a: unknown[]) => mockMigrateSessionToDevice(...a),
   },
 }));
 jest.mock('../../utils/socket', () => ({ broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a) }));
@@ -47,12 +53,12 @@ import { errorHandler } from '../../middleware/errorHandler';
 
 const STATE = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
 
-async function requestJson(server: http.Server, method: string, path: string, payload?: unknown) {
+async function requestJson(server: http.Server, method: string, path: string, payload?: unknown, extraHeaders?: Record<string, string>) {
   const address = server.address() as AddressInfo;
   const body = payload === undefined ? '' : JSON.stringify(payload);
   return new Promise<{ status: number; body: Record<string, unknown> }>((resolve, reject) => {
     const req = http.request({ method, host: '127.0.0.1', port: address.port, path,
-      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body), Authorization: 'Bearer t' } },
+      headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body), Authorization: 'Bearer t', ...(extraHeaders ?? {}) } },
       (res) => { let raw = ''; res.on('data', c => { raw += c; }); res.on('end', () => { resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }); }); });
     req.on('error', reject); if (body) req.write(body); req.end();
   });
@@ -184,5 +190,57 @@ describe('POST /session/device/add', () => {
     expect(res.body.error).toBe('Invalid session');
     expect(mockAddAccount).not.toHaveBeenCalled();
     expect(mockBroadcast).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /session/device/add — cookie-device convergence', () => {
+  it('migrates the session onto the cookie device when the cookie deviceId differs from the JWT claim', async () => {
+    // JWT claims deviceId 'd1' (mockDecodeToken default); cookie resolves to the
+    // canonical 'cookie-dev'. The session must MOVE onto the cookie device.
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'cookie-dev', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    mockMigrateSessionToDevice.mockResolvedValueOnce({ accessToken: 'fresh-cookie-token', expiresAt: new Date(), migrated: true });
+    const convergedState = { deviceId: 'cookie-dev', accounts: [{ accountId: '64b0000000000000000000aa', sessionId: 's1', authuser: 0 }], activeAccountId: '64b0000000000000000000aa', revision: 1, updatedAt: 2 };
+    const oldState = { deviceId: 'd1', accounts: [], activeAccountId: null, revision: 9, updatedAt: 3 };
+    mockConvergeAccountOntoDevice.mockResolvedValueOnce({ cookieState: convergedState, oldState, changed: true });
+    // The migrated session's fresh token is served via resolveActiveToken.
+    mockResolveActiveToken.mockResolvedValueOnce({ accessToken: 'fresh-cookie-token', expiresAt: '2026-07-07T00:00:00.000Z' });
+
+    const res = await requestJson(server, 'POST', '/session/device/add', {}, { Cookie: 'oxy_device=cookiesecret' });
+
+    expect(res.status).toBe(200);
+    // Session re-minted onto the cookie device, then the account converged.
+    expect(mockMigrateSessionToDevice).toHaveBeenCalledWith('s1', 'cookie-dev');
+    expect(mockConvergeAccountOntoDevice).toHaveBeenCalledWith('cookie-dev', 'd1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
+    // BOTH device rooms broadcast on a real migration.
+    expect(mockBroadcast).toHaveBeenCalledWith(convergedState);
+    expect(mockBroadcast).toHaveBeenCalledWith(oldState);
+    // Plain (non-converging) addAccount NOT used.
+    expect(mockAddAccount).not.toHaveBeenCalled();
+    // The response carries the fresh cookie-device token for the client to plant.
+    expect(res.body.data.state).toEqual(convergedState);
+    expect(res.body.data.activeToken.accessToken).toBe('fresh-cookie-token');
+  });
+
+  it('does NOT converge (uses the plain add path) when the cookie resolves to the SAME device as the JWT', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    mockAddAccount.mockResolvedValueOnce({ state: STATE, changed: true });
+
+    const res = await requestJson(server, 'POST', '/session/device/add', {}, { Cookie: 'oxy_device=cookiesecret' });
+
+    expect(res.status).toBe(200);
+    expect(mockMigrateSessionToDevice).not.toHaveBeenCalled();
+    expect(mockConvergeAccountOntoDevice).not.toHaveBeenCalled();
+    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
+  });
+
+  it('does NOT converge when no oxy_device cookie is present (plain add path)', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: STATE, changed: true });
+
+    const res = await requestJson(server, 'POST', '/session/device/add', {});
+
+    expect(res.status).toBe(200);
+    expect(mockGetStateByCookieKey).not.toHaveBeenCalled();
+    expect(mockConvergeAccountOntoDevice).not.toHaveBeenCalled();
+    expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
   });
 });

--- a/packages/api/src/routes/deviceAuth.ts
+++ b/packages/api/src/routes/deviceAuth.ts
@@ -26,7 +26,6 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { registrableApex } from '@oxyhq/core/server';
 import type { DeviceBootFragment, DeviceBootReason } from '@oxyhq/contracts';
 import { deviceBootFragmentSchema } from '@oxyhq/contracts';
 import { authMiddleware } from '../middleware/auth';
@@ -37,6 +36,7 @@ import { asyncHandler } from '../utils/asyncHandler';
 import { logger } from '../utils/logger';
 import { normaliseOrigin, isLoopbackOrigin } from '../utils/origin';
 import { isTrustedOrigin } from '../config/dynamicOriginRegistry';
+import { isSameSiteTrustedRequest } from '../utils/sameSite';
 import { hasValidInternalSecret } from '../utils/internalSecret';
 import { readDeviceCookie, setDeviceCookie } from '../utils/deviceCookie';
 import deviceSessionService from '../services/deviceSession.service';
@@ -246,39 +246,14 @@ const webSessionLimiter = rateLimit({
 });
 
 /**
- * Same-site fast path. The Origin MUST be present, on the trusted lane, AND
- * share the API host's registrable apex (a true `*.oxy.so` sibling) — loopback
- * dev origins are exempted from the apex check. Rejects otherwise.
+ * Same-site fast path. Delegates the trusted-lane + registrable-apex (or exact
+ * host for IP/single-label) decision to the shared `isSameSiteTrustedRequest`
+ * predicate, then returns the normalised origin for the deviceToken binding.
  */
 function assertSameSiteApex(req: Request): { ok: true; origin: string } | { ok: false } {
-  const originRaw = req.headers.origin;
-  if (typeof originRaw !== 'string' || originRaw.length === 0) return { ok: false };
-  const origin = normaliseOrigin(originRaw);
-  if (!origin || !isTrustedLaneOrigin(origin)) return { ok: false };
-
-  if (isLoopbackOrigin(origin)) return { ok: true, origin };
-
-  // Use Express's `req.hostname` — it strips the port and handles IPv6 literals
-  // (`[::1]:3000` → `[::1]`) correctly, unlike a naive `host.split(':')` which
-  // shreds an IPv6 address.
-  const apiHost = req.hostname;
-  if (typeof apiHost !== 'string' || apiHost.length === 0) return { ok: false };
-  let originHost: string;
-  try {
-    originHost = new URL(origin).hostname;
-  } catch {
-    return { ok: false };
-  }
-
-  const apiApex = registrableApex(apiHost);
-  const originApex = registrableApex(originHost);
-  if (apiApex && originApex) {
-    // Registrable-domain match (the `*.oxy.so` sibling case).
-    return apiApex === originApex ? { ok: true, origin } : { ok: false };
-  }
-  // No registrable apex (IP literal / single-label host): same-site ONLY on an
-  // exact host match — never treat two different bare hosts as same-site.
-  return originHost.toLowerCase() === apiHost.toLowerCase() ? { ok: true, origin } : { ok: false };
+  if (!isSameSiteTrustedRequest(req)) return { ok: false };
+  const origin = normaliseOrigin(req.headers.origin as string);
+  return origin ? { ok: true, origin } : { ok: false };
 }
 
 router.post(

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -6,6 +6,7 @@ import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
 import deviceSessionService from '../services/deviceSession.service';
 import sessionService from '../services/session.service';
 import { broadcastDeviceState } from '../utils/socket';
+import { readDeviceCookie } from '../utils/deviceCookie';
 import { asyncHandler } from '../utils/asyncHandler';
 
 const router = Router();
@@ -49,6 +50,38 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
   // deactivated) — such a session must NOT be re-added to the device set.
   if (!sessionDoc) { res.status(401).json({ error: 'Invalid session' }); return; }
   const operatedByUserId = sessionDoc.operatedByUserId ? sessionDoc.operatedByUserId.toString() : undefined;
+
+  // CONVERGENCE: same-site callers send the `oxy_device` cookie. If it resolves
+  // to a DIFFERENT (canonical) device than the caller's JWT-claims deviceId,
+  // migrate this session onto the cookie device so the whole ecosystem converges
+  // on ONE device identity. Fixes the split-brain: a pre-cookie session lives on
+  // the old JWT-claims doc while the cookie doc (born empty during bootstrap) is
+  // what `/auth/device/resolve` + bootstrap/web-session read — so a signed-in
+  // user looked signed-out to the new device-first surface + IdP chooser.
+  const rawCookie = readDeviceCookie(req);
+  const cookieState = rawCookie ? await deviceSessionService.getStateByCookieKey(rawCookie) : null;
+  if (cookieState && cookieState.deviceId !== session.deviceId) {
+    // Re-mint the session's tokens on the cookie device FIRST so the returned
+    // activeToken carries the cookie deviceId claim — the caller's JWT still
+    // claims the OLD deviceId, so the client must replace its bearer immediately
+    // (SessionClient plants activeToken from /add) to target the right socket
+    // room + hit the canonical doc on subsequent /session/device/* calls.
+    await sessionService.migrateSessionToDevice(session.sessionId, cookieState.deviceId);
+    const { cookieState: convergedState, oldState, changed } = await deviceSessionService.convergeAccountOntoDevice(
+      cookieState.deviceId,
+      session.deviceId,
+      { accountId, sessionId: session.sessionId, ...(operatedByUserId ? { operatedByUserId } : {}) },
+    );
+    // Broadcast BOTH rooms on a real migration: the cookie device (account
+    // arrived) and the old device (account left). No-op re-converge → no change.
+    if (changed) {
+      broadcastDeviceState(convergedState);
+      broadcastDeviceState(oldState);
+    }
+    res.json({ data: await withActiveToken(convergedState) });
+    return;
+  }
+
   const { state, changed } = await deviceSessionService.addAccount(session.deviceId, {
     accountId,
     sessionId: session.sessionId,

--- a/packages/api/src/services/__tests__/deviceLogin.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceLogin.service.test.ts
@@ -13,14 +13,21 @@ import type { Request } from 'express';
 
 const mockGetStateByCookieKey = jest.fn();
 const mockAddAccount = jest.fn();
+const mockEnsureDeviceForCookie = jest.fn();
 jest.mock('../deviceSession.service', () => {
   const svc = {
     getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a),
     addAccount: (...a: unknown[]) => mockAddAccount(...a),
+    ensureDeviceForCookie: (...a: unknown[]) => mockEnsureDeviceForCookie(...a),
   };
   // deviceLogin.service dynamically imports the NAMED `deviceSessionService`.
   return { __esModule: true, default: svc, deviceSessionService: svc };
 });
+
+const mockIsSameSiteTrustedRequest = jest.fn(() => false);
+jest.mock('../../utils/sameSite', () => ({
+  isSameSiteTrustedRequest: (...a: unknown[]) => mockIsSameSiteTrustedRequest(...a),
+}));
 
 const mockResolveDeviceToken = jest.fn();
 jest.mock('../deviceToken.service', () => ({
@@ -46,7 +53,7 @@ jest.mock('../../utils/logger', () => ({
   logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
 }));
 
-import { resolveLoginDeviceId, finalizeDeviceLogin } from '../deviceLogin.service';
+import { resolveLoginDeviceId, resolveLoginDevice, finalizeDeviceLogin } from '../deviceLogin.service';
 
 function req(headers: Record<string, string> = {}): Request {
   return { headers } as unknown as Request;
@@ -56,6 +63,31 @@ beforeEach(() => {
   jest.resetAllMocks();
   mockIssueRefreshToken.mockResolvedValue({ token: 'rt', family: 'f', expiresAt: new Date() });
   mockIsTrustedOrigin.mockReturnValue(false);
+  mockIsSameSiteTrustedRequest.mockReturnValue(false);
+});
+
+describe('resolveLoginDevice — same-site cookie mint', () => {
+  it('returns the existing binding without minting when a cookie resolves', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'existing-dev' });
+    const result = await resolveLoginDevice(req({ cookie: 'oxy_device=secret' }), undefined);
+    expect(result).toEqual({ deviceId: 'existing-dev' });
+    expect(mockEnsureDeviceForCookie).not.toHaveBeenCalled();
+  });
+
+  it('mints a device cookie for a same-site trusted login with no existing binding', async () => {
+    mockIsSameSiteTrustedRequest.mockReturnValue(true);
+    mockEnsureDeviceForCookie.mockResolvedValueOnce({ deviceId: 'new-dev', rawCookieKey: 'minted-secret' });
+    const result = await resolveLoginDevice(req({ origin: 'https://accounts.oxy.so' }), undefined);
+    expect(result).toEqual({ deviceId: 'new-dev', setCookieSecret: 'minted-secret' });
+    expect(mockEnsureDeviceForCookie).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT mint for a non-same-site (cross-site / untrusted) login', async () => {
+    mockIsSameSiteTrustedRequest.mockReturnValue(false);
+    const result = await resolveLoginDevice(req({ origin: 'https://third-party.example' }), undefined);
+    expect(result).toEqual({ deviceId: null });
+    expect(mockEnsureDeviceForCookie).not.toHaveBeenCalled();
+  });
 });
 
 describe('resolveLoginDeviceId', () => {

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -683,3 +683,67 @@ describe('ensureDeviceForCookie', () => {
     expect(created.cookieKeyHash).not.toBe(rawCookieKey);
   });
 });
+
+describe('convergeAccountOntoDevice', () => {
+  it('adds the account to the cookie doc, advances its revision past the old doc, detaches (preserving the migrated session), and returns both states', async () => {
+    mockUpdateOne.mockResolvedValue({});
+    // 1) oldBefore load — the retired doc is at revision 5.
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'old-dev',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 5,
+    }));
+    // 2) addAccount loads the (empty) cookie doc.
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'cookie-dev', accounts: [], activeAccountId: null, revision: 0 }));
+    // 3) addAccount writes → cookie doc with the account, active, revision 1.
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'cookie-dev',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+      updatedAt: new Date(1720000000000),
+    }));
+    // 4) revision bump (1 <= 5) → cookie doc revision advanced to old+1 = 6.
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'cookie-dev',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 6,
+      updatedAt: new Date(1720000000000),
+    }));
+    // 5) detachMigratedAccount loads the OLD doc (still holds a1 with session s1).
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'old-dev',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 5,
+    }));
+    // 6) convergeAccountOntoDevice re-loads the OLD doc (now emptied) for oldState.
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'old-dev', accounts: [], activeAccountId: null, revision: 6, updatedAt: new Date(1720000000001),
+    }));
+
+    const { cookieState, oldState, changed } = await deviceSessionService.convergeAccountOntoDevice(
+      'cookie-dev',
+      'old-dev',
+      { accountId: 'a1', sessionId: 's1' },
+    );
+
+    expect(changed).toBe(true);
+    expect(cookieState.deviceId).toBe('cookie-dev');
+    expect(cookieState.activeAccountId).toBe('a1');
+    expect(cookieState.accounts).toHaveLength(1);
+    // The canonical cookie doc out-ranks the retired doc so the client applies it.
+    expect(cookieState.revision).toBe(6);
+    expect(cookieState.revision).toBeGreaterThan(5);
+    // The bump update targeted the cookie device with the advanced revision.
+    const bumpCall = mockFindOneAndUpdate.mock.calls[1];
+    expect(bumpCall[0]).toEqual({ deviceId: 'cookie-dev' });
+    expect(bumpCall[1]).toEqual({ $set: { revision: 6 } });
+    expect(oldState.deviceId).toBe('old-dev');
+    expect(oldState.accounts).toHaveLength(0);
+    // The just-migrated session (s1) is PRESERVED — never deactivated by detach.
+    expect(mockDeactivate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -746,4 +746,37 @@ describe('convergeAccountOntoDevice', () => {
     // The just-migrated session (s1) is PRESERVED — never deactivated by detach.
     expect(mockDeactivate).not.toHaveBeenCalled();
   });
+
+  it('synthesizes an empty old state WITHOUT upserting when the old doc is absent (no garbage doc)', async () => {
+    mockUpdateOne.mockResolvedValue({});
+    // 1) oldBefore load — no old doc.
+    mockFindOne.mockReturnValueOnce(lean(null));
+    // 2) addAccount loads the (empty) cookie doc.
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'cookie-dev', accounts: [], activeAccountId: null, revision: 0 }));
+    // 3) addAccount writes → cookie doc revision 1 (bump path: 1 > oldRevisionBefore 0, so NO bump).
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'cookie-dev',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 1,
+      updatedAt: new Date(1720000000000),
+    }));
+    // 4) detachMigratedAccount load (old doc absent → no-op).
+    mockFindOne.mockReturnValueOnce(lean(null));
+    // 5) convergeAccountOntoDevice re-load (old doc still absent → synthetic state).
+    mockFindOne.mockReturnValueOnce(lean(null));
+
+    const { oldState, cookieState } = await deviceSessionService.convergeAccountOntoDevice(
+      'cookie-dev',
+      'missing-old-dev',
+      { accountId: 'a1', sessionId: 's1' },
+    );
+
+    // Synthetic empty old state (deviceId echoed), never persisted.
+    expect(oldState).toEqual({ deviceId: 'missing-old-dev', accounts: [], activeAccountId: null, revision: 0, updatedAt: expect.any(Number) });
+    expect(cookieState.deviceId).toBe('cookie-dev');
+    // Exactly ONE findOneAndUpdate (the addAccount write) — NO getState upsert,
+    // NO revision bump (cookie revision 1 already > old 0).
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -623,4 +623,36 @@ describe('Session Service', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('migrateSessionToDevice', () => {
+    it('re-mints tokens on the new device and updates the Session (migrated=true)', async () => {
+      mockFindOneResults.push({ userId: 'user-1', deviceId: 'old-dev', accessToken: 'old-tok', expiresAt: new Date('2030-01-01T00:00:00.000Z') });
+      mockFindOneAndUpdate.mockResolvedValueOnce({ deviceId: 'cookie-dev', expiresAt: new Date('2030-01-01T00:00:00.000Z') });
+
+      const result = await sessionService.migrateSessionToDevice('session-123', 'cookie-dev');
+
+      expect(result).toEqual({ accessToken: 'mock-access-token', expiresAt: new Date('2030-01-01T00:00:00.000Z'), migrated: true });
+      // The re-minted token embeds the NEW deviceId (3rd generateSessionTokens arg).
+      expect(generateSessionTokens as jest.Mock).toHaveBeenCalledWith('user-1', 'session-123', 'cookie-dev');
+      const updateArg = mockFindOneAndUpdate.mock.calls[0][1] as { $set: Record<string, unknown> };
+      expect(updateArg.$set.deviceId).toBe('cookie-dev');
+      expect(updateArg.$set.accessToken).toBe('mock-access-token');
+      expect(sessionCache.invalidate).toHaveBeenCalledWith('session-123');
+    });
+
+    it('is idempotent: no re-mint when the session is already on the target device (migrated=false)', async () => {
+      mockFindOneResults.push({ userId: 'user-1', deviceId: 'cookie-dev', accessToken: 'current-tok', expiresAt: new Date('2030-01-01T00:00:00.000Z') });
+
+      const result = await sessionService.migrateSessionToDevice('session-123', 'cookie-dev');
+
+      expect(result).toEqual({ accessToken: 'current-tok', expiresAt: new Date('2030-01-01T00:00:00.000Z'), migrated: false });
+      expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+      expect(generateSessionTokens as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it('returns null for a missing/inactive session', async () => {
+      mockFindOneResults.push(null);
+      expect(await sessionService.migrateSessionToDevice('gone', 'cookie-dev')).toBeNull();
+    });
+  });
 });

--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -627,7 +627,8 @@ describe('Session Service', () => {
   describe('migrateSessionToDevice', () => {
     it('re-mints tokens on the new device and updates the Session (migrated=true)', async () => {
       mockFindOneResults.push({ userId: 'user-1', deviceId: 'old-dev', accessToken: 'old-tok', expiresAt: new Date('2030-01-01T00:00:00.000Z') });
-      mockFindOneAndUpdate.mockResolvedValueOnce({ deviceId: 'cookie-dev', expiresAt: new Date('2030-01-01T00:00:00.000Z') });
+      // findOneAndUpdate is now `.lean()`-chained → return a lean-shaped query.
+      mockFindOneAndUpdate.mockReturnValueOnce({ lean: () => Promise.resolve({ deviceId: 'cookie-dev', expiresAt: new Date('2030-01-01T00:00:00.000Z') }) });
 
       const result = await sessionService.migrateSessionToDevice('session-123', 'cookie-dev');
 

--- a/packages/api/src/services/deviceLogin.service.ts
+++ b/packages/api/src/services/deviceLogin.service.ts
@@ -24,6 +24,7 @@ import type { Request } from 'express';
 import { readDeviceCookie } from '../utils/deviceCookie';
 import { normaliseOrigin, isLoopbackOrigin } from '../utils/origin';
 import { isTrustedOrigin } from '../config/dynamicOriginRegistry';
+import { isSameSiteTrustedRequest } from '../utils/sameSite';
 import { issueRefreshToken } from './refreshToken.service';
 import { broadcastDeviceState } from '../utils/socket';
 import { logger } from '../utils/logger';
@@ -60,6 +61,38 @@ export async function resolveLoginDeviceId(
     logger.warn('resolveLoginDeviceId failed', { error });
   }
   return null;
+}
+
+/**
+ * Resolve the login device, MINTING a device cookie when appropriate. Precedence:
+ *   1. an existing binding (oxy_device cookie > deviceToken), OR
+ *   2. for a SAME-SITE TRUSTED login with no existing binding — the IdP form on
+ *      auth.oxy.so and oxy.so apps hitting api.oxy.so — mint a fresh device +
+ *      `oxy_device` cookie so a first-ever sign-in gets a durable device identity
+ *      WITHOUT a bootstrap hop (this is what feeds the IdP chooser its own logins
+ *      and gives new oxy.so users a device to converge on).
+ *   3. otherwise no device (cross-site callers stay on the deviceToken lane).
+ *
+ * Returns the deviceId (or null) plus, when a cookie was minted, the raw secret
+ * the caller must Set-Cookie on the login response. Never throws.
+ */
+export async function resolveLoginDevice(
+  req: Request,
+  deviceToken: unknown,
+): Promise<{ deviceId: string | null; setCookieSecret?: string }> {
+  const existing = await resolveLoginDeviceId(req, deviceToken);
+  if (existing) return { deviceId: existing };
+
+  if (isSameSiteTrustedRequest(req)) {
+    try {
+      const { deviceSessionService } = await import('./deviceSession.service.js');
+      const { deviceId, rawCookieKey } = await deviceSessionService.ensureDeviceForCookie();
+      return { deviceId, setCookieSecret: rawCookieKey };
+    } catch (error) {
+      logger.warn('resolveLoginDevice: same-site cookie mint failed', { error });
+    }
+  }
+  return { deviceId: null };
 }
 
 /**

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -435,8 +435,14 @@ class DeviceSessionService {
     }
 
     await this.detachMigratedAccount(oldDeviceId, input.accountId, input.sessionId);
+    // Plain find, NEVER `getState` — the latter UPSERTS an empty doc, which would
+    // manufacture a garbage device record for a retired/unknown old deviceId. When
+    // the old doc is absent (session was never registered on a device doc, or the
+    // id is stale), synthesize an empty state to broadcast WITHOUT persisting.
     const oldDoc = await this.load(oldDeviceId);
-    const oldState = oldDoc ? projectState(oldDoc) : await this.getState(oldDeviceId);
+    const oldState: DeviceSessionState = oldDoc
+      ? projectState(oldDoc)
+      : { deviceId: oldDeviceId, accounts: [], activeAccountId: null, revision: 0, updatedAt: Date.now() };
     return { cookieState, oldState, changed };
   }
 }

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -392,6 +392,53 @@ class DeviceSessionService {
     });
     return { deviceId, rawCookieKey };
   }
+
+  /**
+   * Converge a caller's account onto the CANONICAL `oxy_device`-cookie device
+   * doc. Fixes the split-brain where a pre-cookie session lives on the old
+   * JWT-claims-era device doc while the cookie doc (born via `ensureDeviceForCookie`
+   * during bootstrap) is empty — so `/auth/device/resolve` + bootstrap/web-session
+   * saw an empty device despite live sessions.
+   *
+   * The session must ALREADY have been migrated onto `cookieDeviceId` at the
+   * Session level (`sessionService.migrateSessionToDevice`) BEFORE this call, so
+   * the follow-up `resolveActiveToken(cookieState)` mints an access token whose
+   * `deviceId` claim addresses the cookie device. Here we: register the account
+   * on the cookie doc (`activate: 'always'` — an explicit `/add` sets it active,
+   * matching today's behaviour), detach it from the old doc (preserving the
+   * just-migrated session), and return BOTH resulting states so the route can
+   * broadcast both device rooms. `changed` is the cookie-doc mutation flag.
+   */
+  async convergeAccountOntoDevice(
+    cookieDeviceId: string,
+    oldDeviceId: string,
+    input: { accountId: string; sessionId: string; operatedByUserId?: string },
+  ): Promise<{ cookieState: DeviceSessionState; oldState: DeviceSessionState; changed: boolean }> {
+    // Capture the old doc's revision BEFORE detaching. The client's `applyState`
+    // is last-writer-wins by `revision` ACROSS the device set, so the canonical
+    // cookie doc must out-rank the retired doc's revision — otherwise the fresh
+    // (low-revision) converged state loses to the stale high-revision old-device
+    // state the client still holds and the migration would never be applied.
+    const oldBefore = await this.load(oldDeviceId);
+    const oldRevisionBefore = oldBefore?.revision ?? 0;
+
+    const { state: added, changed } = await this.addAccount(cookieDeviceId, input);
+
+    let cookieState = added;
+    if (changed && added.revision <= oldRevisionBefore) {
+      const bumped = await DeviceSession.findOneAndUpdate(
+        { deviceId: cookieDeviceId },
+        { $set: { revision: oldRevisionBefore + 1 } },
+        { new: true },
+      ).lean<IDeviceSession>();
+      if (bumped) cookieState = projectState(bumped);
+    }
+
+    await this.detachMigratedAccount(oldDeviceId, input.accountId, input.sessionId);
+    const oldDoc = await this.load(oldDeviceId);
+    const oldState = oldDoc ? projectState(oldDoc) : await this.getState(oldDeviceId);
+    return { cookieState, oldState, changed };
+  }
 }
 
 // Exported BOTH as the default (existing static `import deviceSessionService`

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -972,6 +972,9 @@ class SessionService {
       const now = new Date();
       const { accessToken, refreshToken } = generateSessionTokens(userId, sessionId, newDeviceId);
 
+      // `.lean()` — store a PLAIN object in the cache, not a full Mongoose
+      // Document (avoids memory bloat + an accidentally-mutable hydrated doc in
+      // the in-memory cache), matching the lean-read convention of `getSession`.
       const updated = await Session.findOneAndUpdate(
         { sessionId, isActive: true },
         {
@@ -985,7 +988,7 @@ class SessionService {
           },
         },
         { new: true },
-      );
+      ).lean<ISession>();
       if (!updated) return null;
 
       sessionCache.invalidate(sessionId);

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -938,6 +938,76 @@ class SessionService {
       return null;
     }
   }
+
+  /**
+   * Migrate an ACTIVE session onto a different (canonical) deviceId and re-mint
+   * its tokens so the fresh access token's `deviceId` claim addresses the new
+   * device — the room the client's SessionClient must join. Used by the
+   * device-doc convergence path (`POST /session/device/add`) when a same-site
+   * caller's `oxy_device` cookie resolves to a different device than the
+   * session's stored (JWT-claims-era) deviceId.
+   *
+   * Idempotent: when the session is already on `newDeviceId` the tokens are NOT
+   * re-minted — the current access token (already carrying that deviceId claim)
+   * is returned. Returns null when the session is missing/inactive. The re-mint
+   * is an explicit field whitelist (deviceId + tokens + activity), never a
+   * `req.body` spread.
+   */
+  async migrateSessionToDevice(
+    sessionId: string,
+    newDeviceId: string,
+  ): Promise<{ accessToken: string; expiresAt: Date; migrated: boolean } | null> {
+    try {
+      const existing = await Session.findOne({ sessionId, isActive: true })
+        .select('userId deviceId accessToken expiresAt')
+        .lean();
+      if (!existing) return null;
+
+      // Already canonical — no re-mint. Hand back the current access token.
+      if (existing.deviceId === newDeviceId) {
+        return { accessToken: existing.accessToken, expiresAt: existing.expiresAt, migrated: false };
+      }
+
+      const userId = existing.userId.toString();
+      const now = new Date();
+      const { accessToken, refreshToken } = generateSessionTokens(userId, sessionId, newDeviceId);
+
+      const updated = await Session.findOneAndUpdate(
+        { sessionId, isActive: true },
+        {
+          $set: {
+            deviceId: newDeviceId,
+            accessToken,
+            refreshToken,
+            lastRefresh: now,
+            'deviceInfo.lastActive': now,
+            updatedAt: now,
+          },
+        },
+        { new: true },
+      );
+      if (!updated) return null;
+
+      sessionCache.invalidate(sessionId);
+      sessionCache.set(sessionId, updated as ISession);
+
+      logger.info('[SessionService] Migrated session onto cookie device', {
+        component: 'SessionService',
+        method: 'migrateSessionToDevice',
+        sessionId: sessionId.substring(0, 8),
+        toDeviceId: newDeviceId.substring(0, 8),
+      });
+
+      return { accessToken, expiresAt: updated.expiresAt, migrated: true };
+    } catch (error) {
+      logger.error('[SessionService] Failed to migrate session to device', error instanceof Error ? error : new Error(String(error)), {
+        component: 'SessionService',
+        method: 'migrateSessionToDevice',
+        sessionId,
+      });
+      return null;
+    }
+  }
 }
 
 // Export singleton instance

--- a/packages/api/src/utils/sameSite.ts
+++ b/packages/api/src/utils/sameSite.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared "same-site trusted request" predicate.
+ *
+ * True when the request carries an `Origin` that is (a) on the trusted CREDENTIALED
+ * lane (first-party / internal / system / official app, or an http loopback dev
+ * origin) AND (b) same-site with the API host — i.e. it shares the API host's
+ * registrable apex (a `*.oxy.so` sibling), or, for IP-literal / single-label
+ * hosts that have no registrable apex, it is the exact same host.
+ *
+ * Used by the device-first surface for two same-site fast paths that ride the
+ * ambient `oxy_device` cookie: `POST /auth/device/web-session` and the login
+ * flows that MINT the device cookie for a first-ever same-site sign-in. A
+ * third-party-lane or cross-apex origin is never same-site-trusted.
+ *
+ * Uses Express `req.hostname` (strips the port, handles IPv6 literals like
+ * `[::1]:3000`) rather than a manual `Host` split.
+ */
+
+import type { Request } from 'express';
+import { registrableApex } from '@oxyhq/core/server';
+import { normaliseOrigin, isLoopbackOrigin } from './origin';
+import { isTrustedOrigin } from '../config/dynamicOriginRegistry';
+
+export function isSameSiteTrustedRequest(req: Request): boolean {
+  const originRaw = req.headers.origin;
+  if (typeof originRaw !== 'string' || originRaw.length === 0) return false;
+  const origin = normaliseOrigin(originRaw);
+  if (!origin) return false;
+
+  // Trusted lane = credentialed first-party/internal/official app origins, plus
+  // http loopback dev origins (which `isTrustedOrigin` deliberately excludes).
+  if (!(isTrustedOrigin(origin) || isLoopbackOrigin(origin))) return false;
+
+  // Loopback dev origins are same-site by fiat (no meaningful apex to compare).
+  if (isLoopbackOrigin(origin)) return true;
+
+  const apiHost = req.hostname;
+  if (typeof apiHost !== 'string' || apiHost.length === 0) return false;
+  let originHost: string;
+  try {
+    originHost = new URL(origin).hostname;
+  } catch {
+    return false;
+  }
+
+  const apiApex = registrableApex(apiHost);
+  const originApex = registrableApex(originHost);
+  if (apiApex && originApex) {
+    return apiApex === originApex;
+  }
+  // No registrable apex (IP literal / single-label host): same-site ONLY on an
+  // exact host match.
+  return originHost.toLowerCase() === apiHost.toLowerCase();
+}


### PR DESCRIPTION
## Device-doc convergence (unblocks IdP chooser #531 + Mention F6)

Fixes the split-brain the plan flagged (riesgo #2): pre-cookie `DeviceSession`s carry claims-era `deviceId`s with no `cookieKeyHash`, while the `oxy_device` cookie doc is born **empty** via `ensureDeviceForCookie`. So a signed-in user's sessions live on the OLD JWT-claims doc, and `/auth/device/resolve` + bootstrap/web-session read the empty cookie doc → **empty IdP chooser + `no_session` bootstrap despite live sessions**.

### 1. `POST /session/device/add` converges

When a same-site caller's `oxy_device` cookie resolves to a **different** (canonical) device than the bearer JWT's `deviceId`, the session migrates onto the cookie device:

- `sessionService.migrateSessionToDevice` re-mints the session's tokens on the cookie `deviceId` (explicit field whitelist; **idempotent** — no re-mint when already there) so the returned `activeToken` carries the cookie `deviceId` claim. The client replaces its bearer immediately — `SessionClient.addCurrentAccount` → `applySync` plants `activeToken` from `/add` (confirmed in core).
- `deviceSessionService.convergeAccountOntoDevice` registers the account on the cookie doc, **detaches** it from the old doc (preserving the just-migrated session), and **advances the cookie doc's `revision` past the retired doc's**. Rationale: the client's `applyState` is last-writer-wins by `revision` **across** the device set, so the canonical doc must out-rank the retired one or the fresh (low-revision) converged state would be discarded.
- Broadcasts **both** device rooms on a real migration. Idempotent same-doc / no-cookie paths are unchanged.

### 2. Login mints the device cookie when absent (same-site trusted only)

New shared predicate `isSameSiteTrustedRequest` (`utils/sameSite.ts`, which also now backs `deviceAuth`'s web-session same-site check — DRY). When a `login` / `signup` / `verify` / `2fa` request carries **no** `oxy_device` cookie and **no** `deviceToken`, but its `Origin` is trusted-lane **and** shares the API host's registrable apex (the IdP form + `oxy.so` apps), a device + cookie are minted and `Set-Cookie`'d on the response, registered `activate: 'if-empty'`. Cross-site callers are unchanged (they stay on the `deviceToken` lane). This feeds the IdP chooser its own logins and gives first-ever `oxy.so` sign-ins a device identity without a hop.

### Client-side note (for core-f3)

The revision-advance above makes convergence work with the **shipped** `SessionClient`. The underlying limitation — `applyState` compares `revision` across devices (a state for a different `deviceId` isn't strictly comparable) — is worth hardening in core as defense-in-depth (reset the revision baseline on a `deviceId` change). Not required for this PR; the server advance is sufficient.

### Tests

Convergence migration (moves + fresh token + revision advance + old-doc detach + both rooms broadcast); same-device + no-cookie non-convergence; `migrateSessionToDevice` re-mint + idempotency + missing session; `resolveLoginDevice` same-site mint vs cross-site unchanged vs existing-binding. Full api suite green (**152 suites / 1507 tests**), `tsc --noEmit` clean, `eslint` clean. Legacy surface untouched.

**Do not merge** — the lead coordinates; #531 (IdP chooser) merges after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)