### PR TITLE
chore: sweep stale FedCM/SSO comments post-wave-2 deletion

### DIFF
--- a/packages/accounts/app/(auth)/index.tsx
+++ b/packages/accounts/app/(auth)/index.tsx
@@ -13,15 +13,15 @@ import { CREATE_ACCOUNT_HELP_URL } from '@/constants/auth';
  * Accounts owns no sign-in UI of its own. Authentication is an ecosystem
  * concern, so this screen is a thin branded shell — logo, welcome copy, and a
  * single "Sign in with Oxy" button — that hands off entirely to the SDK's
- * `SignInModal` (mounted globally by `OxyProvider`). That modal owns every auth
- * path: the "Continue with Oxy" IdP popup (which internally offers password,
- * social, etc.), the same-device deep-link handoff to the Oxy app, and the
- * cross-device QR. There is no app-local password form, 2FA step, or FedCM path
- * here — the SDK is the single sign-in authority.
+ * in-app `SignInModal` (mounted globally by `OxyProvider`). That modal owns
+ * every auth path: the first-party password + optional-2FA flow as the
+ * primary action, plus the cross-app device flow (same-device deep-link +
+ * "sign in on another device" QR) as a secondary option. There is no
+ * app-local password form, 2FA step, or IdP redirect here — the SDK is the
+ * single sign-in authority, and it never navigates away from the app.
  *
- * Cross-domain web restore (per-apex `/auth/silent` iframe + `/sso` bounce) is
- * owned entirely by the SDK's `OxyProvider` cold boot — this screen never wires
- * it.
+ * Cross-domain restore is device-first, owned entirely by the SDK's
+ * `OxyProvider` cold boot (`runSessionColdBoot`) — this screen never wires it.
  *
  * The root Stack (`app/_layout.tsx`) owns the `(auth)`↔`(tabs)` swap keyed on
  * session, so this screen never navigates across that boundary itself: it

