### PR TITLE
feat(commons): Commons emblem watermark on the ID card

### DIFF
--- a/packages/commons/components/OxyID/front-side.tsx
+++ b/packages/commons/components/OxyID/front-side.tsx
@@ -10,6 +10,7 @@ import { useMemo } from 'react';
 import { StyleSheet, Text, View, Image } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { LogoIcon } from '@oxyhq/services';
+import { CommonsLogo } from '@/components/commons-logo';
 import { Fonts } from '@/constants/theme';
 import { AVATAR_ELEVATION, ParallaxLayer, TEXT_ELEVATION } from './tilt-context';
 
@@ -59,6 +60,10 @@ export const FrontSide: React.FC<FrontSideProps> = ({
 
     return (
         <View style={styles.container}>
+            {/* Commons issuer emblem — a faint corner watermark sitting over the
+                hologram, rendered behind the printed content. */}
+            <CommonsLogo size={26} color="rgba(92,94,112,0.28)" style={styles.commonsMark} />
+
             {/* Issuer header */}
             <View style={styles.header}>
                 <LogoIcon height={22} />
@@ -140,6 +145,11 @@ const styles = StyleSheet.create({
         flex: 1,
         padding: 18,
         justifyContent: 'space-between',
+    },
+    commonsMark: {
+        position: 'absolute',
+        right: 14,
+        bottom: 14,
     },
     header: {
         flexDirection: 'row',

--- a/packages/commons/components/commons-logo.tsx
+++ b/packages/commons/components/commons-logo.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+import type { ViewStyle } from 'react-native';
+
+/**
+ * The Commons wordmark glyph — three interlocking lenses. Source of truth is
+ * `assets/images/commons-logo.svg`; the path is inlined here (there is no
+ * react-native-svg-transformer in this app) so it renders as a crisp vector at
+ * any size/colour, exactly like `LogoIcon` does for the Oxy mark.
+ */
+const COMMONS_PATH =
+    'M640-162q-18.09 0-34.9-1.57-16.8-1.57-34.1-5.43 72-63 113.5-143.5Q726-393.01 726-480q0-88-41.5-168T571-791q16.89-3.62 34.1-5.31Q622.3-798 640-798q132.45 0 225.22 92.89Q958-612.22 958-479.61T865.22-254.5Q772.45-162 640-162Zm-160-43q-71-42-114.5-114.5T322-480q0-88 43.5-160.5T480-755q71 42 114.5 114.5T638-480q0 88-43.5 160.5T480-205Zm-160 43q-132.45 0-225.22-92.89Q2-347.78 2-480.39T94.78-705.5Q187.55-798 320-798q18.09 0 34.9 1.57 16.8 1.57 34.1 5.43-72 63-113.5 143.16Q234-567.67 234-480.29 234-385 274.5-304 315-223 382-167q-14.47 2.63-30.22 3.82Q336.03-162 320-162Z';
+
+interface CommonsLogoProps {
+    /** Square edge length in pixels. */
+    size?: number;
+    /** Glyph fill colour. */
+    color?: string;
+    style?: ViewStyle;
+}
+
+export function CommonsLogo({ size = 24, color = '#ffffff', style }: CommonsLogoProps) {
+    return (
+        <Svg width={size} height={size} viewBox="0 -960 960 960" style={style}>
+            <Path d={COMMONS_PATH} fill={color} />
+        </Svg>
+    );
+}


### PR DESCRIPTION
Adds a faint **Commons glyph** (the three interlocking lenses) in the **bottom-right corner of the card front**, sitting over the guilloché hologram like an issuer/security watermark, next to the MRZ. Complements the Oxy mark in the header (Oxy = issuer, Commons = the vault that holds it).

Rendered from the inlined `commons-logo.svg` path via `react-native-svg` (new `CommonsLogo` component — no svg transformer in this app, mirroring how `LogoIcon` inlines the Oxy mark). Absolutely positioned, faint, decorative.

`packages/commons` typecheck exit 0. Verified on a Pixel 10 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/597" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->