### PR TITLE
fix(auth): restore IdP worker execution — /api/device-accounts serves JSON not SPA

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -59,15 +59,20 @@ jobs:
       # `build:worker`.
       - run: bun x turbo run build --filter=auth
       # Safety net: regenerate the Pages Function directly (bypasses any stale
-      # turbo cache) and fail fast if the advanced-mode worker is missing, so we
-      # never deploy a static-only build that serves SPA HTML for the dynamic
-      # /api/device-accounts feed.
-      - name: Ensure the Pages Function is built
+      # turbo cache) and fail fast if the advanced-mode worker OR its routing
+      # manifest is missing, so we never deploy a static-only build that serves
+      # SPA HTML for the dynamic /api/device-accounts feed. `_routes.json`
+      # (`public/_routes.json` copied by Vite) is REQUIRED — it forces CF Pages to
+      # invoke `_worker.js` for `/api/*` instead of falling through to the static
+      # SPA (the incident #539 hit: worker present but not invoked → SPA HTML).
+      - name: Ensure the Pages Function + routes manifest are built
         working-directory: packages/auth
         run: |
           bun run build:worker
           test -f dist/_worker.js || { echo "::error::dist/_worker.js missing — the /api/device-accounts feed would not deploy"; exit 1; }
+          test -f dist/_routes.json || { echo "::error::dist/_routes.json missing — CF Pages would serve SPA HTML for /api/device-accounts (worker not invoked)"; exit 1; }
           echo "dist/_worker.js present ($(wc -c < dist/_worker.js) bytes)"
+          echo "dist/_routes.json: $(cat dist/_routes.json | tr -d '\n ')"
       - uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/packages/auth/public/_routes.json
+++ b/packages/auth/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/api/*"],
+  "exclude": []
+}


### PR DESCRIPTION
## Prod incident fix-forward — auth.oxy.so worker not invoked after #539

After #539 merged, the `oxy-auth` Cloudflare Pages deploy served **static SPA HTML for every path**, including the dynamic `GET /api/device-accounts` chooser feed (it returned JSON before, after #531). Impact was limited to the auth.oxy.so third-party-OAuth authorize chooser — accounts/console/apps hit api.oxy.so directly and were unaffected.

### Root cause (ruled out the code — it's correct)
I reproduced locally and eliminated all three code hypotheses:
1. **Entry/format** — the built `dist/_worker.js` (22KB) has a valid module-worker default export (`export default { async fetch(req, env, ctx) }`). ✅
2. **Routing** — running the built worker, `/api/device-accounts` returns `200 application/json {accounts:[]}` and `/login` / `/.well-known/web-identity` fall through to `env.ASSETS` (SPA). The app route matches. ✅
3. **Empty stub** — the 22KB worker executes real logic. ✅

So the worker code + build are correct; **CF Pages simply wasn't invoking the advanced-mode `_worker.js`** and served the static SPA instead (SPA history-fallback to `index.html`) for the dynamic route. The deploy relied on CF Pages' implicit "advanced-mode worker handles `/*`" default, with **no explicit `_routes.json`**.

### Fix
Ship **`packages/auth/public/_routes.json`** (Vite copies `public/*` → `dist/`):
```json
{ "version": 1, "include": ["/api/*"], "exclude": [] }
```
This EXPLICITLY routes `/api/*` to the Function and leaves every other path to CF Pages' static + SPA-fallback serving — the documented mechanism to control Function invocation, removing the reliance on CF's default heuristic. It also means the worker is no longer invoked for static SPA requests (faster).

Hardened the deploy guard to fail fast if `dist/_routes.json` is missing (alongside the existing `dist/_worker.js` check).

### Verified locally
- `bun run build` emits `dist/_routes.json` + `dist/_worker.js`.
- Running the built `_worker.js`: `/api/device-accounts` → `200 application/json {accounts:[]}`; `/login` → SPA HTML via ASSETS.
- `packages/auth` bun test: **64 pass / 0 fail**.

Once merged + deployed, re-verify live: `GET https://auth.oxy.so/api/device-accounts` should be `200 application/json {accounts:[]}` (not SPA HTML), and the smoke gate's `device-accounts feed` check should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)