### PR TITLE
refactor(core,services): authorized-apps on AppGrant endpoints; drop dead CENTRAL_AUTH_URL; rename fapiAutoDetect→registrableApex

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -504,8 +504,8 @@ export type { QuickAccount, DisplayNameUserShape } from './utils/accountUtils';
 // constant. `@oxyhq/core/server` re-exports `registrableApex` + `SSO_CALLBACK_PATH`
 // for the api; the IdP imports all three from here.
 // ---------------------------------------------------------------------------
-export { registrableApex } from './utils/fapiAutoDetect';
-export { CENTRAL_AUTH_URL, CENTRAL_IDP_APEX } from './utils/authWebUrl';
+export { registrableApex } from './utils/registrableApex';
+export { CENTRAL_IDP_APEX } from './utils/authWebUrl';
 export { SSO_CALLBACK_PATH } from './utils/ssoBounce';
 
 export { runColdBoot } from './utils/coldBoot';

--- a/packages/core/src/mixins/OxyServices.authorizedApps.ts
+++ b/packages/core/src/mixins/OxyServices.authorizedApps.ts
@@ -1,46 +1,49 @@
 /**
- * Authorized-apps mixin — the "Connected apps" management surface that survived
- * the FedCM removal.
+ * Authorized-apps mixin — the "Connected apps" management surface.
  *
- * These two methods read/revoke the user's LEGACY FedCM authorization grants
- * (`GET`/`DELETE /fedcm/me/authorized-apps`). They are the last live consumers
- * of that endpoint (services' `ConnectedAppsScreen` via `useAccountQueries` /
- * `useAccountMutations`) and stay until the AppGrant migration retires the
- * FedCM grant store. All FedCM SIGN-IN machinery was deleted with
- * `OxyServices.fedcm.ts`; this is management-only, so it has no dependency on
- * the credential/nonce pipeline.
+ * Reads/revokes the user's OAuth application grants on the AppGrant endpoints
+ * (`GET /apps/authorized`, `DELETE /apps/authorized/:clientId`) — the successor
+ * to the retired FedCM `/fedcm/me/authorized-apps` surface. The method NAMES
+ * (`listAuthorizedApps` / `revokeAuthorizedApp`) are unchanged so services'
+ * `ConnectedAppsScreen` (via `useAccountQueries` / `useAccountMutations`) keeps
+ * its call sites; only the wire shape + endpoints moved. Management-only — no
+ * dependency on any sign-in/credential pipeline.
  */
 import type { OxyServicesBase } from '../OxyServices.base';
 
 /**
- * Public summary of an RP application the user has authorized — mirrors the
- * `AuthorizedAppSummary` shape returned by `GET /fedcm/me/authorized-apps`.
+ * One OAuth application the user has authorized — the `GET /apps/authorized`
+ * entry shape (`AppGrant` projection). `clientId` is the app's OAuth client id
+ * and the revoke key; `appIconUrl` / `scopes` are optional.
  */
 export interface AuthorizedApp {
-  /** Normalised RP origin. */
-  origin: string;
+  /** The authorized application's OAuth client id — the revoke key. */
+  clientId: string;
   /** Friendly display name. */
-  name: string;
-  /** Optional human-readable description. */
-  description?: string;
-  /** ISO-8601 timestamp of when the user first authorized this RP. */
-  firstGrantedAt: string;
-  /** ISO-8601 timestamp of the most recent FedCM exchange for this user+RP. */
-  lastUsedAt: string;
+  appName: string;
+  /** Optional app icon URL. */
+  appIconUrl?: string;
+  /** ISO-8601 timestamp of when the user granted this app. */
+  grantedAt: string;
+  /** Optional scopes the grant covers. */
+  scopes?: string[];
 }
