### PR TITLE
Cross-app session sync: IdP hub + silent OAuth (zero cookies)

### DIFF
--- a/docs/SESSION-ARCHITECTURE.md
+++ b/docs/SESSION-ARCHITECTURE.md
@@ -86,10 +86,17 @@ The transport that carries "which device is this?" across reloads is **`deviceId
 3. **Revocation** — sign-out-all (`POST /session/device/signout { all: true }`) clears
    `secretHash` so a retained secret can never mint again. A theft divergence is detected
    at the next mint (the loser's secret no longer matches → `invalid_device_secret`).
-4. **No cross-origin implicit sync.** A `deviceId` is per origin (web) / per app-group
-   (native). Each new web origin does its own first sign-in; there is no shared device
-   cookie tying `*.oxy.so` subdomains together and no cross-app device token on native.
-   This is the deliberate trade for zero cookies.
+4. **Cross-origin sync via IdP hub (zero cookies).** Each web origin still persists
+   its own `{ deviceId, deviceSecret }` copy in `localStorage`, but all official apps
+   (including custom domains like `mention.earth`) and third-party RPs converge on the
+   **same** server-side `DeviceSession` through two mechanisms:
+   - **IdP handoff** — after a first-party sign-in, the SDK redirects once to
+     `auth.oxy.so/handoff` to plant the shared credentials on the IdP hub origin.
+   - **Silent OAuth (`prompt=none`)** — on cold boot, when local mint fails, the SDK
+     redirects to `auth.oxy.so/authorize?prompt=none` + PKCE; the IdP auto-approves when
+     it already has a session + grant, exchanges the code for tokens on the **same**
+     `deviceId`, and persists locally. Realtime changes propagate over Socket.IO
+     `session_state` on `device:<deviceId>` once each app holds a bearer.
 
 ## Cold boot
 
@@ -101,8 +108,14 @@ wins. It is invoked by `OxyProvider` on mount — apps never implement restore t
    `deviceSecret`, mint a short access token with a single bearer-less POST to
    `/session/device/token`, persist the rotated secret, plant the token. A
    `no_active_session` 401 is an authoritative signed-out; an `invalid_device_secret` 401
-   drops the (diverged) secret.
-2. **`shared-key-signin`** (native) — re-mint from the shared Commons identity in the
+   drops the (diverged) secret and falls through to silent OAuth on web.
+2. **`silent-oauth-restore`** (web only, in `@oxyhq/services`) — when local mint finds no
+   credential (or the secret was stale), redirect to `auth.oxy.so/authorize?prompt=none`
+   + PKCE. The IdP hub auto-approves when it has a session + grant; the RP exchanges the
+   returned code for tokens on the **same** `deviceId`. One attempt per navigation
+   (`sessionStorage.oxy.silent_oauth_attempted`); `error=login_required` ends signed-out
+   silently.
+3. **`shared-key-signin`** (native) — re-mint from the shared Commons identity in the
    app-group keychain.
 
 If nothing yields a session, the app is silently signed out — no redirect, no dialog.

--- a/docs/auth/device-session.md
+++ b/docs/auth/device-session.md
@@ -63,6 +63,8 @@ Present when the entry is a **managed account** (org / project / bot) the operat
 
 The device set stores exactly **one `sessionId` per account**. Every surface that authenticates the same account on the same device converges on that session (`resolveRegisteredSession`) instead of minting per-origin sessions — this is what makes all apps on a device join the same socket room and see each other's changes. Re-adding the same account with a *different* sessionId (a deliberate re-auth) replaces the entry and deactivates the displaced session.
 
+OAuth token exchange, password login, QR handoff, and IdP handoff all thread the same `deviceId` so cross-origin web apps (official domains like `mention.earth` and third-party RPs) share one `DeviceSession` document server-side. Each origin still persists its own `{ deviceId, deviceSecret }` copy in `localStorage` (zero cookies); convergence happens via IdP hub handoff + silent OAuth (`prompt=none`) documented in [`SESSION-ARCHITECTURE.md`](../SESSION-ARCHITECTURE.md).
+
 ### Self-healing
 
 Dead entries never sit in the set silently:

--- a/docs/auth/integration-guide.md
+++ b/docs/auth/integration-guide.md
@@ -308,9 +308,9 @@ Design your app so a revoked grant simply means the user is signed out of it unt
 
 Third-party integration is **standard OAuth only**. Do not expect — or try to rebuild — any of the following:
 
-1. **No silent cross-domain session sharing.** A user signed in on `mention.earth` is not automatically signed in on `merchant.example`. Instant cross-app session sync (the device-session model — see [`device-session.md`](./device-session.md)) is exclusive to official Oxy apps on the same device; it is not part of the third-party contract.
-2. **No Oxy session cookies on your domain.** Oxy's own session transport (a first-party device cookie on `oxy.so` origins plus a rotating refresh-token family) never extends to third-party domains. Never read, set, or depend on Oxy cookies; never send `credentials: 'include'` to Oxy APIs expecting a session to appear.
-3. **No browser federated-identity or iframe tricks.** FedCM, hidden-iframe session probes, and top-level "bounce" flows were removed from the platform entirely. There is nothing to call; the only cross-origin hop is your top-level authorize redirect.
+1. **Silent restore after first consent (Google-style).** After the user approves once, Oxy persists an `AppGrant`. On subsequent visits the SDK cold-boots with `prompt=none` against `auth.oxy.so` — no consent screen, no re-login — as long as the grant remains and scopes are unchanged. Revoke the grant in Connected apps (`DELETE /auth/grants/:applicationId`) to force re-consent. First visit still requires the full interactive authorize + consent flow.
+2. **No Oxy session cookies on your domain.** Oxy's device transport (`deviceId` + `deviceSecret` in your origin's `localStorage`) never uses cookies. Never read, set, or depend on Oxy cookies; never send `credentials: 'include'` to Oxy APIs expecting a session to appear.
+3. **No browser federated-identity or hidden iframe tricks.** FedCM and iframe session probes were removed. The only cross-origin hops are top-level redirects: interactive authorize (first visit) and silent authorize (`prompt=none`, reloads).
 4. **No Oxy-internal callback routes.** Your callback is the plain OAuth `redirectUri` you registered in Console. Do not register Oxy-internal callback paths in your app or expect an injected bootstrap script to consume the redirect — those mechanisms no longer exist.
 5. **No client secret in a browser or app bundle.** SPAs and native apps use `public` credentials + PKCE. Only a server may hold a `confidential` secret.
 6. **No skipping `state` validation.** Always generate `state` with `generateOAuthState()` and reject any callback whose `state` doesn't match — this is your CSRF defense across the redirect.
@@ -325,7 +325,7 @@ Third-party integration is **standard OAuth only**. Do not expect — or try to 
 
 | Method | Endpoint | Auth | Purpose |
 |--------|----------|------|---------|
-| GET | `https://auth.oxy.so/authorize` | — (browser) | Authorization + consent UI. Query: `client_id`, `redirect_uri`, `response_type=code`, `state`, `scope`, `code_challenge`, `code_challenge_method=S256` |
+| GET | `https://auth.oxy.so/authorize` | — (browser) | Authorization + consent UI. Query: `client_id`, `redirect_uri`, `response_type=code`, `state`, `scope`, `code_challenge`, `code_challenge_method=S256`, optional `prompt=none` for silent restore |
 | GET | `api.oxy.so/auth/oauth/client/:clientId` | none | Public, sanitized application metadata (name, icon, type, scopes, legal URLs). Generic 404 for unknown/revoked clients |
 | POST | `api.oxy.so/auth/oauth/token` | none (code-bound) | Exchange `{ code, clientId, redirectUri, codeVerifier \| clientSecret }` → `{ data: { access_token, refresh_token, token_type, expires_in, session_id, user } }` |
 | GET | `api.oxy.so/auth/grants` | Bearer | User's connected apps |

