### PR TITLE
fix(auth): refresh hub device secret before join redirect

### DIFF
--- a/packages/auth/src/pages/device-join.tsx
+++ b/packages/auth/src/pages/device-join.tsx
@@ -5,7 +5,7 @@ import {
   buildDeviceJoinReturnUrl,
   createWebAuthStateStore,
   isAllowedDeviceJoinOrigin,
-  type AuthStateStore,
+  resolveHubDeviceCredentialForJoin,
 } from "@oxyhq/core";
 import { getApiBaseUrl } from "@/lib/oxy-api-client";
 
@@ -25,29 +25,9 @@ function safeReturnUrl(raw: string | null): string | null {
   }
 }
 
-async function resolveHubDeviceCredential(
-  oxyServices: OxyServices,
-  store: AuthStateStore,
-): Promise<{ deviceId: string; deviceSecret: string }> {
-  const existing = await store.load();
-  if (existing?.deviceId && existing?.deviceSecret) {
-    return { deviceId: existing.deviceId, deviceSecret: existing.deviceSecret };
-  }
-  const provisioned = await oxyServices.provisionDevice();
-  await store.save({
-    sessionId: existing?.sessionId ?? "",
-    userId: existing?.userId ?? "",
-    deviceId: provisioned.deviceId,
-    deviceSecret: provisioned.deviceSecret,
-    ...(existing?.accessToken ? { accessToken: existing.accessToken } : {}),
-    ...(existing?.expiresAt ? { expiresAt: existing.expiresAt } : {}),
-  });
-  return provisioned;
-}
-
 /**
- * Zero-UI device join hub: read or provision the canonical device credential on
- * auth.oxy.so and redirect back to the caller with `#oxy_device=…` in the fragment.
+ * Zero-UI device join hub: sync the canonical device credential on auth.oxy.so
+ * (mint or re-issue when stale) and redirect back with `#oxy_device=…`.
  */
 export function DeviceJoinPage() {
   const [searchParams] = useSearchParams();
@@ -61,7 +41,7 @@ export function DeviceJoinPage() {
     void (async () => {
       const oxyServices = new OxyServices({ baseURL: getApiBaseUrl() });
       const store = createWebAuthStateStore();
-      const creds = await resolveHubDeviceCredential(oxyServices, store);
+      const creds = await resolveHubDeviceCredentialForJoin(oxyServices, store);
       window.location.replace(buildDeviceJoinReturnUrl(returnUrl, creds));
     })();
   }, [returnUrl]);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -545,10 +545,11 @@ export {
     isAllowedDeviceJoinOrigin,
     isDeviceJoinV2Complete,
     markDeviceJoinV2Complete,
+    resolveHubDeviceCredentialForJoin,
     parseDeviceJoinFragment,
     stripDeviceJoinFragmentFromUrl,
 } from './utils/deviceJoin';
