### PR TITLE
fix(auth): robust redirect_uri for trusted first-party apps + clean password handoff

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -389,7 +389,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "dependencies": {
         "@oxyhq/contracts": "workspace:^",
         "@oxyhq/protocol": "workspace:^",

--- a/packages/api/src/routes/__tests__/oauthAuthorizeRedirect.test.ts
+++ b/packages/api/src/routes/__tests__/oauthAuthorizeRedirect.test.ts
@@ -343,3 +343,124 @@ describe('POST /auth/oauth/authorize — redirect_uri allowlist (#216)', () => {
     expect(mockIssueAuthCode).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Trusted (first-party / official / internal / system) apps additionally accept
+ * a redirect_uri whose http(s) ORIGIN matches a registered origin — deep links,
+ * sub-routes, `?v=…` cache busters, and the trailing slash the IdP's
+ * `new URL().toString()` normalisation adds to a bare origin. THIRD-PARTY apps
+ * never get this relaxation (strict exact match preserved).
+ */
+describe('POST /auth/oauth/authorize — trusted-app origin relaxation', () => {
+  function trustedApp(redirectUris: string[], overrides: Record<string, unknown> = {}) {
+    return {
+      _id: { toString: () => 'app-1' },
+      status: 'active',
+      isOfficial: true,
+      type: 'first_party',
+      redirectUris,
+      ...overrides,
+    };
+  }
+
+  it('accepts a redirect_uri with extra query + path on a registered origin (official app)', async () => {
+    mockApplicationFindOne.mockResolvedValueOnce(trustedApp(['https://accounts.oxy.so']));
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/oauth/authorize',
+      { clientId: 'oxy_dk_client', redirectUri: 'https://accounts.oxy.so/manage?v=abc123&foo=bar' },
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueAuthCode).toHaveBeenCalledTimes(1);
+    // The exact (dirty) redirect_uri is preserved through to the issued code.
+    expect(mockIssueAuthCode).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUri: 'https://accounts.oxy.so/manage?v=abc123&foo=bar' })
+    );
+  });
+
+  it('absorbs the trailing slash the IdP adds to a bare registered origin', async () => {
+    mockApplicationFindOne.mockResolvedValueOnce(trustedApp(['https://accounts.oxy.so']));
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/oauth/authorize',
+      { clientId: 'oxy_dk_client', redirectUri: 'https://accounts.oxy.so/' },
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueAuthCode).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a deep link when only a path-specific callback origin is registered', async () => {
+    mockApplicationFindOne.mockResolvedValueOnce(
+      trustedApp(['https://accounts.oxy.so/__oxy/sso-callback'], { isOfficial: false, type: 'first_party' })
+    );
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/oauth/authorize',
+      { clientId: 'oxy_dk_client', redirectUri: 'https://accounts.oxy.so/settings/security' },
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockIssueAuthCode).toHaveBeenCalledTimes(1);
+  });
+
+  it('still rejects a different origin for a trusted app (no cross-origin relaxation)', async () => {
+    mockApplicationFindOne.mockResolvedValueOnce(trustedApp(['https://accounts.oxy.so']));
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/oauth/authorize',
+      { clientId: 'oxy_dk_client', redirectUri: 'https://evil.example.com/callback' },
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockIssueAuthCode).not.toHaveBeenCalled();
+  });
+
+  it('does not relax custom (non-web) schemes — origin "null" collisions are rejected', async () => {
+    mockApplicationFindOne.mockResolvedValueOnce(trustedApp(['astro://auth']));
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/oauth/authorize',
+      { clientId: 'oxy_dk_client', redirectUri: 'astro://evil' },
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockIssueAuthCode).not.toHaveBeenCalled();
+  });
+
+  it('THIRD-PARTY app still rejects a redirect_uri that differs only by a query string', async () => {
+    mockApplicationFindOne.mockResolvedValueOnce({
+      _id: { toString: () => 'app-1' },
+      status: 'active',
+      type: 'third_party',
+      redirectUris: ['https://app.example.com/callback'],
+    });
+
+    const res = await requestJson(
+      server,
+      'POST',
+      '/auth/oauth/authorize',
+      { clientId: 'oxy_dk_client', redirectUri: 'https://app.example.com/callback?x=1' },
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockIssueAuthCode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/__tests__/oauthConsentGrants.test.ts
+++ b/packages/api/src/routes/__tests__/oauthConsentGrants.test.ts
@@ -271,6 +271,57 @@ describe('GET /auth/oauth/consent', () => {
     expect(mockAppGrantFindOne).not.toHaveBeenCalled();
   });
 
+  it('auto-approves a TRUSTED app when the redirect_uri only matches by origin (deep link / query)', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValue(credential('app-1'));
+    mockApplicationFindOne.mockResolvedValue({
+      _id: { toString: () => 'app-1' },
+      status: 'active',
+      type: 'first_party',
+      // Only the bare origin is registered; the request carries a path + query.
+      redirectUris: ['https://accounts.oxy.so'],
+    });
+
+    const params = new URLSearchParams({
+      clientId: 'oxy_dk_client',
+      redirectUri: 'https://accounts.oxy.so/manage?v=abc123',
+    });
+
+    const res = await requestJson(
+      server,
+      'GET',
+      `/auth/oauth/consent?${params.toString()}`,
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ consentRequired: false, reason: 'trusted' });
+    expect(mockAppGrantFindOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects a THIRD-PARTY redirect_uri that only matches by origin (no relaxation) with 403', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValue(credential('app-1'));
+    mockApplicationFindOne.mockResolvedValue({
+      _id: { toString: () => 'app-1' },
+      status: 'active',
+      type: 'third_party',
+      redirectUris: ['https://app.example.com/callback'],
+    });
+
+    const params = new URLSearchParams({
+      clientId: 'oxy_dk_client',
+      redirectUri: 'https://app.example.com/callback?x=1',
+    });
+
+    const res = await requestJson(
+      server,
+      'GET',
+      `/auth/oauth/consent?${params.toString()}`,
+      { Authorization: 'Bearer t' }
+    );
+
+    expect(res.status).toBe(403);
+  });
+
   it('skips consent when a prior grant covers the requested scopes (reason: granted)', async () => {
     mockApplicationCredentialFindOne.mockResolvedValue(credential('app-1'));
     mockApplicationFindOne.mockResolvedValue({

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1809,15 +1809,51 @@ router.post(
 // Access tokens never appear in the URL bar.
 
 /**
- * Validate a redirect URI against the Application allowlist using an exact
- * match (per OAuth2 RFC 6749 §3.1.2). Partial / prefix matching is the
- * source of countless open-redirect vulnerabilities — we never normalise
- * away path or query for the comparison. Constant-time equality keeps the
- * comparison from leaking the allowlist contents via timing.
+ * Parse the http(s) origin of a redirect URI, or null when the URI is malformed
+ * or uses a non-web scheme. Restricting to http/https is deliberate for the
+ * trusted-app origin relaxation below: a custom scheme (e.g. `astro://…`) has an
+ * opaque `URL.origin` of the literal string `"null"`, so two unrelated
+ * custom-scheme URIs would falsely share an origin — never a safe basis for
+ * loosening the redirect allowlist.
  */
-function isAllowedRedirectUri(app: { redirectUris?: string[] }, redirectUri: string): boolean {
+function webOriginFromRedirectUri(redirectUri: string): string | null {
+  try {
+    const url = new URL(redirectUri);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate a redirect URI against the Application allowlist.
+ *
+ * THIRD-PARTY apps: strict EXACT match (per OAuth2 RFC 6749 §3.1.2) via a
+ * constant-time comparison — partial / prefix / origin matching is the source
+ * of countless open-redirect vulnerabilities, so we never normalise away path
+ * or query and never relax the boundary for self-service clients. Constant-time
+ * equality also keeps the comparison from leaking the allowlist via timing.
+ *
+ * TRUSTED first-party apps (isOfficial / first_party / internal / system — the
+ * staff-controlled set, never settable via the Console / member RBAC path):
+ * ADDITIONALLY accept a redirect URI whose http(s) ORIGIN matches the origin of
+ * any registered `redirectUris` entry. This lets an official app (accounts,
+ * console, …) pass deep links, sub-routes, and cache-busting query params
+ * (`?v=…`) — and absorbs the trailing slash the IdP's `new URL().toString()`
+ * normalisation adds to a bare origin — without registering every variant,
+ * while still confining the redirect to an origin the app itself registered.
+ * The trust set is not a secret, so the origin compare need not be constant time.
+ */
+function isAllowedRedirectUri(
+  app: Pick<IApplication, 'redirectUris' | 'isOfficial' | 'isInternal' | 'type'>,
+  redirectUri: string
+): boolean {
   const allowlist = app.redirectUris ?? [];
   if (allowlist.length === 0) return false;
+
+  // Strict exact match (constant-time) — the ONLY acceptance path for
+  // third-party clients, and the primary path for trusted apps too.
   const provided = Buffer.from(redirectUri);
   for (const allowed of allowlist) {
     const allowedBuf = Buffer.from(allowed);
@@ -1825,6 +1861,18 @@ function isAllowedRedirectUri(app: { redirectUris?: string[] }, redirectUri: str
       return true;
     }
   }
+
+  // Trusted-only origin relaxation. Third-party apps NEVER reach this branch.
+  if (isTrustedApplication(app)) {
+    const providedOrigin = webOriginFromRedirectUri(redirectUri);
+    if (
+      providedOrigin &&
+      allowlist.some((registered) => webOriginFromRedirectUri(registered) === providedOrigin)
+    ) {
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/session/__tests__/accountDialogController.test.ts
+++ b/packages/core/src/session/__tests__/accountDialogController.test.ts
@@ -565,6 +565,69 @@ describe('AccountDialogController — openPasswordAtOxyAuth', () => {
     const url = controller.openPasswordAtOxyAuth({ returnUrl: 'https://alia.onl/' });
     expect(new URL(url).origin).toBe('https://auth.alia.onl');
   });
+
+  it('defaults redirect_uri to the clean origin (not the full href with query/path)', () => {
+    const oxy = makeOxy();
+    const sc = new TestSessionClient(host());
+    const controller = new AccountDialogController({
+      oxyServices: oxy as unknown as OxyServices,
+      sessionClient: sc,
+      clientId: 'oxy_dk_test',
+    });
+    const originalLocation = (globalThis as { location?: unknown }).location;
+    Object.defineProperty(globalThis, 'location', {
+      value: { origin: 'https://accounts.oxy.so', href: 'https://accounts.oxy.so/?v=x' },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const parsed = new URL(controller.openPasswordAtOxyAuth());
+      // The registered redirectUris entry is the bare origin; a live query/path
+      // would fail the IdP's exact-match validation.
+      expect(parsed.searchParams.get('redirect_uri')).toBe('https://accounts.oxy.so');
+      expect(parsed.searchParams.get('redirect_uri')).not.toBe('https://accounts.oxy.so/?v=x');
+    } finally {
+      if (originalLocation === undefined) {
+        delete (globalThis as { location?: unknown }).location;
+      } else {
+        Object.defineProperty(globalThis, 'location', {
+          value: originalLocation,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
+
+  it('honors an explicit returnUrl over the current-origin default', () => {
+    const oxy = makeOxy();
+    const sc = new TestSessionClient(host());
+    const controller = new AccountDialogController({
+      oxyServices: oxy as unknown as OxyServices,
+      sessionClient: sc,
+      clientId: 'oxy_dk_test',
+    });
+    const originalLocation = (globalThis as { location?: unknown }).location;
+    Object.defineProperty(globalThis, 'location', {
+      value: { origin: 'https://accounts.oxy.so', href: 'https://accounts.oxy.so/?v=x' },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      const parsed = new URL(controller.openPasswordAtOxyAuth({ returnUrl: 'https://mention.earth/callback' }));
+      expect(parsed.searchParams.get('redirect_uri')).toBe('https://mention.earth/callback');
+    } finally {
+      if (originalLocation === undefined) {
+        delete (globalThis as { location?: unknown }).location;
+      } else {
+        Object.defineProperty(globalThis, 'location', {
+          value: originalLocation,
+          configurable: true,
+          writable: true,
+        });
+      }
+    }
+  });
 });
 
 describe('AccountDialogController — lifecycle', () => {

--- a/packages/core/src/session/accountDialogController.ts
+++ b/packages/core/src/session/accountDialogController.ts
@@ -544,15 +544,16 @@ export class AccountDialogController {
    * the right return.
    *
    * @param params.returnUrl - Where the IdP returns after login. Defaults to the
-   *   current document URL on web (`globalThis.location.href`); pass explicitly
-   *   on native (no `location`).
+   *   current origin on web (`globalThis.location.origin` — no query/path, so it
+   *   exact-matches a registered `redirectUris` entry); pass explicitly on native
+   *   (no `location`).
    * @param params.state - Optional opaque state echoed back on return.
    * @returns The absolute auth.oxy.so sign-in URL.
    */
   openPasswordAtOxyAuth(params: { returnUrl?: string; state?: string } = {}): string {
     const base = `https://auth.${this.idpApex}`;
     const url = new URL('/login', base);
-    const returnUrl = params.returnUrl ?? currentLocationHref();
+    const returnUrl = params.returnUrl ?? currentLocationOrigin();
     if (returnUrl) {
       url.searchParams.set('redirect_uri', returnUrl);
     }
@@ -762,8 +763,12 @@ function readRefreshToken(value: unknown): string | undefined {
   return typeof token === 'string' ? token : undefined;
 }
 
-/** Current document URL on web; empty string where `location` is absent (native/SSR). */
-function currentLocationHref(): string {
-  const location = (globalThis as { location?: { href?: string } }).location;
-  return typeof location?.href === 'string' ? location.href : '';
+/**
+ * Current page origin on web (`https://accounts.oxy.so` — no query, no path, no
+ * trailing slash) so it exact-matches a registered OAuth `redirectUris` entry;
+ * empty string where `location` is absent (native/SSR).
+ */
+function currentLocationOrigin(): string {
+  const location = (globalThis as { location?: { origin?: string } }).location;
+  return typeof location?.origin === 'string' ? location.origin : '';
 }


### PR DESCRIPTION
Fixes the "redirect_uri is not registered for this client" error on the account dialog's "Use a password" handoff (reported live on accounts.oxy.so).

## Root cause
`openPasswordAtOxyAuth` sent the full page URL (with query) as `redirect_uri`; the authorize endpoint exact-matched it against registered `redirectUris` → fail on any query/path. The IdP then fail-safed to a consent screen even for first-party apps (the redirect 403 ran before the trusted auto-approve check).

## Fix
- **core 7.1.2** — handoff sends the clean origin (`location.origin`), not `location.href`.
- **api** — `isAllowedRedirectUri`: third-party stays strict exact-match; trusted first-party/official apps also accept a redirect whose origin matches a registered `redirectUris` origin (robust to query/path/trailing-slash). Custom schemes never origin-relaxed. Fixes the spurious consent screen too (consent already auto-approves trusted apps; the redirect 403 was the blocker).

Third-party security unchanged. core 725 / api 1366 tests green (+10). Will browser-verify the live handoff before declaring done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->