### PR TITLE
perf(api): GET /apps/authorized bulk $in queries (no N+1); align tests to real query shape

### DIFF
--- a/packages/api/src/routes/__tests__/authorizedApps.test.ts
+++ b/packages/api/src/routes/__tests__/authorizedApps.test.ts
@@ -13,7 +13,8 @@ import { AddressInfo } from 'net';
 
 const mockAppGrantFind = jest.fn();
 const mockAppGrantDeleteOne = jest.fn();
-const mockApplicationFindById = jest.fn();
+const mockApplicationFind = jest.fn();
+const mockCredentialFind = jest.fn();
 const mockCredentialFindOne = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
@@ -32,13 +33,19 @@ jest.mock('../../models/AppGrant', () => ({
 }));
 jest.mock('../../models/Application', () => ({
   __esModule: true,
-  Application: { findById: (...a: unknown[]) => mockApplicationFindById(...a) },
-  default: { findById: (...a: unknown[]) => mockApplicationFindById(...a) },
+  Application: { find: (...a: unknown[]) => mockApplicationFind(...a) },
+  default: { find: (...a: unknown[]) => mockApplicationFind(...a) },
 }));
 jest.mock('../../models/ApplicationCredential', () => ({
   __esModule: true,
-  ApplicationCredential: { findOne: (...a: unknown[]) => mockCredentialFindOne(...a) },
-  default: { findOne: (...a: unknown[]) => mockCredentialFindOne(...a) },
+  ApplicationCredential: {
+    find: (...a: unknown[]) => mockCredentialFind(...a),
+    findOne: (...a: unknown[]) => mockCredentialFindOne(...a),
+  },
+  default: {
+    find: (...a: unknown[]) => mockCredentialFind(...a),
+    findOne: (...a: unknown[]) => mockCredentialFindOne(...a),
+  },
 }));
 jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
 
@@ -71,12 +78,12 @@ afterAll((done) => { server.close(done); });
 beforeEach(() => { jest.clearAllMocks(); });
 
 describe('GET /apps/authorized', () => {
-  it('returns the connected apps with clientId/appName/appIconUrl/grantedAt/scopes', async () => {
+  it('returns the connected apps, resolving applications + client_ids in BULK $in queries', async () => {
     mockAppGrantFind.mockReturnValueOnce(sortLean([
       { applicationId: 'app-1', scopes: ['read', 'write'], firstGrantedAt: new Date('2026-01-01T00:00:00.000Z') },
     ]));
-    mockApplicationFindById.mockReturnValueOnce(lean({ name: 'Acme', icon: 'https://cdn/acme.png' }));
-    mockCredentialFindOne.mockReturnValueOnce({ select: () => ({ lean: () => Promise.resolve({ publicKey: 'oxy_dk_acme' }) }) });
+    mockApplicationFind.mockReturnValueOnce(lean([{ _id: 'app-1', name: 'Acme', icon: 'https://cdn/acme.png' }]));
+    mockCredentialFind.mockReturnValueOnce(lean([{ applicationId: 'app-1', publicKey: 'oxy_dk_acme' }]));
 
     const res = await request(server, 'GET', '/apps/authorized');
 
@@ -88,6 +95,11 @@ describe('GET /apps/authorized', () => {
         ],
       },
     });
+    // BULK — exactly one Application.find + one ApplicationCredential.find, never
+    // a per-grant findById/findOne loop.
+    expect(mockApplicationFind).toHaveBeenCalledTimes(1);
+    expect(mockCredentialFind).toHaveBeenCalledTimes(1);
+    expect(mockApplicationFind).toHaveBeenCalledWith({ _id: { $in: ['app-1'] } });
   });
 
   it('skips a grant whose application or public credential no longer resolves', async () => {
@@ -95,15 +107,24 @@ describe('GET /apps/authorized', () => {
       { applicationId: 'gone', scopes: [], firstGrantedAt: new Date() },
       { applicationId: 'no-cred', scopes: [], firstGrantedAt: new Date() },
     ]));
-    // First app is gone (null); second app resolves but has no public credential.
-    mockApplicationFindById
-      .mockReturnValueOnce(lean(null))
-      .mockReturnValueOnce(lean({ name: 'NoCred' }));
-    mockCredentialFindOne.mockReturnValueOnce({ select: () => ({ lean: () => Promise.resolve(null) }) });
+    // 'gone' is absent from the bulk Application result; 'no-cred' resolves but
+    // has no active public credential in the bulk credential result.
+    mockApplicationFind.mockReturnValueOnce(lean([{ _id: 'no-cred', name: 'NoCred' }]));
+    mockCredentialFind.mockReturnValueOnce(lean([]));
 
     const res = await request(server, 'GET', '/apps/authorized');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ data: { apps: [] } });
+  });
+
+  it('returns an empty list WITHOUT querying applications when the user has no grants', async () => {
+    mockAppGrantFind.mockReturnValueOnce(sortLean([]));
+
+    const res = await request(server, 'GET', '/apps/authorized');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ data: { apps: [] } });
+    expect(mockApplicationFind).not.toHaveBeenCalled();
+    expect(mockCredentialFind).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/routes/authorizedApps.ts
+++ b/packages/api/src/routes/authorizedApps.ts
@@ -71,20 +71,47 @@ router.get(
       scopes?: string[];
     }> = [];
 
