### PR TITLE
feat(api,core): signed-out device sync — cookie-authed socket + BroadcastChannel wake idle tabs

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -63,7 +63,6 @@ import { startNodeIngestJobs, stopNodeIngestJobs } from './queue/nodeIngest.queu
 import { startLinkPreviewWarmJobs, stopLinkPreviewWarmJobs } from './queue/linkPreviewWarm.queue';
 import { getEnvBoolean, validateRequiredEnvVars, getSanitizedConfig, getEnvNumber } from './config/env';
 import { getDbName } from './config/db';
-import jwt from 'jsonwebtoken';
 import { logger } from './utils/logger';
 import { Response } from 'express';
 import { authMiddleware } from './middleware/auth';
@@ -73,7 +72,8 @@ import { createCorsMiddleware, SOCKET_IO_CORS_CONFIG } from './config/cors';
 import { refreshOriginRegistry } from './config/dynamicOriginRegistry';
 import { createAdapter } from '@socket.io/redis-adapter';
 import { getRedisClient, closeRedis } from './config/redis';
-import { initializeIO, deviceRoomFor } from './utils/socket';
+import { initializeIO, socketRoomsFor } from './utils/socket';
+import { resolveSocketIdentity } from './utils/socketAuth';
 import performanceMiddleware, { getMemoryStats, getConnectionPoolStats } from './middleware/performance';
 import { performanceMonitor } from './utils/performanceMonitor';
 import { waitForMongoConnection } from './utils/dbConnection';
@@ -218,51 +218,55 @@ interface AuthenticatedSocket extends Socket {
     deviceId?: string;
     [key: string]: any;
   };
+  /**
+   * Anonymous device socket: the server-resolved deviceId for a cookie- or
+   * device-token-authed connection with NO user identity (a signed-out tab
+   * listening on its `device:<id>` room). Never set from client input.
+   */
+  deviceId?: string;
 }
 
 // Socket.IO rate limiting (applied before auth to protect against unauthenticated floods)
 import { createSocketRateLimiter } from './middleware/socketRateLimit';
 io.use(createSocketRateLimiter(100, 10_000)); // 100 events per 10s
 
-// Socket.IO authentication middleware
+// Socket.IO authentication middleware. Accepts either an authenticated user
+// (valid bearer) OR an anonymous device socket (a signed-out tab authed by its
+// first-party `oxy_device` cookie / native device token) — see resolveSocketIdentity.
 io.use((socket: AuthenticatedSocket, next) => {
-  const token = socket.handshake.auth.token;
-
-  if (!token) {
-    return next(new Error('Authentication error'));
-  }
-
-  try {
-    // Verify the token
-    if (!process.env.ACCESS_TOKEN_SECRET) {
-      throw new Error('ACCESS_TOKEN_SECRET is not configured');
-    }
-    const decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET) as any;
-    // Normalize userId: tokens use 'userId' field, but socket interface expects 'id'
-    const userId = decoded.userId || decoded.id;
-    if (!userId) {
-      return next(new Error('Token missing user ID'));
-    }
-    socket.user = { id: userId, ...decoded };
-    next();
-  } catch (error) {
-    logger.error('Socket authentication error:', error);
-    next(new Error('Authentication error'));
-  }
+  resolveSocketIdentity(socket.handshake)
+    .then((identity) => {
+      if (!identity) {
+        next(new Error('Authentication error'));
+        return;
+      }
+      if (identity.kind === 'user') {
+        socket.user = identity.user;
+      } else {
+        socket.deviceId = identity.deviceId;
+      }
+      next();
+    })
+    .catch((error) => {
+      logger.error('Socket authentication error:', error);
+      next(new Error('Authentication error'));
+    });
 });
 
