### PR TITLE
fix(commons): confine Oxy ID card gestures to the card (drop hitSlop)

### DIFF
--- a/packages/commons/components/OxyID/index.tsx
+++ b/packages/commons/components/OxyID/index.tsx
@@ -95,9 +95,7 @@ export const Ticket: FC<TicketProps> = memo(({ width, height, frontSide, backSid
     // Press tilt (Pan with minDistance 0 catches any touch).
     const pressGesture = Gesture.Pan()
         .minDistance(0)
-        .maxPointers(1)
-        .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
-        .onBegin((event) => {
+        .maxPointers(1)        .onBegin((event) => {
             'worklet';
             isPressed.value = 1;
             const normalizedY = (event.y - height / 2) / (height / 2);
@@ -125,9 +123,7 @@ export const Ticket: FC<TicketProps> = memo(({ width, height, frontSide, backSid
         });
 
     // Tap flips between front and the public-key back (never the QR).
-    const tapGesture = Gesture.Tap()
-        .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
-        .onEnd(() => {
+    const tapGesture = Gesture.Tap()        .onEnd(() => {
             scheduleOnRN(Haptics.selectionAsync);
             scheduleOnRN(setShowQr, false);
             rotation.value = withSpring(rotation.value === 0 ? 180 : 0, {
@@ -139,9 +135,7 @@ export const Ticket: FC<TicketProps> = memo(({ width, height, frontSide, backSid
     // Long-press (>2s) reveals the QR on the back face.
     const longPressGesture = Gesture.LongPress()
         .minDuration(QR_REVEAL_MS)
-        .maxDistance(40)
-        .hitSlop({ top: 50, bottom: 50, left: 50, right: 50 })
-        .onStart(() => {
+        .maxDistance(40)        .onStart(() => {
             scheduleOnRN(Haptics.selectionAsync);
             scheduleOnRN(setShowQr, true);
             rotation.value = withSpring(180, { dampingRatio: 1.5, duration: 500 });


### PR DESCRIPTION
The 50px `hitSlop` on the Oxy ID card's pan/tap/long-press gestures extended the touch target ~50px beyond the card, so touching nearby (e.g. the scroll area just below the card) tilted/flipped the card and blocked scrolling. Removing it confines the gestures to the card itself; touches outside now scroll normally.

Follow-up to #589. Verified: `packages/commons` typecheck exit 0, and scroll tested on a Pixel 10 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)