### PR TITLE
fix(auth): restore first-party password sign-in OAuth flow

### DIFF
--- a/packages/api/src/config/reconcileOfficialRedirectUris.ts
+++ b/packages/api/src/config/reconcileOfficialRedirectUris.ts
@@ -1,0 +1,50 @@
+/**
+ * Self-heal official Application redirect URIs when `redirectUris` is empty.
+ *
+ * Production drift (empty allowlist) blocks `POST /auth/oauth/authorize` with
+ * "redirect_uri is not registered for this client", breaking password sign-in
+ * hand-offs from every first-party app. Official apps always declare a
+ * `websiteUrl`; its origin is the canonical OAuth redirect surface.
+ */
+
+import mongoose from 'mongoose';
+import { logger } from '../utils/logger';
+
+export async function reconcileOfficialRedirectUris(): Promise<number> {
+  if (mongoose.connection.readyState !== 1) {
+    return 0;
+  }
+
+  const { Application } = await import('../models/Application.js');
+  const candidates = await Application.find({
+    status: 'active',
+    isOfficial: true,
+    websiteUrl: { $exists: true, $ne: '' },
+    $or: [{ redirectUris: { $exists: false } }, { redirectUris: { $size: 0 } }],
+  }).select('name websiteUrl redirectUris');
+
+  let repaired = 0;
+  for (const app of candidates) {
+    const websiteUrl = app.websiteUrl?.trim();
+    if (!websiteUrl) continue;
+    let origin: string;
+    try {
+      origin = new URL(websiteUrl).origin;
+    } catch {
+      logger.warn('[reconcileOfficialRedirectUris] invalid websiteUrl', {
+        name: app.name,
+        websiteUrl,
+      });
+      continue;
+    }
+    app.redirectUris = [origin];
+    await app.save();
+    repaired += 1;
+    logger.info('[reconcileOfficialRedirectUris] restored redirectUris', {
+      name: app.name,
+      redirectUris: [origin],
+    });
+  }
+
+  return repaired;
+}

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -30,6 +30,7 @@ import { emitAuthSessionUpdate } from '../utils/authSessionSocket';
 import socialAuthRouter from './socialAuth';
 import { validate } from '../middleware/validate';
 import sessionService from '../services/session.service';
+import { finalizeDeviceLogin } from '../services/deviceLogin.service';
 import { formatUserResponse } from '../utils/userTransform';
 import { issueAuthCode, exchangeAuthCode, AUTH_CODE_TTL_MS } from '../services/oauthCode.service';
 import { claimAuthSession, authorizeSessionWithSignedChallenge } from '../services/authSession.service';
@@ -2401,6 +2402,11 @@ router.post(
       { deviceName: `${app.name} OAuth` },
     );
 
+    const deviceExtras = await finalizeDeviceLogin({
+      session: { sessionId: session.sessionId, deviceId: session.deviceId },
+      userId,
+    });
+
     app.lastUsedAt = new Date();
     await app.save();
 
@@ -2412,6 +2418,8 @@ router.post(
       token_type: 'Bearer',
       expires_in: 15 * 60,
       session_id: session.sessionId,
+      deviceId: session.deviceId,
+      ...(deviceExtras.deviceSecret ? { deviceSecret: deviceExtras.deviceSecret } : {}),
       user: userData,
     });
   })

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -69,6 +69,7 @@ import cookieParser from 'cookie-parser';
 import { csrfProtection, getCsrfToken } from './middleware/csrf';
 import { createCorsMiddleware, SOCKET_IO_CORS_CONFIG } from './config/cors';
 import { refreshOriginRegistry } from './config/dynamicOriginRegistry';
+import { reconcileOfficialRedirectUris } from './config/reconcileOfficialRedirectUris';
 import { createAdapter } from '@socket.io/redis-adapter';
 import { getRedisClient, closeRedis } from './config/redis';
 import { initializeIO, socketRoomsFor } from './utils/socket';
