### PR TITLE
fix(services): strip device join secrets from URL before first paint

### DIFF
--- a/packages/accounts/app/+html.tsx
+++ b/packages/accounts/app/+html.tsx
@@ -1,4 +1,5 @@
 import { ScrollViewStyleReset } from 'expo-router/html';
+import { DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT } from '@oxyhq/core';
 import type { PropsWithChildren } from 'react';
 
 const DEFAULT_TITLE = 'Accounts by Oxy';
@@ -28,6 +29,9 @@ export default function Root({ children }: PropsWithChildren) {
         <meta property="og:site_name" content="Accounts by Oxy" />
         <meta property="og:title" content={DEFAULT_TITLE} />
         <meta property="og:description" content={DEFAULT_DESCRIPTION} />
+
+        {/* Strip device-join credentials from the URL before the JS bundle loads. */}
+        <script dangerouslySetInnerHTML={{ __html: DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT }} />
 
         <ScrollViewStyleReset />
       </head>

--- a/packages/console/index.html
+++ b/packages/console/index.html
@@ -11,6 +11,10 @@
     <meta name="theme-color" content="#0a0a0a" />
     <meta name="description" content="Oxy Developers Console" />
     <title>%APP_NAME%</title>
+    <!-- Strip device-join credentials before the app bundle loads (mirrors @oxyhq/core). -->
+    <script>
+      (function(){try{var l=location;if(!l.hash)return;var p=new URLSearchParams(l.hash.charAt(0)==="#"?l.hash.slice(1):l.hash);var d=p.get("oxy_device");var s=p.get("device_secret");if(!d||!s)return;sessionStorage.setItem("oxy.device_join_pending",JSON.stringify({deviceId:d,deviceSecret:s}));history.replaceState(history.state,"",l.pathname+l.search)}catch(e){}})();
+    </script>
     <!--
       Pre-mount splash: painted before the JS bundle loads so the first frame
       already shows the Oxy logo + macOS-style loading bar (no blank/"Loading..."

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -537,6 +537,7 @@ export type { PkcePair, BuildOAuthAuthorizeUrlParams } from './utils/oauthPkce';
 export {
     OXY_DEVICE_JOIN_ATTEMPTED_KEY,
     OXY_DEVICE_JOIN_V2_KEY,
+    OXY_DEVICE_JOIN_PENDING_KEY,
     DEVICE_JOIN_FRAGMENT_DEVICE_ID,
     DEVICE_JOIN_FRAGMENT_DEVICE_SECRET,
     buildIdpHubOrigin,
@@ -546,6 +547,8 @@ export {
     isDeviceJoinV2Complete,
     markDeviceJoinV2Complete,
     resolveHubDeviceCredentialForJoin,
+    captureDeviceJoinFragmentFromUrl,
+    readPendingDeviceJoinCredential,
     parseDeviceJoinFragment,
     stripDeviceJoinFragmentFromUrl,
 } from './utils/deviceJoin';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -551,6 +551,7 @@ export {
     readPendingDeviceJoinCredential,
     parseDeviceJoinFragment,
     stripDeviceJoinFragmentFromUrl,
+    DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT,
 } from './utils/deviceJoin';
 export type { DeviceJoinFragment, DeviceJoinHubClient } from './utils/deviceJoin';
 

--- a/packages/core/src/utils/__tests__/deviceJoin.test.ts
+++ b/packages/core/src/utils/__tests__/deviceJoin.test.ts
@@ -7,6 +7,9 @@ import {
   OXY_DEVICE_JOIN_V2_KEY,
   parseDeviceJoinFragment,
   resolveHubDeviceCredentialForJoin,
+  captureDeviceJoinFragmentFromUrl,
+  readPendingDeviceJoinCredential,
+  stripDeviceJoinFragmentFromUrl,
 } from '../deviceJoin';
 import { createMemoryAuthStateStore } from '../../session/authStateStore';
 
@@ -66,6 +69,57 @@ describe('deviceJoin', () => {
     markDeviceJoinV2Complete();
     expect(isDeviceJoinV2Complete()).toBe(true);
     expect(localStorage.getItem(OXY_DEVICE_JOIN_V2_KEY)).toBe('1');
+  });
+
+  describe('captureDeviceJoinFragmentFromUrl', () => {
+    let sessionStorageData: Record<string, string>;
+    const replaceState = jest.fn();
+
+    beforeEach(() => {
+      sessionStorageData = {};
+      replaceState.mockClear();
+      Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: {
+          getItem: (key: string) => sessionStorageData[key] ?? null,
+          setItem: (key: string, value: string) => {
+            sessionStorageData[key] = value;
+          },
+          removeItem: (key: string) => {
+            delete sessionStorageData[key];
+          },
+        },
+      });
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: {
+          pathname: '/inbox',
+          search: '',
+          hash: '',
+          href: 'https://inbox.oxy.so/inbox',
+        },
+      });
+      Object.defineProperty(globalThis, 'history', {
+        configurable: true,
+        value: { replaceState },
+      });
+    });
+
+    afterEach(() => {
+      delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+      delete (globalThis as { location?: Location }).location;
+      delete (globalThis as { history?: History }).history;
+    });
+
+    it('strips join credentials from the URL and stages them in sessionStorage', () => {
+      const location = (globalThis as { location: { hash: string } }).location;
+      location.hash = '#oxy_device=d1&device_secret=s1';
+
+      const creds = captureDeviceJoinFragmentFromUrl();
+      expect(creds).toEqual({ deviceId: 'd1', deviceSecret: 's1' });
+      expect(replaceState).toHaveBeenCalledWith(undefined, '', '/inbox');
+      expect(readPendingDeviceJoinCredential()).toEqual({ deviceId: 'd1', deviceSecret: 's1' });
+    });
   });
 
   describe('resolveHubDeviceCredentialForJoin', () => {

--- a/packages/core/src/utils/__tests__/deviceJoin.test.ts
+++ b/packages/core/src/utils/__tests__/deviceJoin.test.ts
@@ -10,6 +10,7 @@ import {
   captureDeviceJoinFragmentFromUrl,
   readPendingDeviceJoinCredential,
   stripDeviceJoinFragmentFromUrl,
+  DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT,
 } from '../deviceJoin';
 import { createMemoryAuthStateStore } from '../../session/authStateStore';
 
@@ -119,6 +120,12 @@ describe('deviceJoin', () => {
       expect(creds).toEqual({ deviceId: 'd1', deviceSecret: 's1' });
       expect(replaceState).toHaveBeenCalledWith(undefined, '', '/inbox');
       expect(readPendingDeviceJoinCredential()).toEqual({ deviceId: 'd1', deviceSecret: 's1' });
+    });
+
+    it('DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT uses the same storage key and fragment params', () => {
+      expect(DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT).toContain('oxy.device_join_pending');
+      expect(DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT).toContain('oxy_device');
+      expect(DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT).toContain('device_secret');
     });
   });
 

