### PR TITLE
fix(services): strip device join secrets from URL before first paint

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -537,6 +537,7 @@ export type { PkcePair, BuildOAuthAuthorizeUrlParams } from './utils/oauthPkce';
 export {
     OXY_DEVICE_JOIN_ATTEMPTED_KEY,
     OXY_DEVICE_JOIN_V2_KEY,
+    OXY_DEVICE_JOIN_PENDING_KEY,
     DEVICE_JOIN_FRAGMENT_DEVICE_ID,
     DEVICE_JOIN_FRAGMENT_DEVICE_SECRET,
     buildIdpHubOrigin,
@@ -546,6 +547,8 @@ export {
     isDeviceJoinV2Complete,
     markDeviceJoinV2Complete,
     resolveHubDeviceCredentialForJoin,
+    captureDeviceJoinFragmentFromUrl,
+    readPendingDeviceJoinCredential,
     parseDeviceJoinFragment,
     stripDeviceJoinFragmentFromUrl,
 } from './utils/deviceJoin';

--- a/packages/core/src/utils/__tests__/deviceJoin.test.ts
+++ b/packages/core/src/utils/__tests__/deviceJoin.test.ts
@@ -7,6 +7,9 @@ import {
   OXY_DEVICE_JOIN_V2_KEY,
   parseDeviceJoinFragment,
   resolveHubDeviceCredentialForJoin,
+  captureDeviceJoinFragmentFromUrl,
+  readPendingDeviceJoinCredential,
+  stripDeviceJoinFragmentFromUrl,
 } from '../deviceJoin';
 import { createMemoryAuthStateStore } from '../../session/authStateStore';
 
@@ -66,6 +69,57 @@ describe('deviceJoin', () => {
     markDeviceJoinV2Complete();
     expect(isDeviceJoinV2Complete()).toBe(true);
     expect(localStorage.getItem(OXY_DEVICE_JOIN_V2_KEY)).toBe('1');
+  });
+
+  describe('captureDeviceJoinFragmentFromUrl', () => {
+    let sessionStorageData: Record<string, string>;
+    const replaceState = jest.fn();
+
+    beforeEach(() => {
+      sessionStorageData = {};
+      replaceState.mockClear();
+      Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: {
+          getItem: (key: string) => sessionStorageData[key] ?? null,
+          setItem: (key: string, value: string) => {
+            sessionStorageData[key] = value;
+          },
+          removeItem: (key: string) => {
+            delete sessionStorageData[key];
+          },
+        },
+      });
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: {
+          pathname: '/inbox',
+          search: '',
+          hash: '',
+          href: 'https://inbox.oxy.so/inbox',
+        },
+      });
+      Object.defineProperty(globalThis, 'history', {
+        configurable: true,
+        value: { replaceState },
+      });
+    });
+
+    afterEach(() => {
+      delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+      delete (globalThis as { location?: Location }).location;
+      delete (globalThis as { history?: History }).history;
+    });
+
+    it('strips join credentials from the URL and stages them in sessionStorage', () => {
+      const location = (globalThis as { location: { hash: string } }).location;
+      location.hash = '#oxy_device=d1&device_secret=s1';
+
+      const creds = captureDeviceJoinFragmentFromUrl();
+      expect(creds).toEqual({ deviceId: 'd1', deviceSecret: 's1' });
+      expect(replaceState).toHaveBeenCalledWith(undefined, '', '/inbox');
+      expect(readPendingDeviceJoinCredential()).toEqual({ deviceId: 'd1', deviceSecret: 's1' });
+    });
   });
 
   describe('resolveHubDeviceCredentialForJoin', () => {

--- a/packages/core/src/utils/deviceJoin.ts
+++ b/packages/core/src/utils/deviceJoin.ts
@@ -18,6 +18,9 @@ export const OXY_DEVICE_JOIN_ATTEMPTED_KEY = 'oxy.device_join_attempted';
 /** Per-origin marker: this app aligned its device credential via auth.oxy.so/device/join. */
 export const OXY_DEVICE_JOIN_V2_KEY = 'oxy.device_join_v2';
 
+/** sessionStorage bridge between sync URL capture and async auth store persist. */
+export const OXY_DEVICE_JOIN_PENDING_KEY = 'oxy.device_join_pending';
+
 /** Fragment keys returned by auth.oxy.so/device/join. */
 export const DEVICE_JOIN_FRAGMENT_DEVICE_ID = 'oxy_device';
 export const DEVICE_JOIN_FRAGMENT_DEVICE_SECRET = 'device_secret';
@@ -150,12 +153,67 @@ export function stripDeviceJoinFragmentFromUrl(): boolean {
   if (!parsed) {
     return false;
   }
+  const cleanPath = `${location.pathname}${location.search}`;
   if (history?.replaceState) {
-    const url = new URL(location.href);
-    url.hash = '';
-    history.replaceState(history.state, '', `${url.pathname}${url.search}`);
+    history.replaceState(history.state, '', cleanPath);
   }
   return true;
+}
+
+/**
+ * Synchronously capture join credentials from the URL fragment and strip them
+ * BEFORE React paints. Called at module load in `OxyProvider` so secrets never
+ * linger in the address bar or bookmarkable history entry.
+ */
+export function captureDeviceJoinFragmentFromUrl(): DeviceJoinFragment | null {
+  if (typeof globalThis === 'undefined') {
+    return null;
+  }
+  const location = (globalThis as { location?: Location }).location;
+  if (!location?.hash) {
+    return null;
+  }
+  const creds = parseDeviceJoinFragment(location.hash);
+  if (!creds) {
+    return null;
+  }
+  stripDeviceJoinFragmentFromUrl();
+  try {
+    (globalThis as { sessionStorage?: Storage }).sessionStorage?.setItem(
+      OXY_DEVICE_JOIN_PENDING_KEY,
+      JSON.stringify(creds),
+    );
+  } catch {
+    // Async persist will re-parse if hash somehow remains.
+  }
+  return creds;
+}
+
+/** Read + clear credentials staged by {@link captureDeviceJoinFragmentFromUrl}. */
+export function readPendingDeviceJoinCredential(): DeviceJoinFragment | null {
+  try {
+    const raw = (globalThis as { sessionStorage?: Storage }).sessionStorage?.getItem(
+      OXY_DEVICE_JOIN_PENDING_KEY,
+    );
+    if (!raw) {
+      return null;
+    }
+    (globalThis as { sessionStorage?: Storage }).sessionStorage?.removeItem(
+      OXY_DEVICE_JOIN_PENDING_KEY,
+    );
+    const parsed = JSON.parse(raw) as DeviceJoinFragment;
+    if (
+      typeof parsed?.deviceId === 'string' &&
+      parsed.deviceId.length > 0 &&
+      typeof parsed?.deviceSecret === 'string' &&
+      parsed.deviceSecret.length > 0
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Best-effort.
+  }
+  return null;
 }
 
 /** Minimal client surface for hub-side join credential resolution. */

--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -12,6 +12,13 @@ import { setupFonts } from './FontLoader';
 import { RequireOxyAuth } from './RequireOxyAuth';
 import { attachQueryPersistence, createQueryClient } from '../hooks/queryClient';
 import { createPlatformStorage, type StorageInterface } from '../utils/storageHelpers';
+import { captureDeviceJoinFragmentFromUrl } from '../utils/deviceJoin';
+
+// Strip `#oxy_device=…&device_secret=…` synchronously on first module load —
+// before React paints — so join credentials never linger in the address bar.
+if (typeof globalThis !== 'undefined' && typeof globalThis.window !== 'undefined') {
+  captureDeviceJoinFragmentFromUrl();
+}
 
 /**
  * Background color shown for the brief window between mount and the

--- a/packages/services/src/ui/utils/deviceJoin.ts
+++ b/packages/services/src/ui/utils/deviceJoin.ts
@@ -2,24 +2,32 @@ import type { AuthStateStore, OxyServices, PersistedAuthState } from '@oxyhq/cor
 import {
   OXY_DEVICE_JOIN_ATTEMPTED_KEY,
   buildDeviceJoinUrl,
+  captureDeviceJoinFragmentFromUrl,
   isAllowedDeviceJoinOrigin,
   isDeviceJoinV2Complete,
   markDeviceJoinV2Complete,
   parseDeviceJoinFragment,
+  readPendingDeviceJoinCredential,
   resolveHubDeviceCredentialForJoin,
   stripDeviceJoinFragmentFromUrl,
 } from '@oxyhq/core';
 import { isWebBrowser } from './isWebBrowser';
 import { isIdpHubOrigin } from './idpHubOrigin';
 
+export { captureDeviceJoinFragmentFromUrl } from '@oxyhq/core';
+
 /** Persist device credentials from the join-return fragment. Returns true when applied. */
 export async function applyDeviceJoinReturn(store: AuthStateStore): Promise<boolean> {
   if (!isWebBrowser()) return false;
-  const location = (globalThis as { location?: Location }).location;
-  if (!location?.hash) return false;
 
-  const creds = parseDeviceJoinFragment(location.hash);
-  if (!creds) return false;
+  let creds = readPendingDeviceJoinCredential();
+  if (!creds) {
+    const location = (globalThis as { location?: Location }).location;
+    if (!location?.hash) return false;
+    creds = parseDeviceJoinFragment(location.hash);
+    if (!creds) return false;
+    stripDeviceJoinFragmentFromUrl();
+  }
 
   const existing = await store.load();
   const next: PersistedAuthState = {
@@ -31,7 +39,6 @@ export async function applyDeviceJoinReturn(store: AuthStateStore): Promise<bool
     ...(existing?.expiresAt ? { expiresAt: existing.expiresAt } : {}),
   };
   await store.save(next);
-  stripDeviceJoinFragmentFromUrl();
   markDeviceJoinV2Complete();
 
   try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Join redirect briefly put `deviceId` + `deviceSecret` in the URL fragment. Stripping only ran during async cold boot, so users saw secrets in the address bar.

**Fix:** synchronous capture at `OxyProvider` module load → `replaceState` cleans URL → creds staged in sessionStorage for async persist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

