### PR TITLE
fix(auth): render app without React.StrictMode so bottom sheets paint on web

### DIFF
--- a/packages/auth/src/main.tsx
+++ b/packages/auth/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import { useEffect } from "react"
 import ReactDOM from "react-dom/client"
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
 import { BloomThemeProvider } from "@oxyhq/bloom/theme"
@@ -89,9 +89,11 @@ function App() {
 
 const rootEl = document.getElementById("root")
 if (rootEl) {
-    ReactDOM.createRoot(rootEl).render(
-        <React.StrictMode>
-            <App />
-        </React.StrictMode>
-    )
+    // NOTE: Do NOT wrap <App /> in <React.StrictMode>. On web, react-native-web's
+    // Modal (used by Bloom's BottomSheet / bottom-placement Dialog, i.e. the
+    // "Sign in with Oxy" sheet) mounts its ModalPortal host during render and
+    // removes it in an effect cleanup; StrictMode's dev double-invoke never
+    // re-attaches it, so bottom sheets never paint. accounts (Expo) renders
+    // without StrictMode for the same reason.
+    ReactDOM.createRoot(rootEl).render(<App />)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the bug where the "Sign in with Oxy" bottom sheet / dialog (`OxyAccountDialog`) never appears in the `auth` app, while it works in `accounts`.

## Root cause

`OxyAccountDialog` (opened via `openAccountDialog('signin')`) uses Bloom's `<Dialog placement={{ base: 'bottom', md: 'center' }}>`. On narrow viewports the `bottom` placement routes to Bloom's `BottomSheet`, which on web is built on react-native-web's `Modal`. RN-Web's `ModalPortal` creates its host `div` during render and removes it in an effect cleanup (`node_modules/react-native-web/.../Modal/ModalPortal.js`). Under `React.StrictMode`'s dev double-invoke, that host node is detached and never re-attached, so the sheet's portal is orphaned and never paints.

`packages/auth/src/main.tsx` wrapped the app in `<React.StrictMode>`; `packages/accounts` (Expo) does not — which is why the sheet worked in accounts but not auth. This exact hazard is already documented in `packages/services/src/ui/components/OxyAccountDialog.tsx`.

## Change

- `packages/auth/src/main.tsx`: render `<App />` directly instead of inside `<React.StrictMode>` (and drop the now-unused `React` default import), aligning auth with accounts. StrictMode only double-invokes in dev, so production behavior is unchanged.

## Evidence

Instrumented the RN-Web Modal path to confirm: with StrictMode the `ModalPortal` host was orphaned/empty; after the change the portal attaches, `ModalAnimation` renders `position:fixed; z-index:9999; opacity:1`, and the sheet's reanimated entrance animates in. A controlled reliability check (3 fresh loads, single click after the app initializes) opened the sheet 3/3 times.

### Before (broken) — narrow viewport, clicking "Sign in with Oxy" does nothing
[auth_bottom_sheet_before_broken.mp4](https://cursor.com/agents/bc-38e1f472-8431-4103-bdb3-bcec41883c1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_bottom_sheet_before_broken.mp4)

### After (fixed) — the dialog/sheet opens with a dimmed backdrop
[auth_bottom_sheet_after_fixed.mp4](https://cursor.com/agents/bc-38e1f472-8431-4103-bdb3-bcec41883c1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_bottom_sheet_after_fixed.mp4)
[Sign-in dialog open with dimmed backdrop](https://cursor.com/agents/bc-38e1f472-8431-4103-bdb3-bcec41883c1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_sheet_after_fixed.webp)

## Package(s) affected

- [x] auth app

## Test plan

- [x] Reproduced the failure (sheet never appears) on a narrow viewport with StrictMode
- [x] After the fix, the sheet reliably appears (3/3 fresh loads) on narrow viewport
- [x] Wide viewport still shows the centered dialog (no regression)
- [x] `eslint` passes in `packages/auth`

## Notes

- The sheet only opens once the app has initialized its lazy-loaded `OxyAccountDialog` chunk (a click fired in the first moment after load can be a no-op); this matches accounts and is unrelated to the StrictMode bug.
- A deeper fix would be to make Bloom's `bottom`-placement dialog avoid RN-Web `Modal` on web, but Bloom is an external dependency; this app-level change resolves the reported issue.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38e1f472-8431-4103-bdb3-bcec41883c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38e1f472-8431-4103-bdb3-bcec41883c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

