### PR TITLE
fix(inbox): resolve type drift — expo-file-system v19 Paths, FlashList v2, ref typing

### DIFF
--- a/packages/inbox/components/InboxList.tsx
+++ b/packages/inbox/components/InboxList.tsx
@@ -615,7 +615,6 @@ export function InboxList({ replaceNavigation }: InboxListProps) {
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           getItemType={getItemType}
-          estimatedItemSize={72}
           ItemSeparatorComponent={renderSeparator}
           ListEmptyComponent={renderEmpty}
           ListFooterComponent={renderFooter}
@@ -708,10 +707,11 @@ export function InboxList({ replaceNavigation }: InboxListProps) {
             ref={aliaChatRef}
             apiUrl={ALIA_PROXY_API_URL}
             clientContext="User is in the Inbox app viewing their email. Use oxy_inbox tools to access their emails."
-            suggestions={[
-              { label: 'Unread emails', icon: 'mail', prompt: 'What emails need my attention?' },
-              { label: "Today's summary", icon: 'text', prompt: 'Summarize my emails from today' },
-              { label: 'With attachments', icon: 'paperclip', prompt: 'Find emails with attachments' },
+            // AliaChatSheet's welcome suggestions are {id, title, description}; per-item icons are no longer supported upstream.
+            welcomeSuggestions={[
+              { id: 'unread', title: 'Unread emails', description: 'What emails need my attention?' },
+              { id: 'today-summary', title: "Today's summary", description: 'Summarize my emails from today' },
+              { id: 'with-attachments', title: 'With attachments', description: 'Find emails with attachments' },
             ]}
           />
         </>

--- a/packages/inbox/components/MailboxDrawer.tsx
+++ b/packages/inbox/components/MailboxDrawer.tsx
@@ -195,7 +195,7 @@ export function MailboxDrawer({ onClose, onToggle, collapsed }: { onClose?: () =
   const { data: mailboxes = [] } = useMailboxes();
   const { data: labels = [] } = useLabels();
 
-  const activeUserId = user?.id ?? user?._id ?? null;
+  const activeUserId = user?.id ?? null;
   const previousUserIdRef = useRef<string | null>(activeUserId);
 
   useEffect(() => {

--- a/packages/inbox/components/cards/EventCard.tsx
+++ b/packages/inbox/components/cards/EventCard.tsx
@@ -116,17 +116,15 @@ export function EventCard({ data }: EventCardProps) {
     } else {
       // Native: use expo-file-system and expo-sharing
       try {
-        const FileSystem = await import('expo-file-system');
+        const { File, Paths } = await import('expo-file-system');
         const Sharing = await import('expo-sharing');
 
         const filename = `${(data.title || 'event').replace(/[^a-zA-Z0-9]/g, '_')}.ics`;
-        const fileUri = `${FileSystem.cacheDirectory}${filename}`;
-        await FileSystem.writeAsStringAsync(fileUri, icsContent, {
-          encoding: FileSystem.EncodingType.UTF8,
-        });
+        const file = new File(Paths.cache, filename);
+        file.write(icsContent);
 
         if (await Sharing.isAvailableAsync()) {
-          await Sharing.shareAsync(fileUri, {
+          await Sharing.shareAsync(file.uri, {
             mimeType: 'text/calendar',
             dialogTitle: 'Add to Calendar',
           });


### PR DESCRIPTION
Fixes 5 pre-existing `tsc` errors in `packages/inbox` caused by dependency version drift (unrelated to auth work). `bunx tsc --noEmit -p packages/inbox/tsconfig.json` went from **5 errors → 0**.

### Fixes
1. **`components/cards/EventCard.tsx:123`** — expo-file-system v56 removed the legacy `cacheDirectory` / `writeAsStringAsync` / `EncodingType` API. Migrated to the new object API: `new File(Paths.cache, filename)` + `file.write(icsContent)` (synchronous, auto-creates, UTF-8 default) + `file.uri` for `Sharing.shareAsync`.
2. **`components/InboxList.tsx:618`** — FlashList v2 dropped `estimatedItemSize` (no longer needed). Removed the prop.
3. **`components/InboxList.tsx:711`** — `@alia.onl/sdk` renamed `AliaChatSheet`'s `suggestions` prop to `welcomeSuggestions` with a new item shape (`{id, title, description}` instead of `{label, icon, prompt}`). Migrated the call site: old `label`→`title`, old `prompt`→`description`. Per-item icons were removed upstream (noted in a one-line comment).
4-5. **`components/MailboxDrawer.tsx:199,205`** — `user?.id ?? user?._id ?? null` widened to `{} | null` because `_id` resolves through the core `User` index signature (`[key: string]: unknown`) rather than a real typed field, breaking `useRef<string | null>`. Dropped the redundant `_id` fallback so it reads `user?.id ?? null` — matching every other user-id read across the inbox package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)