### PR TITLE
fix(auth): deploy IdP via bunx wrangler, not wrangler-action (npm EOVERRIDE)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -68,14 +68,19 @@ jobs:
         run: bunx wrangler@4 pages functions build functions --outfile "$RUNNER_TEMP/functions-worker.js"
       # Deploy from packages/auth so wrangler picks up the sibling `functions/`
       # directory (CF Pages compiles `./functions` relative to the CWD) alongside
-      # the `dist` static assets. Pinned wrangler 4.
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          wranglerVersion: '4'
-          workingDirectory: packages/auth
-          command: pages deploy dist --project-name=oxy-auth --branch=main
+      # the `dist` static assets. Invoke `bunx wrangler` DIRECTLY rather than
+      # cloudflare/wrangler-action: that action's `npx --no-install wrangler`
+      # path runs npm's Arborist from packages/auth, which rejects the repo-root
+      # `overrides["@oxyhq/bloom"]` against this package's newer direct bloom dep
+      # (`npm error code EOVERRIDE`). The whole monorepo installs with bun, and
+      # bun's resolver does not perform that npm-only override validation — the
+      # compile step above already proves `bunx wrangler@4` runs clean here.
+      - name: Deploy to Cloudflare Pages
+        working-directory: packages/auth
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler@4 pages deploy dist --project-name=oxy-auth --branch=main
       # Post-deploy smoke gate: hit the LIVE host and assert the post-FedCM
       # contract on PUBLIC, unauthenticated endpoints only (no secrets). A broken
       # deploy (blank SPA, missing _worker.js / static-only serving SPA HTML for


### PR DESCRIPTION
## Problem

#545 (Pages Functions migration) merged, but the **auth deploy step failed** — prod still serves the old advanced-mode deployment (`/_worker.js` → 200, `/api/device-accounts` → SPA HTML).

Exact CI error at the wrangler step:
```
npm error code EOVERRIDE
Override for @oxyhq/bloom@^0.24.1 conflicts with direct dependency
```

## Root cause

#545 set `workingDirectory: packages/auth` on `cloudflare/wrangler-action` so wrangler picks up the sibling `functions/` dir (CF Pages compiles `./functions` relative to CWD). That action installs wrangler via `npx --no-install`, which runs npm's **Arborist** from `packages/auth`. Arborist rejects the repo-root `overrides["@oxyhq/bloom"]="^0.20.0"` against this package's direct `@oxyhq/bloom@^0.24.1` — npm forbids an override that contradicts a direct dep. The whole monorepo installs with **bun**, whose resolver does not perform that npm-only validation, so this only surfaces on the npx path.

## Fix

Replace the `cloudflare/wrangler-action@v3` step with a direct `bunx wrangler@4 pages deploy dist` `run:` step — same `working-directory: packages/auth`, same project/branch/wrangler-4, CF token + account passed via `env`. This sidesteps npm entirely. The existing **"Verify Pages Functions compile"** step already runs `bunx wrangler@4` from `packages/auth` and passes, proving this path is clean.

Scope: auth job only. The accounts/inbox/console deploy steps keep `wrangler-action` (they run from repo root with no `workingDirectory`, so they never hit EOVERRIDE).

## Verification
- `bun test lib/__tests__ components/__tests__` → 68 pass / 0 fail
- `bunx wrangler@4 pages functions build functions` → ✨ Compiled Worker successfully
- YAML parses; compile guard + post-deploy smoke gate unchanged.

The real test is the live deploy reaching "Deploying..." instead of EOVERRIDE, then `/api/device-accounts` → JSON and `/_worker.js` → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)