### PR TITLE
feat(commons): holographic security-hologram Oxy ID card

### DIFF
--- a/docs/superpowers/plans/2026-07-11-nfc-attest-card-effect.md
+++ b/docs/superpowers/plans/2026-07-11-nfc-attest-card-effect.md
@@ -1,0 +1,1482 @@
+# NFC Attestation + Oxy ID Card Scan Effect Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Android phones emit the real-life-attestation payload over NFC (HCE) while the Oxy ID card is on screen; any phone can tap to receive it; the card physically reacts when read (level 1) and when the server confirms the attestation (level 2, QR flow included).
+
+**Architecture:** The NFC tag content is byte-for-byte the QR string (`oxycommons://attest?payload=…` from `useAttestQr`). Emission = `react-native-hce` NDEF Type 4 session armed while `(id)/index` is focused. Reception = Android system NDEF dispatch (deep link, app closed included) or an in-app `react-native-nfc-manager` reader button (iPhone). Confirmation = new `civic:attested` Socket.IO event to the subject's `user:<id>` room, surfaced to apps through a new generic `SessionClient.onServerEvent` API in `@oxyhq/core` + `useOxyEvent` hook in `@oxyhq/services`. Card effect = two Reanimated shared values (`scanPulse`, `attestGlow`) threaded through the existing `TiltContext` into the Skia canvas.
+
+**Tech Stack:** Expo SDK 57 / RN 0.86, react-native-reanimated + @shopify/react-native-skia, react-native-hce, react-native-nfc-manager, Socket.IO, Jest (per-package configs).
+
+**Spec:** `docs/superpowers/specs/2026-07-11-nfc-attest-card-effect-design.md`
+
+## Global Constraints
+
+- Package manager: **bun only** (`bun add`, `bun install`, `bunx`). After any `package.json` change run `bun install` at the repo root and commit `bun.lock` **in the same commit**.
+- TypeScript strict. NEVER: `as any`, `@ts-ignore`, `@ts-expect-error`, `!` non-null assertions, `var`, silent `catch {}`, TODO/FIXME comments, `console.log` (`console.warn`/`console.error` with context are the existing commons convention).
+- Avoid `useEffect` when derived state/handlers work; the effects in this plan are legitimate (imperative native-module lifecycles, subscriptions, timers).
+- **Concurrent sessions may hold uncommitted work in this repo. PATH-SCOPE every `git add` (list files explicitly). NEVER `git add -A` / `git add .`**
+- Workspace deps resolve from build output: after changing `packages/core` run `bun run core:build`; after `packages/services` run `bun run services:build` — BEFORE running commons/type checks that consume them.
+- Run each package's own `bun run test` (dispatches to the right runner). Never blanket `bun test` across the monorepo.
+- NFC cannot run in emulators — device verification is a separate manual checklist at the end; automated steps stop at unit tests + typecheck + prebuild inspection.
+- Commit messages end with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+---
+
+### Task 1: `SessionClient.onServerEvent` (core)
+
+**Files:**
+- Modify: `packages/core/src/session/SessionClient.ts`
+- Test: `packages/core/src/session/__tests__/SessionClient.serverEvents.test.ts` (new)
+
+**Interfaces:**
+- Consumes: existing `SessionClient` socket plumbing (`connectSocket`, `MinimalSocket`, injectable `socketFactory`).
+- Produces: `onServerEvent(event: string, listener: (payload: unknown) => void): () => void` — public method on `SessionClient`. Registers a listener for a named server-pushed Socket.IO event; returns an unsubscribe function. Listeners survive socket reconnects and are bound when the socket is (re)created.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/src/session/__tests__/SessionClient.serverEvents.test.ts`. Reuse the exact harness from `SessionClient.socketFactory.test.ts` (`FakeSocket`, `makeHost`, `SYNC`):
+
+```ts
+import type { DeviceSessionState } from '@oxyhq/contracts';
+import type { MinimalSocket, SocketIOFactory } from '../socketLoader';
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+
+type Handler = (...args: unknown[]) => void;
+class FakeSocket implements MinimalSocket {
+  connected = false;
+  handlers = new Map<string, Handler[]>();
+  on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
+  off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+  connect() { this.connected = true; }
+  disconnect() { this.connected = false; }
+  emitServer(event: string, payload: unknown) { for (const h of this.handlers.get(event) ?? []) h(payload); }
+}
+
+const STATE = (rev: number): DeviceSessionState => ({ deviceId: 'd1', accounts: [{ accountId: 'a1', sessionId: 's1', authuser: 0 }], activeAccountId: 'a1', revision: rev, updatedAt: 1720000000000 });
+const SYNC = (rev: number) => ({ state: STATE(rev), activeToken: { accessToken: `jwt-${rev}`, expiresAt: 'x' } });
+
+function makeHost(over: Partial<SessionClientHost> = {}): SessionClientHost {
+  return {
+    makeRequest: jest.fn().mockResolvedValue(SYNC(1)),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => 'tok',
+    getDeviceCredential: () => null,
+    onTokensChanged: () => () => undefined,
+    setTokens: jest.fn(),
+    getCurrentAccountId: () => 'a1',
+    ...over,
+  };
+}
+
+describe('SessionClient.onServerEvent', () => {
+  it('delivers a server event to a listener registered BEFORE the socket exists', async () => {
+    let created: FakeSocket | null = null;
+    const factory: SocketIOFactory = jest.fn(() => { created = new FakeSocket(); created.connected = true; return created; });
+    const client = new SessionClient(makeHost(), { socketFactory: factory });
+    const seen: unknown[] = [];
+    client.onServerEvent('civic:attested', (p) => seen.push(p));
+    await client.start();
+    created?.emitServer('civic:attested', { byUserId: 'u2' });
+    expect(seen).toEqual([{ byUserId: 'u2' }]);
+    client.stop();
+  });
+
+  it('delivers to a listener registered AFTER the socket exists, and unsubscribe stops delivery', async () => {
+    let created: FakeSocket | null = null;
+    const factory: SocketIOFactory = jest.fn(() => { created = new FakeSocket(); created.connected = true; return created; });
+    const client = new SessionClient(makeHost(), { socketFactory: factory });
+    await client.start();
+    const seen: unknown[] = [];
+    const unsub = client.onServerEvent('civic:attested', (p) => seen.push(p));
+    created?.emitServer('civic:attested', 1);
+    unsub();
+    created?.emitServer('civic:attested', 2);
+    expect(seen).toEqual([1]);
+    client.stop();
+  });
+
+  it('one listener throwing does not break the others', async () => {
+    let created: FakeSocket | null = null;
+    const factory: SocketIOFactory = jest.fn(() => { created = new FakeSocket(); created.connected = true; return created; });
+    const client = new SessionClient(makeHost(), { socketFactory: factory });
+    await client.start();
+    const seen: unknown[] = [];
+    client.onServerEvent('civic:attested', () => { throw new Error('boom'); });
+    client.onServerEvent('civic:attested', (p) => seen.push(p));
+    created?.emitServer('civic:attested', 'ok');
+    expect(seen).toEqual(['ok']);
+    client.stop();
+  });
+});
+```
+
+If `MinimalSocket` lacks a member used here, extend the FakeSocket only — do NOT change `MinimalSocket`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && bunx jest src/session/__tests__/SessionClient.serverEvents.test.ts`
+Expected: FAIL — `client.onServerEvent is not a function`.
+
+- [ ] **Step 3: Implement `onServerEvent`**
+
+In `packages/core/src/session/SessionClient.ts`:
+
+Add fields near the other private members:
+
+```ts
+  /** App-facing subscriptions to named server-pushed socket events. */
+  private readonly serverEvents = new Map<string, Set<(payload: unknown) => void>>();
+  /** Event names already bound on the CURRENT socket instance. */
+  private readonly boundServerEvents = new Set<string>();
+```
+
+Add the public method + private binder (near `subscribe`):
+
+```ts
+  /**
+   * Subscribe to a named server-pushed Socket.IO event (e.g. `civic:attested`).
+   * Listeners survive reconnects and socket re-creation; the returned function
+   * unsubscribes. Payloads are delivered as-is — callers validate shape.
+   */
+  onServerEvent(event: string, listener: (payload: unknown) => void): () => void {
+    let listeners = this.serverEvents.get(event);
+    if (!listeners) {
+      listeners = new Set();
+      this.serverEvents.set(event, listeners);
+    }
+    listeners.add(listener);
+    this.bindServerEvent(event);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  private bindServerEvent(event: string): void {
+    if (!this.socket || this.boundServerEvents.has(event)) return;
+    this.boundServerEvents.add(event);
+    this.socket.on(event, (payload: unknown) => {
+      const listeners = this.serverEvents.get(event);
+      if (!listeners) return;
+      for (const listener of [...listeners]) {
+        try {
+          listener(payload);
+        } catch (error) {
+          logger.warn('[SessionClient] server-event listener threw', { component: 'SessionClient' }, error);
+        }
+      }
+    });
+  }
+```
+
+At the END of `connectSocket()`, immediately after `this.socket = socket;`, add:
+
+```ts
+    // (Re)bind app-facing server-event subscriptions on the fresh socket.
+    this.boundServerEvents.clear();
+    for (const event of this.serverEvents.keys()) {
+      this.bindServerEvent(event);
+    }
+```
+
+In `stop()`, inside the `if (this.socket)` block after `this.socket = null;`, add:
+
+```ts
+      this.boundServerEvents.clear();
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && bunx jest src/session/__tests__/`
+Expected: all session tests PASS (new file 3/3, no regressions in socket/socketFactory/broadcastChannel tests).
+
+- [ ] **Step 5: Build core and run the full core suite**
+
+Run: `bun run core:build && cd packages/core && bun run test`
+Expected: build clean; suite passes (baseline ~722 tests, +3).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/session/SessionClient.ts packages/core/src/session/__tests__/SessionClient.serverEvents.test.ts
+git commit -m "feat(core): SessionClient.onServerEvent — generic server-push event subscription
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `useOxyEvent` hook (services)
+
+**Files:**
+- Create: `packages/services/src/ui/hooks/useOxyEvent.ts`
+- Modify: `packages/services/src/index.ts` (export)
+- Modify (only if needed): `packages/services/src/ui/context/oxyContextTypes.ts` — `sessionClient` must be reachable from the context consumed by hooks. `OxyContext.tsx` already places `sessionClient` in the context value (see `OxyContext.tsx` around lines 334/367); if the context TYPE omits it, add `sessionClient: SessionClient` to the type rather than casting.
+
+**Interfaces:**
+- Consumes: `SessionClient.onServerEvent` (Task 1), the internal Oxy context.
+- Produces: `useOxyEvent(event: string, handler: (payload: unknown) => void): void` — exported from `@oxyhq/services`. Subscribes for the component's lifetime; `handler` identity may change freely (ref-stable internally).
+
+No unit test in services: the hook is a 15-line lifetime wrapper over `onServerEvent`, which Task 1 tests directly, and Task 4's commons test covers the consumer contract. (Standing up a context harness in services for this would test React, not our logic.)
+
+- [ ] **Step 1: Implement the hook**
+
+`packages/services/src/ui/hooks/useOxyEvent.ts`:
+
+```ts
+import { useEffect, useRef } from 'react';
+
+import { useOxy } from '../context/OxyContext';
+
+/**
+ * Subscribe to a named server-pushed Socket.IO event (e.g. `civic:attested`)
+ * for the lifetime of the component. Payloads arrive as `unknown` — callers
+ * validate shape. Handler identity may change between renders; the latest one
+ * is always invoked.
+ */
+export function useOxyEvent(event: string, handler: (payload: unknown) => void): void {
+  const { sessionClient } = useOxy();
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    if (!sessionClient) return;
+    return sessionClient.onServerEvent(event, (payload) => {
+      handlerRef.current(payload);
+    });
+  }, [sessionClient, event]);
+}
+```
+
+Adjust the import path/name to match how sibling hooks in `packages/services/src/ui/hooks/` import `useOxy` (mirror an existing hook file's import exactly). If `useOxy()`'s return type does not include `sessionClient`, add it to the context type in `oxyContextTypes.ts` (typed as the `SessionClient` class imported `import type { SessionClient } from '@oxyhq/core'` — check how `OxyContext.tsx` already types it and reuse that).
+
+- [ ] **Step 2: Export from the package root**
+
+In `packages/services/src/index.ts`, next to the other hook exports, add:
+
+```ts
+export { useOxyEvent } from './ui/hooks/useOxyEvent';
+```
+
+- [ ] **Step 3: Build services + run its suite**
+
+Run: `bun run services:build && cd packages/services && bun run test`
+Expected: build clean (react-native-builder-bob), suite passes (baseline ~195).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/services/src/ui/hooks/useOxyEvent.ts packages/services/src/index.ts
+# plus packages/services/src/ui/context/oxyContextTypes.ts if it was touched
+git commit -m "feat(services): useOxyEvent — subscribe to server-pushed socket events
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `civic:attested` socket emit (api)
+
+**Files:**
+- Modify: `packages/api/src/routes/civic.ts` (the `POST /civic/attestations` handler, ~line 286)
+- Test: `packages/api/src/routes/__tests__/civicAttestations.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `getIO()` from `packages/api/src/utils/socket.ts`; `submitRealLifeAttestation` result (`{ ok, recordId, subjectUserId, attestorUserId, points }`).
+- Produces: Socket.IO event `civic:attested` to room `user:<subjectUserId>` with payload `{ byUserId: string; recordId: string; points: number; at: string /* ISO */ }`. This exact shape is what Task 4's client hook validates.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `packages/api/src/routes/__tests__/civicAttestations.test.ts`, add a socket mock alongside the existing mocks (top of file, `mock`-prefixed names so Jest's hoisting allows them):
+
+```ts
+const mockEmit = jest.fn();
+const mockTo = jest.fn(() => ({ emit: mockEmit }));
+jest.mock('../../utils/socket', () => ({ getIO: () => ({ to: mockTo }) }));
+```
+
+Clear them in the existing `beforeEach` (or add one): `mockEmit.mockClear(); mockTo.mockClear();`
+
+Add two tests following the file's existing request pattern (mirror how the existing 201-success test builds the request and `mockSubmit` resolution — copy that test and extend the assertions):
+
+```ts
+it('emits civic:attested to the subject user room on success', async () => {
+  mockSubmit.mockResolvedValue({ ok: true, recordId: 'r1', subjectUserId: 'subj1', attestorUserId: B, points: 25 });
+  // ...perform the same POST /civic/attestations request the success test does...
+  expect(mockTo).toHaveBeenCalledWith('user:subj1');
+  expect(mockEmit).toHaveBeenCalledWith('civic:attested', expect.objectContaining({
+    byUserId: B,
+    recordId: 'r1',
+    points: 25,
+    at: expect.any(String),
+  }));
+});
+
+it('does NOT emit civic:attested when the attestation is rejected', async () => {
+  mockSubmit.mockResolvedValue({ ok: false, reason: 'nonce_reused' });
+  // ...perform the same POST request the rejection tests do (expecting the mapped error status)...
+  expect(mockEmit).not.toHaveBeenCalled();
+});
+```
+
+Use the file's real request helper/shape and a real rejection `reason` value from the existing tests — do not invent new harness code.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd packages/api && bunx jest src/routes/__tests__/civicAttestations.test.ts`
+Expected: new success-emit test FAILS (`mockTo` not called); rejection test may already pass — fine.
+
+- [ ] **Step 3: Implement the emit**
+
+In `packages/api/src/routes/civic.ts`:
+
+Add to the imports: `import { getIO } from '../utils/socket';`
+
+In the `POST /attestations` handler, after the `if (!result.ok) { throwForRealLifeReason(result.reason); }` block and before `res.status(201)`, add:
+
+```ts
+    // Level-2 card feedback: tell the subject (A) their attestation landed.
+    // Best-effort — a missing io (tests, boot) must never fail the request.
+    const io = getIO();
+    if (io) {
+      io.to(`user:${result.subjectUserId}`).emit('civic:attested', {
+        byUserId: result.attestorUserId,
+        recordId: result.recordId,
+        points: result.points,
+        at: new Date().toISOString(),
+      });
+    }
+```
+
+- [ ] **Step 4: Run the civic route tests, then the api suite**
+
+Run: `cd packages/api && bunx jest src/routes/__tests__/civicAttestations.test.ts` → PASS.
+Run: `cd packages/api && bun run test`
+Expected: full suite passes (baseline ~1322, +2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/routes/civic.ts packages/api/src/routes/__tests__/civicAttestations.test.ts
+git commit -m "feat(api): emit civic:attested to subject on accepted real-life attestation
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `useAttestedEvent` hook (commons)
+
+**Files:**
+- Create: `packages/commons/hooks/civic/useAttestedEvent.ts`
+- Modify: `packages/commons/__mocks__/oxyhq-services.ts` (add `useOxyEvent` support)
+- Test: `packages/commons/__tests__/hooks/useAttestedEvent.test.tsx`
+
+**Interfaces:**
+- Consumes: `useOxyEvent` from `@oxyhq/services` (Task 2); event shape from Task 3.
+- Produces: `useAttestedEvent(onAttested: (payload: AttestedEventPayload) => void): void` and `interface AttestedEventPayload { byUserId: string; recordId: string; points: number; at: string }`.
+
+- [ ] **Step 1: Extend the services mock**
+
+In `packages/commons/__mocks__/oxyhq-services.ts` (match the file's existing style), add a capture-and-fire helper:
+
+```ts
+type OxyEventHandler = (payload: unknown) => void;
+const oxyEventHandlers = new Map<string, Set<OxyEventHandler>>();
+
+export function useOxyEvent(event: string, handler: OxyEventHandler): void {
+  React.useEffect(() => {
+    let set = oxyEventHandlers.get(event);
+    if (!set) {
+      set = new Set();
+      oxyEventHandlers.set(event, set);
+    }
+    set.add(handler);
+    return () => {
+      set.delete(handler);
+    };
+  }, [event, handler]);
+}
+
+/** Test helper: fire a fake server-pushed event at all registered handlers. */
+export function __emitOxyEvent(event: string, payload: unknown): void {
+  for (const handler of [...(oxyEventHandlers.get(event) ?? [])]) handler(payload);
+}
+```
+
+If the mock file has a `__reset…` helper, clear `oxyEventHandlers` there too. Use whatever React import style the mock already uses.
+
+- [ ] **Step 2: Write the failing test**
+
+`packages/commons/__tests__/hooks/useAttestedEvent.test.tsx`:
+
+```tsx
+import { renderHook, act } from '@testing-library/react';
+import { __emitOxyEvent } from '@/__mocks__/oxyhq-services';
+import { useAttestedEvent } from '@/hooks/civic/useAttestedEvent';
+
+describe('useAttestedEvent', () => {
+  it('fires the callback for a well-formed civic:attested payload', () => {
+    const onAttested = jest.fn();
+    renderHook(() => useAttestedEvent(onAttested));
+    act(() => {
+      __emitOxyEvent('civic:attested', { byUserId: 'u2', recordId: 'r1', points: 25, at: '2026-07-11T00:00:00.000Z' });
+    });
+    expect(onAttested).toHaveBeenCalledWith({ byUserId: 'u2', recordId: 'r1', points: 25, at: '2026-07-11T00:00:00.000Z' });
+  });
+
+  it('ignores malformed payloads (strict whitelist)', () => {
+    const onAttested = jest.fn();
+    renderHook(() => useAttestedEvent(onAttested));
+    act(() => {
+      __emitOxyEvent('civic:attested', null);
+      __emitOxyEvent('civic:attested', 'nope');
+      __emitOxyEvent('civic:attested', { byUserId: 42 });
+    });
+    expect(onAttested).not.toHaveBeenCalled();
+  });
+
+  it('never reacts to other event names', () => {
+    const onAttested = jest.fn();
+    renderHook(() => useAttestedEvent(onAttested));
+    act(() => {
+      __emitOxyEvent('session_removed', { byUserId: 'u2', recordId: 'r1' });
+    });
+    expect(onAttested).not.toHaveBeenCalled();
+  });
+});
+```
+
+Run: `cd packages/commons && bunx jest __tests__/hooks/useAttestedEvent.test.tsx`
+Expected: FAIL — module `@/hooks/civic/useAttestedEvent` not found.
+
+- [ ] **Step 3: Implement the hook**
+
+`packages/commons/hooks/civic/useAttestedEvent.ts`:
+
+```ts
+import { useOxyEvent } from '@oxyhq/services';
+
+export interface AttestedEventPayload {
+  byUserId: string;
+  recordId: string;
+  points: number;
+  at: string;
+}
+
+/**
+ * Fires when the server confirms a real-life attestation for the CURRENT user
+ * (`civic:attested` on the user socket room). Strict shape whitelist — a
+ * malformed push is dropped, never partially applied.
+ */
+export function useAttestedEvent(onAttested: (payload: AttestedEventPayload) => void): void {
+  useOxyEvent('civic:attested', (payload) => {
+    if (payload === null || typeof payload !== 'object') return;
+    const p = payload as Record<string, unknown>;
+    if (typeof p.byUserId !== 'string' || typeof p.recordId !== 'string') return;
+    onAttested({
+      byUserId: p.byUserId,
+      recordId: p.recordId,
+      points: typeof p.points === 'number' ? p.points : 0,
+      at: typeof p.at === 'string' ? p.at : '',
+    });
+  });
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd packages/commons && bunx jest __tests__/hooks/useAttestedEvent.test.tsx`
+Expected: 3/3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/commons/hooks/civic/useAttestedEvent.ts packages/commons/__mocks__/oxyhq-services.ts packages/commons/__tests__/hooks/useAttestedEvent.test.tsx
+git commit -m "feat(commons): useAttestedEvent — server-confirmed attestation listener
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: NFC dependencies + config plugins (commons)
+
+**Files:**
+- Create: `packages/commons/plugins/with-hce.js`
+- Modify: `packages/commons/package.json`, `packages/commons/app.config.js`, root `bun.lock`
+
+**Interfaces:**
+- Produces: installed `react-native-hce` + `react-native-nfc-manager`; Android manifest gains the HCE `CardService`, NFC permission/feature, and an `NDEF_DISCOVERED` intent filter for `oxycommons://attest`; iOS gains NFC reader entitlement + usage string. Later tasks import both libraries.
+
+- [ ] **Step 1: Install deps**
+
+```bash
+cd packages/commons && bun add react-native-hce react-native-nfc-manager
+cd /home/nate/Oxy/OxyHQServices && bun install
+```
+
+Expected: both appear in `packages/commons/package.json` dependencies; `bun.lock` updated.
+
+- [ ] **Step 2: Write the HCE config plugin**
+
+`packages/commons/plugins/with-hce.js` (plain JS — `app.config.js` is JS; mirror its module style):
+
+```js
+/**
+ * Config plugin for react-native-hce (which ships no plugin of its own) plus
+ * the NDEF tap deep link:
+ *  - android.permission.NFC + android.hardware.nfc.hce (not required — the app
+ *    must install on NFC-less devices; the emitter hook degrades to 'unsupported')
+ *  - the HCE CardService (starts DISABLED; react-native-hce toggles it at runtime)
+ *  - res/xml/aid_list.xml with the standard NDEF Type 4 AID (D2760000850101)
+ *  - NDEF_DISCOVERED intent filter on MainActivity for oxycommons://attest so a
+ *    tap opens the scan/attest flow even when the app is closed
+ */
+const { withAndroidManifest, withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const AID_LIST_XML = `<?xml version="1.0" encoding="utf-8"?>
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_name"
+    android:requireDeviceUnlock="false">
+    <aid-group android:category="other" android:description="@string/app_name">
+        <aid-filter android:name="D2760000850101" />
+    </aid-group>
+</host-apdu-service>
+`;
+
+function withHce(config) {
+  config = withDangerousMod(config, [
+    'android',
+    async (modConfig) => {
+      const resXmlDir = path.join(modConfig.modRequest.platformProjectRoot, 'app', 'src', 'main', 'res', 'xml');
+      fs.mkdirSync(resXmlDir, { recursive: true });
+      fs.writeFileSync(path.join(resXmlDir, 'aid_list.xml'), AID_LIST_XML);
+      return modConfig;
+    },
+  ]);
+
+  config = withAndroidManifest(config, (modConfig) => {
+    const manifest = modConfig.modResults.manifest;
+
+    manifest['uses-permission'] = manifest['uses-permission'] ?? [];
+    if (!manifest['uses-permission'].some((p) => p.$['android:name'] === 'android.permission.NFC')) {
+      manifest['uses-permission'].push({ $: { 'android:name': 'android.permission.NFC' } });
+    }
+
+    manifest['uses-feature'] = manifest['uses-feature'] ?? [];
+    if (!manifest['uses-feature'].some((f) => f.$['android:name'] === 'android.hardware.nfc.hce')) {
+      manifest['uses-feature'].push({ $: { 'android:name': 'android.hardware.nfc.hce', 'android:required': 'false' } });
+    }
+
+    const app = manifest.application?.[0];
+    if (!app) throw new Error('with-hce: AndroidManifest has no <application>');
+
+    app.service = app.service ?? [];
+    if (!app.service.some((s) => s.$['android:name'] === 'com.reactnativehce.services.CardService')) {
+      app.service.push({
+        $: {
+          'android:name': 'com.reactnativehce.services.CardService',
+          'android:exported': 'true',
+          'android:enabled': 'false',
+          'android:permission': 'android.permission.BIND_NFC_SERVICE',
+        },
+        'intent-filter': [
+          {
+            action: [{ $: { 'android:name': 'android.nfc.cardemulation.action.HOST_APDU_SERVICE' } }],
+            category: [{ $: { 'android:name': 'android.intent.category.DEFAULT' } }],
+          },
+        ],
+        'meta-data': [
+          {
+            $: {
+              'android:name': 'android.nfc.cardemulation.host_apdu_service',
+              'android:resource': '@xml/aid_list',
+            },
+          },
+        ],
+      });
+    }
+
+    const mainActivity = (app.activity ?? []).find((a) => a.$['android:name'] === '.MainActivity');
+    if (mainActivity) {
+      mainActivity['intent-filter'] = mainActivity['intent-filter'] ?? [];
+      const hasNdef = mainActivity['intent-filter'].some((f) =>
+        (f.action ?? []).some((a) => a.$['android:name'] === 'android.nfc.action.NDEF_DISCOVERED'),
+      );
+      if (!hasNdef) {
+        mainActivity['intent-filter'].push({
+          action: [{ $: { 'android:name': 'android.nfc.action.NDEF_DISCOVERED' } }],
+          category: [{ $: { 'android:name': 'android.intent.category.DEFAULT' } }],
+          data: [{ $: { 'android:scheme': 'oxycommons', 'android:host': 'attest' } }],
+        });
+      }
+    }
+
+    return modConfig;
+  });
+
+  return config;
+}
+
+module.exports = withHce;
+```
+
+**Before finalizing, verify the two react-native-hce facts against the installed package** (`packages/commons/node_modules/react-native-hce/` — or the isolated-linker path `node_modules/.bun/react-native-hce@*/node_modules/react-native-hce`): (a) the service class name `com.reactnativehce.services.CardService` in its `android/src/main/AndroidManifest.xml` or README, and (b) the runtime API names used in Task 6 (`HCESession.getInstance`, `setApplication`, `setEnabled`, `HCESession.Events.HCE_STATE_READ`, `NFCTagType4`, `NFCTagType4NDEFContentType.URL`) in its `src/` TypeScript. Adjust plugin/hook to the real names if they differ.
+
+- [ ] **Step 3: Wire plugins into app.config.js**
+
+In `packages/commons/app.config.js`, in the `plugins` array (after the `expo-camera` entry), add:
+
+```js
+      [
+        'react-native-nfc-manager',
+        {
+          nfcPermission: 'Allow $(PRODUCT_NAME) to read attestation cards from nearby phones.',
+        },
+      ],
+      './plugins/with-hce',
+```
+
+- [ ] **Step 4: Validate with a prebuild**
+
+```bash
+cd packages/commons && bunx expo prebuild --platform android --no-install
+grep -A2 "CardService" android/app/src/main/AndroidManifest.xml
+grep -B1 -A3 "NDEF_DISCOVERED" android/app/src/main/AndroidManifest.xml
+cat android/app/src/main/res/xml/aid_list.xml
+```
+
+Expected: service present with `BIND_NFC_SERVICE` + `@xml/aid_list` meta-data; NDEF intent filter with scheme `oxycommons` host `attest`; aid_list.xml matches. Then remove the generated project (CNG — it must not be committed):
+
+```bash
+cd packages/commons && rm -rf android ios
+```
+
+- [ ] **Step 5: Commit (lockfile in the SAME commit)**
+
+```bash
+git add packages/commons/package.json packages/commons/app.config.js packages/commons/plugins/with-hce.js bun.lock
+git commit -m "feat(commons): NFC deps + HCE/NDEF config plugins
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: `useNfcAttestEmitter` hook (commons)
+
+**Files:**
+- Create: `packages/commons/hooks/nfc/useNfcAttestEmitter.ts`
+- Test: `packages/commons/__tests__/hooks/useNfcAttestEmitter.test.tsx`
+
+**Interfaces:**
+- Consumes: `react-native-hce` (`HCESession`, `NFCTagType4`, `NFCTagType4NDEFContentType`), `react-native-nfc-manager` (`isSupported`, `isEnabled`).
+- Produces: `useNfcAttestEmitter(options: { payload: string | null; enabled: boolean; onRead: () => void }): { state: NfcEmitterState }` with `type NfcEmitterState = 'unsupported' | 'off' | 'emitting'`. `'off'` covers both NFC-disabled-in-settings and not-currently-armed (blurred / no payload); the UI only distinguishes `'emitting'`.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/commons/__tests__/hooks/useNfcAttestEmitter.test.tsx`:
+
+```tsx
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { Platform } from 'react-native';
+
+const mockIsSupported = jest.fn(async () => true);
+const mockIsEnabled = jest.fn(async () => true);
+jest.mock('react-native-nfc-manager', () => ({
+  __esModule: true,
+  default: { isSupported: () => mockIsSupported(), isEnabled: () => mockIsEnabled() },
+}));
+
+const mockSetApplication = jest.fn(async () => undefined);
+const mockSetEnabled = jest.fn(async () => undefined);
+let readListener: (() => void) | null = null;
+const mockRemoveListener = jest.fn();
+const mockSession = {
+  setApplication: mockSetApplication,
+  setEnabled: mockSetEnabled,
+  on: jest.fn((_event: string, cb: () => void) => {
+    readListener = cb;
+    return mockRemoveListener;
+  }),
+};
+jest.mock('react-native-hce', () => ({
+  __esModule: true,
+  HCESession: {
+    getInstance: jest.fn(async () => mockSession),
+    Events: { HCE_STATE_READ: 'hceStateRead' },
+  },
+  NFCTagType4: jest.fn(function (this: Record<string, unknown>, props: unknown) { this.props = props; }),
+  NFCTagType4NDEFContentType: { URL: 'url', Text: 'text' },
+}));
+
+// eslint-disable-next-line import/first
+import { useNfcAttestEmitter } from '@/hooks/nfc/useNfcAttestEmitter';
+
+const PAYLOAD = 'oxycommons://attest?payload=abc';
+
+describe('useNfcAttestEmitter', () => {
+  const originalOS = Platform.OS;
+  beforeEach(() => {
+    Object.defineProperty(Platform, 'OS', { value: 'android', configurable: true });
+    jest.clearAllMocks();
+    readListener = null;
+  });
+  afterAll(() => {
+    Object.defineProperty(Platform, 'OS', { value: originalOS, configurable: true });
+  });
+
+  it('arms HCE with the payload and reports emitting', async () => {
+    const onRead = jest.fn();
+    const { result } = renderHook(() => useNfcAttestEmitter({ payload: PAYLOAD, enabled: true, onRead }));
+    await waitFor(() => expect(result.current.state).toBe('emitting'));
+    expect(mockSetApplication).toHaveBeenCalledTimes(1);
+    expect(mockSetEnabled).toHaveBeenCalledWith(true);
+  });
+
+  it('fires onRead when the HCE read event arrives', async () => {
+    const onRead = jest.fn();
+    const { result } = renderHook(() => useNfcAttestEmitter({ payload: PAYLOAD, enabled: true, onRead }));
+    await waitFor(() => expect(result.current.state).toBe('emitting'));
+    act(() => { readListener?.(); });
+    expect(onRead).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports off when NFC is disabled in settings', async () => {
+    mockIsEnabled.mockResolvedValueOnce(false);
+    const { result } = renderHook(() => useNfcAttestEmitter({ payload: PAYLOAD, enabled: true, onRead: jest.fn() }));
+    await waitFor(() => expect(result.current.state).toBe('off'));
+    expect(mockSetEnabled).not.toHaveBeenCalled();
+  });
+
+  it('reports unsupported on iOS and never touches native modules', async () => {
+    Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+    const { result } = renderHook(() => useNfcAttestEmitter({ payload: PAYLOAD, enabled: true, onRead: jest.fn() }));
+    expect(result.current.state).toBe('unsupported');
+    expect(mockIsSupported).not.toHaveBeenCalled();
+  });
+
+  it('disarms on unmount', async () => {
+    const { result, unmount } = renderHook(() => useNfcAttestEmitter({ payload: PAYLOAD, enabled: true, onRead: jest.fn() }));
+    await waitFor(() => expect(result.current.state).toBe('emitting'));
+    unmount();
+    expect(mockRemoveListener).toHaveBeenCalled();
+    expect(mockSetEnabled).toHaveBeenLastCalledWith(false);
+  });
+});
+```
+
+Adjust the `react-native-hce` mock surface to the REAL API discovered in Task 5 step 2 (event listener may be `session.on(event, cb)` returning a remover, or an `addListener`-style API — mirror reality, and update the hook below to match).
+
+Run: `cd packages/commons && bunx jest __tests__/hooks/useNfcAttestEmitter.test.tsx`
+Expected: FAIL — hook module not found.
+
+- [ ] **Step 2: Implement the hook**
+
+`packages/commons/hooks/nfc/useNfcAttestEmitter.ts`:
+
+```ts
+import { useEffect, useRef, useState } from 'react';
+import { Platform } from 'react-native';
+
+export type NfcEmitterState = 'unsupported' | 'off' | 'emitting';
+
+interface UseNfcAttestEmitterOptions {
+  /** The `oxycommons://attest?…` string (same bytes as the QR); null while loading. */
+  payload: string | null;
+  /** Arm only while the owning screen is focused. */
+  enabled: boolean;
+  /** Fired once per HCE read session — the counterparty pulled the payload. */
+  onRead: () => void;
+}
+
+/**
+ * Emits the attestation payload as an NDEF Type 4 tag via HCE while enabled
+ * (Android only). `'off'` covers NFC-disabled AND not-armed; only `'emitting'`
+ * drives UI. Arms/disarms with the effect lifecycle; the caller regenerates
+ * the payload on read/expiry, which re-arms with fresh bytes.
+ */
+export function useNfcAttestEmitter({ payload, enabled, onRead }: UseNfcAttestEmitterOptions): {
+  state: NfcEmitterState;
+} {
+  const [state, setState] = useState<NfcEmitterState>(
+    Platform.OS === 'android' ? 'off' : 'unsupported',
+  );
+  const onReadRef = useRef(onRead);
+  onReadRef.current = onRead;
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    if (!enabled || !payload) {
+      setState('off');
+      return;
+    }
+
+    let cancelled = false;
+    let removeListener: (() => void) | null = null;
+    let armedSession: { setEnabled: (value: boolean) => Promise<unknown> } | null = null;
+
+    (async () => {
+      try {
+        const NfcManager = (await import('react-native-nfc-manager')).default;
+        const [supported, nfcOn] = await Promise.all([NfcManager.isSupported(), NfcManager.isEnabled()]);
+        if (cancelled) return;
+        if (!supported) {
+          setState('unsupported');
+          return;
+        }
+        if (!nfcOn) {
+          setState('off');
+          return;
+        }
+
+        const { HCESession, NFCTagType4, NFCTagType4NDEFContentType } = await import('react-native-hce');
+        if (cancelled) return;
+        const tag = new NFCTagType4({
+          type: NFCTagType4NDEFContentType.URL,
+          content: payload,
+          writable: false,
+        });
+        const session = await HCESession.getInstance();
+        // Register the disarm target BEFORE enabling — if the effect is
+        // cancelled mid-arm, cleanup must still switch the service off.
+        armedSession = session;
+        await session.setApplication(tag);
+        await session.setEnabled(true);
+        if (cancelled) return;
+        removeListener = session.on(HCESession.Events.HCE_STATE_READ, () => {
+          onReadRef.current();
+        });
+        setState('emitting');
+      } catch (error) {
+        console.error('[useNfcAttestEmitter] failed to arm HCE session', error);
+        if (!cancelled) setState('off');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      removeListener?.();
+      if (armedSession) {
+        armedSession.setEnabled(false).catch((error) => {
+          console.warn('[useNfcAttestEmitter] failed to disarm HCE session', error);
+        });
+      }
+    };
+  }, [payload, enabled]);
+
+  return { state };
+}
+```
+
+Match the real `react-native-hce` API surface verified in Task 5 (constructor arguments, event API, whether `setApplication` precedes `setEnabled`). Keep the dynamic `await import(...)` — the module must never load on iOS.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd packages/commons && bunx jest __tests__/hooks/useNfcAttestEmitter.test.tsx`
+Expected: 5/5 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/commons/hooks/nfc/useNfcAttestEmitter.ts packages/commons/__tests__/hooks/useNfcAttestEmitter.test.tsx
+git commit -m "feat(commons): useNfcAttestEmitter — HCE attest payload emission
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: `useNfcReader` hook (commons)
+
+**Files:**
+- Create: `packages/commons/hooks/nfc/useNfcReader.ts`
+- Test: `packages/commons/__tests__/hooks/useNfcReader.test.tsx`
+
+**Interfaces:**
+- Consumes: `react-native-nfc-manager` (`start`, `isSupported`, `requestTechnology`, `getTag`, `cancelTechnologyRequest`, `Ndef.uri.decodePayload`, `NfcTech.Ndef`).
+- Produces: `useNfcReader(): { available: boolean; readOnce: () => Promise<NfcReadResult> }` with `type NfcReadResult = { ok: true; uri: string } | { ok: false; reason: 'cancelled' | 'empty' }`.
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/commons/__tests__/hooks/useNfcReader.test.tsx`:
+
+```tsx
+import { renderHook, waitFor } from '@testing-library/react';
+
+const mockStart = jest.fn(async () => undefined);
+const mockIsSupported = jest.fn(async () => true);
+const mockRequestTechnology = jest.fn(async () => undefined);
+const mockGetTag = jest.fn();
+const mockCancel = jest.fn(async () => undefined);
+const mockDecodePayload = jest.fn(() => 'oxycommons://attest?payload=abc');
+
+jest.mock('react-native-nfc-manager', () => ({
+  __esModule: true,
+  default: {
+    start: () => mockStart(),
+    isSupported: () => mockIsSupported(),
+    requestTechnology: (tech: unknown) => mockRequestTechnology(tech),
+    getTag: () => mockGetTag(),
+    cancelTechnologyRequest: () => mockCancel(),
+  },
+  NfcTech: { Ndef: 'Ndef' },
+  Ndef: { uri: { decodePayload: (bytes: Uint8Array) => mockDecodePayload(bytes) } },
+}));
+
+// eslint-disable-next-line import/first
+import { useNfcReader } from '@/hooks/nfc/useNfcReader';
+
+describe('useNfcReader', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reports availability from isSupported', async () => {
+    const { result } = renderHook(() => useNfcReader());
+    await waitFor(() => expect(result.current.available).toBe(true));
+  });
+
+  it('reads one NDEF URI record and always releases the technology', async () => {
+    mockGetTag.mockResolvedValue({ ndefMessage: [{ payload: [1, 2, 3] }] });
+    const { result } = renderHook(() => useNfcReader());
+    const read = await result.current.readOnce();
+    expect(read).toEqual({ ok: true, uri: 'oxycommons://attest?payload=abc' });
+    expect(mockCancel).toHaveBeenCalled();
+  });
+
+  it('returns empty for a tag with no NDEF payload', async () => {
+    mockGetTag.mockResolvedValue({ ndefMessage: [] });
+    const { result } = renderHook(() => useNfcReader());
+    const read = await result.current.readOnce();
+    expect(read).toEqual({ ok: false, reason: 'empty' });
+    expect(mockCancel).toHaveBeenCalled();
+  });
+
+  it('returns cancelled when the session throws (user dismissed)', async () => {
+    mockRequestTechnology.mockRejectedValueOnce(new Error('cancelled'));
+    const { result } = renderHook(() => useNfcReader());
+    const read = await result.current.readOnce();
+    expect(read).toEqual({ ok: false, reason: 'cancelled' });
+    expect(mockCancel).toHaveBeenCalled();
+  });
+});
+```
+
+Run: `cd packages/commons && bunx jest __tests__/hooks/useNfcReader.test.tsx` → FAIL (module not found).
+
+- [ ] **Step 2: Implement the hook**
+
+`packages/commons/hooks/nfc/useNfcReader.ts`:
+
+```ts
+import { useCallback, useEffect, useState } from 'react';
+
+import NfcManager, { Ndef, NfcTech } from 'react-native-nfc-manager';
+
+export type NfcReadResult = { ok: true; uri: string } | { ok: false; reason: 'cancelled' | 'empty' };
+
+/**
+ * One-shot NDEF reader for the "hold near the other phone" action (iPhone, and
+ * Android as an in-app alternative to the system tap). `available` gates the
+ * button; `readOnce` opens a reader session, decodes the first URI record, and
+ * ALWAYS releases the NFC technology.
+ */
+export function useNfcReader(): { available: boolean; readOnce: () => Promise<NfcReadResult> } {
+  const [available, setAvailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    NfcManager.isSupported()
+      .then((supported) => {
+        if (!cancelled) setAvailable(supported);
+      })
+      .catch((error) => {
+        console.warn('[useNfcReader] isSupported failed', error);
+        if (!cancelled) setAvailable(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const readOnce = useCallback(async (): Promise<NfcReadResult> => {
+    try {
+      await NfcManager.start();
+      await NfcManager.requestTechnology(NfcTech.Ndef);
+      const tag = await NfcManager.getTag();
+      const record = tag?.ndefMessage?.[0];
+      if (!record?.payload?.length) return { ok: false, reason: 'empty' };
+      const uri = Ndef.uri.decodePayload(Uint8Array.from(record.payload));
+      if (!uri) return { ok: false, reason: 'empty' };
+      return { ok: true, uri };
+    } catch (error) {
+      // Thrown on user dismissal of the OS sheet — expected, not an error state.
+      console.warn('[useNfcReader] read session ended', error);
+      return { ok: false, reason: 'cancelled' };
+    } finally {
+      NfcManager.cancelTechnologyRequest().catch((error) => {
+        console.warn('[useNfcReader] cancelTechnologyRequest failed', error);
+      });
+    }
+  }, []);
+
+  return { available, readOnce };
+}
+```
+
+If the `start()` call placement differs from the real API (some versions require it once at module init), match the installed package's README.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd packages/commons && bunx jest __tests__/hooks/useNfcReader.test.tsx` → 4/4 PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/commons/hooks/nfc/useNfcReader.ts packages/commons/__tests__/hooks/useNfcReader.test.tsx
+git commit -m "feat(commons): useNfcReader — one-shot NDEF read for attest handoff
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Card effect plumbing — `scanPulse` + `attestGlow` (commons)
+
+**Files:**
+- Modify: `packages/commons/components/OxyID/tilt-context.tsx`
+- Modify: `packages/commons/components/OxyID/index.tsx`
+- Modify: `packages/commons/components/holographic-card.tsx`
+
+**Interfaces:**
+- Consumes: existing `TiltContextValue` / `Ticket` / `HolographicCard`.
+- Produces: `TiltContextValue` gains `scanPulse: SharedValue<number>` and `attestGlow: SharedValue<number>`. `Ticket` gains optional props `scanPulse?: SharedValue<number>` / `attestGlow?: SharedValue<number>` (internal zero-valued defaults when absent — existing call sites keep compiling). Semantics: `scanPulse` animates 0→1 once per NFC read (drives a diagonal shine sweep + a −3° pitch nudge shaped by `sin(π·t)`); `attestGlow` animates 0→1→0 on server confirmation (boosts iridescence + edge glow). The card only RENDERS these; triggering lives in Task 9.
+
+No new unit test — this is pure Reanimated/Skia rendering (jsdom cannot exercise it); the gate is `tsc` + existing suite + the manual device checklist. Coordinate with any concurrently-running agent on these files (they were recently edited): re-read each file before editing.
+
+- [ ] **Step 1: Extend the tilt context**
+
+In `packages/commons/components/OxyID/tilt-context.tsx`, add to `TiltContextValue` (after `rotation`):
+
+```ts
+    /** 0→1 once per NFC read — shine sweep + pitch nudge (level-1 feedback). */
+    scanPulse: SharedValue<number>;
+    /** 0→1→0 on server-confirmed attestation — full shimmer (level-2 feedback). */
+    attestGlow: SharedValue<number>;
+```
+
+- [ ] **Step 2: Thread through `Ticket`**
+
+In `packages/commons/components/OxyID/index.tsx`:
+
+Extend props:
+
+```ts
+type TicketProps = {
+    width: number;
+    height: number;
+    frontSide?: ReactNode;
+    backSide?: ReactNode;
+    /** Optional QR face, revealed by a long-press (tap only flips front↔back). */
+    qrSide?: ReactNode;
+    /** Level-1 NFC-read feedback value (0→1 per read). Internal default: inert. */
+    scanPulse?: SharedValue<number>;
+    /** Level-2 attestation-confirmed feedback value (0→1→0). Internal default: inert. */
+    attestGlow?: SharedValue<number>;
+};
+```
+
+Inside the component (after `rotation`):
+
+```ts
+    // Effect channels — inert local values unless the screen supplies live ones.
+    const internalScanPulse = useSharedValue(0);
+    const internalAttestGlow = useSharedValue(0);
+    const scanPulse = scanPulseProp ?? internalScanPulse;
+    const attestGlow = attestGlowProp ?? internalAttestGlow;
+```
+
+(Destructure the props as `scanPulse: scanPulseProp, attestGlow: attestGlowProp`.) Add both to the `tiltContext` memo value and its dependency array. Import `SharedValue` type from `react-native-reanimated` if not present.
+
+Add the nudge to `rTiltStyle` — replace the `rotateX` line:
+
+```ts
+            { rotateX: `${pitchDeg.value + pressRotateX.value - 3 * Math.sin(Math.min(1, Math.max(0, scanPulse.value)) * Math.PI)}deg` },
+```
+
+- [ ] **Step 3: Render the shine sweep + confirm shimmer in the Skia canvas**
+
+In `packages/commons/components/holographic-card.tsx`:
+
+Destructure the new values: `const { nx, ny, mag, isPressed, scanPulse, attestGlow } = useTilt();`
+
+Boost the iridescence with the glow — replace `irisOpacity`:
+
+```ts
+    const irisOpacity = useDerivedValue(() =>
+        Math.min(1, 0.32 + mag.value * 0.45 + isPressed.value * 0.16 + attestGlow.value * 0.5),
+    );
+```
+
+Add derived values after `glossOpacity`:
+
+```ts
+    // NFC-read shine: a narrow diagonal band that sweeps corner-to-corner as
+    // scanPulse runs 0→1, fading in/out with sin(π·t) so it never pops.
+    const scanBandStart = useDerivedValue(() => {
+        const p = scanPulse.value * 2 - 1;
+        return vec(width * (p - 0.6), height * (p - 0.6));
+    });
+    const scanBandEnd = useDerivedValue(() => {
+        const p = scanPulse.value * 2 - 1;
+        return vec(width * (p + 0.6), height * (p + 0.6));
+    });
+    const scanBandOpacity = useDerivedValue(() =>
+        Math.sin(Math.min(1, Math.max(0, scanPulse.value)) * Math.PI) * 0.9,
+    );
+
+    // Attestation-confirmed edge glow.
+    const attestEdgeOpacity = useDerivedValue(() => attestGlow.value * 0.9);
+```
+
+Add two groups inside the `<Group>` — the scan band right AFTER the gloss `<Group>`, the edge glow right BEFORE the final edge-definition `RoundedRect`:
+
+```tsx
+                {/* NFC-read shine sweep (scanPulse-driven; invisible at rest). */}
+                <Group opacity={scanBandOpacity}>
+                    <RoundedRect x={0} y={0} width={width} height={height} r={24}>
+                        <LinearGradient
+                            start={scanBandStart}
+                            end={scanBandEnd}
+                            colors={[
+                                'rgba(255,255,255,0)',
+                                'rgba(255,255,255,0)',
+                                'rgba(255,255,255,0.9)',
+                                'rgba(255,255,255,0)',
+                                'rgba(255,255,255,0)',
+                            ]}
+                            positions={[0, 0.42, 0.5, 0.58, 1]}
+                        />
+                    </RoundedRect>
+                </Group>
+
+                {/* Attestation-confirmed iridescent edge glow (attestGlow-driven). */}
+                <Group opacity={attestEdgeOpacity}>
+                    <RoundedRect
+                        x={1.5}
+                        y={1.5}
+                        width={width - 3}
+                        height={height - 3}
+                        r={23}
+                        style="stroke"
+                        strokeWidth={3}>
+                        <LinearGradient start={vec(0, 0)} end={vec(width, height)} colors={IRIDESCENT} />
+                    </RoundedRect>
+                </Group>
+```
+
+- [ ] **Step 4: Typecheck + full commons suite**
+
+Run: `cd packages/commons && bunx tsc --noEmit && bun run test`
+Expected: clean typecheck; suite passes (both values are optional — `attest-me`/other `Ticket` call sites unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/commons/components/OxyID/tilt-context.tsx packages/commons/components/OxyID/index.tsx packages/commons/components/holographic-card.tsx
+git commit -m "feat(commons): scanPulse + attestGlow effect channels on the Oxy ID card
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: ID screen integration + i18n (commons)
+
+**Files:**
+- Modify: `packages/commons/app/(tabs)/(id)/index.tsx`
+- Modify: `packages/commons/lib/i18n/locales/en.json`, `packages/commons/lib/i18n/locales/es.json`
+
+**Interfaces:**
+- Consumes: `useAttestQr` (existing), `useNfcAttestEmitter` (Task 6), `useAttestedEvent` (Task 4), `Ticket` effect props (Task 8).
+- Produces: the ID screen emits NFC while focused (Android), pulses on read, shimmers + shows a temporary check badge on confirmation, and shows a small "NFC active" hint while emitting.
+
+- [ ] **Step 1: Wire the hooks into `IdScreen`**
+
+In `packages/commons/app/(tabs)/(id)/index.tsx`:
+
+New imports (merge with existing lines):
+
+```ts
+import { useFocusEffect } from 'expo-router';
+import * as Haptics from 'expo-haptics';
+import {
+  Easing,
+  useReducedMotion,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import { useAttestQr } from '@/hooks/useAttestQr';
+import { useNfcAttestEmitter } from '@/hooks/nfc/useNfcAttestEmitter';
+import { useAttestedEvent } from '@/hooks/civic/useAttestedEvent';
+```
+
+Inside the component (after the existing `qrPayload` memo):
+
+```ts
+  // ---- NFC attest emission + card feedback -------------------------------
+  const scanPulse = useSharedValue(0);
+  const attestGlow = useSharedValue(0);
+  const reducedMotion = useReducedMotion();
+
+  const [focused, setFocused] = useState(false);
+  useFocusEffect(
+    useCallback(() => {
+      setFocused(true);
+      return () => setFocused(false);
+    }, []),
+  );
+
+  // Same payload the attest-me QR uses; one interaction id per screen session.
+  const attestContext = useMemo(() => `irl-nfc-${Date.now().toString(36)}`, []);
+  const { payload: attestPayload, exp: attestExp, regenerate: regenerateAttest } = useAttestQr(attestContext);
+
+  // Single-use nonce: re-mint when it expires while we are emitting.
+  useEffect(() => {
+    if (!focused || !attestExp) return;
+    const ms = attestExp - Date.now();
+    if (ms <= 0) {
+      regenerateAttest();
+      return;
+    }
+    const id = setTimeout(regenerateAttest, ms);
+    return () => clearTimeout(id);
+  }, [focused, attestExp, regenerateAttest]);
+
+  const triggerScanPulse = useCallback(() => {
+    void Haptics.selectionAsync();
+    if (reducedMotion) return;
+    scanPulse.value = 0;
+    scanPulse.value = withTiming(1, { duration: 700, easing: Easing.inOut(Easing.quad) }, (finished) => {
+      if (finished) scanPulse.value = 0;
+    });
+  }, [scanPulse, reducedMotion]);
+
+  const [attestedVisible, setAttestedVisible] = useState(false);
+  const triggerAttestGlow = useCallback(() => {
+    void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    setAttestedVisible(true);
+    setTimeout(() => setAttestedVisible(false), 2500);
+    if (reducedMotion) return;
+    attestGlow.value = withSequence(
+      withTiming(1, { duration: 400 }),
+      withDelay(1000, withTiming(0, { duration: 1400 })),
+    );
+  }, [attestGlow, reducedMotion]);
+
+  const { state: nfcState } = useNfcAttestEmitter({
+    payload: attestPayload,
+    enabled: focused,
+    onRead: () => {
+      triggerScanPulse();
+      regenerateAttest();
+    },
+  });
+
+  useAttestedEvent(triggerAttestGlow);
+```
+
+The `setTimeout` in `triggerAttestGlow` must not leak: hold it in a ref and clear it in a small unmount effect (`useEffect(() => () => clearTimeout(ref.current), [])`), replacing the timer on each trigger.
+
+- [ ] **Step 2: Render — effect props, badge, NFC hint**
+
+Pass the values to the card: `<OxyID width={CARD_WIDTH} height={CARD_HEIGHT} scanPulse={scanPulse} attestGlow={attestGlow} …>` (existing faces unchanged).
+
+Inside the `styles.hero` view, after the card, replace the flip-hint block with:
+
+```tsx
+          {attestedVisible && (
+            <View style={[styles.attestedBadge, { backgroundColor: colors.card }]}>
+              <MaterialCommunityIcons name="check-decagram" size={18} color={colors.success ?? colors.tint} />
+              <ThemedText style={styles.attestedBadgeText}>{t('civic.attest.confirmed')}</ThemedText>
+            </View>
+          )}
+          <ThemedText style={[styles.flipHint, { color: colors.textSecondary }]}>
+            {nfcState === 'emitting' ? t('civic.nfc.active') : t('civic.id.flipHint')}
+          </ThemedText>
+```
+
+(Use whatever success-tone color key `useColors()` actually provides — check `hooks/useColors.ts`; fall back to `colors.tint`.) Add styles:
+
+```ts
+  attestedBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderCurve: 'continuous',
+  },
+  attestedBadgeText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+```
+
+- [ ] **Step 3: i18n strings**
+
+Add to `packages/commons/lib/i18n/locales/en.json` (inside the existing `civic` object, matching its nesting style):
+
+```json
+"nfc": {
+  "active": "NFC active — hold phones together to verify",
+  "read": "Hold near the other phone"
+},
+```
+
+and under `civic.attest`: `"confirmed": "Verified in person"`.
+
+Add to `es.json`:
+
+```json
+"nfc": {
+  "active": "NFC activo — acerca los móviles para verificar",
+  "read": "Acerca el móvil al otro dispositivo"
+},
+```
+
+and under `civic.attest`: `"confirmed": "Verificado en persona"`.
+
+(`civic.nfc.read` is consumed by Task 10.)
+
+- [ ] **Step 4: Typecheck + suite**
+
+Run: `cd packages/commons && bunx tsc --noEmit && bun run test`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "packages/commons/app/(tabs)/(id)/index.tsx" packages/commons/lib/i18n/locales/en.json packages/commons/lib/i18n/locales/es.json
+git commit -m "feat(commons): ID screen emits attest payload over NFC with card feedback
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 10: Receiver — scan-screen NFC button + attest deep-link payload (commons)
+
+**Files:**
+- Modify: `packages/commons/app/(scan)/index.tsx`
+- Modify: `packages/commons/app/(scan)/attest.tsx`
+
+**Interfaces:**
+- Consumes: `useNfcReader` (Task 7), `parseScan` from `@/lib/commons-signin/parse-scan`, `parseAttestPayload` from `@oxyhq/core`.
+- Produces: an NFC read lands on `(scan)/attest` with the SAME params the QR path produces; a system NDEF tap (`oxycommons://attest?payload=…`, Android, app possibly closed) is parsed by `attest.tsx` directly.
+
+- [ ] **Step 1: Route NFC reads through the existing scan routing**
+
+In `packages/commons/app/(scan)/index.tsx`, the barcode handler already parses + routes (`parsed.kind === 'approval' | 'id' | 'attest'`). Extract that routing block into a `routeParsed(parsed: ScanResult)` `useCallback` used by `handleBarcodeScanned`, then add the NFC button:
+
+```tsx
+const { available: nfcAvailable, readOnce } = useNfcReader();
+
+const handleNfcRead = useCallback(async () => {
+  const read = await readOnce();
+  if (!read.ok) return; // cancelled/empty — stay on the scanner
+  routeParsed(parseScan(read.uri));
+}, [readOnce, routeParsed]);
+```
+
+Render a secondary action under the camera view (match the screen's existing control styling — there are already overlay controls; mirror one):
+
+```tsx
+{nfcAvailable && (
+  <PrimaryButton icon="nfc" label={t('civic.nfc.read')} onPress={handleNfcRead} />
+)}
+```
+
+Use the screen's real button/overlay components and t() import — mirror what the file already uses rather than introducing new ones. If `parseScan(read.uri)` yields an unknown kind, fall through to the screen's existing invalid-QR feedback path.
+
+- [ ] **Step 2: Accept the raw payload param in attest.tsx**
+
+`(scan)/attest.tsx` currently reads `{ subjectDid?, context?, nonce?, exp? }` params (set by the scanner). A system NDEF tap deep-links `oxycommons://attest?payload=…` → expo-router lands here with a `payload` param instead. Extend the param type with `payload?: string` and derive:
+
+```ts
+// System NFC tap (Android) deep-links the raw signed payload; the scanner
+// paths pass pre-parsed fields. Normalize both into one shape.
+const fromPayload = useMemo(() => {
+  if (!raw.payload) return null;
+  try {
+    return parseAttestPayload(`oxycommons://attest?payload=${encodeURIComponent(raw.payload)}`);
+  } catch (error) {
+    console.warn('[AttestScreen] invalid NFC attest payload', error);
+    return null;
+  }
+}, [raw.payload]);
+```
+
+then prefer `fromPayload`'s fields over the individual params when present. **Before coding, read `packages/commons/lib/commons-signin/parse-scan.ts` lines ~55–85** — it shows exactly how `parseAttestPayload` output maps to the router params (`subjectDid`, `context`, `nonce`, `exp`); mirror that mapping so both entry paths produce identical state, including the exp string→number conversion the screen already does. If `parseAttestPayload` returns null on bad input instead of throwing, drop the try/catch and null-check instead — match the real signature in `@oxyhq/core`.
+
+- [ ] **Step 3: Typecheck + full suite**
+
+Run: `cd packages/commons && bunx tsc --noEmit && bun run test`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "packages/commons/app/(scan)/index.tsx" "packages/commons/app/(scan)/attest.tsx"
+git commit -m "feat(commons): NFC receive path — reader button + NDEF deep-link attest
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 11: Full verification + manual device checklist
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full builds + suites**
+
+```bash
+cd /home/nate/Oxy/OxyHQServices
+bun run build:all
+bun run --filter @oxyhq/core test
+bun run --filter @oxyhq/services test
+bun run --filter @oxyhq/api test
+cd packages/commons && bun run test && bunx tsc --noEmit
+```
+
+Expected: all green (core ~722+3, services ~195, api ~1322+2, commons prior +12 new).
+
+- [ ] **Step 2: Prebuild smoke (config plugins still valid after all changes)**
+
+```bash
+cd packages/commons && bunx expo prebuild --platform android --no-install && rm -rf android ios
+```
+
+Expected: prebuild completes without plugin errors.
+
+- [ ] **Step 3: Manual device checklist (real hardware — REQUIRED before shipping; emulators have no NFC)**
+
+Requires a NEW dev-client / EAS build (two new native modules): `cd packages/commons && bunx eas build --profile development --platform android` (and iOS for the reader button).
+
+1. Android A on `(id)` tab → "NFC active" hint appears (NFC on) / absent (NFC off in settings).
+2. Android B, **app closed**, tap against A → B opens directly into the attest screen showing A's card; A's card pulses (nudge + shine + haptic) at the moment of the tap.
+3. iPhone B → scan FAB → "Hold near the other phone" → tap against A → same attest screen; A pulses.
+4. B completes biometric + signs → A's card runs the full shimmer + edge glow + "Verified in person" badge (level 2) within a few seconds.
+5. QR path regression: attest-me QR scanned by B → still works end-to-end AND A gets the level-2 shimmer.
+6. Reduced motion enabled on A → haptics + badge only, no card animation.
+7. Repeat a tap after a completed read → new nonce was minted (payload regenerated), second attest attempt is correctly rejected by the server if within cooldown/exclusion rules.
+
+- [ ] **Step 4: Docs**
+
+Spawn **docs-keeper** to add the NFC attest transport + `useOxyEvent`/`onServerEvent` API to `packages/commons`'s section and the "Key Entry Points" list in `~/Oxy/OxyHQServices/AGENTS.md` (durable rules only, no version pins).

--- a/docs/superpowers/specs/2026-07-11-nfc-attest-card-effect-design.md
+++ b/docs/superpowers/specs/2026-07-11-nfc-attest-card-effect-design.md
@@ -1,0 +1,162 @@
+# NFC Real-Life Attestation + Oxy ID Card Scan Effect — Design
+
+**Date:** 2026-07-11
+**Scope:** `packages/commons` (Expo app), one small addition in `packages/api`
+**Status:** Approved by owner (conversation, 2026-07-11)
+
+## Goal
+
+Give the Commons real-life attestation flow a second transport besides the QR:
+on Android, the Oxy ID card emits its attestation payload over NFC (HCE) while
+it is on screen, so the counterparty can tap phones instead of scanning a QR.
+The card gives physical feedback: a subtle nudge + shine when it is read over
+NFC, and a full holographic shimmer when the attestation is confirmed by the
+server (the confirmation effect fires for the QR flow too).
+
+This also serves the broader proof-of-personhood goal: an NFC tap is a
+strictly-proximity channel (~4 cm), which is a stronger "we really met"
+signal than a QR that could be photographed remotely.
+
+## Platform matrix (hard constraint)
+
+NFC **emission** (tag emulation / HCE) is Android-only — Apple does not grant
+HCE to third-party apps (the EEA iOS 17.4+ payments entitlement is not
+practically available). NFC **reading** works on both platforms.
+
+| Card shown by (A, emits) | Scanner (B, receives) | NFC works? |
+|---|---|---|
+| Android | Android | Yes — tap even with B's app closed (system NDEF dispatch) |
+| Android | iPhone | Yes — B taps a "Hold near the other phone" button (CoreNFC reader session) |
+| iPhone | any | No — A's card offers QR only; the server-confirmation effect still fires |
+
+QR remains the universal fallback and is unchanged.
+
+## Architecture
+
+### Payload
+
+The NFC tag content is **byte-for-byte the same string** the QR encodes:
+`oxycommons://attest?payload=…` as built by `useAttestQr` /
+`oxyServices.buildAttestQrPayload` (DID + single-use nonce, 10-minute expiry).
+No contract or core-mixin changes. It is exposed as an NDEF URI record on an
+emulated Type 4 tag.
+
+### Emitter (A, Android, `(id)/index` screen)
+
+- New hook `useNfcAttestEmitter` arms a `react-native-hce` NDEF session while
+  the ID screen is focused and a fresh payload exists; disarms on blur/unmount.
+- States: `unsupported | off | emitting`. `unsupported` on iOS / no NFC
+  hardware (renders nothing extra); `off` when NFC is disabled in Android
+  settings (no prompts).
+- The HCE session's read event fires `onRead` → triggers the level-1 card
+  effect and regenerates the payload (nonce is single-use). Debounced to one
+  pulse per reader session.
+- Payload expiry (10 min) auto-re-arms with a fresh payload, mirroring the QR
+  countdown lifecycle.
+- A small "NFC active" indicator shows on the ID screen while `emitting`.
+
+### Receiver (B)
+
+- **Android, app closed or open:** config plugin adds an
+  `android.nfc.action.NDEF_DISCOVERED` intent filter for scheme `oxycommons`
+  → the system tap dispatch opens `(scan)/attest` with the payload — the exact
+  route the QR scanner already uses. Zero in-app reader code on this path.
+- **iPhone (and Android in-app fallback):** a "Hold near the other phone"
+  button on `(scan)/index` (shown only when NFC hardware is available) starts
+  a one-shot `react-native-nfc-manager` NDEF reader session; on read it
+  navigates to `(scan)/attest` with the URI.
+- From `(scan)/attest` onward the flow is the existing one: B sees A's public
+  card, biometric gate, on-device signature, `POST /civic/attest`.
+
+### Server confirmation (both transports)
+
+- `packages/api`: when `POST /civic/attest` accepts an attestation, emit a
+  Socket.IO event `civic:attested` `{ byUserId, at }` to the subject's user
+  room — same emit pattern as `notification.controller.ts`.
+- Commons hook `useAttestedEvent` subscribes with a strict event whitelist
+  (pattern: `useSessionSocket`) and fires the level-2 effect.
+- This is the **only backend change**.
+
+## Card effect
+
+Wired through the existing `TiltContext` (Reanimated shared values; no JS
+re-renders on the animation path). Two new shared values:
+
+- `scanPulse: SharedValue<number>` — level 1
+- `attestGlow: SharedValue<number>` — level 2
+
+`Ticket` accepts them as optional props and feeds them into the context;
+`holographic-card.tsx` consumes them on its existing Skia canvas.
+
+### Level 1 — "you've been read" (local HCE read event, instant)
+
+- Haptic `selectionAsync`.
+- Physical nudge: `withSequence(withTiming(-3° , 90ms), withSpring(0,
+  dampingRatio 1.2))` composed into the card's container transform — reads as
+  the other phone's tap physically pushing the card.
+- Shine sweep: `scanPulse` 0→1 over ~700 ms; the holographic canvas maps it to
+  a specular band crossing the card diagonally.
+
+### Level 2 — "attestation confirmed" (socket event; fires for QR and NFC)
+
+- Haptic `notificationAsync(Success)`.
+- `attestGlow` 0→1→0 over ~1.8 s: full holographic shimmer (intensifies the
+  base hologram) + brief edge glow.
+- Temporary check badge overlaid on the card ~2.5 s (plain RN overlay, not in
+  the Skia canvas).
+
+`useReducedMotion`: haptics + badge only, no card animation.
+
+## New/changed files
+
+**New (commons):**
+- `plugins/with-hce.ts` — config plugin: HCE `<service>` + `aid_list.xml` +
+  NFC permission + `NDEF_DISCOVERED` intent filter (Android manifest).
+- `hooks/nfc/useNfcAttestEmitter.ts`
+- `hooks/nfc/useNfcReader.ts`
+- `hooks/civic/useAttestedEvent.ts`
+
+**Changed (commons):**
+- `app/(tabs)/(id)/index.tsx` — mount emitter + socket hook; pass effect
+  shared values; NFC-active indicator.
+- `components/OxyID/tilt-context.tsx` — add `scanPulse`/`attestGlow`.
+- `components/OxyID/index.tsx` — optional effect props; nudge in transform.
+- `components/holographic-card.tsx` — shine sweep + shimmer from the shared
+  values.
+- `app/(scan)/index.tsx` — NFC read button.
+- `app.json` — `react-native-nfc-manager` plugin (`NFCReaderUsageDescription`,
+  Android NFC permission) + `plugins/with-hce.ts`.
+
+**Changed (api):**
+- Civic attest route/service — emit `civic:attested` to the subject's room on
+  accepted attestation.
+
+**Dependencies (commons only):** `react-native-hce`, `react-native-nfc-manager`.
+Both require a new EAS build (dev client included). Neither is pinned by
+`@oxyhq/services`, so no `expo.install.exclude` entry is needed.
+
+**Unchanged:** `@oxyhq/contracts`, `@oxyhq/core` mixins (payload builder
+already exists), `attest-me.tsx` (QR screen stays as-is).
+
+## Error handling
+
+- NFC off in Android settings → emitter state `off`, indicator hidden, no
+  prompts.
+- Nonce expires while emitting → auto re-arm with fresh payload.
+- Repeated/partial HCE reads → debounce: one pulse per reader session; nonce
+  regenerates regardless (single-use).
+- Socket down at confirmation time → level-2 effect is lost; acceptable — the
+  attestation history screen remains the source of truth. No extra polling.
+- B reads but cancels/never signs → only level 1 ever fired; level 2 is
+  strictly server-confirmed, so the semantics stay honest.
+
+## Testing
+
+- **Unit (Jest, commons):** emitter state machine (arm/disarm/regenerate-on-
+  read/expiry), reader URI parsing, `useAttestedEvent` strict whitelist.
+- **Unit (Jest, api):** `civic:attested` emitted on accepted attestation; not
+  emitted on rejection.
+- **Manual on real hardware (mandatory — emulators have no NFC):**
+  Android→Android tap with B's app closed; Android→iPhone via the read
+  button; level-1 pulse on A in both; QR flow still works and fires level 2;
+  reduced-motion behavior.

--- a/packages/commons/app/(tabs)/(id)/index.tsx
+++ b/packages/commons/app/(tabs)/(id)/index.tsx
@@ -10,18 +10,16 @@ import { ThemedText } from '@/components/themed-text';
 import { Screen, Section, GroupedList, ListRow, Callout } from '@/components/ui';
 import { Ticket as OxyID } from '@/components/OxyID';
 import { FrontSide } from '@/components/OxyID/front-side';
+import { BackSide } from '@/components/OxyID/back-side';
 import { IdQrBack } from '@/components/civic/IdQrBack';
-import { CivicBadge } from '@/components/civic/CivicBadge';
 import { useIdentity } from '@/hooks/useIdentity';
 import { useAvatarUrl } from '@/hooks/useAvatarUrl';
 import { useCivicProfileState } from '@/hooks/useCivicProfileState';
-import { useCivicCard } from '@/hooks/useCivicCard';
-import { getTrustTierMeta } from '@/lib/civic/card-presentation';
 import { getDisplayName } from '@/utils/date-utils';
 import { useTranslation } from '@/lib/i18n';
 
-const CARD_WIDTH = 340;
-const CARD_HEIGHT = 214;
+const CARD_WIDTH = 240;
+const CARD_HEIGHT = 380;
 
 /**
  * The Oxy ID screen — the landing/home surface of Commons.
@@ -98,10 +96,6 @@ export default function IdScreen() {
     }
   }, [oxyServices, userId]);
 
-  // Live trust tier from the signed public card (cache-first).
-  const cardQuery = useCivicCard(userId);
-  const trustTier = cardQuery.data?.card.trustTier;
-
   const publicKeyShort = useMemo(() => {
     if (!publicKey) return undefined;
     if (publicKey.length <= 16) return publicKey;
@@ -130,26 +124,22 @@ export default function IdScreen() {
             width={CARD_WIDTH}
             height={CARD_HEIGHT}
             frontSide={
-              <View style={StyleSheet.absoluteFill}>
-                <FrontSide
-                  displayName={displayName}
-                  username={user?.username}
-                  avatarUrl={avatarUrl}
-                  accountCreated={user?.createdAt}
-                  publicKeyShort={publicKeyShort}
-                />
-                {trustTier && (
-                  <View style={styles.cardBadgeOverlay} pointerEvents="none">
-                    <CivicBadge
-                      tone={getTrustTierMeta(trustTier).tone}
-                      icon="shield-check"
-                      label={t(`civic.trustTier.${trustTier}`)}
-                    />
-                  </View>
-                )}
-              </View>
+              <FrontSide
+                displayName={displayName}
+                username={user?.username}
+                avatarUrl={avatarUrl}
+                accountCreated={user?.createdAt}
+                publicKeyShort={publicKeyShort}
+              />
             }
             backSide={
+              <BackSide
+                publicKey={publicKey ?? undefined}
+                displayName={displayName}
+                accountCreated={user?.createdAt}
+              />
+            }
+            qrSide={
               qrPayload ? (
                 <IdQrBack payload={qrPayload} caption={t('civic.id.qrCaption')} />
               ) : (
@@ -234,11 +224,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 16,
     paddingTop: 8,
-  },
-  cardBadgeOverlay: {
-    position: 'absolute',
-    top: 12,
-    right: 12,
   },
   qrPlaceholder: {
     flex: 1,

--- a/packages/commons/app/(tabs)/(settings)/about-identity.native.tsx
+++ b/packages/commons/app/(tabs)/(settings)/about-identity.native.tsx
@@ -36,6 +36,17 @@ export default function AboutIdentityScreen() {
   const displayName = useMemo(() => getDisplayName(user), [user]);
   const avatarUrl = useAvatarUrl(user);
 
+  // DID-only QR payload, revealed by a long-press on the card.
+  const qrPayload = useMemo(() => {
+    if (!oxyServices) return undefined;
+    try {
+      return oxyServices.getMyIdPayload();
+    } catch (error) {
+      console.error('[AboutIdentity] Failed to build ID payload', error);
+      return undefined;
+    }
+  }, [oxyServices, user?.id]);
+
   const handleEditName = useCallback(() => {
     showBottomSheet?.({
       screen: 'EditProfileField',
@@ -418,6 +429,8 @@ export default function AboutIdentityScreen() {
                 avatarUrl={avatarUrl}
                 accountCreated={user?.createdAt}
                 publicKey={publicKey || undefined}
+                qrPayload={qrPayload}
+                qrCaption={t('civic.id.qrCaption')}
               />
             </View>
             {publicKey && (

--- a/packages/commons/components/OxyID/back-side.tsx
+++ b/packages/commons/components/OxyID/back-side.tsx
@@ -1,9 +1,11 @@
 /**
- * Back side of the ID card component displaying public key and identity information.
- * Features a large, readable public key like real IDs show numbers.
+ * Back face of the Oxy ID card — the public-key face, laid out like the front so
+ * both sides read as one document: an issuer header, the full public key in a
+ * readable engraved block, and a footer with the issue date + self-custody note.
  */
 
 import { StyleSheet, Text, View } from 'react-native';
+import { LogoIcon } from '@oxyhq/services';
 import { Fonts } from '@/constants/theme';
 
 interface BackSideProps {
@@ -12,48 +14,54 @@ interface BackSideProps {
     accountCreated?: string;
 }
 
-export const BackSide: React.FC<BackSideProps> = ({
-    publicKey,
-    displayName,
-    accountCreated
-}) => {
-    // Format public key for display (split into groups for readability)
-    const formatPublicKey = (key?: string) => {
-        if (!key) return 'N/A';
-        // Remove 0x prefix if present
-        const cleanKey = key.replace(/^0x/i, '');
-        // Split into groups of 8 characters for better readability
-        return cleanKey.match(/.{1,8}/g)?.join(' ') || cleanKey;
-    };
+const formatPublicKey = (key?: string) => {
+    if (!key) return 'N/A';
+    const cleanKey = key.replace(/^0x/i, '');
+    return cleanKey.match(/.{1,8}/g)?.join(' ') || cleanKey;
+};
 
-    // Format date for display
-    const formatDate = (dateString?: string) => {
-        if (!dateString) return 'N/A';
-        const date = new Date(dateString);
-        const month = String(date.getMonth() + 1).padStart(2, '0');
-        const day = String(date.getDate()).padStart(2, '0');
-        const year = date.getFullYear();
-        return `${month}/${day}/${year}`;
-    };
+const formatDate = (dateString?: string) => {
+    if (!dateString) return 'N/A';
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) return 'N/A';
+    const dd = String(date.getDate()).padStart(2, '0');
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const yyyy = date.getFullYear();
+    return `${dd}.${mm}.${yyyy}`;
+};
 
+export const BackSide: React.FC<BackSideProps> = ({ publicKey, displayName, accountCreated }) => {
     return (
         <View style={styles.container}>
-            {/* Main public key display - large and readable */}
+            {/* Header — mirrors the front. */}
+            <View style={styles.header}>
+                <LogoIcon height={20} />
+                <Text style={styles.docType}>PUBLIC KEY</Text>
+            </View>
+
+            {/* The public key, engraved and readable. */}
             <View style={styles.keySection}>
                 <Text style={styles.keyLabel}>PUBLIC KEY</Text>
                 <Text style={styles.keyValue} selectable>
                     {formatPublicKey(publicKey)}
                 </Text>
+                {displayName ? (
+                    <>
+                        <Text style={[styles.keyLabel, styles.holderLabel]}>HOLDER</Text>
+                        <Text style={styles.holderValue} numberOfLines={1}>
+                            {displayName}
+                        </Text>
+                    </>
+                ) : null}
             </View>
 
-            {/* Additional information */}
-            <View style={styles.infoSection}>
+            {/* Footer — issue date + self-custody note. */}
+            <View style={styles.footer}>
                 <View style={styles.infoRow}>
-                    <Text style={styles.infoLabel}>ISSUED</Text>
-                    <Text style={styles.infoValue}>
-                        {formatDate(accountCreated)}
-                    </Text>
+                    <Text style={styles.footerStrong}>ISSUED</Text>
+                    <Text style={styles.footerStrong}>{formatDate(accountCreated)}</Text>
                 </View>
+                <Text style={styles.footerNote}>SELF-CUSTODY · NO PASSWORD · YOU HOLD THE KEY</Text>
             </View>
         </View>
     );
@@ -62,49 +70,71 @@ export const BackSide: React.FC<BackSideProps> = ({
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        padding: 24,
+        padding: 18,
         justifyContent: 'space-between',
+    },
+    header: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: 'rgba(0,0,0,0.18)',
+        paddingBottom: 6,
+    },
+    docType: {
+        fontSize: 9,
+        fontWeight: '600',
+        letterSpacing: 1.2,
+        color: '#6E6E73',
     },
     keySection: {
         flex: 1,
         justifyContent: 'center',
-        alignItems: 'flex-start',
     },
     keyLabel: {
-        color: '#8E8E93',
-        fontSize: 10,
-        letterSpacing: 0.8,
+        color: '#6E6E73',
+        fontSize: 8.5,
+        letterSpacing: 0.7,
         textTransform: 'uppercase',
-        marginBottom: 12,
-        fontWeight: '400',
+        fontWeight: '600',
+        marginBottom: 8,
+    },
+    holderLabel: {
+        marginTop: 16,
+        marginBottom: 2,
     },
     keyValue: {
         color: '#1C1C1E',
-        // Platform monospace stack (`Geist Mono` was never bundled).
         fontFamily: Fonts?.mono,
-        fontSize: 10,
-        fontWeight: '400',
-        letterSpacing: 0.3,
-        lineHeight: 15,
+        fontSize: 12,
+        fontWeight: '500',
+        letterSpacing: 0.5,
+        lineHeight: 18,
     },
-    infoSection: {
-        marginTop: 'auto',
+    holderValue: {
+        color: '#1C1C1E',
+        fontSize: 15,
+        fontWeight: '700',
+    },
+    footer: {
+        borderTopWidth: StyleSheet.hairlineWidth,
+        borderTopColor: 'rgba(0,0,0,0.18)',
+        paddingTop: 8,
+        gap: 3,
     },
     infoRow: {
         flexDirection: 'row',
         justifyContent: 'space-between',
     },
-    infoLabel: {
-        color: '#8E8E93',
-        fontSize: 10,
+    footerStrong: {
+        color: '#2B2B2E',
+        fontSize: 9.5,
+        fontWeight: '700',
         letterSpacing: 0.8,
-        textTransform: 'uppercase',
-        fontWeight: '400',
     },
-    infoValue: {
-        color: '#1C1C1E',
-        fontSize: 12,
-        fontWeight: '500',
-        textAlign: 'right',
+    footerNote: {
+        color: '#6E6E73',
+        fontSize: 9,
+        letterSpacing: 0.3,
     },
 });

--- a/packages/commons/components/OxyID/front-side.tsx
+++ b/packages/commons/components/OxyID/front-side.tsx
@@ -1,11 +1,17 @@
 /**
- * Front side of the ID card component displaying user identity.
- * Government ID style layout with avatar mask and formal typography.
+ * Front face of the Oxy ID card — laid out like a real vertical ID / passport
+ * data page: an issuer header, a framed portrait beside the primary name, a
+ * column of labelled fields, and a machine-readable zone (MRZ) at the bottom.
+ * The content is printed FLAT on the card (no parallax float) so it reads as an
+ * engraved document over the hologram, not UI floating on top.
  */
 
+import { useMemo } from 'react';
 import { StyleSheet, Text, View, Image } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
+import { LogoIcon } from '@oxyhq/services';
 import { Fonts } from '@/constants/theme';
+import { AVATAR_ELEVATION, ParallaxLayer, TEXT_ELEVATION } from './tilt-context';
 
 interface FrontSideProps {
     displayName?: string;
@@ -15,301 +21,223 @@ interface FrontSideProps {
     publicKeyShort?: string;
 }
 
+// Reduce a value to the MRZ alphabet (A–Z, 0–9, filler '<'), collapse runs of
+// filler, and pad/truncate to a fixed width — passport-style.
+const sanitizeMrz = (value: string | undefined, length: number) =>
+    (value ?? '')
+        .toUpperCase()
+        .replace(/[^A-Z0-9]/g, '<')
+        .replace(/<{2,}/g, '<')
+        .padEnd(length, '<')
+        .slice(0, length);
+
+const MRZ_WIDTH = 26;
+
 export const FrontSide: React.FC<FrontSideProps> = ({
     displayName,
     username,
     avatarUrl,
     accountCreated,
-    publicKeyShort
+    publicKeyShort,
 }) => {
+    const mrzLines = useMemo(() => {
+        const name = sanitizeMrz(username ?? displayName, MRZ_WIDTH - 5);
+        const line1 = `IDOXY${name}`.padEnd(MRZ_WIDTH, '<').slice(0, MRZ_WIDTH);
+        const line2 = sanitizeMrz(publicKeyShort, MRZ_WIDTH);
+        return [line1, line2];
+    }, [username, displayName, publicKeyShort]);
+
+    const issued = useMemo(() => {
+        if (!accountCreated) return undefined;
+        const d = new Date(accountCreated);
+        if (Number.isNaN(d.getTime())) return undefined;
+        const yy = String(d.getFullYear()).slice(2);
+        const mm = String(d.getMonth() + 1).padStart(2, '0');
+        const dd = String(d.getDate()).padStart(2, '0');
+        return `${dd}.${mm}.${yy}`;
+    }, [accountCreated]);
+
     return (
         <View style={styles.container}>
-            {/* Main content area */}
-            <View style={styles.content}>
-                {/* Avatar section with government ID style fade mask */}
-                <View style={styles.avatarSection}>
-                    <View style={styles.avatarContainer}>
-                        {avatarUrl ? (
-                            <Image
-                                source={{ uri: avatarUrl }}
-                                style={styles.avatar}
-                                resizeMode="cover"
-                            />
-                        ) : (
-                            <View style={styles.avatarPlaceholder}>
-                                <Text style={styles.avatarPlaceholderText}>
-                                    {displayName?.charAt(0)?.toUpperCase() || '?'}
-                                </Text>
-                            </View>
-                        )}
-                        {/* Oval fade mask - transparent to show hologram through edges */}
-                        {/* Top fade - creates oval top edge */}
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0.3)', 'rgba(0,0,0,0)']}
-                            locations={[0, 0.4, 1]}
-                            start={{ x: 0.5, y: 0 }}
-                            end={{ x: 0.5, y: 1 }}
-                            style={styles.fadeOvalTop}
-                        />
-                        {/* Bottom fade - creates oval bottom edge */}
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0.3)', 'rgba(0,0,0,0)']}
-                            locations={[0, 0.4, 1]}
-                            start={{ x: 0.5, y: 1 }}
-                            end={{ x: 0.5, y: 0 }}
-                            style={styles.fadeOvalBottom}
-                        />
-                        {/* Left fade - creates oval left edge */}
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0.3)', 'rgba(0,0,0,0)']}
-                            locations={[0, 0.4, 1]}
-                            start={{ x: 0, y: 0.5 }}
-                            end={{ x: 1, y: 0.5 }}
-                            style={styles.fadeOvalLeft}
-                        />
-                        {/* Right fade - creates oval right edge */}
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0.3)', 'rgba(0,0,0,0)']}
-                            locations={[0, 0.4, 1]}
-                            start={{ x: 1, y: 0.5 }}
-                            end={{ x: 0, y: 0.5 }}
-                            style={styles.fadeOvalRight}
-                        />
-                        {/* Corner overlays for smoother oval shape - smaller to not affect center */}
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0)']}
-                            start={{ x: 0, y: 0 }}
-                            end={{ x: 1, y: 1 }}
-                            style={styles.fadeOvalCornerTL}
-                        />
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0)']}
-                            start={{ x: 1, y: 0 }}
-                            end={{ x: 0, y: 1 }}
-                            style={styles.fadeOvalCornerTR}
-                        />
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0)']}
-                            start={{ x: 0, y: 1 }}
-                            end={{ x: 1, y: 0 }}
-                            style={styles.fadeOvalCornerBL}
-                        />
-                        <LinearGradient
-                            colors={['rgba(0,0,0,0.6)', 'rgba(0,0,0,0)']}
-                            start={{ x: 1, y: 1 }}
-                            end={{ x: 0, y: 0 }}
-                            style={styles.fadeOvalCornerBR}
-                        />
-                    </View>
-                </View>
+            {/* Issuer header */}
+            <View style={styles.header}>
+                <LogoIcon height={22} />
+                <Text style={styles.docType}>IDENTITY CARD</Text>
+            </View>
 
-                {/* User info section */}
-                <View style={styles.infoSection}>
-                    <View style={styles.field}>
-                        <Text style={styles.fieldLabel}>FULL NAME</Text>
-                        <Text style={styles.fieldValue} numberOfLines={2}>
-                            {/* The caller (`IdentityCard`) computes a friendly */}
-                            {/* fallback via core's `getAccountDisplayName`, so */}
-                            {/* this defensive fallback only fires for genuinely */}
-                            {/* blank cards. */}
-                            {displayName || publicKeyShort || '—'}
-                        </Text>
-                    </View>
-
-                    {username && (
-                        <View style={styles.field}>
-                            <Text style={styles.fieldLabel}>USERNAME</Text>
-                            <Text style={styles.fieldValueSmall} numberOfLines={1}>
-                                {username}
+            {/* Portrait + primary name */}
+            <ParallaxLayer elevation={AVATAR_ELEVATION} style={styles.identityRow}>
+                <View style={styles.avatarContainer}>
+                    {avatarUrl ? (
+                        <Image source={{ uri: avatarUrl }} style={styles.avatar} resizeMode="cover" />
+                    ) : (
+                        <View style={styles.avatarPlaceholder}>
+                            <Text style={styles.avatarPlaceholderText}>
+                                {displayName?.charAt(0)?.toUpperCase() || '?'}
                             </Text>
                         </View>
                     )}
+                    {avatarUrl && (
+                        <>
+                            <LinearGradient
+                                colors={['rgba(0,0,0,0.18)', 'rgba(0,0,0,0)']}
+                                start={{ x: 0.5, y: 1 }}
+                                end={{ x: 0.5, y: 0.4 }}
+                                style={styles.avatarShade}
+                            />
+                        </>
+                    )}
+                </View>
+                <View style={styles.primaryCol}>
+                    <Text style={styles.fieldLabel}>NAME</Text>
+                    <Text style={styles.primaryValue} numberOfLines={2}>
+                        {displayName || publicKeyShort || '—'}
+                    </Text>
+                    <Text style={styles.fieldLabel}>TYPE</Text>
+                    <Text style={styles.fieldValueSmall}>SELF-CUSTODY</Text>
+                </View>
+            </ParallaxLayer>
 
+            {/* Labelled fields */}
+            <ParallaxLayer elevation={TEXT_ELEVATION} style={styles.fields}>
+                {username && (
                     <View style={styles.field}>
-                        <Text style={styles.fieldLabel}>ID NUMBER</Text>
-                        <Text style={styles.idNumber} numberOfLines={1}>
-                            {publicKeyShort || 'N/A'}
+                        <Text style={styles.fieldLabel}>USERNAME</Text>
+                        <Text style={styles.fieldValueSmall} numberOfLines={1}>
+                            {username}
                         </Text>
                     </View>
+                )}
+                <View style={styles.field}>
+                    <Text style={styles.fieldLabel}>ID NUMBER</Text>
+                    <Text style={styles.idNumber} numberOfLines={1}>
+                        {publicKeyShort || 'N/A'}
+                    </Text>
                 </View>
-            </View>
+                {issued && (
+                    <View style={styles.field}>
+                        <Text style={styles.fieldLabel}>ISSUED</Text>
+                        <Text style={styles.fieldValueSmall}>{issued}</Text>
+                    </View>
+                )}
+            </ParallaxLayer>
 
-            {/* Footer */}
-            <View style={styles.footer}>
-                <Text style={styles.footerText}>SELF-CUSTODY IDENTITY</Text>
-            </View>
+            {/* Machine-readable zone */}
+            <ParallaxLayer elevation={TEXT_ELEVATION} style={styles.mrz}>
+                <Text style={styles.mrzLine} numberOfLines={1}>
+                    {mrzLines[0]}
+                </Text>
+                <Text style={styles.mrzLine} numberOfLines={1}>
+                    {mrzLines[1]}
+                </Text>
+            </ParallaxLayer>
         </View>
     );
 };
 
-/**
- * Styles for the FrontSide component - Government ID style layout
- */
 const styles = StyleSheet.create({
     container: {
         flex: 1,
-        padding: 20,
+        padding: 18,
         justifyContent: 'space-between',
     },
-    content: {
+    header: {
+        flexDirection: 'row',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: 'rgba(0,0,0,0.18)',
+        paddingBottom: 6,
+    },
+    docType: {
+        fontSize: 9,
+        fontWeight: '600',
+        letterSpacing: 1.2,
+        color: '#6E6E73',
+    },
+    identityRow: {
         flexDirection: 'row',
         alignItems: 'flex-start',
-        flex: 1,
-    },
-    avatarSection: {
-        marginRight: 16,
-        justifyContent: 'flex-start',
-        alignItems: 'center',
-        position: 'relative',
-        alignSelf: 'stretch', // Allow section to stretch to full height
+        gap: 12,
     },
     avatarContainer: {
-        width: 100, // Wider than tall (government ID style)
-        flex: 1, // Use full available height
-        minHeight: 120, // Minimum height for portrait aspect ratio
-        borderRadius: 8, // Rounded rectangle
+        width: 84,
+        height: 104,
+        borderRadius: 6,
         overflow: 'hidden',
-        backgroundColor: 'transparent', // Transparent to show hologram through
-        position: 'relative',
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: 'rgba(0,0,0,0.2)',
+        backgroundColor: 'rgba(255,255,255,0.35)',
     },
     avatar: {
         width: '100%',
         height: '100%',
-        backgroundColor: 'transparent', // Ensure no black background
     },
-    fadeOvalTop: {
+    avatarShade: {
         position: 'absolute',
-        top: 0,
         left: 0,
         right: 0,
-        height: '35%', // Reduced from 45% to keep center clear
-        pointerEvents: 'none',
-    },
-    fadeOvalBottom: {
-        position: 'absolute',
         bottom: 0,
-        left: 0,
-        right: 0,
-        height: '35%', // Reduced from 45% to keep center clear
-        pointerEvents: 'none',
-    },
-    fadeOvalLeft: {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        bottom: 0,
-        width: '30%', // Reduced from 40% to keep center clear
-        pointerEvents: 'none',
-    },
-    fadeOvalRight: {
-        position: 'absolute',
-        top: 0,
-        right: 0,
-        bottom: 0,
-        width: '30%', // Reduced from 40% to keep center clear
-        pointerEvents: 'none',
-    },
-    fadeOvalCornerTL: {
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '28%', // Reduced from 35% to keep center clear
-        height: '28%', // Reduced from 35% to keep center clear
-        pointerEvents: 'none',
-    },
-    fadeOvalCornerTR: {
-        position: 'absolute',
-        top: 0,
-        right: 0,
-        width: '28%', // Reduced from 35% to keep center clear
-        height: '28%', // Reduced from 35% to keep center clear
-        pointerEvents: 'none',
-    },
-    fadeOvalCornerBL: {
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        width: '28%', // Reduced from 35% to keep center clear
-        height: '28%', // Reduced from 35% to keep center clear
-        pointerEvents: 'none',
-    },
-    fadeOvalCornerBR: {
-        position: 'absolute',
-        bottom: 0,
-        right: 0,
-        width: '28%', // Reduced from 35% to keep center clear
-        height: '28%', // Reduced from 35% to keep center clear
-        pointerEvents: 'none',
+        height: '45%',
     },
     avatarPlaceholder: {
         width: '100%',
         height: '100%',
-        backgroundColor: '#E0E0E0',
         justifyContent: 'center',
         alignItems: 'center',
     },
     avatarPlaceholderText: {
-        fontSize: 42,
+        fontSize: 40,
         fontWeight: '600',
-        color: '#8E8E93',
+        color: 'rgba(28,28,30,0.5)',
     },
-    infoSection: {
+    primaryCol: {
         flex: 1,
         justifyContent: 'flex-start',
     },
+    fields: {
+        gap: 8,
+    },
     field: {
-        marginBottom: 10,
-    },
-    fieldRow: {
-        flexDirection: 'row',
-        justifyContent: 'space-between',
-        marginTop: 4,
-    },
-    fieldHalf: {
-        flex: 1,
-        marginRight: 12,
+        gap: 1,
     },
     fieldLabel: {
         color: '#6E6E73',
-        fontSize: 9,
-        letterSpacing: 0.6,
+        fontSize: 8.5,
+        letterSpacing: 0.7,
         textTransform: 'uppercase',
-        marginBottom: 2,
-        fontWeight: '500',
-    },
-    fieldValue: {
-        color: '#1C1C1E',
-        fontSize: 18,
         fontWeight: '600',
+        marginTop: 4,
+    },
+    primaryValue: {
+        color: '#1C1C1E',
+        fontSize: 17,
+        fontWeight: '700',
         letterSpacing: -0.2,
-        lineHeight: 22,
+        lineHeight: 20,
     },
     fieldValueSmall: {
         color: '#1C1C1E',
-        fontSize: 14,
+        fontSize: 13,
         fontWeight: '500',
-        letterSpacing: -0.1,
     },
     idNumber: {
         color: '#1C1C1E',
-        // Platform monospace stack (`Geist Mono` was never bundled).
         fontFamily: Fonts?.mono,
         fontSize: 12,
         fontWeight: '600',
-        letterSpacing: 0.8,
+        letterSpacing: 0.6,
     },
-    footer: {
-        marginTop: 12,
+    mrz: {
+        borderTopWidth: StyleSheet.hairlineWidth,
+        borderTopColor: 'rgba(0,0,0,0.18)',
         paddingTop: 8,
-        borderTopWidth: 1,
-        borderTopColor: '#E5E5EA',
-        alignItems: 'center',
+        gap: 2,
     },
-    footerText: {
-        color: '#8E8E93',
-        fontSize: 8,
-        fontWeight: '400',
-        letterSpacing: 0.5,
-        textTransform: 'uppercase',
+    mrzLine: {
+        fontFamily: Fonts?.mono,
+        fontSize: 9.5,
+        letterSpacing: 1,
+        color: '#2B2B2E',
     },
 });

--- a/packages/commons/components/OxyID/index.tsx
+++ b/packages/commons/components/OxyID/index.tsx
@@ -1,11 +1,22 @@
 /**
- * A flippable ID card component that supports tap gesture to toggle between front and back.
- * The card has two sides (front and back) and uses a holographic effect that responds to device tilt.
+ * The flippable, tilt-reactive Oxy ID card.
+ *
+ * Three-level tree so depth reads convincingly:
+ *   - outer wrapper: no clip, no rotation. Hosts the float shadow (which must
+ *     escape the clip) and the card.
+ *   - card clip: rounded-rect + overflow hidden, carries the container
+ *     perspective/flip/tilt/press transform.
+ *   - inside the clip: base hologram, parallaxed front/back content, and the
+ *     specular gloss on top. All share tilt via `TiltProvider`.
+ *
+ * True 3D comes from the container `perspective + rotateX/rotateY` driven by the
+ * device's real attitude (`useDeviceTilt`); per-layer parallax (`ParallaxLayer`)
+ * makes the avatar/text/badge float above the card face.
  */
 
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 
-import { type FC, memo, type ReactNode } from 'react';
+import { type FC, memo, type ReactNode, useMemo, useState } from 'react';
 
 import * as Haptics from 'expo-haptics';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
@@ -20,208 +31,201 @@ import { scheduleOnRN } from 'react-native-worklets';
 
 import { HolographicCard } from '../holographic-card';
 import { useDeviceTilt } from '../../hooks/use-device-tilt';
+import { ShadowLayer } from './shadow-layer';
+import {
+    HOLOGRAM_ELEVATION,
+    ParallaxLayer,
+    TEXT_ELEVATION,
+    TiltProvider,
+    type TiltContextValue,
+} from './tilt-context';
 
-/**
- * Props for the Ticket component
- * @typedef {Object} TicketProps
- * @property {number} width - The width of the ticket
- * @property {number} height - The height of the ticket
- * @property {ReactNode} [frontSide] - Content to display on the front of the ticket
- * @property {ReactNode} [backSide] - Content to display on the back of the ticket
- */
+// Hold this long to reveal the QR on the back (deliberate, so it never shows by
+// accident).
+const QR_REVEAL_MS = 700;
+
 type TicketProps = {
     width: number;
     height: number;
     frontSide?: ReactNode;
     backSide?: ReactNode;
+    /** Optional QR face, revealed by a long-press (tap only flips front↔back). */
+    qrSide?: ReactNode;
 };
 
-export const Ticket: FC<TicketProps> = memo(
-    ({ width, height, frontSide, backSide }) => {
-        // Get device gyroscope rotation for 3D card movement (Airbnb-style)
-        const { rotateX: deviceRotateX, rotateY: deviceRotateY } = useDeviceTilt();
+export const Ticket: FC<TicketProps> = memo(({ width, height, frontSide, backSide, qrSide }) => {
+    // Drift-free device attitude driving the 3D turn.
+    const tilt = useDeviceTilt();
+    const { pitchDeg, yawDeg } = tilt;
 
-        // Shared value for rotation (0 = front, 180 = back)
-        const rotation = useSharedValue(0);
+    // Flip (0 = front, 180 = back).
+    const rotation = useSharedValue(0);
 
-        // Shared values for press tilt effect
-        const pressRotateX = useSharedValue(0);
-        const pressRotateZ = useSharedValue(0);
-        const pressTranslateY = useSharedValue(0);
+    // The back shows the public-key face by default; a long-press swaps it to the
+    // QR. Tap always returns to the public-key back.
+    const [showQr, setShowQr] = useState(false);
 
-        // Shared values for press position (for hologram effect)
-        const pressX = useSharedValue(width / 2);
-        const pressY = useSharedValue(height / 2);
-        const isPressed = useSharedValue(0);
+    // Press interaction.
+    const pressRotateX = useSharedValue(0);
+    const pressTranslateY = useSharedValue(0);
+    const isPressed = useSharedValue(0);
 
-        // Derived value for Y-axis rotation
-        const rotateY = useDerivedValue(() => {
-            return rotation.value;
+    // Which face is visible — keyed off the FLIP only, so ±tilt never flips it.
+    const isFront = useDerivedValue(() => {
+        const r = ((rotation.value % 360) + 360) % 360;
+        return r < 90 || r > 270;
+    });
+
+    const tiltContext = useMemo<TiltContextValue>(
+        () => ({
+            pitchDeg: tilt.pitchDeg,
+            yawDeg: tilt.yawDeg,
+            nx: tilt.nx,
+            ny: tilt.ny,
+            mag: tilt.mag,
+            pressRotateX,
+            isPressed,
+            rotation,
+            isFront,
+            motionEnabled: tilt.motionEnabled,
+        }),
+        [tilt, pressRotateX, isPressed, rotation, isFront],
+    );
+
+    // Press tilt (Pan with minDistance 0 catches any touch).
+    const pressGesture = Gesture.Pan()
+        .minDistance(0)
+        .maxPointers(1)
+        .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
+        .onBegin((event) => {
+            'worklet';
+            isPressed.value = 1;
+            const normalizedY = (event.y - height / 2) / (height / 2);
+            const maxTilt = 6;
+            pressRotateX.value = withTiming(-normalizedY * maxTilt, { duration: 80 });
+            pressTranslateY.value = withTiming(5, { duration: 80 });
+        })
+        .onUpdate((event) => {
+            'worklet';
+            const normalizedY = (event.y - height / 2) / (height / 2);
+            const maxTilt = 6;
+            pressRotateX.value = -normalizedY * maxTilt;
+        })
+        .onEnd(() => {
+            'worklet';
+            isPressed.value = 0;
+            pressRotateX.value = withSpring(0, { dampingRatio: 3 });
+            pressTranslateY.value = withSpring(0, { dampingRatio: 3 });
+        })
+        .onFinalize(() => {
+            'worklet';
+            isPressed.value = 0;
+            pressRotateX.value = withSpring(0, { dampingRatio: 3 });
+            pressTranslateY.value = withSpring(0, { dampingRatio: 3 });
         });
 
-        // Press gesture handler for tilt effect (using Pan with minDistance 0 to detect any touch)
-        const pressGesture = Gesture.Pan()
-            .minDistance(0)
-            .maxPointers(1)
-            .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
-            .onBegin((event) => {
-                'worklet';
-                // Store press position for hologram effect
-                pressX.value = event.x;
-                pressY.value = event.y;
-                isPressed.value = 1;
-
-                // Calculate tilt based on press position relative to card center
-                const centerY = height / 2;
-
-                // Normalize Y position (-1 to 1) relative to center
-                const normalizedY = (event.y - centerY) / centerY;
-
-                // Calculate tilt angles based on press position (only X rotation for realistic feel)
-                // Pressing top tilts forward (positive rotateX), bottom tilts backward (negative rotateX)
-                const maxTilt = 6; // Subtle tilt like metal card (stiffer)
-
-                pressRotateX.value = withTiming(-normalizedY * maxTilt, { duration: 80 });
-                pressRotateZ.value = 0; // No Z rotation for realistic press feel
-                // No scale - keep card at full size
-                pressTranslateY.value = withTiming(5, { duration: 80 }); // Push down more (like pressing metal)
-            })
-            .onUpdate((event) => {
-                'worklet';
-                // Update press position for hologram
-                pressX.value = event.x;
-                pressY.value = event.y;
-
-                // Update tilt as finger moves
-                const centerY = height / 2;
-
-                const normalizedY = (event.y - centerY) / centerY;
-
-                const maxTilt = 6;
-
-                pressRotateX.value = -normalizedY * maxTilt;
-                pressRotateZ.value = 0; // No Z rotation for realistic press feel
-            })
-            .onEnd(() => {
-                'worklet';
-                isPressed.value = 0;
-                // Return to normal when released (stiff spring like metal)
-                pressRotateX.value = withSpring(0, { dampingRatio: 3 });
-                pressRotateZ.value = withSpring(0, { dampingRatio: 3 });
-                // No scale - keep card at full size
-                pressTranslateY.value = withSpring(0, { dampingRatio: 3 });
-            })
-            .onFinalize(() => {
-                'worklet';
-                isPressed.value = 0;
-                // Ensure it returns to normal (stiff spring like metal)
-                pressRotateX.value = withSpring(0, { dampingRatio: 3 });
-                pressRotateZ.value = withSpring(0, { dampingRatio: 3 });
-                // No scale - keep card at full size
-                pressTranslateY.value = withSpring(0, { dampingRatio: 3 });
+    // Tap flips between front and the public-key back (never the QR).
+    const tapGesture = Gesture.Tap()
+        .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
+        .onEnd(() => {
+            scheduleOnRN(Haptics.selectionAsync);
+            scheduleOnRN(setShowQr, false);
+            rotation.value = withSpring(rotation.value === 0 ? 180 : 0, {
+                dampingRatio: 1.5,
+                duration: 500,
             });
-
-        // Tap gesture handler for toggling between front and back
-        const tapGesture = Gesture.Tap()
-            .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
-            .onEnd(() => {
-                scheduleOnRN(Haptics.selectionAsync);
-                // Toggle between 0 (front) and 180 (back)
-                rotation.value = withSpring(rotation.value === 0 ? 180 : 0, {
-                    dampingRatio: 1.5,
-                    duration: 500,
-                });
-            });
-
-        // Combine press and tap gestures - both can work simultaneously
-        const gesture = Gesture.Simultaneous(pressGesture, tapGesture);
-
-        // Derived values for combined 3D rotation (for hologram)
-        const combinedRotateX = useDerivedValue(() => pressRotateX.value + deviceRotateX.value);
-        const combinedRotateZ = useDerivedValue(() => pressRotateZ.value + deviceRotateY.value);
-
-        const rTicketStyle = useAnimatedStyle(() => {
-            // Combine device gyroscope rotation (3D movement) with press tilt and flip rotation
-            // Device rotation is already in degrees with limits applied
-            const rotateYValue = `${rotateY.value}deg`; // Flip rotation (0 or 180)
-            const rotateXValue = `${combinedRotateX.value}deg`; // X rotation (pitch)
-            const rotateZValue = `${combinedRotateZ.value}deg`; // Z rotation (roll) - using deviceRotateY for left/right
-
-            return {
-                transform: [
-                    { perspective: 1000 },
-                    { translateY: pressTranslateY.value },
-                    // No scale - keep card at full size
-                    { rotateY: rotateYValue }, // Flip rotation
-                    { rotateX: rotateXValue }, // 3D pitch + press
-                    { rotateZ: rotateZValue }, // 3D roll + press (no Z from press, so just device)
-                ],
-            };
         });
 
-        // Determine which side is currently visible
-        const isFront = useDerivedValue(() => {
-            const absRotate = Math.abs(rotateY.value);
-            return absRotate < 90 || absRotate > 270;
+    // Long-press (>2s) reveals the QR on the back face.
+    const longPressGesture = Gesture.LongPress()
+        .minDuration(QR_REVEAL_MS)
+        .maxDistance(40)
+        .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
+        .onStart(() => {
+            scheduleOnRN(Haptics.selectionAsync);
+            scheduleOnRN(setShowQr, true);
+            rotation.value = withSpring(180, { dampingRatio: 1.5, duration: 500 });
         });
 
-        const rFrontStyle = useAnimatedStyle(() => {
-            return {
-                opacity: isFront.value ? 1 : 0,
-                zIndex: isFront.value ? 1 : 0,
-            };
-        });
+    // Press-tilt runs alongside; long-press wins over tap when held.
+    const gesture = Gesture.Simultaneous(
+        pressGesture,
+        Gesture.Exclusive(longPressGesture, tapGesture),
+    );
 
-        const rBackStyle = useAnimatedStyle(() => {
-            return {
-                opacity: isFront.value ? 0 : 1,
-                zIndex: isFront.value ? 0 : 1,
-            };
-        });
+    const rTiltStyle = useAnimatedStyle(() => ({
+        transform: [
+            { perspective: 900 },
+            { translateY: pressTranslateY.value },
+            { rotateY: `${rotation.value + yawDeg.value}deg` }, // flip composed with tilt-yaw
+            { rotateX: `${pitchDeg.value + pressRotateX.value}deg` },
+            { rotateZ: `${yawDeg.value * 0.15}deg` }, // subtle micro-roll
+        ],
+    }));
 
-        return (
-            <GestureDetector gesture={gesture}>
-                <Animated.View
-                    style={[
-                        {
-                            width,
-                            height,
-                            overflow: 'hidden',
-                            borderRadius: 24,
-                        },
-                        rTicketStyle,
-                    ]}>
-                    {/* Holographic effect layer */}
-                    <HolographicCard
-                        width={width}
-                        height={height}
-                        rotateY={rotateY}
-                        rotateX={combinedRotateX}
-                        rotateZ={combinedRotateZ}
-                        pressX={pressX}
-                        pressY={pressY}
-                        isPressed={isPressed}
-                        color="#FFFFFF"
-                    />
-                    {/* Front side content */}
-                    <Animated.View style={[StyleSheet.absoluteFill, rFrontStyle]}>
-                        {frontSide}
+    const rFrontStyle = useAnimatedStyle(() => ({
+        opacity: isFront.value ? 1 : 0,
+        zIndex: isFront.value ? 1 : 0,
+    }));
+
+    const rBackStyle = useAnimatedStyle(() => ({
+        opacity: isFront.value ? 0 : 1,
+        zIndex: isFront.value ? 0 : 1,
+    }));
+
+    return (
+        <GestureDetector gesture={gesture}>
+            <Animated.View style={[styles.outerWrapper, { width, height }]}>
+                <TiltProvider value={tiltContext}>
+                    {/* Float shadow — behind the card, escapes the clip. */}
+                    <ShadowLayer width={width} height={height} />
+
+                    {/* The clipped, rotated card. */}
+                    <Animated.View style={[styles.cardClip, { width, height }, rTiltStyle]}>
+                        {/* Base hologram (recedes slightly under tilt). */}
+                        <ParallaxLayer
+                            elevation={HOLOGRAM_ELEVATION}
+                            pointerEvents="none"
+                            style={StyleSheet.absoluteFill}>
+                            <HolographicCard width={width} height={height} />
+                        </ParallaxLayer>
+
+                        {/* Front content (its own avatar/text parallax is internal). */}
+                        <Animated.View style={[StyleSheet.absoluteFill, rFrontStyle]}>
+                            {frontSide}
+                        </Animated.View>
+
+                        {/* Back content, parallaxed as a unit outside its mirror. */}
+                        <Animated.View style={[StyleSheet.absoluteFill, rBackStyle]}>
+                            <ParallaxLayer
+                                elevation={TEXT_ELEVATION}
+                                face="back"
+                                style={StyleSheet.absoluteFill}>
+                                <View style={[StyleSheet.absoluteFill, styles.backMirror]}>
+                                    {showQr && qrSide ? qrSide : backSide}
+                                </View>
+                            </ParallaxLayer>
+                        </Animated.View>
                     </Animated.View>
-                    {/* Back side content (mirrored with scaleX: -1) */}
-                    <Animated.View
-                        style={[
-                            StyleSheet.absoluteFill,
-                            {
-                                transform: [{ scaleX: -1 }],
-                            },
-                            rBackStyle,
-                        ]}>
-                        {backSide}
-                    </Animated.View>
-                </Animated.View>
-            </GestureDetector>
-        );
-    },
-);
+                </TiltProvider>
+            </Animated.View>
+        </GestureDetector>
+    );
+});
 
 Ticket.displayName = 'Ticket';
+
+const styles = StyleSheet.create({
+    outerWrapper: {
+        position: 'relative',
+    },
+    cardClip: {
+        overflow: 'hidden',
+        borderRadius: 24,
+        // White stock hides any 1–2px edge exposed by the hologram's parallax.
+        backgroundColor: '#FFFFFF',
+    },
+    backMirror: {
+        transform: [{ scaleX: -1 }],
+    },
+});

--- a/packages/commons/components/OxyID/shadow-layer.tsx
+++ b/packages/commons/components/OxyID/shadow-layer.tsx
@@ -1,0 +1,41 @@
+/**
+ * Float shadow for the Oxy ID card.
+ *
+ * Rendered as a sibling BEHIND the card inside the un-clipped outer wrapper, so
+ * the blurred shadow can spill past the card's rounded-rect clip. It stays flat
+ * on the "ground" to sell the card floating above the surface.
+ *
+ * IMPORTANT — intentionally STATIC (no tilt reactivity). An RNSkia `<Canvas>` is
+ * an Android `TextureView` whose content updates below the 120Hz display rate;
+ * redrawing the shadow every frame during tilt would lag/stutter behind the
+ * card. A fixed shadow renders once and composites smoothly.
+ */
+
+import { Canvas, RoundedRect, Shadow } from '@shopify/react-native-skia';
+
+// Extra room around the card so the blurred shadow is not clipped by the canvas.
+const PAD = 40;
+
+interface ShadowLayerProps {
+    width: number;
+    height: number;
+    radius?: number;
+}
+
+export const ShadowLayer = ({ width, height, radius = 24 }: ShadowLayerProps) => {
+    return (
+        <Canvas
+            style={{
+                position: 'absolute',
+                left: -PAD,
+                top: -PAD,
+                width: width + PAD * 2,
+                height: height + PAD * 2,
+            }}
+            pointerEvents="none">
+            <RoundedRect x={PAD} y={PAD} width={width} height={height} r={radius} color="black">
+                <Shadow dx={0} dy={13} blur={20} color="rgba(0,0,0,0.34)" shadowOnly />
+            </RoundedRect>
+        </Canvas>
+    );
+};

--- a/packages/commons/components/OxyID/tilt-context.tsx
+++ b/packages/commons/components/OxyID/tilt-context.tsx
@@ -1,0 +1,107 @@
+/**
+ * Shared tilt state for the Oxy ID card, plus the `ParallaxLayer` primitive.
+ *
+ * Depth on the card is faked with manual parallax: RN 0.86's transform whitelist
+ * has no reliable per-layer `translateZ`, so instead each layer translates in the
+ * plane proportional to the current tilt angle and its assigned "elevation". A
+ * higher elevation leads the motion (floats above the face); a negative elevation
+ * trails (recedes below it). All layers share one container `perspective +
+ * rotateX/rotateY`, so together they read as genuine 3D.
+ */
+
+import { type ReactNode } from 'react';
+import { type StyleProp, type ViewStyle } from 'react-native';
+
+import { createContext, useContext } from 'react';
+import Animated, {
+    useAnimatedStyle,
+    type DerivedValue,
+    type SharedValue,
+} from 'react-native-reanimated';
+
+// Per-layer depths (screen-space parallax lead/trail). Kept at 0 so the printed
+// content stays FLAT on the card surface (like a real ID/passport) instead of
+// floating above the hologram. The card still tilts as a whole in 3D.
+export const HOLOGRAM_ELEVATION = 0;
+export const AVATAR_ELEVATION = 0;
+export const TEXT_ELEVATION = 0;
+export const BADGE_ELEVATION = 0;
+export const GLOSS_ELEVATION = 0;
+
+// Global parallax intensity knob.
+const PARALLAX_SCALE = 0;
+const DEG_TO_RAD = Math.PI / 180;
+
+export interface TiltContextValue {
+    pitchDeg: SharedValue<number>;
+    yawDeg: SharedValue<number>;
+    nx: SharedValue<number>;
+    ny: SharedValue<number>;
+    mag: SharedValue<number>;
+    pressRotateX: SharedValue<number>;
+    isPressed: SharedValue<number>;
+    rotation: SharedValue<number>;
+    isFront: DerivedValue<boolean>;
+    motionEnabled: boolean;
+}
+
+const TiltContext = createContext<TiltContextValue | null>(null);
+
+export const TiltProvider = ({
+    value,
+    children,
+}: {
+    value: TiltContextValue;
+    children: ReactNode;
+}) => <TiltContext.Provider value={value}>{children}</TiltContext.Provider>;
+
+export const useTilt = (): TiltContextValue => {
+    const ctx = useContext(TiltContext);
+    if (!ctx) {
+        throw new Error('useTilt must be used within a TiltProvider');
+    }
+    return ctx;
+};
+
+interface ParallaxLayerProps {
+    /** Depth of this layer; see the elevation constants above. */
+    elevation: number;
+    /** Which face the layer belongs to (back layers translate in mirror). */
+    face?: 'front' | 'back';
+    pointerEvents?: 'auto' | 'none' | 'box-none' | 'box-only';
+    children: ReactNode;
+    style?: StyleProp<ViewStyle>;
+}
+
+/**
+ * Wraps content and offsets it in-plane by an amount proportional to the current
+ * tilt and its `elevation`. The translate is applied on a wrapper OUTSIDE any
+ * `scaleX: -1` mirror the caller adds, so back-side content parallaxes correctly.
+ */
+export const ParallaxLayer = ({
+    elevation,
+    face = 'front',
+    pointerEvents,
+    children,
+    style,
+}: ParallaxLayerProps) => {
+    const { yawDeg, pitchDeg, pressRotateX } = useTilt();
+    const facing = face === 'front' ? 1 : -1;
+
+    const animatedStyle = useAnimatedStyle(() => {
+        const yr = yawDeg.value * DEG_TO_RAD;
+        const pr = (pitchDeg.value + pressRotateX.value) * DEG_TO_RAD;
+        return {
+            transform: [
+                { translateX: facing * elevation * PARALLAX_SCALE * Math.sin(yr) },
+                { translateY: -elevation * PARALLAX_SCALE * Math.sin(pr) },
+            ],
+        };
+    });
+
+    return (
+        <Animated.View pointerEvents={pointerEvents} style={[style, animatedStyle]}>
+            {children}
+        </Animated.View>
+    );
+};

--- a/packages/commons/components/civic/IdQrBack.tsx
+++ b/packages/commons/components/civic/IdQrBack.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
+import { LogoIcon } from '@oxyhq/services';
 
 interface IdQrBackProps {
   /** The Oxy ID QR payload (`oxycommons://card?did=…&v=1`) to encode. */
@@ -10,22 +11,38 @@ interface IdQrBackProps {
 }
 
 /**
- * Back side of the flippable Oxy ID card: a QR code of the user's ID payload.
+ * Back side of the flippable Oxy ID card: a QR of the user's ID payload, laid
+ * out like the front — an issuer header, the QR in a framed "verification zone",
+ * and a footer note — so both faces read as one official document.
  *
  * The payload encodes ONLY the DID (no trust data) — a scanner resolves and
- * re-verifies the signed card server-side. Rendered on a light card face to
- * match the OxyID front; the parent `Ticket` already compensates for the 180°
- * flip (`scaleX: -1`) so the QR reads in the correct orientation.
+ * re-verifies the signed card server-side. The parent `Ticket` already
+ * compensates for the 180° flip (`scaleX: -1`) so this reads upright.
  */
 export function IdQrBack({ payload, caption }: IdQrBackProps) {
   return (
     <View style={styles.container}>
-      <View style={styles.qrWrapper}>
-        <QRCode value={payload} size={128} color="#1C1C1E" backgroundColor="transparent" />
+      {/* Header — mirrors the front. */}
+      <View style={styles.header}>
+        <LogoIcon height={20} />
+        <Text style={styles.docType}>VERIFY</Text>
       </View>
-      <Text style={styles.caption} numberOfLines={2}>
-        {caption}
-      </Text>
+
+      {/* Verification zone. */}
+      <View style={styles.qrZone}>
+        <View style={styles.qrFrame}>
+          <QRCode value={payload} size={150} color="#1C1C1E" backgroundColor="transparent" />
+        </View>
+        <Text style={styles.caption} numberOfLines={2}>
+          {caption}
+        </Text>
+      </View>
+
+      {/* Footer note. */}
+      <View style={styles.footer}>
+        <Text style={styles.footerStrong}>SIGNED · SELF-CUSTODY IDENTITY</Text>
+        <Text style={styles.footerNote}>Resolves & verifies on the Oxy network</Text>
+      </View>
     </View>
   );
 }
@@ -33,15 +50,35 @@ export function IdQrBack({ payload, caption }: IdQrBackProps) {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 20,
+    padding: 18,
+    justifyContent: 'space-between',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(0,0,0,0.18)',
+    paddingBottom: 6,
+  },
+  docType: {
+    fontSize: 9,
+    fontWeight: '600',
+    letterSpacing: 1.2,
+    color: '#6E6E73',
+  },
+  qrZone: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 14,
+    gap: 12,
   },
-  qrWrapper: {
+  qrFrame: {
     padding: 12,
     borderRadius: 12,
     backgroundColor: 'rgba(255,255,255,0.85)',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: 'rgba(0,0,0,0.15)',
   },
   caption: {
     color: '#3A3A3C',
@@ -50,5 +87,22 @@ const styles = StyleSheet.create({
     letterSpacing: 0.4,
     textTransform: 'uppercase',
     textAlign: 'center',
+  },
+  footer: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: 'rgba(0,0,0,0.18)',
+    paddingTop: 8,
+    gap: 2,
+  },
+  footerStrong: {
+    color: '#2B2B2E',
+    fontSize: 9.5,
+    fontWeight: '700',
+    letterSpacing: 0.8,
+  },
+  footerNote: {
+    color: '#6E6E73',
+    fontSize: 9,
+    letterSpacing: 0.3,
   },
 });

--- a/packages/commons/components/holographic-card.tsx
+++ b/packages/commons/components/holographic-card.tsx
@@ -1,353 +1,171 @@
+/**
+ * Base holographic layer of the Oxy ID card — a WHITE card with a fine engraved
+ * GUILLOCHÉ pattern (smooth rosette curves, like the engine-turned lines on
+ * official ID / banknote holograms). The card itself is white; the rainbow is
+ * ONLY the holographic effect that lives on the guilloché lines and SHIFTS as
+ * the phone tilts.
+ *
+ * The iridescence uses a LINEAR gradient (a directional band, NO centre pivot) so
+ * there is no visible "colour-wheel" hotspot. Uses only plain GPU gradients +
+ * stroked Paths — no `Mask`/`BlurMask` (blocky on Android).
+ */
+
 import { type FC, useMemo } from 'react';
 
 import {
-    BlurMask,
     Canvas,
-    Circle,
     Group,
-    interpolate,
     LinearGradient,
-    Mask,
     Path,
-    Rect,
     RoundedRect,
     Skia,
+    vec,
 } from '@shopify/react-native-skia';
-import {
-    Extrapolation,
-    useDerivedValue,
-} from 'react-native-reanimated';
+import { useDerivedValue } from 'react-native-reanimated';
 
-// Device tilt removed - hologram only responds to card rotation
+import { useTilt } from './OxyID/tilt-context';
 
-import type { SharedValue } from 'react-native-reanimated';
-
-/**
- * Props for the HolographicCard component
- * @typedef {Object} HolographicCardProps
- * @property {number} width - The width of the card
- * @property {number} height - The height of the card
- * @property {SharedValue<number>} rotateY - Animated rotation value around Y axis (flip)
- * @property {SharedValue<number>} [rotateX] - Animated rotation value around X axis (3D pitch)
- * @property {SharedValue<number>} [rotateZ] - Animated rotation value around Z axis (3D roll)
- * @property {string} [color='#FFF'] - Background color of the card
- */
 interface HolographicCardProps {
     width: number;
     height: number;
-    rotateY: SharedValue<number>;
-    rotateX?: SharedValue<number>;
-    rotateZ?: SharedValue<number>;
-    pressX?: SharedValue<number>;
-    pressY?: SharedValue<number>;
-    isPressed?: SharedValue<number>;
-    color?: string;
 }
 
-export const HolographicCard: FC<HolographicCardProps> = ({
-    width,
-    height,
-    rotateY,
-    rotateX,
-    rotateZ,
-    pressX,
-    pressY,
-    isPressed,
-    color = '#FFF',
-}) => {
-    // Calculate mask center based on card's 3D rotation (flip + 3D tilt) AND press position
-    const maskCenterX = useDerivedValue(() => {
-        const normalizedRotation = rotateY.value % 360;
-        const rotation =
-            normalizedRotation < 0 ? normalizedRotation + 360 : normalizedRotation;
+// Full-spectrum iridescence for the line shimmer.
+const IRIDESCENT = [
+    '#ff4d6d',
+    '#ff9e2c',
+    '#ffe14d',
+    '#43e97b',
+    '#22d3ee',
+    '#4f8dff',
+    '#a06bff',
+    '#ff6bd6',
+];
 
-        // Base position from card flip rotation
-        const baseX =
-            width / 2 - Math.sin((rotation * Math.PI) / 180) * (width / 2);
-
-        // Add 3D rotation influence (rotateZ affects X position)
-        const tilt3DX = rotateZ ? (rotateZ.value / 15) * (width / 3) : 0; // Normalize by max rotation (15°)
-
-        // Add press position influence
-        const pressInfluence = isPressed?.value ?? 0;
-        const pressOffsetX = pressX
-            ? (pressX.value - width / 2) * pressInfluence * 0.4
-            : 0;
-
-        return baseX + tilt3DX + pressOffsetX;
-    });
-
-    const maskCenterY = useDerivedValue(() => {
-        // Base Y position
-        const baseY = height / 2;
-
-        // Add 3D rotation influence (rotateX affects Y position)
-        const tilt3DY = rotateX ? (rotateX.value / 15) * (height / 3) : 0; // Normalize by max rotation (15°)
-
-        // Add press position influence
-        const pressInfluence = isPressed?.value ?? 0;
-        const pressOffsetY = pressY
-            ? (pressY.value - height / 2) * pressInfluence * 0.4
-            : 0;
-
-        return baseY + tilt3DY + pressOffsetY;
-    });
-
-    // Calculate 3D lighting position based on card rotation and press (simulates light reflection)
-    const lightingX = useDerivedValue(() => {
-        // Base lighting from card rotation (simulates 3D lighting)
-        const normalizedRotation = rotateY.value % 360;
-        const rotation =
-            normalizedRotation < 0 ? normalizedRotation + 360 : normalizedRotation;
-
-        // Simulate light coming from top-left (like real cards)
-        const lightAngle = (rotation * Math.PI) / 180;
-        const baseX = width * 0.2 + Math.sin(lightAngle) * width * 0.3;
-
-        // 3D rotation influence on lighting position
-        const tilt3DX = rotateZ ? (rotateZ.value / 15) * width * 0.2 : 0;
-
-        // Press creates a highlight at press position (like light reflection on metal)
-        const pressInfluence = isPressed?.value ?? 0;
-        const pressOffsetX = pressX ? (pressX.value - width / 2) * pressInfluence * 0.5 : 0;
-
-        return baseX + tilt3DX + pressOffsetX;
-    });
-
-    const lightingY = useDerivedValue(() => {
-        // Base lighting from card rotation
-        const normalizedRotation = rotateY.value % 360;
-        const rotation =
-            normalizedRotation < 0 ? normalizedRotation + 360 : normalizedRotation;
-
-        const lightAngle = (rotation * Math.PI) / 180;
-        const baseY = height * 0.2 + Math.cos(lightAngle) * height * 0.3;
-
-        // 3D rotation influence
-        const tilt3DY = rotateX ? (rotateX.value / 15) * height * 0.2 : 0;
-
-        // Press creates a highlight at press position
-        const pressInfluence = isPressed?.value ?? 0;
-        const pressOffsetY = pressY ? (pressY.value - height / 2) * pressInfluence * 0.5 : 0;
-
-        return baseY + tilt3DY + pressOffsetY;
-    });
-
-    // Calculate lighting intensity/brightness (reduced for subtle effect)
-    const lightingIntensity = useDerivedValue(() => {
-        // Base intensity - very subtle
-        const baseIntensity = 0.08;
-
-        // Press creates brightness boost (like light reflection)
-        const pressBoost = isPressed?.value ?? 0;
-        const pressIntensity = pressBoost * 0.15;
-
-        // Add gyroscope influence for 3D effect
-        const gyroInfluence = rotateX && rotateZ
-            ? (Math.abs(rotateX.value) + Math.abs(rotateZ.value)) / 30 * 0.1
-            : 0;
-
-        return Math.min(baseIntensity + pressIntensity + gyroInfluence, 0.25);
-    });
-
-    // Calculate mask opacity - always show hologram with base opacity
-    const maskOpacity = useDerivedValue(() => {
-        // Base opacity - always show hologram even when card is normal (like real metal cards)
-        const baseOpacity = 0.35; // Visible at normal state
-
-        // Rotation-based variation (peaks at certain angles)
-        const rotationVariation = interpolate(
-            Math.abs(rotateY.value),
-            [0, 90, 180, 270, 360],
-            [0, 0.3, 0, 0.3, 0],
-            Extrapolation.CLAMP,
-        );
-
-        // Gyroscope 3D rotation influence - hologram becomes more visible when tilted
-        const gyroVariation = rotateX && rotateZ
-            ? (Math.abs(rotateX.value) + Math.abs(rotateZ.value)) / 30 * 0.2
-            : 0;
-
-        // Press boost - increase opacity when pressed (like real cards get brighter)
-        const pressBoost = isPressed?.value ?? 0;
-        const pressOpacity = pressBoost * 0.15; // More visible when pressed
-
-        return Math.min(baseOpacity + rotationVariation + gyroVariation + pressOpacity, 0.8);
-    });
-
-    // Mask radius constant
-    const maskRadius = Math.max(width, height) * 0.7;
-
-    // No cutouts - full card coverage
-
-    // Calculate grid dimensions for the pattern
-    const LogoAmountHorizontal = 25;
-    const LogoSize = width / LogoAmountHorizontal;
-    const LogoAmountVertical = Math.round(height / LogoSize) + 1;
-
-    // Create the grid pattern of circles
-    const GridPath = useMemo(() => {
-        const skPath = Skia.Path.Make();
-        for (let i = 0; i < LogoAmountHorizontal; i++) {
-            for (let j = 0; j < LogoAmountVertical; j++) {
-                skPath.addCircle(
-                    LogoSize / 2 + i * LogoSize,
-                    LogoSize / 2 + j * LogoSize,
-                    LogoSize / 2,
-                );
+// Guilloché rosette: a set of nested flower curves (radius modulated by a
+// sinusoid) with alternating phase, so the rings interleave into the classic
+// engine-turned weave. Smooth curves — no straight-chord mesh.
+const buildGuilloche = (width: number, height: number) => {
+    const path = Skia.Path.Make();
+    const cx = width / 2;
+    const cy = height / 2;
+    const aspect = width / height;
+    const maxR = Math.min(width, height) * 0.52;
+    const rings = 7;
+    const petals = 14;
+    const steps = 260;
+    for (let m = 1; m <= rings; m++) {
+        const baseR = (m / rings) * maxR;
+        const amp = baseR * 0.16;
+        const phase = m % 2 === 0 ? Math.PI / petals : 0;
+        for (let i = 0; i <= steps; i++) {
+            const t = (i / steps) * Math.PI * 2;
+            const r = baseR + amp * Math.cos(petals * t + phase);
+            const x = cx + r * Math.cos(t) * aspect;
+            const y = cy + r * Math.sin(t);
+            if (i === 0) {
+                path.moveTo(x, y);
+            } else {
+                path.lineTo(x, y);
             }
         }
-        return skPath;
-    }, [LogoAmountVertical, LogoSize]);
+    }
+    return path;
+};
 
-    // Gradient positions influenced by card's 3D rotation (flip + 3D tilt) AND press position
-    const gradientStart = useDerivedValue(() => {
-        const normalizedRotation = rotateY.value % 360;
-        const rotation =
-            normalizedRotation < 0 ? normalizedRotation + 360 : normalizedRotation;
+export const HolographicCard: FC<HolographicCardProps> = ({ width, height }) => {
+    const { nx, ny, mag, isPressed } = useTilt();
 
-        // Flip rotation influence on gradient
-        const rotationX = Math.sin((rotation * Math.PI) / 180) * width * 0.3;
-        const rotationY = Math.cos((rotation * Math.PI) / 180) * height * 0.3;
+    const guilloche = useMemo(() => buildGuilloche(width, height), [width, height]);
 
-        // 3D rotation influence (enhanced for gyroscope)
-        const tilt3DX = rotateZ ? (rotateZ.value / 15) * width * 0.25 : 0;
-        const tilt3DY = rotateX ? (rotateX.value / 15) * height * 0.25 : 0;
+    // Diagonal iridescence band (NO centre pivot). Its endpoints shift with tilt,
+    // so the rainbow slides along the guilloché lines as the phone turns.
+    const irisStart = useDerivedValue(() =>
+        vec(width * (-0.3 + nx.value * 0.6), height * (-0.3 + ny.value * 0.6)),
+    );
+    const irisEnd = useDerivedValue(() =>
+        vec(width * (1.3 + nx.value * 0.6), height * (1.3 + ny.value * 0.6)),
+    );
 
-        // Press position influence
-        const pressInfluence = isPressed?.value ?? 0;
-        const pressOffsetX = pressX ? (pressX.value - width / 2) * pressInfluence * 0.2 : 0;
-        const pressOffsetY = pressY ? (pressY.value - height / 2) * pressInfluence * 0.2 : 0;
+    // Subtle at rest → flares as you tilt (the reflejo).
+    const irisOpacity = useDerivedValue(() =>
+        Math.min(0.85, 0.32 + mag.value * 0.45 + isPressed.value * 0.16),
+    );
 
-        // Add 3D perspective offset for depth effect (calculated directly here)
-        const rotateXValue = rotateX ? rotateX.value : 0;
-        const rotateZValue = rotateZ ? rotateZ.value : 0;
-        const rotateXRad = (rotateXValue * Math.PI) / 180;
-        const rotateZRad = (rotateZValue * Math.PI) / 180;
-        const perspectiveX = Math.sin(rotateZRad) * width * 0.15; // Horizontal perspective shift
-        const perspectiveY = Math.sin(rotateXRad) * height * 0.15; // Vertical perspective shift
-
-        return {
-            x: width * 0.1 + rotationX + tilt3DX + pressOffsetX + perspectiveX,
-            y: height * 0.1 + rotationY + tilt3DY + pressOffsetY + perspectiveY
-        };
-    });
-
-    const gradientEnd = useDerivedValue(() => {
-        const normalizedRotation = rotateY.value % 360;
-        const rotation =
-            normalizedRotation < 0 ? normalizedRotation + 360 : normalizedRotation;
-
-        // Flip rotation influence on gradient (opposite direction)
-        const rotationX = -Math.sin((rotation * Math.PI) / 180) * width * 0.3;
-        const rotationY = -Math.cos((rotation * Math.PI) / 180) * height * 0.3;
-
-        // 3D rotation influence (opposite direction, enhanced for gyroscope)
-        const tilt3DX = rotateZ ? -(rotateZ.value / 15) * width * 0.25 : 0;
-        const tilt3DY = rotateX ? -(rotateX.value / 15) * height * 0.25 : 0;
-
-        // Press position influence (opposite direction for gradient)
-        const pressInfluence = isPressed?.value ?? 0;
-        const pressOffsetX = pressX ? -(pressX.value - width / 2) * pressInfluence * 0.2 : 0;
-        const pressOffsetY = pressY ? -(pressY.value - height / 2) * pressInfluence * 0.2 : 0;
-
-        // Add 3D perspective offset for depth effect (calculated directly here, opposite direction)
-        const rotateXValue = rotateX ? rotateX.value : 0;
-        const rotateZValue = rotateZ ? rotateZ.value : 0;
-        const rotateXRad = (rotateXValue * Math.PI) / 180;
-        const rotateZRad = (rotateZValue * Math.PI) / 180;
-        const perspectiveX = -Math.sin(rotateZRad) * width * 0.15; // Horizontal perspective shift (opposite)
-        const perspectiveY = -Math.sin(rotateXRad) * height * 0.15; // Vertical perspective shift (opposite)
-
-        return {
-            x: width * 0.9 + rotationX + tilt3DX + pressOffsetX + perspectiveX,
-            y: height * 0.9 + rotationY + tilt3DY + pressOffsetY + perspectiveY
-        };
-    });
-
+    // Glossy laminate sheen — a bright diagonal glare streak that sweeps across
+    // the surface (opposite the tilt), like light on a plastic card. A cool tint
+    // so it reads as a glass reflection on the white stock.
+    const glossStart = useDerivedValue(() =>
+        vec(
+            width * (0.5 - nx.value * 0.7) - width * 0.5,
+            height * (0.5 - ny.value * 0.7) - height * 0.5,
+        ),
+    );
+    const glossEnd = useDerivedValue(() =>
+        vec(
+            width * (0.5 - nx.value * 0.7) + width * 0.5,
+            height * (0.5 - ny.value * 0.7) + height * 0.5,
+        ),
+    );
+    const glossOpacity = useDerivedValue(() =>
+        Math.min(0.7, 0.28 + mag.value * 0.4 + isPressed.value * 0.22),
+    );
 
     return (
         <Canvas style={{ width, height, backgroundColor: 'transparent' }}>
             <Group>
-                {/* Main card background */}
-                <RoundedRect
-                    x={0}
-                    y={0}
-                    width={width}
-                    height={height}
-                    color={color || '#FFFFFF'}
-                    r={24}
+                {/* White card stock. */}
+                <RoundedRect x={0} y={0} width={width} height={height} r={24} color="#FFFFFF" />
+
+                {/* Faint engraved guilloché — always visible on white so the
+                    pattern reads even where the rainbow is dim. */}
+                <Path
+                    path={guilloche}
+                    style="stroke"
+                    strokeWidth={0.5}
+                    color="rgba(120,120,140,0.13)"
                 />
-                <Group>
-                    {/* Holographic effect mask */}
-                    <Mask
-                        mode="luminance"
-                        mask={
-                            <Group>
-                                <Rect
-                                    x={0}
-                                    y={0}
-                                    width={width}
-                                    height={height}
-                                    color={'white'}
-                                    opacity={maskOpacity}
-                                />
-                                <Group>
-                                    <Circle
-                                        cx={maskCenterX}
-                                        cy={maskCenterY}
-                                        r={maskRadius}
-                                        color={'rgba(0,0,0,0.5)'}>
-                                        <BlurMask blur={15} style="normal" />
-                                    </Circle>
-                                </Group>
-                            </Group>
-                        }>
-                        <Group>
-                            <Path path={GridPath}>
-                                {/* Holographic gradient with 3D lighting/brightness effect */}
-                                <LinearGradient
-                                    start={gradientStart}
-                                    end={gradientEnd}
-                                    colors={[
-                                        'rgba(52,168,82,1)',   // Green
-                                        'rgba(255,211,20,1)',  // Yellow
-                                        'rgba(255,70,65,1)',   // Red
-                                        'rgba(49,134,255,1)',  // Blue
-                                        'rgba(49,134,255,0.5)', // Blue (faded)
-                                        'rgba(52,168,82,1)',   // Green (back to start)
-                                    ]}
-                                    positions={[0, 0.17, 0.33, 0.5, 0.67, 1]}
-                                />
-                            </Path>
-                        </Group>
-                        {/* 3D lighting overlay - very subtle, only visible when pressed/tilted */}
-                        <Group opacity={lightingIntensity}>
-                            <Circle
-                                cx={lightingX}
-                                cy={lightingY}
-                                r={Math.max(width, height) * 0.35}
-                            >
-                                <LinearGradient
-                                    start={useDerivedValue(() => ({
-                                        x: lightingX.value - Math.max(width, height) * 0.15,
-                                        y: lightingY.value - Math.max(width, height) * 0.15
-                                    }))}
-                                    end={useDerivedValue(() => ({
-                                        x: lightingX.value + Math.max(width, height) * 0.15,
-                                        y: lightingY.value + Math.max(width, height) * 0.15
-                                    }))}
-                                    colors={[
-                                        'rgba(255,255,255,0.15)',
-                                        'rgba(255,255,255,0.08)',
-                                        'rgba(255,255,255,0)',
-                                    ]}
-                                    positions={[0, 0.4, 1]}
-                                />
-                            </Circle>
-                        </Group>
-                    </Mask>
+
+                {/* Holographic iridescence on the SAME lines — a diagonal rainbow
+                    band (no pivot) that slides with tilt. */}
+                <Group opacity={irisOpacity}>
+                    <Path path={guilloche} style="stroke" strokeWidth={0.9}>
+                        <LinearGradient start={irisStart} end={irisEnd} colors={IRIDESCENT} />
+                    </Path>
                 </Group>
+
+                {/* Glossy laminate sheen — the bright diagonal glare that sweeps
+                    across the surface, giving the physical-card feel. */}
+                <Group opacity={glossOpacity}>
+                    <RoundedRect x={0} y={0} width={width} height={height} r={24}>
+                        <LinearGradient
+                            start={glossStart}
+                            end={glossEnd}
+                            colors={[
+                                'rgba(235,244,255,0)',
+                                'rgba(235,244,255,0)',
+                                'rgba(240,248,255,0.85)',
+                                'rgba(255,255,255,0.95)',
+                                'rgba(240,248,255,0.85)',
+                                'rgba(235,244,255,0)',
+                                'rgba(235,244,255,0)',
+                            ]}
+                            positions={[0, 0.4, 0.47, 0.5, 0.53, 0.6, 1]}
+                        />
+                    </RoundedRect>
+                </Group>
+
+                {/* Subtle edge definition. */}
+                <RoundedRect
+                    x={1}
+                    y={1}
+                    width={width - 2}
+                    height={height - 2}
+                    r={23}
+                    style="stroke"
+                    strokeWidth={1}
+                    color="rgba(150,150,170,0.25)"
+                />
             </Group>
         </Canvas>
     );

--- a/packages/commons/components/identity/IdentityCard.tsx
+++ b/packages/commons/components/identity/IdentityCard.tsx
@@ -9,6 +9,7 @@ import React, { useMemo } from 'react';
 import { Ticket as OxyID } from '@/components/OxyID';
 import { FrontSide } from '@/components/OxyID/front-side';
 import { BackSide } from '@/components/OxyID/back-side';
+import { IdQrBack } from '@/components/civic/IdQrBack';
 
 export interface IdentityCardProps {
   displayName?: string;
@@ -16,6 +17,10 @@ export interface IdentityCardProps {
   avatarUrl?: string;
   accountCreated?: string;
   publicKey?: string;
+  /** Optional QR payload — revealed on the back by a long-press. */
+  qrPayload?: string;
+  /** Caption under the QR (required when `qrPayload` is set). */
+  qrCaption?: string;
   width?: number;
   height?: number;
 }
@@ -26,8 +31,10 @@ export function IdentityCard({
   avatarUrl,
   accountCreated,
   publicKey,
-  width = 340,
-  height = 214,
+  qrPayload,
+  qrCaption,
+  width = 240,
+  height = 380,
 }: IdentityCardProps) {
   // Format public key for FrontSide display (first 8 + last 8 characters)
   const publicKeyShort = useMemo(() => {
@@ -55,6 +62,9 @@ export function IdentityCard({
           displayName={displayName}
           accountCreated={accountCreated}
         />
+      }
+      qrSide={
+        qrPayload ? <IdQrBack payload={qrPayload} caption={qrCaption ?? ''} /> : undefined
       }
     />
   );

--- a/packages/commons/hooks/use-device-tilt.ts
+++ b/packages/commons/hooks/use-device-tilt.ts
@@ -1,81 +1,201 @@
-import { useEffect, useRef } from 'react';
-import { Gyroscope, GyroscopeMeasurement } from 'expo-sensors';
-import { useSharedValue } from 'react-native-reanimated';
+/**
+ * Device-attitude tilt for the Oxy ID card.
+ *
+ * Unlike a gyroscope-rate integration (which drifts and self-damps back to
+ * center), this reads the phone's ABSOLUTE orientation from the rotation
+ * sensor and reports how far it is tilted away from the pose the card was
+ * first shown in. The result is drift-free: the card reflects how the phone is
+ * actually held and holds still when the phone does.
+ *
+ * All outputs are UI-thread shared values updated inside a single
+ * `useFrameCallback` worklet (or, on devices without the reanimated rotation
+ * sensor, a JS-thread `DeviceMotion` fallback). Nothing here triggers a React
+ * re-render.
+ *
+ *   roll  -> yaw   (drives rotateY: the card turns left/right into the tilt)
+ *   pitch -> pitch (drives rotateX: the card tips toward/away from the viewer)
+ */
 
-export const useDeviceTilt = () => {
-  // Shared values for rotation angles (in degrees)
-  const rotateX = useSharedValue(0); // Pitch (forward/backward)
-  const rotateY = useSharedValue(0); // Roll (left/right)
-  
-  // Track last update time for integration
-  const lastUpdateTime = useRef<number | null>(null);
+import { useEffect } from 'react';
 
-  useEffect(() => {
-    let subscription: { remove: () => void } | null = null;
+import { DeviceMotion, type DeviceMotionMeasurement } from 'expo-sensors';
+import {
+    SensorType,
+    useAnimatedSensor,
+    useFrameCallback,
+    useReducedMotion,
+    useSharedValue,
+    type SharedValue,
+} from 'react-native-reanimated';
 
-    // Check if gyroscope is available
-    Gyroscope.isAvailableAsync().then((available: boolean) => {
-      if (!available) {
-        console.warn('Gyroscope is not available on this device');
-        return;
-      }
+// Max tilt in degrees, sensor-to-card gain, and low-pass smoothing factor.
+// Deliberately gentle — the card should tip subtly, not swing.
+const MAX = 9;
+const GAIN = 0.4;
+const ALPHA = 0.1;
+const RAD_TO_DEG = 180 / Math.PI;
+// Dead-zone (degrees): below this per-frame change we DON'T write the shared
+// values, so at rest the derived Skia values stop updating and the canvases go
+// idle instead of redrawing every frame on sensor noise.
+const SETTLE = 0.02;
 
-      // Request permissions
-      Gyroscope.requestPermissionsAsync().then((permission) => {
-        if (!permission.granted) {
-          console.warn('Gyroscope permissions not granted');
-          return;
-        }
+export interface DeviceTilt {
+    /** Card pitch in degrees (rotateX), clamped to [-MAX, MAX]. */
+    pitchDeg: SharedValue<number>;
+    /** Card yaw in degrees (rotateY), clamped to [-MAX, MAX]. */
+    yawDeg: SharedValue<number>;
+    /** Normalized horizontal tilt in [-1, 1] (yaw / MAX). */
+    nx: SharedValue<number>;
+    /** Normalized vertical tilt in [-1, 1] (pitch / MAX). */
+    ny: SharedValue<number>;
+    /** Overall tilt magnitude in [0, 1]. */
+    mag: SharedValue<number>;
+    /** True when a live motion source is driving the values (not reduced-motion). */
+    motionEnabled: boolean;
+}
 
-        // Set update interval to ~60fps
-        Gyroscope.setUpdateInterval(16);
+export const useDeviceTilt = (): DeviceTilt => {
+    const pitchDeg = useSharedValue(0);
+    const yawDeg = useSharedValue(0);
+    const nx = useSharedValue(0);
+    const ny = useSharedValue(0);
+    const mag = useSharedValue(0);
 
-        // Subscribe to gyroscope updates - integrate rotation rates
-        subscription = Gyroscope.addListener((data: GyroscopeMeasurement) => {
-          const now = data.timestamp;
-          
-          if (lastUpdateTime.current === null) {
-            lastUpdateTime.current = now;
-            return;
-          }
+    // Rest attitude captured on the first frame; tilt is measured relative to it.
+    const originPitch = useSharedValue(0);
+    const originRoll = useSharedValue(0);
+    const hasOrigin = useSharedValue(false);
 
-          // Calculate time delta in seconds
-          const deltaTime = (now - lastUpdateTime.current) / 1000;
-          lastUpdateTime.current = now;
-
-          // Convert rotation rates (rad/s) to degrees and integrate
-          // X axis rotation (pitch) - forward/backward tilt
-          const deltaX = (data.x * 180) / Math.PI * deltaTime;
-          // Y axis rotation (roll) - left/right tilt  
-          const deltaY = (data.y * 180) / Math.PI * deltaTime;
-
-          // Apply rotation with limits (Airbnb-style: ±15 degrees) and damping
-          const maxRotation = 15;
-          const damping = 0.95; // Slight damping to prevent infinite accumulation
-          
-          // Apply rotation with damping (returns to center when device stops)
-          const newRotateX = rotateX.value * damping + deltaX * 0.5;
-          const newRotateY = rotateY.value * damping + deltaY * 0.5;
-          
-          rotateX.value = Math.max(-maxRotation, Math.min(maxRotation, newRotateX));
-          rotateY.value = Math.max(-maxRotation, Math.min(maxRotation, newRotateY));
-        });
-      });
+    const reducedMotion = useReducedMotion();
+    const sensor = useAnimatedSensor(SensorType.ROTATION, {
+        interval: 16,
+        adjustToInterfaceOrientation: true,
     });
 
-    // Cleanup on unmount
-    return () => {
-      if (subscription) {
-        subscription.remove();
-      }
-      Gyroscope.removeAllListeners();
-      lastUpdateTime.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // rotateX and rotateY are stable SharedValue references
+    const sensorAvailable = sensor.isAvailable;
+    const motionEnabled = sensorAvailable && !reducedMotion;
 
-  return {
-    rotateX, // Pitch (forward/backward)
-    rotateY, // Roll (left/right)
-  };
+    // Only the SharedValue is captured by the worklet, never the AnimatedSensor
+    // object (which holds non-serializable functions).
+    const rotationSensor = sensor.sensor;
+
+    useFrameCallback(() => {
+        'worklet';
+        if (!motionEnabled) {
+            return;
+        }
+        const s = rotationSensor.value;
+        const rawPitch = s.pitch ?? 0;
+        const rawRoll = s.roll ?? 0;
+
+        if (!hasOrigin.value) {
+            originPitch.value = rawPitch;
+            originRoll.value = rawRoll;
+            hasOrigin.value = true;
+            return;
+        }
+
+        const targetPitch = Math.max(
+            -MAX,
+            Math.min(MAX, (rawPitch - originPitch.value) * RAD_TO_DEG * GAIN),
+        );
+        // Roll drives yaw so the card turns INTO the tilt (rotateY), not spins flat.
+        const targetYaw = Math.max(
+            -MAX,
+            Math.min(MAX, (rawRoll - originRoll.value) * RAD_TO_DEG * GAIN),
+        );
+
+        const nextPitch = pitchDeg.value + ALPHA * (targetPitch - pitchDeg.value);
+        const nextYaw = yawDeg.value + ALPHA * (targetYaw - yawDeg.value);
+
+        // Dead-zone: once the low-pass has settled and only sensor noise remains,
+        // stop writing so the Skia canvases stop redrawing on a still phone.
+        if (
+            Math.abs(nextPitch - pitchDeg.value) < SETTLE &&
+            Math.abs(nextYaw - yawDeg.value) < SETTLE
+        ) {
+            return;
+        }
+
+        pitchDeg.value = nextPitch;
+        yawDeg.value = nextYaw;
+
+        const nxv = Math.max(-1, Math.min(1, nextYaw / MAX));
+        const nyv = Math.max(-1, Math.min(1, nextPitch / MAX));
+        nx.value = nxv;
+        ny.value = nyv;
+        mag.value = Math.min(1, Math.sqrt(nxv * nxv + nyv * nyv));
+    }, true);
+
+    // Release the sensor whenever motion is disabled (reduced motion or no sensor).
+    useEffect(() => {
+        if (!motionEnabled) {
+            sensor.unregister();
+        }
+    }, [motionEnabled, sensor]);
+
+    // Fallback for devices without the reanimated rotation sensor: drive the
+    // same shared values from expo-sensors' DeviceMotion on the JS thread.
+    useEffect(() => {
+        if (sensorAvailable || reducedMotion) {
+            return;
+        }
+
+        let active = true;
+        let origin: { beta: number; gamma: number } | null = null;
+        let filtPitch = 0;
+        let filtYaw = 0;
+        let sub: { remove: () => void } | null = null;
+
+        DeviceMotion.isAvailableAsync()
+            .then((available) => {
+                if (!available || !active) {
+                    return;
+                }
+                DeviceMotion.setUpdateInterval(16);
+                sub = DeviceMotion.addListener((data: DeviceMotionMeasurement) => {
+                    const rotation = data.rotation;
+                    if (!rotation) {
+                        return;
+                    }
+                    // beta = X-axis (pitch), gamma = Y-axis (roll) — radians on native.
+                    const beta = rotation.beta ?? 0;
+                    const gamma = rotation.gamma ?? 0;
+                    if (!origin) {
+                        origin = { beta, gamma };
+                        return;
+                    }
+                    const targetPitch = Math.max(
+                        -MAX,
+                        Math.min(MAX, (beta - origin.beta) * RAD_TO_DEG * GAIN),
+                    );
+                    const targetYaw = Math.max(
+                        -MAX,
+                        Math.min(MAX, (gamma - origin.gamma) * RAD_TO_DEG * GAIN),
+                    );
+                    filtPitch += ALPHA * (targetPitch - filtPitch);
+                    filtYaw += ALPHA * (targetYaw - filtYaw);
+                    pitchDeg.value = filtPitch;
+                    yawDeg.value = filtYaw;
+
+                    const nxv = Math.max(-1, Math.min(1, filtYaw / MAX));
+                    const nyv = Math.max(-1, Math.min(1, filtPitch / MAX));
+                    nx.value = nxv;
+                    ny.value = nyv;
+                    mag.value = Math.min(1, Math.sqrt(nxv * nxv + nyv * nyv));
+                });
+            })
+            .catch((error: unknown) => {
+                // No usable motion source — the card stays flat. Surface the reason
+                // so a genuinely broken sensor pipeline is diagnosable.
+                console.warn('[useDeviceTilt] DeviceMotion unavailable', error);
+            });
+
+        return () => {
+            active = false;
+            sub?.remove();
+        };
+    }, [sensorAvailable, reducedMotion, pitchDeg, yawDeg, nx, ny, mag]);
+
+    return { pitchDeg, yawDeg, nx, ny, mag, motionEnabled };
 };


### PR DESCRIPTION
## Summary
- Full redesign of the Commons "Oxy ID" card into a vertical passport/DNI-style document: white card, guilloché security-hologram (silver + iridescent lines that shift with device tilt), and a glossy laminate sheen
- Device-attitude tilt via a reanimated rotation sensor (drift-free, dead-zoned so it settles when still)
- Passport-style layout: Oxy logo header, framed portrait, labelled fields, and a machine-readable zone (MRZ)
- 3-state flip: tap toggles front (identity) / back (public key); long-press reveals the verification QR (front/back stay "normal")
- Card is reused across the ID home screen and the "About Your Identity" screen

## Test plan
- [x] `packages/commons` typecheck: `bunx tsc --noEmit -p tsconfig.json` → exit 0, no TS errors
- [x] Grepped changed files for banned constructs (`as any`, `@ts-ignore`, `@ts-expect-error`, `catch {}`, `TODO`/`FIXME`) → none found
- [x] Verified on a native device (Pixel 10 Pro): tilt response, tap flip (front/public-key back), long-press QR reveal

🤖 Generated with [Claude Code](https://claude.com/claude-code)