### PR TITLE
fix(auth): stop infinite redirect loop in cross-origin session restore

### DIFF
--- a/packages/auth/src/pages/authorize.tsx
+++ b/packages/auth/src/pages/authorize.tsx
@@ -191,8 +191,9 @@ export function AuthorizePage() {
 
   // Silent restore: when prompt=none and the IdP has no session, bounce
   // `login_required` immediately (OAuth standard) instead of the login page.
+  // Wait until device-first cold boot finishes so we don't race a slow mint.
   useEffect(() => {
-    if (prompt !== "none" || !isAuthResolved) return;
+    if (prompt !== "none" || !isAuthResolved || deviceAccountsLoading) return;
     if (isAuthenticated || currentSessionId || deviceAccounts.length > 0) return;
     redirectOAuthError("login_required");
   }, [
@@ -201,6 +202,7 @@ export function AuthorizePage() {
     isAuthenticated,
     currentSessionId,
     deviceAccounts.length,
+    deviceAccountsLoading,
   ]);
 
   // Silent restore with an IdP session: probe consent and auto-approve without UI.
@@ -208,6 +210,7 @@ export function AuthorizePage() {
     if (
       prompt !== "none" ||
       !isAuthResolved ||
+      deviceAccountsLoading ||
       !isAuthenticated ||
       !clientId ||
       autoApproveAttemptedRef.current
@@ -262,6 +265,7 @@ export function AuthorizePage() {
     scope,
     state,
     oxyServices,
+    deviceAccountsLoading,
   ]);
 
   useEffect(() => {

--- a/packages/auth/src/pages/handoff.tsx
+++ b/packages/auth/src/pages/handoff.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
-import { OXY_IDP_HANDOFF_ATTEMPTED_KEY } from "@oxyhq/core";
 import { useOxy } from "@oxyhq/services";
 import {
   AuthFormLayout,
@@ -8,14 +7,6 @@ import {
   LoadingSpinner,
 } from "@/components/auth-form-layout";
 import { useTranslation } from "@/lib/i18n/use-translation";
-
-function clearIdpHandoffAttemptFlag(): void {
-  try {
-    sessionStorage.removeItem(OXY_IDP_HANDOFF_ATTEMPTED_KEY);
-  } catch {
-    // Best-effort only.
-  }
-}
 
 function safeReturnUrl(raw: string | null): string | null {
   if (!raw) return null;
@@ -62,7 +53,6 @@ export function HandoffPage() {
           expiresAt: session.expiresAt,
           user: session.user,
         });
-        clearIdpHandoffAttemptFlag();
         if (returnUrl) {
           window.location.replace(returnUrl);
           return;

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -46,7 +46,6 @@ import {
 import {
   maybeStartSilentOAuthRestore,
   consumeSilentOAuthError,
-  clearSilentOAuthAttemptFlag,
 } from '../utils/silentOAuthRestore';
 import { useAuthStore, type AuthState } from '../stores/authStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -775,7 +774,10 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   // Used by the QR device flow (`handleWebSession`), password sign-in, 2FA
   // completion, and the cold boot.
   const commitSession = useCallback(
-    async (input: CommitInput, options: { activate: boolean }): Promise<void> => {
+    async (
+      input: CommitInput,
+      options: { activate: boolean; skipIdpHandoff?: boolean },
+    ): Promise<void> => {
       if (input.accessToken) {
         oxyServices.setTokens(input.accessToken);
       }
@@ -862,9 +864,16 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       }
       markAuthResolvedRef.current();
 
-      // Propagate credentials to auth.oxy.so (IdP hub) after deliberate sign-in.
-      if (options.activate && isWebBrowser() && !isIdpHubOrigin()) {
-        void maybeRedirectIdpHandoff({ oxyServices }).catch(() => undefined);
+      // Propagate credentials to auth.oxy.so (IdP hub) after interactive sign-in
+      // only — never after silent OAuth return, cold boot, account switch, or
+      // handoff exchange (those paths already converged via IdP or local mint).
+      if (
+        options.activate &&
+        !options.skipIdpHandoff &&
+        isWebBrowser() &&
+        !isIdpHubOrigin()
+      ) {
+        await maybeRedirectIdpHandoff({ oxyServices }).catch(() => false);
       }
     },
     [oxyServices, authStore, updateSessions, setActiveSessionId, sessionClient, syncFromClient, loginSuccess, logger],
@@ -1043,10 +1052,12 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
           clientId: clientIdProp,
           authRedirectUri,
           commitSession: (input) =>
-            commitSessionRef.current(input, { activate: true }),
+            commitSessionRef.current(input, {
+              activate: true,
+              skipIdpHandoff: true,
+            }),
         });
         if (oauthCompleted) {
-          clearSilentOAuthAttemptFlag();
           setTokenReady(true);
           markAuthResolvedRef.current();
           return;
@@ -1275,7 +1286,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
           userId: result.user.id,
           user: result.user,
         },
-        { activate: true },
+        { activate: true, skipIdpHandoff: true },
       );
       await runPostAccountSwitchSideEffects();
     },

--- a/packages/services/src/ui/utils/idpHandoffRedirect.ts
+++ b/packages/services/src/ui/utils/idpHandoffRedirect.ts
@@ -24,6 +24,18 @@ function buildIdpHandoffUrl(handoffCode: string, returnUrl: string): string {
   return url.toString();
 }
 
+function cleanReturnUrl(href: string): string {
+  try {
+    const url = new URL(href);
+    for (const key of ['code', 'state', 'error', 'error_description']) {
+      url.searchParams.delete(key);
+    }
+    return url.toString();
+  } catch {
+    return href;
+  }
+}
+
 /**
  * After a first-party sign-in on a non-IdP origin, redirect once to auth.oxy.so
  * so the hub plants the same `{ deviceId, deviceSecret }` locally (zero cookies).
@@ -49,7 +61,7 @@ export async function maybeRedirectIdpHandoff(opts: {
   try {
     const { handoffCode } = await opts.oxyServices.createIdpHandoff();
     sessionStore?.setItem(OXY_IDP_HANDOFF_ATTEMPTED_KEY, '1');
-    location.href = buildIdpHandoffUrl(handoffCode, location.href);
+    location.href = buildIdpHandoffUrl(handoffCode, cleanReturnUrl(location.href));
     return true;
   } catch (error) {
     logger.warn('IdP handoff redirect skipped', { component: 'idpHandoffRedirect' }, error);

--- a/packages/services/src/ui/utils/oauthReturn.ts
+++ b/packages/services/src/ui/utils/oauthReturn.ts
@@ -69,6 +69,10 @@ export async function tryCompleteOAuthReturn(opts: {
       redirectUri,
       codeVerifier: handshake.codeVerifier,
     });
+    // Strip OAuth params before commit so a concurrent IdP-handoff return URL
+    // cannot capture a stale `?code=` and re-enter the exchange loop.
+    clearOAuthHandshake();
+    stripOAuthParamsFromUrl();
     await opts.commitSession({
       sessionId: result.sessionId,
       accessToken: result.accessToken,
@@ -78,8 +82,6 @@ export async function tryCompleteOAuthReturn(opts: {
       expiresAt: result.expiresAt,
       user: result.user,
     });
-    clearOAuthHandshake();
-    stripOAuthParamsFromUrl();
     return true;
   } catch (error) {
     logger.warn('OAuth return exchange failed', { component: 'oauthReturn' }, error);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After deploying cross-origin session restore (IdP handoff + silent OAuth), users hit an infinite redirect loop between the RP app, `auth.oxy.so/authorize?prompt=none`, and `auth.oxy.so/handoff`.

## Root cause

1. **IdP handoff ran after OAuth return** — `commitSession({ activate: true })` always triggered `maybeRedirectIdpHandoff`, so silent OAuth success immediately bounced to the handoff hub and back, re-entering cold boot.
2. **Silent OAuth flag cleared too early** — clearing `oxy.silent_oauth_attempted` on OAuth success allowed another silent OAuth attempt if the next navigation still lacked local credentials.
3. **OAuth params race** — handoff `return=` captured a stale `?code=` because URL cleanup happened after `commitSession` (which could redirect).
4. **`prompt=none` race on IdP** — `login_required` could fire before device-account cold boot finished loading.

## Fix

- Add `skipIdpHandoff` to `commitSession`; set it for OAuth return and account switch paths.
- Strip OAuth query params **before** committing the session from OAuth return.
- Sanitize handoff return URLs (remove `code`/`state`/`error` params).
- Stop clearing the silent-OAuth attempt flag on successful OAuth return.
- On `authorize.tsx`, wait for `deviceAccountsLoading` before emitting `login_required` or auto-approving.

## Expected behavior

1. Interactive sign-in (password / 2FA / QR) → one-shot IdP handoff to plant hub credentials.
2. Cross-origin restore → one silent OAuth attempt; success plants local credentials without handoff.
3. No repeated screens or redirect loops.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

