### PR TITLE
fix(auth): OAuth redirect_uri trailing slash breaks official app sign-in

### DIFF
--- a/packages/accounts/app/_layout.tsx
+++ b/packages/accounts/app/_layout.tsx
@@ -31,7 +31,7 @@ import AppSplashScreen from '@/components/AppSplashScreen';
 import { AppInitializer } from '@/lib/appInitializer';
 import { LocaleProvider, useTranslation } from '@/lib/i18n';
 import { MinimalErrorFallback } from '@/components/error-fallback';
-import { OXY_CLIENT_ID } from '@/constants/oxy';
+import { OXY_CLIENT_ID, OXY_AUTH_REDIRECT_URI } from '@/constants/oxy';
 import {
   preventNativeSplashAutoHide,
   useHideNativeSplashWhenReady,
@@ -147,7 +147,7 @@ function RootLayoutInner() {
             (this app) owns the BloomThemeProvider and feeds it the resolved
             theme mode from ThemeModeProvider. */}
         <BloomThemeProvider mode={themeMode}>
-          <OxyProvider baseURL={API_URL} clientId={OXY_CLIENT_ID}>
+          <OxyProvider baseURL={API_URL} clientId={OXY_CLIENT_ID} authRedirectUri={OXY_AUTH_REDIRECT_URI}>
             <AppImageResolver>
               <LocaleProvider>
                 <AppHead />

--- a/packages/accounts/constants/oxy.ts
+++ b/packages/accounts/constants/oxy.ts
@@ -12,6 +12,10 @@ export const OXY_CLIENT_ID =
   process.env.EXPO_PUBLIC_OXY_CLIENT_ID ??
   'oxy_dk_00f0e5d5a2e4697740a476d3cfc54f4490f01245d0d2dd05';
 
+/** Registered OAuth redirect surface for this web origin (exact match). */
+export const OXY_AUTH_REDIRECT_URI =
+  process.env.EXPO_PUBLIC_OXY_AUTH_REDIRECT_URI ?? 'https://accounts.oxy.so';
+
 /**
  * Deep link into the Commons app's delete-account flow. Account deletion is
  * key-gated (the API verifies a signature over `delete:<publicKey>:<ts>`), and

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -32,7 +32,7 @@ import { validate } from '../middleware/validate';
 import sessionService from '../services/session.service';
 import { finalizeDeviceLogin } from '../services/deviceLogin.service';
 import { formatUserResponse } from '../utils/userTransform';
-import { issueAuthCode, exchangeAuthCode, AUTH_CODE_TTL_MS } from '../services/oauthCode.service';
+import { issueAuthCode, exchangeAuthCode, AUTH_CODE_TTL_MS, canonicalizeOAuthRedirectUri } from '../services/oauthCode.service';
 import { claimAuthSession, authorizeSessionWithSignedChallenge } from '../services/authSession.service';
 import Session from '../models/Session';
 import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils';
@@ -1753,13 +1753,16 @@ router.post(
  * source of countless open-redirect vulnerabilities — we never normalise
  * away path or query for the comparison. Constant-time equality keeps the
  * comparison from leaking the allowlist contents via timing.
+ *
+ * Origin-only https URLs are canonicalized so `https://app.example` and
+ * `https://app.example/` match the same registered apex origin.
  */
 function isAllowedRedirectUri(app: { redirectUris?: string[] }, redirectUri: string): boolean {
   const allowlist = app.redirectUris ?? [];
   if (allowlist.length === 0) return false;
-  const provided = Buffer.from(redirectUri);
+  const provided = Buffer.from(canonicalizeOAuthRedirectUri(redirectUri));
   for (const allowed of allowlist) {
-    const allowedBuf = Buffer.from(allowed);
+    const allowedBuf = Buffer.from(canonicalizeOAuthRedirectUri(allowed));
     if (allowedBuf.length === provided.length && crypto.timingSafeEqual(allowedBuf, provided)) {
       return true;
     }

--- a/packages/api/src/services/__tests__/oauthCode.service.test.ts
+++ b/packages/api/src/services/__tests__/oauthCode.service.test.ts
@@ -216,6 +216,22 @@ describe('exchangeAuthCode (H6 — single-use, binding checks)', () => {
     if (!res.ok) expect(res.reason).toBe('invalid_grant');
   });
 
+  it('accepts apex origin with or without a trailing slash', async () => {
+    const { code } = await issueAuthCode({
+      userId: USER_ID,
+      appId: APP_ID,
+      redirectUri: 'https://inbox.oxy.so/',
+    });
+
+    const res = await exchangeAuthCode({
+      rawCode: code,
+      appId: APP_ID,
+      redirectUri: 'https://inbox.oxy.so',
+      clientSecretProvided: true,
+    });
+    expect(res.ok).toBe(true);
+  });
+
   it('rejects when the appId does not match', async () => {
     const { code } = await issueAuthCode({
       userId: USER_ID,

--- a/packages/api/src/services/oauthCode.service.ts
+++ b/packages/api/src/services/oauthCode.service.ts
@@ -39,6 +39,22 @@ export function timingSafeStringEqual(a: string, b: string): boolean {
   return crypto.timingSafeEqual(aBuf, bBuf);
 }
 
+/** Collapse `https://app.example/` → `https://app.example` for OAuth binding. */
+export function canonicalizeOAuthRedirectUri(redirectUri: string): string {
+  try {
+    const parsed = new URL(redirectUri);
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return redirectUri;
+    }
+    if (parsed.pathname === '/' && !parsed.search && !parsed.hash) {
+      return parsed.origin;
+    }
+    return redirectUri;
+  } catch {
+    return redirectUri;
+  }
+}
+
 export interface IssueCodeOptions {
   userId: Types.ObjectId | string;
   appId: string;
@@ -64,7 +80,7 @@ export async function issueAuthCode(options: IssueCodeOptions): Promise<IssueCod
     codeHash,
     userId: options.userId,
     appId: options.appId,
-    redirectUri: options.redirectUri,
+    redirectUri: canonicalizeOAuthRedirectUri(options.redirectUri),
     codeChallenge: options.codeChallenge ?? null,
     codeChallengeMethod: options.codeChallenge ? 'S256' : null,
     scopes: options.scopes ?? [],
@@ -122,7 +138,12 @@ export async function exchangeAuthCode(options: ExchangeCodeOptions): Promise<Ex
     return { ok: false, reason: 'invalid_grant' };
   }
 
-  if (!timingSafeStringEqual(stored.redirectUri, options.redirectUri)) {
+  if (
+    !timingSafeStringEqual(
+      canonicalizeOAuthRedirectUri(stored.redirectUri),
+      canonicalizeOAuthRedirectUri(options.redirectUri),
+    )
+  ) {
     return { ok: false, reason: 'invalid_grant' };
   }
 

--- a/packages/auth/src/pages/authorize.tsx
+++ b/packages/auth/src/pages/authorize.tsx
@@ -80,6 +80,11 @@ function safeRedirectUrl(value?: string | null): string | null {
       // Block raw IP addresses for web redirects
       if (/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(parsed.hostname))
         return null;
+      // Apex origins only — never propagate the spurious trailing slash from
+      // `URL.toString()` or `redirect_uri=https://app.example/`.
+      if (parsed.pathname === "/" && !parsed.search && !parsed.hash) {
+        return parsed.origin;
+      }
       return parsed.toString();
     }
     // Allow registered native app schemes (no IP check needed)

--- a/packages/console/src/lib/config.ts
+++ b/packages/console/src/lib/config.ts
@@ -9,6 +9,8 @@ const config = {
   clientId:
     import.meta.env.VITE_OXY_CLIENT_ID ||
     'oxy_dk_2bdf04f596037ac720f94a54df405b974f240e5392a2e668',
+  authRedirectUri:
+    import.meta.env.VITE_OXY_AUTH_REDIRECT_URI || 'https://console.oxy.so',
 };
 
 export default config;

--- a/packages/console/src/routes/__root.tsx
+++ b/packages/console/src/routes/__root.tsx
@@ -40,7 +40,7 @@ function RootComponent() {
     <QueryClientProvider client={queryClient}>
       <LocaleProvider>
         <BloomThemeProvider mode="system" colorPreset="oxy">
-          <OxyProvider baseURL={config.oxyUrl} clientId={config.clientId} queryClient={queryClient}>
+          <OxyProvider baseURL={config.oxyUrl} clientId={config.clientId} authRedirectUri={config.authRedirectUri} queryClient={queryClient}>
             <AccountProvider>
               <TooltipProvider delayDuration={300}>
                 <Outlet />

--- a/packages/inbox/app/_layout.tsx
+++ b/packages/inbox/app/_layout.tsx
@@ -25,7 +25,7 @@ import { useInboxSocket } from '@/hooks/useInboxSocket';
 import { useEmailStore } from '@/hooks/useEmail';
 import { registerServiceWorker } from '@/utils/registerServiceWorker';
 import { onConnectivityChange, flushQueue } from '@/utils/offlineQueue';
-import { OXY_CLIENT_ID } from '@/constants/oxy';
+import { OXY_CLIENT_ID, OXY_AUTH_REDIRECT_URI } from '@/constants/oxy';
 import * as SplashScreen from 'expo-splash-screen';
 
 // Hide the native splash immediately on import. `BloomThemeProvider` configures
@@ -83,7 +83,7 @@ function RootLayoutContent() {
           user's `language` preference via `useOxy()` and seed the initial
           locale accordingly. Persisted overrides flow through AsyncStorage.
         */}
-        <OxyProvider baseURL={API_URL} clientId={OXY_CLIENT_ID}>
+        <OxyProvider baseURL={API_URL} clientId={OXY_CLIENT_ID} authRedirectUri={OXY_AUTH_REDIRECT_URI}>
           <BloomImageResolver>
             <LocaleProvider>
               <SafeAreaProvider>

--- a/packages/inbox/constants/oxy.ts
+++ b/packages/inbox/constants/oxy.ts
@@ -11,3 +11,7 @@
 export const OXY_CLIENT_ID =
   process.env.EXPO_PUBLIC_OXY_CLIENT_ID ??
   'oxy_dk_19cf17069d097a6ebf17a622709a53d13692ee69487224e3';
+
+/** Registered OAuth redirect surface for this web origin (exact match). */
+export const OXY_AUTH_REDIRECT_URI =
+  process.env.EXPO_PUBLIC_OXY_AUTH_REDIRECT_URI ?? 'https://inbox.oxy.so';

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -37,6 +37,8 @@ import {
   notifyAccountDialogVisibility,
 } from '../navigation/accountDialogManager';
 import { tryCompleteOAuthReturn } from '../utils/oauthReturn';
+import { redirectToAuthorize } from '../components/oauthNavigation';
+import { isWebBrowser } from '../utils/isWebBrowser';
 import { useAuthStore, type AuthState } from '../stores/authStore';
 import { useShallow } from 'zustand/react/shallow';
 import type { UseFollowHook } from '../hooks/useFollow.types';
@@ -902,6 +904,10 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       commitSession: (session) => handleWebSessionRef.current(session),
       onSignedIn: () => setAccountDialogOpen(false),
       openUrl: (url) => {
+        if (isWebBrowser()) {
+          redirectToAuthorize(url);
+          return;
+        }
         void Linking.openURL(url);
       },
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

`URL.toString()` turns `https://inbox.oxy.so` into `https://inbox.oxy.so/`. The IdP passed that trailing slash to OAuth authorize, which requires exact match against registered apex origins.

## Fix

Canonicalize origin-only https redirect URIs in API + IdP; web password hand-off uses location.assign; authRedirectUri wired on inbox/accounts/console.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

