### PR TITLE
fix(commons): render the Oxy header mark as holographic foil, not strokes

### DIFF
--- a/packages/commons/components/OxyID/holographic-logo.tsx
+++ b/packages/commons/components/OxyID/holographic-logo.tsx
@@ -1,11 +1,15 @@
 /**
- * The Oxy issuer mark rendered as engraved, tilt-iridescent lines — the header
- * counterpart to the Commons emblem in the card body. Instead of the solid brand
- * fill, the mark is STROKED and lit with the SAME tilt-driven iridescence as the
- * card's guilloché hologram, so it reads as part of the security engraving and
- * shimmers as the phone turns.
+ * The Oxy issuer mark rendered as a holographic FOIL — the card's header logo.
  *
- * Rendered as face content (not in the shared hologram layer) so the back face's
+ * The Oxy mark is a solid brand shape (an overlapping-lens silhouette with an
+ * interior detail), so — unlike the line-based Commons emblem — it can't be
+ * reduced to strokes without falling apart into loose construction outlines.
+ * Instead it keeps its true, recognizable form and swaps the solid brand fill for
+ * a tilt-driven iridescent gradient (the SAME band as the card's guilloché), so
+ * it reads as a foil-stamped logo that shifts colour as the phone turns. The
+ * interior marks stay white, exactly as in the brand logo.
+ *
+ * Rendered as face content (not the shared hologram layer) so the back face's
  * counter-mirror keeps it upright. Must be mounted inside the card `TiltProvider`.
  */
 
