### PR TITLE
fix(auth): never render empty shell for prompt=none

### DIFF
--- a/packages/auth/src/pages/authorize.tsx
+++ b/packages/auth/src/pages/authorize.tsx
@@ -722,6 +722,15 @@ export function AuthorizePage() {
     return <LoadingSpinner />;
   }
 
+  if (prompt === "none") {
+    return (
+      <AuthFormLayout>
+        <AuthFormHeader title={t("authorize.signingIn")} />
+        <LoadingSpinner />
+      </AuthFormLayout>
+    );
+  }
+
   // Trusted / already-granted OAuth request: authorizing + redirecting without
   // ever showing the consent screen. Neutral backdrop while that completes.
   if (autoApproving) {


### PR DESCRIPTION
## Summary
- On `prompt=none`, `authorize.tsx` no longer falls through to an empty AuthFormLayout while device-first cold boot is still unresolved.
- Always render the neutral “Signing you in…” state until existing silent-restore effects bounce `login_required` / auto-approve.
- Fixes the broken flash users hit when `accounts.oxy.so` cold-boots into silent OAuth with no local device credential.

## Test plan
- [ ] Open `auth.oxy.so/authorize?...&prompt=none` signed out → see “Signing you in…”, then return to RP with `login_required` (no empty shell).
- [ ] Hard-refresh `accounts.oxy.so` signed out → silent OAuth hop no longer shows the empty IdP page.
- [ ] Interactive authorize (`prompt` absent) still shows login/consent as before.
- [ ] Signed-in silent restore still auto-approves when consent allows.


Made with [Cursor](https://cursor.com)