+    if (grants.length === 0) {
+      res.json({ data: { apps } });
+      return;
+    }
+
+    // BULK-resolve the applications + their representative public client_ids in
+    // two `$in` queries (NOT N+1 per grant). `applicationId` is unique per grant
+    // (one grant row per user+application).
+    const applicationIds = grants.map((grant) => grant.applicationId);
+
+    const applications = await Application.find({ _id: { $in: applicationIds } })
+      .select('name icon')
+      .lean();
+    const appById = new Map(applications.map((app) => [app._id.toString(), app]));
+
+    const credentials = await ApplicationCredential.find({
+      applicationId: { $in: applicationIds },
+      type: 'public',
+      status: 'active',
+    })
+      .select('applicationId publicKey')
+      .lean();
+    // First active public credential per application wins (a stable, representative
+    // client_id); later credentials for the same app are ignored.
+    const clientIdByApp = new Map<string, string>();
+    for (const credential of credentials) {
+      const key = credential.applicationId.toString();
+      if (credential.publicKey && !clientIdByApp.has(key)) {
+        clientIdByApp.set(key, credential.publicKey);
+      }
+    }
+
     for (const grant of grants) {
-      const app = await Application.findById(grant.applicationId).select('name icon').lean();
-      if (!app) continue;
-      const credential = await ApplicationCredential.findOne({
-        applicationId: grant.applicationId,
-        type: 'public',
-        status: 'active',
-      })
-        .select('publicKey')
-        .lean();
-      if (!credential?.publicKey) continue;
+      const key = grant.applicationId.toString();
+      const app = appById.get(key);
+      const clientId = clientIdByApp.get(key);
+      // Skip a grant whose app or public credential no longer resolves (orphaned).
+      if (!app || !clientId) continue;
 
       apps.push({
-        clientId: credential.publicKey,
+        clientId,
         appName: app.name,
         ...(typeof app.icon === 'string' && app.icon.length > 0 ? { appIconUrl: app.icon } : {}),
         grantedAt: new Date(grant.firstGrantedAt).toISOString(),


### PR DESCRIPTION
## Deferred Gemini MEDIUM follow-up (non-blocking) — authorizedApps

Verified the route's REAL query shape first: `GET /apps/authorized` read grants in one `AppGrant.find` but then did a **per-grant** `Application.findById` + `ApplicationCredential.findOne` — an N+1 (2N+1 queries) for a list endpoint. (The prior tests *did* faithfully mock that N+1 chain — not a mock-green≠real-green bug — but the underlying N+1 is the real substance of the finding.)

### Fix
Bulk-resolve applications + their representative active-public `client_id`s in **two `$in` queries**, mapped in memory — **3 queries total, independent of grant count**. Early-return before any join when the user has no grants. Behaviour is identical: same skip-orphaned-grant semantics, same first-active-public-credential-per-app `clientId`.

### Tests
Rewrote the GET tests onto the bulk `Application.find` / `ApplicationCredential.find` shape, asserting **exactly one** bulk call each (proving no per-grant loop) + the `_id: { $in: [...] }` filter + the no-grants short-circuit (no join queries). The DELETE handler is inherently single-key and unchanged.

Full api suite green (145 suites / 1346 tests), `tsc` + `eslint` clean. Only `authorizedApps.ts` + its test changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)