### PR TITLE
Fase 6: apps oficiales sin auth local — inbox SDK client, examples device-first

### DIFF
--- a/docs/architecture/oxy-auth-agent-handoff.md
+++ b/docs/architecture/oxy-auth-agent-handoff.md
@@ -1078,7 +1078,7 @@ bun run services:build
 | 3 | merge-auth-sdk | ✅ 2026-07-05 — console en @oxyhq/services; auth-sdk ELIMINADO; rolldown-vite + vite-plugin-react-native-web; bloom ^0.29.2 (PR #557) |
 | 4 | unify-ui | ✅ 2026-07-06 — OxyAccountDialog sobre Bloom Dialog (placement bottom/md-center; mata bug RNW Modal+StrictMode); OxySignInButton bifurcado official→Dialog / third_party→OAuth+PKCE; helpers PKCE en core; i18n scan* keys |
 | 5 | auth-idp-rnweb | ✅ 2026-07-06 — IdP sobre rolldown-vite+RN-Web; OxyProvider modo-IdP (coldBoot=false, sin session authority); OxyConsentScreen (services) en authorize; superficie sign-in services en login; /settings/* eliminadas→redirect accounts.oxy.so; browser-verified. Detalle previo: — gate re-scoped con Nate: checkboxes refresh-all/FedCM-server ya satisfechos en main; integración = provider services modo-IdP (sin cold boot / sin session authority, fix upstream limpio) + montar piezas services existentes (QR/device-flow) + OxyConsentScreen nueva en services; consent/password/signup/recover conservan shell DOM+Bloom; /settings/* (rotas: POST /auth/refresh borrado) → DELETE + redirect permanente (password/linked→accounts.oxy.so/security, sessions→/sessions). REGLA DURABLE: el IdP NO expone gestión de cuenta — accounts.oxy.so es el único dueño |
-| 6 | migrate-apps | ⬜ Pendiente |
+| 6 | migrate-apps | ✅ 2026-07-06 — inbox sin bearer manual (SDK http same-origin + SSE/socket justificados); examples reescritos device-first; test-app-expo con clientId; oxy-main-domain (well-known FedCM) eliminado. Bootstrap SSO en +html.tsx y @oxyhq/auth en apps ya estaban a 0 desde main/F3 |
 | 7 | clean-cut-docs | ⬜ Pendiente |
 
 ---

--- a/examples/expo-54-universal-auth.tsx
+++ b/examples/expo-54-universal-auth.tsx
@@ -1,678 +1,148 @@
 /**
- * Expo 54 Universal Authentication Example
+ * Universal Sign in with Oxy — Expo / React Native (device-first SDK, 2026)
  *
- * This example works on iOS, Android, AND Web with the SAME code!
+ * ONE codebase for iOS, Android, and Web. The exact same provider + hook +
+ * button work everywhere; the SDK picks the right restore path per platform:
  *
- * Platform-specific behavior:
- * - iOS/Android: Uses shared Keychain/Account Manager + cryptographic identity
- * - Web: Uses CrossDomainAuth (FedCM/Popup/Redirect)
+ *   - Native (iOS/Android): device-first cold boot restores a session silently
+ *     from the on-device deviceId, and the shared keychain (`group.so.oxy.shared`)
+ *     lets a user already signed into another Oxy app carry that session over —
+ *     both automatic, no code here.
+ *   - Web: device-first cold boot (durable `oxy_device` cookie → mint) restores
+ *     the session via react-native-web. No FedCM, no `/sso` bounce, no cookies
+ *     you manage.
  *
- * Setup required:
- * 1. iOS: Enable Keychain Sharing with group "group.com.oxy.shared"
- * 2. Android: Add sharedUserId="com.oxy.shared" to AndroidManifest.xml
- * 3. Web: Deploy auth.oxy.so server
+ * Cold boot NEVER redirects to a login page — it either restores a session or
+ * resolves as signed-out. Interactive sign-in is the in-app dialog / OAuth
+ * redirect below, not an IdP redirect.
+ *
+ * (This file is not tied to any specific Expo SDK version — it uses only the
+ * version-agnostic device-first SDK surface.)
  */
 
-import React, { useEffect, useState, createContext, useContext } from 'react';
-import { View, Text, Button, ActivityIndicator, Platform, TextInput, Alert, StyleSheet } from 'react-native';
-import { OxyServices } from '@oxyhq/services';
-import { createCrossDomainAuth, type CrossDomainAuth } from '@oxyhq/services/core';
-import type { User } from '@oxyhq/services';
+import React from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { OxyProvider, OxySignInButton, useAuth } from '@oxyhq/services';
+import type { User } from '@oxyhq/core';
+import { BloomThemeProvider } from '@oxyhq/bloom/theme';
 
-// Import crypto modules - these are native-only, so we'll conditionally import
-let KeyManager: any = null;
-let SignatureService: any = null;
-let RecoveryPhraseService: any = null;
+// ==================== 1. Config ====================
 
-// Only import crypto on native platforms
-if (Platform.OS !== 'web') {
-  KeyManager = require('@oxyhq/services/crypto').KeyManager;
-  SignatureService = require('@oxyhq/services/crypto').SignatureService;
-  RecoveryPhraseService = require('@oxyhq/services/crypto').RecoveryPhraseService;
-}
+// Your app's registered OAuth client id (the `ApplicationCredential` publicKey
+// from the Oxy Console). Public value — safe to commit; override via
+// `EXPO_PUBLIC_OXY_CLIENT_ID`.
+const OXY_CLIENT_ID =
+  process.env.EXPO_PUBLIC_OXY_CLIENT_ID ?? 'oxy_dk_your_client_id';
+const OXY_API_URL =
+  process.env.EXPO_PUBLIC_API_URL ?? 'https://api.oxy.so';
 
-// ==================== 1. Platform Detection ====================
+// ==================== 2. App root ====================
 
-/**
- * Check if running on native platform (iOS/Android)
- */
-const isNative = Platform.OS === 'ios' || Platform.OS === 'android';
-
-/**
- * Check if running on web
- */
-const isWeb = Platform.OS === 'web';
-
-// ==================== 2. Setup ====================
-
-const oxyServices = new OxyServices({
-  baseURL: 'https://api.oxy.so',
-  cloudURL: 'https://cloud.oxy.so',
-});
-
-// Create cross-domain auth (only used on web)
-const crossDomainAuth = isWeb ? createCrossDomainAuth(oxyServices) : null;
-
-// ==================== 3. Universal Auth Context ====================
-
-interface AuthContextType {
-  user: User | null;
-  loading: boolean;
-  platform: 'ios' | 'android' | 'web';
-
-  // Universal methods (work on all platforms)
-  signOut: () => Promise<void>;
-
-  // Native-only methods
-  hasIdentity?: boolean;
-  createIdentity?: () => Promise<string[]>;
-  importIdentity?: (phrase: string) => Promise<void>;
-
-  // Web-only methods
-  signInWeb?: () => Promise<void>;
-  crossDomainAuth?: CrossDomainAuth;
-}
-
-const AuthContext = createContext<AuthContextType | null>(null);
-
-export function UniversalAuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [hasIdentity, setHasIdentity] = useState(false);
-
-  useEffect(() => {
-    initializeAuth();
-  }, []);
-
-  // ==================== Native Auth (iOS/Android) ====================
-
-  const initializeNativeAuth = async () => {
-    if (!KeyManager) return;
-
-    try {
-      // 1. Check for shared session first (from other Oxy apps)
-      const sharedSession = await KeyManager.getSharedSession();
-      if (sharedSession) {
-        console.log(`[${Platform.OS}] Found shared session from another Oxy app!`);
-        oxyServices.setTokens(sharedSession.accessToken);
-
-        try {
-          const user = await oxyServices.getCurrentUser();
-          setUser(user);
-          setHasIdentity(true);
-          setLoading(false);
-          return;
-        } catch (error) {
-          console.warn('Shared session invalid');
-        }
-      }
-
-      // 2. Check for shared identity
-      const hasShared = await KeyManager.hasSharedIdentity();
-      if (hasShared) {
-        console.log(`[${Platform.OS}] Found shared identity`);
-        setHasIdentity(true);
-
-        // Try to sign in with shared identity
-        const publicKey = await KeyManager.getSharedPublicKey();
-        if (publicKey) {
-          try {
-            const user = await signInWithIdentity(publicKey, true);
-            setUser(user);
-          } catch (error) {
-            console.error('Auto sign-in failed:', error);
-          }
-        }
-      } else {
-        // 3. Migrate local identity to shared (for existing users)
-        const hasLocal = await KeyManager.hasIdentity();
-        if (hasLocal) {
-          console.log(`[${Platform.OS}] Migrating local identity to shared...`);
-          const migrated = await KeyManager.migrateToSharedIdentity();
-          if (migrated) {
-            setHasIdentity(true);
-            const publicKey = await KeyManager.getSharedPublicKey();
-            if (publicKey) {
-              try {
-                const user = await signInWithIdentity(publicKey, true);
-                setUser(user);
-              } catch (error) {
-                console.error('Auto sign-in after migration failed:', error);
-              }
-            }
-          }
-        }
-      }
-    } catch (error) {
-      console.error(`[${Platform.OS}] Auth initialization failed:`, error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const signInWithIdentity = async (publicKey: string, isShared: boolean = true): Promise<User> => {
-    if (!SignatureService) throw new Error('SignatureService not available on web');
-
-    // Request challenge from server
-    const { challenge } = await oxyServices.requestChallenge(publicKey);
-
-    // Sign challenge with private key
-    const privateKey = isShared
-      ? await KeyManager.getSharedPrivateKey()
-      : await KeyManager.getPrivateKey();
-    const signature = await SignatureService.signChallenge(challenge, privateKey);
-
-    // Verify challenge and get session
-    const session = await oxyServices.verifyChallenge(
-      publicKey,
-      challenge,
-      signature,
-      Date.now()
-    );
-
-    // Store session in shared storage for other apps
-    await KeyManager.storeSharedSession(session.sessionId, session.accessToken || '');
-
-    // Set access token
-    oxyServices.setTokens(session.accessToken || '');
-
-    return session.user;
-  };
-
-  const createNativeIdentity = async (): Promise<string[]> => {
-    if (!RecoveryPhraseService) throw new Error('RecoveryPhraseService not available on web');
-
-    setLoading(true);
-    try {
-      // Generate new identity with recovery phrase
-      const { publicKey, recoveryPhrase } = await RecoveryPhraseService.generateIdentityWithRecovery();
-
-      // Import to shared storage so all Oxy apps can use it
-      const privateKey = await RecoveryPhraseService.privateKeyFromPhrase(recoveryPhrase.join(' '));
-      await KeyManager.importSharedIdentity(privateKey);
-
-      // Register with server
-      const signature = await SignatureService.createRegistrationSignature(
-        await KeyManager.getSharedPrivateKey()
-      );
-      await oxyServices.register(publicKey, signature, Date.now());
-
-      // Sign in
-      const user = await signInWithIdentity(publicKey, true);
-
-      setUser(user);
-      setHasIdentity(true);
-
-      return recoveryPhrase;
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const importNativeIdentity = async (phrase: string): Promise<void> => {
-    if (!RecoveryPhraseService) throw new Error('RecoveryPhraseService not available on web');
-
-    setLoading(true);
-    try {
-      // Convert phrase to private key
-      const privateKey = await RecoveryPhraseService.privateKeyFromPhrase(phrase);
-
-      // Import to shared storage
-      const publicKey = await KeyManager.importSharedIdentity(privateKey);
-
-      // Check if already registered
-      const { registered } = await oxyServices.checkPublicKeyRegistered(publicKey);
-
-      if (!registered) {
-        // Register with server
-        const signature = await SignatureService.createRegistrationSignature(privateKey);
-        await oxyServices.register(publicKey, signature, Date.now());
-      }
-
-      // Sign in
-      const user = await signInWithIdentity(publicKey, true);
-
-      setUser(user);
-      setHasIdentity(true);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // ==================== Web Auth ====================
-
-  const initializeWebAuth = async () => {
-    if (!crossDomainAuth) return;
-
-    try {
-      console.log('[web] Initializing cross-domain auth...');
-
-      // This handles:
-      // 1. Redirect callbacks
-      // 2. Stored sessions
-      // 3. Silent SSO check
-      const session = await crossDomainAuth.initialize();
-
-      if (session) {
-        console.log('[web] User authenticated via SSO:', session.user?.username);
-        setUser(session.user);
-      } else {
-        console.log('[web] No existing session found');
-      }
-    } catch (error) {
-      console.error('[web] Auth initialization failed:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const signInWeb = async () => {
-    if (!crossDomainAuth) return;
-
-    setLoading(true);
-    try {
-      // Auto-selects best method: FedCM → Popup → Redirect
-      const session = await crossDomainAuth.signIn({
-        method: 'auto',
-        onMethodSelected: (method) => {
-          console.log(`[web] Authenticating with: ${method}`);
-        },
-      });
-
-      if (session) {
-        setUser(session.user);
-      }
-    } catch (error) {
-      console.error('[web] Sign in failed:', error);
-      throw error;
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  // ==================== Universal Methods ====================
-
-  const initializeAuth = async () => {
-    if (isNative) {
-      await initializeNativeAuth();
-    } else {
-      await initializeWebAuth();
-    }
-  };
-
-  const signOut = async () => {
-    setLoading(true);
-    try {
-      if (isNative && KeyManager) {
-        // Native: Clear shared session (signs out from ALL Oxy apps)
-        const sharedSession = await KeyManager.getSharedSession();
-        if (sharedSession) {
-          await oxyServices.logoutSession(sharedSession.sessionId);
-        }
-        await KeyManager.clearSharedSession();
-      } else if (isWeb) {
-        // Web: Logout and clear stored session
-        const sessionId = (oxyServices as any).getStoredSessionId?.();
-        if (sessionId) {
-          await oxyServices.logoutSession(sessionId);
-        }
-        (oxyServices as any).clearStoredSession?.();
-      }
-
-      oxyServices.clearTokens();
-      setUser(null);
-    } catch (error) {
-      console.error('Sign out failed:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const contextValue: AuthContextType = {
-    user,
-    loading,
-    platform: Platform.OS as 'ios' | 'android' | 'web',
-    signOut,
-    // Native-only
-    ...(isNative && {
-      hasIdentity,
-      createIdentity: createNativeIdentity,
-      importIdentity: importNativeIdentity,
-    }),
-    // Web-only
-    ...(isWeb && {
-      signInWeb,
-      crossDomainAuth: crossDomainAuth || undefined,
-    }),
-  };
-
+// `BloomThemeProvider` owns theming — `OxySignInButton` calls Bloom's
+// `useTheme()`, which throws outside a `BloomThemeProvider`. `OxyProvider` is
+// the single device-first session authority.
+export default function App() {
   return (
-    <AuthContext.Provider value={contextValue}>
-      {children}
-    </AuthContext.Provider>
+    <BloomThemeProvider mode="system">
+      <OxyProvider baseURL={OXY_API_URL} clientId={OXY_CLIENT_ID}>
+        <AppContent />
+      </OxyProvider>
+    </BloomThemeProvider>
   );
 }
 
-export function useAuth() {
-  const context = useContext(AuthContext);
-  if (!context) {
-    throw new Error('useAuth must be used within UniversalAuthProvider');
-  }
-  return context;
-}
+function AppContent() {
+  const { isAuthenticated, isAuthResolved, user } = useAuth();
 
-// ==================== 4. Universal UI Components ====================
-
-function WelcomeScreen() {
-  const { platform, createIdentity, importIdentity, signInWeb, loading } = useAuth();
-  const [showImport, setShowImport] = useState(false);
-  const [recoveryPhrase, setRecoveryPhrase] = useState('');
-
-  // Native: Identity creation flow
-  const handleCreateIdentity = async () => {
-    if (!createIdentity) return;
-
-    try {
-      const phrase = await createIdentity();
-
-      Alert.alert(
-        '✅ Identity Created!',
-        `Save your recovery phrase:\n\n${phrase.join(' ')}\n\nThis phrase can be used to sign in from any Oxy app!`,
-        [{ text: 'I saved it', style: 'default' }]
-      );
-    } catch (error) {
-      Alert.alert('Error', error instanceof Error ? error.message : 'Failed to create identity');
-    }
-  };
-
-  const handleImportIdentity = async () => {
-    if (!importIdentity || !recoveryPhrase.trim()) {
-      Alert.alert('Error', 'Please enter your recovery phrase');
-      return;
-    }
-
-    try {
-      await importIdentity(recoveryPhrase.trim());
-      Alert.alert('✅ Success', 'Identity imported successfully!');
-    } catch (error) {
-      Alert.alert('Error', error instanceof Error ? error.message : 'Failed to import identity');
-    }
-  };
-
-  // Web: Cross-domain sign in
-  const handleWebSignIn = async () => {
-    if (!signInWeb) return;
-
-    try {
-      await signInWeb();
-    } catch (error) {
-      Alert.alert('Error', error instanceof Error ? error.message : 'Sign in failed');
-    }
-  };
-
-  if (loading) {
+  // `isAuthResolved` flips to `true` once cold boot finishes (session restored
+  // or none found). Until then, `isAuthenticated: false` is UNDETERMINED — show
+  // a neutral loading state so a cold-boot reload with an existing session does
+  // not flash the signed-out UI.
+  if (!isAuthResolved) {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" />
-        <Text style={styles.loadingText}>
-          Checking for existing {platform === 'web' ? 'session' : 'identity'}...
-        </Text>
       </View>
     );
   }
 
+  return isAuthenticated && user ? <Dashboard user={user} /> : <WelcomeScreen />;
+}
+
+// ==================== 3. Signed-out ====================
+
+function WelcomeScreen() {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Welcome to Oxy</Text>
+      <Text style={styles.subtitle}>
+        Sign in once — the SDK carries your session to every Oxy app.
+      </Text>
 
-      <View style={styles.platformBadge}>
-        <Text style={styles.platformText}>
-          {platform === 'web' ? '🌐 Web' : platform === 'ios' ? '🍎 iOS' : '🤖 Android'}
-        </Text>
-      </View>
-
-      {/* Native: Identity creation/import */}
-      {isNative && !showImport && (
-        <>
-          <Text style={styles.subtitle}>
-            Create a new identity or import from another Oxy app
-          </Text>
-          <Button title="Create New Identity" onPress={handleCreateIdentity} />
-          <View style={styles.spacer} />
-          <Button title="Import Existing Identity" onPress={() => setShowImport(true)} />
-        </>
-      )}
-
-      {/* Native: Import flow */}
-      {isNative && showImport && (
-        <>
-          <Text style={styles.subtitle}>Enter your 12 or 24 word recovery phrase:</Text>
-          <TextInput
-            style={styles.textArea}
-            multiline
-            value={recoveryPhrase}
-            onChangeText={setRecoveryPhrase}
-            placeholder="word1 word2 word3 ..."
-            placeholderTextColor="#999"
-          />
-          <Button title="Import" onPress={handleImportIdentity} />
-          <View style={styles.spacer} />
-          <Button title="Back" onPress={() => setShowImport(false)} color="#999" />
-        </>
-      )}
-
-      {/* Web: Simple sign in button */}
-      {isWeb && (
-        <>
-          <Text style={styles.subtitle}>
-            Sign in once, access all Oxy apps across all domains
-          </Text>
-          <Button title="Sign in with Oxy" onPress={handleWebSignIn} />
-          <Text style={styles.hint}>
-            Works across homiio.com, mention.earth, alia.onl, etc.
-          </Text>
-        </>
-      )}
+      {/*
+        One button, two behaviors — resolved from your Application's `type`
+        (via `GET /auth/oauth/client/:clientId`):
+          - first_party / internal / system / isOfficial → opens the in-app
+            "Sign in with Oxy" dialog (Commons-first).
+          - third_party → runs an OAuth 2.0 + PKCE flow to `auth.oxy.so`. On
+            native, pass a custom-scheme `oauthRedirectUri` and read the handshake
+            back via `onOAuthResult` to finish the token exchange; on web the SDK
+            persists the PKCE pair across the redirect for you.
+      */}
+      <OxySignInButton variant="contained" />
 
       <Text style={styles.footer}>
-        {isNative
-          ? `Your identity is shared across all Oxy apps on ${platform}`
-          : 'Using modern browser-native authentication (no third-party cookies)'}
+        Already signed into another Oxy app on this device? You'll be signed in
+        automatically via the shared keychain.
       </Text>
     </View>
   );
 }
 
-function DashboardScreen() {
-  const { user, signOut, loading, platform } = useAuth();
+// ==================== 4. Signed-in ====================
 
-  if (!user) return null;
+function Dashboard({ user }: { user: User }) {
+  const { signOut } = useAuth();
+
+  // Render `name.displayName` when present; otherwise fall back to the handle.
+  // Never recompose a name from first/last/full.
+  const displayName = user.name?.displayName?.trim() || user.username;
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
-        <View style={styles.userInfo}>
-          <View style={styles.avatar} />
-          <View>
-            <Text style={styles.username}>{user.username}</Text>
-            <Text style={styles.email}>{user.email}</Text>
-          </View>
-        </View>
-
-        <Button title={loading ? 'Signing out...' : 'Sign Out'} onPress={signOut} disabled={loading} />
-      </View>
+      <Text style={styles.username}>{displayName}</Text>
+      {user.email ? <Text style={styles.email}>{user.email}</Text> : null}
 
       <View style={styles.card}>
-        <Text style={styles.cardTitle}>✅ You're signed in!</Text>
+        <Text style={styles.cardTitle}>You're signed in!</Text>
         <Text style={styles.cardText}>
-          {isNative
-            ? `Your session is shared via ${platform === 'ios' ? 'iOS Keychain' : 'Android Account Manager'}. Open any other Oxy app and you'll be automatically signed in!`
-            : 'Open any other Oxy app (homiio.com, mention.earth, etc.) in this browser and you\'ll be automatically signed in. No need to sign in again!'}
+          Open any other Oxy app and the SDK restores this session — no
+          re-authentication needed.
         </Text>
       </View>
 
-      <View style={styles.statusList}>
-        <Text style={styles.statusTitle}>Authentication Status:</Text>
-        {isNative ? (
-          <>
-            <Text style={styles.statusItem}>✅ Identity stored in shared storage</Text>
-            <Text style={styles.statusItem}>✅ Session accessible to all Oxy apps</Text>
-            <Text style={styles.statusItem}>✅ Works offline (cryptographic auth)</Text>
-            <Text style={styles.statusItem}>✅ No passwords needed</Text>
-          </>
-        ) : (
-          <>
-            <Text style={styles.statusItem}>✅ Authenticated across all Oxy domains</Text>
-            <Text style={styles.statusItem}>✅ No third-party cookies required</Text>
-            <Text style={styles.statusItem}>✅ Privacy-preserving identity</Text>
-            <Text style={styles.statusItem}>✅ Browser-native security</Text>
-          </>
-        )}
-      </View>
+      {/* `showWhenAuthenticated` reuses the branded button as a sign-out CTA. */}
+      <OxySignInButton
+        variant="outline"
+        showWhenAuthenticated
+        text="Sign out"
+        onPress={() => signOut()}
+      />
     </View>
   );
 }
 
-// ==================== 5. Main App ====================
-
-export default function App() {
-  return (
-    <UniversalAuthProvider>
-      <AppContent />
-    </UniversalAuthProvider>
-  );
-}
-
-function AppContent() {
-  const { user, loading } = useAuth();
-
-  if (loading) {
-    return (
-      <View style={styles.centered}>
-        <ActivityIndicator size="large" />
-      </View>
-    );
-  }
-
-  return user ? <DashboardScreen /> : <WelcomeScreen />;
-}
-
-// ==================== 6. Styles ====================
+// ==================== 5. Styles ====================
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    padding: 20,
-    backgroundColor: '#fff',
-  },
-  centered: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#fff',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 10,
-    textAlign: 'center',
-  },
-  subtitle: {
-    fontSize: 14,
-    color: '#666',
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  platformBadge: {
-    alignSelf: 'center',
-    backgroundColor: '#f0f0f0',
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 12,
-    marginBottom: 20,
-  },
-  platformText: {
-    fontSize: 12,
-    fontWeight: '600',
-  },
-  loadingText: {
-    marginTop: 10,
-    color: '#666',
-  },
-  textArea: {
-    borderWidth: 1,
-    borderColor: '#ccc',
-    padding: 10,
-    marginBottom: 10,
-    minHeight: 100,
-    borderRadius: 8,
-    textAlignVertical: 'top',
-  },
-  spacer: {
-    height: 10,
-  },
-  hint: {
-    fontSize: 12,
-    color: '#999',
-    textAlign: 'center',
-    marginTop: 10,
-  },
-  footer: {
-    marginTop: 30,
-    fontSize: 12,
-    color: '#666',
-    textAlign: 'center',
-  },
-  header: {
-    marginBottom: 20,
-  },
-  userInfo: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 15,
-  },
-  avatar: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    backgroundColor: '#ddd',
-    marginRight: 15,
-  },
-  username: {
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  email: {
-    fontSize: 14,
-    color: '#666',
-  },
-  card: {
-    backgroundColor: '#f0f9ff',
-    padding: 15,
-    borderRadius: 8,
-    marginBottom: 20,
-  },
-  cardTitle: {
-    fontSize: 16,
-    fontWeight: 'bold',
-    marginBottom: 10,
-  },
-  cardText: {
-    fontSize: 14,
-    color: '#666',
-    lineHeight: 20,
-  },
-  statusList: {
-    marginTop: 10,
-  },
-  statusTitle: {
-    fontSize: 14,
-    fontWeight: 'bold',
-    marginBottom: 5,
-  },
-  statusItem: {
-    fontSize: 14,
-    color: '#666',
-    marginBottom: 3,
-  },
+  container: { flex: 1, padding: 20, justifyContent: 'center', gap: 12 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 24, fontWeight: 'bold', textAlign: 'center' },
+  subtitle: { fontSize: 14, color: '#666', textAlign: 'center', marginBottom: 8 },
+  footer: { fontSize: 12, color: '#999', textAlign: 'center', marginTop: 16 },
+  username: { fontSize: 20, fontWeight: 'bold' },
+  email: { fontSize: 14, color: '#666' },
+  card: { backgroundColor: '#f0f9ff', padding: 15, borderRadius: 8, marginVertical: 16 },
+  cardTitle: { fontSize: 16, fontWeight: 'bold', marginBottom: 8 },
+  cardText: { fontSize: 14, color: '#666', lineHeight: 20 },
 });

--- a/examples/native-react-native-auth.tsx
+++ b/examples/native-react-native-auth.tsx
@@ -1,30 +1,37 @@
 /**
- * Complete React Native Example: Cross-App Shared Identity
+ * React Native example: cross-app shared cryptographic identity
  *
- * This example shows how to implement shared authentication across multiple
- * React Native apps using iOS Keychain Groups and Android Account Manager.
+ * Shows the LOW-LEVEL identity primitives that Commons by Oxy uses under the
+ * hood: create/import a keypair, promote it to the shared keychain, register it
+ * with the server, and sign in with it. Most apps do NOT need this — they mount
+ * `<OxyProvider>` and the device-first cold boot + shared keychain handle
+ * everything automatically (see `expo-54-universal-auth.tsx`). This example is
+ * for building an identity/vault surface like Commons.
  *
- * Apps that share authentication:
+ * Apps that share one identity (illustrative bundle ids):
  * - Homiio (com.homiio.app)
  * - Mention (com.mention.app)
  * - Alia (com.alia.app)
  *
  * Setup required:
- * - iOS: Enable Keychain Sharing with group "group.com.oxy.shared"
- * - Android: Add sharedUserId="com.oxy.shared" to AndroidManifest.xml
+ * - iOS: enable Keychain Sharing with access group "group.so.oxy.shared"
+ * - Android: configure the shared identity store under "so.oxy.shared"
  */
 
 import React, { useEffect, useState, createContext, useContext } from 'react';
-import { View, Text, Button, ActivityIndicator, Alert } from 'react-native';
-import { OxyServices } from '@oxyhq/services';
-import { KeyManager, SignatureService, RecoveryPhraseService } from '@oxyhq/services/crypto';
-import type { User } from '@oxyhq/services';
+import { View, Text, Button, ActivityIndicator, Alert, TextInput, Platform } from 'react-native';
+import {
+  OxyServices,
+  KeyManager,
+  SignatureService,
+  RecoveryPhraseService,
+} from '@oxyhq/core';
+import type { User } from '@oxyhq/core';
 
 // ==================== 1. Setup ====================
 
 const oxyServices = new OxyServices({
   baseURL: 'https://api.oxy.so',
-  cloudURL: 'https://cloud.oxy.so',
 });
 
 // ==================== 2. Auth Context ====================
@@ -33,7 +40,7 @@ interface AuthContextType {
   user: User | null;
   loading: boolean;
   hasIdentity: boolean;
-  createIdentity: () => Promise<string[]>; // Returns recovery phrase
+  createIdentity: () => Promise<string[]>; // Returns recovery phrase words
   importIdentity: (phrase: string) => Promise<void>;
   signOut: () => Promise<void>;
 }
@@ -51,58 +58,34 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const initializeAuth = async () => {
     try {
-      // 1. Check for shared session first (from other Oxy apps)
+      // 1. Reuse a warm shared session planted by another Oxy app.
       const sharedSession = await KeyManager.getSharedSession();
       if (sharedSession) {
-        console.log('Found shared session from another Oxy app!');
         oxyServices.setTokens(sharedSession.accessToken);
-
         try {
-          const user = await oxyServices.getCurrentUser();
-          setUser(user);
+          setUser(await oxyServices.getCurrentUser());
           setHasIdentity(true);
-          setLoading(false);
           return;
-        } catch (error) {
-          console.warn('Shared session invalid, will try identity auth');
+        } catch {
+          // Shared session is stale — fall through to key-based sign-in.
         }
       }
 
-      // 2. Check for shared identity
-      const hasShared = await KeyManager.hasSharedIdentity();
-      if (hasShared) {
-        console.log('Found shared identity');
+      // 2. A shared identity exists (this or another app created it): the SDK
+      //    runs the whole challenge → sign → verify exchange and plants tokens.
+      if (await KeyManager.hasSharedIdentity()) {
         setHasIdentity(true);
+        await signInWithSharedIdentity();
+        return;
+      }
 
-        // Try to sign in with shared identity
-        const publicKey = await KeyManager.getSharedPublicKey();
-        if (publicKey) {
-          try {
-            const user = await signInWithIdentity(publicKey, true);
-            setUser(user);
-          } catch (error) {
-            console.error('Auto sign-in failed:', error);
-          }
-        }
-      } else {
-        // 3. Check for local identity (migrate to shared)
-        const hasLocal = await KeyManager.hasIdentity();
-        if (hasLocal) {
-          console.log('Migrating local identity to shared...');
-          const migrated = await KeyManager.migrateToSharedIdentity();
-          if (migrated) {
-            setHasIdentity(true);
-            // Try to sign in
-            const publicKey = await KeyManager.getSharedPublicKey();
-            if (publicKey) {
-              try {
-                const user = await signInWithIdentity(publicKey, true);
-                setUser(user);
-              } catch (error) {
-                console.error('Auto sign-in after migration failed:', error);
-              }
-            }
-          }
+      // 3. Only a LOCAL (app-private) identity exists: promote it to the shared
+      //    keychain so every Oxy app can use it, then sign in.
+      if (await KeyManager.hasIdentity()) {
+        const migrated = await KeyManager.migrateToSharedIdentity();
+        if (migrated) {
+          setHasIdentity(true);
+          await signInWithSharedIdentity();
         }
       }
     } catch (error) {
@@ -112,56 +95,39 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  const signInWithIdentity = async (publicKey: string, isShared: boolean = true): Promise<User> => {
-    // Request challenge from server
-    const { challenge } = await oxyServices.requestChallenge(publicKey);
-
-    // Sign challenge with private key
-    const signature = isShared
-      ? await SignatureService.signChallenge(challenge, await KeyManager.getSharedPrivateKey())
-      : await SignatureService.signChallenge(challenge);
-
-    // Verify challenge and get session
-    const session = await oxyServices.verifyChallenge(
-      publicKey,
-      challenge,
-      signature,
-      Date.now()
-    );
-
-    // Store session in shared storage for other apps
-    await KeyManager.storeSharedSession(session.sessionId, session.accessToken || '');
-
-    // Set access token
-    oxyServices.setTokens(session.accessToken || '');
-
-    return session.user;
+  // `signInWithSharedIdentity()` requests a challenge for the shared public key,
+  // signs it with the shared private key, verifies it, and plants the tokens —
+  // returns null on web or when no shared identity is present. We then read the
+  // full profile for display.
+  const signInWithSharedIdentity = async (): Promise<void> => {
+    const session = await oxyServices.signInWithSharedIdentity();
+    if (session) {
+      setUser(await oxyServices.getCurrentUser());
+    }
   };
 
   const createIdentity = async (): Promise<string[]> => {
     setLoading(true);
     try {
-      // Generate new identity with recovery phrase
-      const { publicKey, recoveryPhrase } = await RecoveryPhraseService.generateIdentityWithRecovery();
+      // Generate a new keypair + recovery phrase (written to the local keychain).
+      const { words } = await RecoveryPhraseService.generateIdentityWithRecovery();
 
-      // Import to shared storage so all Oxy apps can use it
-      await KeyManager.importSharedIdentity(
-        await RecoveryPhraseService.privateKeyFromPhrase(recoveryPhrase.join(' '))
+      // Promote it to the shared keychain so all Oxy apps can use it.
+      await KeyManager.migrateToSharedIdentity();
+
+      // Register the identity with the server (signature over the current key).
+      const registration = await SignatureService.createRegistrationSignature();
+      await oxyServices.register(
+        registration.publicKey,
+        registration.signature,
+        registration.timestamp,
       );
 
-      // Register with server
-      const signature = await SignatureService.createRegistrationSignature(
-        await KeyManager.getSharedPrivateKey()
-      );
-      await oxyServices.register(publicKey, signature, Date.now());
-
-      // Sign in
-      const user = await signInWithIdentity(publicKey, true);
-
-      setUser(user);
+      // Sign in with the freshly registered shared identity.
+      await signInWithSharedIdentity();
       setHasIdentity(true);
 
-      return recoveryPhrase;
+      return words;
     } catch (error) {
       console.error('Identity creation failed:', error);
       throw error;
@@ -173,25 +139,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const importIdentity = async (phrase: string): Promise<void> => {
     setLoading(true);
     try {
-      // Convert phrase to private key
-      const privateKey = await RecoveryPhraseService.privateKeyFromPhrase(phrase);
+      // Restore the keypair from the recovery phrase (written to the local
+      // keychain) and promote it to the shared keychain.
+      const publicKey = await RecoveryPhraseService.restoreFromPhrase(phrase);
+      await KeyManager.migrateToSharedIdentity();
 
-      // Import to shared storage
-      const publicKey = await KeyManager.importSharedIdentity(privateKey);
-
-      // Check if already registered
+      // Register only if the server hasn't seen this key before.
       const { registered } = await oxyServices.checkPublicKeyRegistered(publicKey);
-
       if (!registered) {
-        // Register with server
-        const signature = await SignatureService.createRegistrationSignature(privateKey);
-        await oxyServices.register(publicKey, signature, Date.now());
+        const registration = await SignatureService.createRegistrationSignature();
+        await oxyServices.register(
+          registration.publicKey,
+          registration.signature,
+          registration.timestamp,
+        );
       }
 
-      // Sign in
-      const user = await signInWithIdentity(publicKey, true);
-
-      setUser(user);
+      await signInWithSharedIdentity();
       setHasIdentity(true);
     } catch (error) {
       console.error('Identity import failed:', error);
@@ -204,16 +168,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signOut = async () => {
     setLoading(true);
     try {
-      // Logout from server
+      // Revoke the server session, then clear the shared session (signs out of
+      // EVERY Oxy app on this device).
       const sharedSession = await KeyManager.getSharedSession();
       if (sharedSession) {
         await oxyServices.logoutSession(sharedSession.sessionId);
       }
-
-      // Clear shared session (signs out from ALL Oxy apps)
       await KeyManager.clearSharedSession();
 
-      // Clear local state
       oxyServices.clearTokens();
       setUser(null);
     } catch (error) {
@@ -340,6 +302,9 @@ function DashboardScreen() {
 
   if (!user) return null;
 
+  // Render `name.displayName` when present; otherwise fall back to the handle.
+  const displayName = user.name?.displayName?.trim() || user.username;
+
   return (
     <View style={{ flex: 1, padding: 20 }}>
       <View style={{ alignItems: 'center', marginVertical: 20 }}>
@@ -352,8 +317,8 @@ function DashboardScreen() {
             marginBottom: 10,
           }}
         />
-        <Text style={{ fontSize: 20, fontWeight: 'bold' }}>{user.username}</Text>
-        <Text style={{ color: '#666' }}>{user.email}</Text>
+        <Text style={{ fontSize: 20, fontWeight: 'bold' }}>{displayName}</Text>
+        {user.email ? <Text style={{ color: '#666' }}>{user.email}</Text> : null}
       </View>
 
       <View
@@ -365,10 +330,10 @@ function DashboardScreen() {
         }}
       >
         <Text style={{ fontSize: 16, fontWeight: 'bold', marginBottom: 10 }}>
-          ✅ Signed in across all Oxy apps
+          Signed in across all Oxy apps
         </Text>
         <Text style={{ color: '#666' }}>
-          Your identity is shared via {Platform.OS === 'ios' ? 'iOS Keychain' : 'Android Account Manager'}.
+          Your identity is shared via {Platform.OS === 'ios' ? 'iOS Keychain' : 'the Android identity store'}.
           Open any other Oxy app and you'll be automatically signed in!
         </Text>
       </View>
@@ -379,17 +344,15 @@ function DashboardScreen() {
         <Text style={{ fontSize: 14, fontWeight: 'bold', marginBottom: 5 }}>
           Shared Identity Status:
         </Text>
-        <Text style={{ color: '#666' }}>✅ Identity stored in shared storage</Text>
-        <Text style={{ color: '#666' }}>✅ Session accessible to all Oxy apps</Text>
-        <Text style={{ color: '#666' }}>✅ No re-authentication needed</Text>
+        <Text style={{ color: '#666' }}>Identity stored in the shared keychain</Text>
+        <Text style={{ color: '#666' }}>Session accessible to all Oxy apps</Text>
+        <Text style={{ color: '#666' }}>No re-authentication needed</Text>
       </View>
     </View>
   );
 }
 
 // ==================== 4. Main App ====================
-
-import { TextInput, Platform } from 'react-native';
 
 export default function App() {
   return (
@@ -475,7 +438,7 @@ function ExampleComponent() {
   if (hasSharedSession) {
     return (
       <Text>
-        ✅ You're already signed in from another Oxy app! (Homiio, Mention, or Alia)
+        You're already signed in from another Oxy app! (Homiio, Mention, or Alia)
       </Text>
     );
   }

--- a/examples/web-react-auth.tsx
+++ b/examples/web-react-auth.tsx
@@ -1,316 +1,122 @@
 /**
- * Complete React Example: Cross-Domain Auth with Oxy
+ * Web React example — Sign in with Oxy (device-first SDK, 2026)
  *
- * This example shows how to implement Google-style SSO in a React app.
- * Users sign in once and are automatically authenticated across all Oxy apps.
+ * The whole flow is owned by the SDK. You mount one provider, read auth state
+ * from one hook, and drop in one button. There is NO cookie plumbing, no FedCM,
+ * no `/sso` bounce, and no per-app session restore — `OxyProvider`'s device-first
+ * cold boot (durable `oxy_device` cookie → mint) restores an existing session on
+ * its own and NEVER redirects to a login page.
+ *
+ * Runs on the web via react-native-web (the same SDK powers Expo/native — see
+ * `expo-54-universal-auth.tsx`).
  */
 
-import React, { useEffect, useState, createContext, useContext } from 'react';
-import { OxyServices, createCrossDomainAuth, type CrossDomainAuth } from '@oxyhq/services';
-import type { User } from '@oxyhq/services';
+import React from 'react';
+import { OxyProvider, OxySignInButton, useAuth } from '@oxyhq/services';
+import type { User } from '@oxyhq/core';
+import { BloomThemeProvider } from '@oxyhq/bloom/theme';
 
-// ==================== 1. Setup ====================
+// ==================== 1. Config ====================
 
-const oxyServices = new OxyServices({
-  baseURL: 'https://api.oxy.so',
-  cloudURL: 'https://cloud.oxy.so',
-});
+// Your app's registered OAuth client id (the `ApplicationCredential` publicKey
+// from the Oxy Console). Public value — safe to commit; override per environment.
+const OXY_CLIENT_ID = process.env.OXY_CLIENT_ID ?? 'oxy_dk_your_client_id';
+const OXY_API_URL = process.env.OXY_API_URL ?? 'https://api.oxy.so';
 
-const auth = createCrossDomainAuth(oxyServices);
+// ==================== 2. App root ====================
 
-// ==================== 2. Auth Context ====================
-
-interface AuthContextType {
-  user: User | null;
-  loading: boolean;
-  signIn: () => Promise<void>;
-  signOut: () => Promise<void>;
-  crossDomainAuth: CrossDomainAuth;
-}
-
-const AuthContext = createContext<AuthContextType | null>(null);
-
-export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    // Initialize auth on mount
-    const initializeAuth = async () => {
-      try {
-        // This handles:
-        // 1. Redirect callbacks
-        // 2. Stored sessions
-        // 3. Silent SSO check
-        const session = await auth.initialize();
-
-        if (session) {
-          setUser(session.user);
-          console.log('User authenticated via SSO:', session.user.username);
-        }
-      } catch (error) {
-        console.error('Auth initialization failed:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    initializeAuth();
-  }, []);
-
-  const signIn = async () => {
-    setLoading(true);
-    try {
-      // Auto-selects best method: FedCM → Popup → Redirect
-      const session = await auth.signIn({
-        method: 'auto',
-        onMethodSelected: (method) => {
-          console.log(`Authenticating with: ${method}`);
-        },
-      });
-
-      if (session) {
-        setUser(session.user);
-      }
-    } catch (error) {
-      console.error('Sign in failed:', error);
-      throw error;
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const signOut = async () => {
-    setLoading(true);
-    try {
-      const sessionId = (oxyServices as any).getStoredSessionId?.();
-      if (sessionId) {
-        await oxyServices.logoutSession(sessionId);
-      }
-
-      // Clear stored session
-      (oxyServices as any).clearStoredSession?.();
-
-      setUser(null);
-    } catch (error) {
-      console.error('Sign out failed:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
+// `BloomThemeProvider` owns theming — `OxySignInButton` (and other services UI)
+// calls Bloom's `useTheme()`, which throws outside a `BloomThemeProvider`.
+// `OxyProvider` is the single session authority; do NOT also mount
+// `WebOxyProvider` (that legacy web provider is gone — one provider only).
+export default function App() {
   return (
-    <AuthContext.Provider value={{ user, loading, signIn, signOut, crossDomainAuth: auth }}>
-      {children}
-    </AuthContext.Provider>
+    <BloomThemeProvider mode="system">
+      <OxyProvider baseURL={OXY_API_URL} clientId={OXY_CLIENT_ID}>
+        <AppContent />
+      </OxyProvider>
+    </BloomThemeProvider>
   );
 }
 
-export function useAuth() {
-  const context = useContext(AuthContext);
-  if (!context) {
-    throw new Error('useAuth must be used within AuthProvider');
+function AppContent() {
+  const { isAuthenticated, isAuthResolved, user } = useAuth();
+
+  // `isAuthResolved` flips to `true` once cold boot finishes (session restored
+  // or none found). Until then, `isAuthenticated: false` is UNDETERMINED — hold
+  // a neutral loading state so a reload with an existing session doesn't flash
+  // the logged-out UI.
+  if (!isAuthResolved) {
+    return (
+      <div className="loading">
+        <div className="spinner" />
+        <p>Loading…</p>
+      </div>
+    );
   }
-  return context;
+
+  return isAuthenticated && user ? <Dashboard user={user} /> : <LoginPage />;
 }
 
-// ==================== 3. Components ====================
+// ==================== 3. Signed-out ====================
 
 function LoginPage() {
-  const { signIn, loading } = useAuth();
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSignIn = async () => {
-    try {
-      setError(null);
-      await signIn();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Sign in failed');
-    }
-  };
-
   return (
     <div className="login-page">
       <h1>Welcome to Oxy</h1>
-      <p>Sign in once, access all Oxy apps</p>
+      <p>Sign in once, then you're signed in across every Oxy app.</p>
 
-      {error && (
-        <div className="error">
-          {error}
-        </div>
-      )}
-
-      <button onClick={handleSignIn} disabled={loading}>
-        {loading ? 'Signing in...' : 'Sign in with Oxy'}
-      </button>
-
-      <p className="hint">
-        Works across homiio.com, mention.earth, alia.onl, and all Oxy apps
-      </p>
+      {/*
+        One button, two behaviors — resolved from your Application's `type`
+        (via `GET /auth/oauth/client/:clientId`):
+          - third_party  → the SDK runs an OAuth 2.0 + PKCE redirect to
+            `auth.oxy.so/authorize` (it generates and stores the PKCE pair and
+            CSRF `state` for you). Pass `oauthRedirectUri` for third-party apps.
+          - first_party / internal / system / isOfficial → opens the in-app
+            "Sign in with Oxy" dialog (Commons-first); no redirect.
+      */}
+      <OxySignInButton variant="contained" />
     </div>
   );
 }
 
-function Dashboard() {
-  const { user, signOut, loading } = useAuth();
+// ==================== 4. Signed-in ====================
 
-  if (!user) return null;
+function Dashboard({ user }: { user: User }) {
+  const { signOut } = useAuth();
+
+  // Render `name.displayName` when present; otherwise fall back to the handle.
+  // Never recompose a name from first/last/full.
+  const displayName = user.name?.displayName?.trim() || user.username;
 
   return (
     <div className="dashboard">
       <header>
         <div className="user-info">
-          <img
-            src={user.avatarUrl || `https://api.dicebear.com/7.x/avataaars/svg?seed=${user.username}`}
-            alt={user.username}
-            className="avatar"
-          />
-          <div>
-            <h2>{user.username}</h2>
-            <p>{user.email}</p>
-          </div>
+          <h2>{displayName}</h2>
+          {user.email ? <p>{user.email}</p> : null}
         </div>
-
-        <button onClick={signOut} disabled={loading}>
-          {loading ? 'Signing out...' : 'Sign Out'}
-        </button>
+        <button onClick={() => signOut()}>Sign out</button>
       </header>
 
       <main>
         <h3>You're signed in!</h3>
-        <p>
-          Open any other Oxy app (homiio.com, mention.earth, etc.) and you'll be
-          automatically signed in. No need to sign in again!
-        </p>
-
-        <div className="sso-status">
-          <h4>SSO Status</h4>
-          <ul>
-            <li>✅ Authenticated across all Oxy domains</li>
-            <li>✅ No third-party cookies required</li>
-            <li>✅ Privacy-preserving identity</li>
-          </ul>
-        </div>
+        <p>Open any other Oxy app and the SDK restores this session for you.</p>
       </main>
     </div>
   );
 }
 
-// ==================== 4. Main App ====================
-
-export default function App() {
-  return (
-    <AuthProvider>
-      <AppContent />
-    </AuthProvider>
-  );
-}
-
-function AppContent() {
-  const { user, loading } = useAuth();
-
-  if (loading) {
-    return (
-      <div className="loading">
-        <div className="spinner" />
-        <p>Loading...</p>
-      </div>
-    );
-  }
-
-  return user ? <Dashboard /> : <LoginPage />;
-}
-
-// ==================== 5. Advanced: Method Selection ====================
-
-function AdvancedAuthExample() {
-  const { crossDomainAuth } = useAuth();
-
-  const handleFedCMOnly = async () => {
-    try {
-      const session = await crossDomainAuth.signInWithFedCM();
-      console.log('Signed in with FedCM:', session.user);
-    } catch (error) {
-      console.error('FedCM not supported, try popup:', error);
-    }
-  };
-
-  const handleRedirectOnly = () => {
-    crossDomainAuth.signInWithRedirect({
-      redirectUri: window.location.href,
-    });
-    // Will navigate away
-  };
-
-  const handleSilentSignIn = async () => {
-    const session = await crossDomainAuth.silentSignIn();
-    if (session) {
-      console.log('Silent sign-in successful:', session.user);
-    } else {
-      console.log('No existing session found');
-    }
-  };
-
-  const checkMethod = () => {
-    const { method, reason } = crossDomainAuth.getRecommendedMethod();
-    console.log(`Recommended: ${method} - ${reason}`);
-  };
-
-  return (
-    <div>
-      <h3>Advanced Auth Methods</h3>
-      <button onClick={handleFedCMOnly}>Sign in with FedCM (Chrome 108+)</button>
-      <button onClick={handlePopupOnly}>Sign in with Popup</button>
-      <button onClick={handleRedirectOnly}>Sign in with Redirect</button>
-      <button onClick={handleSilentSignIn}>Try Silent Sign-in</button>
-      <button onClick={checkMethod}>Check Recommended Method</button>
-    </div>
-  );
-}
-
-// ==================== 6. Hooks ====================
+// ==================== 5. Programmatic sign-in (optional) ====================
 
 /**
- * Custom hook for current user data
+ * `useAuth().signIn()` is the imperative equivalent of the button for official
+ * apps — it opens the same in-app sign-in dialog. It does NOT navigate to a
+ * login page (device-first cold boot already restored a session if one exists),
+ * so a caller reacts to `isAuthenticated` rather than awaiting this promise.
+ * Third-party apps should sign in via `<OxySignInButton oauthRedirectUri=… />`.
  */
-export function useCurrentUser() {
-  const { user } = useAuth();
-  return user;
-}
-
-/**
- * Custom hook for authentication state
- */
-export function useAuthState() {
-  const { user, loading } = useAuth();
-  return {
-    isAuthenticated: !!user,
-    isLoading: loading,
-    user,
-  };
-}
-
-/**
- * Custom hook for protected routes
- */
-export function useRequireAuth() {
-  const { user, loading, signIn } = useAuth();
-
-  useEffect(() => {
-    if (!loading && !user) {
-      signIn();
-    }
-  }, [loading, user, signIn]);
-
-  return { user, loading };
-}
-
-// Usage in component:
-function ProtectedPage() {
-  const { user, loading } = useRequireAuth();
-
-  if (loading) return <div>Loading...</div>;
-  if (!user) return null; // Will trigger sign-in
-
-  return <div>Protected content for {user.username}</div>;
+export function useSignInAction() {
+  const { signIn, isAuthenticated } = useAuth();
+  return { signIn, isAuthenticated };
 }

--- a/packages/inbox/hooks/mutations/useAiCompose.ts
+++ b/packages/inbox/hooks/mutations/useAiCompose.ts
@@ -96,17 +96,11 @@ export function useAiCompose(): UseAiComposeReturn {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
-  const getToken = useCallback(() => {
-    const token = oxyServices.httpService.getAccessToken();
-    if (!token) throw new Error('Not authenticated');
-    return token;
-  }, [oxyServices]);
-
   const draft = useCallback(async (prompt: string, tone: ComposeTone = 'professional'): Promise<string> => {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await aliaChatCompletion({
+      const result = await aliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: [
           { role: 'system', content: DRAFT_SYSTEM_PROMPT },
@@ -114,7 +108,6 @@ export function useAiCompose(): UseAiComposeReturn {
         ],
         maxTokens: 800,
         temperature: 0.7,
-        token: getToken(),
       });
       return result.trim();
     } catch (err) {
@@ -124,7 +117,7 @@ export function useAiCompose(): UseAiComposeReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [getToken]);
+  }, [oxyServices]);
 
   const streamDraft = useCallback(async (
     prompt: string,
@@ -135,7 +128,7 @@ export function useAiCompose(): UseAiComposeReturn {
     setError(null);
     try {
       let fullText = '';
-      const generator = streamAliaChatCompletion({
+      const generator = streamAliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: [
           { role: 'system', content: DRAFT_SYSTEM_PROMPT },
@@ -143,7 +136,6 @@ export function useAiCompose(): UseAiComposeReturn {
         ],
         maxTokens: 800,
         temperature: 0.7,
-        token: getToken(),
       });
 
       for await (const chunk of generator) {
@@ -159,13 +151,13 @@ export function useAiCompose(): UseAiComposeReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [getToken]);
+  }, [oxyServices]);
 
   const polish = useCallback(async (text: string): Promise<string> => {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await aliaChatCompletion({
+      const result = await aliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: [
           { role: 'system', content: POLISH_SYSTEM_PROMPT },
@@ -173,7 +165,6 @@ export function useAiCompose(): UseAiComposeReturn {
         ],
         maxTokens: 1000,
         temperature: 0.5,
-        token: getToken(),
       });
       return result.trim();
     } catch (err) {
@@ -183,13 +174,13 @@ export function useAiCompose(): UseAiComposeReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [getToken]);
+  }, [oxyServices]);
 
   const changeTone = useCallback(async (text: string, tone: ComposeTone): Promise<string> => {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await aliaChatCompletion({
+      const result = await aliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: [
           { role: 'system', content: TONE_SYSTEM_PROMPT },
@@ -197,7 +188,6 @@ export function useAiCompose(): UseAiComposeReturn {
         ],
         maxTokens: 1000,
         temperature: 0.6,
-        token: getToken(),
       });
       return result.trim();
     } catch (err) {
@@ -207,13 +197,13 @@ export function useAiCompose(): UseAiComposeReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [getToken]);
+  }, [oxyServices]);
 
   const adjustLength = useCallback(async (text: string, direction: 'shorter' | 'longer'): Promise<string> => {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await aliaChatCompletion({
+      const result = await aliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: [
           { role: 'system', content: LENGTH_SYSTEM_PROMPT },
@@ -221,7 +211,6 @@ export function useAiCompose(): UseAiComposeReturn {
         ],
         maxTokens: direction === 'longer' ? 1500 : 500,
         temperature: 0.5,
-        token: getToken(),
       });
       return result.trim();
     } catch (err) {
@@ -231,13 +220,13 @@ export function useAiCompose(): UseAiComposeReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [getToken]);
+  }, [oxyServices]);
 
   const suggestSubject = useCallback(async (body: string): Promise<string> => {
     setIsLoading(true);
     setError(null);
     try {
-      const result = await aliaChatCompletion({
+      const result = await aliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: [
           { role: 'system', content: SUBJECT_SYSTEM_PROMPT },
@@ -245,7 +234,6 @@ export function useAiCompose(): UseAiComposeReturn {
         ],
         maxTokens: 60,
         temperature: 0.6,
-        token: getToken(),
       });
       return result.trim().replace(/^["']|["']$/g, '');
     } catch (err) {
@@ -255,7 +243,7 @@ export function useAiCompose(): UseAiComposeReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [getToken]);
+  }, [oxyServices]);
 
   return {
     draft,

--- a/packages/inbox/hooks/queries/useDailyBrief.ts
+++ b/packages/inbox/hooks/queries/useDailyBrief.ts
@@ -36,7 +36,7 @@ function getBriefCacheKey(): string[] {
 
 export function useDailyBrief(messages: Message[]) {
   const queryClient = useQueryClient();
-  const { oxyServices } = useOxy();
+  const { oxyServices, user } = useOxy();
   const cacheKey = getBriefCacheKey();
 
   const [briefText, setBriefText] = useState('');
@@ -62,8 +62,7 @@ export function useDailyBrief(messages: Message[]) {
       return;
     }
 
-    const token = oxyServices.httpService.getAccessToken();
-    if (!token) return;
+    if (!user) return;
 
     setIsStreaming(true);
     setBriefText('');
@@ -74,12 +73,11 @@ export function useDailyBrief(messages: Message[]) {
       const prompt = buildPrompt(messages);
       let accumulated = '';
 
-      for await (const delta of streamAliaChatCompletion({
+      for await (const delta of streamAliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: prompt,
         maxTokens: 300,
         temperature: 0.7,
-        token,
       })) {
         if (abortRef.current) break;
         accumulated += delta;
@@ -106,7 +104,7 @@ export function useDailyBrief(messages: Message[]) {
         setIsStreaming(false);
       }
     }
-  }, [messages, queryClient, cacheKey, oxyServices]);
+  }, [messages, queryClient, cacheKey, oxyServices, user]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/packages/inbox/hooks/queries/useNaturalLanguageSearch.ts
+++ b/packages/inbox/hooks/queries/useNaturalLanguageSearch.ts
@@ -85,10 +85,7 @@ export function useNaturalLanguageSearch() {
     setError(null);
 
     try {
-      const token = oxyServices.httpService.getAccessToken();
-      if (!token) throw new Error('Not authenticated');
-
-      const response = await aliaChatCompletion({
+      const response = await aliaChatCompletion(oxyServices.httpService, {
         model: 'alia-lite',
         messages: [
           { role: 'system', content: SEARCH_PARSE_PROMPT },
@@ -96,7 +93,6 @@ export function useNaturalLanguageSearch() {
         ],
         maxTokens: 200,
         temperature: 0.3,
-        token,
       });
 
       const trimmed = response.trim();

--- a/packages/inbox/hooks/queries/useSmartReplies.ts
+++ b/packages/inbox/hooks/queries/useSmartReplies.ts
@@ -7,8 +7,11 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useOxy } from '@oxyhq/services';
+import type { OxyServices } from '@oxyhq/core';
 import { aliaChatCompletion } from '@/services/aliaApi';
 import type { Message } from '@/services/emailApi';
+
+type HttpService = OxyServices['httpService'];
 
 interface SmartRepliesResult {
   replies: string[];
@@ -109,7 +112,7 @@ function shouldSkipSmartReplies(message: Message): boolean {
   return sensitivePatterns.some((pattern) => pattern.test(sensitiveText));
 }
 
-async function fetchSmartReplies(message: Message, token: string): Promise<string[]> {
+async function fetchSmartReplies(message: Message, http: HttpService): Promise<string[]> {
   if (shouldSkipSmartReplies(message)) {
     return [];
   }
@@ -117,7 +120,7 @@ async function fetchSmartReplies(message: Message, token: string): Promise<strin
   const prompt = buildPrompt(message);
 
   try {
-    const response = await aliaChatCompletion({
+    const response = await aliaChatCompletion(http, {
       model: 'alia-lite',
       messages: [
         { role: 'system', content: SMART_REPLY_SYSTEM_PROMPT },
@@ -125,7 +128,6 @@ async function fetchSmartReplies(message: Message, token: string): Promise<strin
       ],
       maxTokens: 150,
       temperature: 0.7,
-      token,
     });
 
     // Parse JSON array from response
@@ -153,11 +155,10 @@ async function fetchSmartReplies(message: Message, token: string): Promise<strin
 
 export function useSmartReplies(message: Message | null | undefined): SmartRepliesResult {
   const { oxyServices } = useOxy();
-  const token = oxyServices.httpService.getAccessToken() ?? '';
 
   const query = useQuery({
     queryKey: ['smartReplies', message?._id],
-    queryFn: () => fetchSmartReplies(message!, token),
+    queryFn: () => fetchSmartReplies(message!, oxyServices.httpService),
     enabled: false,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
     gcTime: 10 * 60 * 1000,

--- a/packages/inbox/hooks/queries/useThreadSummary.ts
+++ b/packages/inbox/hooks/queries/useThreadSummary.ts
@@ -9,8 +9,11 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useOxy } from '@oxyhq/services';
+import type { OxyServices } from '@oxyhq/core';
 import { aliaChatCompletion } from '@/services/aliaApi';
 import type { Message } from '@/services/emailApi';
+
+type HttpService = OxyServices['httpService'];
 
 export interface ThreadSummaryResult {
   summary: string;
@@ -90,11 +93,11 @@ function buildThreadPrompt(messages: Message[]): string {
   return parts.join('\n\n---\n\n');
 }
 
-async function fetchThreadSummary(messages: Message[], token: string): Promise<ThreadSummaryResult> {
+async function fetchThreadSummary(messages: Message[], http: HttpService): Promise<ThreadSummaryResult> {
   const prompt = buildThreadPrompt(messages);
 
   try {
-    const response = await aliaChatCompletion({
+    const response = await aliaChatCompletion(http, {
       model: 'alia-lite',
       messages: [
         { role: 'system', content: THREAD_SUMMARY_SYSTEM_PROMPT },
@@ -102,7 +105,6 @@ async function fetchThreadSummary(messages: Message[], token: string): Promise<T
       ],
       maxTokens: 600,
       temperature: 0.5,
-      token,
     });
 
     // Parse JSON from response
@@ -142,14 +144,13 @@ export function useThreadSummary(
   messages: Message[] | undefined,
   options: UseThreadSummaryOptions = {}
 ) {
-  const { oxyServices } = useOxy();
-  const token = oxyServices.httpService.getAccessToken() ?? '';
+  const { oxyServices, user } = useOxy();
   const { enabled = true, minMessages = 4 } = options;
-  const shouldFetch = enabled && !!token && !!messages && messages.length >= minMessages;
+  const shouldFetch = enabled && !!user && !!messages && messages.length >= minMessages;
 
   const query = useQuery({
     queryKey: ['threadSummary', messages?.map((m) => m._id).join(',')],
-    queryFn: () => fetchThreadSummary(messages!, token),
+    queryFn: () => fetchThreadSummary(messages!, oxyServices.httpService),
     enabled: shouldFetch,
     staleTime: 10 * 60 * 1000, // Cache for 10 minutes
     gcTime: 30 * 60 * 1000,

--- a/packages/inbox/services/aliaApi.ts
+++ b/packages/inbox/services/aliaApi.ts
@@ -1,11 +1,23 @@
 /**
  * Alia AI API client
  *
- * Proxies requests through the Oxy backend API which handles
- * Alia API key management server-side.
+ * Proxies requests through the Oxy backend API (`api.oxy.so`) which handles
+ * Alia API key management server-side. That backend IS the origin the
+ * OxyProvider session owner already talks to, so authentication rides the
+ * SDK's own `HttpService` — no app-local token provider, interceptor, or
+ * manual `Authorization` plumbing (see `@oxyhq/services` D4 contract).
  */
 
-const API_URL = process.env.EXPO_PUBLIC_API_URL;
+import type { OxyServices } from '@oxyhq/core';
+
+type HttpService = OxyServices['httpService'];
+
+const ALIA_COMPLETIONS_PATH = '/alia/chat/completions';
+
+// Matches the OxyProvider baseURL wired in `app/_layout.tsx`; only used by the
+// streaming path, which must issue a raw fetch (HttpService has no streaming
+// body — it fully reads every response).
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'https://api.oxy.so';
 
 export interface AliaMessage {
   role: 'system' | 'user' | 'assistant';
@@ -17,29 +29,69 @@ export interface AliaRequestOptions {
   messages: AliaMessage[];
   maxTokens?: number;
   temperature?: number;
-  /** User session JWT for backend authentication */
-  token: string;
+}
+
+/** OpenAI-compatible chat-completion response shape returned by the proxy. */
+interface AliaChatResponse {
+  choices?: Array<{
+    message?: { content?: string };
+    delta?: { content?: string };
+  }>;
+}
+
+function buildRequestBody(options: AliaRequestOptions, stream: boolean) {
+  return {
+    model: options.model ?? 'alia-lite',
+    messages: options.messages,
+    max_tokens: options.maxTokens ?? 512,
+    temperature: options.temperature ?? 0.7,
+    stream,
+  };
+}
+
+/**
+ * Non-streaming chat completion. Returns the full response text.
+ *
+ * Routes through the SDK `HttpService`, which owns the bearer token
+ * (auto-refresh + 401 retry). No manual `Authorization` header.
+ */
+export async function aliaChatCompletion(
+  http: HttpService,
+  options: AliaRequestOptions,
+): Promise<string> {
+  const response = await http.post<AliaChatResponse>(
+    ALIA_COMPLETIONS_PATH,
+    buildRequestBody(options, false),
+  );
+  return response.choices?.[0]?.message?.content ?? '';
 }
 
 /**
  * Stream a chat completion from Alia. Yields text deltas as they arrive.
+ *
+ * `HttpService` has no streaming path (`request()` fully reads the body), so
+ * this SSE call must use a raw `fetch`. The endpoint is same-origin with the
+ * session owner (`api.oxy.so`), so we borrow the SDK-owned access token for the
+ * `Authorization` header — the same sanctioned same-origin pattern
+ * `useInboxSocket` uses for its socket.io handshake. This is NOT an app-local
+ * auth interceptor or token provider.
  */
 export async function* streamAliaChatCompletion(
+  http: HttpService,
   options: AliaRequestOptions,
 ): AsyncGenerator<string> {
-  const response = await fetch(`${API_URL}/alia/chat/completions`, {
+  const token = http.getAccessToken();
+  if (!token) {
+    throw new Error('Not authenticated');
+  }
+
+  const response = await fetch(`${API_URL}${ALIA_COMPLETIONS_PATH}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${options.token}`,
+      Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({
-      model: options.model ?? 'alia-lite',
-      messages: options.messages,
-      max_tokens: options.maxTokens ?? 512,
-      temperature: options.temperature ?? 0.7,
-      stream: true,
-    }),
+    body: JSON.stringify(buildRequestBody(options, true)),
   });
 
   if (!response.ok) {
@@ -49,7 +101,7 @@ export async function* streamAliaChatCompletion(
 
   // Fall back to non-streaming if ReadableStream is unavailable
   if (!response.body || typeof response.body.getReader !== 'function') {
-    const json = await response.json();
+    const json = (await response.json()) as AliaChatResponse;
     const content = json.choices?.[0]?.message?.content ?? '';
     if (content) yield content;
     return;
@@ -75,7 +127,7 @@ export async function* streamAliaChatCompletion(
         if (data === '[DONE]') return;
 
         try {
-          const parsed = JSON.parse(data);
+          const parsed = JSON.parse(data) as AliaChatResponse;
           const delta = parsed.choices?.[0]?.delta?.content;
           if (delta) yield delta;
         } catch {
@@ -86,34 +138,4 @@ export async function* streamAliaChatCompletion(
   } finally {
     reader.releaseLock();
   }
-}
-
-/**
- * Non-streaming chat completion. Returns the full response text.
- */
-export async function aliaChatCompletion(
-  options: AliaRequestOptions,
-): Promise<string> {
-  const response = await fetch(`${API_URL}/alia/chat/completions`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${options.token}`,
-    },
-    body: JSON.stringify({
-      model: options.model ?? 'alia-lite',
-      messages: options.messages,
-      max_tokens: options.maxTokens ?? 512,
-      temperature: options.temperature ?? 0.7,
-      stream: false,
-    }),
-  });
-
-  if (!response.ok) {
-    const text = await response.text().catch(() => '');
-    throw new Error(`Alia API error ${response.status}: ${text}`);
-  }
-
-  const json = await response.json();
-  return json.choices?.[0]?.message?.content ?? '';
 }

--- a/packages/oxy-main-domain/web-identity
+++ b/packages/oxy-main-domain/web-identity
@@ -1,3 +1,0 @@
-{
-  "provider_urls": ["https://auth.oxy.so/fedcm.json"]
-}

--- a/packages/test-app-expo/app/_layout.tsx
+++ b/packages/test-app-expo/app/_layout.tsx
@@ -10,6 +10,14 @@ import { BloomThemeProvider, useNavigationTheme } from '@oxyhq/bloom/theme';
 
 const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3001';
 const AUTH_REDIRECT_URI = Linking.createURL('/');
+// Public OAuth client id (the registered `ApplicationCredential` publicKey) —
+// drives the app-identity flow when passed to `OxyProvider`. Env-with-default
+// pattern, mirroring `packages/console/src/lib/config.ts`: a committed public
+// default, overridable per environment via `EXPO_PUBLIC_OXY_CLIENT_ID`. This is
+// a playground, so it reuses the Console app's credential rather than owning one.
+const OXY_CLIENT_ID =
+  process.env.EXPO_PUBLIC_OXY_CLIENT_ID ??
+  'oxy_dk_2bdf04f596037ac720f94a54df405b974f240e5392a2e668';
 
 export const unstable_settings = {
   anchor: '(tabs)',
@@ -22,7 +30,7 @@ export default function RootLayout() {
     // services UI like OxySignInButton calls bloom's useTheme().
     <SafeAreaProvider>
       <BloomThemeProvider mode="system">
-        <OxyProvider baseURL={API_URL} authRedirectUri={AUTH_REDIRECT_URI}>
+        <OxyProvider baseURL={API_URL} clientId={OXY_CLIENT_ID} authRedirectUri={AUTH_REDIRECT_URI}>
           <RootNavigator />
         </OxyProvider>
       </BloomThemeProvider>


### PR DESCRIPTION
## Auth platform Fase 6 — limpieza apps consumidoras

### Qué hace
1. **inbox**: fuera el bearer manual (regla D4). El proxy Alia vive en api.oxy.so (same-origin con el session owner) → las 6 rutas de hooks + aliaApi usan el `HttpService` del SDK (auto-refresh + 401). Residuales sancionados y documentados: handshake socket.io + fetch SSE de streaming (HttpService no tiene path de streaming) — same-origin, sin interceptors ni token providers propios.
2. **examples/** reescritos para el SDK device-first: `web-react-auth.tsx` y `expo-54-universal-auth.tsx` (antes usaban `createCrossDomainAuth`/FedCM/`signInWithRedirect` con imports ROTOS) ahora muestran `OxyProvider` + `useAuth` + `OxySignInButton`; `native-react-native-auth.tsx` corrige imports de crypto (→ `@oxyhq/core`) y el app group (`group.so.oxy.shared`).
3. **test-app-expo**: `OxyProvider` registra `clientId` (patrón env-with-default de console).
4. **`packages/oxy-main-domain` eliminado**: solo contenía el well-known FedCM apuntando a un `fedcm.json` borrado en wave 2; cero referencias.

### Gates Fase 6 (handoff)
- [x] accounts/inbox/console sin bootstrap SSO en `+html.tsx` — ya a 0 en main (verificado en Fase 0/audit)
- [x] Sin `@oxyhq/auth` en apps oficiales — desde Fase 3 (#557)
- [x] Sin auth local/interceptors — inbox era el último (este PR)

Tests inbox/typechecks verdes; greps residuales justificados en el commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)