-export type { DeviceJoinFragment } from './utils/deviceJoin';
+export type { DeviceJoinFragment, DeviceJoinHubClient } from './utils/deviceJoin';
 
 // Deprecated bridge exports — kept for backward compatibility during migration.
 export {

--- a/packages/core/src/utils/__tests__/deviceJoin.test.ts
+++ b/packages/core/src/utils/__tests__/deviceJoin.test.ts
@@ -6,7 +6,9 @@ import {
   markDeviceJoinV2Complete,
   OXY_DEVICE_JOIN_V2_KEY,
   parseDeviceJoinFragment,
+  resolveHubDeviceCredentialForJoin,
 } from '../deviceJoin';
+import { createMemoryAuthStateStore } from '../../session/authStateStore';
 
 describe('deviceJoin', () => {
   let storage: Record<string, string>;
@@ -64,5 +66,81 @@ describe('deviceJoin', () => {
     markDeviceJoinV2Complete();
     expect(isDeviceJoinV2Complete()).toBe(true);
     expect(localStorage.getItem(OXY_DEVICE_JOIN_V2_KEY)).toBe('1');
+  });
+
+  describe('resolveHubDeviceCredentialForJoin', () => {
+    it('provisions when the hub store is empty', async () => {
+      const store = createMemoryAuthStateStore();
+      const oxy = {
+        mintFromDeviceSecret: jest.fn(),
+        provisionDevice: jest.fn(async () => ({ deviceId: 'd-new', deviceSecret: 's-new' })),
+      };
+      const creds = await resolveHubDeviceCredentialForJoin(oxy, store);
+      expect(creds).toEqual({ deviceId: 'd-new', deviceSecret: 's-new' });
+      expect(oxy.provisionDevice).toHaveBeenCalledWith();
+    });
+
+    it('returns rotated secret after a successful mint', async () => {
+      const store = createMemoryAuthStateStore();
+      await store.save({
+        sessionId: '',
+        userId: '',
+        deviceId: 'd1',
+        deviceSecret: 's-old',
+      });
+      const oxy = {
+        mintFromDeviceSecret: jest.fn(async () => ({
+          accessToken: 'tok',
+          expiresAt: new Date().toISOString(),
+          nextDeviceSecret: 's-next',
+          state: {
+            deviceId: 'd1',
+            activeAccountId: 'u1',
+            accounts: [{ accountId: 'u1', sessionId: 'sess1' }],
+          },
+        })),
+        provisionDevice: jest.fn(),
+      };
+      const creds = await resolveHubDeviceCredentialForJoin(oxy, store);
+      expect(creds).toEqual({ deviceId: 'd1', deviceSecret: 's-next' });
+      expect(oxy.provisionDevice).not.toHaveBeenCalled();
+    });
+
+    it('keeps the cached secret on no_active_session', async () => {
+      const store = createMemoryAuthStateStore();
+      await store.save({
+        sessionId: '',
+        userId: '',
+        deviceId: 'd1',
+        deviceSecret: 's-valid',
+      });
+      const oxy = {
+        mintFromDeviceSecret: jest.fn(async () => {
+          throw Object.assign(new Error('no_active_session'), { status: 401 });
+        }),
+        provisionDevice: jest.fn(),
+      };
+      const creds = await resolveHubDeviceCredentialForJoin(oxy, store);
+      expect(creds).toEqual({ deviceId: 'd1', deviceSecret: 's-valid' });
+    });
+
+    it('re-issues via provision when the cached secret is stale', async () => {
+      const store = createMemoryAuthStateStore();
+      await store.save({
+        sessionId: '',
+        userId: '',
+        deviceId: 'd1',
+        deviceSecret: 's-stale',
+      });
+      const oxy = {
+        mintFromDeviceSecret: jest.fn(async () => {
+          throw Object.assign(new Error('invalid_device_secret'), { status: 401 });
+        }),
+        provisionDevice: jest.fn(async () => ({ deviceId: 'd1', deviceSecret: 's-fresh' })),
+      };
+      const creds = await resolveHubDeviceCredentialForJoin(oxy, store);
+      expect(creds).toEqual({ deviceId: 'd1', deviceSecret: 's-fresh' });
+      expect(oxy.provisionDevice).toHaveBeenCalledWith('d1');
+    });
   });
 });

--- a/packages/core/src/utils/deviceJoin.ts
+++ b/packages/core/src/utils/deviceJoin.ts
@@ -9,6 +9,8 @@
 
 import { CENTRAL_IDP_APEX } from './authWebUrl';
 import { registrableApex } from './registrableApex';
+import { extractErrorStatus } from './errorUtils';
+import type { AuthStateStore, PersistedAuthState } from '../session/authStateStore';
 
 /** One join redirect attempt per tab navigation (sessionStorage). */
 export const OXY_DEVICE_JOIN_ATTEMPTED_KEY = 'oxy.device_join_attempted';
@@ -154,4 +156,93 @@ export function stripDeviceJoinFragmentFromUrl(): boolean {
     history.replaceState(history.state, '', `${url.pathname}${url.search}`);
   }
   return true;
+}
+
+/** Minimal client surface for hub-side join credential resolution. */
+export interface DeviceJoinHubClient {
+  mintFromDeviceSecret(
+    deviceId: string,
+    deviceSecret: string,
+  ): Promise<{
+    accessToken: string;
+    expiresAt: string;
+    nextDeviceSecret: string;
+    state: {
+      deviceId: string;
+      activeAccountId?: string | null;
+      accounts: Array<{ accountId: string; sessionId: string }>;
+    };
+  }>;
+  provisionDevice(deviceId?: string): Promise<{ deviceId: string; deviceSecret: string }>;
+}
+
+function isMintNoActiveSession(error: unknown): boolean {
+  if (extractErrorStatus(error) !== 401) return false;
+  const message = (error as { message?: unknown })?.message;
+  return typeof message === 'string' && message.includes('no_active_session');
+}
+
+function isMintInvalidDeviceSecret(error: unknown): boolean {
+  if (extractErrorStatus(error) !== 401) return false;
+  const message = (error as { message?: unknown })?.message;
+  return typeof message === 'string' && message.includes('invalid_device_secret');
+}
+
+async function persistHubCredential(
+  store: AuthStateStore,
+  prior: PersistedAuthState | null,
+  creds: DeviceJoinFragment,
+  extras?: Partial<Pick<PersistedAuthState, 'accessToken' | 'expiresAt' | 'sessionId' | 'userId'>>,
+): Promise<void> {
+  await store.save({
+    sessionId: extras?.sessionId ?? prior?.sessionId ?? '',
+    userId: extras?.userId ?? prior?.userId ?? '',
+    deviceId: creds.deviceId,
+    deviceSecret: creds.deviceSecret,
+    ...(extras?.accessToken ? { accessToken: extras.accessToken } : {}),
+    ...(extras?.expiresAt ? { expiresAt: extras.expiresAt } : {}),
+  });
+}
+
+/**
+ * Resolve the canonical device credential on auth.oxy.so before redirecting back.
+ *
+ * The hub MUST NOT return a cached secret blindly: another origin (e.g.
+ * accounts.oxy.so) may have rotated it via `POST /session/device/token`.
+ * Attempt a mint first to sync rotation; when the cache is stale, re-issue via
+ * provision on the same deviceId (rotation-in-use grace keeps other tabs alive).
+ */
+export async function resolveHubDeviceCredentialForJoin(
+  oxy: DeviceJoinHubClient,
+  store: AuthStateStore,
+): Promise<DeviceJoinFragment> {
+  const existing = await store.load();
+
+  if (!existing?.deviceId || !existing?.deviceSecret) {
+    const provisioned = await oxy.provisionDevice();
+    await persistHubCredential(store, existing, provisioned);
+    return provisioned;
+  }
+
+  try {
+    const mint = await oxy.mintFromDeviceSecret(existing.deviceId, existing.deviceSecret);
+    const creds = { deviceId: existing.deviceId, deviceSecret: mint.nextDeviceSecret };
+    const active = mint.state.accounts.find((a) => a.accountId === mint.state.activeAccountId);
+    await persistHubCredential(store, existing, creds, {
+      accessToken: mint.accessToken,
+      expiresAt: mint.expiresAt,
+      ...(active ? { sessionId: active.sessionId, userId: active.accountId } : {}),
+    });
+    return creds;
+  } catch (error) {
+    if (isMintNoActiveSession(error)) {
+      return { deviceId: existing.deviceId, deviceSecret: existing.deviceSecret };
+    }
+    if (isMintInvalidDeviceSecret(error)) {
+      const refreshed = await oxy.provisionDevice(existing.deviceId);
+      await persistHubCredential(store, existing, refreshed);
+      return refreshed;
+    }
+    throw error;
+  }
 }