--- a/packages/accounts/app/(tabs)/family.tsx
+++ b/packages/accounts/app/(tabs)/family.tsx
@@ -20,7 +20,7 @@ function isAbsoluteUrl(value: string): boolean {
 /**
  * Third-party connections (the visible `family` drawer route, labelled
  * `drawer.thirdParty`): lists the third-party apps and services the user has
- * authorized against their Oxy account via the OAuth/FedCM consent flow
+ * authorized against their Oxy account via the OAuth consent flow
  * (`oxyServices.listConnectedApps()` → `GET /auth/grants`) and lets them revoke
  * any grant. The data + revoke logic live in the shared {@link useConnectedApps}
  * / {@link useRevokeAppGrant} hooks so the security-screen summary reuses the

--- a/packages/api/scripts/register-commons-clients.ts
+++ b/packages/api/scripts/register-commons-clients.ts
@@ -7,9 +7,9 @@
  *      `OxyProvider clientId` (`EXPO_PUBLIC_OXY_CLIENT_ID` in
  *      `packages/commons/constants/oxy.ts`) must be a real registered public
  *      `ApplicationCredential`.
- *   2. Oxy Auth        — the FedCM IdP app, which now ALSO acts as its own
- *      Relying Party for the Sign-in-with-Oxy QR handoff and therefore needs a
- *      public client id + its own redirect origins.
+ *   2. Oxy Auth        — the third-party OAuth IdP app, which ALSO acts as its
+ *      own Relying Party for the Sign-in-with-Oxy QR handoff and therefore
+ *      needs a public client id + its own redirect origins.
  *
  * Both Applications live in the production "Oxy" team workspace, owned by the
  * platform user `oxy`. For each app this UPSERTS (never duplicates on re-run):
@@ -110,11 +110,17 @@ const CLIENTS: ClientSpec[] = [
     key: 'AUTH_IDP_CLIENT_ID',
     name: 'Oxy Auth',
     description:
-      'Official Oxy authentication app and FedCM Identity Provider, acting as its own Relying Party for Sign in with Oxy.',
+      'Official Oxy authentication app and third-party OAuth Identity Provider, acting as its own Relying Party for Sign in with Oxy.',
     websiteUrl: 'https://auth.oxy.so',
     type: 'first_party',
     // The IdP now consumes Sign-in-with-Oxy as an RP, so it needs its own origin
-    // + SSO callback registered. UNIONed into any existing redirectUris.
+    // + callback registered. UNIONed into any existing redirectUris.
+    // NOTE (found during the wave-2 comment sweep, NOT fixed here — logic, not
+    // a comment): `cb()` below builds `${origin}${SSO_CALLBACK_PATH}`, i.e.
+    // `https://auth.oxy.so/__oxy/sso-callback` — the deleted SSO-bounce
+    // callback path. If Oxy Auth's own RP flow no longer consumes that path,
+    // this redirectUri may be seeding a dead route; needs an engineer decision
+    // + a live check of what path the QR/Commons RP flow actually redeems.
     redirectUris: ['https://auth.oxy.so', cb('https://auth.oxy.so')],
     scopes: ['user:read'],
   },

--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -113,11 +113,21 @@ const SEED_APPS: SeedAppSpec[] = [
   },
   {
     name: 'Oxy Auth',
-    description: 'Official Oxy authentication app and FedCM Identity Provider.',
+    description: 'Official Oxy authentication app and third-party OAuth Identity Provider.',
     websiteUrl: 'https://auth.oxy.so',
     type: 'first_party',
-    // The auth app is the central IdP, but it now ALSO consumes Sign-in-with-Oxy
-    // as its own Relying Party, so it registers its own origin + SSO callback.
+    // The auth app is the third-party OAuth IdP, but it now ALSO consumes
+    // Sign-in-with-Oxy as its own Relying Party, so it registers its own
+    // origin + callback.
+    // NOTE (found during the wave-2 comment sweep, NOT fixed here — logic,
+    // not a comment): `cb()` (defined above) hardcodes `SSO_CALLBACK_PATH =
+    // '/__oxy/sso-callback'` — the deleted SSO-bounce callback path — as the
+    // registered redirectUri for EVERY official app this script seeds, not
+    // just this one. That path is only ever used for its ORIGIN in current
+    // trust derivation (`dynamicOriginRegistry` extracts origins, not exact
+    // paths), so this is likely harmless dead configuration rather than a
+    // functional break, but it needs an engineer decision + verification
+    // before re-running this script for a new official app.
     redirectUris: ['https://auth.oxy.so', cb('https://auth.oxy.so')],
   },
   // ── Ecosystem first-party apps ──

--- a/packages/api/src/config/dynamicOriginRegistry.ts
+++ b/packages/api/src/config/dynamicOriginRegistry.ts
@@ -4,9 +4,10 @@
  * Registering an Application in OxyConsole (with `redirectUris`) must
  * automatically authorize that app's origin for CORS, with NO code change. The
  * trust gate is the canonical {@link isTrustedApplication} predicate — the SAME
- * staff-controlled boundary FedCM/SSO uses — NOT `status: 'active'` (every
- * self-service third-party app is active too, so `active` alone is never a
- * trust boundary).
+ * staff-controlled boundary the OAuth consent auto-approve decision and the
+ * device-first bootstrap `return_to` validation use — NOT `status: 'active'`
+ * (every self-service third-party app is active too, so `active` alone is
+ * never a trust boundary).
  *
  * Two snapshots are maintained in memory and swapped atomically on refresh:
  *  - `trustedOrigins`     — first-party / internal / system / official apps

--- a/packages/api/src/middleware/originGuard.ts
+++ b/packages/api/src/middleware/originGuard.ts
@@ -2,11 +2,11 @@
  * Origin Guard Middleware (MED-1 CSRF hardening, Phase A)
  *
  * Browser-enforced CSRF defence for cookie-credentialed auth endpoints
- * (`/auth/refresh`, `/auth/session`, `/auth/logout`). Browsers attach the
- * `Origin` header automatically on cross-origin (and all non-GET) requests
- * and it cannot be forged from a page, so requiring an allowlisted Origin
- * blocks cross-site requests even when the `oxy_rt` cookie would otherwise
- * ride along.
+ * (`/auth/device/web-session`, `/auth/logout`, `/auth/recover/reset`, and the
+ * `session/device` routes). Browsers attach the `Origin` header automatically
+ * on cross-origin (and all non-GET) requests and it cannot be forged from a
+ * page, so requiring an allowlisted Origin blocks cross-site requests even
+ * when the `oxy_device` cookie would otherwise ride along.
  *
  * Decision table for non-safe methods (POST/PUT/PATCH/DELETE):
  *  - `Origin` present + allowlisted                       → allow

--- a/packages/api/src/middleware/rateLimiter.ts
+++ b/packages/api/src/middleware/rateLimiter.ts
@@ -11,7 +11,7 @@ interface RateLimitOptions {
    * that flows through more than one of them increments the same counter
    * multiple times (express-rate-limit emits `ERR_ERL_DOUBLE_COUNT` and the
    * effective per-IP budget is silently halved). Use a short, stable, unique
-   * string per call site, e.g. `'auth:challenge:'`, `'fedcm:nonce:'`.
+   * string per call site, e.g. `'auth:challenge:'`, `'auth:device:bootstrap:'`.
    */
   prefix: string;
   windowMs: number;

--- a/packages/api/src/middleware/security.ts
+++ b/packages/api/src/middleware/security.ts
@@ -57,9 +57,9 @@ export function isIdpServiceToServicePath(path: string): boolean {
 // General rate limiting middleware (exclude file uploads). The previous
 // ceiling of 150/15min was below what a single signed-in user generates
 // against the API in normal usage (feed scrolling, profile loads, sockets'
-// REST fallback, FedCM exchanges), which surfaced as misleading 429s on
-// unrelated endpoints. The userRateLimiter below still caps per-account
-// traffic. IdP worker server-to-server paths are skipped (see
+// REST fallback, device-first refresh/bootstrap calls), which surfaced as
+// misleading 429s on unrelated endpoints. The userRateLimiter below still caps
+// per-account traffic. IdP worker server-to-server paths are skipped (see
 // isIdpServiceToServicePath) so shared-egress traffic never exhausts this budget.
 const rateLimiter = rateLimit({
   ...makeStore('rl:general:'),
@@ -73,11 +73,14 @@ const rateLimiter = rateLimit({
 });
 
 // Dedicated high-ceiling limiter for the IdP worker's server-to-server READ
-// calls (see isIdpServiceToServicePath). Because those paths are skipped by
-// rl:general, this is their SOLE per-IP budget. The ceiling is deliberately
-// high: each hit is the shared Cloudflare Worker egress fanning MANY users'
-// FedCM/SSO flows through one IP, not a single browser — yet it still bounds a
-// runaway or compromised caller. Unique prefix (`rl:fedcm:service:`) keeps its
+// calls (see isIdpServiceToServicePath: /session/validate/* and
+// /auth/device/resolve, the device-account chooser feed's lookup). Because
+// those paths are skipped by rl:general, this is their SOLE per-IP budget.
+// The ceiling is deliberately high: each hit is the shared Cloudflare Worker
+// egress fanning MANY users' device-first/IdP-chooser calls through one IP,
+// not a single browser — yet it still bounds a runaway or compromised caller.
+// Unique prefix (`rl:fedcm:service:` — name predates the wave-2 FedCM
+// deletion, kept as-is to avoid an unnecessary Redis key migration) keeps its
 // counter distinct from every other limiter (no ERR_ERL_DOUBLE_COUNT).
 const idpServiceLimiter = rateLimit({
   ...makeStore('rl:fedcm:service:'),

--- a/packages/api/src/models/RefreshToken.ts
+++ b/packages/api/src/models/RefreshToken.ts
@@ -3,19 +3,19 @@ import mongoose, { Document, Schema } from "mongoose";
 /**
  * RefreshToken Model
  *
- * Backs the first-party httpOnly refresh-token cookie that enables secure
- * cold-boot session persistence. When a user signs in (password, FedCM, or
- * public-key flow) the server mints an opaque refresh token, stores ONLY its
- * SHA-256 hash here, and drops the raw token into an httpOnly + Secure cookie
- * scoped to `/auth` (so it reaches `/auth/session`, `/auth/refresh`, and
- * `/auth/logout`). On a cold boot the browser replays the cookie to
- * `POST /auth/refresh`, which rotates the token and mints a fresh access token
- * — no bearer credential ever lives in JS-readable storage.
+ * Backs the device-first persisted-refresh lane (see
+ * `services/refreshToken.service.ts`). When a user signs in (password, public
+ * key, or a device exchange) the server mints an opaque refresh token, stores
+ * ONLY its SHA-256 hash here, and hands the raw token to the client, which
+ * persists it itself (web localStorage / native SecureStore) — this is a
+ * body-based rotation, not a cookie. The client rotates it via
+ * `POST /auth/refresh-token` (`deviceAuth.ts`), which consumes the presented
+ * token and mints a fresh access token + the next token in the family.
  *
  * Security model:
- * - Rotation: every successful `/auth/refresh` consumes the presented token
- *   (sets `usedAt`) and issues a brand-new token in the SAME `family` with a
- *   fresh sliding expiry. A refresh token is therefore strictly single-use.
+ * - Rotation: every successful rotation consumes the presented token (sets
+ *   `usedAt`) and issues a brand-new token in the SAME `family` with a fresh
+ *   sliding expiry. A refresh token is therefore strictly single-use.
  * - Reuse-detection = theft signal: a refresh token that is presented AFTER it
  *   has already been consumed (`usedAt` set) can only mean the token leaked and
  *   both the legitimate client and an attacker now hold copies. We treat this as
@@ -24,7 +24,7 @@ import mongoose, { Document, Schema } from "mongoose";
  *   is the OWASP-recommended refresh-token-rotation defense.
  * - Hash-only storage: the raw token is a bearer credential, so we persist only
  *   its SHA-256 hash (`tokenHash`, unique). Leakage of this collection cannot be
- *   replayed against `/auth/refresh` because the attacker never sees a raw token.
+ *   replayed at `/auth/refresh-token` because the attacker never sees a raw token.
  * - Sliding expiry: each rotation extends `expiresAt` by the 30-day TTL, so an
  *   actively-used session stays signed in indefinitely while an abandoned one
  *   lapses after 30 days of inactivity.

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -389,13 +389,11 @@ router.post(
       throw new Error('Failed to format account data');
     }
 
-    // The device multi-account refresh cookie is deliberately NOT set here — see
-    // the route docstring. The `oxy_rt_<authuser>` cookies are `Path=/auth`
-    // scoped, so this `/accounts/*` route never receives them; issuing one blind
-    // would always pick slot 0 and overwrite the operator's own primary session.
-    // The SDK plants the returned `accessToken` and establishes the cookie via
-    // `POST /auth/session` (under `/auth`, where the slots are visible) so the
-    // switched session lands in a correctly-allocated NEW slot.
+    // No cookie is planted here — the device-set registration above
+    // (`deviceSessionService.addAccount` + `broadcastDeviceState`) is what makes
+    // the switch survive reload and sync cross-domain via the socket room. The
+    // SDK plants the returned `accessToken` directly; there is no separate
+    // cookie-establishing round trip.
 
     // Mirror the canonical login / claimSession response shape.
     const response: SessionAuthResponse = {

--- a/packages/api/src/routes/applications.ts
+++ b/packages/api/src/routes/applications.ts
@@ -546,7 +546,7 @@ router.post(
     });
 
     // A newly-created app is `active` and may carry redirectUris, so it can add
-    // origins to the FedCM/SSO approved-clients allow-list. Drop the cached set.
+    // origins to the approved-clients allow-list. Drop the cached set.
     if (application.status === 'active' && (application.redirectUris?.length ?? 0) > 0) {
       approvedClientsCache.invalidate();
       refreshDynamicCorsOrigins();
@@ -662,7 +662,7 @@ router.patch(
     // status stop authorising federation signing immediately.
     credentialDomainCache.invalidate(application._id.toString());
 
-    // The FedCM/SSO approved-clients allow-list is ALSO derived from active
+    // The approved-clients allow-list is ALSO derived from active
     // Applications' redirectUris — drop the cached origin set.
     approvedClientsCache.invalidate();
     refreshDynamicCorsOrigins();
@@ -696,7 +696,7 @@ router.delete(
 
     // A deleted app must immediately stop authorising federation signing.
     credentialDomainCache.invalidate(application._id.toString());
-    // Likewise drop the FedCM/SSO approved-clients origin set.
+    // Likewise drop the approved-clients origin set.
     approvedClientsCache.invalidate();
     refreshDynamicCorsOrigins();
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2291,10 +2291,8 @@ router.get(
  *       - Authentication
  *     summary: Revoke a connected app's OAuth grant
  *     description: >
- *       Deletes the user's AppGrant for the application so the next sign-in
- *       prompts for consent again. ALSO deletes any FedCMGrant rows for the
- *       user whose origin matches one of the app's registered redirect origins,
- *       so silent FedCM/SSO stops resolving for that app too.
+ *       Deletes the user's AppGrant for the application so the next OAuth
+ *       authorize for this app prompts for consent again.
  *     security:
  *       - bearerAuth: []
  *     parameters:

--- a/packages/api/src/routes/deviceAuth.ts
+++ b/packages/api/src/routes/deviceAuth.ts
@@ -19,8 +19,11 @@
  *                                   chooser.
  *
  * The legacy `/sso*`, `/fedcm/*`, `/auth/refresh`, `/auth/refresh-all`,
- * `/auth/session`, and `oxy_rt` cookie machinery are BYTE-UNTOUCHED — everything
- * here is new surface. NO token or deviceId is ever placed in a URL/query/
+ * `/auth/session`, and `oxy_rt` cookie machinery were left byte-untouched when
+ * this router was first added (this surface was purely additive); a later
+ * cleanup pass deleted all of that legacy surface entirely once every
+ * consuming app had migrated — this router is now the sole session-bootstrap
+ * surface. NO token or deviceId is ever placed in a URL/query/
  * fragment/response-body of these endpoints (the cookie secret ≠ deviceId, the
  * boot code is opaque, and the deviceToken is opaque).
  */

--- a/packages/api/src/routes/federation.ts
+++ b/packages/api/src/routes/federation.ts
@@ -31,7 +31,7 @@ const REQUIRED_SCOPE = 'federation:write';
  * Uncached loader for the federation domains a given Application may sign for.
  *
  * SECURITY BOUNDARY (see {@link credentialDomainCache}): there is no explicit
- * federation-domain field on the Application, so — mirroring the FedCM
+ * federation-domain field on the Application, so — mirroring the
  * approved-clients derivation — we take the hostnames of the Application's
  * `redirectUris` as the set of domains its credentials may operate on. Only
  * `active` applications qualify; a suspended/deleted/pending app yields an empty

--- a/packages/api/src/scripts/grantMentionFederationAssetScope.ts
+++ b/packages/api/src/scripts/grantMentionFederationAssetScope.ts
@@ -30,7 +30,7 @@
  * CACHE: service-token scopes are read FRESH from Mongo on every
  * `POST /auth/service-token` mint — there is NO scope cache to bust. The change
  * takes effect on the credential's next token mint. (`approvedClientsCache` is
- * unrelated: it caches FedCM approved client ORIGINS derived from Application
+ * unrelated: it caches approved-client ORIGINS derived from Application
  * `redirectUris`, not service-token scopes.)
  *
  * SAFETY:

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -408,16 +408,18 @@ class SessionService {
   ): Promise<ISession> {
     try {
       const { deviceName, deviceFingerprint, stableDeviceKey, deviceId: explicitDeviceId, operatedByUserId } = options;
-      // For IdP/FedCM-issued sessions the request is a server-to-server call
-      // from the IdP (UA = 'unknown', egress IP varies per call), so the
+      // For a server-to-server session mint where the request itself carries no
+      // stable client identity (UA = 'unknown', egress IP varies per call), the
       // UA/IP-derived deviceId would be random every time and sprawl a new
       // session per exchange. When a `stableDeviceKey` is supplied, derive a
       // deterministic deviceId from (userId, key) and feed it as the provided
       // deviceId so `extractDeviceInfo` skips the UA/IP derivation entirely —
-      // one (user, RP) then reuses a single session via the lookup below. An
-      // explicit `deviceId` (e.g. threaded from a FedCM id_token claim) wins
-      // over the derived stable id, letting the caller stamp a unified central
-      // device id verbatim. Precedence: deviceId > stableDeviceKey > UA/IP > random.
+      // one (user, RP) then reuses a single session via the lookup below (no
+      // current caller passes `stableDeviceKey`; see `SessionCreateOptions`).
+      // An explicit `deviceId` — e.g. the account-switch route threading the
+      // operator's own central deviceId onto the minted managed-account
+      // session — wins over the derived stable id, letting the caller stamp a
+      // unified central device id verbatim. Precedence: deviceId > stableDeviceKey > UA/IP > random.
       // The origin-derived stable id (per (user, RP)). Kept SEPARATELY from the
       // attribution id below so we can still locate a LEGACY per-origin session
       // — one minted before deviceId unification, pinned to this synthetic
@@ -436,9 +438,9 @@ class SessionService {
       // stable deviceId MUST win. Running the `deviceFingerprint` →
       // `registerDevice` override below would call `findExistingDeviceId` and
       // could silently replace the stable id with a fingerprint-matched one,
-      // re-introducing the FedCM session-sprawl this fix exists to prevent.
-      // So we skip that path entirely on the stable-key branch. If a future
-      // caller passes BOTH, `stableDeviceKey` takes precedence and the
+      // re-introducing the per-exchange session-sprawl this branch exists to
+      // prevent. So we skip that path entirely on the stable-key branch. If a
+      // future caller passes BOTH, `stableDeviceKey` takes precedence and the
       // `deviceFingerprint` is ignored (with a single dev warning).
       if (stableId) {
         if (deviceFingerprint) {

--- a/packages/api/src/types/session.types.ts
+++ b/packages/api/src/types/session.types.ts
@@ -18,10 +18,12 @@ export interface SessionCreateOptions {
   deviceFingerprint?: DeviceFingerprintInput;
   /**
    * When set, the session's deviceId is derived deterministically from
-   * (userId, stableDeviceKey) via `deriveServiceDeviceId` — used for
-   * IdP/FedCM-issued sessions so one (user, RP) reuses a single session. The
-   * request's IP/UA are NOT used for the deviceId on this path. Real device
-   * logins (no stableDeviceKey) are unaffected.
+   * (userId, stableDeviceKey) via `deriveServiceDeviceId` so one (user, RP)
+   * reuses a single session, independent of request IP/UA. Originally added
+   * for IdP/FedCM-issued sessions; no current call site passes this option
+   * post-wave-2 (kept for any future server-minted-session caller that needs
+   * the same stable-per-RP-session property). Real device logins (no
+   * stableDeviceKey) are unaffected.
    */
   stableDeviceKey?: string;
   /**

--- a/packages/api/src/utils/approvedClientsCache.ts
+++ b/packages/api/src/utils/approvedClientsCache.ts
@@ -2,8 +2,8 @@ import { getRedisClient } from '../config/redis';
 import { logger } from './logger';
 
 // Short, security-relevant TTL. Deliberately shorter than userCache's 5min:
-// the approved-clients allow-list is part of the SSO/FedCM trust boundary, so
-// we keep cross-task staleness tightly bounded.
+// the approved-clients allow-list is part of the OAuth-consent/device-first
+// trust boundary, so we keep cross-task staleness tightly bounded.
 const DEFAULT_TTL = 60_000; // 60s in ms
 const REDIS_KEY = 'approved:origins';
 const LOCAL_KEY = 'approved:origins';
@@ -13,10 +13,9 @@ const LOG_COMPONENT = 'ApprovedClientsCache';
  * Cached approved-clients snapshot. `origins` is the full approved-clients
  * allow-list (dev/native + trusted-Application origins + manual escape-hatch
  * rows); `trusted` is the strict subset of first-party/official/internal
- * origins the API classifies as never requiring per-user FedCM consent (see
+ * origins the API classifies as never requiring per-user OAuth consent (see
  * `isTrustedApplication`). Both derive from ONE Mongo read and are cached
- * together so the IdP worker can consume both from a single `/fedcm/clients/approved`
- * fetch.
+ * together as a single entry.
  */
 export interface ApprovedClientsData {
   origins: string[];
@@ -24,25 +23,32 @@ export interface ApprovedClientsData {
 }
 
 /**
- * In-process cache for NON-AUTHORITATIVE FedCM approved-client list reads.
+ * In-process cache for NON-AUTHORITATIVE approved-client list reads.
  *
- * Collapses the redundant `FedCMClient`/`Application` reads per SSO/FedCM
- * sign-in (e.g. `getUserGrantedOrigins` / `approved_clients` derivation on cold
- * boot) into at most one Mongo read per TTL window. The approved set is tiny
- * and changes rarely (create / delete / seed only), so the whole origin list is
- * cached as a single entry.
+ * Collapses redundant `Application` reads for consumers that need the
+ * approved-origin/trusted-origin snapshot into at most one Mongo read per TTL
+ * window. The approved set is tiny and changes rarely (create / update /
+ * delete only), so the whole origin list is cached as a single entry.
  *
  * SECURITY BOUNDARY: this cache is safe ONLY for list/catalog-style callers
  * that can tolerate a short refresh delay. Security-sensitive AUTHORIZATION
- * checks (the FedCM token-exchange audience check via
- * `fedcmService.isClientApproved`) must BYPASS this cache and read the canonical
- * registry directly — oxy-api runs as multiple ECS Fargate tasks, so this
- * in-process Map is per-task: a revoke (`removeApprovedClient`) on task A clears
- * only task A's cache, and other tasks would otherwise serve the stale list
- * until their own 60s TTL expires. Authorization reading the registry live
- * closes that cross-task staleness window. The TTL still caps staleness for the
- * non-authoritative readers at 60s; the best-effort Redis tier shortens it
- * further when Valkey is reachable.
+ * checks must BYPASS this cache and read the canonical registry
+ * (`dynamicOriginRegistry` / `isTrustedApplication`) directly — oxy-api runs
+ * as multiple ECS Fargate tasks, so this in-process Map is per-task: an
+ * `invalidate()` on task A clears only task A's cache, and other tasks would
+ * otherwise serve the stale list until their own 60s TTL expires.
+ * Authorization reading the registry live closes that cross-task staleness
+ * window. The TTL still caps staleness for the non-authoritative readers at
+ * 60s; the best-effort Redis tier shortens it further when Valkey is
+ * reachable.
+ *
+ * NOTE: as of the wave-2 FedCM/SSO deletion, `invalidate()` is called from
+ * `routes/applications.ts` on every Application create/update/delete, but no
+ * current code path calls `getApprovedData()` to actually read the cache —
+ * its only consumer (the FedCM IdP worker's approved-clients fetch) was
+ * deleted along with FedCM. Left in place rather than removed here since
+ * deleting a class + its call sites is a logic change, not a comment fix;
+ * flag for a follow-up dead-code pass if no future consumer claims it.
  */
 class ApprovedClientsCache {
   private local: Map<string, { data: ApprovedClientsData; timestamp: number; ttl: number }> = new Map();
@@ -70,8 +76,8 @@ class ApprovedClientsCache {
 
   /**
    * Clear the cached list everywhere this task can reach: the local entry and
-   * the best-effort Redis tier. Called by the only mutators of the allow-list
-   * (`addApprovedClient`, `removeApprovedClient`, `seedApprovedClients`).
+   * the best-effort Redis tier. Called from `routes/applications.ts` on
+   * Application create/update/delete (see the dead-consumer note above).
    */
   invalidate(): void {
     this.local.delete(LOCAL_KEY);

--- a/packages/api/src/utils/credentialDomainCache.ts
+++ b/packages/api/src/utils/credentialDomainCache.ts
@@ -7,12 +7,12 @@ import { logger } from './logger';
  * SECURITY BOUNDARY: the federation sign/public-key endpoints must only let a
  * credential operate on keyIds whose host belongs to that credential's own
  * Application. The Application model has no explicit "federation domain" field,
- * so — exactly as the FedCM approved-clients allow-list is DERIVED from active
+ * so — exactly as the approved-clients allow-list is DERIVED from active
  * `Application.redirectUris` (see {@link ApprovedClientsCache}) — we derive the
  * allowed federation hosts from the hostnames of the Application's
- * `redirectUris`. Registering Mention with a
- * `https://mention.earth/__oxy/sso-callback` redirect therefore authorises that
- * credential to sign `mention.earth` keyIds. Nothing is hand-maintained.
+ * `redirectUris`. Registering Mention with a `https://mention.earth/oauth/callback`
+ * redirect therefore authorises that credential to sign `mention.earth`
+ * keyIds. Nothing is hand-maintained.
  *
  * FAIL CLOSED: if the Application is missing, not `active`, or has no usable
  * redirectUri hosts, the allowed set is EMPTY and every host check fails (403).

--- a/packages/api/src/utils/deviceUtils.ts
+++ b/packages/api/src/utils/deviceUtils.ts
@@ -115,17 +115,24 @@ export function deriveStableDeviceId(
 }
 
 /**
- * Derive a stable, non-PII deviceId for an IdP/FedCM-issued session, keyed by
+ * Derive a stable, non-PII deviceId for a session minted server-to-server on
+ * behalf of a caller with no stable client identity of its own, keyed by
  * `(userId, key)` instead of the request's UA/IP. The output is the first 32
- * hex chars of `sha256("${salt}|${userId}|fedcm|${key}")`.
+ * hex chars of `sha256("${salt}|${userId}|fedcm|${key}")` — the `fedcm` hash
+ * segment is cryptographic derivation material, kept unchanged even though
+ * the feature it was named for (see below) is gone, since changing it would
+ * change every derived deviceId.
  *
- * **Why a separate helper?** FedCM token exchange runs server-to-server from
- * the IdP Cloudflare Worker, so the request's User-Agent is `'unknown'` and
- * the egress IP varies per call. Feeding that into `deriveStableDeviceId`
- * yields a fresh random id every exchange → a brand-new "FedCM Sign-In"
- * session row on every silent-auth / SSO bounce. Keying off the RP origin
- * (`key`) instead makes one `(user, RP)` reuse a single session that simply
- * refreshes its tokens/expiry.
+ * **Why a separate helper?** Originally added for FedCM token exchange, which
+ * ran server-to-server from the IdP Cloudflare Worker, so the request's
+ * User-Agent was `'unknown'` and the egress IP varied per call. Feeding that
+ * into `deriveStableDeviceId` would yield a fresh random id every exchange →
+ * a brand-new session row on every silent-auth/SSO bounce. Keying off a
+ * stable per-caller key (`key`) instead makes one `(user, RP)` reuse a single
+ * session that simply refreshes its tokens/expiry. FedCM itself is deleted
+ * (wave 2); this helper (`deriveServiceDeviceId` / `stableDeviceKey`) has no
+ * current caller but is kept for any future server-minted-session flow that
+ * needs the same stable-per-RP-session property.
  *
  * **Why the `'fedcm'` namespace segment?** It guarantees the output can never
  * collide with an IP/UA-derived id from `deriveStableDeviceId` (whose hash
@@ -144,7 +151,7 @@ export function deriveStableDeviceId(
  * weak/unsalted id.
  *
  * @param userId - Authenticated user id. Required for per-user scoping.
- * @param key - Stable per-RP key (the FedCM `clientOrigin` / token aud).
+ * @param key - Stable per-RP key (originally the FedCM `clientOrigin` / token aud).
  * @throws Error when `DEVICE_ID_SALT` is unset (fail-closed).
  */
 export function deriveServiceDeviceId(userId: string, key: string): string {
@@ -197,7 +204,8 @@ export const generateDeviceFingerprint = (fingerprint: DeviceFingerprintInput): 
  * @param userId - Optional authenticated user id. When set, the derived
  *   deviceId is scoped to this user so two distinct users behind the same
  *   NAT/proxy on the same browser do NOT collide on the same id. Pre-auth
- *   callers (signup, pre-credential FedCM) should pass `null` / omit.
+ *   callers (signup, device bootstrap before a session exists) should pass
+ *   `null` / omit.
  */
 export const extractDeviceInfo = (
   req: Request,

--- a/packages/api/src/utils/origin.ts
+++ b/packages/api/src/utils/origin.ts
@@ -1,6 +1,7 @@
 /**
- * Canonical origin-normalisation helper shared across the SSO controller, the
- * SSO router CORS guard, and the FedCM service.
+ * Canonical origin-normalisation helper shared across the CORS/CSRF origin
+ * guard, the dynamic origin registry, and the device-first auth surface
+ * (`deviceAuth.ts`, `auth.ts`).
  *
  * Normalises an origin string for equality / allow-list comparisons:
  *  - lowercases the scheme and the host;

--- a/packages/api/src/utils/trustedApplication.ts
+++ b/packages/api/src/utils/trustedApplication.ts
@@ -10,14 +10,13 @@ import type { ApplicationType } from '../models/Application';
  * `status: 'active'`, so `status: 'active'` alone is never a trust boundary.
  *
  * This is the single source of truth for trust-gated decisions that must agree:
- *  - FedCM/SSO approved-origin derivation (`fedcm.service.ts`).
+ *  - Trusted/third-party CORS + device-first bootstrap origin derivation
+ *    (`config/dynamicOriginRegistry.ts`).
+ *  - OAuth consent auto-approve (trusted apps skip the consent screen entirely).
  *  - Service-credential creation + service-token minting (`applications.ts`,
  *    `auth.ts`) — bearer credentials for Oxy-to-Oxy/internal routes.
  *  - Requiring an Origin proof before showing official branding on the device
  *    consent UI (`auth.ts` `POST /session/create`).
- *
- * Keep this aligned with `TRUSTED_APPLICATION_FEDCM_FILTER` in
- * `fedcm.service.ts` (the Mongo-query form of the same policy).
  */
 export function isTrustedApplication(
   app: { isOfficial?: boolean; isInternal?: boolean; type?: ApplicationType }

--- a/packages/contracts/src/fedcmToken.ts
+++ b/packages/contracts/src/fedcmToken.ts
@@ -1,6 +1,16 @@
 /**
  * Canonical contract for the FedCM ID-token JWT payload.
  *
+ * DEAD SINCE THE WAVE-2 FEDCM DELETION (found during the comment sweep, not
+ * fixed here — this is a published `@oxyhq/contracts` export, so removing it
+ * is a breaking change/major-version decision, out of scope for a comment
+ * fix): `POST /fedcm/exchange`, `fedcm.service.exchangeIdToken`, and
+ * `packages/auth/server/index.ts`'s `mintSessionForClient` — every consumer
+ * and producer this file describes — are all deleted. No current code
+ * imports `fedcmTokenPayloadSchema` / `FedcmTokenPayload` outside this
+ * package. Flag for a follow-up major-version cleanup.
+ *
+ * Original doc (historical, describes the now-deleted system):
  * SINGLE SOURCE OF TRUTH for the decoded claims of the HS256 ID token the auth
  * IdP (`auth.oxy.so`) signs and `POST /fedcm/exchange` consumes. The API decodes
  * the JWT, verifies its signature, then validates the resulting claim object

--- a/packages/contracts/src/userResponse.ts
+++ b/packages/contracts/src/userResponse.ts
@@ -16,7 +16,8 @@
  *
  * Faithful to the producers:
  *  - `packages/api/src/utils/userTransform.ts` `formatUserResponse` — the
- *    canonical serialization used by `/auth/refresh-all`, device sessions, etc.
+ *    canonical serialization used by the device-first bootstrap/exchange
+ *    endpoints (`deviceAuth.ts`), login/signup, device sessions, etc.
  *    Emits `id` (NOT `_id`), forwards `username` verbatim (may be absent), and
  *    emits `name` as the structured `{ first, last, full, displayName }`
  *    subdocument.
@@ -24,8 +25,6 @@
  *    `''`; `full` and `displayName` are Mongoose VIRTUALS. Formatted API
  *    responses compose both fields, while raw-document responses may omit the
  *    virtuals if the query did not materialise them.
- *  - The `/auth/refresh-all` handler in `packages/api/src/routes/auth.ts`, whose
- *    per-slot `authuser` is the numeric `oxy_rt_${authuser}` cookie slot.
  *
  * Platform-agnostic — zod only, no react/react-native/expo. ESM-safe (no
  * `require()`).

--- a/packages/core/src/HttpService.ts
+++ b/packages/core/src/HttpService.ts
@@ -820,7 +820,7 @@ export class HttpService {
    * `clearCacheByPrefix` sweeps and `clearCacheEntry` base-key matching.
    * The `clearCacheEntry` callsites all pass fixed, dataless logical keys
    * (`GET:/users/<id>`, `GET:/session/user/<sessionId>`,
-   * `GET:/fedcm/me/authorized-apps`), so this readable suffix can never be
+   * `GET:/auth/grants`), so this readable suffix can never be
    * ambiguous with a serialized request body.
    */
   private static readonly CACHE_IDENTITY_DELIM = ' id=';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -498,11 +498,15 @@ export type { QuickAccount, DisplayNameUserShape } from './utils/accountUtils';
 // Registrable-domain + central-IdP-apex helpers.
 //
 // The client SSO-bounce / silent-iframe / FedCM machinery was removed in the
-// device-first cutover. These three symbols survive because the api SSO surface
-// and the IdP (both lista B, gated on the ecosystem bump) still import them:
-// `registrableApex` (eTLD+1), `CENTRAL_IDP_APEX`, and the `SSO_CALLBACK_PATH`
-// constant. `@oxyhq/core/server` re-exports `registrableApex` + `SSO_CALLBACK_PATH`
-// for the api; the IdP imports all three from here.
+// device-first cutover (wave 2, ecosystem-wide bump complete). `registrableApex`
+// (eTLD+1) and `CENTRAL_IDP_APEX` are still genuinely used: `registrableApex`
+// via the `@oxyhq/core/server` re-export consumed by
+// `packages/api/src/utils/sameSite.ts` for same-site origin checks, and
+// `CENTRAL_IDP_APEX` by `server/cors.ts`'s `createOxyCors` (auto-allows
+// `*.oxy.so`). `SSO_CALLBACK_PATH` has no remaining importer outside this
+// module as of wave 2 — kept exported for now rather than removed here (an
+// export deletion is a logic change, out of scope for a comment sweep); flag
+// for a follow-up dead-export cleanup pass.
 // ---------------------------------------------------------------------------
 export { registrableApex } from './utils/registrableApex';
 export { CENTRAL_IDP_APEX } from './utils/authWebUrl';

--- a/packages/core/src/mixins/OxyServices.accounts.ts
+++ b/packages/core/src/mixins/OxyServices.accounts.ts
@@ -28,8 +28,9 @@
  * SWITCHING INTO AN ACCOUNT: `switchToAccount(accountId)` mints a REAL session
  * for the target account and plants it as the active session — there is no
  * per-request "acting-as" header. Identity is carried by the session/token, not
- * a delegation header, so a switch propagates through reload and `refresh-all`
- * exactly like a login.
+ * a delegation header, so a switch propagates through reload and cross-domain
+ * exactly like a login, via the device-first session model (the server
+ * registers the switched session into the operator's device-set directly).
  */
 import type { User } from '../models/interfaces';
 import type { SessionLoginResponse } from '../models/session';
@@ -434,22 +435,22 @@ export interface AccountSuccessResult {
 /**
  * Result of {@link OxyServicesAccountsMixin.switchToAccount} — the freshly
  * minted session for the target account, in the SAME shape the canonical login
- * / `claimSessionByToken` responses use (`SessionLoginResponse`), plus the
- * device-local refresh-cookie slot index.
+ * / `claimSessionByToken` responses use (`SessionLoginResponse`).
  *
  * `accessToken` is the first access token for the new session (already planted
- * as the active token by `switchToAccount`). The refresh token is NOT in the
- * body — the server sets it as the httpOnly `oxy_rt_<authuser>` cookie, which
- * joins the device multi-account set so the switched session survives reload and
- * propagates cross-domain via `/auth/refresh-all`. `user` is the target account.
+ * as the active token by `switchToAccount`). The switched session's survival
+ * across reload and cross-domain sync is device-first: the server registers
+ * it into the operator's `DeviceSession` set directly
+ * (`deviceSessionService.addAccount`, broadcast to the device room) — there is
+ * no client-side refresh-cookie slot to establish. `user` is the target
+ * account.
  */
 export interface SwitchAccountResult extends SessionLoginResponse {
   /**
-   * The device-local refresh-cookie slot index (`oxy_rt_<authuser>`) the server
-   * assigned to the minted session. Surfaced so the consumer can register the
-   * new session in its device multi-account set exactly like a login response.
-   * Absent only when the server could not set the cookie (best-effort — the
-   * switch itself still succeeds).
+   * Legacy device-local refresh-cookie slot index. The current server switch
+   * response never sets this field (device-set registration replaced the
+   * cookie-slot model) — kept optional for backward type-compatibility with
+   * any caller still reading it, but always `undefined` in practice.
    */
   authuser?: number;
 }
@@ -515,24 +516,18 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
      * target, directly or inherited — else 403; 404 if missing/archived; 403 if
      * the target is a personal account), then mints a REAL session for the
      * target account and returns it in the canonical login / `claimSessionByToken`
-     * shape (`{ sessionId, deviceId, expiresAt, accessToken, user, authuser }`).
+     * shape (`{ sessionId, deviceId, expiresAt, accessToken, user }`).
      *
      * Unlike the removed `X-Acting-As` delegation header, the returned session
      * IS the new identity: this plants `accessToken` as the active token —
      * exactly like `claimSessionByToken` / `verifyChallenge` — so every
      * subsequent request authenticates as the target account.
      *
-     * Joining the device multi-account set (so the switch survives a reload and
-     * propagates cross-domain via `/auth/refresh-all`) requires a SECOND call, to
-     * `POST /auth/session`, made here after the token is planted. The switch route
-     * lives at `/accounts/*`, OUTSIDE the `oxy_rt_<authuser>` cookie's `Path=/auth`
-     * scope, so the server never sees the device's existing slots from it and
-     * would clobber slot 0 (destroying the operator's own session). `/auth/session`
-     * runs where those cookies ARE visible, so the server allocates a NEW slot that
-     * coexists with the operator's and returns its `authuser`. This step is
-     * web-only (native multi-account uses stored sessions, not cookies) and
-     * best-effort — a failure leaves the in-session switch intact; the switched
-     * account simply won't survive a reload until the cookie is next established.
+     * A single call is all that's needed: the server registers the switched
+     * session into the operator's `DeviceSession` set directly, inheriting the
+     * operator's central `deviceId` so the switch survives a reload and syncs
+     * cross-domain via the same device-first session model as a normal login —
+     * there is no separate client-side cookie/slot step to make it stick.
      *
      * After planting, the SDK's identity-scoped GET cache is fully cleared so
      * every cached read re-fetches as the new account. (The consuming
@@ -542,7 +537,7 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
      * same-user silent refreshes, so the sweep here is explicit.)
      *
      * @param accountId - The target account's Mongo `_id`.
-     * @returns The minted session (planted) plus the device `authuser` slot.
+     * @returns The minted session, already planted as the active session.
      */
     async switchToAccount(accountId: string): Promise<SwitchAccountResult> {
       try {

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -96,9 +96,13 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     // Base authentication
     OxyServicesAuthMixin,
 
-    // Legacy FedCM "Connected apps" management (list/revoke authorized RP grants).
-    // The FedCM sign-in surface was removed in the device-first cutover; only
-    // this management pair survives until the AppGrant migration.
+    // "Connected apps" management (list/revoke authorized RP grants) on the
+    // AppGrant model — the successor to the retired FedCM authorized-apps
+    // surface. NOTE: `OxyServicesConnectedAppsMixin` below also exposes a
+    // list/revoke pair (`listConnectedApps`/`revokeAppGrant` on `/auth/grants`)
+    // over the SAME AppGrant data — found during the wave-2 comment sweep;
+    // this duplication predates it and wasn't introduced here, flagging for a
+    // follow-up consolidation decision.
     OxyServicesAuthorizedAppsMixin,
 
     // User management (requires auth)

--- a/packages/core/src/models/session.ts
+++ b/packages/core/src/models/session.ts
@@ -8,11 +8,10 @@ export interface ClientSession {
   userId?: string;
   isCurrent?: boolean;
   /**
-   * Web-only: the device-local refresh-cookie slot index (0..N) that backs
-   * this session. Populated from `POST /auth/refresh-all` and from login /
-   * signup / fedcm-exchange responses. Required for per-session web token
-   * refresh via `refreshTokenViaCookie({ authuser })` without a bearer token.
-   * Absent on native (RN uses the bearer-protected session id directly).
+   * The account's ordinal slot (0..N) within the device's account set
+   * (`SessionAccount.authuser` in `@oxyhq/contracts`), projected from the
+   * device-first `DeviceSessionState` — used purely for stable Google-style
+   * account-chooser ordering, not for any token-refresh mechanism.
    */
   authuser?: number;
 }

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -9,7 +9,7 @@ import { getSocketIO } from './socketLoader';
 import type { MinimalSocket, SocketIOFactory } from './socketLoader';
 
 export interface TokenTransport {
-  /** Ensure this app holds a per-domain access token for state.activeAccountId (mint via FedCM/silent/sso/keychain). Best-effort. */
+  /** Ensure this app holds a per-domain access token for state.activeAccountId (mint via the persisted refresh family / shared keychain). Best-effort. */
   ensureActiveToken(state: DeviceSessionState): Promise<void>;
 }
 

--- a/packages/core/src/shared/utils/debugUtils.ts
+++ b/packages/core/src/shared/utils/debugUtils.ts
@@ -24,7 +24,7 @@ export const isDev = (): boolean => {
 
 /**
  * Log a debug message (only in development)
- * @param prefix - Log prefix (e.g., '[FedCM]')
+ * @param prefix - Log prefix (e.g., '[ColdBoot]')
  * @param args - Arguments to log
  */
 export const debugLog = (prefix: string, ...args: unknown[]): void => {
@@ -57,12 +57,12 @@ export const debugError = (prefix: string, ...args: unknown[]): void => {
 
 /**
  * Create a namespaced debug logger
- * @param namespace - Logger namespace (e.g., 'FedCM', 'SilentAuth')
+ * @param namespace - Logger namespace (e.g., 'ColdBoot', 'DeviceAuth')
  * @returns Object with log, warn, error methods
  *
  * @example
  * ```ts
- * const debug = createDebugLogger('FedCM');
+ * const debug = createDebugLogger('ColdBoot');
  * debug.log('Starting authentication');
  * debug.warn('Token expires soon');
  * debug.error('Authentication failed', error);

--- a/packages/core/src/utils/authWebUrl.ts
+++ b/packages/core/src/utils/authWebUrl.ts
@@ -3,16 +3,15 @@
  *
  * The client SSO/FedCM resolvers (`resolveCentralAuthUrl`, `CENTRAL_AUTH_URL`)
  * were removed in the device-first / legacy-final cutovers. The lone survivor is
- * `CENTRAL_IDP_APEX`, kept because it has a LIVE device-first consumer —
- * `@oxyhq/core/server`'s CORS helper auto-allows `*.oxy.so` from it — as well as
- * the (lista-B) IdP worker branding its assertions. The CORS use is permanent,
- * so this stays past the SSO/FedCM teardown.
+ * `CENTRAL_IDP_APEX`, kept because it has a LIVE consumer —
+ * `@oxyhq/core/server`'s CORS helper (`server/cors.ts`'s `createOxyCors`)
+ * auto-allows `*.oxy.so` from it. That CORS use is permanent, so this stays
+ * past the SSO/FedCM teardown.
  */
 
 /**
  * The registrable apex (eTLD+1) of the Oxy ecosystem's central Identity
- * Provider. The central IdP is reachable at `auth.${CENTRAL_IDP_APEX}` and the
- * ID-token assertion issuer is always `https://auth.${CENTRAL_IDP_APEX}`.
- * A single source of truth so the IdP worker + the CORS helper never drift.
+ * Provider, reachable at `auth.${CENTRAL_IDP_APEX}`. Single source of truth so
+ * the CORS helper (and anything else that needs the central apex) never drifts.
  */
 export const CENTRAL_IDP_APEX = 'oxy.so';

--- a/packages/core/src/utils/coldBoot.ts
+++ b/packages/core/src/utils/coldBoot.ts
@@ -3,19 +3,21 @@
  * authentication resolution.
  *
  * On a fresh page load / app launch the SDK may have several ways to recover an
- * existing session (silent FedCM, a persisted refresh token, a cross-domain
- * claim, a redirect SSO return, ...). They must be attempted in a deterministic
- * order*, and the FIRST one that yields a session wins — every later step is
- * skipped. This module encodes exactly that contract and nothing else.
+ * existing session (a persisted refresh-token family, a shared-keychain
+ * identity, a cross-domain boot-fragment return, ...). They must be attempted
+ * in a deterministic order, and the FIRST one that yields a session wins —
+ * every later step is skipped. This module encodes exactly that contract and
+ * nothing else.
  *
  * Design constraints (all enforced):
  *   - PURE: no DOM, no `navigator`, no `window`, no React, no platform globals.
  *   - NO module-level mutable state. Every call to {@link runColdBoot} is fully
  *     self-contained, so it is safe under bundler re-evaluation (e.g. the Metro
- *     web bundle, which is precisely why the FedCM silent-SSO guard had to live
- *     in consumers rather than a core singleton).
- *   - Architecture-agnostic: both candidate cross-domain SSO designs consume
- *     this same primitive; it knows nothing about HOW a step resolves a session.
+ *     web bundle — the reason any run-once guard for a step must live in the
+ *     calling consumer, never in a core module-level singleton).
+ *   - Architecture-agnostic: it knows nothing about HOW a step resolves a
+ *     session; `runSessionColdBoot` (`boot/coldBootV2.ts`) is the current
+ *     device-first consumer.
  *
  * A step is skipped (without running) when its `enabled` predicate returns
  * false. Any thrown error — from either `enabled` or `run` — is reported via
@@ -104,15 +106,16 @@ export interface RunColdBootOptions<S> {
    * fails to settle before the deadline, the runner abandons the await for that
    * step (reporting it via `onStepDeadline`) and CONTINUES to the next step,
    * each now racing against an already-expired deadline. This is deliberate:
-   * the runner keeps iterating so the TERMINAL step (e.g. the `/sso` bounce,
-   * whose `run()` performs its side effect synchronously before its first
-   * `await`) still gets to fire. A step that has nothing to contribute after
-   * the deadline simply doesn't settle and is skipped in turn.
+   * the runner keeps iterating so the TERMINAL step (e.g. `coldBootV2`'s
+   * `bootstrap-hop`, whose `run()` performs its navigation side effect
+   * synchronously before its first `await`) still gets to fire. A step that
+   * has nothing to contribute after the deadline simply doesn't settle and is
+   * skipped in turn.
    *
    * Per-step timeouts inside `run()` remain the first line of defense and
    * should keep every step well under this budget on a healthy load; this only
-   * trips when one of them regresses (the production FedCM-silent hang). When
-   * omitted there is no overall deadline.
+   * trips when one of them regresses (a step hanging past its own timeout).
+   * When omitted there is no overall deadline.
    */
   readonly overallDeadlineMs?: number;
   /**

--- a/packages/core/src/utils/registrableApex.ts
+++ b/packages/core/src/utils/registrableApex.ts
@@ -4,12 +4,12 @@
  * The client FAPI auto-detection helper was removed in the device-first cutover
  * (which is why this file is now named for what it actually is, not the old
  * `fapiAutoDetect`). What survives is the pure registrable-domain kernel, still
- * used server-side by the api (`deviceAuth` same-apex trust checks via
- * `sameSite.ts`, `fedcm.service`, `sso.controller`), the `@oxyhq/core/server`
- * CORS/re-export layer, and the IdP worker.
+ * used server-side by the api's device-first same-apex trust checks
+ * (`deviceAuth.ts`'s `POST /auth/device/web-session`, via `sameSite.ts`'s
+ * `isSameSiteTrustedRequest`) and the `@oxyhq/core/server` CORS/re-export layer.
  *
- * `registrableApex` is NOT legacy — `deviceAuth` (device-first) is a live
- * consumer, so this kernel stays regardless of the SSO/FedCM lista-B teardown.
+ * `registrableApex` is NOT legacy — the device-first same-apex check is a live
+ * consumer, so this kernel stays regardless of the SSO/FedCM removal.
  */
 
 import { getDomain } from 'tldts';

--- a/packages/services/src/ui/hooks/mutations/mutationKeys.ts
+++ b/packages/services/src/ui/hooks/mutations/mutationKeys.ts
@@ -32,7 +32,7 @@ export const mutationKeys = {
     removeDevice: ['mutation', 'session', 'removeDevice'] as const,
   },
 
-  // Connected apps (FedCM grants)
+  // Connected apps (OAuth grants)
   connectedApps: {
     revoke: ['mutation', 'connectedApps', 'revoke'] as const,
   },

--- a/packages/services/src/ui/hooks/queries/queryKeys.ts
+++ b/packages/services/src/ui/hooks/queries/queryKeys.ts
@@ -77,7 +77,7 @@ export const queryKeys = {
     usage: (accountScope?: string) => [...queryKeys.storage.all, 'usage', accountScope] as const,
   },
 
-  // Connected apps (FedCM grants the user has authorized)
+  // Connected apps (OAuth grants the user has authorized)
   connectedApps: {
     all: ['connectedApps'] as const,
     list: () => [...queryKeys.connectedApps.all, 'list'] as const,

--- a/packages/services/src/ui/navigation/routes.ts
+++ b/packages/services/src/ui/navigation/routes.ts
@@ -43,7 +43,7 @@ export type RouteName =
     | 'AccountSettings' // Per-account profile edit + members + danger zone
     | 'AvatarCrop' // Square-crop editor presented before avatar upload
     | 'Notifications' // Per-channel notification preferences
-    | 'ConnectedApps' // FedCM-authorized RP apps the user can revoke
+    | 'ConnectedApps' // OAuth-authorized third-party apps the user can revoke
     | 'Preferences'; // General user preferences (theme, reduce-motion, etc.)
 
 // Lazy screen loaders - functions that return screen components on-demand

--- a/packages/services/src/ui/utils/storageHelpers.ts
+++ b/packages/services/src/ui/utils/storageHelpers.ts
@@ -11,13 +11,13 @@ export interface SessionStorageKeys {
   language: string;
   /**
    * DURABLE "this device/app has had a signed-in Oxy session before" hint.
-   *
-   * Lives in the SAME `storageKeyPrefix`-scoped durable store as the stored
-   * session ids, so it survives a session expiring (cleared only on explicit
-   * full sign-out). Read at cold boot to drive the smart `sso-bounce` gate:
-   * a returning visitor still gets ONE establish bounce so a central-only
-   * cross-domain session recovers, while a first-time anonymous visitor is
-   * never force-redirected. See `allowSsoBounce` in `@oxyhq/core`.
+   * Originally read at cold boot to drive the FedCM-era smart `sso-bounce`
+   * gate (a returning visitor still got one establish bounce; a first-time
+   * anonymous visitor was never force-redirected). That gate and
+   * `allowSsoBounce` were deleted in the device-first cutover — this storage
+   * key is currently defined but not read anywhere; kept rather than removed
+   * here since deleting a storage key is a logic change, out of scope for a
+   * comment sweep. Flag for a follow-up dead-field cleanup.
    */
   priorSession: string;
 }


### PR DESCRIPTION
## Summary
Comment-only sweep across `api`/`core`/`contracts`/`services`/`accounts` fixing docblocks, JSDoc, illustrative examples, and user-facing OpenAPI/seed-data strings that still described FedCM/SSO/`oxy_rt`/`CrossDomainAuth`/`refresh-all` as live mechanisms after the wave-2 deletion. No logic changed — verified with green test suites + clean builds across all five touched packages.

## Most significant find
`OxyServices.accounts.ts`'s `switchToAccount()` docblock described a stale **second call** to the deleted `POST /auth/session` endpoint with `oxy_rt` cookie-slot allocation. The actual implementation already only calls the device-first `POST /accounts/:id/switch` route and lets the server register the session into the `DeviceSession` set directly — the code was already correct, only the docs lied about it. Rewrote the docs to match the real (correct) behavior.

## Genuinely dead code found and flagged (not removed — deletion is a logic change, out of scope for a comment sweep)
- `approvedClientsCache`'s read path (`getApprovedData`) has zero callers anywhere in the codebase; only `invalidate()` is still called, achieving nothing useful. Its own docblock described consumers (`fedcmService.isClientApproved`, an IdP `/fedcm/clients/approved` fetch) that no longer exist.
- `SessionCreateOptions.stableDeviceKey` / `deriveServiceDeviceId` — zero current call sites.
- `CENTRAL_IDP_APEX` is still genuinely used (`server/cors.ts`); `SSO_CALLBACK_PATH` has zero importers outside its own module.
- `packages/contracts/src/fedcmToken.ts` — the whole file (`fedcmTokenPayloadSchema`/`FedcmTokenPayload`) is dead but is a **published** `@oxyhq/contracts` export, so removing it is a breaking/major-version decision.
- `SessionStorageKeys.priorSession` in `services/storageHelpers.ts` — defined and keyed but never read anywhere; backed the deleted FedCM-era smart `sso-bounce` gate.
- **Architecture duplication**: `OxyServices.connectedApps.ts` (`GET/DELETE /auth/grants`) and `OxyServices.authorizedApps.ts` (`GET/DELETE /apps/authorized`) are two parallel client mixins + two parallel backend route surfaces reading/writing the **same** `AppGrant` data — `packages/accounts` uses the former, `packages/services`' generic account hooks use the latter. Worth a consolidation decision.

## Flagged but NOT touched (seed/register scripts — logic, not comments)
`register-commons-clients.ts` and `seed-oxy-applications.ts` both hardcode `SSO_CALLBACK_PATH` (`/__oxy/sso-callback`, the deleted SSO-bounce callback) into the registered `redirectUris` for every official app they seed, including "Oxy Auth" itself. Current trust derivation (`dynamicOriginRegistry`) only extracts the *origin* from `redirectUris`, not the exact path, so this is likely harmless dead configuration rather than a functional break — but it needs an engineer decision + verification before either script is re-run for a new official app. Left the redirectUris/`cb()` logic untouched per instructions; fixed only the adjacent stale description strings and comments.

## Gates
- [x] `@oxyhq/contracts`, `@oxyhq/core`, `@oxyhq/auth`, `@oxyhq/services`, `@oxyhq/api` all build clean
- [x] Full test suites green: api 145 suites/1343 tests, core 62/677, services 30/205, auth-sdk 12/80, contracts 8/150
- [x] `packages/accounts` tsc: zero errors in the two edited files (pre-existing unrelated `className`/NativeWind errors elsewhere, confirmed present on the unedited baseline too)
- [x] biome lint: confirmed the same 66 pre-existing errors occur on the unedited baseline (stashed my changes, re-ran, identical count) — nothing new introduced
- [x] Path-scoped commit (no `git add -A`)

Not merged, per instructions.