### PR TITLE
Fase 4: Bloom Dialog sign-in + OxySignInButton official/third_party (OAuth+PKCE)

### DIFF
--- a/docs/architecture/oxy-auth-agent-handoff.md
+++ b/docs/architecture/oxy-auth-agent-handoff.md
@@ -1073,9 +1073,9 @@ bun run services:build
 | Fase | ID | Estado |
 |------|-----|--------|
 | 0 | audit | ✅ 2026-07-05 — [`oxy-auth-audit.md`](./oxy-auth-audit.md); baselines main: contracts 150 / core 723 / api 1358 / services 165 / auth 51+9f(env); **blockers §10 del audit esperan decisión Nate** |
-| 1 | reconcile-p1 / DeviceSession | 🟡 **Ya en main** (server authority completa) — pendiente re-scope del gate (audit §10.2) |
-| 2 | contracts | ⬜ Pendiente |
-| 3 | merge-auth-sdk | ⬜ Pendiente |
+| 1 | reconcile-p1 / DeviceSession | ✅ 2026-07-05 — ya estaba en main (waves 1+2); gate re-scoped verificado + colisión DTO resuelta (`DeviceLinkedSession*`, PR #556) |
+| 2 | contracts | 🟡 schemas deviceSession/deviceBoot ya en main+npm; **2b ✅** privacy/terms (PR #556); **2c ⬜ workshop Nate pendiente** |
+| 3 | merge-auth-sdk | ✅ 2026-07-05 — console en @oxyhq/services; auth-sdk ELIMINADO; rolldown-vite + vite-plugin-react-native-web; bloom ^0.29.2 (PR #557) |
 | 4 | unify-ui | ⬜ Pendiente |
 | 5 | auth-idp-rnweb | ⬜ Pendiente |
 | 6 | migrate-apps | ⬜ Pendiente |

--- a/docs/architecture/oxy-auth-agent-handoff.md
+++ b/docs/architecture/oxy-auth-agent-handoff.md
@@ -1076,7 +1076,7 @@ bun run services:build
 | 1 | reconcile-p1 / DeviceSession | ✅ 2026-07-05 — ya estaba en main (waves 1+2); gate re-scoped verificado + colisión DTO resuelta (`DeviceLinkedSession*`, PR #556) |
 | 2 | contracts | 🟡 schemas deviceSession/deviceBoot ya en main+npm; **2b ✅** privacy/terms (PR #556); **2c ⬜ workshop Nate pendiente** |
 | 3 | merge-auth-sdk | ✅ 2026-07-05 — console en @oxyhq/services; auth-sdk ELIMINADO; rolldown-vite + vite-plugin-react-native-web; bloom ^0.29.2 (PR #557) |
-| 4 | unify-ui | ⬜ Pendiente |
+| 4 | unify-ui | ✅ 2026-07-06 — OxyAccountDialog sobre Bloom Dialog (placement bottom/md-center; mata bug RNW Modal+StrictMode); OxySignInButton bifurcado official→Dialog / third_party→OAuth+PKCE; helpers PKCE en core; i18n scan* keys |
 | 5 | auth-idp-rnweb | ⬜ Pendiente |
 | 6 | migrate-apps | ⬜ Pendiente |
 | 7 | clean-cut-docs | ⬜ Pendiente |

--- a/packages/core/src/i18n/locales/en-US.json
+++ b/packages/core/src/i18n/locales/en-US.json
@@ -384,7 +384,11 @@
       "subtitle": "Add another account to switch between them quickly"
     },
     "label": "Account switcher",
-    "searchPlaceholder": "Search accounts"
+    "searchPlaceholder": "Search accounts",
+    "scanTitle": "Scan to sign in",
+    "scanSubtitle": "Open the Oxy app on your phone and scan this code",
+    "scanWithOxy": "Scan with the Oxy app to continue",
+    "scanQr": "Scan QR code"
   },
   "reputation": {
     "faq": {

--- a/packages/core/src/i18n/locales/es-ES.json
+++ b/packages/core/src/i18n/locales/es-ES.json
@@ -581,7 +581,11 @@
       "subtitle": "Añade otra cuenta para cambiar rápidamente entre ellas"
     },
     "label": "Selector de cuentas",
-    "searchPlaceholder": "Buscar cuentas"
+    "searchPlaceholder": "Buscar cuentas",
+    "scanTitle": "Escanea para iniciar sesión",
+    "scanSubtitle": "Abre la app de Oxy en tu móvil y escanea este código",
+    "scanWithOxy": "Escanea con la app de Oxy para continuar",
+    "scanQr": "Escanear código QR"
   },
   "feedback": {
     "type": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -520,6 +520,20 @@ export type {
 } from './utils/coldBoot';
 
 // ---------------------------------------------------------------------------
+// OAuth 2.0 Authorization Code + PKCE helpers ("Sign in with Oxy" third party).
+// Standard OAuth against auth.oxy.so/authorize — no FedCM/cookies/SSO bounce.
+// ---------------------------------------------------------------------------
+export {
+    buildOAuthAuthorizeUrl,
+    computeCodeChallenge,
+    generateOAuthState,
+    generatePkcePair,
+    DEFAULT_OAUTH_SCOPE,
+    OXY_AUTHORIZE_URL,
+} from './utils/oauthPkce';
+export type { PkcePair, BuildOAuthAuthorizeUrlParams } from './utils/oauthPkce';
+
+// ---------------------------------------------------------------------------
 // Session sync (device-scoped multi-account session client)
 // ---------------------------------------------------------------------------
 export { SessionClient } from './session/SessionClient';

--- a/packages/core/src/utils/__tests__/oauthPkce.test.ts
+++ b/packages/core/src/utils/__tests__/oauthPkce.test.ts
@@ -128,6 +128,20 @@ describe('buildOAuthAuthorizeUrl', () => {
     expect(new URL(url).searchParams.get('client_id')).toBe(base.clientId);
   });
 
+  it('preserves a query string already present on authorizeBaseUrl', () => {
+    const params = new URL(
+      buildOAuthAuthorizeUrl({
+        ...base,
+        authorizeBaseUrl: 'https://auth.merchant.co/authorize?foo=bar&tenant=acme',
+      }),
+    ).searchParams;
+    // Pre-existing params survive alongside the OAuth params.
+    expect(params.get('foo')).toBe('bar');
+    expect(params.get('tenant')).toBe('acme');
+    expect(params.get('client_id')).toBe(base.clientId);
+    expect(params.get('code_challenge_method')).toBe('S256');
+  });
+
   it('URL-encodes a redirect_uri that carries a query string and special chars', () => {
     const redirectUri = 'https://merchant.co/auth/callback?next=/dashboard&lang=es';
     const url = buildOAuthAuthorizeUrl({ ...base, redirectUri });

--- a/packages/core/src/utils/__tests__/oauthPkce.test.ts
+++ b/packages/core/src/utils/__tests__/oauthPkce.test.ts
@@ -1,0 +1,140 @@
+import { createHash } from 'node:crypto';
+import {
+  buildOAuthAuthorizeUrl,
+  computeCodeChallenge,
+  DEFAULT_OAUTH_SCOPE,
+  generateOAuthState,
+  generatePkcePair,
+  OXY_AUTHORIZE_URL,
+} from '../oauthPkce';
+
+/** RFC 7636 unreserved subset produced by base64url (no `+`, `/`, `=`). */
+const BASE64URL_RE = /^[A-Za-z0-9\-_]+$/;
+
+/** Independent base64url(SHA-256(input)) via Node crypto for cross-checking. */
+function nodeCodeChallenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
+}
+
+describe('computeCodeChallenge', () => {
+  it('matches the RFC 7636 Appendix B known-answer vector', async () => {
+    // From RFC 7636 §Appendix B: verifier -> S256 challenge.
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    const expected = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+    await expect(computeCodeChallenge(verifier)).resolves.toBe(expected);
+  });
+
+  it('produces unpadded base64url (no +, /, or = characters)', async () => {
+    const challenge = await computeCodeChallenge('some-arbitrary-code-verifier-value-123');
+    expect(challenge).toMatch(BASE64URL_RE);
+    expect(challenge).not.toContain('=');
+  });
+
+  it('agrees with an independent Node crypto implementation', async () => {
+    const verifier = 'another_verifier-value.with~allowed_chars-0123456789';
+    await expect(computeCodeChallenge(verifier)).resolves.toBe(nodeCodeChallenge(verifier));
+  });
+
+  it('encodes the full 32-byte SHA-256 digest as 43 base64url chars', async () => {
+    const challenge = await computeCodeChallenge('x');
+    expect(challenge).toHaveLength(43);
+  });
+});
+
+describe('generatePkcePair', () => {
+  it('returns a verifier, challenge, and S256 method', async () => {
+    const pair = await generatePkcePair();
+    expect(pair.method).toBe('S256');
+    expect(typeof pair.codeVerifier).toBe('string');
+    expect(typeof pair.codeChallenge).toBe('string');
+  });
+
+  it('produces a verifier in the RFC 7636 length range with only unreserved chars', async () => {
+    const { codeVerifier } = await generatePkcePair();
+    expect(codeVerifier).toMatch(BASE64URL_RE);
+    expect(codeVerifier.length).toBeGreaterThanOrEqual(43);
+    expect(codeVerifier.length).toBeLessThanOrEqual(128);
+  });
+
+  it('derives the challenge as base64url(SHA-256(verifier))', async () => {
+    const { codeVerifier, codeChallenge } = await generatePkcePair();
+    await expect(computeCodeChallenge(codeVerifier)).resolves.toBe(codeChallenge);
+    expect(codeChallenge).toBe(nodeCodeChallenge(codeVerifier));
+  });
+
+  it('generates a fresh, unpredictable verifier on each call', async () => {
+    const [a, b] = await Promise.all([generatePkcePair(), generatePkcePair()]);
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+    expect(a.codeChallenge).not.toBe(b.codeChallenge);
+  });
+});
+
+describe('generateOAuthState', () => {
+  it('returns an unreserved base64url token of 32 random bytes (43 chars)', async () => {
+    const state = await generateOAuthState();
+    expect(state).toMatch(BASE64URL_RE);
+    expect(state).toHaveLength(43);
+  });
+
+  it('is unique across calls', async () => {
+    const [a, b] = await Promise.all([generateOAuthState(), generateOAuthState()]);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('buildOAuthAuthorizeUrl', () => {
+  const base = {
+    clientId: 'oxy_dk_example',
+    redirectUri: 'https://merchant.co/auth/callback',
+    state: 'csrf-state-token',
+    codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+  };
+
+  it('defaults to the Oxy authorize endpoint', () => {
+    const url = buildOAuthAuthorizeUrl(base);
+    expect(url.startsWith(`${OXY_AUTHORIZE_URL}?`)).toBe(true);
+    expect(OXY_AUTHORIZE_URL).toBe('https://auth.oxy.so/authorize');
+  });
+
+  it('includes every required OAuth authorization-code + PKCE parameter', () => {
+    const params = new URL(buildOAuthAuthorizeUrl(base)).searchParams;
+    expect(params.get('client_id')).toBe(base.clientId);
+    expect(params.get('redirect_uri')).toBe(base.redirectUri);
+    expect(params.get('response_type')).toBe('code');
+    expect(params.get('state')).toBe(base.state);
+    expect(params.get('scope')).toBe(DEFAULT_OAUTH_SCOPE);
+    expect(params.get('code_challenge')).toBe(base.codeChallenge);
+    expect(params.get('code_challenge_method')).toBe('S256');
+  });
+
+  it('defaults the scope to "openid profile"', () => {
+    const params = new URL(buildOAuthAuthorizeUrl(base)).searchParams;
+    expect(params.get('scope')).toBe('openid profile');
+  });
+
+  it('honors a custom scope', () => {
+    const params = new URL(
+      buildOAuthAuthorizeUrl({ ...base, scope: 'openid profile email wallet' }),
+    ).searchParams;
+    expect(params.get('scope')).toBe('openid profile email wallet');
+  });
+
+  it('honors an authorizeBaseUrl override', () => {
+    const url = buildOAuthAuthorizeUrl({
+      ...base,
+      authorizeBaseUrl: 'https://auth.merchant.co/authorize',
+    });
+    expect(url.startsWith('https://auth.merchant.co/authorize?')).toBe(true);
+    expect(new URL(url).searchParams.get('client_id')).toBe(base.clientId);
+  });
+
+  it('URL-encodes a redirect_uri that carries a query string and special chars', () => {
+    const redirectUri = 'https://merchant.co/auth/callback?next=/dashboard&lang=es';
+    const url = buildOAuthAuthorizeUrl({ ...base, redirectUri });
+    // The raw string must be percent-encoded (its own & must not leak as a delimiter).
+    expect(url).toContain('redirect_uri=https%3A%2F%2Fmerchant.co%2Fauth%2Fcallback');
+    expect(url).not.toContain('redirect_uri=https://merchant.co');
+    // Round-trips back to the exact original when parsed.
+    expect(new URL(url).searchParams.get('redirect_uri')).toBe(redirectUri);
+  });
+});

--- a/packages/core/src/utils/oauthPkce.ts
+++ b/packages/core/src/utils/oauthPkce.ts
@@ -1,0 +1,187 @@
+/**
+ * OAuth 2.0 Authorization Code + PKCE helpers for "Sign in with Oxy" third-party
+ * sign-in.
+ *
+ * Third-party Relying Parties (SPAs, static sites, and native apps that are NOT
+ * Oxy first-party) authenticate through the standard OAuth flow against
+ * `auth.oxy.so/authorize` — never FedCM, SSO bounces, or Oxy session cookies.
+ * Public clients (no secret) prove possession of the authorization code with
+ * PKCE (RFC 7636, S256): the RP generates a random `code_verifier`, sends its
+ * `code_challenge = BASE64URL(SHA-256(code_verifier))` on the authorize
+ * redirect, and later replays the raw verifier on the token exchange.
+ *
+ * All cross-platform crypto (random bytes, SHA-256) is delegated to the shared
+ * `@oxyhq/protocol` platform loaders — the exact primitives the rest of core's
+ * crypto already uses — so these helpers run identically on web, Node, and
+ * React Native. No `require()`, so the ESM build stays bundler-clean.
+ */
+
+import { isNodeJS, isReactNative, loadExpoCrypto, loadNodeCrypto, sha256 } from '@oxyhq/protocol';
+import { logger } from './loggerUtils';
+
+/** The central Oxy IdP authorization endpoint used by default. */
+export const OXY_AUTHORIZE_URL = 'https://auth.oxy.so/authorize';
+
+/** Default OAuth scope requested for a "Sign in with Oxy" third-party flow. */
+export const DEFAULT_OAUTH_SCOPE = 'openid profile';
+
+/**
+ * Number of random bytes behind a PKCE `code_verifier`. 64 bytes → 86 base64url
+ * characters, comfortably inside RFC 7636 §4.1's required 43–128 range.
+ */
+const PKCE_VERIFIER_BYTES = 64;
+
+/** Number of random bytes behind an OAuth `state` (CSRF) token. */
+const OAUTH_STATE_BYTES = 32;
+
+/** RFC 4648 §5 base64url alphabet (URL- and filename-safe, no padding). */
+const BASE64URL_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+
+/** A generated PKCE verifier/challenge pair. */
+export interface PkcePair {
+  /** The high-entropy secret replayed on the token exchange (kept client-side). */
+  codeVerifier: string;
+  /** `BASE64URL(SHA-256(codeVerifier))` — sent on the authorize redirect. */
+  codeChallenge: string;
+  /** The PKCE transformation method. Always `S256`. */
+  method: 'S256';
+}
+
+/** Parameters for {@link buildOAuthAuthorizeUrl}. */
+export interface BuildOAuthAuthorizeUrlParams {
+  /** Authorize endpoint; defaults to {@link OXY_AUTHORIZE_URL}. */
+  authorizeBaseUrl?: string;
+  /** The registered `ApplicationCredential` public key (`oxy_dk_…`). */
+  clientId: string;
+  /** Exact registered redirect URI to return the authorization code to. */
+  redirectUri: string;
+  /** Requested scope; defaults to {@link DEFAULT_OAUTH_SCOPE}. */
+  scope?: string;
+  /** Opaque CSRF token from {@link generateOAuthState}. */
+  state: string;
+  /** The PKCE `codeChallenge` from {@link generatePkcePair}. */
+  codeChallenge: string;
+}
+
+/**
+ * Cryptographically-secure random bytes, cross-platform.
+ *
+ * Mirrors the platform gating the rest of core's crypto already uses:
+ * `expo-crypto` on React Native, Node's built-in `crypto` on the server, and
+ * the Web Crypto API in the browser (also the fallback if Node's `crypto`
+ * fails to load in an unusual bundled-Node environment).
+ */
+async function getSecureRandomBytes(byteLength: number): Promise<Uint8Array> {
+  if (isReactNative()) {
+    const crypto = await loadExpoCrypto();
+    return Uint8Array.from(await crypto.getRandomBytesAsync(byteLength));
+  }
+
+  if (isNodeJS()) {
+    try {
+      const nodeCrypto = await loadNodeCrypto();
+      return Uint8Array.from(nodeCrypto.randomBytes(byteLength));
+    } catch (error) {
+      logger.warn(
+        '[oxy.oauth] Node crypto unavailable for PKCE random bytes, falling back to Web Crypto',
+        { component: 'oauthPkce' },
+        error,
+      );
+    }
+  }
+
+  const bytes = new Uint8Array(byteLength);
+  globalThis.crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+/** Encode raw bytes as unpadded base64url (RFC 4648 §5). */
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let output = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const byte0 = bytes[i];
+    const hasByte1 = i + 1 < bytes.length;
+    const hasByte2 = i + 2 < bytes.length;
+    const byte1 = hasByte1 ? bytes[i + 1] : 0;
+    const byte2 = hasByte2 ? bytes[i + 2] : 0;
+
+    output += BASE64URL_ALPHABET[byte0 >> 2];
+    output += BASE64URL_ALPHABET[((byte0 & 0x03) << 4) | (byte1 >> 4)];
+    if (hasByte1) {
+      output += BASE64URL_ALPHABET[((byte1 & 0x0f) << 2) | (byte2 >> 6)];
+    }
+    if (hasByte2) {
+      output += BASE64URL_ALPHABET[byte2 & 0x3f];
+    }
+  }
+  return output;
+}
+
+/** Decode a lowercase-hex string into its raw bytes. */
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i += 1) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Compute the PKCE S256 `code_challenge` for a given verifier:
+ * `BASE64URL(SHA-256(ASCII(codeVerifier)))` (RFC 7636 §4.2). The verifier is
+ * base64url (ASCII), so its UTF-8 and ASCII byte encodings are identical.
+ *
+ * Reuses `@oxyhq/protocol`'s cross-platform {@link sha256} (which returns
+ * lowercase hex); the digest bytes are recovered and re-encoded as base64url.
+ */
+export async function computeCodeChallenge(codeVerifier: string): Promise<string> {
+  const digestHex = await sha256(codeVerifier);
+  return bytesToBase64Url(hexToBytes(digestHex));
+}
+
+/**
+ * Generate a fresh PKCE verifier/challenge pair for an OAuth authorization-code
+ * flow. The verifier is 64 random bytes as base64url (86 chars, within RFC 7636
+ * §4.1's 43–128 range and drawn only from the unreserved set); the challenge is
+ * its S256 transform.
+ */
+export async function generatePkcePair(): Promise<PkcePair> {
+  const codeVerifier = bytesToBase64Url(await getSecureRandomBytes(PKCE_VERIFIER_BYTES));
+  const codeChallenge = await computeCodeChallenge(codeVerifier);
+  return { codeVerifier, codeChallenge, method: 'S256' };
+}
+
+/**
+ * Generate an opaque, single-use OAuth `state` token (32 random bytes as
+ * base64url) for CSRF protection across the authorize redirect.
+ */
+export async function generateOAuthState(): Promise<string> {
+  return bytesToBase64Url(await getSecureRandomBytes(OAUTH_STATE_BYTES));
+}
+
+/**
+ * Build the `auth.oxy.so/authorize` redirect URL for an OAuth authorization-code
+ * + PKCE (S256) flow. All values are URL-encoded via {@link URLSearchParams}.
+ */
+export function buildOAuthAuthorizeUrl(params: BuildOAuthAuthorizeUrlParams): string {
+  const {
+    authorizeBaseUrl = OXY_AUTHORIZE_URL,
+    clientId,
+    redirectUri,
+    scope = DEFAULT_OAUTH_SCOPE,
+    state,
+    codeChallenge,
+  } = params;
+
+  const search = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    state,
+    scope,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  });
+
+  return `${authorizeBaseUrl}?${search.toString()}`;
+}

--- a/packages/core/src/utils/oauthPkce.ts
+++ b/packages/core/src/utils/oauthPkce.ts
@@ -161,7 +161,10 @@ export async function generateOAuthState(): Promise<string> {
 
 /**
  * Build the `auth.oxy.so/authorize` redirect URL for an OAuth authorization-code
- * + PKCE (S256) flow. All values are URL-encoded via {@link URLSearchParams}.
+ * + PKCE (S256) flow. Built via the WHATWG `URL` API so a custom
+ * `authorizeBaseUrl` that already carries a query string keeps its existing
+ * params (the OAuth params are merged in, not clobbered by a naive `?` concat).
+ * All values are percent-encoded by `URL.searchParams`.
  */
 export function buildOAuthAuthorizeUrl(params: BuildOAuthAuthorizeUrlParams): string {
   const {
@@ -173,15 +176,14 @@ export function buildOAuthAuthorizeUrl(params: BuildOAuthAuthorizeUrlParams): st
     codeChallenge,
   } = params;
 
-  const search = new URLSearchParams({
-    client_id: clientId,
-    redirect_uri: redirectUri,
-    response_type: 'code',
-    state,
-    scope,
-    code_challenge: codeChallenge,
-    code_challenge_method: 'S256',
-  });
+  const url = new URL(authorizeBaseUrl);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('state', state);
+  url.searchParams.set('scope', scope);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
 
-  return `${authorizeBaseUrl}?${search.toString()}`;
+  return url.toString();
 }

--- a/packages/services/__tests__/__mocks__/bloom.ts
+++ b/packages/services/__tests__/__mocks__/bloom.ts
@@ -6,7 +6,7 @@
  * can spy on the exported `toast` object directly.
  */
 
-import { createElement, type ReactNode } from 'react';
+import { createElement, Fragment, type ReactNode } from 'react';
 
 type ToastFn = (message: string, options?: Record<string, unknown>) => void;
 
@@ -56,7 +56,18 @@ export const APP_COLOR_NAMES: readonly string[] = [];
 
 export const APP_COLOR_PRESETS: Record<string, { hex: string }> = {};
 
-export const Dialog = () => null;
+/**
+ * `@oxyhq/bloom/dialog` `<Dialog>` stub. The real component renders its own
+ * portal/backdrop chrome; here we only need the controlled `open` gate and the
+ * `children` so a component under test (e.g. `OxyAccountDialog`) can be queried
+ * for its content. Extra props (`placement`, `onClose`, `dismissOnBackdrop`, …)
+ * are ignored.
+ */
+export const Dialog = ({
+  open,
+  children,
+}: { open?: boolean; children?: ReactNode } & Record<string, unknown>) =>
+  open === false ? null : createElement(Fragment, null, children);
 
 export const useDialogControl = (): {
   open: () => void;

--- a/packages/services/__tests__/components/OxyAccountDialog.test.tsx
+++ b/packages/services/__tests__/components/OxyAccountDialog.test.tsx
@@ -73,11 +73,6 @@ jest.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({ invalidateQueries }),
 }));
 
-jest.mock('react-native-gesture-handler', () => ({
-  __esModule: true,
-  GestureHandlerRootView: ({ children }: { children?: React.ReactNode }) => children,
-}));
-
 jest.mock('react-native-qrcode-svg', () => ({
   __esModule: true,
   default: ({ value }: { value: string }) =>

--- a/packages/services/__tests__/components/OxySignInButton.test.tsx
+++ b/packages/services/__tests__/components/OxySignInButton.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * `OxySignInButton` — the public "Sign in with Oxy" button.
+ *
+ * These tests cover the Fase 4 fork: on press the button resolves the requesting
+ * Application (via `oxyServices.getPublicApplication(clientId)`) and routes by
+ * type — an official / first-party app opens the in-app account dialog, a
+ * `third_party` app starts an OAuth 2.0 + PKCE redirect to `auth.oxy.so`. The
+ * cross-platform PKCE/URL helpers are the REAL `@oxyhq/core` implementations so
+ * the asserted authorize URL is the one an RP actually receives.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { logger } from '@oxyhq/core';
+import type { PublicApplication } from '@oxyhq/core';
+import { redirectToAuthorize } from '../../src/ui/components/oauthNavigation';
+import OxySignInButton, {
+  OXY_OAUTH_STATE_STORAGE_KEY,
+  OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
+} from '../../src/ui/components/OxySignInButton';
+
+const makeApp = (over: Partial<PublicApplication>): PublicApplication => ({
+  id: 'app-1',
+  name: 'Test App',
+  type: 'first_party',
+  isOfficial: false,
+  isInternal: false,
+  scopes: ['openid', 'profile'],
+  ...over,
+});
+
+const openAccountDialog = jest.fn();
+const getPublicApplication = jest.fn<Promise<PublicApplication>, [string]>();
+let clientId: string | null = 'oxy_dk_test';
+
+jest.mock('../../src/ui/context/OxyContext', () => ({
+  __esModule: true,
+  useOxy: () => ({ openAccountDialog, oxyServices: { getPublicApplication }, clientId }),
+}));
+
+jest.mock('../../src/ui/stores/authStore', () => ({
+  __esModule: true,
+  useAuthStore: (selector: (s: { isAuthenticated: boolean; isLoading: boolean }) => unknown) =>
+    selector({ isAuthenticated: false, isLoading: false }),
+}));
+
+jest.mock('zustand/react/shallow', () => ({
+  __esModule: true,
+  useShallow: (fn: unknown) => fn,
+}));
+
+jest.mock('../../src/ui/navigation/accountDialogManager', () => ({
+  __esModule: true,
+  subscribeToSignInModal: () => () => undefined,
+}));
+
+jest.mock('../../src/ui/components/OxyLogo', () => ({ __esModule: true, default: () => null }));
+
+jest.mock('../../src/ui/components/oauthNavigation', () => ({
+  __esModule: true,
+  redirectToAuthorize: jest.fn(),
+  openAuthorizeUrlNative: jest.fn(async () => undefined),
+}));
+
+const redirectToAuthorizeMock = redirectToAuthorize as jest.MockedFunction<typeof redirectToAuthorize>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clientId = 'oxy_dk_test';
+  window.sessionStorage.clear();
+});
+
+describe('OxySignInButton', () => {
+  it('opens the in-app dialog for a first-party / official application', async () => {
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'first_party', isOfficial: true }));
+
+    render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(openAccountDialog).toHaveBeenCalledWith('signin'));
+    expect(getPublicApplication).toHaveBeenCalledWith('oxy_dk_test');
+    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('starts an OAuth + PKCE redirect for a third_party application (web)', async () => {
+    getPublicApplication.mockResolvedValue(
+      makeApp({ type: 'third_party', isOfficial: false, name: 'Third Party' }),
+    );
+
+    render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(redirectToAuthorizeMock).toHaveBeenCalledTimes(1));
+    expect(openAccountDialog).not.toHaveBeenCalled();
+
+    const url = new URL(redirectToAuthorizeMock.mock.calls[0][0]);
+    expect(`${url.origin}${url.pathname}`).toBe('https://auth.oxy.so/authorize');
+    expect(url.searchParams.get('client_id')).toBe('oxy_dk_test');
+    expect(url.searchParams.get('redirect_uri')).toBe('https://rp.example/callback');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    const state = url.searchParams.get('state');
+    const codeChallenge = url.searchParams.get('code_challenge');
+    expect(state).toBeTruthy();
+    expect(codeChallenge).toBeTruthy();
+
+    // The CSRF state + PKCE verifier are persisted for the RP's redirect-URI
+    // callback: state matches the redirect, and a verifier is stored.
+    expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBe(state);
+    expect(window.sessionStorage.getItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY)).toBeTruthy();
+  });
+
+  it('aborts (no redirect) for a third_party application with no oauthRedirectUri', async () => {
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+
+    render(<OxySignInButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(openAccountDialog).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
+
+    errorSpy.mockRestore();
+  });
+
+  it('falls back to the dialog when the application cannot be resolved', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    getPublicApplication.mockRejectedValue(new Error('network'));
+
+    render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(openAccountDialog).toHaveBeenCalledWith('signin'));
+    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('opens the dialog without resolving when there is no clientId', async () => {
+    clientId = null;
+
+    render(<OxySignInButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(openAccountDialog).toHaveBeenCalledWith('signin'));
+    expect(getPublicApplication).not.toHaveBeenCalled();
+  });
+
+  it('defers entirely to a caller-supplied onPress', () => {
+    const onPress = jest.fn();
+
+    render(<OxySignInButton onPress={onPress} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(getPublicApplication).not.toHaveBeenCalled();
+    expect(openAccountDialog).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/__tests__/components/OxySignInButton.test.tsx
+++ b/packages/services/__tests__/components/OxySignInButton.test.tsx
@@ -10,9 +10,10 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Platform } from 'react-native';
 import { logger } from '@oxyhq/core';
 import type { PublicApplication } from '@oxyhq/core';
-import { redirectToAuthorize } from '../../src/ui/components/oauthNavigation';
+import { redirectToAuthorize, openAuthorizeUrlNative } from '../../src/ui/components/oauthNavigation';
 import OxySignInButton, {
   OXY_OAUTH_STATE_STORAGE_KEY,
   OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
@@ -58,15 +59,24 @@ jest.mock('../../src/ui/components/OxyLogo', () => ({ __esModule: true, default:
 jest.mock('../../src/ui/components/oauthNavigation', () => ({
   __esModule: true,
   redirectToAuthorize: jest.fn(),
-  openAuthorizeUrlNative: jest.fn(async () => undefined),
+  openAuthorizeUrlNative: jest.fn(async () => ({ redirectUrl: null })),
 }));
 
 const redirectToAuthorizeMock = redirectToAuthorize as jest.MockedFunction<typeof redirectToAuthorize>;
+const openAuthorizeUrlNativeMock = openAuthorizeUrlNative as jest.MockedFunction<
+  typeof openAuthorizeUrlNative
+>;
 
 beforeEach(() => {
   jest.clearAllMocks();
   clientId = 'oxy_dk_test';
+  Platform.OS = 'web';
+  openAuthorizeUrlNativeMock.mockResolvedValue({ redirectUrl: null });
   window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  Platform.OS = 'web';
 });
 
 describe('OxySignInButton', () => {
@@ -157,5 +167,77 @@ describe('OxySignInButton', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
     expect(getPublicApplication).not.toHaveBeenCalled();
     expect(openAccountDialog).not.toHaveBeenCalled();
+  });
+
+  it('hands the OAuth handshake to onOAuthResult for a third_party application (native)', async () => {
+    Platform.OS = 'ios';
+    openAuthorizeUrlNativeMock.mockResolvedValue({ redirectUrl: 'myapp://cb?code=abc123&state=xyz' });
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+    const onOAuthResult = jest.fn();
+
+    render(<OxySignInButton oauthRedirectUri="myapp://cb" onOAuthResult={onOAuthResult} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(openAuthorizeUrlNativeMock).toHaveBeenCalledTimes(1));
+    // Native never touches sessionStorage or the web full-page redirect.
+    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
+
+    await waitFor(() => expect(onOAuthResult).toHaveBeenCalledTimes(1));
+    const [authorizeUrl] = openAuthorizeUrlNativeMock.mock.calls[0];
+    const sentState = new URL(authorizeUrl).searchParams.get('state');
+    const result = onOAuthResult.mock.calls[0][0];
+    expect(result.redirectUrl).toBe('myapp://cb?code=abc123&state=xyz');
+    expect(result.state).toBe(sentState);
+    expect(typeof result.codeVerifier).toBe('string');
+    expect(result.codeVerifier.length).toBeGreaterThan(40);
+  });
+
+  it('warns when a native third_party sign-in has no onOAuthResult handler', async () => {
+    Platform.OS = 'ios';
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+
+    render(<OxySignInButton oauthRedirectUri="myapp://cb" />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(openAuthorizeUrlNativeMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('re-resolves the application when clientId changes (cache invalidation)', async () => {
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'first_party', isOfficial: true }));
+
+    const { rerender } = render(<OxySignInButton />);
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(getPublicApplication).toHaveBeenCalledWith('oxy_dk_test'));
+
+    clientId = 'oxy_dk_other';
+    rerender(<OxySignInButton />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(getPublicApplication).toHaveBeenCalledWith('oxy_dk_other'));
+    expect(getPublicApplication).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts the third_party web redirect when the handshake cannot be persisted', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+
+    render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(openAccountDialog).not.toHaveBeenCalled();
+
+    setItemSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/services/__tests__/components/oauthNavigation.test.ts
+++ b/packages/services/__tests__/components/oauthNavigation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `oauthNavigation` — platform navigation for the third-party OAuth flow.
+ *
+ * Covers the native `openAuthorizeUrlNative` contract: it returns the deep-link
+ * URL the auth session came back to, falls back to `Linking.openURL` when the
+ * auth session is unavailable, and never throws out of the sign-in flow even
+ * when the fallback itself rejects.
+ */
+
+import { Linking } from 'react-native';
+import { logger } from '@oxyhq/core';
+
+const mockOpenAuthSessionAsync = jest.fn();
+jest.mock(
+  'expo-web-browser',
+  () => ({ __esModule: true, openAuthSessionAsync: mockOpenAuthSessionAsync }),
+  { virtual: true },
+);
+
+// eslint-disable-next-line import/first
+import { openAuthorizeUrlNative } from '../../src/ui/components/oauthNavigation';
+
+const AUTHORIZE_URL = 'https://auth.oxy.so/authorize?client_id=c&state=s';
+const REDIRECT_URI = 'myapp://cb';
+
+describe('openAuthorizeUrlNative', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the redirect URL when the auth session succeeds', async () => {
+    mockOpenAuthSessionAsync.mockResolvedValue({ type: 'success', url: 'myapp://cb?code=1&state=s' });
+    const openURLSpy = jest.spyOn(Linking, 'openURL');
+
+    const result = await openAuthorizeUrlNative(AUTHORIZE_URL, REDIRECT_URI);
+
+    expect(mockOpenAuthSessionAsync).toHaveBeenCalledWith(AUTHORIZE_URL, REDIRECT_URI);
+    expect(result).toEqual({ redirectUrl: 'myapp://cb?code=1&state=s' });
+    expect(openURLSpy).not.toHaveBeenCalled();
+
+    openURLSpy.mockRestore();
+  });
+
+  it('returns null for a dismissed/cancelled auth session (no fallback)', async () => {
+    mockOpenAuthSessionAsync.mockResolvedValue({ type: 'cancel' });
+    const openURLSpy = jest.spyOn(Linking, 'openURL');
+
+    const result = await openAuthorizeUrlNative(AUTHORIZE_URL, REDIRECT_URI);
+
+    expect(result).toEqual({ redirectUrl: null });
+    expect(openURLSpy).not.toHaveBeenCalled();
+
+    openURLSpy.mockRestore();
+  });
+
+  it('falls back to Linking and returns null when the auth session throws', async () => {
+    mockOpenAuthSessionAsync.mockRejectedValue(new Error('no browser'));
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const openURLSpy = jest.spyOn(Linking, 'openURL').mockResolvedValue(true);
+
+    const result = await openAuthorizeUrlNative(AUTHORIZE_URL, REDIRECT_URI);
+
+    expect(openURLSpy).toHaveBeenCalledWith(AUTHORIZE_URL);
+    expect(result).toEqual({ redirectUrl: null });
+    expect(warnSpy).toHaveBeenCalled();
+
+    openURLSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('logs and returns null when the Linking fallback rejects (invalid scheme)', async () => {
+    mockOpenAuthSessionAsync.mockRejectedValue(new Error('no browser'));
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const openURLSpy = jest.spyOn(Linking, 'openURL').mockRejectedValue(new Error('no activity found'));
+
+    const result = await openAuthorizeUrlNative(AUTHORIZE_URL, REDIRECT_URI);
+
+    expect(result).toEqual({ redirectUrl: null });
+    // Two warns: the auth-session failure and the Linking rejection.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    openURLSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -192,7 +192,12 @@ export type { ViewMode, SortBy, SortOrder } from './ui/hooks/useFileFiltering';
 // ---------------------------------------------------------------------------
 export { default as Avatar } from './ui/components/Avatar';
 export type { AvatarProps } from './ui/components/Avatar';
-export { OxySignInButton } from './ui/components/OxySignInButton';
+export {
+  OxySignInButton,
+  OXY_OAUTH_STATE_STORAGE_KEY,
+  OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
+} from './ui/components/OxySignInButton';
+export type { OxySignInButtonProps } from './ui/components/OxySignInButton';
 export { OxyAuthPrompt } from './ui/components/OxyAuthPrompt';
 export type { OxyAuthPromptProps } from './ui/components/OxyAuthPrompt';
 export { default as OxyLogo } from './ui/components/OxyLogo';

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -197,7 +197,7 @@ export {
   OXY_OAUTH_STATE_STORAGE_KEY,
   OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
 } from './ui/components/OxySignInButton';
-export type { OxySignInButtonProps } from './ui/components/OxySignInButton';
+export type { OxySignInButtonProps, OxyOAuthResult } from './ui/components/OxySignInButton';
 export { OxyAuthPrompt } from './ui/components/OxyAuthPrompt';
 export type { OxyAuthPromptProps } from './ui/components/OxyAuthPrompt';
 export { default as OxyLogo } from './ui/components/OxyLogo';

--- a/packages/services/src/ui/components/OxyAccountDialog.tsx
+++ b/packages/services/src/ui/components/OxyAccountDialog.tsx
@@ -22,14 +22,29 @@
  * Per-account color re-theming uses Bloom's `APP_COLOR_PRESETS` + `BloomColorScope`
  * (same visual language auth.oxy.so uses). Base theming is `useTheme()` + a
  * `StyleSheet`, so the dialog renders correctly in EVERY consumer — including apps
- * that do not use NativeWind (e.g. the accounts app). Modal contents are wrapped
- * in `<GestureHandlerRootView>` because RN's `Modal` renders into its own window.
+ * that do not use NativeWind (e.g. the accounts app).
+ *
+ * The surface is Bloom's `<Dialog>` (`@oxyhq/bloom/dialog`) with a responsive
+ * `placement` — a bottom sheet on narrow viewports, a centered card on wide ones.
+ * It REPLACES the hand-rolled RN `<Modal>` + `<GestureHandlerRootView>` + manual
+ * backdrop/card wrapper this component used before. That RN `<Modal>` is invisible
+ * under React StrictMode on web: react-native-web's `ModalPortal` appends its host
+ * node during render but removes it in an effect cleanup and never re-attaches, so
+ * the dialog never paints in a dev Vite build. Bloom's `<Dialog>` renders through
+ * its own Portal and has no such lifecycle hazard.
+ *
+ * Open/close is CONTROLLED by `isAccountDialogOpen` (the `open` prop); the Dialog
+ * stays mounted whenever the controller exists so it can animate its own close.
+ * Backdrop / swipe-to-dismiss is disabled (`dismissOnBackdrop={false}`) on purpose:
+ * Bloom's controlled `bottom` placement does not fire `onClose` on a gesture or
+ * backdrop dismissal, so allowing it would desync `isAccountDialogOpen` from the
+ * sheet and block reopening. The header close button (and a successful switch)
+ * drive `closeAccountDialog`, which flips `open` and runs the exit animation.
  */
 
 import type React from 'react';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import {
-  Modal,
   Platform,
   Pressable,
   ScrollView,
@@ -38,11 +53,11 @@ import {
   type StyleProp,
   type ViewStyle,
 } from 'react-native';
-import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
 import QRCode from 'react-native-qrcode-svg';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { Button } from '@oxyhq/bloom/button';
+import { Dialog } from '@oxyhq/bloom/dialog';
 import { Text } from '@oxyhq/bloom/typography';
 import {
   useTheme,
@@ -172,7 +187,7 @@ const OxyAccountDialog: React.FC = () => {
     [handleSwitch, controller, handleManage, closeAccountDialog],
   );
 
-  if (!isAccountDialogOpen || !controller) {
+  if (!controller) {
     return null;
   }
 
@@ -180,65 +195,48 @@ const OxyAccountDialog: React.FC = () => {
   const showBack = view === 'qr' || (view === 'add' && snapshot.accounts.length > 0);
 
   return (
-    <Modal
-      visible
-      transparent
-      animationType={isWeb ? 'fade' : 'slide'}
-      statusBarTranslucent
-      onRequestClose={closeAccountDialog}
+    <Dialog
+      open={isAccountDialogOpen}
+      onClose={closeAccountDialog}
+      placement={{ base: 'bottom', md: 'center' }}
+      dismissOnBackdrop={false}
+      maxWidth={420}
+      label={headerCopy(view, snapshot.accounts.length, t).title}
     >
-      <GestureHandlerRootView style={styles.root}>
-        <View style={[styles.backdrop, { backgroundColor: theme.colors.overlay }]}>
-          <Pressable
-            style={StyleSheet.absoluteFill}
-            onPress={closeAccountDialog}
-            accessibilityLabel={t('common.actions.close') || 'Close'}
-            accessibilityRole="button"
+      <DialogHeader
+        snapshot={snapshot}
+        theme={theme}
+        t={t}
+        showBack={showBack}
+        onBack={() => controller.setView('accounts')}
+        onClose={closeAccountDialog}
+      />
+      <ScrollView
+        style={styles.body}
+        contentContainerStyle={styles.bodyContent}
+        showsVerticalScrollIndicator={false}
+      >
+        {view === 'accounts' ? (
+          <AccountsView snapshot={snapshot} theme={theme} t={t} handlers={handlers} />
+        ) : view === 'qr' ? (
+          <QrView snapshot={snapshot} theme={theme} t={t} onRetry={() => void controller.showQr()} />
+        ) : (
+          <SignInView
+            snapshot={snapshot}
+            theme={theme}
+            t={t}
+            handlers={handlers}
+            onSignInWithOxy={() => void controller.signInWithOxy()}
+            onScanQr={() => void controller.showQr()}
+            onUsePassword={() =>
+              controller.openPasswordAtOxyAuth({
+                returnUrl: isWeb ? currentHref() : undefined,
+              })
+            }
           />
-          <View
-            style={[
-              styles.card,
-              isWeb ? styles.cardCentered : styles.cardSheet,
-              { backgroundColor: theme.colors.card, borderColor: theme.colors.border },
-            ]}
-          >
-            <DialogHeader
-              snapshot={snapshot}
-              theme={theme}
-              t={t}
-              showBack={showBack}
-              onBack={() => controller.setView('accounts')}
-              onClose={closeAccountDialog}
-            />
-            <ScrollView
-              style={styles.body}
-              contentContainerStyle={styles.bodyContent}
-              showsVerticalScrollIndicator={false}
-            >
-              {view === 'accounts' ? (
-                <AccountsView snapshot={snapshot} theme={theme} t={t} handlers={handlers} />
-              ) : view === 'qr' ? (
-                <QrView snapshot={snapshot} theme={theme} t={t} onRetry={() => void controller.showQr()} />
-              ) : (
-                <SignInView
-                  snapshot={snapshot}
-                  theme={theme}
-                  t={t}
-                  handlers={handlers}
-                  onSignInWithOxy={() => void controller.signInWithOxy()}
-                  onScanQr={() => void controller.showQr()}
-                  onUsePassword={() =>
-                    controller.openPasswordAtOxyAuth({
-                      returnUrl: isWeb ? currentHref() : undefined,
-                    })
-                  }
-                />
-              )}
-            </ScrollView>
-          </View>
-        </View>
-      </GestureHandlerRootView>
-    </Modal>
+        )}
+      </ScrollView>
+    </Dialog>
   );
 };
 
@@ -583,29 +581,6 @@ const EMPTY_SNAPSHOT: AccountDialogSnapshot = {
 };
 
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-  },
-  backdrop: {
-    flex: 1,
-    justifyContent: isWeb ? 'center' : 'flex-end',
-    alignItems: 'center',
-  },
-  card: {
-    width: '100%',
-    maxWidth: 420,
-    borderWidth: StyleSheet.hairlineWidth,
-    paddingHorizontal: 20,
-    paddingTop: 16,
-    paddingBottom: 24,
-  },
-  cardCentered: {
-    borderRadius: 28,
-  },
-  cardSheet: {
-    borderTopLeftRadius: 28,
-    borderTopRightRadius: 28,
-  },
   header: {
     alignItems: 'center',
     marginBottom: 12,

--- a/packages/services/src/ui/components/OxySignInButton.tsx
+++ b/packages/services/src/ui/components/OxySignInButton.tsx
@@ -1,12 +1,46 @@
 import type React from 'react';
-import { useCallback, useState, useEffect, useMemo } from 'react';
+import { useCallback, useState, useEffect, useMemo, useRef } from 'react';
 import { TouchableOpacity, Text, View, StyleSheet, type ViewStyle, type TextStyle, type StyleProp, Platform } from 'react-native';
+import {
+    logger,
+    generatePkcePair,
+    generateOAuthState,
+    buildOAuthAuthorizeUrl,
+    type PublicApplication,
+} from '@oxyhq/core';
 import { useAuthStore } from '../stores/authStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { useOxy } from '../context/OxyContext';
 import OxyLogo from './OxyLogo';
 import { subscribeToSignInModal } from '../navigation/accountDialogManager';
+import { redirectToAuthorize, openAuthorizeUrlNative } from './oauthNavigation';
+
+const isWeb = Platform.OS === 'web';
+
+/**
+ * `sessionStorage` keys under which a third-party "Sign in with Oxy" OAuth flow
+ * persists its CSRF `state` and PKCE `code_verifier` across the authorize
+ * redirect. The Relying Party's redirect-URI callback reads them back to
+ * validate the returned `state` and replay the verifier on the token exchange.
+ *
+ * Web only: a browser RP navigates away to `auth.oxy.so` and back, so the
+ * handshake must survive a full-page redirect. Native completes the flow inside
+ * a single `WebBrowser` auth session and has no cross-navigation gap to bridge.
+ */
+export const OXY_OAUTH_STATE_STORAGE_KEY = 'oxy_oauth_state';
+export const OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY = 'oxy_oauth_code_verifier';
+
+/**
+ * Persist the OAuth CSRF `state` + PKCE `code_verifier` for the RP callback.
+ * No-op where `sessionStorage` is unavailable (SSR / non-browser hosts).
+ */
+function persistOAuthHandshake(state: string, codeVerifier: string): void {
+    const store = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+    if (!store) return;
+    store.setItem(OXY_OAUTH_STATE_STORAGE_KEY, state);
+    store.setItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY, codeVerifier);
+}
 
 export interface OxySignInButtonProps {
     /**
@@ -48,6 +82,16 @@ export interface OxySignInButtonProps {
      * @default false
      */
     showWhenAuthenticated?: boolean;
+
+    /**
+     * Exact registered redirect URI the OAuth authorization code is returned to.
+     * REQUIRED only for third-party (`type: 'third_party'`) applications, which
+     * sign in via an OAuth + PKCE redirect to `auth.oxy.so`. First-party /
+     * official apps open the in-app dialog and ignore this prop. If a third-party
+     * app resolves without it, the button logs an error and does nothing (it will
+     * not invent a redirect URI).
+     */
+    oauthRedirectUri?: string;
 }
 
 /**
@@ -82,9 +126,10 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
     text = 'Sign in with Oxy',
     disabled = false,
     showWhenAuthenticated = false,
+    oauthRedirectUri,
 }) => {
     const theme = useTheme();
-    const { openAccountDialog } = useOxy();
+    const { openAccountDialog, oxyServices, clientId } = useOxy();
     const { isAuthenticated, isLoading } = useAuthStore(
         useShallow((state) => ({ isAuthenticated: state.isAuthenticated, isLoading: state.isLoading }))
     );
@@ -95,15 +140,112 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
 
     useEffect(() => subscribeToSignInModal(setIsModalOpen), []);
 
-    // Open the unified account dialog on its sign-in view (same surface on web +
-    // native), or defer to a caller-supplied handler.
+    // The application's public identity is resolved ONCE per mounted button and
+    // its promise cached here, so the click handler stays lazy (no fetch until
+    // first press) and rapid taps share one in-flight resolve. A rejected resolve
+    // clears the cache so a later press can retry a transient failure.
+    const appResolutionRef = useRef<Promise<PublicApplication> | null>(null);
+    // Re-entrancy guard: a routing pass may await network + crypto before it
+    // redirects, so block a second concurrent press from racing the sessionStorage
+    // handshake against a different PKCE pair.
+    const routingRef = useRef(false);
+
+    const resolvePublicApplication = useCallback((): Promise<PublicApplication> | null => {
+        if (!clientId) return null;
+        if (!appResolutionRef.current) {
+            appResolutionRef.current = oxyServices.getPublicApplication(clientId).catch((error) => {
+                appResolutionRef.current = null;
+                throw error;
+            });
+        }
+        return appResolutionRef.current;
+    }, [clientId, oxyServices]);
+
+    // Official / first-party surface: the in-app account + sign-in dialog.
+    const startOfficialSignIn = useCallback(() => {
+        openAccountDialog('signin');
+    }, [openAccountDialog]);
+
+    // Third-party surface: an OAuth 2.0 authorization-code + PKCE redirect to
+    // auth.oxy.so. No FedCM, no SSO bounce, no Oxy session cookies.
+    const startThirdPartyOAuth = useCallback(
+        async (app: PublicApplication): Promise<void> => {
+            if (!clientId) {
+                startOfficialSignIn();
+                return;
+            }
+            if (!oauthRedirectUri) {
+                logger.error(
+                    'OxySignInButton: a third_party application requires the `oauthRedirectUri` prop to start the OAuth redirect; sign-in aborted',
+                    undefined,
+                    { component: 'OxySignInButton', clientId, application: app.name },
+                );
+                return;
+            }
+
+            const [pkce, state] = await Promise.all([generatePkcePair(), generateOAuthState()]);
+            const authorizeUrl = buildOAuthAuthorizeUrl({
+                clientId,
+                redirectUri: oauthRedirectUri,
+                state,
+                codeChallenge: pkce.codeChallenge,
+            });
+
+            if (isWeb) {
+                // Persist the handshake for the RP callback, then hand the
+                // top-level document to the IdP.
+                persistOAuthHandshake(state, pkce.codeVerifier);
+                redirectToAuthorize(authorizeUrl);
+                return;
+            }
+
+            await openAuthorizeUrlNative(authorizeUrl, oauthRedirectUri);
+        },
+        [clientId, oauthRedirectUri, startOfficialSignIn],
+    );
+
+    // Resolve the Application once, then route: third-party → OAuth redirect;
+    // first-party / official / unresolved → the in-app dialog. Resolution failure
+    // NEVER breaks an official app's sign-in — it falls back to the dialog.
+    const routeSignIn = useCallback(async (): Promise<void> => {
+        if (routingRef.current) return;
+        routingRef.current = true;
+        try {
+            const resolving = resolvePublicApplication();
+            if (!resolving) {
+                startOfficialSignIn();
+                return;
+            }
+            let app: PublicApplication;
+            try {
+                app = await resolving;
+            } catch (error) {
+                logger.warn(
+                    'OxySignInButton: could not resolve the application; opening the sign-in dialog',
+                    { component: 'OxySignInButton', clientId },
+                    error,
+                );
+                startOfficialSignIn();
+                return;
+            }
+            if (app.type === 'third_party' && !app.isOfficial) {
+                await startThirdPartyOAuth(app);
+                return;
+            }
+            startOfficialSignIn();
+        } finally {
+            routingRef.current = false;
+        }
+    }, [resolvePublicApplication, startOfficialSignIn, startThirdPartyOAuth, clientId]);
+
+    // Defer to a caller-supplied handler, otherwise route by application type.
     const handlePress = useCallback(() => {
         if (onPress) {
             onPress();
             return;
         }
-        openAccountDialog('signin');
-    }, [onPress, openAccountDialog]);
+        void routeSignIn();
+    }, [onPress, routeSignIn]);
 
     const themedStyles = useMemo(() => StyleSheet.create({
         button: {

--- a/packages/services/src/ui/components/OxySignInButton.tsx
+++ b/packages/services/src/ui/components/OxySignInButton.tsx
@@ -16,8 +16,6 @@ import OxyLogo from './OxyLogo';
 import { subscribeToSignInModal } from '../navigation/accountDialogManager';
 import { redirectToAuthorize, openAuthorizeUrlNative } from './oauthNavigation';
 
-const isWeb = Platform.OS === 'web';
-
 /**
  * `sessionStorage` keys under which a third-party "Sign in with Oxy" OAuth flow
  * persists its CSRF `state` and PKCE `code_verifier` across the authorize
@@ -26,20 +24,49 @@ const isWeb = Platform.OS === 'web';
  *
  * Web only: a browser RP navigates away to `auth.oxy.so` and back, so the
  * handshake must survive a full-page redirect. Native completes the flow inside
- * a single `WebBrowser` auth session and has no cross-navigation gap to bridge.
+ * a single `WebBrowser` auth session and surfaces the handshake via
+ * {@link OxySignInButtonProps.onOAuthResult} instead.
  */
 export const OXY_OAUTH_STATE_STORAGE_KEY = 'oxy_oauth_state';
 export const OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY = 'oxy_oauth_code_verifier';
 
 /**
- * Persist the OAuth CSRF `state` + PKCE `code_verifier` for the RP callback.
- * No-op where `sessionStorage` is unavailable (SSR / non-browser hosts).
+ * The OAuth handshake surfaced to a NATIVE third-party RP via
+ * {@link OxySignInButtonProps.onOAuthResult} so it can finish the code exchange
+ * (`POST /auth/oauth/token`). Web RPs read the same `state` / `code_verifier`
+ * back from `sessionStorage` across the redirect and do not need this callback.
  */
-function persistOAuthHandshake(state: string, codeVerifier: string): void {
+export interface OxyOAuthResult {
+    /** Deep-link URL the native auth session returned to (`?code=…&state=…`), or `null` if unobserved. */
+    redirectUrl: string | null;
+    /** The CSRF `state` sent on the authorize request; the RP must match it on return. */
+    state: string;
+    /** The PKCE `code_verifier` to replay on the token exchange. */
+    codeVerifier: string;
+}
+
+/**
+ * Persist the OAuth CSRF `state` + PKCE `code_verifier` for the RP callback.
+ * Returns `false` when the handshake could not be stored — no `sessionStorage`
+ * (SSR / non-browser host) or a write that threw (`SecurityError` /
+ * `QuotaExceededError`, e.g. Safari private mode) — so the caller aborts the
+ * flow cleanly rather than redirect to a callback that cannot validate `state`.
+ */
+function persistOAuthHandshake(state: string, codeVerifier: string): boolean {
     const store = (globalThis as { sessionStorage?: Storage }).sessionStorage;
-    if (!store) return;
-    store.setItem(OXY_OAUTH_STATE_STORAGE_KEY, state);
-    store.setItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY, codeVerifier);
+    try {
+        if (!store) throw new Error('sessionStorage is unavailable');
+        store.setItem(OXY_OAUTH_STATE_STORAGE_KEY, state);
+        store.setItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY, codeVerifier);
+        return true;
+    } catch (error) {
+        logger.warn(
+            'OxySignInButton: could not persist the OAuth handshake to sessionStorage; aborting third-party sign-in',
+            { component: 'OxySignInButton' },
+            error,
+        );
+        return false;
+    }
 }
 
 export interface OxySignInButtonProps {
@@ -92,6 +119,27 @@ export interface OxySignInButtonProps {
      * not invent a redirect URI).
      */
     oauthRedirectUri?: string;
+
+    /**
+     * Native only: receives the OAuth handshake after a third-party auth session
+     * so the RP can finish the token exchange. On web the handshake is read back
+     * from `sessionStorage` across the full-page redirect, so this is not used
+     * there. A native third-party sign-in with NO `onOAuthResult` handler cannot
+     * complete (the `state` + `code_verifier` are lost) and logs a warning.
+     *
+     * @example
+     * ```tsx
+     * <OxySignInButton
+     *   oauthRedirectUri="myapp://oauth/callback"
+     *   onOAuthResult={({ redirectUrl, state, codeVerifier }) => {
+     *     if (!redirectUrl) return;
+     *     const code = new URL(redirectUrl).searchParams.get('code');
+     *     // → POST /auth/oauth/token { code, code_verifier: codeVerifier, state }
+     *   }}
+     * />
+     * ```
+     */
+    onOAuthResult?: (result: OxyOAuthResult) => void;
 }
 
 /**
@@ -127,6 +175,7 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
     disabled = false,
     showWhenAuthenticated = false,
     oauthRedirectUri,
+    onOAuthResult,
 }) => {
     const theme = useTheme();
     const { openAccountDialog, oxyServices, clientId } = useOxy();
@@ -140,11 +189,16 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
 
     useEffect(() => subscribeToSignInModal(setIsModalOpen), []);
 
-    // The application's public identity is resolved ONCE per mounted button and
-    // its promise cached here, so the click handler stays lazy (no fetch until
-    // first press) and rapid taps share one in-flight resolve. A rejected resolve
-    // clears the cache so a later press can retry a transient failure.
-    const appResolutionRef = useRef<Promise<PublicApplication> | null>(null);
+    // The application's public identity is resolved lazily on first press and its
+    // promise cached, so rapid taps share one in-flight resolve. The cache is
+    // KEYED on the identity inputs (clientId + the oxyServices instance): if
+    // either changes the cache is invalidated and re-resolved — without a
+    // useEffect. A rejected resolve clears the cache so a later press can retry.
+    const appResolutionRef = useRef<{
+        clientId: string;
+        oxyServices: typeof oxyServices;
+        promise: Promise<PublicApplication>;
+    } | null>(null);
     // Re-entrancy guard: a routing pass may await network + crypto before it
     // redirects, so block a second concurrent press from racing the sessionStorage
     // handshake against a different PKCE pair.
@@ -152,13 +206,20 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
 
     const resolvePublicApplication = useCallback((): Promise<PublicApplication> | null => {
         if (!clientId) return null;
-        if (!appResolutionRef.current) {
-            appResolutionRef.current = oxyServices.getPublicApplication(clientId).catch((error) => {
-                appResolutionRef.current = null;
-                throw error;
-            });
+        const cached = appResolutionRef.current;
+        if (cached && cached.clientId === clientId && cached.oxyServices === oxyServices) {
+            return cached.promise;
         }
-        return appResolutionRef.current;
+        const promise = oxyServices.getPublicApplication(clientId).catch((error) => {
+            // Only clear if this is still the live entry (a later resolve may have
+            // replaced it after a clientId/oxyServices change).
+            if (appResolutionRef.current?.promise === promise) {
+                appResolutionRef.current = null;
+            }
+            throw error;
+        });
+        appResolutionRef.current = { clientId, oxyServices, promise };
+        return promise;
     }, [clientId, oxyServices]);
 
     // Official / first-party surface: the in-app account + sign-in dialog.
@@ -191,17 +252,30 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                 codeChallenge: pkce.codeChallenge,
             });
 
-            if (isWeb) {
+            if (Platform.OS === 'web') {
                 // Persist the handshake for the RP callback, then hand the
-                // top-level document to the IdP.
-                persistOAuthHandshake(state, pkce.codeVerifier);
+                // top-level document to the IdP. Without storage the callback
+                // cannot validate `state`, so abort cleanly rather than redirect.
+                if (!persistOAuthHandshake(state, pkce.codeVerifier)) {
+                    return;
+                }
                 redirectToAuthorize(authorizeUrl);
                 return;
             }
 
-            await openAuthorizeUrlNative(authorizeUrl, oauthRedirectUri);
+            // Native: open the in-app auth session, then hand the handshake to the
+            // RP so it can complete the token exchange from its deep-link callback.
+            const { redirectUrl } = await openAuthorizeUrlNative(authorizeUrl, oauthRedirectUri);
+            if (onOAuthResult) {
+                onOAuthResult({ redirectUrl, state, codeVerifier: pkce.codeVerifier });
+                return;
+            }
+            logger.warn(
+                'OxySignInButton: native third-party sign-in cannot complete without an `onOAuthResult` handler; the code exchange is the RP\'s responsibility (state + code_verifier were not surfaced)',
+                { component: 'OxySignInButton', application: app.name },
+            );
         },
-        [clientId, oauthRedirectUri, startOfficialSignIn],
+        [clientId, oauthRedirectUri, onOAuthResult, startOfficialSignIn],
     );
 
     // Resolve the Application once, then route: third-party → OAuth redirect;

--- a/packages/services/src/ui/components/oauthNavigation.ts
+++ b/packages/services/src/ui/components/oauthNavigation.ts
@@ -11,9 +11,26 @@
 import { Linking } from 'react-native';
 import { logger } from '@oxyhq/core';
 
+/** Minimal shape of the optional `expo-web-browser` auth-session result. */
+interface WebBrowserAuthResult {
+    type?: string;
+    url?: string;
+}
+
 /** Minimal shape of the optional `expo-web-browser` native module we depend on. */
 interface WebBrowserModule {
-    openAuthSessionAsync?: (url: string, redirectUrl: string) => Promise<unknown>;
+    openAuthSessionAsync?: (url: string, redirectUrl: string) => Promise<WebBrowserAuthResult>;
+}
+
+/** Outcome of opening the authorize URL on native. */
+export interface OpenAuthorizeResult {
+    /**
+     * The deep-link URL the auth session returned to (carries `?code=…&state=…`)
+     * when `expo-web-browser` observed it, else `null`. `null` means the RP must
+     * complete the exchange from its own deep-link handler (e.g. after the
+     * `Linking.openURL` fallback, which cannot observe the return URL).
+     */
+    redirectUrl: string | null;
 }
 
 /**
@@ -30,20 +47,43 @@ export function redirectToAuthorize(url: string): void {
  * `expo-web-browser` module (`openAuthSessionAsync` returns to `redirectUri`),
  * degrading to `Linking.openURL` when the module is not installed — the same
  * dynamic-import-with-fallback pattern services uses for haptics/netinfo.
+ *
+ * Returns the deep-link URL the session came back to when it can be observed, so
+ * the caller can hand `?code=…&state=…` back to the RP for the token exchange.
  */
-export async function openAuthorizeUrlNative(url: string, redirectUri: string): Promise<void> {
+export async function openAuthorizeUrlNative(
+    url: string,
+    redirectUri: string,
+): Promise<OpenAuthorizeResult> {
     try {
         const mod = (await import('expo-web-browser')) as unknown as WebBrowserModule;
         if (mod && typeof mod.openAuthSessionAsync === 'function') {
-            await mod.openAuthSessionAsync(url, redirectUri);
-            return;
+            const result = await mod.openAuthSessionAsync(url, redirectUri);
+            const redirectUrl =
+                result && result.type === 'success' && typeof result.url === 'string'
+                    ? result.url
+                    : null;
+            return { redirectUrl };
         }
     } catch (error) {
         logger.warn(
-            'OxySignInButton: expo-web-browser unavailable; falling back to Linking.openURL',
+            'OxySignInButton: expo-web-browser auth session failed; falling back to Linking.openURL',
             { component: 'oauthNavigation' },
             error,
         );
     }
-    await Linking.openURL(url);
+
+    // Fallback: Linking cannot observe the return URL, so the RP completes the
+    // exchange from its own deep-link handler. A rejected openURL (e.g. an
+    // unregistered scheme) must not throw out of the sign-in flow.
+    try {
+        await Linking.openURL(url);
+    } catch (error) {
+        logger.warn(
+            'OxySignInButton: Linking.openURL rejected the authorize URL',
+            { component: 'oauthNavigation' },
+            error,
+        );
+    }
+    return { redirectUrl: null };
 }

--- a/packages/services/src/ui/components/oauthNavigation.ts
+++ b/packages/services/src/ui/components/oauthNavigation.ts
@@ -1,0 +1,49 @@
+/**
+ * Platform navigation for the third-party "Sign in with Oxy" OAuth flow.
+ *
+ * Kept out of `OxySignInButton` so the button's routing logic can be unit-tested
+ * without driving a real browser navigation (jsdom's `location.assign` is
+ * non-configurable and cannot be spied). Both entry points hand a fully-built
+ * `auth.oxy.so/authorize` URL to the platform — never FedCM, an SSO bounce, or
+ * an Oxy session cookie.
+ */
+
+import { Linking } from 'react-native';
+import { logger } from '@oxyhq/core';
+
+/** Minimal shape of the optional `expo-web-browser` native module we depend on. */
+interface WebBrowserModule {
+    openAuthSessionAsync?: (url: string, redirectUrl: string) => Promise<unknown>;
+}
+
+/**
+ * Web: hand the TOP-LEVEL document to the OAuth authorize URL (a full-page
+ * redirect, not a popup) so the RP returns to its registered `redirect_uri`.
+ * No-op where `location` is unavailable (SSR / non-browser hosts).
+ */
+export function redirectToAuthorize(url: string): void {
+    (globalThis as { location?: Location }).location?.assign(url);
+}
+
+/**
+ * Native: open the authorize URL in an in-app auth session via the optional
+ * `expo-web-browser` module (`openAuthSessionAsync` returns to `redirectUri`),
+ * degrading to `Linking.openURL` when the module is not installed — the same
+ * dynamic-import-with-fallback pattern services uses for haptics/netinfo.
+ */
+export async function openAuthorizeUrlNative(url: string, redirectUri: string): Promise<void> {
+    try {
+        const mod = (await import('expo-web-browser')) as unknown as WebBrowserModule;
+        if (mod && typeof mod.openAuthSessionAsync === 'function') {
+            await mod.openAuthSessionAsync(url, redirectUri);
+            return;
+        }
+    } catch (error) {
+        logger.warn(
+            'OxySignInButton: expo-web-browser unavailable; falling back to Linking.openURL',
+            { component: 'oauthNavigation' },
+            error,
+        );
+    }
+    await Linking.openURL(url);
+}


### PR DESCRIPTION
## Auth platform Fase 4 — UI unificada

### Qué hace
1. **`OxyAccountDialog` sobre Bloom `<Dialog placement={{ base: 'bottom', md: 'center' }}>`** — reemplaza el wrapper RN `Modal` + `GestureHandlerRootView` + backdrop manual. Elimina de raíz el bug de react-native-web `ModalPortal` bajo React StrictMode (dialog invisible en dev Vite). El contenido (switcher/QR/sign-in views) se conserva.
2. **PKCE en `@oxyhq/core`**: `generatePkcePair()` (RFC 7636, S256, verifier 86 chars base64url), `generateOAuthState()`, `buildOAuthAuthorizeUrl()`, `computeCodeChallenge()` + constantes `OXY_AUTHORIZE_URL`/`DEFAULT_OAUTH_SCOPE`. Reusa la infra crypto multiplataforma existente (expo-crypto/node/WebCrypto); known-answer test del Appendix B.
3. **`OxySignInButton` bifurcado** (plan § Paso 5): resuelve la Application vía `getPublicApplication(clientId)` → `first_party|internal|system|isOfficial` abre el Dialog in-app; `third_party` genera state+PKCE, persiste `{state, codeVerifier}` (sessionStorage `oxy_oauth_*` en web; WebBrowser/Linking en native) y redirige a `auth.oxy.so/authorize`. Sin clientId o fallo de resolución → fallback al Dialog con warn.
4. **i18n**: keys `accountSwitcher.scan*` que faltaban desde #554 (la vista QR mostraba keys crudas) — en-US + es-ES.

### Verificación (browser real)
- Dev (rolldown-vite + StrictMode): click Sign in → **Bloom Dialog visible** (antes: invisible), vista QR con QR real renderizado y textos traducidos, cero errores de consola.
- Prod preview: dashboard completo con sesión device-first restaurada, cero errores.
- Tests: contracts **150** · core **739** (723+16 PKCE) · services **171** (165+6 botón) · console build 956ms.

### Gates Fase 4 (handoff)
- [x] Sign-in usa Bloom Dialog (verificado con screenshot en dev+prod)
- [x] OxySignInButton: third_party → OAuth redirect; official → Dialog (tests)
- [x] Un solo account menu export público (ya desde #554)
- [x] `crossApex.ts` eliminado (ya en main, wave 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->