--- a/packages/core/src/utils/deviceJoin.ts
+++ b/packages/core/src/utils/deviceJoin.ts
@@ -18,6 +18,9 @@ export const OXY_DEVICE_JOIN_ATTEMPTED_KEY = 'oxy.device_join_attempted';
 /** Per-origin marker: this app aligned its device credential via auth.oxy.so/device/join. */
 export const OXY_DEVICE_JOIN_V2_KEY = 'oxy.device_join_v2';
 
+/** sessionStorage bridge between sync URL capture and async auth store persist. */
+export const OXY_DEVICE_JOIN_PENDING_KEY = 'oxy.device_join_pending';
+
 /** Fragment keys returned by auth.oxy.so/device/join. */
 export const DEVICE_JOIN_FRAGMENT_DEVICE_ID = 'oxy_device';
 export const DEVICE_JOIN_FRAGMENT_DEVICE_SECRET = 'device_secret';
@@ -150,12 +153,67 @@ export function stripDeviceJoinFragmentFromUrl(): boolean {
   if (!parsed) {
     return false;
   }
+  const cleanPath = `${location.pathname}${location.search}`;
   if (history?.replaceState) {
-    const url = new URL(location.href);
-    url.hash = '';
-    history.replaceState(history.state, '', `${url.pathname}${url.search}`);
+    history.replaceState(history.state, '', cleanPath);
   }
   return true;
+}
+
+/**
+ * Synchronously capture join credentials from the URL fragment and strip them
+ * BEFORE React paints. Called at module load in `OxyProvider` so secrets never
+ * linger in the address bar or bookmarkable history entry.
+ */
+export function captureDeviceJoinFragmentFromUrl(): DeviceJoinFragment | null {
+  if (typeof globalThis === 'undefined') {
+    return null;
+  }
+  const location = (globalThis as { location?: Location }).location;
+  if (!location?.hash) {
+    return null;
+  }
+  const creds = parseDeviceJoinFragment(location.hash);
+  if (!creds) {
+    return null;
+  }
+  stripDeviceJoinFragmentFromUrl();
+  try {
+    (globalThis as { sessionStorage?: Storage }).sessionStorage?.setItem(
+      OXY_DEVICE_JOIN_PENDING_KEY,
+      JSON.stringify(creds),
+    );
+  } catch {
+    // Async persist will re-parse if hash somehow remains.
+  }
+  return creds;
+}
+
+/** Read + clear credentials staged by {@link captureDeviceJoinFragmentFromUrl}. */
+export function readPendingDeviceJoinCredential(): DeviceJoinFragment | null {
+  try {
+    const raw = (globalThis as { sessionStorage?: Storage }).sessionStorage?.getItem(
+      OXY_DEVICE_JOIN_PENDING_KEY,
+    );
+    if (!raw) {
+      return null;
+    }
+    (globalThis as { sessionStorage?: Storage }).sessionStorage?.removeItem(
+      OXY_DEVICE_JOIN_PENDING_KEY,
+    );
+    const parsed = JSON.parse(raw) as DeviceJoinFragment;
+    if (
+      typeof parsed?.deviceId === 'string' &&
+      parsed.deviceId.length > 0 &&
+      typeof parsed?.deviceSecret === 'string' &&
+      parsed.deviceSecret.length > 0
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Best-effort.
+  }
+  return null;
 }
 
 /** Minimal client surface for hub-side join credential resolution. */

--- a/packages/core/src/utils/deviceJoin.ts
+++ b/packages/core/src/utils/deviceJoin.ts
@@ -25,6 +25,13 @@ export const OXY_DEVICE_JOIN_PENDING_KEY = 'oxy.device_join_pending';
 export const DEVICE_JOIN_FRAGMENT_DEVICE_ID = 'oxy_device';
 export const DEVICE_JOIN_FRAGMENT_DEVICE_SECRET = 'device_secret';
 
+/**
+ * Inline `<head>` bootstrap — strips join credentials before the app bundle loads.
+ * Mirrors {@link captureDeviceJoinFragmentFromUrl} so Expo/Vite chunks cannot delay
+ * the strip until after first paint.
+ */
+export const DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT = `(function(){try{var l=location;if(!l.hash)return;var p=new URLSearchParams(l.hash.charAt(0)==="#"?l.hash.slice(1):l.hash);var d=p.get("${DEVICE_JOIN_FRAGMENT_DEVICE_ID}");var s=p.get("${DEVICE_JOIN_FRAGMENT_DEVICE_SECRET}");if(!d||!s)return;sessionStorage.setItem("${OXY_DEVICE_JOIN_PENDING_KEY}",JSON.stringify({deviceId:d,deviceSecret:s}));history.replaceState(history.state,"",l.pathname+l.search)}catch(e){}})();`;
+
 /** Official first-party registrable apexes (mirrors API trusted origins). */
 const JOIN_OFFICIAL_APEXES = new Set([
   'oxy.so',

--- a/packages/inbox/app/+html.tsx
+++ b/packages/inbox/app/+html.tsx
@@ -9,6 +9,7 @@
  */
 
 import { ScrollViewStyleReset } from 'expo-router/html';
+import { DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT } from '@oxyhq/core';
 import { type PropsWithChildren } from 'react';
 
 const DEFAULT_TITLE = 'Inbox by Oxy';
@@ -65,6 +66,9 @@ export default function Root({ children }: PropsWithChildren) {
         <link rel="manifest" href="/manifest.json" />
         <link rel="icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+
+        {/* Strip device-join credentials from the URL before the JS bundle loads. */}
+        <script dangerouslySetInnerHTML={{ __html: DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT }} />
 
         <ScrollViewStyleReset />
       </head>

--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -12,6 +12,13 @@ import { setupFonts } from './FontLoader';
 import { RequireOxyAuth } from './RequireOxyAuth';
 import { attachQueryPersistence, createQueryClient } from '../hooks/queryClient';
 import { createPlatformStorage, type StorageInterface } from '../utils/storageHelpers';
+import { captureDeviceJoinFragmentFromUrl } from '../utils/deviceJoin';
+
+// Strip `#oxy_device=…&device_secret=…` synchronously on first module load —
+// before React paints — so join credentials never linger in the address bar.
+if (typeof globalThis !== 'undefined' && typeof globalThis.window !== 'undefined') {
+  captureDeviceJoinFragmentFromUrl();
+}
 
 /**
  * Background color shown for the brief window between mount and the

--- a/packages/services/src/ui/utils/deviceJoin.ts
+++ b/packages/services/src/ui/utils/deviceJoin.ts
@@ -2,24 +2,32 @@ import type { AuthStateStore, OxyServices, PersistedAuthState } from '@oxyhq/cor
 import {
   OXY_DEVICE_JOIN_ATTEMPTED_KEY,
   buildDeviceJoinUrl,
+  captureDeviceJoinFragmentFromUrl,
   isAllowedDeviceJoinOrigin,
   isDeviceJoinV2Complete,
   markDeviceJoinV2Complete,
   parseDeviceJoinFragment,
+  readPendingDeviceJoinCredential,
   resolveHubDeviceCredentialForJoin,
   stripDeviceJoinFragmentFromUrl,
 } from '@oxyhq/core';
 import { isWebBrowser } from './isWebBrowser';
 import { isIdpHubOrigin } from './idpHubOrigin';
 
+export { captureDeviceJoinFragmentFromUrl } from '@oxyhq/core';
+
 /** Persist device credentials from the join-return fragment. Returns true when applied. */
 export async function applyDeviceJoinReturn(store: AuthStateStore): Promise<boolean> {
   if (!isWebBrowser()) return false;
-  const location = (globalThis as { location?: Location }).location;
-  if (!location?.hash) return false;
 
-  const creds = parseDeviceJoinFragment(location.hash);
-  if (!creds) return false;
+  let creds = readPendingDeviceJoinCredential();
+  if (!creds) {
+    const location = (globalThis as { location?: Location }).location;
+    if (!location?.hash) return false;
+    creds = parseDeviceJoinFragment(location.hash);
+    if (!creds) return false;
+    stripDeviceJoinFragmentFromUrl();
+  }
 
   const existing = await store.load();
   const next: PersistedAuthState = {
@@ -31,7 +39,6 @@ export async function applyDeviceJoinReturn(store: AuthStateStore): Promise<bool
     ...(existing?.expiresAt ? { expiresAt: existing.expiresAt } : {}),
   };
   await store.save(next);
-  stripDeviceJoinFragmentFromUrl();
   markDeviceJoinV2Complete();
 
   try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the device-join redirect from `auth.oxy.so/device/join`, official apps return with credentials in the URL fragment:

```
https://inbox.oxy.so/inbox#oxy_device=…&device_secret=…
```

Those secrets should never linger in the address bar. Previously, stripping only ran asynchronously during cold boot (after React could paint), so users briefly — or persistently, if the bundle loaded late — saw the full credential trace.

## Fix

1. **Sync capture in `OxyProvider`** — on module load, parse the fragment, stage creds in `sessionStorage`, and `history.replaceState` to the clean path before React paints.
2. **Early `<head>` bootstrap** — inline script (exported as `DEVICE_JOIN_URL_STRIP_INLINE_SCRIPT` from `@oxyhq/core`) runs before the JS bundle on inbox, accounts, and console so Expo/Vite code-splitting cannot delay the strip.
3. **`applyDeviceJoinReturn`** reads staged creds from `sessionStorage` first (fallback: parse remaining hash).

## Apps touched

- `@oxyhq/core` / `@oxyhq/services` — capture + strip utilities
- `packages/inbox/app/+html.tsx`
- `packages/accounts/app/+html.tsx`
- `packages/console/index.html`

## Test plan

- [x] `packages/core` deviceJoin tests (11 passed, incl. inline script key parity)
- [ ] After deploy: open accounts → inbox; URL should stay `https://inbox.oxy.so/inbox` with no `#oxy_device` fragment
- [ ] Session sync still works after join return
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5350a8a-17ed-46c8-acf9-dfd421014146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

