### PR TITLE
2c PR1: deviceSecret mint — server authority (aditivo)

### DIFF
--- a/docs/architecture/oxy-auth-audit.md
+++ b/docs/architecture/oxy-auth-audit.md
@@ -189,4 +189,5 @@ Grafo completo en main (`account.service.ts`, `/accounts`, `POST /accounts/:id/s
 - [x] `docs/auth/integration-guide.md` + `docs/auth/device-session.md` creados
 - [x] AGENTS.md repo reescrito (secciones auth device-first); `~/AGENTS.md` global alineado; `~/Oxy/AGENTS.md` ya limpio
 - [x] Tests ≥ baselines: contracts 150 · core 740 · api 1363 · services 194 · auth IdP 63/0
-- [ ] **Workshop 2c** — transporte cero-cookies PENDIENTE de Nate (decisión 2026-07-06: transporte actual congelado)
+- [x] **Cierre operativo (2026-07-06):** specs superpowers session-sync phase1-3 BORRADAS (implementadas; citas en los docs canónicos = registro histórico); PR #519 cerrado (superseded); ramas locales+remotas del proyecto purgadas
+- [~] **Workshop 2c CELEBRADO (2026-07-06)** — decisiones: deviceId web POR ORIGEN; rotación en uso + grace 60s; refresh family MUERE; migración aditiva con telemetría mint_source, cookie fuera al llegar ≈0; sin cookie-optimización para el IdP. Implementación en curso (PRs 2c)

--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -432,10 +432,11 @@ export class SessionController {
       if (!baseSignupResponse) {
         return res.status(500).json({ message: 'Failed to format user data' });
       }
-      const response: typeof baseSignupResponse & { refreshToken?: string } = baseSignupResponse;
+      const response: typeof baseSignupResponse & { refreshToken?: string; deviceSecret?: string } = baseSignupResponse;
 
       // Register into the device set (add-only) + broadcast, and additively
-      // attach a rotating refresh token when the lane allows it. Best-effort.
+      // attach a rotating refresh token + deviceSecret when the lane allows it.
+      // Best-effort.
       const signupDeviceExtras = await finalizeDeviceLogin({
         req,
         deviceId: signupDevice.deviceId,
@@ -444,6 +445,9 @@ export class SessionController {
       });
       if (signupDeviceExtras.refreshToken) {
         response.refreshToken = signupDeviceExtras.refreshToken;
+      }
+      if (signupDeviceExtras.deviceSecret) {
+        response.deviceSecret = signupDeviceExtras.deviceSecret;
       }
 
       try {
@@ -634,7 +638,7 @@ export class SessionController {
         return res.status(500).json({ message: 'Failed to format user data' });
       }
 
-      const response: SessionAuthResponse & { refreshToken?: string } = {
+      const response: SessionAuthResponse & { refreshToken?: string; deviceSecret?: string } = {
         sessionId: session.sessionId,
         deviceId: session.deviceId,
         expiresAt: session.expiresAt.toISOString(),
@@ -647,7 +651,8 @@ export class SessionController {
       };
 
       // Register into the device set (add-only) + broadcast, and additively
-      // attach a rotating refresh token when the lane allows it. Best-effort.
+      // attach a rotating refresh token + deviceSecret when the lane allows it.
+      // Best-effort.
       const verifyDeviceExtras = await finalizeDeviceLogin({
         req,
         deviceId: verifyDevice.deviceId,
@@ -656,6 +661,9 @@ export class SessionController {
       });
       if (verifyDeviceExtras.refreshToken) {
         response.refreshToken = verifyDeviceExtras.refreshToken;
+      }
+      if (verifyDeviceExtras.deviceSecret) {
+        response.deviceSecret = verifyDeviceExtras.deviceSecret;
       }
 
       res.json(response);
@@ -792,6 +800,7 @@ export class SessionController {
       const response: SessionAuthResponse & {
         securityAlert?: { message: string; anomalies: Array<{ type: string; reason: string; details?: string }> };
         refreshToken?: string;
+        deviceSecret?: string;
       } = baseResponse;
       if (anomalyCheck.hasAnomalies) {
         response.securityAlert = {
@@ -802,7 +811,8 @@ export class SessionController {
 
       // Device-first lane: register the session into the resolved device set
       // (add-only, never flips active) + broadcast, and additively attach a
-      // rotating refresh token when the lane allows it. Best-effort.
+      // rotating refresh token + deviceSecret when the lane allows it.
+      // Best-effort.
       const deviceExtras = await finalizeDeviceLogin({
         req,
         deviceId: loginDevice.deviceId,
@@ -811,6 +821,9 @@ export class SessionController {
       });
       if (deviceExtras.refreshToken) {
         response.refreshToken = deviceExtras.refreshToken;
+      }
+      if (deviceExtras.deviceSecret) {
+        response.deviceSecret = deviceExtras.deviceSecret;
       }
 
       try {

--- a/packages/api/src/controllers/twoFactor.controller.ts
+++ b/packages/api/src/controllers/twoFactor.controller.ts
@@ -417,10 +417,11 @@ export async function verify2FALogin(req: Request, res: Response) {
     if (!baseTwoFactorResponse) {
       return res.status(500).json({ message: 'Failed to format user data' });
     }
-    const response: typeof baseTwoFactorResponse & { refreshToken?: string } = baseTwoFactorResponse;
+    const response: typeof baseTwoFactorResponse & { refreshToken?: string; deviceSecret?: string } = baseTwoFactorResponse;
 
     // Register into the device set (add-only) + broadcast, and additively attach
-    // a rotating refresh token when the lane allows it. Best-effort.
+    // a rotating refresh token + deviceSecret when the lane allows it.
+    // Best-effort.
     const twoFactorDeviceExtras = await finalizeDeviceLogin({
       req,
       deviceId: twoFactorDevice.deviceId,
@@ -429,6 +430,9 @@ export async function verify2FALogin(req: Request, res: Response) {
     });
     if (twoFactorDeviceExtras.refreshToken) {
       response.refreshToken = twoFactorDeviceExtras.refreshToken;
+    }
+    if (twoFactorDeviceExtras.deviceSecret) {
+      response.deviceSecret = twoFactorDeviceExtras.deviceSecret;
     }
 
     try {

--- a/packages/api/src/models/DeviceSession.ts
+++ b/packages/api/src/models/DeviceSession.ts
@@ -20,6 +20,24 @@ export interface IDeviceSession extends Document {
    * legacy device docs predate it and carry none.
    */
   cookieKeyHash?: string;
+  /**
+   * SHA-256 hex of the current `deviceSecret` (phase 2c — zero-cookie transport).
+   * The client stores the raw 256-bit secret first-party (web localStorage /
+   * native SecureStore) and presents it at `POST /session/device/token`; only the
+   * hash is stored server-side, so a Mongo dump cannot forge the secret. Sparse-
+   * unique, exactly like `cookieKeyHash`: legacy device docs predate it and carry
+   * none, and it is populated on the next sign-in / mint.
+   */
+  secretHash?: string;
+  /**
+   * The PREVIOUS `deviceSecret` hash, kept valid for a short grace window
+   * (`prevSecretExpiresAt`) after a rotation so a multi-tab race presenting the
+   * just-superseded secret still succeeds (rotation-in-use, mirroring the
+   * refresh-family single-use-with-grace pattern). Transient — never indexed.
+   */
+  prevSecretHash?: string;
+  /** Epoch after which `prevSecretHash` is no longer accepted. Transient. */
+  prevSecretExpiresAt?: Date;
   revision: number;
   createdAt: Date;
   updatedAt: Date;
@@ -45,6 +63,13 @@ const DeviceSessionSchema = new Schema<IDeviceSession>(
     // hash. Never `default: null`, or sparse uniqueness would collide across
     // legacy docs.
     cookieKeyHash: { type: String, default: undefined },
+    // Sparse-unique: only device docs bound to a `deviceSecret` carry a hash.
+    // Never `default: null`, or sparse uniqueness would collide across legacy
+    // docs — same rationale as `cookieKeyHash`.
+    secretHash: { type: String, default: undefined },
+    // Transient grace fields — never indexed (they churn on every rotation).
+    prevSecretHash: { type: String, default: undefined },
+    prevSecretExpiresAt: { type: Date, default: undefined },
     revision: { type: Number, default: 0 },
   },
   { timestamps: true },
@@ -52,5 +77,6 @@ const DeviceSessionSchema = new Schema<IDeviceSession>(
 
 DeviceSessionSchema.index({ deviceId: 1 }, { unique: true });
 DeviceSessionSchema.index({ cookieKeyHash: 1 }, { unique: true, sparse: true });
+DeviceSessionSchema.index({ secretHash: 1 }, { unique: true, sparse: true });
 
 export default mongoose.model<IDeviceSession>('DeviceSession', DeviceSessionSchema);

--- a/packages/api/src/models/__tests__/deviceSession.model.test.ts
+++ b/packages/api/src/models/__tests__/deviceSession.model.test.ts
@@ -27,4 +27,32 @@ describe('DeviceSession model', () => {
     expect(doc.accounts[0].authuser).toBe(0);
     expect(doc.accounts[0].addedAt).toBeInstanceOf(Date);
   });
+
+  it('leaves the phase-2c device-secret fields unset by default (sparse — legacy docs predate them)', () => {
+    const doc = new DeviceSession({ deviceId: 'd1' });
+    expect(doc.secretHash).toBeUndefined();
+    expect(doc.prevSecretHash).toBeUndefined();
+    expect(doc.prevSecretExpiresAt).toBeUndefined();
+  });
+
+  it('stores the device-secret fields when provided', () => {
+    const expiresAt = new Date();
+    const doc = new DeviceSession({ deviceId: 'd1', secretHash: 'h1', prevSecretHash: 'h0', prevSecretExpiresAt: expiresAt });
+    expect(doc.secretHash).toBe('h1');
+    expect(doc.prevSecretHash).toBe('h0');
+    expect(doc.prevSecretExpiresAt).toBe(expiresAt);
+  });
+
+  it('declares a sparse-unique index on secretHash (mirrors cookieKeyHash)', () => {
+    const indexes = DeviceSession.schema.indexes();
+    const secretIndex = indexes.find(([keys]) => keys.secretHash === 1);
+    expect(secretIndex).toBeDefined();
+    expect(secretIndex?.[1]).toMatchObject({ unique: true, sparse: true });
+  });
+
+  it('does NOT declare an index on the transient prev-secret fields', () => {
+    const indexes = DeviceSession.schema.indexes();
+    expect(indexes.some(([keys]) => keys.prevSecretHash !== undefined)).toBe(false);
+    expect(indexes.some(([keys]) => keys.prevSecretExpiresAt !== undefined)).toBe(false);
+  });
 });

--- a/packages/api/src/routes/__tests__/deviceAuth.test.ts
+++ b/packages/api/src/routes/__tests__/deviceAuth.test.ts
@@ -49,12 +49,14 @@ jest.mock('../../utils/internalSecret', () => ({
 const mockGetStateByCookieKey = jest.fn();
 const mockEnsureDeviceForCookie = jest.fn();
 const mockAddAccount = jest.fn();
+const mockIssueDeviceSecret = jest.fn();
 jest.mock('../../services/deviceSession.service', () => ({
   __esModule: true,
   default: {
     getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a),
     ensureDeviceForCookie: (...a: unknown[]) => mockEnsureDeviceForCookie(...a),
     addAccount: (...a: unknown[]) => mockAddAccount(...a),
+    issueDeviceSecret: (...a: unknown[]) => mockIssueDeviceSecret(...a),
   },
 }));
 
@@ -103,6 +105,7 @@ jest.mock('../../utils/logger', () => ({
 
 import deviceAuthRouter from '../deviceAuth';
 import { errorHandler } from '../../middleware/errorHandler';
+import { logger } from '../../utils/logger';
 
 interface Res {
   status: number;
@@ -476,5 +479,65 @@ describe('POST /auth/device/resolve', () => {
     expect(accounts).toHaveLength(1);
     expect(accounts[0]).toMatchObject({ sessionId: 's-good', accessToken: 'acc2' });
     expect(res.body.activeAccountId).toBe('u2');
+  });
+});
+
+describe('buildTokenBundle — cookie-lane telemetry + deviceSecret (phase 2c)', () => {
+  const sameSite = { host: 'api.oxy.so', origin: 'https://accounts.oxy.so' };
+
+  it('web-session: logs the cookie-lane mint and attaches the rotating deviceSecret', async () => {
+    mockGetStateByCookieKey.mockResolvedValueOnce({
+      deviceId: 'd1',
+      activeAccountId: 'u1',
+      accounts: [{ accountId: 'u1', sessionId: 's1' }],
+    });
+    mockValidateSessionById.mockResolvedValueOnce({ session: {} }); // resolveActiveSessionRef
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc', expiresAt: new Date(Date.now() + 60_000) });
+    // buildTokenBundle's own validate — the session carries its device binding.
+    mockValidateSessionById.mockResolvedValueOnce({ session: { deviceId: 'd1' }, user: { _id: 'u1', username: 'bob' } });
+    mockIssueDeviceSecret.mockResolvedValueOnce('ds-web-secret');
+
+    const res = await request('POST', '/auth/device/web-session', {
+      body: {},
+      headers: { ...sameSite, cookie: 'oxy_device=known' },
+    });
+
+    expect(res.status).toBe(200);
+    const session = (res.body.data as Record<string, unknown>).session as Record<string, unknown>;
+    expect(session.deviceSecret).toBe('ds-web-secret');
+    expect(mockIssueDeviceSecret).toHaveBeenCalledWith('d1');
+    expect(logger.info).toHaveBeenCalledWith('device.token.mint', { mint_source: 'cookie', deviceId: 'd1' });
+  });
+
+  it('exchange: logs the cookie-lane mint and includes the deviceSecret in the bundle', async () => {
+    mockRedeemBootCode.mockResolvedValueOnce({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc', expiresAt: new Date(Date.now() + 60_000) });
+    mockValidateSessionById.mockResolvedValueOnce({ session: { deviceId: 'd2' }, user: { _id: 'u1', username: 'bob' } });
+    mockIssueDeviceSecret.mockResolvedValueOnce('ds-exch-secret');
+
+    const res = await request('POST', '/auth/device/exchange', {
+      body: { code: 'boot-code-abcdefghijklmnopqrst' },
+      headers: { origin: 'https://mention.earth' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.deviceSecret).toBe('ds-exch-secret');
+    expect(logger.info).toHaveBeenCalledWith('device.token.mint', { mint_source: 'cookie', deviceId: 'd2' });
+  });
+
+  it('omits the deviceSecret and does NOT log when the session carries no device binding', async () => {
+    mockRedeemBootCode.mockResolvedValueOnce({ sessionId: 's1', userId: 'u1', clientOrigin: 'https://mention.earth' });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'acc', expiresAt: new Date(Date.now() + 60_000) });
+    mockValidateSessionById.mockResolvedValueOnce({ session: {}, user: { _id: 'u1', username: 'bob' } });
+
+    const res = await request('POST', '/auth/device/exchange', {
+      body: { code: 'boot-code-abcdefghijklmnopqrst' },
+      headers: { origin: 'https://mention.earth' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.deviceSecret).toBeUndefined();
+    expect(mockIssueDeviceSecret).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith('device.token.mint', expect.anything());
   });
 });

--- a/packages/api/src/routes/__tests__/sessionClaim.test.ts
+++ b/packages/api/src/routes/__tests__/sessionClaim.test.ts
@@ -124,6 +124,15 @@ jest.mock('../../models/RefreshToken', () => ({
   RefreshToken: { findOne: jest.fn(), findOneAndUpdate: jest.fn(), create: jest.fn(), updateMany: jest.fn() },
 }));
 
+// The claim handler now (phase 2c) dynamically imports deviceSessionService to
+// additively mint a rotating deviceSecret. Mock it — default: no secret (the
+// device carries no doc), so the base response shape is unchanged.
+const mockIssueDeviceSecret = jest.fn();
+jest.mock('../../services/deviceSession.service', () => {
+  const svc = { issueDeviceSecret: (...a: unknown[]) => mockIssueDeviceSecret(...a) };
+  return { __esModule: true, default: svc, deviceSessionService: svc };
+});
+
 jest.mock('../../utils/userTransform', () => ({
   formatUserResponse: (...args: unknown[]) => mockFormatUserResponse(...args),
 }));
@@ -342,6 +351,70 @@ describe('POST /auth/session/claim', () => {
     expect(res.body.data.refreshToken).not.toBe('refresh-jwt');
     expect(res.body.data.refreshToken.length).toBeGreaterThan(0);
     expect(mockGetAccessToken).toHaveBeenCalledWith(sessionId);
+    // No device doc for this session → no deviceSecret in the base response.
+    expect(res.body.data.deviceSecret).toBeUndefined();
+  });
+
+  it('includes a rotating deviceSecret when the claimed session carries a device doc (phase 2c)', async () => {
+    const userId = '64f7c2a1b8e9d3f4a1c2b3d4';
+    const sessionId = 'sess-with-device';
+    const expiresAt = new Date(Date.now() + 60_000);
+
+    mockClaimAuthSession.mockResolvedValueOnce({
+      ok: true,
+      authSession: {
+        sessionToken: 'good-token',
+        authorizedSessionId: sessionId,
+        authorizedUserId: { toString: () => userId },
+        applicationId: { toString: () => '64f7c2a1b8e9d3f4a1c2b3ab' },
+      },
+    });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'access-jwt', expiresAt });
+    mockUserFindById.mockReturnValueOnce({ lean: jest.fn().mockResolvedValue({ _id: userId, username: 'alice' }) });
+    mockSessionFindOne.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ deviceId: 'dev-9', expiresAt: new Date(Date.now() + 60 * 60 * 1000) }),
+      }),
+    });
+    mockFormatUserResponse.mockReturnValueOnce({ id: userId, username: 'alice' });
+    mockIssueDeviceSecret.mockResolvedValueOnce('claim-device-secret');
+
+    const res = await requestJson(server, 'POST', '/auth/session/claim', { sessionToken: 'good-token' });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueDeviceSecret).toHaveBeenCalledWith('dev-9');
+    expect(res.body.data.deviceSecret).toBe('claim-device-secret');
+  });
+
+  it('still succeeds without a deviceSecret when the mint throws (best-effort)', async () => {
+    const userId = '64f7c2a1b8e9d3f4a1c2b3d4';
+    const sessionId = 'sess-mint-fail';
+    const expiresAt = new Date(Date.now() + 60_000);
+
+    mockClaimAuthSession.mockResolvedValueOnce({
+      ok: true,
+      authSession: {
+        sessionToken: 'good-token',
+        authorizedSessionId: sessionId,
+        authorizedUserId: { toString: () => userId },
+        applicationId: { toString: () => '64f7c2a1b8e9d3f4a1c2b3ab' },
+      },
+    });
+    mockGetAccessToken.mockResolvedValueOnce({ accessToken: 'access-jwt', expiresAt });
+    mockUserFindById.mockReturnValueOnce({ lean: jest.fn().mockResolvedValue({ _id: userId, username: 'alice' }) });
+    mockSessionFindOne.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue({ deviceId: 'dev-9', expiresAt: new Date(Date.now() + 60 * 60 * 1000) }),
+      }),
+    });
+    mockFormatUserResponse.mockReturnValueOnce({ id: userId, username: 'alice' });
+    mockIssueDeviceSecret.mockRejectedValueOnce(new Error('db down'));
+
+    const res = await requestJson(server, 'POST', '/auth/session/claim', { sessionToken: 'good-token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.accessToken).toBe('access-jwt');
+    expect(res.body.data.deviceSecret).toBeUndefined();
   });
 
   it('rejects with 401 if the access token cannot be issued', async () => {

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -14,6 +14,11 @@ const mockGetSession = jest.fn();
 const mockGetStateByCookieKey = jest.fn();
 const mockConvergeAccountOntoDevice = jest.fn();
 const mockMigrateSessionToDevice = jest.fn();
+const mockGetStateBySecret = jest.fn();
+const mockIssueDeviceSecret = jest.fn();
+const mockIsLockedOut = jest.fn();
+const mockRecordFailure = jest.fn();
+const mockClearFailures = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (...a: unknown[]) => mockAuthMiddleware(...a),
@@ -36,6 +41,8 @@ jest.mock('../../services/deviceSession.service', () => ({
     resolveActiveToken: (...a: unknown[]) => mockResolveActiveToken(...a),
     getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a),
     convergeAccountOntoDevice: (...a: unknown[]) => mockConvergeAccountOntoDevice(...a),
+    getStateBySecret: (...a: unknown[]) => mockGetStateBySecret(...a),
+    issueDeviceSecret: (...a: unknown[]) => mockIssueDeviceSecret(...a),
   },
 }));
 jest.mock('../../services/session.service', () => ({
@@ -45,11 +52,17 @@ jest.mock('../../services/session.service', () => ({
     migrateSessionToDevice: (...a: unknown[]) => mockMigrateSessionToDevice(...a),
   },
 }));
+jest.mock('../../services/loginLockout.service', () => ({
+  isLockedOut: (...a: unknown[]) => mockIsLockedOut(...a),
+  recordFailure: (...a: unknown[]) => mockRecordFailure(...a),
+  clearFailures: (...a: unknown[]) => mockClearFailures(...a),
+}));
 jest.mock('../../utils/socket', () => ({ broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a) }));
 jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
 
 import sessionDeviceRouter from '../sessionDevice';
 import { errorHandler } from '../../middleware/errorHandler';
+import { logger } from '../../utils/logger';
 
 const STATE = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 1, updatedAt: 1720000000000 };
 
@@ -84,6 +97,10 @@ beforeEach(() => {
   // Default to an active first-party session; individual tests override this
   // to exercise managed sessions or the expired/revoked (null) 401 path.
   mockGetSession.mockResolvedValue({ operatedByUserId: null });
+  // Default: device is not locked out. Tests override for the 429 path.
+  mockIsLockedOut.mockResolvedValue({ locked: false, attempts: 0 });
+  mockRecordFailure.mockResolvedValue({ locked: false, attempts: 1 });
+  mockClearFailures.mockResolvedValue(undefined);
 });
 
 describe('GET /session/device/state', () => {
@@ -304,5 +321,93 @@ describe('POST /session/device/add — cookie-device convergence', () => {
     expect(mockGetStateByCookieKey).not.toHaveBeenCalled();
     expect(mockConvergeAccountOntoDevice).not.toHaveBeenCalled();
     expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
+  });
+});
+
+describe('POST /session/device/token (phase 2c — public deviceSecret mint)', () => {
+  const SECRET_STATE = {
+    deviceId: 'd1',
+    accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }],
+    activeAccountId: 'a1',
+    revision: 3,
+    updatedAt: 1720000000000,
+  };
+
+  it('mints a short access token and rotates the device secret on a valid secret', async () => {
+    mockGetStateBySecret.mockResolvedValueOnce(SECRET_STATE);
+    mockResolveActiveToken.mockResolvedValueOnce({ accessToken: 'jwt-mint', expiresAt: '2026-07-07T00:00:00.000Z' });
+    mockIssueDeviceSecret.mockResolvedValueOnce('next-secret-value');
+
+    const res = await requestJson(server, 'POST', '/session/device/token', { deviceId: 'd1', deviceSecret: 'raw-secret' });
+
+    expect(res.status).toBe(200);
+    expect(mockGetStateBySecret).toHaveBeenCalledWith('d1', 'raw-secret');
+    expect(mockClearFailures).toHaveBeenCalledWith({ scope: 'device-token', identifier: 'd1' });
+    expect(mockIssueDeviceSecret).toHaveBeenCalledWith('d1');
+    expect(res.body.data).toEqual({
+      accessToken: 'jwt-mint',
+      expiresAt: '2026-07-07T00:00:00.000Z',
+      nextDeviceSecret: 'next-secret-value',
+      state: SECRET_STATE,
+    });
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+    // Telemetry: the mint is attributed to the secret lane.
+    expect(logger.info).toHaveBeenCalledWith('device.token.mint', { mint_source: 'secret', deviceId: 'd1' });
+  });
+
+  it('401 invalid_device_secret and records a failure on an unknown/mismatched secret', async () => {
+    mockGetStateBySecret.mockResolvedValueOnce(null);
+
+    const res = await requestJson(server, 'POST', '/session/device/token', { deviceId: 'd1', deviceSecret: 'bad' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('invalid_device_secret');
+    expect(mockRecordFailure).toHaveBeenCalledWith({ scope: 'device-token', identifier: 'd1' });
+    expect(mockIssueDeviceSecret).not.toHaveBeenCalled();
+    expect(mockClearFailures).not.toHaveBeenCalled();
+  });
+
+  it('429 when the device is locked out — never touches the secret', async () => {
+    mockIsLockedOut.mockResolvedValueOnce({ locked: true, retryAfterSeconds: 42, attempts: 5 });
+
+    const res = await requestJson(server, 'POST', '/session/device/token', { deviceId: 'd1', deviceSecret: 'x' });
+
+    expect(res.status).toBe(429);
+    expect(mockGetStateBySecret).not.toHaveBeenCalled();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+  });
+
+  it('401 no_active_session WITHOUT rotating when the secret is valid but the session is dead', async () => {
+    mockGetStateBySecret.mockResolvedValueOnce(SECRET_STATE);
+    mockResolveActiveToken.mockResolvedValueOnce(null);
+
+    const res = await requestJson(server, 'POST', '/session/device/token', { deviceId: 'd1', deviceSecret: 'raw-secret' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('no_active_session');
+    // Valid secret → failures cleared, but the secret is NOT rotated: the client
+    // must re-auth and keeps its still-valid secret.
+    expect(mockClearFailures).toHaveBeenCalledWith({ scope: 'device-token', identifier: 'd1' });
+    expect(mockIssueDeviceSecret).not.toHaveBeenCalled();
+    expect(mockRecordFailure).not.toHaveBeenCalled();
+  });
+
+  it('accepts an in-grace (previous) secret — the route trusts getStateBySecret and rotates', async () => {
+    mockGetStateBySecret.mockResolvedValueOnce(SECRET_STATE);
+    mockResolveActiveToken.mockResolvedValueOnce({ accessToken: 'jwt-grace', expiresAt: '2026-07-07T00:00:00.000Z' });
+    mockIssueDeviceSecret.mockResolvedValueOnce('rotated-again');
+
+    const res = await requestJson(server, 'POST', '/session/device/token', { deviceId: 'd1', deviceSecret: 'previous-secret' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.accessToken).toBe('jwt-grace');
+    expect(res.body.data.nextDeviceSecret).toBe('rotated-again');
+  });
+
+  it('400 when the body shape is invalid (missing deviceSecret)', async () => {
+    const res = await requestJson(server, 'POST', '/session/device/token', { deviceId: 'd1' });
+    expect(res.status).toBe(400);
+    expect(mockGetStateBySecret).not.toHaveBeenCalled();
+    expect(mockIsLockedOut).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1575,6 +1575,22 @@ router.post(
 
     const userData = formatUserResponse(user);
 
+    // Additive 2c mint: when the claimed session's device carries a
+    // `DeviceSession` doc, hand the client a rotating `deviceSecret` so it can
+    // migrate onto the zero-cookie lane. Best-effort — a mint failure never fails
+    // the claim, and a device with no doc simply omits the secret.
+    let deviceSecret: string | undefined;
+    try {
+      const { deviceSessionService } = await import('../services/deviceSession.service.js');
+      const minted = await deviceSessionService.issueDeviceSecret(session.deviceId);
+      if (minted) deviceSecret = minted;
+    } catch (error) {
+      logger.warn('[AuthSession] deviceSecret mint failed on claim', {
+        sessionId: authSession.authorizedSessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     logger.info('[AuthSession] Claim succeeded', {
       sessionToken: sessionToken.substring(0, 8) + '...',
       sessionId: authSession.authorizedSessionId,
@@ -1589,6 +1605,7 @@ router.post(
       deviceId: session.deviceId,
       expiresAt: tokenResult.expiresAt.toISOString(),
       user: userData,
+      ...(deviceSecret ? { deviceSecret } : {}),
     });
   })
 );

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1581,9 +1581,11 @@ router.post(
     // the claim, and a device with no doc simply omits the secret.
     let deviceSecret: string | undefined;
     try {
-      const { deviceSessionService } = await import('../services/deviceSession.service.js');
-      const minted = await deviceSessionService.issueDeviceSecret(session.deviceId);
-      if (minted) deviceSecret = minted;
+      if (typeof session.deviceId === 'string' && session.deviceId.length > 0) {
+        const { deviceSessionService } = await import('../services/deviceSession.service.js');
+        const minted = await deviceSessionService.issueDeviceSecret(session.deviceId);
+        if (minted) deviceSecret = minted;
+      }
     } catch (error) {
       logger.warn('[AuthSession] deviceSecret mint failed on claim', {
         sessionId: authSession.authorizedSessionId,

--- a/packages/api/src/routes/deviceAuth.ts
+++ b/packages/api/src/routes/deviceAuth.ts
@@ -137,6 +137,7 @@ async function buildTokenBundle(
   refreshToken: string;
   expiresAt: string;
   user: SerializedUser;
+  deviceSecret?: string;
 } | null> {
   const tokenResult = await sessionService.getAccessToken(sessionId);
   if (!tokenResult) return null;
@@ -147,12 +148,26 @@ async function buildTokenBundle(
 
   const refresh = await issueRefreshToken({ sessionId, userId });
 
+  // Cookie-lane mint telemetry + additive deviceSecret (phase 2c). When the
+  // session is bound to a device doc, record the cookie-lane mint (feeds the
+  // `mint_source` cutover metric) and hand the client a rotating `deviceSecret`
+  // so it can migrate onto the zero-cookie lane. Best-effort: a device with no
+  // doc simply omits the secret.
+  const deviceId = resolved?.session?.deviceId;
+  let deviceSecret: string | undefined;
+  if (typeof deviceId === 'string' && deviceId.length > 0) {
+    logger.info('device.token.mint', { mint_source: 'cookie', deviceId });
+    const minted = await deviceSessionService.issueDeviceSecret(deviceId);
+    if (minted) deviceSecret = minted;
+  }
+
   return {
     sessionId,
     accessToken: tokenResult.accessToken,
     refreshToken: refresh.token,
     expiresAt: tokenResult.expiresAt.toISOString(),
     user,
+    ...(deviceSecret ? { deviceSecret } : {}),
   };
 }
 

--- a/packages/api/src/routes/deviceAuth.ts
+++ b/packages/api/src/routes/deviceAuth.ts
@@ -157,8 +157,15 @@ async function buildTokenBundle(
   let deviceSecret: string | undefined;
   if (typeof deviceId === 'string' && deviceId.length > 0) {
     logger.info('device.token.mint', { mint_source: 'cookie', deviceId });
-    const minted = await deviceSessionService.issueDeviceSecret(deviceId);
-    if (minted) deviceSecret = minted;
+    try {
+      const minted = await deviceSessionService.issueDeviceSecret(deviceId);
+      if (minted) deviceSecret = minted;
+    } catch (error) {
+      logger.warn('buildTokenBundle: deviceSecret mint failed (best-effort)', {
+        deviceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   return {

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -1,15 +1,104 @@
-import { Router, Response } from 'express';
+import { Router, Request, Response } from 'express';
 import type { DeviceSessionState } from '@oxyhq/contracts';
+import { deviceTokenMintRequestSchema } from '@oxyhq/contracts';
 import { authMiddleware, AuthRequest } from '../middleware/auth';
 import { requireSameSiteOrigin } from '../middleware/originGuard';
 import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
+import { rateLimit } from '../middleware/rateLimiter';
+import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
 import deviceSessionService from '../services/deviceSession.service';
 import sessionService from '../services/session.service';
 import { broadcastDeviceState } from '../utils/socket';
 import { readDeviceCookie } from '../utils/deviceCookie';
 import { asyncHandler } from '../utils/asyncHandler';
+import { logger } from '../utils/logger';
 
 const router = Router();
+
+/** Lockout scope for the public deviceSecret mint (per-deviceId sliding window). */
+const DEVICE_TOKEN_LOCKOUT_SCOPE = 'device-token';
+
+const deviceTokenLimiter = rateLimit({
+  prefix: 'rl:session:device-token:',
+  windowMs: 60_000,
+  max: 30,
+});
+
+/**
+ * POST /session/device/token — the phase-2c zero-cookie mint.
+ *
+ * PUBLIC by design and mounted ABOVE the router-wide
+ * `requireSameSiteOrigin, authMiddleware` below: it carries NO bearer and NO
+ * cookies. The client presents the `deviceId` it stored first-party plus the
+ * opaque `deviceSecret`; possession of the secret IS the ownership proof, so the
+ * mint can be initiated from any registered cross-apex origin over normal CORS.
+ *
+ * On a valid secret it mints a short access token for the device's active
+ * account and ROTATES the secret in-use (returns `nextDeviceSecret`; the
+ * presented secret stays valid for a short grace so multi-tab races don't lock
+ * out). A dead/absent active session returns `no_active_session` WITHOUT rotating
+ * — the client must re-authenticate and keeps its still-valid secret. Per-device
+ * lockout + rate limiting blunt online secret-guessing.
+ */
+router.post(
+  '/token',
+  deviceTokenLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = deviceTokenMintRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({ error: 'deviceId and deviceSecret are required' });
+      return;
+    }
+    const { deviceId, deviceSecret } = parsed.data;
+
+    const lockout = await isLockedOut({ scope: DEVICE_TOKEN_LOCKOUT_SCOPE, identifier: deviceId });
+    if (lockout.locked) {
+      if (typeof lockout.retryAfterSeconds === 'number') {
+        res.setHeader('Retry-After', String(lockout.retryAfterSeconds));
+      }
+      res.status(429).json({ error: 'Too many attempts' });
+      return;
+    }
+
+    const state = await deviceSessionService.getStateBySecret(deviceId, deviceSecret);
+    if (!state) {
+      await recordFailure({ scope: DEVICE_TOKEN_LOCKOUT_SCOPE, identifier: deviceId });
+      res.status(401).json({ error: 'invalid_device_secret' });
+      return;
+    }
+
+    // The secret matched — clear the failure counter regardless of whether the
+    // device currently has a live active session.
+    await clearFailures({ scope: DEVICE_TOKEN_LOCKOUT_SCOPE, identifier: deviceId });
+
+    const activeToken = await deviceSessionService.resolveActiveToken(state);
+    if (!activeToken) {
+      // Known device, but no live active session to mint for. Do NOT rotate — the
+      // client re-authenticates and keeps its still-valid secret.
+      res.status(401).json({ error: 'no_active_session' });
+      return;
+    }
+
+    const nextDeviceSecret = await deviceSessionService.issueDeviceSecret(deviceId);
+    if (!nextDeviceSecret) {
+      // The device doc vanished between resolve and rotate (should not happen for
+      // a live session). Fail closed rather than return a secret-less response.
+      logger.error('device.token.mint could not rotate the device secret', new Error('rotation failed'), { deviceId });
+      res.status(500).json({ error: 'Internal server error' });
+      return;
+    }
+
+    logger.info('device.token.mint', { mint_source: 'secret', deviceId });
+    res.json({
+      data: {
+        accessToken: activeToken.accessToken,
+        expiresAt: activeToken.expiresAt,
+        nextDeviceSecret,
+        state,
+      },
+    });
+  }),
+);
 
 async function withActiveToken(state: DeviceSessionState) {
   const activeToken = await deviceSessionService.resolveActiveToken(state);

--- a/packages/api/src/services/__tests__/deviceLogin.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceLogin.service.test.ts
@@ -14,11 +14,13 @@ import type { Request } from 'express';
 const mockGetStateByCookieKey = jest.fn();
 const mockAddAccount = jest.fn();
 const mockEnsureDeviceForCookie = jest.fn();
+const mockIssueDeviceSecret = jest.fn();
 jest.mock('../deviceSession.service', () => {
   const svc = {
     getStateByCookieKey: (...a: unknown[]) => mockGetStateByCookieKey(...a),
     addAccount: (...a: unknown[]) => mockAddAccount(...a),
     ensureDeviceForCookie: (...a: unknown[]) => mockEnsureDeviceForCookie(...a),
+    issueDeviceSecret: (...a: unknown[]) => mockIssueDeviceSecret(...a),
   };
   // deviceLogin.service dynamically imports the NAMED `deviceSessionService`.
   return { __esModule: true, default: svc, deviceSessionService: svc };
@@ -165,6 +167,72 @@ describe('finalizeDeviceLogin — device registration (add-only)', () => {
       { accountId: 'org1', sessionId: 's-org', operatedByUserId: 'op1' },
       { activate: 'if-empty' },
     );
+  });
+});
+
+describe('finalizeDeviceLogin — deviceSecret emission (phase 2c)', () => {
+  it('mints and attaches a rotating deviceSecret when a device binding resolved', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: { deviceId: 'd1' }, changed: true });
+    mockIssueDeviceSecret.mockResolvedValueOnce('ds-first');
+
+    const extras = await finalizeDeviceLogin({
+      req: req(),
+      deviceId: 'd1',
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+
+    // Bound to the session's (just-registered) device.
+    expect(mockIssueDeviceSecret).toHaveBeenCalledWith('d1');
+    expect(extras.deviceSecret).toBe('ds-first');
+    expect(extras.refreshToken).toBe('rt');
+  });
+
+  it('does NOT emit a deviceSecret when there is no device binding', async () => {
+    const extras = await finalizeDeviceLogin({
+      req: req(),
+      deviceId: null,
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+    expect(mockIssueDeviceSecret).not.toHaveBeenCalled();
+    expect(extras.deviceSecret).toBeUndefined();
+  });
+
+  it('two successive sign-ins rotate to DIFFERENT device secrets', async () => {
+    mockAddAccount.mockResolvedValue({ state: {}, changed: false });
+    mockIssueDeviceSecret.mockResolvedValueOnce('ds-A').mockResolvedValueOnce('ds-B');
+
+    const first = await finalizeDeviceLogin({
+      req: req(),
+      deviceId: 'd1',
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+    const second = await finalizeDeviceLogin({
+      req: req(),
+      deviceId: 'd1',
+      session: { sessionId: 's2', deviceId: 'd1' },
+      userId: 'u1',
+    });
+
+    expect(first.deviceSecret).toBe('ds-A');
+    expect(second.deviceSecret).toBe('ds-B');
+  });
+
+  it('still returns the refresh token when the deviceSecret mint fails (best-effort)', async () => {
+    mockAddAccount.mockResolvedValueOnce({ state: { deviceId: 'd1' }, changed: true });
+    mockIssueDeviceSecret.mockRejectedValueOnce(new Error('db down'));
+
+    const extras = await finalizeDeviceLogin({
+      req: req(),
+      deviceId: 'd1',
+      session: { sessionId: 's1', deviceId: 'd1' },
+      userId: 'u1',
+    });
+
+    expect(extras.deviceSecret).toBeUndefined();
+    expect(extras.refreshToken).toBe('rt');
   });
 });
 

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -41,6 +41,12 @@ jest.mock('../oauthCode.service', () => {
   return {
     sha256Hex: (value: string) => nodeCrypto.createHash('sha256').update(value).digest('hex'),
     base64UrlEncode: (buf: Buffer) => buf.toString('base64url'),
+    timingSafeStringEqual: (a: string, b: string) => {
+      const ab = Buffer.from(a);
+      const bb = Buffer.from(b);
+      if (ab.length !== bb.length) return false;
+      return nodeCrypto.timingSafeEqual(ab, bb);
+    },
   };
 });
 
@@ -661,6 +667,177 @@ describe('getStateByCookieKey', () => {
     mockFindOne.mockReturnValueOnce(lean(null));
     expect(await deviceSessionService.getStateByCookieKey('unknown')).toBeNull();
     expect(await deviceSessionService.getStateByCookieKey('')).toBeNull();
+  });
+});
+
+describe('issueDeviceSecret', () => {
+  it('mints a fresh secret and stores only its hash — no prior secret means no prev fields', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0 }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({ deviceId: 'd1' }));
+
+    const secret = await deviceSessionService.issueDeviceSecret('d1');
+
+    expect(typeof secret).toBe('string');
+    expect((secret as string).length).toBeGreaterThan(20);
+    const [filter, update] = mockFindOneAndUpdate.mock.calls[0];
+    expect(filter).toEqual({ deviceId: 'd1' });
+    // Only the HASH of the returned secret is stored, never the raw value.
+    expect(update.$set.secretHash).toBe(nodeCrypto.createHash('sha256').update(secret as string).digest('hex'));
+    expect(update.$set.secretHash).not.toBe(secret);
+    // First issuance → no previous secret to grace.
+    expect(update.$set.prevSecretHash).toBeUndefined();
+    expect(update.$set.prevSecretExpiresAt).toBeUndefined();
+  });
+
+  it('rotates: moves the existing secret to prev with a ~60s grace expiry and sets the new secret', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 0, secretHash: 'OLDHASH' }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({ deviceId: 'd1' }));
+
+    const before = Date.now();
+    const secret = await deviceSessionService.issueDeviceSecret('d1');
+    const after = Date.now();
+
+    const [, update] = mockFindOneAndUpdate.mock.calls[0];
+    // The just-superseded secret stays valid for a short grace (rotation-in-use).
+    expect(update.$set.prevSecretHash).toBe('OLDHASH');
+    expect(update.$set.prevSecretExpiresAt).toBeInstanceOf(Date);
+    const graceExpiry = (update.$set.prevSecretExpiresAt as Date).getTime();
+    expect(graceExpiry).toBeGreaterThanOrEqual(before + 60_000);
+    expect(graceExpiry).toBeLessThanOrEqual(after + 60_000);
+    expect(update.$set.secretHash).toBe(nodeCrypto.createHash('sha256').update(secret as string).digest('hex'));
+    // The new secret differs from the old hash it replaced.
+    expect(update.$set.secretHash).not.toBe('OLDHASH');
+  });
+
+  it('two successive mints return DIFFERENT secrets (each mint rotates)', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], revision: 0 }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({ deviceId: 'd1' }));
+    const first = await deviceSessionService.issueDeviceSecret('d1');
+
+    // Second mint sees the (now-stored) first secret as current.
+    const firstHash = nodeCrypto.createHash('sha256').update(first as string).digest('hex');
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], revision: 0, secretHash: firstHash }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({ deviceId: 'd1' }));
+    const second = await deviceSessionService.issueDeviceSecret('d1');
+
+    expect(second).not.toBe(first);
+    // The first secret is preserved as prev (grace) so a lagging tab still mints.
+    const [, secondUpdate] = mockFindOneAndUpdate.mock.calls[1];
+    expect(secondUpdate.$set.prevSecretHash).toBe(firstHash);
+  });
+
+  it('returns null when the device doc does not exist (never mints a secret bound to a phantom device)', async () => {
+    mockFindOne.mockReturnValueOnce(lean(null));
+    expect(await deviceSessionService.issueDeviceSecret('ghost')).toBeNull();
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the doc vanished between read and write', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], revision: 0 }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean(null));
+    expect(await deviceSessionService.issueDeviceSecret('d1')).toBeNull();
+  });
+});
+
+describe('getStateBySecret', () => {
+  const rawSecret = 'raw-device-secret-value';
+  const secretHash = nodeCrypto.createHash('sha256').update(rawSecret).digest('hex');
+
+  it('returns the projected state when the secret matches the current secretHash (constant-time)', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+      updatedAt: new Date(1720000000000),
+      secretHash,
+    }));
+    const state = await deviceSessionService.getStateBySecret('d1', rawSecret);
+    expect(state?.deviceId).toBe('d1');
+    expect(state?.activeAccountId).toBe('a1');
+    // Looked up by deviceId; the raw secret is never part of the query.
+    expect(mockFindOne).toHaveBeenCalledWith({ deviceId: 'd1' });
+  });
+
+  it('accepts the PREVIOUS secret within the grace window', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 1, updatedAt: new Date(1720000000000),
+      secretHash: 'CURRENTHASH', prevSecretHash: secretHash, prevSecretExpiresAt: new Date(Date.now() + 30_000),
+    }));
+    const state = await deviceSessionService.getStateBySecret('d1', rawSecret);
+    expect(state?.deviceId).toBe('d1');
+  });
+
+  it('rejects the previous secret once the grace window has expired', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 1, updatedAt: new Date(),
+      secretHash: 'CURRENTHASH', prevSecretHash: secretHash, prevSecretExpiresAt: new Date(Date.now() - 1_000),
+    }));
+    expect(await deviceSessionService.getStateBySecret('d1', rawSecret)).toBeNull();
+  });
+
+  it('returns null on a secret mismatch', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1', accounts: [], activeAccountId: null, revision: 1, updatedAt: new Date(),
+      secretHash: 'A-DIFFERENT-HASH',
+    }));
+    expect(await deviceSessionService.getStateBySecret('d1', rawSecret)).toBeNull();
+  });
+
+  it('returns null when the doc carries no secretHash at all', async () => {
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 1, updatedAt: new Date() }));
+    expect(await deviceSessionService.getStateBySecret('d1', rawSecret)).toBeNull();
+  });
+
+  it('returns null for an unknown device, and short-circuits (no query) for empty inputs', async () => {
+    mockFindOne.mockReturnValueOnce(lean(null));
+    expect(await deviceSessionService.getStateBySecret('d1', rawSecret)).toBeNull();
+    // Empty deviceId / empty secret never touch the DB.
+    expect(await deviceSessionService.getStateBySecret('d1', '')).toBeNull();
+    expect(await deviceSessionService.getStateBySecret('', rawSecret)).toBeNull();
+    expect(mockFindOne).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('signout — device-secret cleanup (2c)', () => {
+  it('signout-ALL unsets secretHash/prevSecretHash/prevSecretExpiresAt (cookieKeyHash left untouched)', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 }],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], activeAccountId: null, revision: 3 }));
+
+    await deviceSessionService.signout('d1', { all: true });
+
+    const [, update] = mockFindOneAndUpdate.mock.calls[0];
+    expect(update.$unset).toEqual({ secretHash: '', prevSecretHash: '', prevSecretExpiresAt: '' });
+    // The device cookie hash is NEVER cleared here — it lives until the cutover.
+    expect(update.$unset).not.toHaveProperty('cookieKeyHash');
+  });
+
+  it('single-account signout does NOT unset the device secret (other accounts on the device still use it)', async () => {
+    mockFindOne.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [
+        { accountId: { toString: () => 'a1' }, sessionId: 's1', authuser: 0 },
+        { accountId: { toString: () => 'a2' }, sessionId: 's2', authuser: 1 },
+      ],
+      activeAccountId: { toString: () => 'a1' },
+      revision: 2,
+    }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({
+      deviceId: 'd1',
+      accounts: [{ accountId: { toString: () => 'a2' }, sessionId: 's2', authuser: 1 }],
+      activeAccountId: { toString: () => 'a2' },
+      revision: 3,
+    }));
+
+    await deviceSessionService.signout('d1', { accountId: 'a1' });
+
+    const [, update] = mockFindOneAndUpdate.mock.calls[0];
+    expect(update.$unset).toBeUndefined();
   });
 });
 

--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -680,7 +680,8 @@ describe('issueDeviceSecret', () => {
     expect(typeof secret).toBe('string');
     expect((secret as string).length).toBeGreaterThan(20);
     const [filter, update] = mockFindOneAndUpdate.mock.calls[0];
-    expect(filter).toEqual({ deviceId: 'd1' });
+    // CAS filter: first issuance requires no secret to exist yet.
+    expect(filter).toEqual({ deviceId: 'd1', secretHash: { $exists: false } });
     // Only the HASH of the returned secret is stored, never the raw value.
     expect(update.$set.secretHash).toBe(nodeCrypto.createHash('sha256').update(secret as string).digest('hex'));
     expect(update.$set.secretHash).not.toBe(secret);
@@ -732,10 +733,39 @@ describe('issueDeviceSecret', () => {
     expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
   });
 
-  it('returns null when the doc vanished between read and write', async () => {
+  it('returns null when the doc vanished between read and write (CAS retry re-reads, doc gone)', async () => {
     mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], revision: 0 }));
     mockFindOneAndUpdate.mockReturnValueOnce(lean(null));
+    // Retry re-reads; doc is gone → give up.
+    mockFindOne.mockReturnValueOnce(lean(null));
     expect(await deviceSessionService.issueDeviceSecret('d1')).toBeNull();
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('lost CAS race retries once against the concurrent winner hash and succeeds', async () => {
+    // Attempt 1 reads OLDHASH but a concurrent mint wins the CAS → write matches nothing.
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], revision: 0, secretHash: 'OLDHASH' }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean(null));
+    // Attempt 2 re-reads the winner's hash and rotates on top of it.
+    mockFindOne.mockReturnValueOnce(lean({ deviceId: 'd1', accounts: [], revision: 0, secretHash: 'WINNERHASH' }));
+    mockFindOneAndUpdate.mockReturnValueOnce(lean({ deviceId: 'd1' }));
+
+    const secret = await deviceSessionService.issueDeviceSecret('d1');
+
+    expect(typeof secret).toBe('string');
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(2);
+    const [retryFilter, retryUpdate] = mockFindOneAndUpdate.mock.calls[1];
+    // The retry's CAS guard targets the hash it re-read, not the stale one.
+    expect(retryFilter).toEqual({ deviceId: 'd1', secretHash: 'WINNERHASH' });
+    expect(retryUpdate.$set.prevSecretHash).toBe('WINNERHASH');
+    expect(retryUpdate.$set.secretHash).toBe(nodeCrypto.createHash('sha256').update(secret as string).digest('hex'));
+  });
+
+  it('gives up after two lost CAS races (no unbounded retry loop)', async () => {
+    mockFindOne.mockReturnValue(lean({ deviceId: 'd1', accounts: [], revision: 0, secretHash: 'H' }));
+    mockFindOneAndUpdate.mockReturnValue(lean(null));
+    expect(await deviceSessionService.issueDeviceSecret('d1')).toBeNull();
+    expect(mockFindOneAndUpdate).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/api/src/services/deviceLogin.service.ts
+++ b/packages/api/src/services/deviceLogin.service.ts
@@ -119,7 +119,10 @@ function shouldReturnRotatingRefresh(req: Request, hasDeviceBinding: boolean): b
  * a rotating refresh token for the response when the lane allows it. Everything
  * is best-effort — a failure here never breaks the sign-in.
  *
- * Returns `{ refreshToken? }` to be merged additively into the auth response.
+ * Returns `{ refreshToken?, deviceSecret? }` to be merged additively into the
+ * auth response. `deviceSecret` (phase 2c) is emitted ONLY when a device binding
+ * resolved — the client persists it first-party and later mints access tokens via
+ * `POST /session/device/token` (zero-cookie lane).
  */
 export async function finalizeDeviceLogin(opts: {
   req: Request;
@@ -127,8 +130,10 @@ export async function finalizeDeviceLogin(opts: {
   session: { sessionId: string; deviceId: string };
   userId: string;
   operatedByUserId?: string;
-}): Promise<{ refreshToken?: string }> {
+}): Promise<{ refreshToken?: string; deviceSecret?: string }> {
   const { req, deviceId, session, userId, operatedByUserId } = opts;
+
+  const result: { refreshToken?: string; deviceSecret?: string } = {};
 
   if (deviceId) {
     try {
@@ -143,6 +148,11 @@ export async function finalizeDeviceLogin(opts: {
         { activate: 'if-empty' },
       );
       if (changed) broadcastDeviceState(state);
+      // Additive 2c mint: hand the client a rotating deviceSecret bound to the
+      // (just-registered) device so it can migrate onto the zero-cookie lane.
+      // Best-effort — a mint failure never breaks the sign-in.
+      const deviceSecret = await deviceSessionService.issueDeviceSecret(session.deviceId);
+      if (deviceSecret) result.deviceSecret = deviceSecret;
     } catch (error) {
       logger.warn('finalizeDeviceLogin: device registration failed', { userId, error });
     }
@@ -151,10 +161,10 @@ export async function finalizeDeviceLogin(opts: {
   if (shouldReturnRotatingRefresh(req, !!deviceId)) {
     try {
       const refresh = await issueRefreshToken({ sessionId: session.sessionId, userId });
-      return { refreshToken: refresh.token };
+      result.refreshToken = refresh.token;
     } catch (error) {
       logger.warn('finalizeDeviceLogin: refresh mint failed', { userId, error });
     }
   }
-  return {};
+  return result;
 }

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -4,8 +4,17 @@ import DeviceSession, { IDeviceSession, IDeviceSessionAccount } from '../models/
 import sessionService from './session.service';
 import { revokeAllFamiliesBySession } from './refreshToken.service';
 import { revokeDeviceTokens } from './deviceToken.service';
-import { sha256Hex, base64UrlEncode } from './oauthCode.service';
+import { sha256Hex, base64UrlEncode, timingSafeStringEqual } from './oauthCode.service';
 import { logger } from '../utils/logger';
+
+/** Number of random bytes in a raw `deviceSecret` (256-bit). */
+const DEVICE_SECRET_BYTES = 32;
+/**
+ * Grace window during which the just-superseded `deviceSecret` is still accepted
+ * after a rotation, so a multi-tab race presenting the previous secret is not
+ * locked out (rotation-in-use — mirrors the refresh-family single-use-with-grace).
+ */
+const DEVICE_SECRET_GRACE_MS = 60_000;
 
 function idToString(value: unknown): string | null {
   if (value === null || value === undefined) return null;
@@ -267,9 +276,18 @@ class DeviceSessionService {
     const remaining = allAccounts.filter((a) => !removingIds.has(idToString(a.accountId) ?? ''));
     const activeStillPresent = remaining.some((a) => idToString(a.accountId) === idToString(current.activeAccountId));
     const nextActive = activeStillPresent ? idToString(current.activeAccountId) : (remaining[0] ? idToString(remaining[0].accountId) : null);
+    // Signout-ALL also revokes the device's `deviceSecret` (phase 2c): clear the
+    // secret hashes so a retained secret can never later mint a token for the now-
+    // empty set. Single-account signout leaves the secret alone — other accounts
+    // on the SAME device still legitimately mint with it. `cookieKeyHash` is NEVER
+    // cleared here; it lives until the cookie-lane cutover.
     const updated = await DeviceSession.findOneAndUpdate(
       { deviceId },
-      { $set: { accounts: remaining, activeAccountId: nextActive }, $inc: { revision: 1 } },
+      {
+        $set: { accounts: remaining, activeAccountId: nextActive },
+        $inc: { revision: 1 },
+        ...('all' in target ? { $unset: { secretHash: '', prevSecretHash: '', prevSecretExpiresAt: '' } } : {}),
+      },
       { new: true, upsert: true },
     ).lean<IDeviceSession>();
     return projectState(updated as IDeviceSession);
@@ -391,6 +409,74 @@ class DeviceSessionService {
       cookieKeyHash,
     });
     return { deviceId, rawCookieKey };
+  }
+
+  /**
+   * Issue (rotating) the `deviceSecret` bound to a device (phase 2c — zero-cookie
+   * transport). Mints a fresh 256-bit secret, stores only its `sha256` in
+   * `secretHash`, and — when a prior secret existed — moves that prior hash into
+   * `prevSecretHash` with a short `prevSecretExpiresAt` grace so a concurrent tab
+   * presenting the just-superseded secret is not locked out (rotation-in-use).
+   *
+   * The WRITE is a single atomic `findOneAndUpdate`; the grace window (not a lock)
+   * is the multi-tab concurrency mitigation — mirroring the refresh family. The
+   * raw secret is returned to the caller EXACTLY ONCE and is NEVER logged.
+   *
+   * Returns null when no `DeviceSession` doc exists for `deviceId` (or it vanished
+   * between read and write): a secret is only ever bound to a real device doc,
+   * never to a phantom device (no upsert).
+   */
+  async issueDeviceSecret(deviceId: string): Promise<string | null> {
+    const current = await DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
+    if (!current) return null;
+
+    const rawSecret = base64UrlEncode(crypto.randomBytes(DEVICE_SECRET_BYTES));
+    const secretHash = sha256Hex(rawSecret);
+
+    const set: { secretHash: string; prevSecretHash?: string; prevSecretExpiresAt?: Date } = { secretHash };
+    if (current.secretHash) {
+      set.prevSecretHash = current.secretHash;
+      set.prevSecretExpiresAt = new Date(Date.now() + DEVICE_SECRET_GRACE_MS);
+    }
+
+    const updated = await DeviceSession.findOneAndUpdate(
+      { deviceId },
+      { $set: set },
+      { new: true },
+    ).lean<IDeviceSession>();
+    if (!updated) return null;
+
+    return rawSecret;
+  }
+
+  /**
+   * Resolve the `DeviceSessionState` bound to a raw `deviceSecret` (phase 2c). The
+   * secret is hashed and matched — constant-time — against the device's current
+   * `secretHash` OR, within the grace window, its `prevSecretHash`. Returns null
+   * when the device is unknown, carries no secret, or the secret does not match
+   * (possession of the deviceId alone reveals nothing).
+   */
+  async getStateBySecret(deviceId: string, rawSecret: string): Promise<DeviceSessionState | null> {
+    if (typeof deviceId !== 'string' || deviceId.length === 0) return null;
+    if (typeof rawSecret !== 'string' || rawSecret.length === 0) return null;
+
+    const doc = await DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
+    if (!doc) return null;
+
+    const hash = sha256Hex(rawSecret);
+    if (typeof doc.secretHash === 'string' && doc.secretHash.length > 0 && timingSafeStringEqual(hash, doc.secretHash)) {
+      return projectState(doc);
+    }
+    if (
+      typeof doc.prevSecretHash === 'string' &&
+      doc.prevSecretHash.length > 0 &&
+      doc.prevSecretExpiresAt instanceof Date &&
+      doc.prevSecretExpiresAt.getTime() > Date.now() &&
+      timingSafeStringEqual(hash, doc.prevSecretHash)
+    ) {
+      return projectState(doc);
+    }
+    return null;
   }
 
   /**

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -427,26 +427,35 @@ class DeviceSessionService {
    * never to a phantom device (no upsert).
    */
   async issueDeviceSecret(deviceId: string): Promise<string | null> {
-    const current = await DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
-    if (!current) return null;
+    // Two concurrent rotations (multi-tab mint, parallel sign-ins) must not
+    // clobber each other: last-writer-wins would drop the first writer's fresh
+    // secret entirely (neither current nor prev). Compare-and-swap on the
+    // secretHash we read; on a lost race, re-read once and rotate on top of the
+    // winner — the winner's secret then sits in the grace slot, so BOTH clients
+    // end up holding a mintable secret.
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const current = await DeviceSession.findOne({ deviceId }).lean<IDeviceSession>();
+      if (!current) return null;
 
-    const rawSecret = base64UrlEncode(crypto.randomBytes(DEVICE_SECRET_BYTES));
-    const secretHash = sha256Hex(rawSecret);
+      const rawSecret = base64UrlEncode(crypto.randomBytes(DEVICE_SECRET_BYTES));
+      const secretHash = sha256Hex(rawSecret);
 
-    const set: { secretHash: string; prevSecretHash?: string; prevSecretExpiresAt?: Date } = { secretHash };
-    if (current.secretHash) {
-      set.prevSecretHash = current.secretHash;
-      set.prevSecretExpiresAt = new Date(Date.now() + DEVICE_SECRET_GRACE_MS);
+      const set: { secretHash: string; prevSecretHash?: string; prevSecretExpiresAt?: Date } = { secretHash };
+      if (current.secretHash) {
+        set.prevSecretHash = current.secretHash;
+        set.prevSecretExpiresAt = new Date(Date.now() + DEVICE_SECRET_GRACE_MS);
+      }
+
+      const updated = await DeviceSession.findOneAndUpdate(
+        current.secretHash
+          ? { deviceId, secretHash: current.secretHash }
+          : { deviceId, secretHash: { $exists: false } },
+        { $set: set },
+        { new: true },
+      ).lean<IDeviceSession>();
+      if (updated) return rawSecret;
     }
-
-    const updated = await DeviceSession.findOneAndUpdate(
-      { deviceId },
-      { $set: set },
-      { new: true },
-    ).lean<IDeviceSession>();
-    if (!updated) return null;
-
-    return rawSecret;
+    return null;
   }
 
   /**

--- a/packages/contracts/src/__tests__/deviceBoot.test.ts
+++ b/packages/contracts/src/__tests__/deviceBoot.test.ts
@@ -141,6 +141,17 @@ describe('authTokenBundleSchema', () => {
         const { refreshToken, ...noRefresh } = bundle;
         expect(safeParseContract(authTokenBundleSchema, noRefresh)).toBeNull();
     });
+
+    it('parses a bundle carrying the optional deviceSecret (2c additive mint)', () => {
+        const withSecret: AuthTokenBundle = { ...bundle, deviceSecret: 'ds_first_secret' };
+        const parsed = safeParseContract(authTokenBundleSchema, withSecret);
+        expect(parsed?.deviceSecret).toBe('ds_first_secret');
+    });
+
+    it('parses a bundle WITHOUT deviceSecret (optional — cookie-lane bundles omit it)', () => {
+        const parsed = safeParseContract(authTokenBundleSchema, bundle);
+        expect(parsed && 'deviceSecret' in parsed).toBe(false);
+    });
 });
 
 describe('webSessionResultSchema (reason-discriminated union)', () => {
@@ -257,6 +268,19 @@ describe('loginResultSchema (union discrimination)', () => {
             user: { id: 'u1' },
         };
         expect(safeParseContract(loginResultSchema, session)).not.toBeNull();
+    });
+
+    it('parses the session arm carrying the optional deviceSecret (2c additive mint)', () => {
+        const session: LoginResult = {
+            sessionId: 's1',
+            deviceId: 'd1',
+            expiresAt: '2026-07-07T00:00:00.000Z',
+            accessToken: 'jwt.access',
+            deviceSecret: 'ds_first_secret',
+            user: { id: 'u1', username: 'nate' },
+        };
+        const parsed = safeParseContract(loginResultSchema, session);
+        expect(parsed && 'deviceSecret' in parsed && parsed.deviceSecret).toBe('ds_first_secret');
     });
 
     it('rejects a 2FA arm with twoFactorRequired: false', () => {

--- a/packages/contracts/src/__tests__/deviceSession.test.ts
+++ b/packages/contracts/src/__tests__/deviceSession.test.ts
@@ -1,4 +1,4 @@
-import { deviceSessionStateSchema, sessionAccountSchema, deviceSessionSyncSchema, safeParseContract } from '../index';
+import { deviceSessionStateSchema, sessionAccountSchema, deviceSessionSyncSchema, deviceTokenMintRequestSchema, deviceTokenMintResponseSchema, safeParseContract } from '../index';
 
 describe('deviceSessionStateSchema', () => {
   const account = { accountId: 'a1', sessionId: 's1', authuser: 0 };
@@ -39,5 +39,44 @@ describe('deviceSessionSyncSchema', () => {
   });
   it('rejects a state-less sync', () => {
     expect(safeParseContract(deviceSessionSyncSchema, { activeToken: null })).toBeNull();
+  });
+});
+
+describe('deviceTokenMintRequestSchema', () => {
+  it('parses a valid { deviceId, deviceSecret }', () => {
+    const v = { deviceId: 'd1', deviceSecret: 'secret_abc' };
+    expect(safeParseContract(deviceTokenMintRequestSchema, v)).toEqual(v);
+  });
+
+  it('rejects a missing deviceSecret', () => {
+    expect(safeParseContract(deviceTokenMintRequestSchema, { deviceId: 'd1' })).toBeNull();
+  });
+
+  it('rejects a missing deviceId', () => {
+    expect(safeParseContract(deviceTokenMintRequestSchema, { deviceSecret: 's' })).toBeNull();
+  });
+
+  it('rejects an empty deviceId / deviceSecret', () => {
+    expect(safeParseContract(deviceTokenMintRequestSchema, { deviceId: '', deviceSecret: 's' })).toBeNull();
+    expect(safeParseContract(deviceTokenMintRequestSchema, { deviceId: 'd1', deviceSecret: '' })).toBeNull();
+  });
+});
+
+describe('deviceTokenMintResponseSchema', () => {
+  const state = { deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: 3, updatedAt: 1720000000000 };
+
+  it('parses a valid mint response', () => {
+    const v = { accessToken: 'jwt.access', expiresAt: '2026-07-07T00:00:00.000Z', nextDeviceSecret: 'next_secret', state };
+    expect(safeParseContract(deviceTokenMintResponseSchema, v)).toEqual(v);
+  });
+
+  it('rejects a response missing nextDeviceSecret', () => {
+    const v = { accessToken: 'jwt.access', expiresAt: '2026-07-07T00:00:00.000Z', state };
+    expect(safeParseContract(deviceTokenMintResponseSchema, v)).toBeNull();
+  });
+
+  it('rejects a response with an invalid nested state', () => {
+    const v = { accessToken: 'a', expiresAt: 'e', nextDeviceSecret: 'n', state: { deviceId: 'd1' } };
+    expect(safeParseContract(deviceTokenMintResponseSchema, v)).toBeNull();
   });
 });

--- a/packages/contracts/src/deviceBoot.ts
+++ b/packages/contracts/src/deviceBoot.ts
@@ -111,6 +111,14 @@ export interface AuthTokenBundle {
     refreshToken: string;
     expiresAt: string;
     user: UserResponse;
+    /**
+     * The device secret (phase 2c — zero-cookie transport). Present ONLY when
+     * the bundle is minted for a device that carries a `DeviceSession` doc; the
+     * client persists it first-party and later mints access tokens via
+     * `POST /session/device/token`. Optional and additive: cookie-lane bundles
+     * for a device with no doc omit it, so existing consumers are unaffected.
+     */
+    deviceSecret?: string;
 }
 
 export const authTokenBundleSchema: z.ZodType<AuthTokenBundle> = z.object({
@@ -119,6 +127,7 @@ export const authTokenBundleSchema: z.ZodType<AuthTokenBundle> = z.object({
     refreshToken: z.string(),
     expiresAt: z.string(),
     user: userResponseSchema,
+    deviceSecret: z.string().optional(),
 });
 
 /* -------------------------------------------------------------------------- */
@@ -252,6 +261,13 @@ export interface LoginSessionResult {
     expiresAt: string;
     accessToken?: string;
     refreshToken?: string;
+    /**
+     * The device secret (phase 2c — zero-cookie transport). Present ONLY when
+     * the sign-in resolved a device binding; the client persists it first-party
+     * and later mints access tokens via `POST /session/device/token`. Optional
+     * and additive — wired identically to `refreshToken`.
+     */
+    deviceSecret?: string;
     user: {
         id: string;
         username?: string;
@@ -273,6 +289,7 @@ const loginSessionResultSchema = z.object({
     expiresAt: z.string(),
     accessToken: z.string().optional(),
     refreshToken: z.string().optional(),
+    deviceSecret: z.string().optional(),
     user: z.object({
         id: z.string(),
         username: z.string().optional(),

--- a/packages/contracts/src/deviceSession.ts
+++ b/packages/contracts/src/deviceSession.ts
@@ -29,3 +29,36 @@ export type SessionAccount = z.infer<typeof sessionAccountSchema>;
 export type DeviceSessionState = z.infer<typeof deviceSessionStateSchema>;
 export type ActiveToken = z.infer<typeof activeTokenSchema>;
 export type DeviceSessionSync = z.infer<typeof deviceSessionSyncSchema>;
+
+/* -------------------------------------------------------------------------- */
+/*  Device-secret token mint (phase 2c — zero-cookie transport)               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Request body for `POST /session/device/token` — the client presents the
+ * `deviceId` it stored first-party plus the opaque `deviceSecret`. NO bearer:
+ * possession of the secret IS the proof of device ownership. The server matches
+ * `sha256(deviceSecret)` against the device's stored `secretHash` (constant-time)
+ * and mints a short access token for the device's active account.
+ */
+export const deviceTokenMintRequestSchema = z.object({
+  deviceId: z.string().min(1),
+  deviceSecret: z.string().min(1),
+});
+
+/**
+ * Wire shape of a successful `POST /session/device/token`: the freshly-minted
+ * short access token for the active account, its expiry, the NEXT rotating
+ * device secret the client must persist (rotation-in-use — the presented secret
+ * stays valid for a short grace so multi-tab races don't lock out), and the
+ * projected device-session state.
+ */
+export const deviceTokenMintResponseSchema = z.object({
+  accessToken: z.string(),
+  expiresAt: z.string(),
+  nextDeviceSecret: z.string(),
+  state: deviceSessionStateSchema,
+});
+
+export type DeviceTokenMintRequest = z.infer<typeof deviceTokenMintRequestSchema>;
+export type DeviceTokenMintResponse = z.infer<typeof deviceTokenMintResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -209,6 +209,8 @@ export {
     deviceSessionStateSchema,
     activeTokenSchema,
     deviceSessionSyncSchema,
+    deviceTokenMintRequestSchema,
+    deviceTokenMintResponseSchema,
 } from './deviceSession';
 
 export type {
@@ -216,6 +218,8 @@ export type {
     DeviceSessionState,
     ActiveToken,
     DeviceSessionSync,
+    DeviceTokenMintRequest,
+    DeviceTokenMintResponse,
 } from './deviceSession';
 
 export {


### PR DESCRIPTION
## Fase 2c (workshop decidido) — PR1 de 3: lado servidor, ADITIVO

Implementa `docs/architecture/oxy-auth-2c-transport-proposal.md` con las decisiones del workshop: deviceId web por origen · **rotación en uso + grace 60s** · migración aditiva con telemetría · la refresh family y la cookie `oxy_device` NO se tocan aquí (mueren en PR3 cuando `mint_source: cookie ≈ 0`).

### Qué añade
- **Modelo**: `DeviceSession.secretHash` (sha256, sparse-unique, patrón de `cookieKeyHash`) + `prevSecretHash`/`prevSecretExpiresAt` (ventana de gracia).
- **Service**: `issueDeviceSecret` (32B random→base64url; rota moviendo el hash actual a prev con expiry +60s; plaintext jamás logueado) y `getStateBySecret` (compare timing-safe contra actual O prev-en-gracia); `signout all` limpia los secrets del device.
- **`POST /session/device/token`** `{deviceId, deviceSecret}` — sin bearer ni cookie (la posesión del secret ES la prueba): lockout por deviceId (reusa `loginLockout` scope propio) + `rl:session:device-token:`; valida la Session activa vía `resolveActiveToken` (401 `no_active_session` sin rotar si murió); éxito → access token corto + **`nextDeviceSecret`** + state.
- **Emisión aditiva** del secret (rotando, devuelto UNA vez) en todos los caminos que registran cuenta en device: password/signup/2FA/verifyChallenge/social (vía `finalizeDeviceLogin`), bundle web-session/exchange, y claim QR. **Excluido `/auth/oauth/token`** — third-party queda fuera del device-set del ecosistema, por plan.
- **Telemetría de cutover**: `logger.info('device.token.mint', { mint_source: 'cookie'|'secret', deviceId })` en ambos lanes — consultable en CloudWatch Logs Insights para decidir el PR3.
- **Contracts**: `deviceTokenMintRequest/ResponseSchema` + `deviceSecret?` opcional en `AuthTokenBundle`/`LoginSessionResult` (aditivo, no-breaking).

### Tests
contracts **160** (+10) · api **1395** (+32): rotación/grace, lockout, sesión muerta sin rotación, emisión por camino con doble-login rotando, telemetría en ambos lanes, exclusión OAuth.

Siguiente: PR2 (cliente — mint + cold boot v3 aditivo) y PR3 (cutover, gated por telemetría).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->