### PR TITLE
fix(services): ship only native sources, not android/build artifacts

### DIFF
--- a/packages/services/.npmignore
+++ b/packages/services/.npmignore
@@ -12,6 +12,16 @@ node_modules/
 *.log
 .DS_Store
 
+# Native build outputs — regenerated per-app at autolink/build time. Only the
+# sources (android/src, android/build.gradle, ios/*.swift, ios/*.podspec,
+# expo-module.config.json) ship; compiled artifacts must NOT bloat the tarball.
+android/build
+android/.gradle
+android/.cxx
+ios/build
+ios/Pods
+*.tgz
+
 # Tests
 **/*.test.ts
 **/*.spec.ts

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -68,8 +68,10 @@
     "src",
     "lib",
     "assets",
-    "android",
-    "ios",
+    "android/build.gradle",
+    "android/src",
+    "ios/OxyIdentityModule.swift",
+    "ios/OxyIdentity.podspec",
     "plugins",
     "expo-module.config.json"
   ],


### PR DESCRIPTION
Follow-up to #601. `files: ["android"]` bundled the whole Gradle `build/` output into the npm tarball. List specific source paths instead (`android/build.gradle`, `android/src`, iOS swift+podspec). Verified: tarball has 0 `android/build/` entries, all `.kt`/manifest/podspec/plugins present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)