### PR TITLE
fix(api): converge DeviceSession on read + enforce one-session-per-account-per-device (kill deviceId split-brain)

### DIFF
--- a/packages/api/src/routes/__tests__/oauthTokenDevice.test.ts
+++ b/packages/api/src/routes/__tests__/oauthTokenDevice.test.ts
@@ -1,0 +1,294 @@
+/**
+ * POST /auth/oauth/token — device attribution / one-session-per-account-per-device.
+ *
+ * The token grant used to be the last mint path that never threaded a device
+ * attribution — it called `createSession(userId, req, { deviceName })` with no
+ * deviceId, so every exchange orphaned a fresh UA/IP-derived device (the cleanest
+ * reproduction of "an RP shows a different account list"). These tests pin the
+ * seal:
+ *  - a resolved device whose account is ALREADY registered on it → REUSE the
+ *    registered session (no fresh createSession), response carries its tokens;
+ *  - a resolved device with no registered session → createSession threads the
+ *    deviceId + the fresh session is registered into the device set (add-only);
+ *  - no resolvable device → createSession is called WITHOUT a deviceId and the
+ *    device-set machinery is never touched (we do not invent an attribution).
+ */
+
+import express from 'express';
+import http from 'http';
+import { AddressInfo } from 'net';
+
+const mockExchangeAuthCode = jest.fn();
+const mockApplicationCredentialFindOne = jest.fn();
+const mockApplicationFindOne = jest.fn();
+const mockUserFindById = jest.fn();
+const mockIsCredentialUsable = jest.fn(() => true);
+const mockFormatUserResponse = jest.fn(() => ({ id: 'user-1', username: 'u1' }));
+
+const mockResolveLoginDeviceId = jest.fn();
+const mockResolveRegisteredSession = jest.fn();
+const mockAddAccount = jest.fn();
+const mockCreateSession = jest.fn();
+const mockGetSession = jest.fn();
+const mockBroadcast = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  serviceAuthMiddleware: jest.fn(),
+  rejectQueryToken: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// Passthrough validate so the raw body (including the additive optional
+// `deviceToken` field) reaches the handler untouched.
+jest.mock('../../middleware/validate', () => ({
+  validate: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../models/AuthSession', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn() },
+  AuthSession: { findOne: jest.fn() },
+}));
+
+jest.mock('../../models/Session', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn() },
+}));
+
+jest.mock('../../services/authSession.service', () => ({
+  claimAuthSession: jest.fn(),
+  authorizeSessionWithSignedChallenge: jest.fn(),
+}));
+
+jest.mock('../../models/AuthCode', () => ({
+  __esModule: true,
+  AuthCode: { create: jest.fn() },
+  default: { create: jest.fn() },
+}));
+
+jest.mock('../../models/ApplicationCredential', () => ({
+  __esModule: true,
+  ApplicationCredential: { findOne: mockApplicationCredentialFindOne },
+  default: { findOne: mockApplicationCredentialFindOne },
+}));
+
+jest.mock('../../models/Application', () => ({
+  __esModule: true,
+  Application: { findOne: mockApplicationFindOne },
+  default: { findOne: mockApplicationFindOne },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: { findOne: jest.fn(), findById: mockUserFindById },
+  default: { findOne: jest.fn(), findById: mockUserFindById },
+}));
+
+jest.mock('../../models/RefreshToken', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn(), findOneAndUpdate: jest.fn(), create: jest.fn(), updateMany: jest.fn() },
+  RefreshToken: { findOne: jest.fn(), findOneAndUpdate: jest.fn(), create: jest.fn(), updateMany: jest.fn() },
+}));
+
+jest.mock('../../models/AppGrant', () => ({
+  __esModule: true,
+  AppGrant: { findOne: jest.fn(), find: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn() },
+  default: { findOne: jest.fn(), find: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn() },
+}));
+
+jest.mock('../../utils/credentialUsability', () => ({
+  isCredentialUsable: (...a: unknown[]) => mockIsCredentialUsable(...a),
+}));
+
+jest.mock('../../utils/userTransform', () => ({
+  formatUserResponse: (...a: unknown[]) => mockFormatUserResponse(...a),
+}));
+
+jest.mock('../../utils/authSessionSocket', () => ({
+  emitAuthSessionUpdate: jest.fn(),
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: {
+    createSession: (...a: unknown[]) => mockCreateSession(...a),
+    getSession: (...a: unknown[]) => mockGetSession(...a),
+  },
+}));
+
+jest.mock('../../services/deviceSession.service', () => {
+  // auth.ts destructures the NAMED `deviceSessionService` from a lazy
+  // `await import('../services/deviceSession.service.js')` — expose both.
+  const svc = {
+    resolveRegisteredSession: (...a: unknown[]) => mockResolveRegisteredSession(...a),
+    addAccount: (...a: unknown[]) => mockAddAccount(...a),
+  };
+  return { __esModule: true, default: svc, deviceSessionService: svc };
+});
+
+jest.mock('../../services/deviceLogin.service', () => ({
+  resolveLoginDeviceId: (...a: unknown[]) => mockResolveLoginDeviceId(...a),
+}));
+
+jest.mock('../../utils/socket', () => ({
+  broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a),
+}));
+
+jest.mock('../../services/oauthCode.service', () => ({
+  issueAuthCode: jest.fn(),
+  exchangeAuthCode: (...a: unknown[]) => mockExchangeAuthCode(...a),
+  AUTH_CODE_TTL_MS: 60_000,
+}));
+
+jest.mock('../../services/signature.service', () => ({
+  __esModule: true,
+  default: {
+    isValidPublicKey: jest.fn(),
+    verifyChallengeResponse: jest.fn(),
+    verifyRegistrationSignature: jest.fn(),
+    verifySignature: jest.fn(),
+    generateChallenge: jest.fn(),
+    shortenPublicKey: jest.fn(),
+  },
+}));
+
+jest.mock('../../controllers/session.controller', () => ({
+  SessionController: {
+    register: jest.fn(), signUp: jest.fn(), signIn: jest.fn(),
+    requestChallenge: jest.fn(), verifyChallenge: jest.fn(),
+    requestPasswordReset: jest.fn(), verifyRecoveryCode: jest.fn(),
+    resetPassword: jest.fn(), getUserByPublicKey: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../socialAuth', () => ({ __esModule: true, default: express.Router() }));
+
+import authRouter from '../auth';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: {
+    data?: { access_token?: string; refresh_token?: string; session_id?: string };
+    error?: string;
+    message?: string;
+  };
+}
+
+async function requestJson(server: http.Server, path: string, payload: unknown): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload ?? {});
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: 'POST', host: '127.0.0.1', port: address.port, path,
+        headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (c) => { raw += c; });
+        res.on('end', () => {
+          try { resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }); }
+          catch (err) { reject(err); }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/auth', authRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+afterAll((done) => { server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsCredentialUsable.mockReturnValue(true);
+  mockFormatUserResponse.mockReturnValue({ id: 'user-1', username: 'u1' });
+  mockApplicationCredentialFindOne.mockResolvedValue({ publicKey: 'oxy_dk_client', applicationId: 'app-1', status: 'active' });
+  mockApplicationFindOne.mockResolvedValue({ _id: { toString: () => 'app-1' }, name: 'Test App', save: jest.fn().mockResolvedValue(undefined) });
+  mockUserFindById.mockResolvedValue({ _id: { toString: () => 'user-1' } });
+  mockExchangeAuthCode.mockResolvedValue({ ok: true, code: { userId: 'user-1' } });
+});
+
+const BODY = { code: 'raw-code', clientId: 'oxy_dk_client', redirectUri: 'https://rp.example/cb', codeVerifier: 'v'.repeat(43) };
+
+describe('POST /auth/oauth/token — device attribution', () => {
+  it('REUSES the registered session (no fresh mint) when the account is already on the resolved device', async () => {
+    mockResolveLoginDeviceId.mockResolvedValueOnce('central-device');
+    mockResolveRegisteredSession.mockResolvedValueOnce({
+      sessionId: 'registered-sess', deviceId: 'central-device', accessToken: 'x', expiresAt: new Date(),
+    });
+    mockGetSession.mockResolvedValueOnce({
+      sessionId: 'registered-sess', accessToken: 'reg-access', refreshToken: 'reg-refresh',
+    });
+
+    const res = await requestJson(server, '/auth/oauth/token', { ...BODY, deviceToken: 'dt' });
+
+    expect(res.status).toBe(200);
+    // Resolved the device from the presented deviceToken, then reused the doc's session.
+    expect(mockResolveLoginDeviceId).toHaveBeenCalledWith(expect.anything(), 'dt');
+    expect(mockResolveRegisteredSession).toHaveBeenCalledWith('central-device', 'user-1');
+    // No fresh mint, no re-registration — the account was already registered.
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockAddAccount).not.toHaveBeenCalled();
+    // Response carries the REGISTERED session's tokens (central deviceId claim).
+    expect(res.body.data?.access_token).toBe('reg-access');
+    expect(res.body.data?.refresh_token).toBe('reg-refresh');
+    expect(res.body.data?.session_id).toBe('registered-sess');
+  });
+
+  it('threads the resolved deviceId into a fresh mint and registers it (add-only) when nothing is registered yet', async () => {
+    mockResolveLoginDeviceId.mockResolvedValueOnce('central-device');
+    mockResolveRegisteredSession.mockResolvedValueOnce(null);
+    mockCreateSession.mockResolvedValueOnce({
+      sessionId: 'fresh-sess', deviceId: 'central-device', accessToken: 'fresh-access', refreshToken: 'fresh-refresh',
+    });
+    mockAddAccount.mockResolvedValueOnce({ state: { deviceId: 'central-device' }, changed: true });
+
+    const res = await requestJson(server, '/auth/oauth/token', { ...BODY, deviceToken: 'dt' });
+
+    expect(res.status).toBe(200);
+    // Fresh mint carries the resolved central deviceId.
+    expect(mockCreateSession).toHaveBeenCalledWith('user-1', expect.anything(), { deviceName: 'Test App OAuth', deviceId: 'central-device' });
+    // The fresh session is registered into the device set (add-only) and broadcast.
+    expect(mockAddAccount).toHaveBeenCalledWith('central-device', { accountId: 'user-1', sessionId: 'fresh-sess' }, { activate: 'if-empty' });
+    expect(mockBroadcast).toHaveBeenCalledWith({ deviceId: 'central-device' });
+    expect(res.body.data?.access_token).toBe('fresh-access');
+    expect(res.body.data?.session_id).toBe('fresh-sess');
+  });
+
+  it('does NOT invent a device attribution when none resolves (createSession without deviceId; device set untouched)', async () => {
+    mockResolveLoginDeviceId.mockResolvedValueOnce(null);
+    mockCreateSession.mockResolvedValueOnce({
+      sessionId: 'ua-sess', deviceId: 'ua-derived', accessToken: 'ua-access', refreshToken: 'ua-refresh',
+    });
+
+    const res = await requestJson(server, '/auth/oauth/token', BODY);
+
+    expect(res.status).toBe(200);
+    // No deviceId threaded — pre-existing UA/IP attribution preserved.
+    expect(mockCreateSession).toHaveBeenCalledWith('user-1', expect.anything(), { deviceName: 'Test App OAuth' });
+    expect(mockResolveRegisteredSession).not.toHaveBeenCalled();
+    expect(mockAddAccount).not.toHaveBeenCalled();
+    expect(mockBroadcast).not.toHaveBeenCalled();
+    expect(res.body.data?.access_token).toBe('ua-access');
+  });
+});

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -95,6 +95,68 @@ describe('GET /session/device/state', () => {
     expect(res.body.data.activeToken).toEqual({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' });
     expect(mockGetState).toHaveBeenCalledWith('d1');
   });
+
+  it('does NOT converge (plain read) when no oxy_device cookie is present', async () => {
+    mockGetState.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'GET', '/session/device/state');
+    expect(res.status).toBe(200);
+    expect(mockGetStateByCookieKey).not.toHaveBeenCalled();
+    expect(mockMigrateSessionToDevice).not.toHaveBeenCalled();
+    expect(mockConvergeAccountOntoDevice).not.toHaveBeenCalled();
+    expect(mockGetState).toHaveBeenCalledWith('d1');
+  });
+
+  it('does NOT converge (plain read) when the cookie resolves to the SAME device as the JWT', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    mockGetState.mockResolvedValueOnce(STATE);
+    const res = await requestJson(server, 'GET', '/session/device/state', undefined, { Cookie: 'oxy_device=cookiesecret' });
+    expect(res.status).toBe(200);
+    expect(mockMigrateSessionToDevice).not.toHaveBeenCalled();
+    expect(mockConvergeAccountOntoDevice).not.toHaveBeenCalled();
+    expect(mockGetState).toHaveBeenCalledWith('d1');
+    expect(res.body.data.state).toEqual(STATE);
+  });
+
+  it('CONVERGES on read: migrates the session onto the cookie device when the cookie deviceId differs from the JWT claim', async () => {
+    // JWT claims deviceId 'd1'; the oxy_device cookie resolves to the canonical
+    // 'cookie-dev'. A switcher that only READS state must still converge — POST
+    // /add is never called on this path.
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'cookie-dev', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    mockMigrateSessionToDevice.mockResolvedValueOnce({ accessToken: 'fresh-cookie-token', expiresAt: new Date(), migrated: true });
+    const convergedState = { deviceId: 'cookie-dev', accounts: [{ accountId: '64b0000000000000000000aa', sessionId: 's1', authuser: 0 }], activeAccountId: '64b0000000000000000000aa', revision: 10, updatedAt: 2 };
+    const oldState = { deviceId: 'd1', accounts: [], activeAccountId: null, revision: 9, updatedAt: 3 };
+    mockConvergeAccountOntoDevice.mockResolvedValueOnce({ cookieState: convergedState, oldState, changed: true });
+    mockResolveActiveToken.mockResolvedValueOnce({ accessToken: 'fresh-cookie-token', expiresAt: '2026-07-07T00:00:00.000Z' });
+
+    const res = await requestJson(server, 'GET', '/session/device/state', undefined, { Cookie: 'oxy_device=cookiesecret' });
+
+    expect(res.status).toBe(200);
+    // Session re-minted onto the cookie device, then the account converged.
+    expect(mockMigrateSessionToDevice).toHaveBeenCalledWith('s1', 'cookie-dev');
+    expect(mockConvergeAccountOntoDevice).toHaveBeenCalledWith('cookie-dev', 'd1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
+    // BOTH device rooms broadcast on a real migration.
+    expect(mockBroadcast).toHaveBeenCalledWith(convergedState);
+    expect(mockBroadcast).toHaveBeenCalledWith(oldState);
+    // The normal read path is short-circuited — getState never runs.
+    expect(mockGetState).not.toHaveBeenCalled();
+    // Response carries the converged state + fresh cookie-device token to plant.
+    expect(res.body.data.state).toEqual(convergedState);
+    expect(res.body.data.activeToken.accessToken).toBe('fresh-cookie-token');
+  });
+
+  it('does NOT converge (plain read) when the cookie mismatches but the session is expired/revoked (getSession returns null)', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({ deviceId: 'cookie-dev', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    // Dead session — nothing live to converge; fall through to the plain read.
+    mockGetSession.mockResolvedValueOnce(null);
+    mockGetState.mockResolvedValueOnce(STATE);
+
+    const res = await requestJson(server, 'GET', '/session/device/state', undefined, { Cookie: 'oxy_device=cookiesecret' });
+
+    expect(res.status).toBe(200);
+    expect(mockMigrateSessionToDevice).not.toHaveBeenCalled();
+    expect(mockConvergeAccountOntoDevice).not.toHaveBeenCalled();
+    expect(mockGetState).toHaveBeenCalledWith('d1');
+  });
 });
 
 describe('POST /session/device/switch', () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -30,6 +30,8 @@ import { emitAuthSessionUpdate } from '../utils/authSessionSocket';
 import socialAuthRouter from './socialAuth';
 import { validate } from '../middleware/validate';
 import sessionService from '../services/session.service';
+import type { ISession } from '../models/Session';
+import { broadcastDeviceState } from '../utils/socket';
 import { formatUserResponse } from '../utils/userTransform';
 import { issueAuthCode, exchangeAuthCode, AUTH_CODE_TTL_MS } from '../services/oauthCode.service';
 import { claimAuthSession, authorizeSessionWithSignedChallenge } from '../services/authSession.service';
@@ -2450,11 +2452,74 @@ router.post(
       throw new UnauthorizedError('invalid_grant');
     }
 
-    const session = await sessionService.createSession(
-      user._id.toString(),
+    const userId = user._id.toString();
+
+    // Device-first attribution for the token grant — the last mint path that
+    // used to orphan a UA/IP-derived deviceId (the cleanest reproduction of
+    // "an RP shows a different account list"). Resolve the central device from
+    // the oxy_device cookie (same-apex authorize→token) or an add-only
+    // deviceToken (a cross-apex RP that persisted one at bootstrap). Absent →
+    // no device attribution (we deliberately do NOT invent one).
+    const oauthDeviceId = await resolveLoginDeviceId(
       req,
-      { deviceName: `${app.name} OAuth` }
+      (req.body as { deviceToken?: unknown }).deviceToken,
     );
+
+    // ONE session per account per device: when the account is ALREADY registered
+    // on the resolved device (added during the first-party authorize step),
+    // REUSE that exact registered session so this RP converges on the SAME
+    // sessionId + deviceId the DeviceSession doc holds (one socket room, shared
+    // cross-domain broadcasts) instead of minting a per-RP session on a fresh
+    // device. resolveRegisteredSession validates the session (managed act_as
+    // re-check) before reuse and never resurrects a dead one.
+    // `deviceSession.service` (and its DeviceSession Mongoose model) is imported
+    // LAZILY — only when a device actually resolved — so merely loading the auth
+    // router never forces the model to evaluate (mirrors deviceLogin.service).
+    let session: ISession | null = null;
+    if (oauthDeviceId) {
+      const { deviceSessionService } = await import('../services/deviceSession.service.js');
+      const registered = await deviceSessionService.resolveRegisteredSession(oauthDeviceId, userId);
+      if (registered) {
+        // Load the registered session for the response tokens; its access token
+        // was just rotated/minted by resolveRegisteredSession and carries the
+        // central deviceId claim. A race (session vanished) falls through to a
+        // fresh mint below.
+        session = await sessionService.getSession(registered.sessionId, false);
+      }
+    }
+
+    if (!session) {
+      // Fresh mint — thread the resolved device so createSession's reuse-by-
+      // (userId, deviceId) converges, or a first mint lands on the central
+      // device. No resolved device ⇒ pre-existing UA/IP attribution (unchanged).
+      session = await sessionService.createSession(
+        userId,
+        req,
+        { deviceName: `${app.name} OAuth`, ...(oauthDeviceId ? { deviceId: oauthDeviceId } : {}) },
+      );
+
+      // Register the freshly-minted session into the device set (add-only, never
+      // steals the active account) so a SUBSEQUENT grant for this account on this
+      // device reuses it via resolveRegisteredSession. Best-effort — a
+      // registration failure must never fail the token grant. The lazy import is
+      // module-cached, so re-importing here is free.
+      if (oauthDeviceId) {
+        try {
+          const { deviceSessionService } = await import('../services/deviceSession.service.js');
+          const { state, changed } = await deviceSessionService.addAccount(
+            session.deviceId,
+            { accountId: userId, sessionId: session.sessionId },
+            { activate: 'if-empty' },
+          );
+          if (changed) broadcastDeviceState(state);
+        } catch (error) {
+          logger.warn('[OAuth] device-set registration failed', {
+            userId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
 
     app.lastUsedAt = new Date();
     await app.save();

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -29,11 +29,95 @@ function resolveCallerSession(req: AuthRequest): { deviceId: string; sessionId: 
   return { deviceId: decoded.deviceId, sessionId: decoded.sessionId };
 }
 
+/**
+ * CONVERGE ON READ + ADD — collapse the deviceId split-brain onto ONE device doc.
+ *
+ * The `DeviceSession` doc is looked up two ways: the IdP + bootstrap/web-session
+ * read it by `cookieKeyHash` (the `oxy_device` cookie), while RP apps read it by
+ * the bearer JWT's `deviceId` claim. A session minted before the cookie existed
+ * (or by a mint path that did not thread the cookie's deviceId) lives on a doc
+ * the cookie side never sees — so a signed-in user can look signed-out to the
+ * IdP chooser and the two surfaces show DIFFERENT account lists.
+ *
+ * When a same-site caller presents the `oxy_device` cookie AND it resolves to a
+ * DIFFERENT (canonical) device than the caller's JWT deviceId claim, migrate the
+ * caller's session onto the cookie device and converge the account onto the
+ * canonical cookie doc, returning the converged `{ state, activeToken }` with a
+ * FRESH access token that carries the cookie deviceId. The caller replaces its
+ * bearer immediately (SessionClient plants `activeToken`) so its next
+ * `/session/device/*` calls hit the canonical doc + join the right socket room.
+ *
+ * Same-site is proven by the cookie itself: `oxy_device` is `SameSite=Lax` +
+ * `HttpOnly` + `Domain=.oxy.so`, so it only rides same-site requests, and every
+ * `/session/device/*` route additionally requires a valid bearer — a cross-site
+ * sub-request or top-level navigation (which cannot set `Authorization`) is
+ * rejected before reaching here. No cookie / same-doc / cross-apex (cookie never
+ * travels off `.oxy.so`) → returns null and the caller uses its normal path.
+ *
+ * Returns null (no convergence) so `GET /state` and `POST /add` fall through to
+ * their normal read/add behaviour. Idempotent: a no-op re-converge broadcasts
+ * nothing.
+ */
+async function convergeCallerOntoCookieDevice(
+  req: AuthRequest,
+  session: { deviceId: string; sessionId: string },
+  accountId: string,
+): Promise<Awaited<ReturnType<typeof withActiveToken>> | null> {
+  const rawCookie = readDeviceCookie(req);
+  if (!rawCookie) return null;
+  const cookieState = await deviceSessionService.getStateByCookieKey(rawCookie);
+  if (!cookieState || cookieState.deviceId === session.deviceId) return null;
+
+  // Mismatch confirmed. The bearer JWT does not carry `operatedByUserId` (it is
+  // session-doc-only), so resolve it from the session record to bind the device
+  // entry to its operator. A null doc means the session is expired/revoked —
+  // there is nothing live to converge, so bail (the normal read/add path then
+  // reflects reality) rather than resurrect a dead session onto the cookie doc.
+  const sessionDoc = await sessionService.getSession(session.sessionId, true);
+  if (!sessionDoc) return null;
+  const operatedByUserId = sessionDoc.operatedByUserId ? sessionDoc.operatedByUserId.toString() : undefined;
+
+  // Re-mint the session's tokens on the cookie device FIRST so the returned
+  // activeToken carries the cookie deviceId claim.
+  await sessionService.migrateSessionToDevice(session.sessionId, cookieState.deviceId);
+  const { cookieState: convergedState, oldState, changed } = await deviceSessionService.convergeAccountOntoDevice(
+    cookieState.deviceId,
+    session.deviceId,
+    { accountId, sessionId: session.sessionId, ...(operatedByUserId ? { operatedByUserId } : {}) },
+  );
+  // Broadcast BOTH rooms on a real migration: the cookie device (account
+  // arrived) and the old device (account left). No-op re-converge → no change.
+  if (changed) {
+    broadcastDeviceState(convergedState);
+    broadcastDeviceState(oldState);
+  }
+  return withActiveToken(convergedState);
+}
+
 router.use(requireSameSiteOrigin, authMiddleware);
 
+// GET /state returns the DEVICE subset (this device's registered accounts). The
+// IdP's `POST /auth/device/resolve` returns the SAME device subset once deviceIds
+// converge (both derive from one `DeviceSession` doc). The RP client additionally
+// unions the org/shared account graph from `GET /accounts`; that extra graph is
+// legitimate and is NOT part of the device subset — do not try to make the IdP
+// mirror it.
 router.get('/state', asyncHandler(async (req: AuthRequest, res: Response) => {
   const deviceId = resolveCallerDeviceId(req);
   if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
+
+  // Converge on READ so a switcher that only ever reads state still collapses a
+  // split-brain (previously only POST /add converged, so a client that reloads
+  // and reads state stayed split forever). Only attempts a DB touch when the
+  // caller carries both deviceId + sessionId in its JWT and an oxy_device cookie
+  // is present; otherwise a cheap short-circuit to the normal read.
+  const session = resolveCallerSession(req);
+  const accountId = req.user?._id?.toString();
+  if (session && accountId) {
+    const converged = await convergeCallerOntoCookieDevice(req, session, accountId);
+    if (converged) { res.json({ data: converged }); return; }
+  }
+
   res.json({ data: await withActiveToken(await deviceSessionService.getState(deviceId)) });
 }));
 
@@ -51,36 +135,10 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
   if (!sessionDoc) { res.status(401).json({ error: 'Invalid session' }); return; }
   const operatedByUserId = sessionDoc.operatedByUserId ? sessionDoc.operatedByUserId.toString() : undefined;
 
-  // CONVERGENCE: same-site callers send the `oxy_device` cookie. If it resolves
-  // to a DIFFERENT (canonical) device than the caller's JWT-claims deviceId,
-  // migrate this session onto the cookie device so the whole ecosystem converges
-  // on ONE device identity. Fixes the split-brain: a pre-cookie session lives on
-  // the old JWT-claims doc while the cookie doc (born empty during bootstrap) is
-  // what `/auth/device/resolve` + bootstrap/web-session read — so a signed-in
-  // user looked signed-out to the new device-first surface + IdP chooser.
-  const rawCookie = readDeviceCookie(req);
-  const cookieState = rawCookie ? await deviceSessionService.getStateByCookieKey(rawCookie) : null;
-  if (cookieState && cookieState.deviceId !== session.deviceId) {
-    // Re-mint the session's tokens on the cookie device FIRST so the returned
-    // activeToken carries the cookie deviceId claim — the caller's JWT still
-    // claims the OLD deviceId, so the client must replace its bearer immediately
-    // (SessionClient plants activeToken from /add) to target the right socket
-    // room + hit the canonical doc on subsequent /session/device/* calls.
-    await sessionService.migrateSessionToDevice(session.sessionId, cookieState.deviceId);
-    const { cookieState: convergedState, oldState, changed } = await deviceSessionService.convergeAccountOntoDevice(
-      cookieState.deviceId,
-      session.deviceId,
-      { accountId, sessionId: session.sessionId, ...(operatedByUserId ? { operatedByUserId } : {}) },
-    );
-    // Broadcast BOTH rooms on a real migration: the cookie device (account
-    // arrived) and the old device (account left). No-op re-converge → no change.
-    if (changed) {
-      broadcastDeviceState(convergedState);
-      broadcastDeviceState(oldState);
-    }
-    res.json({ data: await withActiveToken(convergedState) });
-    return;
-  }
+  // Converge onto the canonical cookie device when the cookie deviceId differs
+  // from the JWT claim (shared with GET /state — see convergeCallerOntoCookieDevice).
+  const converged = await convergeCallerOntoCookieDevice(req, session, accountId);
+  if (converged) { res.json({ data: converged }); return; }
 
   const { state, changed } = await deviceSessionService.addAccount(session.deviceId, {
     accountId,

--- a/packages/api/src/schemas/auth.schemas.ts
+++ b/packages/api/src/schemas/auth.schemas.ts
@@ -205,6 +205,13 @@ export const oauthTokenSchema = z.object({
   redirectUri: z.string().trim().url(),
   clientSecret: z.string().trim().min(1).optional(),
   codeVerifier: z.string().trim().min(43).max(128).optional(),
+  // Optional add-only device attribution: an RP that persisted an oxy_device
+  // deviceToken at bootstrap may present it here so the minted session lands on
+  // the caller's CENTRAL device set (one session per account per device) instead
+  // of orphaning a fresh UA/IP-derived deviceId. Absent (the common back-channel
+  // exchange) → the grant still resolves the device from the oxy_device cookie
+  // when the exchange is same-apex, else no device attribution.
+  deviceToken: z.string().trim().min(1).optional(),
 }).refine(
   (data) => Boolean(data.clientSecret) || Boolean(data.codeVerifier),
   { message: 'Either clientSecret (confidential client) or codeVerifier (PKCE) is required' }


### PR DESCRIPTION
## The split-brain

The `DeviceSession` doc is the single source of "which accounts are on this device". It is looked up **two different ways**:

- the **IdP** + bootstrap/web-session read it by **`cookieKeyHash`** (the `oxy_device` cookie) — `getStateByCookieKey`
- **RP apps** read it by the bearer JWT's **`deviceId` claim** — `getState(deviceId)`

The cookie doc's own `deviceId` (minted by `ensureDeviceForCookie` at bootstrap) is canonical. A session minted **before** the cookie existed — or by a mint path that never threaded the cookie's deviceId — carries a `deviceId` claim pointing at a *different* doc. So the RP side and the cookie/IdP side disagree, which surfaces as the two live bugs:

1. **auth.oxy.so and RP apps show different account lists** (each reads a different doc).
2. **sign-in in one tab/app doesn't sync to another** (they sit in different `device:<id>` socket rooms).

Before this PR, only `POST /session/device/add` converged the two docs. A client that only ever **reads** state (a switcher, a reload) never hit convergence and stayed split forever. And one mint path — the OAuth token grant — threaded *no* device attribution at all, minting every exchange onto a fresh UA/IP-derived device.

## What each change fixes

**1. Converge on READ — `GET /session/device/state`.** When a same-site caller's `oxy_device` cookie resolves to a *different* canonical device than its JWT `deviceId` claim, migrate the caller's session onto the cookie device using the **exact machinery `/add` already uses** (`sessionService.migrateSessionToDevice` + `deviceSessionService.convergeAccountOntoDevice`, advancing revision past the retired doc), broadcast both device rooms, and return the converged `{ state, activeToken }` with a **fresh access token carrying the cookie deviceId** so the client's next calls target the canonical doc. Idempotent: same-doc / no-cookie / cross-apex (the cookie never travels off `.oxy.so`) / dead-session all fall through to the normal read. Extracted into a shared helper (`convergeCallerOntoCookieDevice`) reused by both `/state` and `/add`, so the two paths cannot drift.

*Same-site gate:* the `oxy_device` cookie is itself the proof — `SameSite=Lax` + `HttpOnly` + `Domain=.oxy.so` means it only rides same-site requests, and every `/session/device/*` route additionally requires a valid bearer (a cross-site sub-request or top-level nav cannot set `Authorization`). This mirrors the existing `/add` convergence exactly rather than adding an `isSameSiteTrustedRequest` check that would require an `Origin` header a same-origin GET may omit and would diverge `/add`.

**2. Activate `resolveRegisteredSession` (was dead code) + seal the OAuth grant — `POST /auth/oauth/token`.** This grant was the last mint path with no device attribution. It now:
- resolves the central device from the `oxy_device` cookie (same-apex authorize→token) or an **add-only `deviceToken`** (new *optional* schema field — additive, backward-compatible);
- consults `resolveRegisteredSession(deviceId, accountId)` to **reuse** the account's already-registered session on that device (same `sessionId` + `deviceId` the doc holds — one socket room, shared broadcasts) instead of minting a per-RP session on a fresh device; `resolveRegisteredSession` re-validates the session (managed `act_as` re-check) and never resurrects a dead one;
- on a miss, threads the resolved `deviceId` into `createSession` (its reuse-by-`(userId, deviceId)` converges) and registers the fresh session into the device set (add-only, `activate: 'if-empty'`) so the *next* grant reuses it;
- when **no** device resolves, invents nothing — the pre-existing UA/IP attribution is unchanged.

`deviceSession.service` is imported **lazily** in the grant (mirrors `deviceLogin.service`) so merely loading the auth router never forces the `DeviceSession` Mongoose model to evaluate.

**3. Login / cross-apex mints were already sealed** and are left untouched: `signIn`, `verifyChallenge`, `signUp`, and 2FA `verify-login` already call `resolveLoginDevice` → `createSession({ deviceId })`, and `createSession`'s reuse-by-`(userId, deviceId)` + `finalizeDeviceLogin`'s add-only registration already enforce one-session-per-account-per-device. Restructuring those four controllers to short-circuit `createSession` via `resolveRegisteredSession` would change their response construction for no net convergence gain and material regression risk, so `resolveRegisteredSession` is activated at the one genuinely-unsealed path (the OAuth grant). Flag me if you want the deeper refactor.

**Shape note:** `/auth/device/resolve` (IdP) and `/session/device/state` (RP) return the **same device subset** once deviceIds converge (both derive from one doc). The RP additionally unions the org/shared account graph from `GET /accounts` — that extra graph is legitimate and is *not* the device subset. Documented in a comment above `/state`; the IdP is not meant to mirror it.

## Client `deviceToken` finding (read-only — not fixed here)

Cross-apex convergence can't ride the cookie (`Domain=.oxy.so` never reaches `mention.earth`), so it depends on the client attaching the persisted `deviceToken` on cross-apex login/verify.

- **Device-first login/verify DO attach it.** `signInWithPassword` (services `OxyContext.tsx:814`) and `completeTwoFactorSignIn` (`:848`), and auth-sdk `submitPassword` / `submitTwoFactor` (`useOxySignIn.ts:150/181`), all call `authStore.loadDeviceToken()` and pass it to `passwordSignIn` / `completeTwoFactorSignIn`, which forward it to `/auth/login` and `/security/2fa/verify-login`. ✅ Cross-apex convergence via `deviceToken` is guaranteed for these paths.
- **Legacy `signIn` (`OxyServices.auth.ts:1089`) does NOT send a `deviceToken`** (only identifier/password/deviceName/deviceFingerprint). Any caller still on it won't converge cross-apex — the device-first surface uses `passwordSignIn`, so this is latent.
- **No SDK client calls `/auth/oauth/token`** at all (only the `oauth/client/:id` metadata lookup exists). So the OAuth-grant seal is only effective when the exchange is **same-apex** (cookie present) or a future RP backend explicitly sends the new optional `deviceToken`. The server side is ready; wiring an RP/back-channel client to send `deviceToken` is FA2/FB scope.

## Verification

- `packages/api` jest: **145 suites / 1346 tests pass** (includes the new `GET /state` convergence suite and the `POST /auth/oauth/token` device-attribution suite; the 9 suites that mount the auth router pass thanks to the lazy `deviceSession.service` import).
- `tsc --noEmit`: clean.
- `eslint`: 0 errors (pre-existing `any`/unused-import warnings only; none in the changed files).

**Do not merge** — merge = prod deploy; lead coordinates + live-verifies with a `DeviceSession` dump (one doc per device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)