### PR TITLE
feat(auth): 2FA security alerts + revoke suspicious sign-in

### DIFF
--- a/packages/api/src/controllers/__tests__/verify2FALogin.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/verify2FALogin.controller.test.ts
@@ -1,0 +1,181 @@
+/**
+ * twoFactor.controller.verify2FALogin tests
+ *
+ * Regression coverage for the security-alert parity between the password login
+ * path (`session.controller.signIn`) and the 2FA completion path: a successful
+ * `POST /security/2fa/verify-login` MUST run anomaly detection and attach a
+ * `securityAlert` to the session response when anomalies are detected — same
+ * shape the password path emits.
+ */
+
+const mockUserFindById = jest.fn();
+const mockVerifyToken = jest.fn();
+const mockVerifyBackupCode = jest.fn();
+const mockCreateSession = jest.fn();
+const mockCheckForAnomalies = jest.fn();
+const mockFinalizeDeviceLogin = jest.fn();
+const mockBuildSessionAuthResponse = jest.fn();
+const mockJwtVerify = jest.fn();
+const mockIsLockedOut = jest.fn();
+const mockRecordFailure = jest.fn();
+const mockClearFailures = jest.fn();
+const mockLogSignIn = jest.fn();
+
+jest.mock('jsonwebtoken', () => ({
+  __esModule: true,
+  default: { verify: (...a: unknown[]) => mockJwtVerify(...a), sign: jest.fn() },
+  verify: (...a: unknown[]) => mockJwtVerify(...a),
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: { findById: mockUserFindById },
+  buildAuthMethod: jest.fn(),
+}));
+
+jest.mock('../../services/twoFactor.service', () => ({
+  __esModule: true,
+  default: {
+    verifyToken: (...a: unknown[]) => mockVerifyToken(...a),
+    verifyBackupCode: (...a: unknown[]) => mockVerifyBackupCode(...a),
+  },
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: (...a: unknown[]) => mockCreateSession(...a) },
+}));
+
+jest.mock('../../services/anomalyDetection.service', () => ({
+  __esModule: true,
+  default: { checkForAnomalies: (...a: unknown[]) => mockCheckForAnomalies(...a) },
+}));
+
+jest.mock('../../services/deviceLogin.service', () => ({
+  finalizeDeviceLogin: (...a: unknown[]) => mockFinalizeDeviceLogin(...a),
+}));
+
+// `./session.controller` transitively imports the full model/service graph.
+// Mock it so we only need its `buildSessionAuthResponse` export here.
+jest.mock('../session.controller', () => ({
+  __esModule: true,
+  buildSessionAuthResponse: (...a: unknown[]) => mockBuildSessionAuthResponse(...a),
+}));
+
+jest.mock('../../services/securityActivityService', () => ({
+  __esModule: true,
+  default: { logSignIn: (...a: unknown[]) => mockLogSignIn(...a), logSecurityEvent: jest.fn() },
+}));
+
+jest.mock('../../services/loginLockout.service', () => ({
+  isLockedOut: (...a: unknown[]) => mockIsLockedOut(...a),
+  recordFailure: (...a: unknown[]) => mockRecordFailure(...a),
+  clearFailures: (...a: unknown[]) => mockClearFailures(...a),
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import { Request, Response } from 'express';
+import { verify2FALogin } from '../twoFactor.controller';
+
+function createMockRes(): Response {
+  const res = {} as Partial<Response>;
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+function createReq(body: Record<string, unknown>): Request {
+  return { body, headers: {}, ip: '127.0.0.1' } as unknown as Request;
+}
+
+const FAKE_SESSION = {
+  sessionId: 's1',
+  deviceId: 'd1',
+  expiresAt: new Date(Date.now() + 60_000),
+  accessToken: 'tok',
+  deviceInfo: { deviceName: 'x', deviceType: 'desktop', platform: 'web' },
+};
+
+function makeUser() {
+  return {
+    _id: { toString: () => 'user-1' },
+    username: 'alice',
+    twoFactorAuth: { enabled: true, secret: 'SECRET', backupCodes: [] },
+    save: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.ACCESS_TOKEN_SECRET = 'test-secret';
+  mockJwtVerify.mockReturnValue({ userId: 'user-1', purpose: '2fa_challenge' });
+  mockIsLockedOut.mockResolvedValue({ locked: false, attempts: 0 });
+  mockRecordFailure.mockResolvedValue({ locked: false, attempts: 1 });
+  mockClearFailures.mockResolvedValue(undefined);
+  mockCreateSession.mockResolvedValue(FAKE_SESSION);
+  mockFinalizeDeviceLogin.mockResolvedValue({ deviceSecret: 'ds1' });
+  mockBuildSessionAuthResponse.mockReturnValue({
+    sessionId: FAKE_SESSION.sessionId,
+    deviceId: FAKE_SESSION.deviceId,
+    expiresAt: FAKE_SESSION.expiresAt.toISOString(),
+    accessToken: FAKE_SESSION.accessToken,
+    user: { id: 'user-1', username: 'alice' },
+  });
+});
+
+describe('verify2FALogin — anomaly detection parity', () => {
+  it('attaches a securityAlert to the session response when anomalies are detected', async () => {
+    mockUserFindById.mockReturnValueOnce({ select: jest.fn().mockResolvedValue(makeUser()) });
+    mockVerifyToken.mockReturnValue(true);
+    mockCheckForAnomalies.mockResolvedValueOnce({
+      hasAnomalies: true,
+      anomalies: [{ type: 'new_device', reason: 'Login from new device' }],
+    });
+
+    const res = createMockRes();
+    await verify2FALogin(createReq({ loginToken: 'lt', token: '123456' }), res);
+
+    // Anomaly detection ran for the verified user, BEFORE the session was minted.
+    expect(mockCheckForAnomalies).toHaveBeenCalledWith('user-1', expect.anything());
+    const invocationOrder =
+      mockCheckForAnomalies.mock.invocationCallOrder[0] < mockCreateSession.mock.invocationCallOrder[0];
+    expect(invocationOrder).toBe(true);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.securityAlert).toEqual({
+      message: 'Unusual activity detected on your account',
+      anomalies: [{ type: 'new_device', reason: 'Login from new device' }],
+    });
+    expect(body.sessionId).toBe('s1');
+    expect(body.deviceSecret).toBe('ds1');
+  });
+
+  it('omits securityAlert when no anomalies are detected (common case)', async () => {
+    mockUserFindById.mockReturnValueOnce({ select: jest.fn().mockResolvedValue(makeUser()) });
+    mockVerifyToken.mockReturnValue(true);
+    mockCheckForAnomalies.mockResolvedValueOnce({ hasAnomalies: false, anomalies: [] });
+
+    const res = createMockRes();
+    await verify2FALogin(createReq({ loginToken: 'lt', token: '123456' }), res);
+
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.securityAlert).toBeUndefined();
+    expect(body.sessionId).toBe('s1');
+  });
+
+  it('does NOT run anomaly detection when the 2FA token is invalid', async () => {
+    mockUserFindById.mockReturnValueOnce({ select: jest.fn().mockResolvedValue(makeUser()) });
+    mockVerifyToken.mockReturnValue(false);
+
+    const res = createMockRes();
+    await verify2FALogin(createReq({ loginToken: 'lt', token: '000000' }), res);
+
+    expect(mockCheckForAnomalies).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});

--- a/packages/api/src/controllers/twoFactor.controller.ts
+++ b/packages/api/src/controllers/twoFactor.controller.ts
@@ -4,6 +4,7 @@ import { User } from '../models/User';
 import twoFactorService from '../services/twoFactor.service';
 import { logger } from '../utils/logger';
 import securityActivityService from '../services/securityActivityService';
+import anomalyDetectionService from '../services/anomalyDetection.service';
 import sessionService from '../services/session.service';
 import { finalizeDeviceLogin } from '../services/deviceLogin.service';
 import { buildSessionAuthResponse } from './session.controller';
@@ -395,6 +396,15 @@ export async function verify2FALogin(req: Request, res: Response) {
     user.twoFactorAuth.verifiedAt = new Date();
     await user.save();
 
+    // Check for anomalous login patterns BEFORE creating the session, so the
+    // just-minted session does not mask "new device" detection. Mirrors the
+    // password path in `session.controller.ts` — attaches a `securityAlert` to
+    // the (already-committed) session response when anomalies are detected.
+    const anomalyCheck = await anomalyDetectionService.checkForAnomalies(
+      user._id.toString(),
+      req
+    );
+
     // Create session (same as signIn would)
     const session = await sessionService.createSession(
       user._id.toString(),
@@ -406,7 +416,16 @@ export async function verify2FALogin(req: Request, res: Response) {
     if (!baseTwoFactorResponse) {
       return res.status(500).json({ message: 'Failed to format user data' });
     }
-    const response: typeof baseTwoFactorResponse & { deviceSecret?: string } = baseTwoFactorResponse;
+    const response: typeof baseTwoFactorResponse & {
+      securityAlert?: { message: string; anomalies: Array<{ type: string; reason: string; details?: string }> };
+      deviceSecret?: string;
+    } = baseTwoFactorResponse;
+    if (anomalyCheck.hasAnomalies) {
+      response.securityAlert = {
+        message: 'Unusual activity detected on your account',
+        anomalies: anomalyCheck.anomalies,
+      };
+    }
 
     // Register into the device set (add-only) + broadcast, and mint the
     // deviceSecret the client persists first-party. Best-effort.

--- a/packages/auth/components/__tests__/login-form-security-alert.test.tsx
+++ b/packages/auth/components/__tests__/login-form-security-alert.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * When the server flags a committed sign-in as anomalous, the login form shows a
+ * "New sign-in detected" acknowledgement. The "That wasn't me" button must
+ * REVOKE the just-committed device session via the SDK
+ * (`useOxy().revokeSuspiciousSignIn()`) — which server-revokes the session and
+ * clears the local zero-cookie device credential — before returning to the
+ * identifier step. It must NOT merely navigate back without revoking.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { BrowserRouter } from "react-router-dom"
+
+const revokeSuspiciousSignIn = mock(async () => undefined)
+const signInWithPassword = mock(async () => ({
+    status: "ok" as const,
+    securityAlert: {
+        message: "We noticed a sign-in from a device we don't recognize.",
+        anomalies: [{ type: "new_device", reason: "Login from new device" }],
+    },
+}))
+
+// `loginHint` routes the form straight to the password step for a known account
+// (bypassing the controlled identifier input), so the test can drive the
+// password → security-alert → repudiate path deterministically. The lookup
+// returns a plain account (no color/avatar branding side effects).
+mock.module("@oxyhq/services", () => ({
+    useOxy: () => ({
+        openAccountDialog: () => undefined,
+        oxyServices: {
+            lookupUsername: async () => ({
+                username: "alice",
+                name: { displayName: "Alice" },
+                avatar: null,
+                color: null,
+            }),
+        },
+        signInWithPassword,
+        completeTwoFactorSignIn: async () => ({}),
+        revokeSuspiciousSignIn,
+        switchToAccount: async () => undefined,
+    }),
+    useSwitchableAccounts: () => ({ isLoading: false, currentSessionId: null, accounts: [] }),
+}))
+
+const { LoginForm } = await import("@/components/login-form")
+
+function renderForm(): { container: HTMLDivElement; unmount: () => void } {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root: Root = createRoot(container)
+    act(() => {
+        root.render(
+            <BrowserRouter>
+                <LoginForm loginHint="alice" />
+            </BrowserRouter>,
+        )
+    })
+    return {
+        container,
+        unmount: () => {
+            act(() => root.unmount())
+            container.remove()
+        },
+    }
+}
+
+/** Drain queued microtasks + timers (lookup / sign-in / revoke promises) and let React re-render. */
+async function flush(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+}
+
+function findButton(container: HTMLElement, label: RegExp): HTMLButtonElement | undefined {
+    return Array.from(container.querySelectorAll("button")).find((b) =>
+        label.test(b.textContent ?? ""),
+    )
+}
+
+describe("LoginForm — security alert repudiation", () => {
+    beforeEach(() => {
+        revokeSuspiciousSignIn.mockClear()
+        signInWithPassword.mockClear()
+    })
+
+    test("'That wasn't me' revokes the sign-in via the SDK and returns to the identifier step", async () => {
+        const { container, unmount } = renderForm()
+
+        // loginHint auto-advances to the password step.
+        await flush()
+        const password = container.querySelector<HTMLInputElement>("#password")
+        expect(password).not.toBeNull()
+
+        // Submit the password → server returns a flagged session.
+        password!.value = "hunter2-correct-horse"
+        const form = password!.closest("form")
+        expect(form).not.toBeNull()
+        act(() => {
+            form!.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }))
+        })
+        await flush()
+
+        expect(signInWithPassword).toHaveBeenCalledTimes(1)
+
+        // The security-alert interstitial is shown.
+        const denyButton = findButton(container, /that wasn.?t me/i)
+        expect(denyButton).toBeDefined()
+        expect(container.textContent).toContain("New sign-in detected")
+
+        // Repudiate → must revoke through the SDK, not just navigate back.
+        act(() => {
+            denyButton?.dispatchEvent(new window.MouseEvent("click", { bubbles: true }))
+        })
+        await flush()
+
+        expect(revokeSuspiciousSignIn).toHaveBeenCalledTimes(1)
+
+        // Back on the identifier step (the revoked account is gone).
+        expect(container.querySelector("#identifier")).not.toBeNull()
+        expect(findButton(container, /that wasn.?t me/i)).toBeUndefined()
+
+        unmount()
+    })
+})

--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -82,6 +82,7 @@ export function LoginForm({
         oxyServices,
         signInWithPassword,
         completeTwoFactorSignIn,
+        revokeSuspiciousSignIn,
         switchToAccount,
         openAccountDialog,
     } = useOxy()
@@ -273,6 +274,32 @@ export function LoginForm({
             return
         }
         redirectAfterLogin()
+    }
+
+    /**
+     * "That wasn't me": the just-committed sign-in was flagged as anomalous and
+     * the user is repudiating it. Revoke the device session server-side and clear
+     * the local zero-cookie device credential via the SDK (no app-local auth
+     * plumbing), then return to the identifier step. Revocation failure is
+     * non-fatal — we still drop the alert and bounce back so the compromised UI
+     * never lingers.
+     */
+    async function handleDenySignIn() {
+        setIsSubmitting(true)
+        try {
+            await revokeSuspiciousSignIn()
+        } catch (err) {
+            const message = err instanceof Error && err.message ? err.message : "Couldn't revoke that sign-in."
+            toast.error("Revoke failed", { description: message })
+        } finally {
+            setSecurityAlert(null)
+            setIsSubmitting(false)
+            // Re-show the identifier form rather than the account chooser: the
+            // repudiated account was just revoked, so returning to the chooser
+            // would be confusing.
+            setShowLoginForm(true)
+            goToStep("identifier", "back")
+        }
     }
 
     /** Map a thrown sign-in error onto the inline error UI (rate-limit aware). */
@@ -571,10 +598,10 @@ export function LoginForm({
                             <p className="text-base text-muted-foreground">{securityAlert?.message}</p>
                         </div>
                         <div className="flex flex-col sm:flex-row gap-3">
-                            <Button variant="outline" size="lg" className="flex-1" onClick={() => { setSecurityAlert(null); goToStep("identifier", "back") }}>
+                            <Button variant="outline" size="lg" className="flex-1" loading={isSubmitting} disabled={isSubmitting} onClick={() => { void handleDenySignIn() }}>
                                 That wasn&apos;t me
                             </Button>
-                            <Button size="lg" className="flex-1" onClick={() => redirectAfterLogin()}>
+                            <Button size="lg" className="flex-1" disabled={isSubmitting} onClick={() => redirectAfterLogin()}>
                                 Yes, it was me
                             </Button>
                         </div>

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -126,6 +126,19 @@ export interface OxyContextState {
   }) => Promise<{ securityAlert?: SecurityAlert }>;
 
   /**
+   * Repudiate the sign-in that just committed — the "That wasn't me" response to
+   * a server-flagged {@link SecurityAlert}. Revokes the current device session
+   * server-side (via the same device-first `POST /session/device/signout` path
+   * {@link logout} uses) and, when no other account remains on this device,
+   * clears the persisted zero-cookie `{deviceId, deviceSecret}` credential and
+   * local session state so the next cold boot finds nothing to restore. Any
+   * sibling accounts already signed in on the device are preserved. There is NO
+   * dedicated "report suspicious" API endpoint — repudiation IS device-session
+   * revocation, so a compromised new sign-in cannot be restored.
+   */
+  revokeSuspiciousSignIn: () => Promise<void>;
+
+  /**
    * Commit a session obtained out-of-band (the "Sign in with Oxy" QR device
    * flow). Plants tokens, persists the zero-cookie device credential, registers
    * the account into the device set, and hydrates the full user profile.
@@ -653,6 +666,15 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     setAuthState,
     logger,
   });
+
+  // "That wasn't me": repudiating a flagged sign-in IS revoking the device
+  // session that just committed — the same server-authoritative
+  // `sessionClient.signOut(...)` path `logout` uses, which also clears the
+  // persisted device credential + local state when no sibling account remains.
+  // No dedicated "report suspicious" API endpoint exists (or is needed).
+  const revokeSuspiciousSignIn = useCallback(async (): Promise<void> => {
+    await logout();
+  }, [logout]);
 
   const clearAllAccountData = useCallback(async (): Promise<void> => {
     queryClient.clear();
@@ -1221,6 +1243,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       signIn,
       signInWithPassword,
       completeTwoFactorSignIn,
+      revokeSuspiciousSignIn,
       handleWebSession,
       logout,
       logoutAll,
@@ -1270,6 +1293,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       signIn,
       signInWithPassword,
       completeTwoFactorSignIn,
+      revokeSuspiciousSignIn,
       handleWebSession,
       logout,
       logoutAll,
@@ -1337,6 +1361,7 @@ const LOADING_STATE: OxyContextState = {
   signIn: () => rejectMissingProvider<User>(),
   signInWithPassword: () => rejectMissingProvider<PasswordSignInResult>(),
   completeTwoFactorSignIn: () => rejectMissingProvider<{ securityAlert?: SecurityAlert }>(),
+  revokeSuspiciousSignIn: () => rejectMissingProvider<void>(),
   handleWebSession: () => rejectMissingProvider<void>(),
   logout: () => rejectMissingProvider<void>(),
   logoutAll: () => rejectMissingProvider<void>(),


### PR DESCRIPTION
## Summary
- **2FA anomaly parity:** `POST /security/2fa/verify-login` now runs `anomalyDetectionService.checkForAnomalies` before session creation and attaches `securityAlert` when flagged (same shape as password login).
- **"That wasn't me":** IdP `login-form` calls new `revokeSuspiciousSignIn()` from `OxyContext`, which reuses bearer-authenticated `POST /session/device/signout` — no new revoke endpoint needed.
- Tests for both paths.

## Test plan
- [x] `packages/api` — `verify2FALogin.controller.test.ts` (3/3)
- [x] `packages/auth` — `login-form-security-alert.test.tsx` (1/1)
- [x] `packages/services` — OxyContext cold boot tests pass


Made with [Cursor](https://cursor.com)