### PR TITLE
fix(services): remove duplicate isWebBrowser import blocking CF deploy

### DIFF
--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -53,7 +53,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { clearQueryCache } from '../hooks/queryClient';
 import { useAvatarPicker } from '../hooks/useAvatarPicker';
 import { useAccountStore } from '../stores/accountStore';
-import { isWebBrowser } from '../utils/isWebBrowser';
 import {
   createSessionClient,
   createPlatformAuthStateStore,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cloudflare Pages deploy failed after #575 merged:

```
packages/services/src/ui/context/OxyContext.tsx: Identifier 'isWebBrowser' has already been declared. (56:9)
```

This blocked redeploy of inbox, accounts, console, and auth frontends with the OAuth trailing-slash fixes.

## Fix

Remove the duplicate `import { isWebBrowser } from '../utils/isWebBrowser'` on line 56 (line 41 import retained).

## Verification

- `bun run core:build && bun run services:build` — passes
- `npx tsc --noEmit` in packages/services — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