--- a/packages/services/src/ui/utils/deviceJoin.ts
+++ b/packages/services/src/ui/utils/deviceJoin.ts
@@ -6,6 +6,7 @@ import {
   isDeviceJoinV2Complete,
   markDeviceJoinV2Complete,
   parseDeviceJoinFragment,
+  resolveHubDeviceCredentialForJoin,
   stripDeviceJoinFragmentFromUrl,
 } from '@oxyhq/core';
 import { isWebBrowser } from './isWebBrowser';
@@ -148,19 +149,5 @@ export async function resolveHubDeviceCredential(
   oxyServices: OxyServices,
   store: AuthStateStore,
 ): Promise<{ deviceId: string; deviceSecret: string }> {
-  const existing = await loadPersistedDeviceCredential(store);
-  if (existing) {
-    return existing;
-  }
-  const provisioned = await oxyServices.provisionDevice();
-  const prior = await store.load();
-  await store.save({
-    sessionId: prior?.sessionId ?? '',
-    userId: prior?.userId ?? '',
-    deviceId: provisioned.deviceId,
-    deviceSecret: provisioned.deviceSecret,
-    ...(prior?.accessToken ? { accessToken: prior.accessToken } : {}),
-    ...(prior?.expiresAt ? { expiresAt: prior.expiresAt } : {}),
-  });
-  return provisioned;
+  return resolveHubDeviceCredentialForJoin(oxyServices, store);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes `POST /session/device/token` returning `invalid_device_secret` after accounts.oxy.so rotated the device secret while auth.oxy.so still cached the old one in localStorage.

**Root cause:** device join returned the hub's cached `deviceSecret` without syncing with the server. After sign-in on accounts mints and rotates the secret, inbox received a stale secret → 401.

**Fix:** `resolveHubDeviceCredentialForJoin` on auth.oxy.so:
1. Try mint with cached creds → return `nextDeviceSecret` on success
2. On `no_active_session` → secret still valid, return as-is (expected when not signed in yet)
3. On `invalid_device_secret` → re-issue via `POST /session/device/provision` for the same deviceId

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