@@ -714,6 +715,7 @@ if (require.main === module) {
       // safe; this adds the registered first-party/third-party app origins.
       // Background-safe (fail-soft) — never blocks startup.
       await refreshOriginRegistry();
+      await reconcileOfficialRedirectUris();
 
       // Seed platform-default reputation rules (idempotent) — currently the
       // cross-app `endorsement_received` rule awarded by /app-signals/ingest.

--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -71,6 +71,18 @@ export function LoginForm({
     ...props
 }: LoginFormProps) {
     const navigate = useNavigate()
+    const signupPath = (() => {
+        const params = new URLSearchParams()
+        if (sessionToken) params.set("token", sessionToken)
+        if (redirectUri) params.set("redirect_uri", redirectUri)
+        if (state) params.set("state", state)
+        if (clientId) params.set("client_id", clientId)
+        if (codeChallenge) params.set("code_challenge", codeChallenge)
+        if (codeChallengeMethod) params.set("code_challenge_method", codeChallengeMethod)
+        if (scope) params.set("scope", scope)
+        const qs = params.toString()
+        return qs ? `/signup?${qs}` : "/signup"
+    })()
     // The IdP authenticates through the SAME device-first SDK path every Oxy app
     // uses: `signInWithPassword` / `completeTwoFactorSignIn` verify credentials,
     // persist the zero-cookie `{deviceId, deviceSecret}` credential, plant the
@@ -499,7 +511,7 @@ export function LoginForm({
                         </Field>
                         <FieldDescription>
                             Don&apos;t have an account?{" "}
-                            <Link to="/signup">Create account</Link>
+                            <Link to={signupPath}>Create account</Link>
                         </FieldDescription>
                         <Field>
                             <Button type="submit" size="lg" className="w-full" loading={isSubmitting} disabled={isSubmitting || rateLimitSeconds > 0}>

--- a/packages/auth/src/pages/authorize.tsx
+++ b/packages/auth/src/pages/authorize.tsx
@@ -458,9 +458,25 @@ export function AuthorizePage() {
           headers: { Authorization: `Bearer ${accessToken}` },
         }
       );
-      // A non-OK response leaves `body` null → `consentRequiredFromBody`
-      // fails safe to true (consent screen shown).
-      body = response.ok ? await response.json().catch(() => null) : null;
+      if (!response.ok) {
+        // Misconfigured redirect_uri (common prod drift) returns 403 before the
+        // trusted-app auto-approve branch runs. Fail closed with a visible error
+        // instead of falling through to the consent screen — official apps should
+        // never prompt here.
+        if (response.status === 403 || response.status === 400) {
+          const errPayload = await response.json().catch(() => ({}));
+          const message =
+            typeof errPayload?.message === "string"
+              ? errPayload.message
+              : "Authorization failed. Return to the app and try again.";
+          setAutoApproving(false);
+          setData((prev) => ({ ...prev, error: message }));
+          return;
+        }
+        body = null;
+      } else {
+        body = await response.json().catch(() => null);
+      }
     } catch {
       body = null;
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -523,6 +523,12 @@ export {
     generatePkcePair,
     DEFAULT_OAUTH_SCOPE,
     OXY_AUTHORIZE_URL,
+    OXY_OAUTH_STATE_STORAGE_KEY,
+    OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
+    normalizeOAuthRedirectUri,
+    persistOAuthHandshake,
+    readOAuthHandshake,
+    clearOAuthHandshake,
 } from './utils/oauthPkce';
 export type { PkcePair, BuildOAuthAuthorizeUrlParams } from './utils/oauthPkce';
 

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -1190,5 +1190,71 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
         throw this.handleError(error);
       }
     }
+
+    /**
+     * Exchange an OAuth authorization code (returned to the RP redirect URI
+     * after password sign-in at auth.oxy.so) for a device-first session.
+     * Public first-party clients use PKCE (`codeVerifier`); the access token is
+     * planted immediately on success.
+     */
+    async exchangeOAuthCode(params: {
+      code: string;
+      clientId: string;
+      redirectUri: string;
+      codeVerifier: string;
+    }): Promise<LoginSessionResult> {
+      try {
+        const res = await this.makeRequest<unknown>('POST', '/auth/oauth/token', {
+          code: params.code,
+          clientId: params.clientId,
+          redirectUri: params.redirectUri,
+          codeVerifier: params.codeVerifier,
+        }, { cache: false });
+        const payload =
+          (res as { data?: Record<string, unknown> }).data ??
+          (res as Record<string, unknown>);
+        if (!payload || typeof payload !== 'object') {
+          throw new Error('auth/oauth/token returned an unexpected response shape');
+        }
+        const record = payload as Record<string, unknown>;
+        const accessToken = (record.access_token ?? record.accessToken) as string | undefined;
+        const sessionId = (record.session_id ?? record.sessionId) as string | undefined;
+        const deviceId = (record.deviceId ?? record.device_id) as string | undefined;
+        const deviceSecret = (record.deviceSecret ?? record.device_secret) as string | undefined;
+        const userRaw = record.user;
+        if (!sessionId || !deviceId || !userRaw || typeof userRaw !== 'object') {
+          throw new Error('auth/oauth/token returned an incomplete session payload');
+        }
+        const userObj = userRaw as Record<string, unknown>;
+        const userId = userObj.id as string | undefined;
+        if (!userId) {
+          throw new Error('auth/oauth/token returned a session without user.id');
+        }
+        const expiresInSec =
+          typeof record.expires_in === 'number'
+            ? record.expires_in
+            : typeof record.expiresIn === 'number'
+              ? record.expiresIn
+              : 15 * 60;
+        const expiresAt = new Date(Date.now() + expiresInSec * 1000).toISOString();
+        if (accessToken) {
+          this.setTokens(accessToken);
+        }
+        return {
+          sessionId,
+          deviceId,
+          expiresAt,
+          accessToken,
+          deviceSecret,
+          user: {
+            id: userId,
+            username: typeof userObj.username === 'string' ? userObj.username : undefined,
+            avatar: typeof userObj.avatar === 'string' ? userObj.avatar : undefined,
+          },
+        };
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
   };
 }

--- a/packages/core/src/session/__tests__/accountDialogController.test.ts
+++ b/packages/core/src/session/__tests__/accountDialogController.test.ts
@@ -533,7 +533,23 @@ describe('AccountDialogController — sign in with Oxy', () => {
 });
 
 describe('AccountDialogController — openPasswordAtOxyAuth', () => {
-  it('builds the IdP sign-in URL with redirect_uri + client_id and invokes openUrl', () => {
+  beforeEach(() => {
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      value: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          store.set(key, value);
+        },
+        removeItem: (key: string) => {
+          store.delete(key);
+        },
+      },
+      configurable: true,
+    });
+  });
+
+  it('builds the IdP sign-in URL with redirect_uri + client_id and invokes openUrl', async () => {
     const oxy = makeOxy();
     const sc = new TestSessionClient(host());
     const openUrl = jest.fn();
@@ -544,17 +560,32 @@ describe('AccountDialogController — openPasswordAtOxyAuth', () => {
       openUrl,
     });
 
-    const url = controller.openPasswordAtOxyAuth({ returnUrl: 'https://mention.earth/', state: 'xyz' });
+    const url = await controller.openPasswordAtOxyAuth({ returnUrl: 'https://mention.earth/dashboard' });
     const parsed = new URL(url);
     expect(parsed.origin).toBe('https://auth.oxy.so');
     expect(parsed.pathname).toBe('/login');
-    expect(parsed.searchParams.get('redirect_uri')).toBe('https://mention.earth/');
+    expect(parsed.searchParams.get('redirect_uri')).toBe('https://mention.earth');
     expect(parsed.searchParams.get('client_id')).toBe('oxy_dk_test');
-    expect(parsed.searchParams.get('state')).toBe('xyz');
+    expect(parsed.searchParams.get('state')).toBeTruthy();
+    expect(parsed.searchParams.get('code_challenge')).toBeTruthy();
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
     expect(openUrl).toHaveBeenCalledWith(url);
   });
 
-  it('honors an idpApex override', () => {
+  it('honors authRedirectUri over returnUrl', async () => {
+    const oxy = makeOxy();
+    const sc = new TestSessionClient(host());
+    const controller = new AccountDialogController({
+      oxyServices: oxy as unknown as OxyServices,
+      sessionClient: sc,
+      authRedirectUri: 'https://inbox.oxy.so',
+    });
+
+    const url = await controller.openPasswordAtOxyAuth({ returnUrl: 'https://inbox.oxy.so/mail' });
+    expect(new URL(url).searchParams.get('redirect_uri')).toBe('https://inbox.oxy.so');
+  });
+
+  it('honors an idpApex override', async () => {
     const oxy = makeOxy();
     const sc = new TestSessionClient(host());
     const controller = new AccountDialogController({
@@ -562,7 +593,7 @@ describe('AccountDialogController — openPasswordAtOxyAuth', () => {
       sessionClient: sc,
       idpApex: 'alia.onl',
     });
-    const url = controller.openPasswordAtOxyAuth({ returnUrl: 'https://alia.onl/' });
+    const url = await controller.openPasswordAtOxyAuth({ returnUrl: 'https://alia.onl/' });
     expect(new URL(url).origin).toBe('https://auth.alia.onl');
   });
 });

--- a/packages/core/src/session/accountDialogController.ts
+++ b/packages/core/src/session/accountDialogController.ts
@@ -31,6 +31,12 @@ import type { SessionLoginResponse, MinimalUserData } from '../models/session';
 import type { User } from '../models/interfaces';
 import { logger } from '../utils/loggerUtils';
 import { CENTRAL_IDP_APEX } from '../utils/authWebUrl';
+import {
+  generateOAuthState,
+  generatePkcePair,
+  normalizeOAuthRedirectUri,
+  persistOAuthHandshake,
+} from '../utils/oauthPkce';
 import { SessionClient } from './SessionClient';
 import {
   projectSwitchableAccounts,
@@ -111,6 +117,12 @@ export interface AccountDialogControllerOptions {
   onSignedIn?: (user: MinimalUserData) => void;
   /** Central IdP apex for `openPasswordAtOxyAuth` (defaults to `CENTRAL_IDP_APEX`). */
   idpApex?: string;
+  /**
+   * Registered OAuth redirect URI for this RP (exact match against
+   * `Application.redirectUris`). When set, wins over `returnUrl` /
+   * `location.origin` normalization in {@link openPasswordAtOxyAuth}.
+   */
+  authRedirectUri?: string | null;
   /** QR device-flow poll interval in ms (default 3000). */
   pollIntervalMs?: number;
   /**
@@ -145,6 +157,7 @@ export class AccountDialogController {
   private readonly commitSession?: (session: SessionLoginResponse) => Promise<void>;
   private readonly onSignedIn?: (user: MinimalUserData) => void;
   private readonly idpApex: string;
+  private readonly authRedirectUri: string | null;
   private readonly pollIntervalMs: number;
   private readonly openUrl?: (url: string) => void;
 
@@ -181,6 +194,7 @@ export class AccountDialogController {
     this.commitSession = options.commitSession;
     this.onSignedIn = options.onSignedIn;
     this.idpApex = options.idpApex ?? CENTRAL_IDP_APEX;
+    this.authRedirectUri = options.authRedirectUri ?? null;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.openUrl = options.openUrl;
     this.snapshot = this.computeSnapshot();
@@ -548,18 +562,30 @@ export class AccountDialogController {
    * @param params.state - Optional opaque state echoed back on return.
    * @returns The absolute auth.oxy.so sign-in URL.
    */
-  openPasswordAtOxyAuth(params: { returnUrl?: string; state?: string } = {}): string {
+  async openPasswordAtOxyAuth(
+    params: { returnUrl?: string; state?: string; redirectUri?: string } = {},
+  ): Promise<string> {
     const base = `https://auth.${this.idpApex}`;
     const url = new URL('/login', base);
-    const returnUrl = params.returnUrl ?? currentLocationHref();
-    if (returnUrl) {
-      url.searchParams.set('redirect_uri', returnUrl);
+    const rawRedirect =
+      params.redirectUri ??
+      this.authRedirectUri ??
+      params.returnUrl ??
+      currentLocationOrigin();
+    const redirectUri = rawRedirect ? normalizeOAuthRedirectUri(rawRedirect) : '';
+    if (redirectUri) {
+      url.searchParams.set('redirect_uri', redirectUri);
     }
     if (this.clientId) {
       url.searchParams.set('client_id', this.clientId);
     }
-    if (params.state) {
-      url.searchParams.set('state', params.state);
+    const state = params.state ?? (await generateOAuthState());
+    url.searchParams.set('state', state);
+    const { codeChallenge, codeVerifier } = await generatePkcePair();
+    url.searchParams.set('code_challenge', codeChallenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+    if (!persistOAuthHandshake(state, codeVerifier)) {
+      throw new Error('Could not persist OAuth handshake for password sign-in');
     }
     const href = url.toString();
     this.openUrl?.(href);
@@ -748,8 +774,8 @@ export function createAccountDialogController(
 // Local helpers
 // ---------------------------------------------------------------------------
 
-/** Current document URL on web; empty string where `location` is absent (native/SSR). */
-function currentLocationHref(): string {
-  const location = (globalThis as { location?: { href?: string } }).location;
-  return typeof location?.href === 'string' ? location.href : '';
+/** Current document origin on web; empty string where `location` is absent (native/SSR). */
+function currentLocationOrigin(): string {
+  const location = (globalThis as { location?: { origin?: string } }).location;
+  return typeof location?.origin === 'string' ? location.origin : '';
 }

--- a/packages/core/src/utils/oauthPkce.ts
+++ b/packages/core/src/utils/oauthPkce.ts
@@ -187,3 +187,60 @@ export function buildOAuthAuthorizeUrl(params: BuildOAuthAuthorizeUrlParams): st
 
   return url.toString();
 }
+
+/** `sessionStorage` key for the OAuth CSRF `state` across an authorize redirect. */
+export const OXY_OAUTH_STATE_STORAGE_KEY = 'oxy_oauth_state';
+
+/** `sessionStorage` key for the PKCE `code_verifier` across an authorize redirect. */
+export const OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY = 'oxy_oauth_code_verifier';
+
+/**
+ * Normalize a redirect URI to its origin. Official Oxy apps register apex
+ * origins (`https://inbox.oxy.so`) — never path-qualified URLs.
+ */
+export function normalizeOAuthRedirectUri(input: string): string {
+  try {
+    return new URL(input).origin;
+  } catch {
+    return input;
+  }
+}
+
+/** Persist the OAuth handshake for a full-page redirect return (web only). */
+export function persistOAuthHandshake(state: string, codeVerifier: string): boolean {
+  const store = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  try {
+    if (!store) throw new Error('sessionStorage is unavailable');
+    store.setItem(OXY_OAUTH_STATE_STORAGE_KEY, state);
+    store.setItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY, codeVerifier);
+    return true;
+  } catch (error) {
+    logger.warn(
+      'Could not persist OAuth handshake to sessionStorage',
+      { component: 'oauthPkce' },
+      error,
+    );
+    return false;
+  }
+}
+
+/** Read the persisted OAuth handshake, or `null` when absent. */
+export function readOAuthHandshake(): { state: string; codeVerifier: string } | null {
+  const store = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  if (!store) return null;
+  const state = store.getItem(OXY_OAUTH_STATE_STORAGE_KEY);
+  const codeVerifier = store.getItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY);
+  if (!state || !codeVerifier) return null;
+  return { state, codeVerifier };
+}
+
+/** Drop persisted OAuth handshake keys after a successful or aborted return. */
+export function clearOAuthHandshake(): void {
+  const store = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  try {
+    store?.removeItem(OXY_OAUTH_STATE_STORAGE_KEY);
+    store?.removeItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY);
+  } catch {
+    // Best-effort cleanup only.
+  }
+}

--- a/packages/services/src/ui/components/OxyAccountDialog.tsx
+++ b/packages/services/src/ui/components/OxyAccountDialog.tsx
@@ -238,11 +238,7 @@ const OxyAccountDialog: React.FC = () => {
             handlers={handlers}
             onSignInWithOxy={() => void controller.signInWithOxy()}
             onScanQr={() => void controller.showQr()}
-            onUsePassword={() =>
-              controller.openPasswordAtOxyAuth({
-                returnUrl: isWeb ? currentHref() : undefined,
-              })
-            }
+            onUsePassword={() => void controller.openPasswordAtOxyAuth()}
           />
         )}
       </ScrollView>

--- a/packages/services/src/ui/components/OxySignInButton.tsx
+++ b/packages/services/src/ui/components/OxySignInButton.tsx
@@ -6,6 +6,9 @@ import {
     generatePkcePair,
     generateOAuthState,
     buildOAuthAuthorizeUrl,
+    OXY_OAUTH_STATE_STORAGE_KEY,
+    OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
+    persistOAuthHandshake,
     type PublicApplication,
 } from '@oxyhq/core';
 import { useAuthStore } from '../stores/authStore';
@@ -18,18 +21,10 @@ import { subscribeToSignInModal } from '../navigation/accountDialogManager';
 import { redirectToAuthorize, openAuthorizeUrlNative } from './oauthNavigation';
 
 /**
- * `sessionStorage` keys under which a third-party "Sign in with Oxy" OAuth flow
- * persists its CSRF `state` and PKCE `code_verifier` across the authorize
- * redirect. The Relying Party's redirect-URI callback reads them back to
- * validate the returned `state` and replay the verifier on the token exchange.
- *
- * Web only: a browser RP navigates away to `auth.oxy.so` and back, so the
- * handshake must survive a full-page redirect. Native completes the flow inside
- * a single `WebBrowser` auth session and surfaces the handshake via
- * {@link OxySignInButtonProps.onOAuthResult} instead.
+ * Re-exported from `@oxyhq/core` for backward compatibility.
+ * @deprecated Import from `@oxyhq/core` instead.
  */
-export const OXY_OAUTH_STATE_STORAGE_KEY = 'oxy_oauth_state';
-export const OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY = 'oxy_oauth_code_verifier';
+export { OXY_OAUTH_STATE_STORAGE_KEY, OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY };
 
 /**
  * The OAuth handshake surfaced to a NATIVE third-party RP via
@@ -53,21 +48,8 @@ export interface OxyOAuthResult {
  * `QuotaExceededError`, e.g. Safari private mode) — so the caller aborts the
  * flow cleanly rather than redirect to a callback that cannot validate `state`.
  */
-function persistOAuthHandshake(state: string, codeVerifier: string): boolean {
-    const store = (globalThis as { sessionStorage?: Storage }).sessionStorage;
-    try {
-        if (!store) throw new Error('sessionStorage is unavailable');
-        store.setItem(OXY_OAUTH_STATE_STORAGE_KEY, state);
-        store.setItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY, codeVerifier);
-        return true;
-    } catch (error) {
-        logger.warn(
-            'OxySignInButton: could not persist the OAuth handshake to sessionStorage; aborting third-party sign-in',
-            { component: 'OxySignInButton' },
-            error,
-        );
-        return false;
-    }
+function persistOAuthHandshakeForButton(state: string, codeVerifier: string): boolean {
+    return persistOAuthHandshake(state, codeVerifier);
 }
 
 export interface OxySignInButtonProps {
@@ -257,7 +239,7 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                 // Persist the handshake for the RP callback, then hand the
                 // top-level document to the IdP. Without storage the callback
                 // cannot validate `state`, so abort cleanly rather than redirect.
-                if (!persistOAuthHandshake(state, pkce.codeVerifier)) {
+                if (!persistOAuthHandshakeForButton(state, pkce.codeVerifier)) {
                     return;
                 }
                 redirectToAuthorize(authorizeUrl);

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -36,6 +36,7 @@ import {
   registerAccountDialogControls,
   notifyAccountDialogVisibility,
 } from '../navigation/accountDialogManager';
+import { tryCompleteOAuthReturn } from '../utils/oauthReturn';
 import { useAuthStore, type AuthState } from '../stores/authStore';
 import { useShallow } from 'zustand/react/shallow';
 import type { UseFollowHook } from '../hooks/useFollow.types';
@@ -896,6 +897,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       oxyServices,
       sessionClient,
       clientId,
+      authRedirectUri,
       locale: currentLanguage,
       commitSession: (session) => handleWebSessionRef.current(session),
       onSignedIn: () => setAccountDialogOpen(false),
@@ -1010,6 +1012,21 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   const runColdBoot = useCallback(async (): Promise<void> => {
     setTokenReady(false);
     try {
+      if (coldBoot) {
+        const oauthCompleted = await tryCompleteOAuthReturn({
+          oxyServices,
+          clientId: clientIdProp,
+          authRedirectUri,
+          commitSession: (input) =>
+            commitSessionRef.current(input, { activate: true }),
+        });
+        if (oauthCompleted) {
+          setTokenReady(true);
+          markAuthResolvedRef.current();
+          return;
+        }
+      }
+
       await runSessionColdBoot({
         oxy: oxyServices,
         store: authStore,
@@ -1062,7 +1079,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       // Backstop: resolve on every exit path so the gate can never hang.
       markAuthResolvedRef.current();
     }
-  }, [oxyServices, authStore]);
+  }, [oxyServices, authStore, coldBoot, clientIdProp, authRedirectUri]);
 
   useEffect(() => {
     if (initialized) {

--- a/packages/services/src/ui/utils/oauthReturn.ts
+++ b/packages/services/src/ui/utils/oauthReturn.ts
@@ -1,0 +1,95 @@
+import type { OxyServices } from '@oxyhq/core';
+import {
+  clearOAuthHandshake,
+  logger,
+  normalizeOAuthRedirectUri,
+  readOAuthHandshake,
+} from '@oxyhq/core';
+import { isWebBrowser } from './isWebBrowser';
+
+export interface OAuthReturnCommitInput {
+  sessionId: string;
+  accessToken?: string;
+  deviceId?: string;
+  deviceSecret?: string;
+  userId: string;
+  expiresAt?: string;
+  user?: { id: string; username?: string; avatar?: string };
+}
+
+/**
+ * When the RP lands with `?code=` after password sign-in at auth.oxy.so, exchange
+ * the code for a device-first session before cold boot runs.
+ */
+export async function tryCompleteOAuthReturn(opts: {
+  oxyServices: OxyServices;
+  clientId?: string | null;
+  authRedirectUri?: string;
+  commitSession: (input: OAuthReturnCommitInput) => Promise<void>;
+}): Promise<boolean> {
+  if (!isWebBrowser()) return false;
+  const location = (globalThis as { location?: Location }).location;
+  if (!location) return false;
+
+  const params = new URLSearchParams(location.search);
+  const code = params.get('code');
+  if (!code) return false;
+
+  const clientId = opts.clientId;
+  if (!clientId) {
+    logger.warn('OAuth return ignored: missing clientId', { component: 'oauthReturn' });
+    stripOAuthParamsFromUrl();
+    return false;
+  }
+
+  const returnedState = params.get('state');
+  const handshake = readOAuthHandshake();
+  if (!handshake || !returnedState || handshake.state !== returnedState) {
+    logger.warn('OAuth return ignored: missing or mismatched handshake', {
+      component: 'oauthReturn',
+    });
+    clearOAuthHandshake();
+    stripOAuthParamsFromUrl();
+    return false;
+  }
+
+  const redirectUri = normalizeOAuthRedirectUri(
+    opts.authRedirectUri ?? location.origin,
+  );
+
+  try {
+    const result = await opts.oxyServices.exchangeOAuthCode({
+      code,
+      clientId,
+      redirectUri,
+      codeVerifier: handshake.codeVerifier,
+    });
+    await opts.commitSession({
+      sessionId: result.sessionId,
+      accessToken: result.accessToken,
+      deviceId: result.deviceId,
+      deviceSecret: result.deviceSecret,
+      userId: result.user.id,
+      expiresAt: result.expiresAt,
+      user: result.user,
+    });
+    clearOAuthHandshake();
+    stripOAuthParamsFromUrl();
+    return true;
+  } catch (error) {
+    logger.warn('OAuth return exchange failed', { component: 'oauthReturn' }, error);
+    clearOAuthHandshake();
+    stripOAuthParamsFromUrl();
+    return false;
+  }
+}
+
+function stripOAuthParamsFromUrl(): void {
+  const location = (globalThis as { location?: Location; history?: History }).location;
+  const history = (globalThis as { history?: History }).history;
+  if (!location || !history?.replaceState) return;
+  const url = new URL(location.href);
+  url.searchParams.delete('code');
+  url.searchParams.delete('state');
+  history.replaceState(history.state, '', `${url.pathname}${url.search}${url.hash}`);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Sign-in across official Oxy apps (Inbox, Accounts, Console, etc.) fails during the password hand-off to `auth.oxy.so`:

1. **Production DB drift** — official `Application` records resolve via `GET /auth/oauth/client/:clientId` but have **empty `redirectUris`**, so `POST /auth/oauth/authorize` returns `redirect_uri is not registered for this client` (verified in prod with curl).

2. **Client flow gaps** — `openPasswordAtOxyAuth` sent the full page URL as `redirect_uri` (must exact-match registered origin), omitted PKCE (required for public client token exchange), and first-party apps never exchanged the returned `?code=` back into a device-first session.

3. **IdP signup link** — "Create account" dropped OAuth params, causing "No authorization request found" after signup mid-flow.

## Fix

### API (`packages/api`)
- **`reconcileOfficialRedirectUris`** — on boot, restores `redirectUris: [origin(websiteUrl)]` for official apps with an empty allowlist (self-heals prod without a manual seed run).
- **`POST /auth/oauth/token`** — calls `finalizeDeviceLogin` and returns `deviceId` + `deviceSecret` so the RP can persist zero-cookie credentials.

### Core / Services SDK
- **`openPasswordAtOxyAuth`** — async; uses registered `authRedirectUri` / origin normalization, PKCE, and `sessionStorage` handshake persistence.
- **`exchangeOAuthCode`** on `OxyServices` + **`tryCompleteOAuthReturn`** in `OxyProvider` cold boot — completes password sign-in when the RP lands with `?code=&state=`.
- Shared OAuth handshake helpers exported from `@oxyhq/core` (re-used by `OxySignInButton`).

### Auth IdP (`packages/auth`)
- Signup link preserves OAuth query params from the login page.

## Verification

- `packages/core` accountDialogController tests: 27 passed
- `packages/api` oauthCode.service tests: 10 passed
- Prod curl before fix: `POST /auth/oauth/authorize` with `redirectUri: https://inbox.oxy.so` → **403 FORBIDDEN**

## Deploy notes

After merge + deploy to ECS, the boot reconciler should repair empty `redirectUris` automatically on the next API restart. Optionally still run `packages/api/scripts/seed-oxy-applications.ts` as a one-shot to fully reconcile all official app metadata.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