+
+/** Cache-key prefix of the authorized-apps read (`GET /apps/authorized`). */
+const AUTHORIZED_APPS_CACHE_KEY = 'GET:/apps/authorized';
 
 export function OxyServicesAuthorizedAppsMixin<T extends typeof OxyServicesBase>(Base: T) {
   return class extends Base {
     /**
-     * List the authenticated user's authorized RP apps — the intersection of the
-     * user's FedCM grants and the currently-approved RP catalog. Powers the
-     * "Connected apps" management UI. Requires a real user session.
+     * List the authenticated user's authorized OAuth applications
+     * (`GET /apps/authorized`). Powers the "Connected apps" management UI.
+     * Requires a real user session.
      */
     async listAuthorizedApps(): Promise<AuthorizedApp[]> {
       try {
         const response = await this.makeRequest<{ apps: AuthorizedApp[] }>(
           'GET',
-          '/fedcm/me/authorized-apps',
+          '/apps/authorized',
           undefined,
           {
             cache: true,
@@ -54,19 +57,19 @@ export function OxyServicesAuthorizedAppsMixin<T extends typeof OxyServicesBase>
     }
 
     /**
-     * Revoke the authenticated user's authorization for a specific RP origin.
-     * The corresponding cache entry is invalidated so a subsequent
-     * `listAuthorizedApps()` sees fresh data.
+     * Revoke the authenticated user's grant for a specific application
+     * (`DELETE /apps/authorized/:clientId`, 204). The corresponding cache entry
+     * is invalidated so a subsequent `listAuthorizedApps()` sees fresh data.
      */
-    async revokeAuthorizedApp(origin: string): Promise<void> {
+    async revokeAuthorizedApp(clientId: string): Promise<void> {
       try {
         await this.makeRequest(
           'DELETE',
-          `/fedcm/me/authorized-apps/${encodeURIComponent(origin)}`,
+          `/apps/authorized/${encodeURIComponent(clientId)}`,
           undefined,
           { cache: false },
         );
-        this.clearCacheEntry('GET:/fedcm/me/authorized-apps');
+        this.clearCacheEntry(AUTHORIZED_APPS_CACHE_KEY);
       } catch (error) {
         throw this.handleError(error);
       }

--- a/packages/core/src/mixins/__tests__/authorizedApps.test.ts
+++ b/packages/core/src/mixins/__tests__/authorizedApps.test.ts
@@ -1,15 +1,16 @@
 /**
- * Authorized-apps mixin tests — the "Connected apps" management pair that
- * survived the FedCM removal. Stubs `makeRequest` (no network).
+ * Authorized-apps mixin tests — the "Connected apps" management pair over the
+ * AppGrant endpoints (`GET`/`DELETE /apps/authorized`). Stubs `makeRequest`.
  */
 import type { AuthorizedApp } from '../OxyServices.authorizedApps';
 import { OxyServices } from '../../OxyServices';
 
 const APP: AuthorizedApp = {
-  origin: 'https://mention.earth',
-  name: 'Mention',
-  firstGrantedAt: '2026-01-01T00:00:00.000Z',
-  lastUsedAt: '2026-06-01T00:00:00.000Z',
+  clientId: 'oxy_dk_mention',
+  appName: 'Mention',
+  appIconUrl: 'https://cloud.oxy.so/icon123',
+  grantedAt: '2026-01-01T00:00:00.000Z',
+  scopes: ['profile', 'email'],
 };
 
 describe('OxyServices.authorizedApps', () => {
@@ -24,12 +25,12 @@ describe('OxyServices.authorizedApps', () => {
   afterEach(() => jest.restoreAllMocks());
 
   describe('listAuthorizedApps', () => {
-    it('GETs the authorized-apps and returns the array', async () => {
+    it('GETs /apps/authorized and returns the apps array', async () => {
       makeRequest.mockResolvedValueOnce({ apps: [APP] });
       expect(await oxy.listAuthorizedApps()).toEqual([APP]);
       expect(makeRequest).toHaveBeenCalledWith(
         'GET',
-        '/fedcm/me/authorized-apps',
+        '/apps/authorized',
         undefined,
         expect.objectContaining({ cache: true }),
       );
@@ -47,17 +48,17 @@ describe('OxyServices.authorizedApps', () => {
   });
 
   describe('revokeAuthorizedApp', () => {
-    it('DELETEs the encoded origin and sweeps the list cache', async () => {
+    it('DELETEs the encoded clientId and sweeps the list cache', async () => {
       const clearCacheEntry = jest.spyOn(oxy, 'clearCacheEntry');
       makeRequest.mockResolvedValueOnce(undefined);
-      await oxy.revokeAuthorizedApp('https://mention.earth');
+      await oxy.revokeAuthorizedApp('oxy_dk_mention');
       expect(makeRequest).toHaveBeenCalledWith(
         'DELETE',
-        '/fedcm/me/authorized-apps/https%3A%2F%2Fmention.earth',
+        '/apps/authorized/oxy_dk_mention',
         undefined,
         { cache: false },
       );
-      expect(clearCacheEntry).toHaveBeenCalledWith('GET:/fedcm/me/authorized-apps');
+      expect(clearCacheEntry).toHaveBeenCalledWith('GET:/apps/authorized');
     });
   });
 });

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -68,7 +68,7 @@ export { verifySecret } from './verifySecret';
 // SOURCE OF TRUTH shared with the IdP worker and the client FAPI auto-detect.
 // Pure host handling (no browser deps), so it is safe on the server subpath and
 // lets `@oxyhq/api` derive `auth.<apex>` without duplicating PSL logic.
-export { registrableApex } from '../utils/fapiAutoDetect';
+export { registrableApex } from '../utils/registrableApex';
 
 // The single RP callback path the IdP redirects back to. A pure wire-contract
 // constant (no browser deps at module top level), re-used server-side so the

--- a/packages/core/src/utils/__tests__/authWebUrl.test.ts
+++ b/packages/core/src/utils/__tests__/authWebUrl.test.ts
@@ -1,26 +1,15 @@
 /**
- * Central IdP apex/origin constants.
+ * Central IdP apex constant.
  *
- * `resolveCentralAuthUrl` was removed in the device-first cutover (the SDK no
- * longer resolves an IdP host). The `CENTRAL_IDP_APEX` / `CENTRAL_AUTH_URL`
- * constants survive because the IdP worker imports them to brand assertions.
+ * `resolveCentralAuthUrl` + `CENTRAL_AUTH_URL` were removed in the device-first /
+ * legacy-final cutovers. `CENTRAL_IDP_APEX` survives because live server-side
+ * callers (the `@oxyhq/core/server` CORS helper + the IdP worker) import it.
  */
 
-import { CENTRAL_AUTH_URL, CENTRAL_IDP_APEX } from '../authWebUrl';
+import { CENTRAL_IDP_APEX } from '../authWebUrl';
 
 describe('CENTRAL_IDP_APEX', () => {
   it('is the central IdP registrable apex', () => {
     expect(CENTRAL_IDP_APEX).toBe('oxy.so');
-  });
-});
-
-describe('CENTRAL_AUTH_URL', () => {
-  it('is the central IdP origin with no trailing slash', () => {
-    expect(CENTRAL_AUTH_URL).toBe('https://auth.oxy.so');
-    expect(CENTRAL_AUTH_URL.endsWith('/')).toBe(false);
-  });
-
-  it('is derived from CENTRAL_IDP_APEX (apex and origin never drift)', () => {
-    expect(CENTRAL_AUTH_URL).toBe(`https://auth.${CENTRAL_IDP_APEX}`);
   });
 });

--- a/packages/core/src/utils/__tests__/registrableApex.test.ts
+++ b/packages/core/src/utils/__tests__/registrableApex.test.ts
@@ -6,7 +6,7 @@
  * surface + the IdP). These cases lock its Public-Suffix-List behaviour.
  */
 
-import { registrableApex } from '../fapiAutoDetect';
+import { registrableApex } from '../registrableApex';
 
 describe('registrableApex', () => {
   it('returns the eTLD+1 for a normal two-label host', () => {

--- a/packages/core/src/utils/authWebUrl.ts
+++ b/packages/core/src/utils/authWebUrl.ts
@@ -1,38 +1,18 @@
 /**
- * Central IdP (auth web) URL resolution for cross-domain SSO.
+ * Central IdP apex constant.
  *
- * The Oxy ecosystem runs a single, central Identity Provider at
- * `auth.oxy.so`. For TRUE central cross-domain SSO (Google/Meta/Clerk style),
- * FedCM and the opaque-code SSO bounce always target this one origin — it owns
- * the host-only `fedcm_session` cookie and the central session store reachable
- * via `api.oxy.so`. Relying Parties (mention.earth, homiio.com, alia.onl, …)
- * delegate to it rather than standing up a per-apex IdP.
- *
- * This module is intentionally pure: it performs no DOM access, reads no
- * `window`/`location`, and has no side effects. It is the single source of
- * truth for the central IdP origin so call sites never hardcode the literal.
- *
- * LEGACY(old-sdk): the client resolver (`resolveCentralAuthUrl`) was removed in
- * the device-first cutover; `CENTRAL_IDP_APEX` / `CENTRAL_AUTH_URL` survive ONLY
- * because the lista-B IdP worker imports them to brand assertions. Deletable
- * once Homiio/Allo/Alia/Syra are bumped off the old SDK AND CloudWatch
- * `/oxy/ecs` shows the `/sso*` + `/fedcm/*` routes quiet — F-final sweep.
+ * The client SSO/FedCM resolvers (`resolveCentralAuthUrl`, `CENTRAL_AUTH_URL`)
+ * were removed in the device-first / legacy-final cutovers. The lone survivor is
+ * `CENTRAL_IDP_APEX`, kept because it has a LIVE device-first consumer —
+ * `@oxyhq/core/server`'s CORS helper auto-allows `*.oxy.so` from it — as well as
+ * the (lista-B) IdP worker branding its assertions. The CORS use is permanent,
+ * so this stays past the SSO/FedCM teardown.
  */
 
 /**
  * The registrable apex (eTLD+1) of the Oxy ecosystem's central Identity
  * Provider. The central IdP is reachable at `auth.${CENTRAL_IDP_APEX}` and the
- * ID-token assertion issuer is always `https://auth.${CENTRAL_IDP_APEX}`
- * regardless of which per-apex `auth.<rp>` host served a given request.
- *
- * Kept as a standalone constant so the IdP worker and the SDK derive the same
- * literal from one source of truth (the worker imports it to brand assertions).
+ * ID-token assertion issuer is always `https://auth.${CENTRAL_IDP_APEX}`.
+ * A single source of truth so the IdP worker + the CORS helper never drift.
  */
 export const CENTRAL_IDP_APEX = 'oxy.so';
-
-/**
- * The canonical central Identity Provider origin for the Oxy ecosystem.
- * No trailing slash. Derived from {@link CENTRAL_IDP_APEX} so the apex and the
- * full origin never drift apart. The IdP worker imports it to brand assertions.
- */
-export const CENTRAL_AUTH_URL = `https://auth.${CENTRAL_IDP_APEX}`;

--- a/packages/core/src/utils/registrableApex.ts
+++ b/packages/core/src/utils/registrableApex.ts
@@ -1,17 +1,15 @@
 /**
  * Registrable-apex (eTLD+1) host kernel.
  *
- * The client FAPI auto-detection helper (`autoDetectAuthWebUrl`) was removed in
- * the device-first cutover — the SDK no longer derives a per-apex `auth.<rp>`
- * IdP host. What survives is the pure registrable-domain kernel, still used by
- * the api SSO surface, `fedcm.service`, `deviceAuth` (same-apex trust checks),
- * and the IdP worker (all lista B / server-side). `@oxyhq/core/server`
- * re-exports it for the api.
+ * The client FAPI auto-detection helper was removed in the device-first cutover
+ * (which is why this file is now named for what it actually is, not the old
+ * `fapiAutoDetect`). What survives is the pure registrable-domain kernel, still
+ * used server-side by the api (`deviceAuth` same-apex trust checks via
+ * `sameSite.ts`, `fedcm.service`, `sso.controller`), the `@oxyhq/core/server`
+ * CORS/re-export layer, and the IdP worker.
  *
- * LEGACY(old-sdk): `registrableApex` survives ONLY for the lista-B server/IdP
- * SSO surface. Deletable once Homiio/Allo/Alia/Syra are bumped off the old SDK
- * AND CloudWatch `/oxy/ecs` shows the `/sso*` + `/fedcm/*` routes quiet — the
- * F-final sweep should remove this file then.
+ * `registrableApex` is NOT legacy — `deviceAuth` (device-first) is a live
+ * consumer, so this kernel stays regardless of the SSO/FedCM lista-B teardown.
  */
 
 import { getDomain } from 'tldts';

--- a/packages/services/src/ui/hooks/mutations/useAccountMutations.ts
+++ b/packages/services/src/ui/hooks/mutations/useAccountMutations.ts
@@ -633,8 +633,8 @@ export const useUpdateUserPreferences = () => {
 
 /**
  * Revoke the authenticated user's authorization for a specific RP origin.
- * Removes the FedCM grant so the origin no longer appears in the user's
- * "Connected apps" list — next sign-in from that origin will require explicit
+ * Removes the OAuth grant so the app no longer appears in the user's
+ * "Connected apps" list — next sign-in for that app will require explicit
  * re-consent.
  */
 export const useRevokeAuthorizedApp = () => {
@@ -643,9 +643,9 @@ export const useRevokeAuthorizedApp = () => {
 
   return useMutation({
     mutationKey: [...mutationKeys.connectedApps.revoke],
-    mutationFn: async (origin: string) => {
+    mutationFn: async (clientId: string) => {
       return authenticatedApiCall<void>(oxyServices, activeSessionId, () =>
-        oxyServices.revokeAuthorizedApp(origin)
+        oxyServices.revokeAuthorizedApp(clientId)
       );
     },
     onSuccess: () => {

--- a/packages/services/src/ui/hooks/mutations/useAccountMutations.ts
+++ b/packages/services/src/ui/hooks/mutations/useAccountMutations.ts
@@ -632,9 +632,9 @@ export const useUpdateUserPreferences = () => {
 };
 
 /**
- * Revoke the authenticated user's authorization for a specific RP origin.
- * Removes the OAuth grant so the app no longer appears in the user's
- * "Connected apps" list — next sign-in for that app will require explicit
+ * Revoke the authenticated user's authorization for a specific application (by
+ * its OAuth `clientId`). Removes the grant so the app no longer appears in the
+ * user's "Connected apps" list — next sign-in for that app will require explicit
  * re-consent.
  */
 export const useRevokeAuthorizedApp = () => {

--- a/packages/services/src/ui/hooks/queries/useAccountQueries.ts
+++ b/packages/services/src/ui/hooks/queries/useAccountQueries.ts
@@ -205,10 +205,8 @@ export const useUsersBySessions = (sessionIds: string[], options?: { enabled?: b
 };
 
 /**
- * List the authenticated user's authorized RP apps (FedCM grants).
- *
- * Returns the intersection of the user's grants with the currently-approved
- * RP catalog. Drives the "Connected apps" management screen.
+ * List the authenticated user's authorized OAuth applications
+ * (`GET /apps/authorized`). Drives the "Connected apps" management screen.
  */
 export const useAuthorizedApps = (options?: { enabled?: boolean }) => {
   const { oxyServices, activeSessionId, isAuthenticated } = useOxy();

--- a/packages/services/src/ui/screens/ConnectedAppsScreen.tsx
+++ b/packages/services/src/ui/screens/ConnectedAppsScreen.tsx
@@ -120,10 +120,10 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
                         icon={<Avatar name={item.appName} size={APP_ICON_SIZE} />}
                         title={item.appName}
                         description={
-                            t('connectedApps.item.lastUsed', {
+                            t('connectedApps.item.granted', {
                                 relative: formatRelative(item.grantedAt),
                             })
-                            || `Last used ${formatRelative(item.grantedAt)}`
+                            || `Granted ${formatRelative(item.grantedAt)}`
                         }
                         onPress={isRevoking ? undefined : () => confirmRevoke(item)}
                         disabled={isRevoking}

--- a/packages/services/src/ui/screens/ConnectedAppsScreen.tsx
+++ b/packages/services/src/ui/screens/ConnectedAppsScreen.tsx
@@ -39,12 +39,11 @@ const formatRelative = (iso: string): string => {
 };
 
 /**
- * ConnectedAppsScreen — list and revoke FedCM-authorized RP applications.
+ * ConnectedAppsScreen — list and revoke authorized OAuth applications.
  *
- * Fetches via `useAuthorizedApps` (drives `GET /fedcm/me/authorized-apps`)
- * and exposes a "Revoke" action that hits `DELETE /fedcm/me/authorized-apps/
- * :origin`. Each revoke invalidates the connected-apps query so the list
- * refreshes immediately.
+ * Fetches via `useAuthorizedApps` (drives `GET /apps/authorized`) and exposes a
+ * "Revoke" action that hits `DELETE /apps/authorized/:clientId`. Each revoke
+ * invalidates the connected-apps query so the list refreshes immediately.
  */
 const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => {
     const bloomTheme = useTheme();
@@ -59,7 +58,7 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
     const revokeMutation = useRevokeAuthorizedApp();
     const revokeDialog = useDialogControl();
     const [pendingRevoke, setPendingRevoke] = useState<AuthorizedApp | null>(null);
-    const [revokingOrigin, setRevokingOrigin] = useState<string | null>(null);
+    const [revokingClientId, setRevokingClientId] = useState<string | null>(null);
 
     const confirmRevoke = useCallback(
         (app: AuthorizedApp) => {
@@ -74,12 +73,12 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
             return;
         }
         const target = pendingRevoke;
-        setRevokingOrigin(target.origin);
+        setRevokingClientId(target.clientId);
         try {
-            await revokeMutation.mutateAsync(target.origin);
+            await revokeMutation.mutateAsync(target.clientId);
             toast.success(
-                t('connectedApps.toasts.revoked', { name: target.name })
-                || `Revoked access for ${target.name}`,
+                t('connectedApps.toasts.revoked', { name: target.appName })
+                || `Revoked access for ${target.appName}`,
             );
         } catch (error) {
             loggerUtil.warn(
@@ -92,7 +91,7 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
                 || 'Failed to revoke access',
             );
         } finally {
-            setRevokingOrigin(null);
+            setRevokingClientId(null);
             setPendingRevoke(null);
         }
     }, [pendingRevoke, revokeMutation, t]);
@@ -114,17 +113,17 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
 
     const renderItem = useCallback(
         ({ item }: { item: AuthorizedApp }) => {
-            const isRevoking = revokingOrigin === item.origin;
+            const isRevoking = revokingClientId === item.clientId;
             return (
                 <SettingsListGroup>
                     <SettingsListItem
-                        icon={<Avatar name={item.name} size={APP_ICON_SIZE} />}
-                        title={item.name}
+                        icon={<Avatar name={item.appName} size={APP_ICON_SIZE} />}
+                        title={item.appName}
                         description={
                             t('connectedApps.item.lastUsed', {
-                                relative: formatRelative(item.lastUsedAt),
+                                relative: formatRelative(item.grantedAt),
                             })
-                            || `Last used ${formatRelative(item.lastUsedAt)}`
+                            || `Last used ${formatRelative(item.grantedAt)}`
                         }
                         onPress={isRevoking ? undefined : () => confirmRevoke(item)}
                         disabled={isRevoking}
@@ -142,7 +141,7 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
                 </SettingsListGroup>
             );
         },
-        [bloomTheme.colors.error, confirmRevoke, revokingOrigin, t],
+        [bloomTheme.colors.error, confirmRevoke, revokingClientId, t],
     );
 
     return (
@@ -158,7 +157,7 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
             ) : (
                 <FlatList
                     data={apps ?? []}
-                    keyExtractor={(item) => item.origin}
+                    keyExtractor={(item) => item.clientId}
                     renderItem={renderItem}
                     contentContainerClassName="px-screen-margin py-space-16"
                     contentContainerStyle={styles.listContent}
@@ -177,8 +176,8 @@ const ConnectedAppsScreen: React.FC<BaseScreenProps> = ({ onClose, goBack }) => 
                 title={t('connectedApps.confirm.title') || 'Revoke access'}
                 description={
                     pendingRevoke
-                        ? (t('connectedApps.confirm.message', { name: pendingRevoke.name })
-                            || `Revoke ${pendingRevoke.name}'s access to your Oxy account?`)
+                        ? (t('connectedApps.confirm.message', { name: pendingRevoke.appName })
+                            || `Revoke ${pendingRevoke.appName}'s access to your Oxy account?`)
                         : ''
                 }
                 actions={[


### PR DESCRIPTION
## SDK legacy-final sweep (items 1, 2, 4 — item 3 blocked)

Merge-gated on the parallel api+IdP deletion PRs (#77-80). Built against current `origin/main` (has #533/#531/#534-537).

### Item 1 — authorized-apps on AppGrant endpoints
- `OxyServices.authorizedApps` now drives **`GET /apps/authorized`** + **`DELETE /apps/authorized/:clientId`** — the AppGrant successor to the retired `/fedcm/me/authorized-apps`. Exact contract consumed: `GET` → `{data:{apps:[{clientId, appName, appIconUrl?, grantedAt, scopes?}]}}` (HttpService unwraps `{data}`); `DELETE` → 204.
- `AuthorizedApp` reshaped to `{clientId, appName, appIconUrl?, grantedAt, scopes?}`. Method names (`listAuthorizedApps`/`revokeAuthorizedApp`) unchanged so call sites are stable.
- services **ConnectedAppsScreen** + `useAccountQueries`/`useAccountMutations` adapted to the new fields (`origin→clientId`, `name→appName`, `lastUsedAt→grantedAt`; revoke by clientId). Mixin test rewritten for the new endpoints/shape (incl. the null-response guard).

### Item 2 — trimmed-LEGACY re-verification (grepped current main)
| Symbol | Verdict | Why |
|---|---|---|
| `CENTRAL_AUTH_URL` | **deleted** | dead — only core index export + its own test |
| `CENTRAL_IDP_APEX` | kept | LIVE device-first: `@oxyhq/core/server` CORS auto-allow `*.oxy.so` + IdP |
| `SSO_CALLBACK_PATH` | kept | LIVE: api scripts + `sso.controller` (lista B) + IdP + `core/server` |
| `registrableApex` | kept | LIVE: `deviceAuth` (device-first same-apex via `sameSite.ts`), `fedcm.service`, IdP, `core/server` re-export |

- Renamed `fapiAutoDetect.ts` → **`registrableApex.ts`** (the FAPI auto-detect helper is gone; the file is now named for what it is). Updated the core index + `@oxyhq/core/server` re-export. Corrected its header: `registrableApex` is NOT legacy — `deviceAuth` (device-first) is a permanent consumer.

### Item 4 — services verification
ConnectedAppsScreen + queries/mutations compile and pass over the switched mixin; no services test referenced the old fields.

### Item 3 — delete refreshAll* + contracts 0.10.0 — **BLOCKED (STOP-and-reported)**
Not done. `refreshAllResponseSchema` is still live:
- `packages/api/src/utils/__tests__/userTransform.contract.test.ts` validates the **lista-B** `/auth/refresh-all` output against it (that endpoint survives until the ecosystem bump).
- `packages/auth/lib/schemas.ts` still imports + re-exports it, and `packages/auth/lib/__tests__/display-name-mapping.test.ts` still parses `/auth/refresh-all` with it — so the IdP is **not** clean post-#531.

Deleting now breaks the api + IdP. Recommendation: keep `refreshAll*` until `/auth/refresh-all` is retired (or have the api/IdP PRs strip these refs first), then delete in a follow-up. Contracts is therefore **not** bumped to 0.10.0 in this PR.

### Gates
core **677** / auth-sdk **80** / services **205** tests green; core (dual CJS+ESM, `require()`-free) / auth-sdk / services builds green; **console vite build** green; no consumer references `CENTRAL_AUTH_URL` or the old `fapiAutoDetect` path.

### Do NOT merge
Coordinated with the api+IdP deletion PRs (must land first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)