### PR TITLE
fix(api): broaden redirectUris reconciler for trusted apps

### DIFF
--- a/packages/api/src/config/dynamicOriginRegistry.ts
+++ b/packages/api/src/config/dynamicOriginRegistry.ts
@@ -296,7 +296,10 @@ export function getCorsDecision(origin: string): CorsDecision {
 
 /** Rebuild the snapshots from the Application registry (background-safe). */
 export function refreshOriginRegistry(): Promise<void> {
-  return registry.refresh();
+  return registry.refresh().then(async () => {
+    const { reconcileOfficialRedirectUris } = await import('./reconcileOfficialRedirectUris.js');
+    await reconcileOfficialRedirectUris();
+  });
 }
 
 /** Stop the background refresh interval (tests / graceful shutdown). */

--- a/packages/api/src/config/reconcileOfficialRedirectUris.ts
+++ b/packages/api/src/config/reconcileOfficialRedirectUris.ts
@@ -1,14 +1,29 @@
 /**
- * Self-heal official Application redirect URIs when `redirectUris` is empty.
+ * Self-heal official Application redirect URIs when missing or drifted.
  *
- * Production drift (empty allowlist) blocks `POST /auth/oauth/authorize` with
+ * Production drift blocks `POST /auth/oauth/authorize` with
  * "redirect_uri is not registered for this client", breaking password sign-in
- * hand-offs from every first-party app. Official apps always declare a
- * `websiteUrl`; its origin is the canonical OAuth redirect surface.
+ * hand-offs from every first-party app. Official apps declare a `websiteUrl`
+ * whose origin is the canonical OAuth redirect surface.
  */
 
 import mongoose from 'mongoose';
 import { logger } from '../utils/logger';
+import { isTrustedApplication } from '../utils/trustedApplication';
+
+function originOfWebsiteUrl(websiteUrl: string): string | null {
+  try {
+    return new URL(websiteUrl.trim()).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Exact-match helper — redirect URIs are compared literally, not by prefix. */
+function includesRedirectUri(allowlist: string[] | undefined, origin: string): boolean {
+  if (!allowlist?.length) return false;
+  return allowlist.some((entry) => entry === origin);
+}
 
 export async function reconcileOfficialRedirectUris(): Promise<number> {
   if (mongoose.connection.readyState !== 1) {
@@ -16,27 +31,27 @@ export async function reconcileOfficialRedirectUris(): Promise<number> {
   }
 
   const { Application } = await import('../models/Application.js');
-  const candidates = await Application.find({
-    status: 'active',
-    isOfficial: true,
-    websiteUrl: { $exists: true, $ne: '' },
-    $or: [{ redirectUris: { $exists: false } }, { redirectUris: { $size: 0 } }],
-  }).select('name websiteUrl redirectUris');
+  const apps = await Application.find({ status: 'active' })
+    .select('name type isOfficial isInternal websiteUrl redirectUris');
 
   let repaired = 0;
-  for (const app of candidates) {
+  for (const app of apps) {
+    if (!isTrustedApplication(app)) continue;
+
     const websiteUrl = app.websiteUrl?.trim();
     if (!websiteUrl) continue;
-    let origin: string;
-    try {
-      origin = new URL(websiteUrl).origin;
-    } catch {
+
+    const origin = originOfWebsiteUrl(websiteUrl);
+    if (!origin) {
       logger.warn('[reconcileOfficialRedirectUris] invalid websiteUrl', {
         name: app.name,
         websiteUrl,
       });
       continue;
     }
+
+    if (includesRedirectUri(app.redirectUris, origin)) continue;
+
     app.redirectUris = [origin];
     await app.save();
     repaired += 1;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #573: production still rejected OAuth authorize because the reconciler only matched `isOfficial: true` with **empty** `redirectUris` arrays.

This broadens repair to all trusted apps (`first_party` / `internal` / `system` / `isOfficial`) whenever `websiteUrl` origin is missing from the allowlist, and runs the reconciler on the existing 60s origin-registry refresh (so prod self-heals within one minute of deploy without waiting for every ECS task to recycle).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