--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -23,6 +23,22 @@ import { recordFailure, clearFailures } from '../services/loginLockout.service';
 import { finalizeDeviceLogin } from '../services/deviceLogin.service';
 import type { AuthRequest } from '../middleware/auth';
 import { exactCaseInsensitiveUsernameRegex } from '../utils/resolveUserIdentifier';
+import type { SessionCreateOptions } from '../types/session.types';
+
+export function sessionCreateOptionsFromBody(body: {
+  deviceName?: string;
+  deviceFingerprint?: string;
+  deviceId?: string;
+}): SessionCreateOptions {
+  const opts: SessionCreateOptions = {
+    deviceName: body.deviceName,
+    deviceFingerprint: body.deviceFingerprint,
+  };
+  if (typeof body.deviceId === 'string' && body.deviceId.trim()) {
+    opts.deviceId = body.deviceId.trim();
+  }
+  return opts;
+}
 
 /**
  * Constant-time dummy Argon2 hash used to keep login response timing
@@ -326,7 +342,7 @@ export class SessionController {
    */
   static async signUp(req: Request, res: Response) {
     try {
-      const { email, username, password, name, deviceName, deviceFingerprint } = req.body;
+      const { email, username, password, name, deviceName, deviceFingerprint, deviceId } = req.body;
 
       if (
         !email ||
@@ -410,7 +426,7 @@ export class SessionController {
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        sessionCreateOptionsFromBody({ deviceName, deviceFingerprint, deviceId }),
       );
 
       const baseSignupResponse = buildSessionAuthResponse(session, user);
@@ -510,7 +526,7 @@ export class SessionController {
    */
   static async verifyChallenge(req: Request, res: Response) {
     try {
-      const { publicKey, challenge, signature, timestamp, deviceName, deviceFingerprint } = req.body;
+      const { publicKey, challenge, signature, timestamp, deviceName, deviceFingerprint, deviceId } = req.body;
 
       if (!publicKey || !challenge || !signature || !timestamp) {
         return res.status(400).json({
@@ -561,7 +577,7 @@ export class SessionController {
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        sessionCreateOptionsFromBody({ deviceName, deviceFingerprint, deviceId }),
       );
       const sessionAfterCreate = Date.now();
 
@@ -654,7 +670,7 @@ export class SessionController {
    */
   static async signIn(req: Request, res: Response) {
     try {
-      const { identifier, email, username, password, deviceName, deviceFingerprint } = req.body;
+      const { identifier, email, username, password, deviceName, deviceFingerprint, deviceId } = req.body;
       const loginIdentifier = identifier || email || username;
 
       if (!loginIdentifier || !password || typeof password !== 'string') {
@@ -738,7 +754,7 @@ export class SessionController {
       const session = await sessionService.createSession(
         user._id.toString(),
         req,
-        { deviceName, deviceFingerprint }
+        sessionCreateOptionsFromBody({ deviceName, deviceFingerprint, deviceId }),
       );
 
       const baseResponse = buildSessionAuthResponse(session, user);

--- a/packages/api/src/controllers/twoFactor.controller.ts
+++ b/packages/api/src/controllers/twoFactor.controller.ts
@@ -7,6 +7,7 @@ import securityActivityService from '../services/securityActivityService';
 import anomalyDetectionService from '../services/anomalyDetection.service';
 import sessionService from '../services/session.service';
 import { finalizeDeviceLogin } from '../services/deviceLogin.service';
+import { sessionCreateOptionsFromBody } from './session.controller';
 import { buildSessionAuthResponse } from './session.controller';
 import { AuthRequest } from '../middleware/auth';
 import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
@@ -296,7 +297,7 @@ export async function verify2FAToken(req: Request, res: Response) {
  */
 export async function verify2FALogin(req: Request, res: Response) {
   try {
-    const { loginToken, token, backupCode, deviceName, deviceFingerprint } = req.body;
+    const { loginToken, token, backupCode, deviceName, deviceFingerprint, deviceId } = req.body;
 
     if (!loginToken) {
       return res.status(400).json({ message: 'Login token is required' });
@@ -409,7 +410,7 @@ export async function verify2FALogin(req: Request, res: Response) {
     const session = await sessionService.createSession(
       user._id.toString(),
       req,
-      { deviceName, deviceFingerprint }
+      sessionCreateOptionsFromBody({ deviceName, deviceFingerprint, deviceId }),
     );
 
     const baseTwoFactorResponse = buildSessionAuthResponse(session, user);

--- a/packages/api/src/models/AuthCode.ts
+++ b/packages/api/src/models/AuthCode.ts
@@ -37,6 +37,11 @@ export interface IAuthCode extends Document {
   codeChallengeMethod?: 'S256';
   /** Optional OAuth scope list bound at issue time. */
   scopes: string[];
+  /**
+   * DeviceSession id from the authorizing bearer — threads cross-app OAuth
+   * token exchange onto the same device doc instead of minting an isolated one.
+   */
+  deviceId?: string;
   /** Set when the code is exchanged. Single-use enforcement. */
   usedAt?: Date;
   expiresAt: Date;
@@ -79,6 +84,10 @@ const AuthCodeSchema: Schema = new Schema(
     scopes: {
       type: [String],
       default: [],
+    },
+    deviceId: {
+      type: String,
+      default: null,
     },
     usedAt: {
       type: Date,

--- a/packages/api/src/models/AuthSession.ts
+++ b/packages/api/src/models/AuthSession.ts
@@ -125,6 +125,10 @@ const AuthSessionSchema: Schema = new Schema(
       type: String,
       default: null,
     },
+    deviceId: {
+      type: String,
+      default: null,
+    },
     consumedAt: {
       type: Date,
       default: null,

--- a/packages/api/src/models/IdpHandoffCode.ts
+++ b/packages/api/src/models/IdpHandoffCode.ts
@@ -1,0 +1,56 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+/**
+ * Single-use codes for cross-origin IdP session handoff (auth.oxy.so hub).
+ * A first-party app with an active bearer mints a code; auth.oxy.so exchanges
+ * it to plant the same DeviceSession credentials locally — no cookies.
+ */
+export interface IIdpHandoffCode extends Document {
+  codeHash: string;
+  deviceId: string;
+  sessionId: string;
+  userId: mongoose.Types.ObjectId;
+  usedAt?: Date;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const IdpHandoffCodeSchema = new Schema(
+  {
+    codeHash: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    deviceId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    sessionId: {
+      type: String,
+      required: true,
+    },
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    usedAt: {
+      type: Date,
+      default: null,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+  },
+  { timestamps: true },
+);
+
+IdpHandoffCodeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 300 });
+
+export const IdpHandoffCode = mongoose.model<IIdpHandoffCode>('IdpHandoffCode', IdpHandoffCodeSchema);
+export default IdpHandoffCode;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -61,7 +61,10 @@ import {
   oauthClientParams,
   oauthConsentQuerySchema,
   grantApplicationIdParams,
+  idpHandoffCreateSchema,
+  idpHandoffExchangeSchema,
 } from '../schemas/auth.schemas';
+import { createIdpHandoffCode, exchangeIdpHandoffCode } from '../services/idpHandoff.service';
 import { AppGrant } from '../models/AppGrant';
 import { normaliseOrigin, isLoopbackOrigin } from '../utils/origin';
 import { serializePublicApplication } from '../utils/serializeApplication';
@@ -937,11 +940,12 @@ import AuthSession from '../models/AuthSession';
  *         description: Application is not available (suspended/deleted/pending review).
  */
 router.post('/session/create', validate({ body: authSessionCreateSchema }), asyncHandler(async (req, res) => {
-  const { sessionToken, expiresAt, clientId, applicationId } = req.body as {
+  const { sessionToken, expiresAt, clientId, applicationId, deviceId } = req.body as {
     sessionToken: string;
     clientId?: string;
     applicationId?: string;
     expiresAt?: string | number;
+    deviceId?: string;
   };
 
   if (!sessionToken) {
@@ -1041,6 +1045,7 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
     challengeNonce: qrNonce,
     expiresAt: expiresAtDate,
     status: 'pending',
+    ...(typeof deviceId === 'string' && deviceId.trim() ? { deviceId: deviceId.trim() } : {}),
   });
 
   // Deep-link / universal-link payload for the QR. Commons parses ONLY `code`
@@ -1883,6 +1888,133 @@ const grantsRevokeLimiter = rateLimit({
   max: process.env.NODE_ENV === 'development' ? 100 : 30,
 });
 
+const idpHandoffCreateLimiter = rateLimit({
+  prefix: 'rl:auth:idp-handoff-create:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 30,
+});
+
+const idpHandoffExchangeLimiter = rateLimit({
+  prefix: 'rl:auth:idp-handoff-exchange:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 30,
+});
+
+/**
+ * @openapi
+ * /auth/idp-handoff/create:
+ *   post:
+ *     tags:
+ *       - Authentication
+ *     summary: Mint a one-shot IdP session handoff code
+ *     description: >
+ *       Authenticated apps call this after sign-in to propagate the same
+ *       DeviceSession credentials to auth.oxy.so (cross-origin hub, zero cookies).
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Handoff code issued.
+ *       401:
+ *         description: Missing bearer or device claim.
+ */
+router.post(
+  '/idp-handoff/create',
+  authMiddleware,
+  idpHandoffCreateLimiter,
+  validate({ body: idpHandoffCreateSchema }),
+  asyncHandler(async (req: AuthRequest, res) => {
+    const user = req.user;
+    if (!user?._id) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const bearerToken = extractTokenFromRequest(req);
+    const decoded = bearerToken ? decodeToken(bearerToken) : null;
+    if (!decoded?.deviceId || !decoded?.sessionId) {
+      throw new UnauthorizedError('Device session required');
+    }
+
+    const { handoffCode, expiresAt } = await createIdpHandoffCode({
+      deviceId: decoded.deviceId,
+      sessionId: decoded.sessionId,
+      userId: user._id.toString(),
+    });
+
+    sendSuccess(res, {
+      handoffCode,
+      expiresIn: Math.max(1, Math.floor((expiresAt.getTime() - Date.now()) / 1000)),
+    });
+  }),
+);
+
+/**
+ * @openapi
+ * /auth/idp-handoff/exchange:
+ *   post:
+ *     tags:
+ *       - Authentication
+ *     security: []
+ *     summary: Exchange an IdP handoff code for device credentials
+ *     description: >
+ *       Called from auth.oxy.so to plant the shared DeviceSession locally.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [handoffCode]
+ *             properties:
+ *               handoffCode:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Device credentials for the IdP origin.
+ *       401:
+ *         description: Invalid or expired handoff code.
+ */
+router.post(
+  '/idp-handoff/exchange',
+  idpHandoffExchangeLimiter,
+  validate({ body: idpHandoffExchangeSchema }),
+  asyncHandler(async (req, res) => {
+    const { handoffCode } = req.body as { handoffCode: string };
+    const exchange = await exchangeIdpHandoffCode(handoffCode);
+    if (!exchange.ok) {
+      throw new UnauthorizedError('invalid_handoff');
+    }
+
+    const { deviceId, sessionId, userId } = exchange.record;
+    const user = await User.findById(userId);
+    if (!user) {
+      throw new UnauthorizedError('invalid_handoff');
+    }
+
+    const { default: deviceSessionService } = await import('../services/deviceSession.service.js');
+    const state = await deviceSessionService.getState(deviceId);
+    const activeToken = await deviceSessionService.resolveActiveToken(state);
+    if (!activeToken) {
+      throw new UnauthorizedError('no_active_session');
+    }
+
+    const deviceSecret = await deviceSessionService.issueDeviceSecret(deviceId);
+    if (!deviceSecret) {
+      throw new UnauthorizedError('invalid_handoff');
+    }
+
+    sendSuccess(res, {
+      deviceId,
+      deviceSecret,
+      sessionId,
+      userId: userId.toString(),
+      accessToken: activeToken.accessToken,
+      expiresAt: activeToken.expiresAt,
+      user: formatUserResponse(user),
+    });
+  }),
+);
+
 /**
  * @openapi
  * /auth/oauth/authorize:
@@ -1992,6 +2124,11 @@ router.post(
 
     const requestedScopes = scope ? scope.split(/\s+/).filter(Boolean) : [];
 
+    const bearerToken = extractTokenFromRequest(req);
+    const bearerDecoded = bearerToken ? decodeToken(bearerToken) : null;
+    const oauthDeviceId =
+      typeof bearerDecoded?.deviceId === 'string' ? bearerDecoded.deviceId : undefined;
+
     // Mint a single-use opaque code. The service persists a hash, never
     // the raw value, so leakage of the AuthCode collection would not
     // allow an attacker to redeem outstanding codes.
@@ -2002,6 +2139,7 @@ router.post(
       codeChallenge,
       codeChallengeMethod: codeChallenge ? 'S256' : undefined,
       scopes: requestedScopes,
+      deviceId: oauthDeviceId,
     });
 
     // Record (or refresh) the user's consent so a returning user skips the
@@ -2396,13 +2534,18 @@ router.post(
 
     const userId = user._id.toString();
 
-    // Third-party OAuth sessions are per-client + per-origin and independent of
-    // the first-party device set (no cross-app device sync) — mint a fresh
-    // session for the grant.
+    const sharedDeviceId =
+      typeof exchange.code.deviceId === 'string' && exchange.code.deviceId.trim()
+        ? exchange.code.deviceId.trim()
+        : undefined;
+
     const session = await sessionService.createSession(
       userId,
       req,
-      { deviceName: `${app.name} OAuth` },
+      {
+        deviceName: `${app.name} OAuth`,
+        ...(sharedDeviceId ? { deviceId: sharedDeviceId } : {}),
+      },
     );
 
     const deviceExtras = await finalizeDeviceLogin({

--- a/packages/api/src/schemas/auth.schemas.ts
+++ b/packages/api/src/schemas/auth.schemas.ts
@@ -3,6 +3,8 @@ import { isValidDisplayName } from '../utils/displayNameSanitize';
 
 const INVALID_NAME_MESSAGE = 'Name may only contain letters, spaces and apostrophes.';
 
+const deviceIdField = z.string().trim().min(1).max(128).optional();
+
 // POST /auth/signup
 export const signupSchema = z.object({
   email: z.string().trim().email(),
@@ -14,6 +16,7 @@ export const signupSchema = z.object({
   }).optional(),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  deviceId: deviceIdField,
 }).superRefine((data, ctx) => {
   // Native users must supply a clean display name (letters/spaces/apostrophe
   // only). Federated names are stripped silently elsewhere; native names are
@@ -42,6 +45,7 @@ export const loginSchema = z.object({
   password: z.string().min(1),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  deviceId: deviceIdField,
 });
 
 // POST /auth/register (public key)
@@ -66,6 +70,7 @@ export const verifyChallengeSchema = z.object({
   timestamp: z.number(),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  deviceId: deviceIdField,
 });
 
 // POST /auth/recover/request
@@ -120,6 +125,8 @@ export const authSessionCreateSchema = z.object({
   clientId: z.string().trim().min(1).optional(),
   applicationId: z.string().trim().min(1).optional(),
   expiresAt: z.union([z.string(), z.number()]).optional(),
+  /** Originating RP device id — converges QR sign-in onto the same DeviceSession. */
+  deviceId: deviceIdField,
 }).refine(
   (data) => Boolean(data.clientId) || Boolean(data.applicationId),
   { message: 'Either clientId or applicationId is required' }
@@ -222,4 +229,12 @@ export const oauthConsentQuerySchema = z.object({
 // Revoke the user's OAuth grant for a connected third-party application.
 export const grantApplicationIdParams = z.object({
   applicationId: z.string().trim().min(1),
+});
+
+// POST /auth/idp-handoff/create — bearer; mints a one-shot code for auth.oxy.so.
+export const idpHandoffCreateSchema = z.object({});
+
+// POST /auth/idp-handoff/exchange — public; redeems handoff code on IdP origin.
+export const idpHandoffExchangeSchema = z.object({
+  handoffCode: z.string().trim().min(1),
 });

--- a/packages/api/src/schemas/security.schemas.ts
+++ b/packages/api/src/schemas/security.schemas.ts
@@ -35,5 +35,6 @@ export const verify2FALoginSchema = z.object({
   backupCode: z.string().trim().optional(),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
+  deviceId: z.string().trim().min(1).max(128).optional(),
   deviceToken: z.string().trim().max(512).optional(),
 });

--- a/packages/api/src/services/__tests__/idpHandoff.service.test.ts
+++ b/packages/api/src/services/__tests__/idpHandoff.service.test.ts
@@ -1,0 +1,101 @@
+/**
+ * IdP handoff code service tests
+ */
+
+import * as crypto from 'crypto';
+
+jest.mock('../../models/AuthCode', () => ({
+  __esModule: true,
+  default: {},
+  AuthCode: {},
+}));
+
+interface StoredHandoff {
+  _id: string;
+  codeHash: string;
+  deviceId: string;
+  sessionId: string;
+  userId: string;
+  usedAt: Date | null;
+  expiresAt: Date;
+}
+
+const store = new Map<string, StoredHandoff>();
+let nextId = 1;
+
+jest.mock('../../models/IdpHandoffCode', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(async (data: Partial<StoredHandoff>) => {
+      const id = `handoff-${nextId++}`;
+      const record: StoredHandoff = {
+        _id: id,
+        codeHash: data.codeHash ?? '',
+        deviceId: data.deviceId ?? '',
+        sessionId: data.sessionId ?? '',
+        userId: data.userId ?? '',
+        usedAt: data.usedAt ?? null,
+        expiresAt: data.expiresAt ?? new Date(Date.now() + 30_000),
+      };
+      store.set(record.codeHash, record);
+      return record;
+    }),
+    findOne: jest.fn(async (query: { codeHash: string }) => store.get(query.codeHash) ?? null),
+    findOneAndUpdate: jest.fn(
+      async (
+        filter: { _id: string; usedAt: null | Date },
+        update: { $set: { usedAt: Date } },
+      ) => {
+        for (const record of store.values()) {
+          if (record._id !== filter._id) continue;
+          if (record.usedAt !== null) return null;
+          record.usedAt = update.$set.usedAt;
+          return record;
+        }
+        return null;
+      },
+    ),
+  },
+  IdpHandoffCode: {},
+}));
+
+import {
+  createIdpHandoffCode,
+  exchangeIdpHandoffCode,
+} from '../idpHandoff.service';
+import { base64UrlEncode, sha256Hex } from '../oauthCode.service';
+
+describe('idpHandoff.service', () => {
+  beforeEach(() => {
+    store.clear();
+    nextId = 1;
+  });
+
+  it('issues and exchanges a handoff code once', async () => {
+    const { handoffCode } = await createIdpHandoffCode({
+      deviceId: 'device-a',
+      sessionId: 'session-a',
+      userId: 'user-a',
+    });
+
+    const first = await exchangeIdpHandoffCode(handoffCode);
+    expect(first.ok).toBe(true);
+    if (first.ok) {
+      expect(first.record.deviceId).toBe('device-a');
+      expect(first.record.sessionId).toBe('session-a');
+    }
+
+    const replay = await exchangeIdpHandoffCode(handoffCode);
+    expect(replay.ok).toBe(false);
+  });
+
+  it('rejects unknown codes', async () => {
+    const raw = base64UrlEncode(crypto.randomBytes(32));
+    const result = await exchangeIdpHandoffCode(raw);
+    expect(result.ok).toBe(false);
+  });
+
+  it('hashes codes consistently', () => {
+    expect(sha256Hex('test')).toHaveLength(64);
+  });
+});

--- a/packages/api/src/services/__tests__/oauthCode.service.test.ts
+++ b/packages/api/src/services/__tests__/oauthCode.service.test.ts
@@ -24,6 +24,7 @@ interface StoredCode {
   codeChallenge: string | null;
   codeChallengeMethod: string | null;
   scopes: string[];
+  deviceId: string | null;
   usedAt: Date | null;
   expiresAt: Date;
 }
@@ -46,6 +47,7 @@ jest.mock('../../models/AuthCode', () => ({
         codeChallenge: data.codeChallenge ?? null,
         codeChallengeMethod: data.codeChallengeMethod ?? null,
         scopes: data.scopes ?? [],
+        deviceId: data.deviceId ?? null,
         usedAt: data.usedAt ?? null,
         expiresAt: data.expiresAt ?? new Date(Date.now() + 60_000),
       };
@@ -108,6 +110,17 @@ describe('issueAuthCode', () => {
     const stored = Array.from(store.values())[0];
     expect(stored.codeHash).toMatch(/^[0-9a-f]{64}$/);
     expect(stored.codeHash).not.toBe(code); // raw code never persisted
+  });
+
+  it('persists deviceId when provided at issue time', async () => {
+    await issueAuthCode({
+      userId: USER_ID,
+      appId: APP_ID,
+      redirectUri: REDIRECT_URI,
+      deviceId: 'shared-device-1',
+    });
+    const stored = Array.from(store.values())[0];
+    expect(stored.deviceId).toBe('shared-device-1');
   });
 });
 

--- a/packages/api/src/services/idpHandoff.service.ts
+++ b/packages/api/src/services/idpHandoff.service.ts
@@ -1,0 +1,67 @@
+/**
+ * IdP handoff codes — one-shot transfer of device session context to auth.oxy.so.
+ */
+
+import * as crypto from 'crypto';
+import { Types } from 'mongoose';
+import IdpHandoffCode, { type IIdpHandoffCode } from '../models/IdpHandoffCode';
+import { base64UrlEncode, sha256Hex } from './oauthCode.service';
+
+export const IDP_HANDOFF_TTL_MS = 30 * 1000;
+export const IDP_HANDOFF_BYTES = 32;
+
+export interface CreateIdpHandoffOptions {
+  deviceId: string;
+  sessionId: string;
+  userId: string;
+  ttlMs?: number;
+}
+
+export interface CreateIdpHandoffResult {
+  handoffCode: string;
+  expiresAt: Date;
+}
+
+export async function createIdpHandoffCode(
+  options: CreateIdpHandoffOptions,
+): Promise<CreateIdpHandoffResult> {
+  const ttlMs = options.ttlMs ?? IDP_HANDOFF_TTL_MS;
+  const rawCode = base64UrlEncode(crypto.randomBytes(IDP_HANDOFF_BYTES));
+  const codeHash = sha256Hex(rawCode);
+  const expiresAt = new Date(Date.now() + ttlMs);
+
+  await IdpHandoffCode.create({
+    codeHash,
+    deviceId: options.deviceId,
+    sessionId: options.sessionId,
+    userId: options.userId,
+    expiresAt,
+  });
+
+  return { handoffCode: rawCode, expiresAt };
+}
+
+export type ExchangeIdpHandoffOutcome =
+  | { ok: true; record: IIdpHandoffCode }
+  | { ok: false; reason: 'invalid_handoff' };
+
+export async function exchangeIdpHandoffCode(rawCode: string): Promise<ExchangeIdpHandoffOutcome> {
+  const codeHash = sha256Hex(rawCode);
+  const stored = await IdpHandoffCode.findOne({ codeHash });
+
+  if (!stored || stored.usedAt || stored.expiresAt < new Date()) {
+    return { ok: false, reason: 'invalid_handoff' };
+  }
+
+  const claimed = await IdpHandoffCode.findOneAndUpdate(
+    { _id: stored._id, usedAt: null },
+    { $set: { usedAt: new Date() } },
+    { new: true },
+  );
+
+  if (!claimed) {
+    return { ok: false, reason: 'invalid_handoff' };
+  }
+
+  return { ok: true, record: claimed };
+}

--- a/packages/api/src/services/oauthCode.service.ts
+++ b/packages/api/src/services/oauthCode.service.ts
@@ -62,6 +62,8 @@ export interface IssueCodeOptions {
   codeChallenge?: string;
   codeChallengeMethod?: 'S256';
   scopes?: string[];
+  /** DeviceSession id from the authorizing bearer JWT. */
+  deviceId?: string;
   ttlMs?: number;
 }
 
@@ -84,6 +86,7 @@ export async function issueAuthCode(options: IssueCodeOptions): Promise<IssueCod
     codeChallenge: options.codeChallenge ?? null,
     codeChallengeMethod: options.codeChallenge ? 'S256' : null,
     scopes: options.scopes ?? [],
+    deviceId: options.deviceId ?? null,
     expiresAt,
   });
 

--- a/packages/auth/src/main.tsx
+++ b/packages/auth/src/main.tsx
@@ -15,6 +15,7 @@ import { SignUpPage } from "@/src/pages/signup"
 import { AuthorizePage } from "@/src/pages/authorize"
 import { RecoverPage } from "@/src/pages/recover"
 import { SocialCallbackPage } from "@/src/pages/social-callback"
+import { HandoffPage } from "@/src/pages/handoff"
 import "@/app/globals.css"
 
 function ExternalRedirect({ url }: { url: string }) {
@@ -74,6 +75,7 @@ function App() {
 
                             {/* Callback routes (no layout) */}
                             <Route path="/auth/social/callback" element={<SocialCallbackPage />} />
+                            <Route path="/handoff" element={<HandoffPage />} />
 
                             <Route path="/" element={<ExternalRedirect url="https://oxy.so" />} />
                             <Route path="*" element={<Navigate to="/login" replace />} />

--- a/packages/auth/src/pages/authorize.tsx
+++ b/packages/auth/src/pages/authorize.tsx
@@ -124,6 +124,7 @@ export function AuthorizePage() {
   const codeChallenge = searchParams.get("code_challenge");
   const codeChallengeMethod = searchParams.get("code_challenge_method");
   const scope = searchParams.get("scope");
+  const prompt = searchParams.get("prompt");
   const statusParam = searchParams.get("status");
   const urlError = searchParams.get("error");
 
@@ -173,6 +174,95 @@ export function AuthorizePage() {
   >(null);
   // The auto-approve probe runs at most once per mount for the active account.
   const autoApproveAttemptedRef = useRef(false);
+
+  // OAuth `prompt=none`: silent cross-origin restore — never show login UI.
+  // Fail with standard OAuth errors back to the RP redirect_uri.
+  function redirectOAuthError(errorCode: string): void {
+    const safeRedirect = safeRedirectUrl(redirectUri);
+    if (!safeRedirect) {
+      setData((prev) => ({ ...prev, error: errorCode }));
+      return;
+    }
+    const url = new URL(safeRedirect);
+    url.searchParams.set("error", errorCode);
+    if (state) url.searchParams.set("state", state);
+    window.location.href = url.toString();
+  }
+
+  // Silent restore: when prompt=none and the IdP has no session, bounce
+  // `login_required` immediately (OAuth standard) instead of the login page.
+  useEffect(() => {
+    if (prompt !== "none" || !isAuthResolved) return;
+    if (isAuthenticated || currentSessionId || deviceAccounts.length > 0) return;
+    redirectOAuthError("login_required");
+  }, [
+    prompt,
+    isAuthResolved,
+    isAuthenticated,
+    currentSessionId,
+    deviceAccounts.length,
+  ]);
+
+  // Silent restore with an IdP session: probe consent and auto-approve without UI.
+  useEffect(() => {
+    if (
+      prompt !== "none" ||
+      !isAuthResolved ||
+      !isAuthenticated ||
+      !clientId ||
+      autoApproveAttemptedRef.current
+    ) {
+      return;
+    }
+    autoApproveAttemptedRef.current = true;
+    void (async () => {
+      const token = oxyServices.getAccessToken();
+      if (!token) {
+        redirectOAuthError("login_required");
+        return;
+      }
+      const safeRedirect = safeRedirectUrl(redirectUri);
+      if (!safeRedirect) return;
+
+      setAutoApproving(true);
+      let body: unknown = null;
+      try {
+        const params = new URLSearchParams();
+        params.set("clientId", clientId);
+        params.set("redirectUri", safeRedirect);
+        if (scope) params.set("scope", scope);
+        const response = await fetch(
+          buildApiUrl(`/auth/oauth/consent?${params.toString()}`),
+          {
+            credentials: "include",
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        );
+        if (response.ok) {
+          body = await response.json().catch(() => null);
+        }
+      } catch {
+        body = null;
+      }
+
+      if (consentRequiredFromBody(body)) {
+        setAutoApproving(false);
+        redirectOAuthError("consent_required");
+        return;
+      }
+
+      await runOAuthAuthorize(token, safeRedirect);
+    })();
+  }, [
+    prompt,
+    isAuthResolved,
+    isAuthenticated,
+    clientId,
+    redirectUri,
+    scope,
+    state,
+    oxyServices,
+  ]);
 
   useEffect(() => {
     async function loadData() {
@@ -654,8 +744,14 @@ export function AuthorizePage() {
   }
 
   // No session on this device (cold boot has resolved and found none) — redirect
-  // to login carrying the full request context.
-  if (isAuthResolved && !isAuthenticated && !currentSessionId && deviceAccounts.length === 0) {
+  // to login carrying the full request context. Skip for `prompt=none` (handled above).
+  if (
+    prompt !== "none" &&
+    isAuthResolved &&
+    !isAuthenticated &&
+    !currentSessionId &&
+    deviceAccounts.length === 0
+  ) {
     return (
       <Navigate
         to={buildRelativeUrl("/login", {

--- a/packages/auth/src/pages/handoff.tsx
+++ b/packages/auth/src/pages/handoff.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { OXY_IDP_HANDOFF_ATTEMPTED_KEY } from "@oxyhq/core";
+import { useOxy } from "@oxyhq/services";
+import {
+  AuthFormLayout,
+  AuthFormHeader,
+  LoadingSpinner,
+} from "@/components/auth-form-layout";
+import { useTranslation } from "@/lib/i18n/use-translation";
+
+function clearIdpHandoffAttemptFlag(): void {
+  try {
+    sessionStorage.removeItem(OXY_IDP_HANDOFF_ATTEMPTED_KEY);
+  } catch {
+    // Best-effort only.
+  }
+}
+
+function safeReturnUrl(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One-shot IdP hub page: exchange a handoff code from another Oxy app and plant
+ * the shared DeviceSession locally, then redirect back to the caller.
+ */
+export function HandoffPage() {
+  const [searchParams] = useSearchParams();
+  const { oxyServices, handleWebSession } = useOxy();
+  const { t } = useTranslation();
+  const [error, setError] = useState<string | null>(null);
+
+  const handoffCode = searchParams.get("code");
+  const returnUrl = safeReturnUrl(searchParams.get("return"));
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function run() {
+      if (!handoffCode) {
+        if (!cancelled) setError("Missing handoff code.");
+        return;
+      }
+
+      try {
+        const session = await oxyServices.exchangeIdpHandoff(handoffCode);
+        await handleWebSession({
+          sessionId: session.sessionId,
+          accessToken: session.accessToken ?? "",
+          deviceId: session.deviceId,
+          deviceSecret: session.deviceSecret,
+          expiresAt: session.expiresAt,
+          user: session.user,
+        });
+        clearIdpHandoffAttemptFlag();
+        if (returnUrl) {
+          window.location.replace(returnUrl);
+          return;
+        }
+        if (!cancelled) setError(null);
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Handoff exchange failed.",
+          );
+        }
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [handoffCode, returnUrl, oxyServices, handleWebSession]);
+
+  if (error) {
+    return (
+      <AuthFormLayout>
+        <AuthFormHeader
+          title={t("authorize.requestTitle")}
+          description={error}
+        />
+      </AuthFormLayout>
+    );
+  }
+
+  return (
+    <AuthFormLayout>
+      <AuthFormHeader title={t("authorize.signingIn")} />
+      <LoadingSpinner />
+    </AuthFormLayout>
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -525,6 +525,8 @@ export {
     OXY_AUTHORIZE_URL,
     OXY_OAUTH_STATE_STORAGE_KEY,
     OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
+    OXY_SILENT_OAUTH_ATTEMPTED_KEY,
+    OXY_IDP_HANDOFF_ATTEMPTED_KEY,
     normalizeOAuthRedirectUri,
     persistOAuthHandshake,
     readOAuthHandshake,

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -1136,7 +1136,7 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
     async passwordSignIn(
       identifier: string,
       password: string,
-      options: { deviceName?: string; deviceFingerprint?: string } = {},
+      options: { deviceName?: string; deviceFingerprint?: string; deviceId?: string } = {},
     ): Promise<LoginResult> {
       try {
         const res = await this.makeRequest<unknown>('POST', '/auth/login', {
@@ -1144,6 +1144,7 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
           password,
           deviceName: options.deviceName,
           deviceFingerprint: options.deviceFingerprint,
+          ...(options.deviceId ? { deviceId: options.deviceId } : {}),
         }, { cache: false });
         const parsed = safeParseContract(loginResultSchema, res);
         if (!parsed) {
@@ -1170,6 +1171,7 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
       token?: string;
       backupCode?: string;
       deviceName?: string;
+      deviceId?: string;
     }): Promise<LoginSessionResult> {
       try {
         const res = await this.makeRequest<unknown>('POST', '/security/2fa/verify-login', {
@@ -1177,6 +1179,7 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
           token: params.token,
           backupCode: params.backupCode,
           deviceName: params.deviceName,
+          ...(params.deviceId ? { deviceId: params.deviceId } : {}),
         }, { cache: false });
         const parsed = safeParseContract(loginResultSchema, res);
         if (!parsed || 'twoFactorRequired' in parsed) {
@@ -1186,6 +1189,87 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
           this.setTokens(parsed.accessToken);
         }
         return parsed;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Mint a one-shot handoff code so auth.oxy.so can plant the same
+     * DeviceSession credentials (cross-origin hub, zero cookies).
+     */
+    async createIdpHandoff(): Promise<{ handoffCode: string; expiresIn: number }> {
+      try {
+        const res = await this.makeRequest<{ handoffCode: string; expiresIn: number }>(
+          'POST',
+          '/auth/idp-handoff/create',
+          {},
+          { cache: false },
+        );
+        const payload = (res as { data?: { handoffCode: string; expiresIn: number } }).data ?? res;
+        if (!payload?.handoffCode) {
+          throw new Error('idp-handoff/create returned an unexpected response shape');
+        }
+        return {
+          handoffCode: payload.handoffCode,
+          expiresIn: payload.expiresIn ?? 30,
+        };
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Exchange a one-shot IdP handoff code for device credentials (called from
+     * auth.oxy.so only).
+     */
+    async exchangeIdpHandoff(handoffCode: string): Promise<LoginSessionResult> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          '/auth/idp-handoff/exchange',
+          { handoffCode },
+          { cache: false },
+        );
+        const payload =
+          (res as { data?: Record<string, unknown> }).data ??
+          (res as Record<string, unknown>);
+        if (!payload || typeof payload !== 'object') {
+          throw new Error('idp-handoff/exchange returned an unexpected response shape');
+        }
+        const record = payload as Record<string, unknown>;
+        const accessToken = record.accessToken as string | undefined;
+        const sessionId = record.sessionId as string | undefined;
+        const deviceId = record.deviceId as string | undefined;
+        const deviceSecret = record.deviceSecret as string | undefined;
+        const userRaw = record.user;
+        if (!sessionId || !deviceId || !deviceSecret || !userRaw || typeof userRaw !== 'object') {
+          throw new Error('idp-handoff/exchange returned an incomplete session payload');
+        }
+        const userObj = userRaw as Record<string, unknown>;
+        const userId = userObj.id as string | undefined;
+        if (!userId) {
+          throw new Error('idp-handoff/exchange returned a session without user.id');
+        }
+        const expiresAt =
+          typeof record.expiresAt === 'string'
+            ? record.expiresAt
+            : new Date(Date.now() + 15 * 60 * 1000).toISOString();
+        if (accessToken) {
+          this.setTokens(accessToken);
+        }
+        return {
+          sessionId,
+          deviceId,
+          deviceSecret,
+          expiresAt,
+          accessToken,
+          user: {
+            id: userId,
+            username: typeof userObj.username === 'string' ? userObj.username : undefined,
+            avatar: typeof userObj.avatar === 'string' ? userObj.avatar : undefined,
+          },
+        };
       } catch (error) {
         throw this.handleError(error);
       }

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -282,6 +282,10 @@ export class SessionClient {
     const socket = io(this.host.getBaseURL(), {
       transports: ['websocket'],
       autoConnect: true,
+      reconnection: true,
+      reconnectionAttempts: Infinity,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 10000,
       auth: (cb: (data: { token: string }) => void) => {
         cb({ token: this.host.getAccessToken() ?? '' });
       },

--- a/packages/core/src/utils/oauthPkce.ts
+++ b/packages/core/src/utils/oauthPkce.ts
@@ -61,6 +61,11 @@ export interface BuildOAuthAuthorizeUrlParams {
   state: string;
   /** The PKCE `codeChallenge` from {@link generatePkcePair}. */
   codeChallenge: string;
+  /**
+   * OAuth `prompt` parameter. Use `none` for silent cross-origin session restore
+   * (no UI when the IdP hub already has a session + grant).
+   */
+  prompt?: 'none' | 'login' | 'consent';
 }
 
 /**
@@ -184,6 +189,9 @@ export function buildOAuthAuthorizeUrl(params: BuildOAuthAuthorizeUrlParams): st
   url.searchParams.set('scope', scope);
   url.searchParams.set('code_challenge', codeChallenge);
   url.searchParams.set('code_challenge_method', 'S256');
+  if (params.prompt) {
+    url.searchParams.set('prompt', params.prompt);
+  }
 
   return url.toString();
 }
@@ -193,6 +201,12 @@ export const OXY_OAUTH_STATE_STORAGE_KEY = 'oxy_oauth_state';
 
 /** `sessionStorage` key for the PKCE `code_verifier` across an authorize redirect. */
 export const OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY = 'oxy_oauth_code_verifier';
+
+/** `sessionStorage` key — at most one silent OAuth attempt per navigation. */
+export const OXY_SILENT_OAUTH_ATTEMPTED_KEY = 'oxy.silent_oauth_attempted';
+
+/** `sessionStorage` key — suppress IdP handoff redirect loops after login. */
+export const OXY_IDP_HANDOFF_ATTEMPTED_KEY = 'oxy.idp_handoff_attempted';
 
 /**
  * Normalize a redirect URI to its origin. Official Oxy apps register apex

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -39,6 +39,15 @@ import {
 import { tryCompleteOAuthReturn } from '../utils/oauthReturn';
 import { redirectToAuthorize } from '../components/oauthNavigation';
 import { isWebBrowser } from '../utils/isWebBrowser';
+import {
+  maybeRedirectIdpHandoff,
+  isIdpHubOrigin,
+} from '../utils/idpHandoffRedirect';
+import {
+  maybeStartSilentOAuthRestore,
+  consumeSilentOAuthError,
+  clearSilentOAuthAttemptFlag,
+} from '../utils/silentOAuthRestore';
 import { useAuthStore, type AuthState } from '../stores/authStore';
 import { useShallow } from 'zustand/react/shallow';
 import type { UseFollowHook } from '../hooks/useFollow.types';
@@ -852,6 +861,11 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
         onAuthStateChangeRef.current?.(fullUser);
       }
       markAuthResolvedRef.current();
+
+      // Propagate credentials to auth.oxy.so (IdP hub) after deliberate sign-in.
+      if (options.activate && isWebBrowser() && !isIdpHubOrigin()) {
+        void maybeRedirectIdpHandoff({ oxyServices }).catch(() => undefined);
+      }
     },
     [oxyServices, authStore, updateSessions, setActiveSessionId, sessionClient, syncFromClient, loginSuccess, logger],
   );
@@ -950,9 +964,11 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       password: string,
       opts?: { deviceName?: string; deviceFingerprint?: string },
     ): Promise<PasswordSignInResult> => {
+      const persisted = await authStore.load();
       const result = await oxyServices.passwordSignIn(identifier, password, {
         deviceName: opts?.deviceName,
         deviceFingerprint: opts?.deviceFingerprint,
+        deviceId: persisted?.deviceId,
       });
       if ('twoFactorRequired' in result) {
         return { status: '2fa_required', loginToken: result.loginToken };
@@ -982,11 +998,13 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       backupCode?: string;
       deviceName?: string;
     }): Promise<{ securityAlert?: SecurityAlert }> => {
+      const persisted = await authStore.load();
       const result = await oxyServices.completeTwoFactorSignIn({
         loginToken: params.loginToken,
         token: params.token,
         backupCode: params.backupCode,
         deviceName: params.deviceName,
+        deviceId: persisted?.deviceId,
       });
       await commitSession(
         {
@@ -1018,6 +1036,8 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     setTokenReady(false);
     try {
       if (coldBoot) {
+        consumeSilentOAuthError();
+
         const oauthCompleted = await tryCompleteOAuthReturn({
           oxyServices,
           clientId: clientIdProp,
@@ -1026,13 +1046,14 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
             commitSessionRef.current(input, { activate: true }),
         });
         if (oauthCompleted) {
+          clearSilentOAuthAttemptFlag();
           setTokenReady(true);
           markAuthResolvedRef.current();
           return;
         }
       }
 
-      await runSessionColdBoot({
+      const outcome = await runSessionColdBoot({
         oxy: oxyServices,
         store: authStore,
         platform: { isWeb: isWebBrowser(), isNative: !isWebBrowser() },
@@ -1072,6 +1093,24 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
           }
         },
       });
+
+      // Web cross-origin restore: silent OAuth against the IdP hub when local
+      // mint found no usable credential (or secret was stale).
+      if (
+        coldBoot &&
+        isWebBrowser() &&
+        clientIdProp &&
+        outcome.kind !== 'session'
+      ) {
+        const redirected = await maybeStartSilentOAuthRestore({
+          oxyServices,
+          clientId: clientIdProp,
+          redirectUri: authRedirectUri,
+        });
+        if (redirected) {
+          return;
+        }
+      }
     } catch (error) {
       if (__DEV__) {
         loggerUtil.error(
@@ -1109,6 +1148,19 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       }
     });
   }, [coldBoot, runColdBoot, storage, initialized, logger, markAuthResolved]);
+
+  // Reconcile device state when the tab returns to foreground (background tabs may
+  // miss socket pushes or have stale bearer tokens).
+  useEffect(() => {
+    if (!isWebBrowser()) return;
+    const onVisibility = (): void => {
+      if (document.visibilityState !== 'visible') return;
+      if (!oxyServices.getAccessToken()) return;
+      void sessionClient.bootstrap().then(() => syncFromClient()).catch(() => undefined);
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [oxyServices, sessionClient, syncFromClient]);
 
   // Exposed `refreshSessions`: re-bootstrap the server-authoritative device
   // state and reproject — the manual counterpart to the realtime socket.

--- a/packages/services/src/ui/hooks/useAuth.ts
+++ b/packages/services/src/ui/hooks/useAuth.ts
@@ -17,10 +17,11 @@
  * }
  * ```
  *
- * Cross-domain SSO:
- * - Web: Automatic via the per-apex `/auth/silent` iframe + terminal `/sso` bounce (SDK cold boot)
- * - Native: Automatic via shared Keychain/Account Manager
- * - Manual sign-in: signIn() redirects to the IdP (web) or opens the auth sheet (native)
+ * Cross-domain session (zero cookies):
+ * - Web: IdP hub handoff to auth.oxy.so + silent OAuth (`prompt=none`) on cold boot
+ * - Native: shared Keychain / app-group identity (Commons)
+ * - Realtime sync: Socket.IO `session_state` on `device:<deviceId>` once authenticated
+ * - Manual sign-in: signIn() opens the in-app account dialog (web + native)
  */
 
 import { useCallback } from 'react';
@@ -114,7 +115,8 @@ export interface UseAuthReturn extends AuthState, AuthActions {
  * Features:
  * - Zero config: Just wrap with OxyProvider and use
  * - Cross-platform: Same API on native and web
- * - Auto SSO: Web apps automatically check for cross-domain sessions
+ * - Auto session restore: Web apps silently restore via device-secret mint, then
+ *   silent OAuth against the IdP hub; native apps use the shared keychain
  * - Type-safe: Full TypeScript support
  */
 export function useAuth(): UseAuthReturn {

--- a/packages/services/src/ui/utils/idpHandoffRedirect.ts
+++ b/packages/services/src/ui/utils/idpHandoffRedirect.ts
@@ -1,0 +1,69 @@
+import type { OxyServices } from '@oxyhq/core';
+import { CENTRAL_IDP_APEX, OXY_IDP_HANDOFF_ATTEMPTED_KEY, logger } from '@oxyhq/core';
+import { isWebBrowser } from './isWebBrowser';
+
+const IDP_HANDOFF_PATH = '/handoff';
+
+/** Whether the current web origin is the central IdP hub (`auth.oxy.so`). */
+export function isIdpHubOrigin(): boolean {
+  if (!isWebBrowser()) return false;
+  const location = (globalThis as { location?: Location }).location;
+  if (!location) return false;
+  try {
+    const { hostname } = new URL(location.href);
+    return hostname === `auth.${CENTRAL_IDP_APEX}`;
+  } catch {
+    return false;
+  }
+}
+
+function buildIdpHandoffUrl(handoffCode: string, returnUrl: string): string {
+  const url = new URL(IDP_HANDOFF_PATH, `https://auth.${CENTRAL_IDP_APEX}`);
+  url.searchParams.set('code', handoffCode);
+  url.searchParams.set('return', returnUrl);
+  return url.toString();
+}
+
+/**
+ * After a first-party sign-in on a non-IdP origin, redirect once to auth.oxy.so
+ * so the hub plants the same `{ deviceId, deviceSecret }` locally (zero cookies).
+ * Returns `true` when a redirect was initiated (caller should stop further work).
+ */
+export async function maybeRedirectIdpHandoff(opts: {
+  oxyServices: OxyServices;
+  /** Skip when already on the IdP hub or when handoff was already attempted. */
+  skip?: boolean;
+}): Promise<boolean> {
+  if (opts.skip || !isWebBrowser() || isIdpHubOrigin()) {
+    return false;
+  }
+
+  const sessionStore = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  if (sessionStore?.getItem(OXY_IDP_HANDOFF_ATTEMPTED_KEY)) {
+    return false;
+  }
+
+  const location = (globalThis as { location?: Location }).location;
+  if (!location) return false;
+
+  try {
+    const { handoffCode } = await opts.oxyServices.createIdpHandoff();
+    sessionStore?.setItem(OXY_IDP_HANDOFF_ATTEMPTED_KEY, '1');
+    location.href = buildIdpHandoffUrl(handoffCode, location.href);
+    return true;
+  } catch (error) {
+    logger.warn('IdP handoff redirect skipped', { component: 'idpHandoffRedirect' }, error);
+    return false;
+  }
+}
+
+/** Clear the handoff loop guard (e.g. after returning from auth.oxy.so). */
+export function clearIdpHandoffAttemptFlag(): void {
+  try {
+    (globalThis as { sessionStorage?: Storage }).sessionStorage?.removeItem(
+      OXY_IDP_HANDOFF_ATTEMPTED_KEY,
+    );
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/packages/services/src/ui/utils/oauthReturn.ts
+++ b/packages/services/src/ui/utils/oauthReturn.ts
@@ -33,6 +33,11 @@ export async function tryCompleteOAuthReturn(opts: {
 
   const params = new URLSearchParams(location.search);
   const code = params.get('code');
+  const oauthError = params.get('error');
+  if (oauthError) {
+    stripOAuthParamsFromUrl();
+    return false;
+  }
   if (!code) return false;
 
   const clientId = opts.clientId;

--- a/packages/services/src/ui/utils/silentOAuthRestore.ts
+++ b/packages/services/src/ui/utils/silentOAuthRestore.ts
@@ -1,0 +1,111 @@
+import type { OxyServices } from '@oxyhq/core';
+import {
+  buildOAuthAuthorizeUrl,
+  generateOAuthState,
+  generatePkcePair,
+  OXY_SILENT_OAUTH_ATTEMPTED_KEY,
+  persistOAuthHandshake,
+  normalizeOAuthRedirectUri,
+  logger,
+} from '@oxyhq/core';
+import { isWebBrowser } from './isWebBrowser';
+import { redirectToAuthorize } from '../components/oauthNavigation';
+
+export interface SilentOAuthRestoreOptions {
+  oxyServices: OxyServices;
+  clientId: string;
+  redirectUri?: string;
+  scope?: string;
+}
+
+/**
+ * Top-level redirect to auth.oxy.so/authorize with `prompt=none` for silent
+ * cross-origin session restore. At most one attempt per navigation
+ * (`sessionStorage.oxy.silent_oauth_attempted`).
+ *
+ * Returns `true` when a redirect was initiated.
+ */
+export async function maybeStartSilentOAuthRestore(
+  opts: SilentOAuthRestoreOptions,
+): Promise<boolean> {
+  if (!isWebBrowser()) return false;
+
+  const sessionStore = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  if (sessionStore?.getItem(OXY_SILENT_OAUTH_ATTEMPTED_KEY)) {
+    return false;
+  }
+
+  const location = (globalThis as { location?: Location }).location;
+  if (!location) return false;
+
+  const params = new URLSearchParams(location.search);
+  if (params.has('code') || params.has('error')) {
+    return false;
+  }
+
+  try {
+    const { codeVerifier, codeChallenge } = await generatePkcePair();
+    const state = await generateOAuthState();
+    if (!persistOAuthHandshake(state, codeVerifier)) {
+      return false;
+    }
+
+    const redirectUri = normalizeOAuthRedirectUri(
+      opts.redirectUri ?? location.origin,
+    );
+
+    const authorizeUrl = buildOAuthAuthorizeUrl({
+      clientId: opts.clientId,
+      redirectUri,
+      state,
+      codeChallenge,
+      scope: opts.scope,
+      prompt: 'none',
+    });
+
+    sessionStore?.setItem(OXY_SILENT_OAUTH_ATTEMPTED_KEY, '1');
+    redirectToAuthorize(authorizeUrl);
+    return true;
+  } catch (error) {
+    logger.warn('Silent OAuth restore skipped', { component: 'silentOAuthRestore' }, error);
+    return false;
+  }
+}
+
+/** Clear the silent-OAuth loop guard after a successful restore or terminal error. */
+export function clearSilentOAuthAttemptFlag(): void {
+  try {
+    (globalThis as { sessionStorage?: Storage }).sessionStorage?.removeItem(
+      OXY_SILENT_OAUTH_ATTEMPTED_KEY,
+    );
+  } catch {
+    // Best-effort only.
+  }
+}
+
+/**
+ * When the RP lands with OAuth error params from a silent authorize attempt,
+ * strip them and return whether the error was terminal for silent restore.
+ */
+export function consumeSilentOAuthError(): 'login_required' | 'consent_required' | null {
+  if (!isWebBrowser()) return null;
+  const location = (globalThis as { location?: Location; history?: History }).location;
+  const history = (globalThis as { history?: History }).history;
+  if (!location) return null;
+
+  const params = new URLSearchParams(location.search);
+  const error = params.get('error');
+  if (error !== 'login_required' && error !== 'consent_required') {
+    return null;
+  }
+
+  clearSilentOAuthAttemptFlag();
+  if (history?.replaceState) {
+    const url = new URL(location.href);
+    url.searchParams.delete('error');
+    url.searchParams.delete('error_description');
+    url.searchParams.delete('state');
+    history.replaceState(history.state, '', `${url.pathname}${url.search}${url.hash}`);
+  }
+  return error;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements shared session across Oxy official apps (including custom domains) and third-party RPs **without cookies**, using `auth.oxy.so` as the IdP session hub and Socket.IO `session_state` for realtime sync.

### API (Phase 1)
- `AuthCode.deviceId` persisted on OAuth authorize; token exchange uses it as `explicitDeviceId` (one `DeviceSession` per browser)
- Login/signup/2FA/QR `session/create` accept optional `deviceId` from the client
- New IdP handoff routes: `POST /auth/idp-handoff/create` (bearer) + `POST /auth/idp-handoff/exchange` (public)
- Tests for OAuth deviceId persistence and handoff one-time exchange

### Client (Phases 2–4)
- **IdP handoff:** after deliberate sign-in on web (non-IdP origin), redirect once to `auth.oxy.so/handoff` to plant the same `{deviceId, deviceSecret}` on the hub
- **Silent OAuth:** cold boot falls through to `authorize?prompt=none` + PKCE when local mint fails; IdP auto-approves when session + grant exist
- **`prompt=none` in authorize.tsx:** `login_required` / `consent_required` OAuth errors instead of login UI
- **Socket:** reconnection backoff on `SessionClient`; `visibilitychange` → `bootstrap()` in `OxyProvider`
- Login/2FA thread persisted `deviceId` to the API

### Docs (Phase 5)
- Updated `SESSION-ARCHITECTURE.md`, `integration-guide.md`, `device-session.md`, and `useAuth` hook comments

## Test plan
- [x] `packages/api` — oauthCode + idpHandoff tests (15 passed)
- [x] `packages/core` — oauthPkce + SessionClient tests (54 passed)
- [x] `packages/auth` — bun test (40 passed)
- [x] `bun run core:build` + `bun run services:build`
- [ ] Manual E2E: login on accounts.oxy.so → open mention.earth (silent auth)
- [ ] Manual E2E: third-party first OAuth + reload (no re-consent)
- [ ] Manual E2E: switch account in app A → app B updates via socket

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

