### PR TITLE
fix: sign-in dialog not opening on narrow web viewports (console/auth)

### DIFF
--- a/packages/console/src/main.tsx
+++ b/packages/console/src/main.tsx
@@ -1,4 +1,3 @@
-import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { RouterProvider } from '@tanstack/react-router';
 import { getRouter } from './router';
@@ -6,8 +5,12 @@ import './styles.css';
 
 const router = getRouter();
 
+// NOTE: Do NOT wrap the app in <React.StrictMode>. On web, react-native-web's
+// Modal (used by Bloom's BottomSheet / bottom-placement Dialog, i.e. the
+// account/sign-in sheet on narrow viewports) mounts its ModalPortal host during
+// render and removes it in an effect cleanup; StrictMode's dev double-invoke
+// never re-attaches it, so bottom sheets never paint. accounts (Expo) and auth
+// render without StrictMode for the same reason.
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <RouterProvider router={router} />
-  </StrictMode>,
+  <RouterProvider router={router} />,
 );

--- a/packages/services/src/ui/components/OxyAccountDialog.tsx
+++ b/packages/services/src/ui/components/OxyAccountDialog.tsx
@@ -198,7 +198,17 @@ const OxyAccountDialog: React.FC = () => {
     <Dialog
       open={isAccountDialogOpen}
       onClose={closeAccountDialog}
-      placement={{ base: 'bottom', md: 'center' }}
+      // On web ALWAYS use the centered placement. Bloom's `bottom` placement
+      // routes through its `BottomSheet`, which on web is built on
+      // react-native-web's `Modal`. That `Modal` creates its `ModalPortal` host
+      // node as a side effect during render and removes it in an effect cleanup;
+      // under React 19 concurrent rendering (and StrictMode's dev double-invoke)
+      // the host is orphaned and never re-attached, so the sheet never paints on
+      // narrow web viewports (reproduced on console.oxy.so / auth.oxy.so, Pixel-7
+      // width). The `center` placement uses Bloom's react-dom Portal (no RN
+      // Modal) and paints reliably at every width. Native keeps the real bottom
+      // sheet on narrow screens.
+      placement={isWeb ? 'center' : { base: 'bottom', md: 'center' }}
       dismissOnBackdrop={false}
       maxWidth={420}
       label={headerCopy(view, snapshot.accounts.length, t).title}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the account / "Sign in with Oxy" dialog not opening on narrow (phone-width) web viewports — reported on `console.oxy.so` at Pixel-7 width, and the same class of bug that affected `auth.oxy.so`.

## Root cause

`OxyAccountDialog` used `placement={{ base: 'bottom', md: 'center' }}`. On web, Bloom's `bottom` placement routes through its `BottomSheet`, which is built on **react-native-web's `Modal`**. RN-Web's `ModalPortal` creates its host `div` as a side effect **during render** and removes it in an effect cleanup. Under React 19 concurrent rendering (and `StrictMode`'s dev double-invoke), that host node gets orphaned and never re-attached, so the sheet never paints on narrow web viewports.

I reproduced this in a **production build** of console at 390px: the dialog appeared **0/3** times. It works in `accounts` because that app is built with Expo/Metro (not Vite) and does not wrap in `StrictMode`. Note `StrictMode` only double-invokes in dev, so removing it does not fix production — the real fix must avoid the RN-Web `Modal` path on web.

## Changes

- `packages/services/src/ui/components/OxyAccountDialog.tsx` — force the `center` placement on web (`placement={isWeb ? 'center' : { base: 'bottom', md: 'center' }}`). The `center` placement uses Bloom's react-dom Portal (no RN `Modal`) and paints reliably at every width. **Native keeps the real bottom sheet on narrow screens.** This fixes the sign-in dialog for all web apps (console, auth, and others).
- `packages/console/src/main.tsx` — render the app without `<React.StrictMode>`, matching `accounts` and the earlier auth fix (dev-hygiene for the RN-Web `Modal` path; not required by the services fix above but kept for consistency).

## Evidence

Verified on a **production build** of console (`vite build` + `vite preview`) at 390px width: the sign-in dialog now appears reliably **3/3** with a dimmed backdrop and the expected options ("Sign in with Oxy", "Scan QR code", "Use a password instead").

[console_signin_narrow_fixed_prodbuild.mp4](https://cursor.com/agents/bc-38e1f472-8431-4103-bdb3-bcec41883c1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_signin_narrow_fixed_prodbuild.mp4)
[Console sign-in dialog open at Pixel-7 width with dimmed backdrop](https://cursor.com/agents/bc-38e1f472-8431-4103-bdb3-bcec41883c1d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_signin_narrow_fixed.webp)

## Package(s) affected

- [x] `@oxyhq/services`
- [x] infra / CI (console app)

## Test plan

- [x] Reproduced the bug in a console production build at 390px (dialog 0/3)
- [x] After the fix, dialog appears reliably 3/3 in the production build at 390px
- [x] Wide/desktop viewport unchanged (already `center`)
- [x] `@oxyhq/services` rebuilds cleanly; console builds cleanly

## Notes / UX

- On mobile **web**, the sign-in surface is now a centered dialog instead of a bottom sheet (the bottom sheet was broken on web anyway). Native apps are unchanged and still get the bottom sheet on narrow screens.
- A deeper fix would be for `@oxyhq/bloom` to make its `bottom`-placement dialog avoid RN-Web `Modal` on web; that's upstream in Bloom.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38e1f472-8431-4103-bdb3-bcec41883c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38e1f472-8431-4103-bdb3-bcec41883c1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