@@ -20,17 +24,17 @@ import { OXY_INNER_OFFSET, OXY_INNER_PATH, OXY_LETTERS_PATH, OXY_OUTER_PATH, OXY
 // Full-spectrum iridescence, matching the guilloché hologram on the card body.
 const IRIDESCENT = ['#ff4d6d', '#ff9e2c', '#ffe14d', '#43e97b', '#22d3ee', '#4f8dff', '#a06bff', '#ff6bd6'];
 
-// A hair of padding so the outermost stroke isn't clipped by the canvas edge.
-const PAD = 2;
+// A hair of padding so the mark isn't clipped by the canvas edge.
+const PAD = 1.5;
 
 const ASPECT = OXY_VIEWBOX.width / OXY_VIEWBOX.height;
 
 /**
- * Composite the outer silhouette with the two inner detail paths (which live
- * under a translate(465,188) group in the source), then scale the whole mark to
- * fit a `size`-tall box pinned at (PAD, PAD).
+ * Reproduce the three LogoIcon layers, each scaled to a `size`-tall box: the
+ * outer silhouette and the inner detail (the "foil" fill), plus the interior
+ * marks (drawn white on top). The inner two carry the source's translate(465,188).
  */
-const buildOxyMark = (size: number) => {
+const buildOxyParts = (size: number) => {
     const outer = Skia.Path.MakeFromSVGString(OXY_OUTER_PATH);
     const inner = Skia.Path.MakeFromSVGString(OXY_INNER_PATH);
     const letters = Skia.Path.MakeFromSVGString(OXY_LETTERS_PATH);
@@ -40,15 +44,14 @@ const buildOxyMark = (size: number) => {
     const offset = Skia.Matrix([1, 0, OXY_INNER_OFFSET.x, 0, 1, OXY_INNER_OFFSET.y, 0, 0, 1]);
     inner.transform(offset);
     letters.transform(offset);
-    outer.addPath(inner);
-    outer.addPath(letters);
 
     // viewBox → padded size-box (uniform scale, top-left origin).
     const s = size / OXY_VIEWBOX.height;
-    const tx = PAD - OXY_VIEWBOX.minX * s;
-    const ty = PAD - OXY_VIEWBOX.minY * s;
-    outer.transform(Skia.Matrix([s, 0, tx, 0, s, ty, 0, 0, 1]));
-    return outer;
+    const scale = Skia.Matrix([s, 0, PAD - OXY_VIEWBOX.minX * s, 0, s, PAD - OXY_VIEWBOX.minY * s, 0, 0, 1]);
+    outer.transform(scale);
+    inner.transform(scale);
+    letters.transform(scale);
+    return { outer, inner, letters };
 };
 
 interface HolographicLogoProps {
@@ -59,30 +62,34 @@ interface HolographicLogoProps {
 export const HolographicLogo: FC<HolographicLogoProps> = ({ size = 22 }) => {
     const { nx, ny, mag } = useTilt();
 
-    const mark = useMemo(() => buildOxyMark(size), [size]);
+    const parts = useMemo(() => buildOxyParts(size), [size]);
 
     const w = size * ASPECT + PAD * 2;
     const h = size + PAD * 2;
 
     // Diagonal iridescence band whose endpoints slide with tilt — the SAME motion
-    // as the card's guilloché, so the mark shimmers in step with the hologram.
+    // as the card's guilloché, so the foil shifts colour in step with the hologram.
     const start = useDerivedValue(() => vec(w * (-0.3 + nx.value * 0.6), h * (-0.3 + ny.value * 0.6)));
     const end = useDerivedValue(() => vec(w * (1.3 + nx.value * 0.6), h * (1.3 + ny.value * 0.6)));
-    // Reads clearly at rest (small mark) and flares as you tilt.
-    const opacity = useDerivedValue(() => Math.min(1, 0.55 + mag.value * 0.45));
+    // Always clearly visible (it's the logo), with a small flare on tilt.
+    const opacity = useDerivedValue(() => Math.min(1, 0.9 + mag.value * 0.1));
 
-    if (!mark) return null;
+    if (!parts) return null;
 
     return (
         <Canvas style={{ width: w, height: h }} pointerEvents="none">
-            {/* Faint engraved base so the mark stays legible where the band is dim. */}
-            <Path path={mark} style="stroke" strokeWidth={0.8} color="rgba(120,120,140,0.32)" />
-            {/* Tilt-driven iridescence on the same lines. */}
+            {/* Foil body: the Oxy silhouette + inner detail, filled with the
+                tilt-driven iridescence in place of the solid brand colour. */}
             <Group opacity={opacity}>
-                <Path path={mark} style="stroke" strokeWidth={1}>
+                <Path path={parts.outer}>
+                    <LinearGradient start={start} end={end} colors={IRIDESCENT} />
+                </Path>
+                <Path path={parts.inner}>
                     <LinearGradient start={start} end={end} colors={IRIDESCENT} />
                 </Path>
             </Group>
+            {/* Interior marks, white on top — exactly as in the brand logo. */}
+            <Path path={parts.letters} color="#FFFFFF" />
         </Canvas>
     );
 };

--- a/packages/commons/components/OxyID/holographic-logo.tsx
+++ b/packages/commons/components/OxyID/holographic-logo.tsx
@@ -15,7 +15,7 @@
 
 import { type FC, useMemo } from 'react';
 
-import { Canvas, Group, LinearGradient, Path, Skia, vec } from '@shopify/react-native-skia';
+import { Canvas, Group, LinearGradient, Path, PathOp, Skia, vec } from '@shopify/react-native-skia';
 import { useDerivedValue } from 'react-native-reanimated';
 
 import { useTilt } from './tilt-context';
@@ -51,7 +51,14 @@ const buildOxyParts = (size: number) => {
     outer.transform(scale);
     inner.transform(scale);
     letters.transform(scale);
-    return { outer, inner, letters };
+
+    // Merge the silhouette + inner detail into one foil body so it fills with a
+    // single gradient. A true UNION (not addPath) makes the single fill identical
+    // to painting both layers — no winding cancellation where they overlap.
+    if (!outer.op(inner, PathOp.Union)) {
+        outer.addPath(inner);
+    }
+    return { body: outer, letters };
 };
 
 interface HolographicLogoProps {
@@ -69,8 +76,9 @@ export const HolographicLogo: FC<HolographicLogoProps> = ({ size = 22 }) => {
 
     // Diagonal iridescence band whose endpoints slide with tilt — the SAME motion
     // as the card's guilloché, so the foil shifts colour in step with the hologram.
-    const start = useDerivedValue(() => vec(w * (-0.3 + nx.value * 0.6), h * (-0.3 + ny.value * 0.6)));
-    const end = useDerivedValue(() => vec(w * (1.3 + nx.value * 0.6), h * (1.3 + ny.value * 0.6)));
+    // `w`/`h` are render-scope values, so declare them as explicit deps.
+    const start = useDerivedValue(() => vec(w * (-0.3 + nx.value * 0.6), h * (-0.3 + ny.value * 0.6)), [w, h]);
+    const end = useDerivedValue(() => vec(w * (1.3 + nx.value * 0.6), h * (1.3 + ny.value * 0.6)), [w, h]);
     // Always clearly visible (it's the logo), with a small flare on tilt.
     const opacity = useDerivedValue(() => Math.min(1, 0.9 + mag.value * 0.1));
 
@@ -81,10 +89,7 @@ export const HolographicLogo: FC<HolographicLogoProps> = ({ size = 22 }) => {
             {/* Foil body: the Oxy silhouette + inner detail, filled with the
                 tilt-driven iridescence in place of the solid brand colour. */}
             <Group opacity={opacity}>
-                <Path path={parts.outer}>
-                    <LinearGradient start={start} end={end} colors={IRIDESCENT} />
-                </Path>
-                <Path path={parts.inner}>
+                <Path path={parts.body}>
                     <LinearGradient start={start} end={end} colors={IRIDESCENT} />
                 </Path>
             </Group>


### PR DESCRIPTION
Fixes the badly-rendered Oxy issuer mark from #599.

**Problem:** the Oxy mark is a *solid* brand shape (overlapping-lens silhouette + inner detail + white interior marks). Stroking it — the treatment that suits the line-based Commons emblem — broke it into loose, misaligned construction outlines that didn't read as the logo (a flower + a stray fingerprint offset to the side).

**Fix:** keep the mark's true form and swap the solid brand fill for the same tilt-driven iridescent gradient the guilloché uses — a **foil-stamped** Oxy logo that shifts colour as the phone turns, interior marks left white exactly as in the brand logo. Uses the identical `LogoIcon` paths + transforms + layer order (outer → inner → white letters), so the silhouette is byte-faithful to the real logo; only the colour changes.

Verified on a Pixel 10 Pro — clean, recognizable foil mark on all three faces (front / public-key / QR), upright on the counter-mirrored back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->