-// Socket connection handling for authenticated users
+// Socket connection handling — authenticated users AND anonymous device sockets.
 io.on('connection', (socket: AuthenticatedSocket) => {
   logger.debug('Socket connected', { socketId: socket.id });
 
-  if (socket.user?.id) {
-    const room = `user:${socket.user.id}`;
+  // A user socket joins `user:<id>` + `device:<deviceId>`; an anonymous device
+  // socket joins ONLY `device:<deviceId>` (never a `user:` room). All ids are
+  // server-resolved — see socketRoomsFor.
+  const rooms = socketRoomsFor({ user: socket.user, deviceId: socket.deviceId });
+  for (const room of rooms) {
     socket.join(room);
-    logger.debug('User joined notification room', { userId: socket.user.id, room });
   }
-
-  const deviceRoom = socket.user ? deviceRoomFor(socket.user) : null;
-  if (deviceRoom) socket.join(deviceRoom);
+  if (rooms.length > 0) {
+    logger.debug('Socket joined rooms', { socketId: socket.id, rooms });
+  }
 
   socket.on('disconnect', () => {
     logger.debug('Socket disconnected', { socketId: socket.id });

--- a/packages/api/src/services/deviceToken.service.ts
+++ b/packages/api/src/services/deviceToken.service.ts
@@ -22,7 +22,7 @@
  */
 
 import * as crypto from 'crypto';
-import type { Request } from 'express';
+import type { IncomingHttpHeaders } from 'http';
 import DeviceToken, { DeviceTokenChannel, IDeviceToken } from '../models/DeviceToken';
 import { sha256Hex, base64UrlEncode } from './oauthCode.service';
 import { normaliseOrigin } from '../utils/origin';
@@ -83,7 +83,7 @@ export async function issueDeviceToken(input: IssueDeviceTokenInput): Promise<st
  */
 export async function resolveDeviceToken(
   rawToken: string,
-  req: Request
+  req: { headers: Pick<IncomingHttpHeaders, 'origin'> }
 ): Promise<{ deviceId: string } | null> {
   try {
     if (typeof rawToken !== 'string' || rawToken.length === 0) {

--- a/packages/api/src/utils/__tests__/socketAuth.test.ts
+++ b/packages/api/src/utils/__tests__/socketAuth.test.ts
@@ -1,0 +1,131 @@
+/**
+ * socketAuth unit tests — the single authority for who a Socket.IO connection is
+ * allowed to be.
+ *
+ * Covers:
+ *  - a valid bearer → an AUTHENTICATED user identity (user + device rooms);
+ *  - NO bearer + a resolvable `oxy_device` cookie → an ANONYMOUS device identity
+ *    (deviceId resolved server-side from the cookie hash, never client input);
+ *  - an INVALID bearer falls through to the cookie path (a signed-out tab may
+ *    still hold a valid device cookie);
+ *  - the native device-token fallback (no cookie jar);
+ *  - reject when neither a bearer nor a device anchor resolves;
+ *  - socketRoomsFor: a user socket joins BOTH rooms, an anonymous socket joins
+ *    ONLY its device room (never a `user:` room).
+ */
+import jwt from 'jsonwebtoken';
+
+// `jsonwebtoken` is globally mocked in jest.setup.cjs (verify never throws). Drive
+// `verify` per-test so we can exercise both the valid-bearer and invalid-bearer
+// (throwing) branches.
+const mockVerify = jwt.verify as unknown as jest.Mock;
+
+const mockGetStateByCookieKey = jest.fn();
+jest.mock('../../services/deviceSession.service', () => {
+  const svc = { getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a) };
+  return { __esModule: true, default: svc, deviceSessionService: svc };
+});
+
+const mockResolveDeviceToken = jest.fn();
+jest.mock('../../services/deviceToken.service', () => ({
+  resolveDeviceToken: (...a: unknown[]) => mockResolveDeviceToken(...a),
+}));
+
+jest.mock('../logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+
+import { resolveSocketIdentity, type SocketHandshakeAuthInput } from '../socketAuth';
+import { socketRoomsFor } from '../socket';
+
+const SECRET = 'test-access-secret';
+
+function handshake(over: Partial<SocketHandshakeAuthInput> = {}): SocketHandshakeAuthInput {
+  return { auth: {}, headers: {}, ...over };
+}
+
+beforeAll(() => {
+  process.env.ACCESS_TOKEN_SECRET = SECRET;
+});
+beforeEach(() => {
+  mockGetStateByCookieKey.mockReset();
+  mockResolveDeviceToken.mockReset();
+  mockVerify.mockReset().mockReturnValue({ userId: 'u1', deviceId: 'd1', sessionId: 's1' });
+});
+
+describe('resolveSocketIdentity', () => {
+  it('resolves an authenticated user identity from a valid bearer', async () => {
+    const id = await resolveSocketIdentity(handshake({ auth: { token: 'valid.jwt.here' } }));
+    expect(id).toEqual({ kind: 'user', user: expect.objectContaining({ id: 'u1', deviceId: 'd1' }) });
+    expect(mockVerify).toHaveBeenCalledWith('valid.jwt.here', SECRET);
+    // The bearer path never touches the anonymous device resolvers.
+    expect(mockGetStateByCookieKey).not.toHaveBeenCalled();
+    expect(mockResolveDeviceToken).not.toHaveBeenCalled();
+  });
+
+  it('resolves an anonymous device identity from the oxy_device cookie when there is no bearer', async () => {
+    mockGetStateByCookieKey.mockResolvedValue({ deviceId: 'dev-cookie', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    const id = await resolveSocketIdentity(handshake({ headers: { cookie: 'oxy_device=rawsecret; other=1' } }));
+    expect(id).toEqual({ kind: 'device', deviceId: 'dev-cookie' });
+    // deviceId derived server-side from the RAW cookie value, not client input.
+    expect(mockGetStateByCookieKey).toHaveBeenCalledWith('rawsecret');
+  });
+
+  it('never returns a user identity for a cookie-authed anonymous socket', async () => {
+    mockGetStateByCookieKey.mockResolvedValue({ deviceId: 'dev-cookie', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    const id = await resolveSocketIdentity(handshake({ headers: { cookie: 'oxy_device=rawsecret' } }));
+    expect(id?.kind).toBe('device');
+  });
+
+  it('falls through to the cookie path when the bearer is present but invalid', async () => {
+    mockVerify.mockImplementation(() => { throw new Error('invalid signature'); });
+    mockGetStateByCookieKey.mockResolvedValue({ deviceId: 'dev-cookie', accounts: [], activeAccountId: null, revision: 0, updatedAt: 1 });
+    const id = await resolveSocketIdentity(handshake({ auth: { token: 'not-a-jwt' }, headers: { cookie: 'oxy_device=rawsecret' } }));
+    expect(id).toEqual({ kind: 'device', deviceId: 'dev-cookie' });
+  });
+
+  it('resolves an anonymous device identity from the native device token when no cookie', async () => {
+    mockGetStateByCookieKey.mockResolvedValue(null);
+    mockResolveDeviceToken.mockResolvedValue({ deviceId: 'dev-token' });
+    const id = await resolveSocketIdentity(handshake({ auth: { deviceToken: 'dt-abc' } }));
+    expect(id).toEqual({ kind: 'device', deviceId: 'dev-token' });
+    expect(mockResolveDeviceToken).toHaveBeenCalledWith('dt-abc', { headers: {} });
+  });
+
+  it('prefers the cookie over the device token, only trying the token when the cookie does not resolve', async () => {
+    mockGetStateByCookieKey.mockResolvedValue(null);
+    mockResolveDeviceToken.mockResolvedValue({ deviceId: 'dev-token' });
+    const id = await resolveSocketIdentity(handshake({ auth: { deviceToken: 'dt-abc' }, headers: { cookie: 'oxy_device=stale' } }));
+    expect(mockGetStateByCookieKey).toHaveBeenCalledWith('stale');
+    expect(id).toEqual({ kind: 'device', deviceId: 'dev-token' });
+  });
+
+  it('rejects (null) when neither a bearer nor a resolvable device anchor is present', async () => {
+    const id = await resolveSocketIdentity(handshake());
+    expect(id).toBeNull();
+  });
+
+  it('rejects (null) when a cookie is present but resolves to no device and there is no token', async () => {
+    mockGetStateByCookieKey.mockResolvedValue(null);
+    const id = await resolveSocketIdentity(handshake({ headers: { cookie: 'oxy_device=unknown' } }));
+    expect(id).toBeNull();
+  });
+});
+
+describe('socketRoomsFor', () => {
+  it('an authenticated user joins BOTH the user and device rooms', () => {
+    expect(socketRoomsFor({ user: { id: 'u1', deviceId: 'd1' } })).toEqual(['user:u1', 'device:d1']);
+  });
+
+  it('an authenticated user without a device claim joins only the user room', () => {
+    expect(socketRoomsFor({ user: { id: 'u1' } })).toEqual(['user:u1']);
+  });
+
+  it('an anonymous device socket joins ONLY the device room (never a user room)', () => {
+    const rooms = socketRoomsFor({ deviceId: 'dev-cookie' });
+    expect(rooms).toEqual(['device:dev-cookie']);
+    expect(rooms.some((r) => r.startsWith('user:'))).toBe(false);
+  });
+
+  it('returns no rooms for an unresolved identity', () => {
+    expect(socketRoomsFor({})).toEqual([]);
+  });
+});

--- a/packages/api/src/utils/deviceCookie.ts
+++ b/packages/api/src/utils/deviceCookie.ts
@@ -81,6 +81,28 @@ export function setDeviceCookie(res: Response, secret: string): void {
 }
 
 /**
+ * Parse the raw `oxy_device` cookie secret out of a `Cookie` request header.
+ * The ONE header-parsing implementation, shared by the Express path
+ * ({@link readDeviceCookie}) and the Socket.IO handshake path (which only has
+ * `socket.handshake.headers.cookie`, no cookie-parser). Returns `undefined`
+ * when the header is absent/empty or carries no non-empty `oxy_device` value.
+ */
+export function readDeviceCookieFromHeader(cookieHeader: string | undefined): string | undefined {
+  if (typeof cookieHeader !== 'string' || cookieHeader.length === 0) {
+    return undefined;
+  }
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const name = part.slice(0, eq).trim();
+    if (name !== DEVICE_COOKIE_NAME) continue;
+    const value = part.slice(eq + 1).trim();
+    return value.length > 0 ? value : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Read the raw `oxy_device` cookie secret from a request. Prefers `req.cookies`
  * (cookie-parser) and falls back to parsing the raw `Cookie` header so the
  * helper works in unit tests that mount a bare router. Returns `undefined` when
@@ -94,16 +116,5 @@ export function readDeviceCookie(req: Request): string | undefined {
   }
 
   const header = req.headers.cookie;
-  if (typeof header !== 'string' || header.length === 0) {
-    return undefined;
-  }
-  for (const part of header.split(';')) {
-    const eq = part.indexOf('=');
-    if (eq === -1) continue;
-    const name = part.slice(0, eq).trim();
-    if (name !== DEVICE_COOKIE_NAME) continue;
-    const value = part.slice(eq + 1).trim();
-    return value.length > 0 ? value : undefined;
-  }
-  return undefined;
+  return readDeviceCookieFromHeader(typeof header === 'string' ? header : undefined);
 }

--- a/packages/api/src/utils/socket.ts
+++ b/packages/api/src/utils/socket.ts
@@ -31,3 +31,32 @@ export function broadcastDeviceState(state: DeviceSessionState): void {
 export function deviceRoomFor(decoded: { deviceId?: string | null }): string | null {
   return decoded?.deviceId ? `device:${decoded.deviceId}` : null;
 }
+
+/**
+ * The rooms a connected socket should join, given its resolved identity.
+ *
+ *  - An AUTHENTICATED user socket joins BOTH `user:<id>` (notifications) and its
+ *    `device:<deviceId>` room (JWT claim).
+ *  - An ANONYMOUS device socket (signed-out tab, cookie/device-token authed)
+ *    joins ONLY `device:<deviceId>` — NEVER a `user:` room, so it can learn only
+ *    that its own device's session set changed and nothing about any user.
+ *
+ * The deviceId is always server-resolved (JWT claim, cookie hash, or token hash),
+ * never client-supplied.
+ */
+export function socketRoomsFor(identity: {
+  user?: { id: string; deviceId?: string | null } | null;
+  deviceId?: string | null;
+}): string[] {
+  const rooms: string[] = [];
+  if (identity.user?.id) {
+    rooms.push(`user:${identity.user.id}`);
+  }
+  const deviceRoom = identity.user
+    ? deviceRoomFor(identity.user)
+    : deviceRoomFor({ deviceId: identity.deviceId });
+  if (deviceRoom) {
+    rooms.push(deviceRoom);
+  }
+  return rooms;
+}

--- a/packages/api/src/utils/socketAuth.ts
+++ b/packages/api/src/utils/socketAuth.ts
@@ -1,0 +1,114 @@
+/**
+ * Socket.IO handshake → room identity, resolved WITHOUT ever trusting a
+ * client-supplied user or device id.
+ *
+ * This is the single authority for who a socket is allowed to be. It powers two
+ * kinds of connection:
+ *
+ *  - AUTHENTICATED user socket — a valid bearer access token. Joins the
+ *    `user:<id>` room AND the `device:<deviceId>` room (deviceId from the JWT
+ *    claim).
+ *  - ANONYMOUS device socket — NO (or invalid) bearer, but a resolvable device
+ *    anchor: the first-party `oxy_device` cookie (same-site `*.oxy.so`
+ *    handshake) or, on native (no cookie jar), the shared device token in the
+ *    handshake auth. Joins ONLY `device:<deviceId>` — the deviceId is derived
+ *    SERVER-SIDE from the cookie's / token's hash, never from client input, and
+ *    the socket carries ZERO user identity.
+ *
+ * Why this is safe: an anonymous device socket can only ever LEARN that its own
+ * device's session set changed — it receives the state-only `session_state`
+ * broadcast (account ids + revision, NEVER tokens), cannot mutate anything, and
+ * cannot join another device's room (the room is the server-resolved deviceId).
+ * This is the same posture as the device-first `oxy_device` cookie itself.
+ */
+import jwt from 'jsonwebtoken';
+import type { IncomingHttpHeaders } from 'http';
+import deviceSessionService from '../services/deviceSession.service';
+import { resolveDeviceToken } from '../services/deviceToken.service';
+import { readDeviceCookieFromHeader } from './deviceCookie';
+import { logger } from './logger';
+
+/** An authenticated user socket: full identity, both `user:` and `device:` rooms. */
+export interface SocketUserIdentity {
+  kind: 'user';
+  user: { id: string; deviceId?: string; [key: string]: unknown };
+}
+
+/** An anonymous device socket: `device:` room only, no user identity. */
+export interface SocketDeviceIdentity {
+  kind: 'device';
+  deviceId: string;
+}
+
+/** Resolved handshake identity, or `null` to reject the connection. */
+export type SocketIdentity = SocketUserIdentity | SocketDeviceIdentity | null;
+
+/** The subset of a Socket.IO `Handshake` this resolver reads. */
+export interface SocketHandshakeAuthInput {
+  auth?: Record<string, unknown>;
+  headers: IncomingHttpHeaders;
+}
+
+interface AccessTokenClaims extends jwt.JwtPayload {
+  userId?: string;
+  id?: string;
+  deviceId?: string;
+}
+
+export async function resolveSocketIdentity(
+  handshake: SocketHandshakeAuthInput,
+): Promise<SocketIdentity> {
+  // 1. Bearer access token → authenticated user socket.
+  const rawToken = handshake.auth?.token;
+  const token = typeof rawToken === 'string' ? rawToken : '';
+  if (token) {
+    const secret = process.env.ACCESS_TOKEN_SECRET;
+    if (!secret) {
+      // Misconfiguration — never crash the handshake; degrade to the device
+      // paths below (which may still resolve) or reject.
+      logger.error('resolveSocketIdentity: ACCESS_TOKEN_SECRET is not configured');
+    } else {
+      try {
+        const decoded = jwt.verify(token, secret);
+        if (typeof decoded !== 'string') {
+          const claims = decoded as AccessTokenClaims;
+          const userId = claims.userId ?? claims.id;
+          if (userId) {
+            return { kind: 'user', user: { id: userId, ...claims } };
+          }
+        }
+      } catch (error) {
+        // A present-but-invalid bearer (e.g. an expired token on a tab that just
+        // signed out) is NOT a hard reject — fall through to the anonymous
+        // device paths, which may still resolve a valid `oxy_device` cookie.
+        logger.debug('resolveSocketIdentity: bearer verify failed; trying device paths', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  // 2. First-party `oxy_device` cookie (same-site `*.oxy.so`) → anonymous device
+  //    socket. deviceId derived from the cookie's SHA-256, server-side only.
+  const cookieKey = readDeviceCookieFromHeader(handshake.headers?.cookie);
+  if (cookieKey) {
+    const state = await deviceSessionService.getStateByCookieKey(cookieKey);
+    if (state?.deviceId) {
+      return { kind: 'device', deviceId: state.deviceId };
+    }
+  }
+
+  // 3. Native shared device token in the handshake auth (RN has no cookie jar)
+  //    → anonymous device socket. deviceId derived from the token hash.
+  const rawDeviceToken = handshake.auth?.deviceToken;
+  const deviceToken = typeof rawDeviceToken === 'string' ? rawDeviceToken : '';
+  if (deviceToken) {
+    const resolved = await resolveDeviceToken(deviceToken, { headers: handshake.headers });
+    if (resolved?.deviceId) {
+      return { kind: 'device', deviceId: resolved.deviceId };
+    }
+  }
+
+  // 4. No bearer, no resolvable device anchor → reject.
+  return null;
+}

--- a/packages/auth-sdk/__tests__/sessionClientWiring.test.tsx
+++ b/packages/auth-sdk/__tests__/sessionClientWiring.test.tsx
@@ -209,7 +209,7 @@ describe('WebOxyProvider — SessionClient projection (device-first)', () => {
     expect(stubs.getUsersByIds).not.toHaveBeenCalled();
   });
 
-  it('injects the statically-imported socket.io factory as the third createSessionClient argument', async () => {
+  it('injects the socket.io factory (3rd arg) + signed-out realtime wiring (4th arg) into createSessionClient', async () => {
     const fake = buildFakeClient(null);
     mockedCreateSessionClient.mockReturnValue({
       client: fake.fakeClient as never,
@@ -225,7 +225,14 @@ describe('WebOxyProvider — SessionClient projection (device-first)', () => {
 
     expect(mockedCreateSessionClient).toHaveBeenCalledTimes(1);
     const args = mockedCreateSessionClient.mock.calls[0];
-    expect(args).toHaveLength(3);
+    expect(args).toHaveLength(4);
+    // 3rd arg: the statically-imported socket.io `io` factory.
     expect(typeof args[2]).toBe('function');
+    // 4th arg: signed-out realtime wiring (cookie socket gate + self-acquire hook).
+    const extra = args[3] as { signedOutSocketAuth?: unknown; onSessionAppeared?: unknown };
+    expect(typeof extra.signedOutSocketAuth).toBe('function');
+    expect(typeof extra.onSessionAppeared).toBe('function');
+    // Web is always `*.oxy.so` → the cookie rides the handshake; the gate returns true.
+    expect((extra.signedOutSocketAuth as () => unknown)()).toBe(true);
   });
 });

--- a/packages/auth-sdk/src/WebOxyProvider.tsx
+++ b/packages/auth-sdk/src/WebOxyProvider.tsx
@@ -244,6 +244,12 @@ export function WebOxyProvider({
 
   const isAuthenticated = !!user;
 
+  // Re-boot indirection: the SessionClient is built in the ref initializer below
+  // (before the boot is defined), but its `onSessionAppeared` must re-run the cold
+  // boot to self-acquire when a sibling tab signs in on this device. A ref bridges
+  // the ordering; it is assigned right after `runBoot` is declared.
+  const runBootRef = useRef<(() => Promise<void>) | null>(null);
+
   // Device-first web `TokenTransport`: when the `SessionClient` applies a state
   // and no active token is held (e.g. a cross-tab push), mint one by rotating
   // the persisted refresh family. No native shared-key arm (web-only). Best
@@ -268,7 +274,15 @@ export function WebOxyProvider({
     // imported + injected so realtime sync survives Vite/Rolldown bundling of the
     // published core dist (core's lazy dynamic import of a bare specifier does
     // not resolve reliably there).
-    sessionClientPairRef.current = createSessionClient(oxyServices, transport, io);
+    sessionClientPairRef.current = createSessionClient(oxyServices, transport, io, {
+      // Web is always `*.oxy.so`: the first-party `oxy_device` cookie rides the
+      // same-site socket handshake, so an idle signed-out tab can join its
+      // `device:<id>` room and receive a sibling's sign-in push.
+      signedOutSocketAuth: () => true,
+      onSessionAppeared: () => {
+        void runBootRef.current?.();
+      },
+    });
   }
   const { client: sessionClient, host: sessionClientHost } = sessionClientPairRef.current;
 
@@ -497,8 +511,41 @@ export function WebOxyProvider({
 
   // Cold boot — device-first, zero-redirect. Delegates the entire ordered
   // resolution to core's `runSessionColdBoot`; the provider only reacts to the
-  // outcome (`onSession` → commit; `onSignedOut` → stop loading). No `signIn`
-  // navigation, no SSO bounce.
+  // outcome (`onSession` → commit; `onSignedOut` → open the signed-out realtime
+  // channel + stop loading). No `signIn` navigation, no SSO bounce. Shared by the
+  // mount effect and `onSessionAppeared`'s re-acquisition (a sibling sign-in).
+  const runBoot = useCallback(async () => {
+    await runSessionColdBoot({
+      oxy: oxyServices,
+      store,
+      platform: { isWeb: true, isNative: false },
+      onSession: async (session) => {
+        await commitBootSession(session);
+      },
+      onSignedOut: () => {
+        setIsLoading(false);
+        // Join this idle tab's `device:<id>` room (via the first-party
+        // `oxy_device` cookie) so a sibling's sign-in wakes it. Idempotent +
+        // best-effort — never throw out of the boot.
+        void sessionClient.start().catch((startError) => {
+          logger.debug(
+            'signed-out socket start failed (non-fatal)',
+            { component: 'WebOxyProvider', method: 'coldBoot' },
+            startError,
+          );
+        });
+      },
+      onStepError: (id, stepError) => {
+        logger.debug(
+          'cold-boot step did not resolve a session',
+          { component: 'WebOxyProvider', method: 'coldBoot', step: id },
+          stepError,
+        );
+      },
+    });
+  }, [oxyServices, store, commitBootSession, sessionClient]);
+  runBootRef.current = runBoot;
+
   useEffect(() => {
     if (skipAutoCheck) {
       setIsLoading(false);
@@ -506,48 +553,25 @@ export function WebOxyProvider({
     }
     let mounted = true;
 
-    const boot = async () => {
-      await runSessionColdBoot({
-        oxy: oxyServices,
-        store,
-        platform: { isWeb: true, isNative: false },
-        onSession: async (session) => {
-          if (!mounted) return;
-          await commitBootSession(session);
-        },
-        onSignedOut: () => {
-          if (!mounted) return;
-          setIsLoading(false);
-        },
-        onStepError: (id, stepError) => {
-          logger.debug(
-            'cold-boot step did not resolve a session',
-            { component: 'WebOxyProvider', method: 'coldBoot', step: id },
-            stepError,
-          );
-        },
-      });
-      if (mounted) {
-        setIsLoading(false);
-      }
-    };
-
     // Safety net: if a step stalls, stop loading after a bound.
     const timeoutId = setTimeout(() => {
       if (mounted) setIsLoading(false);
     }, SESSION_HANDOFF_DEADLINE * 2);
 
-    boot()
+    runBoot()
       .catch((bootError) => {
         if (mounted) handleAuthError(bootError);
       })
-      .finally(() => clearTimeout(timeoutId));
+      .finally(() => {
+        clearTimeout(timeoutId);
+        if (mounted) setIsLoading(false);
+      });
 
     return () => {
       mounted = false;
       clearTimeout(timeoutId);
     };
-  }, [oxyServices, store, skipAutoCheck, commitBootSession, handleAuthError]);
+  }, [skipAutoCheck, runBoot, handleAuthError]);
 
   useEffect(() => {
     onAuthStateChange?.(user);

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -46,9 +46,49 @@ export interface SessionClientOptions {
    * absent it falls back to `getSocketIO()`.
    */
   socketFactory?: SocketIOFactory;
+  /**
+   * Gate + credential for opening the realtime socket while SIGNED OUT (no
+   * access token), so an idle tab still joins its `device:<id>` room and can
+   * self-acquire the moment a sibling app/tab signs in on the same device.
+   * Returns:
+   *   - `true`   → connect and rely on the first-party `oxy_device` cookie
+   *     riding the same-site handshake (web `*.oxy.so`; the cookie is HttpOnly
+   *     so JS cannot read it, but the browser sends it automatically).
+   *   - a string → connect and present it as `deviceToken` in the handshake
+   *     auth (native shared-keychain device token; RN has no cookie jar).
+   *   - `false`/`null` → do NOT open a signed-out socket (the default — e.g. a
+   *     native app with no known device yet).
+   * Called at connect time (and each reconnect); may be async (keychain read).
+   */
+  signedOutSocketAuth?: () => boolean | string | null | Promise<boolean | string | null>;
+  /**
+   * Invoked when a `session_state` push (or a same-origin BroadcastChannel wake)
+   * arrives while this tab is SIGNED OUT and the pushed device state has at
+   * least one account — i.e. a sibling just signed in on this device. The
+   * consumer runs its session acquisition (cold boot / `requestWebSession`),
+   * which plants a token and flips the tab to signed-in. Guarded + idempotent:
+   * only one acquisition runs at a time, and a returned promise gates the next.
+   */
+  onSessionAppeared?: () => void | Promise<void>;
 }
 
 type StateListener = (state: DeviceSessionState | null) => void;
+
+/**
+ * Same-origin `BroadcastChannel` name for instant, network-free session wake
+ * across tabs of the SAME origin (e.g. two `accounts.oxy.so` tabs). Complements
+ * the cookie-authed device socket, which covers same-apex cross-origin
+ * (`accounts` ↔ `console` ↔ `inbox`, all `*.oxy.so`). Cross-APEX (mention.earth)
+ * is covered by neither and relies on a reload — the documented limitation.
+ */
+const SESSION_BROADCAST_CHANNEL = 'oxy.session';
+
+/** A minimal, feature-detected `BroadcastChannel` surface (absent on native RN). */
+interface SessionBroadcastChannel {
+  postMessage(message: unknown): void;
+  close(): void;
+  onmessage: ((event: { data: unknown }) => void) | null;
+}
 
 export class SessionClient {
   private state: DeviceSessionState | null = null;
@@ -56,6 +96,12 @@ export class SessionClient {
   protected socket: MinimalSocket | null = null;
   private tokenUnsub: (() => void) | null = null;
   private started = false;
+  /** In-flight guard so a burst of pushes triggers at most ONE acquisition. */
+  private acquiring = false;
+  /** True while the live socket is an anonymous (signed-out) device connection. */
+  private socketAnonymous = false;
+  /** Same-origin cross-tab wake channel; null on platforms without BroadcastChannel. */
+  private channel: SessionBroadcastChannel | null = null;
 
   constructor(
     protected readonly host: SessionClientHost,
@@ -161,16 +207,19 @@ export class SessionClient {
   async switchAccount(accountId: string): Promise<void> {
     const res = await this.host.makeRequest<unknown>('POST', '/session/device/switch', { accountId }, { cache: false });
     this.applySync(res);
+    this.postCommitPing();
   }
 
   async signOut(target: { accountId: string } | { all: true }): Promise<void> {
     const res = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
     this.applySync(res);
+    this.postCommitPing();
   }
 
   async addCurrentAccount(): Promise<void> {
     const res = await this.host.makeRequest<unknown>('POST', '/session/device/add', undefined, { cache: false });
     this.applySync(res);
+    this.postCommitPing();
   }
 
   /**
@@ -199,19 +248,53 @@ export class SessionClient {
     if (this.started) return;
     this.started = true;
     this.tokenUnsub = this.host.onTokensChanged((token) => {
-      if (token && this.socket && !this.socket.connected) {
+      if (!token) return;
+      // A bearer just landed: an in-flight acquisition (if any) succeeded — clear
+      // the guard so a later sign-out can re-acquire.
+      this.acquiring = false;
+      if (!this.socket) return;
+      if (this.socketAnonymous) {
+        // The live socket was an anonymous (device-room-only) connection. Force a
+        // reconnect so the handshake re-runs authenticated and also joins the
+        // `user:<id>` notification room.
+        this.socketAnonymous = false;
+        this.socket.disconnect();
+        this.socket.connect();
+      } else if (!this.socket.connected) {
         this.socket.connect();
       }
     });
-    await this.bootstrap();
+    this.openBroadcastChannel();
+    // `bootstrap` (`GET /session/device/state`) is bearer-authenticated: skip it
+    // when signed out (the signed-out socket below still joins the device room to
+    // receive pushes). A bootstrap failure is non-fatal — the socket must still
+    // connect so realtime sync survives a transient state-fetch error.
+    if (this.host.getAccessToken()) {
+      try {
+        await this.bootstrap();
+      } catch (error) {
+        logger.warn('[SessionClient] bootstrap during start failed (non-fatal)', { component: 'SessionClient' }, error);
+      }
+    }
     await this.connectSocket();
   }
 
   stop(): void {
     this.started = false;
+    this.acquiring = false;
+    this.socketAnonymous = false;
     if (this.tokenUnsub) {
       this.tokenUnsub();
       this.tokenUnsub = null;
+    }
+    if (this.channel) {
+      this.channel.onmessage = null;
+      try {
+        this.channel.close();
+      } catch (error) {
+        logger.debug('[SessionClient] BroadcastChannel close failed', { component: 'SessionClient' }, error);
+      }
+      this.channel = null;
     }
     if (this.socket) {
       this.socket.disconnect();
@@ -230,24 +313,131 @@ export class SessionClient {
     }
     if (!this.started) return; // stopped while the dynamic import was in flight
     const hasToken = Boolean(this.host.getAccessToken());
+
+    // Signed-out connect gate: when there is no bearer, only open the socket if
+    // the consumer supplies a device anchor (web cookie → `true`; native token →
+    // string). This lets an idle tab receive its device's `session_state` pushes
+    // and self-acquire when a sibling signs in.
+    let signedOutAuth: boolean | string | null = false;
+    if (!hasToken && this.options.signedOutSocketAuth) {
+      try {
+        signedOutAuth = await this.options.signedOutSocketAuth();
+      } catch (error) {
+        logger.warn('[SessionClient] signedOutSocketAuth failed', { component: 'SessionClient' }, error);
+        signedOutAuth = false;
+      }
+      if (!this.started) return; // stopped while the async gate was in flight
+    }
+    const signedOutConnect = signedOutAuth !== false && signedOutAuth != null;
+    const signedOutDeviceToken = typeof signedOutAuth === 'string' ? signedOutAuth : undefined;
+    this.socketAnonymous = !hasToken && signedOutConnect;
+
     const socket = io(this.host.getBaseURL(), {
       transports: ['websocket'],
-      autoConnect: hasToken,
-      auth: (cb: (data: { token: string }) => void) => {
-        cb({ token: this.host.getAccessToken() ?? '' });
+      // Send the first-party `oxy_device` cookie on the same-site handshake so a
+      // signed-out browser tab can be resolved to its device room server-side.
+      withCredentials: true,
+      autoConnect: hasToken || signedOutConnect,
+      auth: (cb: (data: { token: string; deviceToken?: string }) => void) => {
+        const token = this.host.getAccessToken() ?? '';
+        // Present the native device token only while signed out (no bearer). Once
+        // a token is held the bearer path wins and the deviceToken is redundant.
+        cb(token || !signedOutDeviceToken ? { token } : { token, deviceToken: signedOutDeviceToken });
       },
     });
     socket.on('session_state', (payload: unknown) => {
       const applied = this.applyState(payload);
-      if (applied) {
-        const active = this.state?.activeAccountId ?? null;
-        if (active && active !== this.host.getCurrentAccountId()) {
-          void this.bootstrap().catch((error) => {
-            logger.warn('[SessionClient] post-push token fetch failed', { component: 'SessionClient' }, error);
-          });
+      if (!applied) return;
+      // Signed-out tab: a session appeared on this device (a sibling signed in).
+      // Acquire it so this tab flips to signed-in; the planted token then
+      // reconnects the socket on the authenticated path.
+      if (!this.host.getAccessToken()) {
+        if ((this.state?.accounts.length ?? 0) > 0) {
+          this.requestAcquisition();
         }
+        return;
+      }
+      const active = this.state?.activeAccountId ?? null;
+      if (active && active !== this.host.getCurrentAccountId()) {
+        void this.bootstrap().catch((error) => {
+          logger.warn('[SessionClient] post-push token fetch failed', { component: 'SessionClient' }, error);
+        });
       }
     });
     this.socket = socket;
+  }
+
+  /**
+   * Run the consumer's session acquisition at most once at a time. A returned
+   * promise gates the next attempt (reset on settle), so a failed acquisition
+   * can retry on the NEXT push while a burst of identical pushes cannot pile up.
+   */
+  private requestAcquisition(): void {
+    if (this.acquiring || !this.options.onSessionAppeared) return;
+    this.acquiring = true;
+    let result: void | Promise<void>;
+    try {
+      result = this.options.onSessionAppeared();
+    } catch (error) {
+      this.acquiring = false;
+      logger.error('[SessionClient] onSessionAppeared threw', error);
+      return;
+    }
+    void Promise.resolve(result).catch((error) => {
+      logger.warn('[SessionClient] onSessionAppeared rejected', { component: 'SessionClient' }, error);
+    }).finally(() => {
+      this.acquiring = false;
+    });
+  }
+
+  /**
+   * Open the same-origin `BroadcastChannel` (web only). A sibling tab that
+   * commits a session posts a wake ping; on receipt a signed-in tab re-syncs its
+   * device state and a signed-out tab self-acquires — instant + network-free for
+   * the common "two tabs of the same origin" case, with no state (and no tokens)
+   * ever crossing the channel. No-op on native (no BroadcastChannel).
+   */
+  private openBroadcastChannel(): void {
+    if (this.channel) return;
+    const Ctor = (globalThis as { BroadcastChannel?: new (name: string) => SessionBroadcastChannel }).BroadcastChannel;
+    if (typeof Ctor !== 'function') return; // native RN / SSR — feature absent
+    let channel: SessionBroadcastChannel;
+    try {
+      channel = new Ctor(SESSION_BROADCAST_CHANNEL);
+    } catch (error) {
+      logger.debug('[SessionClient] BroadcastChannel unavailable', { component: 'SessionClient' }, error);
+      return;
+    }
+    channel.onmessage = (event) => {
+      if (!event || typeof event.data !== 'object' || event.data === null) return;
+      if ((event.data as { type?: unknown }).type !== 'commit') return;
+      // BroadcastChannel never echoes to the posting context, so this is a
+      // sibling's commit. Re-sync (signed-in) or acquire (signed-out). Neither
+      // path re-posts, so there is no cross-tab ping loop.
+      if (this.host.getAccessToken()) {
+        void this.bootstrap().catch((error) => {
+          logger.warn('[SessionClient] broadcast re-sync failed', { component: 'SessionClient' }, error);
+        });
+      } else {
+        this.requestAcquisition();
+      }
+    };
+    this.channel = channel;
+  }
+
+  /**
+   * Wake same-origin sibling tabs after a locally-initiated session mutation.
+   * Opens the channel lazily: a sign-in registers the account (`addCurrentAccount`
+   * / `switchAccount`) BEFORE `start()` runs, so the ping must not depend on
+   * `start()` having opened the channel first.
+   */
+  private postCommitPing(): void {
+    this.openBroadcastChannel();
+    if (!this.channel) return;
+    try {
+      this.channel.postMessage({ type: 'commit', at: Date.now() });
+    } catch (error) {
+      logger.debug('[SessionClient] BroadcastChannel post failed', { component: 'SessionClient' }, error);
+    }
   }
 }

--- a/packages/core/src/session/__tests__/SessionClient.signedOut.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.signedOut.test.ts
@@ -1,0 +1,224 @@
+import type { DeviceSessionState } from '@oxyhq/contracts';
+
+type Handler = (...args: unknown[]) => void;
+class FakeSocket {
+  connected = false;
+  handlers = new Map<string, Handler[]>();
+  connectCalls = 0;
+  disconnectCalls = 0;
+  on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
+  off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+  connect() { this.connectCalls += 1; this.connected = true; this.trigger('connect'); }
+  disconnect() { this.disconnectCalls += 1; this.connected = false; }
+  trigger(event: string, ...args: unknown[]) { for (const h of this.handlers.get(event) ?? []) h(...args); }
+}
+let fakeSocket: FakeSocket;
+let lastOpts: Record<string, unknown> | undefined;
+const ioMock = jest.fn((_uri: string, opts?: Record<string, unknown>) => {
+  lastOpts = opts;
+  if (!opts || opts.autoConnect !== false) fakeSocket.connected = true;
+  return fakeSocket;
+});
+jest.mock('socket.io-client', () => ({ __esModule: true, io: (...args: unknown[]) => ioMock(...(args as [string, Record<string, unknown>?])) }));
+
+// A same-name in-process BroadcastChannel bus: postMessage delivers to every
+// OTHER open channel of the same name (never the sender) — matching the spec.
+type BusEntry = { name: string; onmessage: ((event: { data: unknown }) => void) | null };
+const bus = new Set<BusEntry>();
+class FakeBroadcastChannel {
+  private entry: BusEntry;
+  constructor(public name: string) { this.entry = { name, onmessage: null }; bus.add(this.entry); }
+  get onmessage(): ((event: { data: unknown }) => void) | null { return this.entry.onmessage; }
+  set onmessage(cb: ((event: { data: unknown }) => void) | null) { this.entry.onmessage = cb; }
+  postMessage(data: unknown) {
+    for (const e of bus) {
+      if (e === this.entry || e.name !== this.name) continue;
+      e.onmessage?.({ data });
+    }
+  }
+  close() { bus.delete(this.entry); }
+}
+
+import { SessionClient, type SessionClientHost, type SessionClientOptions } from '../SessionClient';
+
+const STATE = (rev: number, accounts = [{ accountId: 'a1', sessionId: 's1', authuser: 0 }]): DeviceSessionState =>
+  ({ deviceId: 'd1', accounts, activeAccountId: accounts[0]?.accountId ?? null, revision: rev, updatedAt: 1720000000000 });
+const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
+
+function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
+  return {
+    makeRequest: jest.fn().mockResolvedValue(SYNC(1)),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => null,
+    onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => null,
+    ...over,
+  };
+}
+
+const flush = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+beforeEach(() => {
+  fakeSocket = new FakeSocket();
+  lastOpts = undefined;
+  ioMock.mockClear();
+  bus.clear();
+  (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = FakeBroadcastChannel as unknown;
+});
+afterEach(() => {
+  (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = undefined;
+});
+
+describe('SessionClient signed-out socket', () => {
+  it('opens the socket while signed-out when signedOutSocketAuth resolves true (web cookie), with credentials', async () => {
+    const c = new SessionClient(makeHost(), { signedOutSocketAuth: () => true });
+    await c.start();
+    expect(ioMock).toHaveBeenCalledTimes(1);
+    expect(lastOpts?.autoConnect).toBe(true);
+    expect(lastOpts?.withCredentials).toBe(true);
+    // No bearer, no native token → handshake presents an empty token, no deviceToken.
+    const authCb = jest.fn();
+    (lastOpts?.auth as (cb: (d: unknown) => void) => void)(authCb);
+    expect(authCb).toHaveBeenCalledWith({ token: '' });
+    c.stop();
+  });
+
+  it('presents the native device token in the handshake when signedOutSocketAuth returns a string', async () => {
+    const c = new SessionClient(makeHost(), { signedOutSocketAuth: () => 'dt-native' });
+    await c.start();
+    expect(lastOpts?.autoConnect).toBe(true);
+    const authCb = jest.fn();
+    (lastOpts?.auth as (cb: (d: unknown) => void) => void)(authCb);
+    expect(authCb).toHaveBeenCalledWith({ token: '', deviceToken: 'dt-native' });
+    c.stop();
+  });
+
+  it('does NOT open the socket while signed-out when signedOutSocketAuth is absent (default)', async () => {
+    const c = new SessionClient(makeHost());
+    await c.start();
+    expect(lastOpts?.autoConnect).toBe(false);
+    c.stop();
+  });
+
+  it('does NOT open the socket while signed-out when signedOutSocketAuth resolves false', async () => {
+    const c = new SessionClient(makeHost(), { signedOutSocketAuth: async () => false });
+    await c.start();
+    expect(lastOpts?.autoConnect).toBe(false);
+    c.stop();
+  });
+
+  it('skips the bearer-authenticated bootstrap when signed-out', async () => {
+    const makeRequest = jest.fn().mockResolvedValue(SYNC(1));
+    const c = new SessionClient(makeHost({ makeRequest }), { signedOutSocketAuth: () => true });
+    await c.start();
+    expect(makeRequest).not.toHaveBeenCalled();
+    c.stop();
+  });
+
+  it('a session_state push while signed-out triggers acquisition exactly once for a burst', async () => {
+    const onSessionAppeared = jest.fn(() => new Promise<void>(() => undefined)); // never resolves (in flight)
+    const c = new SessionClient(makeHost(), { signedOutSocketAuth: () => true, onSessionAppeared });
+    await c.start();
+    fakeSocket.trigger('session_state', STATE(9));
+    fakeSocket.trigger('session_state', STATE(10));
+    await flush();
+    expect(onSessionAppeared).toHaveBeenCalledTimes(1);
+    c.stop();
+  });
+
+  it('does NOT acquire when the pushed signed-out state has zero accounts', async () => {
+    const onSessionAppeared = jest.fn();
+    const c = new SessionClient(makeHost(), { signedOutSocketAuth: () => true, onSessionAppeared });
+    await c.start();
+    fakeSocket.trigger('session_state', STATE(9, []));
+    await flush();
+    expect(onSessionAppeared).not.toHaveBeenCalled();
+    c.stop();
+  });
+
+  it('re-acquires on a LATER push after the prior acquisition settled (no permanent lock)', async () => {
+    const onSessionAppeared = jest.fn(() => Promise.resolve());
+    const c = new SessionClient(makeHost(), { signedOutSocketAuth: () => true, onSessionAppeared });
+    await c.start();
+    fakeSocket.trigger('session_state', STATE(9));
+    await flush();
+    expect(onSessionAppeared).toHaveBeenCalledTimes(1);
+    fakeSocket.trigger('session_state', STATE(10));
+    await flush();
+    expect(onSessionAppeared).toHaveBeenCalledTimes(2);
+    c.stop();
+  });
+
+  it('reconnects the anonymous socket authenticated once a token arrives', async () => {
+    let tokenListener: ((t: string | null) => void) | null = null;
+    let token: string | null = null;
+    const host = makeHost({
+      getAccessToken: () => token,
+      onTokensChanged: (l) => { tokenListener = l; return () => undefined; },
+    });
+    const c = new SessionClient(host, { signedOutSocketAuth: () => true });
+    await c.start();
+    expect(fakeSocket.connected).toBe(true); // anonymous connect
+    const before = fakeSocket.disconnectCalls;
+    token = 'fresh';
+    tokenListener?.('fresh');
+    // Anonymous → authenticated: force a reconnect so the handshake re-runs.
+    expect(fakeSocket.disconnectCalls).toBe(before + 1);
+    expect(fakeSocket.connected).toBe(true);
+    c.stop();
+  });
+});
+
+describe('SessionClient BroadcastChannel wake', () => {
+  const opts = (over: Partial<SessionClientOptions>): SessionClientOptions => ({ signedOutSocketAuth: () => true, ...over });
+
+  it('a local mutation wakes a signed-out sibling to acquire', async () => {
+    const onSessionAppeared = jest.fn(() => Promise.resolve());
+    // Signed-out sibling B listening on the channel.
+    const b = new SessionClient(makeHost(), opts({ onSessionAppeared }));
+    await b.start();
+    // Signed-in tab A commits (switchAccount posts a commit ping).
+    const a = new SessionClient(makeHost({ getAccessToken: () => 'tok-a' }), opts({}));
+    await a.start();
+    await a.switchAccount('a1');
+    await flush();
+    expect(onSessionAppeared).toHaveBeenCalledTimes(1);
+    a.stop();
+    b.stop();
+  });
+
+  it('a local mutation wakes a signed-in sibling to re-sync (bootstrap)', async () => {
+    const bMakeRequest = jest.fn().mockResolvedValue(SYNC(1));
+    const b = new SessionClient(makeHost({ makeRequest: bMakeRequest, getAccessToken: () => 'tok-b' }), opts({}));
+    await b.start();
+    bMakeRequest.mockClear();
+    const a = new SessionClient(makeHost({ getAccessToken: () => 'tok-a' }), opts({}));
+    await a.start();
+    await a.addCurrentAccount();
+    await flush();
+    expect(bMakeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    a.stop();
+    b.stop();
+  });
+
+  it('does not deliver a commit ping back to the posting tab (no self-loop)', async () => {
+    // A signed-out tab that commits locally must not re-trigger its OWN acquisition.
+    const onSessionAppeared = jest.fn();
+    const a = new SessionClient(makeHost(), opts({ onSessionAppeared }));
+    await a.start();
+    await a.addCurrentAccount();
+    await flush();
+    expect(onSessionAppeared).not.toHaveBeenCalled();
+    a.stop();
+  });
+
+  it('is a no-op on platforms without BroadcastChannel (native)', async () => {
+    (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = undefined;
+    const c = new SessionClient(makeHost({ getAccessToken: () => 'tok' }), { });
+    await c.start();
+    // Mutations must not throw when BroadcastChannel is absent.
+    await expect(c.switchAccount('a1')).resolves.toBeUndefined();
+    c.stop();
+  });
+});

--- a/packages/core/src/session/createSessionClient.ts
+++ b/packages/core/src/session/createSessionClient.ts
@@ -1,5 +1,5 @@
 import type { OxyServices } from '../OxyServices';
-import { SessionClient, type TokenTransport } from './SessionClient';
+import { SessionClient, type SessionClientOptions, type TokenTransport } from './SessionClient';
 import type { SocketIOFactory } from './socketLoader';
 import { createSessionClientHost } from './sessionClientHost';
 
@@ -29,11 +29,18 @@ export function createSessionClient(
   oxyServices: OxyServices,
   transport: TokenTransport,
   socketFactory?: SocketIOFactory,
+  /**
+   * Optional signed-out realtime wiring: `signedOutSocketAuth` (open the socket
+   * while signed out so an idle tab receives its device pushes) and
+   * `onSessionAppeared` (self-acquire when a sibling signs in). See
+   * {@link SessionClientOptions}.
+   */
+  extra?: Pick<SessionClientOptions, 'signedOutSocketAuth' | 'onSessionAppeared'>,
 ): {
   client: SessionClient;
   host: ReturnType<typeof createSessionClientHost>;
 } {
   const host = createSessionClientHost(oxyServices);
-  const client = new SessionClient(host, { transport, socketFactory });
+  const client = new SessionClient(host, { transport, socketFactory, ...extra });
   return { client, host };
 }

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -505,18 +505,47 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   const markAuthResolvedRef = useRef(markAuthResolved);
   markAuthResolvedRef.current = markAuthResolved;
 
+  // Re-boot indirection: the SessionClient is built in the ref initializer below
+  // (before `runColdBoot` is defined), but its `onSessionAppeared` must re-run the
+  // cold boot to self-acquire when a sibling signs in on this device. A ref bridges
+  // the ordering; it is assigned right after `runColdBoot` is declared.
+  const runColdBootRef = useRef<(() => Promise<void>) | null>(null);
+
   // Server-authoritative device session client. Built ONCE per `oxyServices`
   // instance. `onUnauthenticated` (a device signout-all pushed over the socket,
   // or bootstrapped as zero-account) clears the persisted store + local state so
   // a reload does not try to restore a session the device no longer has.
+  // `signedOutSocketAuth` + `onSessionAppeared` power the signed-out sync channel:
+  // an idle tab joins its `device:<id>` room (web via the `oxy_device` cookie,
+  // native via the shared device token) and self-acquires on a sibling sign-in.
   const sessionClientPairRef = useRef<ReturnType<typeof createSessionClient> | null>(null);
   if (!sessionClientPairRef.current) {
-    sessionClientPairRef.current = createSessionClient(oxyServices, authStore, () => {
-      clearPersistedAuthSafe(authStore, logger);
-      void clearSessionStateRef.current().catch((clearError) => {
-        logger('Failed to clear local state on remote sign-out', clearError);
-      });
-    });
+    sessionClientPairRef.current = createSessionClient(
+      oxyServices,
+      authStore,
+      () => {
+        clearPersistedAuthSafe(authStore, logger);
+        void clearSessionStateRef.current().catch((clearError) => {
+          logger('Failed to clear local state on remote sign-out', clearError);
+        });
+      },
+      {
+        signedOutSocketAuth: async () => {
+          // Web (`*.oxy.so`): the first-party `oxy_device` cookie rides the
+          // same-site handshake automatically — just connect.
+          if (isWebBrowser()) return true;
+          // Native (no cookie jar): present the shared device token if we have one.
+          try {
+            return (await authStore.loadDeviceToken()) ?? false;
+          } catch {
+            return false;
+          }
+        },
+        onSessionAppeared: () => {
+          void runColdBootRef.current?.();
+        },
+      },
+    );
   }
   const { client: sessionClient, host: sessionClientHost } = sessionClientPairRef.current;
 
@@ -908,6 +937,18 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
         },
         onSignedOut: () => {
           markAuthResolvedRef.current();
+          // Open the signed-out realtime channel so this idle tab joins its
+          // `device:<id>` room (web `oxy_device` cookie / native device token)
+          // and self-acquires when a sibling signs in. Idempotent, best-effort.
+          void sessionClient.start().catch((startError) => {
+            if (__DEV__) {
+              loggerUtil.debug(
+                'signed-out socket start failed (non-fatal)',
+                { component: 'OxyContext', method: 'runColdBoot' },
+                startError as unknown,
+              );
+            }
+          });
         },
         onStepError: (id, error) => {
           if (__DEV__) {
@@ -931,7 +972,10 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       // Backstop: resolve on every exit path so the gate can never hang.
       markAuthResolvedRef.current();
     }
-  }, [oxyServices, authStore]);
+  }, [oxyServices, authStore, sessionClient]);
+  // Bridge for `onSessionAppeared` (SessionClient) → re-run the cold boot to
+  // self-acquire when a sibling signs in on this device while this tab is idle.
+  runColdBootRef.current = runColdBoot;
 
   useEffect(() => {
     if (!storage || initialized) {

--- a/packages/services/src/ui/session/createSessionClient.ts
+++ b/packages/services/src/ui/session/createSessionClient.ts
@@ -4,6 +4,7 @@ import {
   createSessionClientHost,
   type AuthStateStore,
   type OxyServices,
+  type SessionClientOptions,
 } from '@oxyhq/core';
 import { createTokenTransport } from './tokenTransport';
 
@@ -31,12 +32,19 @@ export function createSessionClient(
   oxyServices: OxyServices,
   store: AuthStateStore,
   onUnauthenticated?: () => void,
+  /**
+   * Optional signed-out realtime wiring: `signedOutSocketAuth` (open the socket
+   * while signed out — web returns `true` to ride the `oxy_device` cookie,
+   * native returns the shared device token) and `onSessionAppeared` (self-acquire
+   * when a sibling signs in on this device).
+   */
+  extra?: Pick<SessionClientOptions, 'signedOutSocketAuth' | 'onSessionAppeared'>,
 ): {
   client: SessionClient;
   host: ReturnType<typeof createSessionClientHost>;
 } {
   const host = createSessionClientHost(oxyServices);
   const transport = createTokenTransport(oxyServices, store);
-  const client = new SessionClient(host, { transport, socketFactory: io, onUnauthenticated });
+  const client = new SessionClient(host, { transport, socketFactory: io, onUnauthenticated, ...extra });
   return { client, host };
 }


### PR DESCRIPTION
## The bug

Sign in on tab A → tab B (still signed out) should auto-sign-in instantly, but it doesn't.

**Root cause (verified):** the device realtime socket required a bearer, so a signed-out tab never connected to any `device:<deviceId>` room and never received the `session_state` broadcast that fires (`broadcastDeviceState`) when tab A signs in / adds an account on the same device. Server `io.use` rejected any handshake without a token (`packages/api/src/server.ts`), and the client `SessionClient.connectSocket` used `autoConnect: hasToken` — a signed-out tab opened no socket at all.

## The fix (two additive mechanisms, security-first — the channel carries STATE only, never tokens)

**1. Cookie-authed anonymous device socket (server).** New `resolveSocketIdentity` (`packages/api/src/utils/socketAuth.ts`) is the single authority for who a socket may be:
- valid bearer → **authenticated user socket** (`user:<id>` + `device:<deviceId>` rooms, as before);
- NO/invalid bearer BUT a resolvable `oxy_device` cookie (same-site `*.oxy.so` handshake) OR a native shared device token → an **anonymous device socket** bound **only** to `device:<deviceId>`.

The deviceId is always resolved **server-side** (cookie SHA-256 via `getStateByCookieKey`, or token hash via `resolveDeviceToken`) — **never from client input**. An anonymous socket carries zero user identity and receives the same state-only `session_state` broadcast (account ids + revision, never tokens) already emitted to the device room — it can only learn that its own device's session set changed, cannot mutate anything, and cannot join another device's room. Same posture as the device-first `oxy_device` cookie itself.

`socketRoomsFor()` (`utils/socket.ts`) makes room derivation testable: a user socket joins both rooms; an anonymous socket joins ONLY its device room (never a `user:` room).

**2. Signed-out socket connect + self-acquire (core `SessionClient`).** New `signedOutSocketAuth` option opens the socket while signed-out when the consumer supplies a device anchor (web → `true`, the `oxy_device` cookie rides the same-site handshake with `withCredentials`; native → the shared device token). `start()` skips the bearer-only bootstrap when signed-out. On a `session_state` push while signed-out it runs the consumer's `onSessionAppeared` (cold boot / `requestWebSession`) **once** — in-flight guarded, retriable on the next revision — to acquire the freshly-added session; when the token lands it reconnects the socket on the authenticated path (joining the `user:` room too).

**3. Same-origin `BroadcastChannel('oxy.session')` (core `SessionClient`).** A local session mutation (switch / add / signout) posts a wake ping; sibling tabs of the **same origin** re-sync (signed-in) or self-acquire (signed-out) — instant, network-free, no state or tokens on the wire. Feature-detected (no-op on native RN).

**Provider wiring:** `WebOxyProvider` (`signedOutSocketAuth: () => true`) and `OxyContext` (web cookie / native shared device token) pass `onSessionAppeared` → re-run the cold boot, and start the signed-out socket on the `onSignedOut` boot outcome.

## Coverage split (and the documented limitation)

- **Same-origin** (two tabs of `accounts.oxy.so`) → BroadcastChannel, instant + network-free.
- **Same-apex cross-origin** (`accounts` ↔ `console` ↔ `inbox` ↔ `auth`, all `*.oxy.so`) → the cookie-authed socket (the `oxy_device` cookie is `Domain=.oxy.so`).
- **Cross-apex** (`mention.earth`) signed-out tab → cannot get the `.oxy.so` cookie on the handshake, so it still relies on a reload. Not fought here; documented.

## Tests

- **core (jest):** +13 in `SessionClient.signedOut.test.ts` — connects the socket signed-out with a device anchor (cookie/native token in handshake), a `session_state` push acquires once (not looping) and is retriable, zero-account pushes don't acquire, anonymous→authenticated reconnect on token, BroadcastChannel wakes a signed-out sibling to acquire and a signed-in sibling to re-sync, no self-loop, native no-op. Full core suite **686 passing**.
- **api (jest):** +12 in `socketAuth.test.ts` — bearer→user; cookie-only→device (deviceId server-resolved); invalid bearer falls through to cookie; native device-token fallback; reject without cookie/bearer; `socketRoomsFor` (user joins both rooms, anonymous joins ONLY its device room). Full api suite **1358 passing**.
- auth-sdk **80 passing** (wiring test updated for the 4th arg), services **205 passing**. tsc clean across api/core/services/auth-sdk; core ESM require-free.

## Not merged

Merge = prod deploy of api + redeploys the 4 Pages apps via core. Left for the lead to coordinate + live-verify 2-tab sign-in sync in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)