### PR TITLE
fix(api): exempt internal /federation/* from browser rate-limit + slowDown

### DIFF
--- a/packages/api/src/middleware/__tests__/federationServiceRateLimit.test.ts
+++ b/packages/api/src/middleware/__tests__/federationServiceRateLimit.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Federation sign-on-behalf server-to-server rate-limit exemption.
+ *
+ * Relying-app backends (e.g. Mention) call the federation surface
+ * server-to-server via a `federation:write` service token, from a SINGLE NAT
+ * egress IP:
+ *
+ *   - POST /federation/sign            (HTTP-Signature signing on behalf)
+ *   - GET  /federation/public-key/:u   (publish an actor's public key block)
+ *   - POST /federation/follow          (mirror a remote follow into the graph)
+ *
+ * These MUST NOT share the per-IP browser budget (`rl:general`, 1000/15min): an
+ * outbox backfill / delivery fan-out legitimately signs tens of thousands of
+ * requests through that one IP, so browser-scale limiting exhausts the budget in
+ * seconds → 429 → outbound federation silently degrades (the empirically
+ * observed prod failure: single calls succeed, a sustained ~25 req/s backfill
+ * fails ~98%). This suite proves the exported general limiter SKIPS these paths
+ * and that they instead carry the dedicated high-ceiling
+ * `federationServiceLimiter`.
+ *
+ * MOUNT-ORDER INVARIANT (documented, enforced by these tests): every path
+ * matched by `isFederationServiceToServicePath` is excluded from `rl:general`,
+ * so the `/federation` mount MUST carry `federationServiceLimiter`.
+ * `isFederationServiceToServicePath` and the router wiring must be kept in sync.
+ */
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+import {
+  rateLimiter,
+  federationServiceLimiter,
+  isFederationServiceToServicePath,
+} from '../security';
+
+interface Probe {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+}
+
+function get(server: http.Server, path: string): Promise<Probe> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method: 'GET', host: '127.0.0.1', port: address.port, path },
+      (res) => {
+        res.on('data', () => undefined);
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function hasRateLimitHeaders(headers: http.IncomingHttpHeaders): boolean {
+  return Object.keys(headers).some((h) => h.toLowerCase().startsWith('ratelimit'));
+}
+
+function listen(app: express.Express): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe('isFederationServiceToServicePath', () => {
+  it('matches the federation sign-on-behalf surface', () => {
+    expect(isFederationServiceToServicePath('/federation/sign')).toBe(true);
+    expect(isFederationServiceToServicePath('/federation/public-key/alice')).toBe(true);
+    expect(isFederationServiceToServicePath('/federation/follow')).toBe(true);
+  });
+
+  it('does NOT match unrelated paths that must stay under the general budget', () => {
+    // Browser-reachable ActivityPub/webfinger surfaces live on other prefixes.
+    expect(isFederationServiceToServicePath('/ap/users/alice')).toBe(false);
+    expect(isFederationServiceToServicePath('/.well-known/webfinger')).toBe(false);
+    expect(isFederationServiceToServicePath('/users/me')).toBe(false);
+    expect(isFederationServiceToServicePath('/')).toBe(false);
+    // The bare mount without a trailing slash is not a real route.
+    expect(isFederationServiceToServicePath('/federation')).toBe(false);
+  });
+});
+
+describe('general limiter (rl:general) exempts federation service paths', () => {
+  let server: http.Server;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(rateLimiter);
+    app.all('*', (_req, res) => res.json({ ok: true }));
+    server = await listen(app);
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it('does not consume / emit the general budget on exempt paths', async () => {
+    for (const path of [
+      '/federation/sign',
+      '/federation/public-key/alice',
+      '/federation/follow',
+    ]) {
+      const res = await get(server, path);
+      expect(res.status).toBe(200);
+      // A skipped request never touches the store and emits NO RateLimit
+      // headers — proof it does not draw down the per-IP browser budget.
+      expect(hasRateLimitHeaders(res.headers)).toBe(false);
+    }
+  });
+
+  it('still enforces the general budget on non-federation paths', async () => {
+    const res = await get(server, '/users/me');
+    expect(res.status).toBe(200);
+    expect(hasRateLimitHeaders(res.headers)).toBe(true);
+    // NODE_ENV is not "development" under jest → production ceiling of 1000.
+    expect(res.headers['ratelimit-limit']).toBe('1000');
+  });
+});
+
+describe('federationServiceLimiter (rl:federation:service) is the dedicated high-cap limiter', () => {
+  let server: http.Server;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(federationServiceLimiter);
+    app.all('*', (_req, res) => res.json({ ok: true }));
+    server = await listen(app);
+  });
+
+  afterAll(async () => {
+    await close(server);
+  });
+
+  it('enforces a ceiling far above the general per-IP budget', async () => {
+    const res = await get(server, '/federation/sign');
+    expect(res.status).toBe(200);
+    expect(hasRateLimitHeaders(res.headers)).toBe(true);
+    // 60x the general 1000 ceiling — sized for a relying app's outbox
+    // backfill / delivery fan-out through one NAT IP; a distinct instance from
+    // rl:general (different limit proves distinctness).
+    expect(res.headers['ratelimit-limit']).toBe('60000');
+    expect(res.headers['ratelimit-limit']).not.toBe('1000');
+  });
+});

--- a/packages/api/src/middleware/__tests__/idpServiceRateLimitPrefix.test.ts
+++ b/packages/api/src/middleware/__tests__/idpServiceRateLimitPrefix.test.ts
@@ -38,10 +38,20 @@ describe('security.ts limiter prefixes are unique', () => {
     expect(capturedPrefixes).toContain('rl:idp:service:');
   });
 
+  it('registers the dedicated federation service limiter with rl:federation:service:', () => {
+    expect(capturedPrefixes).toContain('rl:federation:service:');
+  });
+
   it('keeps every limiter prefix distinct (no ERR_ERL_DOUBLE_COUNT)', () => {
-    // The four Redis-backed limiters defined in security.ts. slowDown's
+    // The five Redis-backed limiters defined in security.ts. slowDown's
     // bruteForceProtection uses an in-memory store (no prefix), so it is absent.
-    const securityPrefixes = ['rl:general:', 'rl:idp:service:', 'rl:auth:', 'rl:user:'];
+    const securityPrefixes = [
+      'rl:general:',
+      'rl:idp:service:',
+      'rl:federation:service:',
+      'rl:auth:',
+      'rl:user:',
+    ];
 
     for (const prefix of securityPrefixes) {
       // Present, and registered EXACTLY once — a duplicate would double-count.

--- a/packages/api/src/middleware/security.ts
+++ b/packages/api/src/middleware/security.ts
@@ -49,6 +49,35 @@ export function isIdpServiceToServicePath(path: string): boolean {
   return path.startsWith('/session/validate/');
 }
 
+/**
+ * Paths hit ONLY by relying-app backends server-to-server via a `federation:write`
+ * service token, never by a browser directly — the federation sign-on-behalf
+ * surface:
+ *   - POST /federation/sign            (HTTP-Signature signing on behalf)
+ *   - GET  /federation/public-key/:u   (publish an actor's public key block)
+ *   - POST /federation/follow          (mirror a remote follow into the graph)
+ *
+ * Every route under `/federation/` is gated by `serviceAuthMiddleware`, so the
+ * whole prefix is service-to-service. A relying app (e.g. Mention) fans ALL of
+ * its outbound ActivityPub signing through a SINGLE NAT egress IP — an outbox
+ * backfill or a large delivery fan-out legitimately signs tens of thousands of
+ * requests in a burst. Subjecting that to the per-IP browser budget
+ * (`rl:general`, 1000/15min) exhausts the shared budget in seconds → 429 → ALL
+ * of that app's federation signing (and every other oxy-api call from the same
+ * IP) fails intermittently, silently degrading outbound federation. So these
+ * paths are excluded from the general per-IP limiter (and the slowDown latency
+ * penalty) and capped instead by their own dedicated high-ceiling limiter
+ * (`federationServiceLimiter`).
+ *
+ * MOUNT-ORDER INVARIANT: the general `rateLimiter` skips these paths, so the
+ * `/federation` mount MUST carry `federationServiceLimiter` (it does, in
+ * server.ts). Adding a path here without that dedicated limiter would leave it
+ * entirely unthrottled.
+ */
+export function isFederationServiceToServicePath(path: string): boolean {
+  return path.startsWith('/federation/');
+}
+
 // General rate limiting middleware (exclude file uploads). The previous
 // ceiling of 150/15min was below what a single signed-in user generates
 // against the API in normal usage (feed scrolling, profile loads, sockets'
@@ -64,7 +93,34 @@ const rateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   skip: (req: Request) =>
-    req.path.startsWith('/files/upload') || isIdpServiceToServicePath(req.path),
+    req.path.startsWith('/files/upload') ||
+    isIdpServiceToServicePath(req.path) ||
+    isFederationServiceToServicePath(req.path),
+});
+
+// Dedicated high-ceiling limiter for the federation sign-on-behalf surface
+// (see isFederationServiceToServicePath: /federation/*). Because those paths are
+// skipped by rl:general, this is their SOLE per-IP budget. Mounted at the
+// `/federation` router in server.ts so it also bounds unauthenticated floods
+// (it runs before serviceAuthMiddleware).
+//
+// The ceiling is deliberately high: a relying app's outbox backfill / delivery
+// fan-out signs tens of thousands of requests through ONE NAT egress IP. Sizing
+// for the empirical worst case — a sustained ~25 req/s backfill (a 12k-post
+// reconciliation) plus concurrent live delivery — needs well above the general
+// 1000/15min: 60000/15min ≈ 66 req/s sustained is ~2.6x that peak, with room
+// for live traffic, while still bounding a runaway loop or a compromised
+// credential (whose signatures are already domain-scoped to its own actor).
+// Unique prefix (`rl:federation:service:`) keeps this budget distinct from every
+// other limiter (no ERR_ERL_DOUBLE_COUNT).
+const federationServiceLimiter = rateLimit({
+  ...makeStore('rl:federation:service:'),
+  windowMs: 15 * 60 * 1000,
+  max: isProd ? 60000 : 120000,
+  message: "Too many federation signing requests, please slow down.",
+  standardHeaders: true,
+  legacyHeaders: false,
+  skip: (req: Request) => req.path.startsWith('/files/upload'),
 });
 
 // Dedicated high-ceiling limiter for the IdP worker's server-to-server READ
@@ -128,7 +184,9 @@ const bruteForceProtection = slowDown({
   delayAfter: isProd ? 100 : 1000,
   delayMs: () => isProd ? 500 : 100,
   skip: (req: Request) =>
-    req.path.startsWith('/files/upload') || isIdpServiceToServicePath(req.path),
+    req.path.startsWith('/files/upload') ||
+    isIdpServiceToServicePath(req.path) ||
+    isFederationServiceToServicePath(req.path),
 });
 
 /**
@@ -179,4 +237,4 @@ const securityHeaders = helmet({
   // X-Permitted-Cross-Domain-Policies: Restrict Adobe Flash and PDF
 });
 
-export { rateLimiter, idpServiceLimiter, authRateLimiter, userRateLimiter, bruteForceProtection, securityHeaders };
+export { rateLimiter, idpServiceLimiter, federationServiceLimiter, authRateLimiter, userRateLimiter, bruteForceProtection, securityHeaders };

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -11,7 +11,7 @@ import dotenv from "dotenv";
 import User, { IUser } from "./models/User";
 import { ensureFileSha256LiveUniqueIndex } from "./models/File";
 import searchRoutes from "./routes/search";
-import { rateLimiter, authRateLimiter, userRateLimiter, bruteForceProtection, securityHeaders } from "./middleware/security";
+import { rateLimiter, authRateLimiter, userRateLimiter, federationServiceLimiter, bruteForceProtection, securityHeaders } from "./middleware/security";
 import privacyRoutes from "./routes/privacy";
 import analyticsRoutes from "./routes/analytics.routes";
 import paymentRoutes from './routes/payment.routes';
@@ -683,7 +683,14 @@ app.get('/.well-known/webfinger', async (req: any, res: Response) => {
 // service token with the `federation:write` scope and bound to the credential's
 // own registered domain. The legacy `GET /federation/keypair/:username` route —
 // which returned `privateKeyPem` — has been removed in favour of these.
-app.use('/federation', federationRoutes);
+// The federation sign-on-behalf surface is service-to-service (federation:write
+// service token) and legitimately high-frequency: a relying app fans its whole
+// outbound-signing workload (outbox backfill, delivery fan-out) through one NAT
+// egress IP. It is therefore EXCLUDED from the per-IP browser budget (rl:general)
+// — which a backfill would exhaust in seconds → 429 → silent federation outage —
+// and capped instead by this dedicated high-ceiling limiter. Mounted before the
+// router so it also bounds unauthenticated floods.
+app.use('/federation', federationServiceLimiter, federationRoutes);
 
 // Self-sovereign DID documents (did:web). Public, cacheable, CORS-open, no
 // auth/CSRF — served at the API root beside the WebFinger/ActivityPub handlers


### PR DESCRIPTION
## Root cause (prod-verified)
`POST /federation/sign` is a high-frequency internal service-to-service endpoint — Mention signs every outbound ActivityPub request through it — but it sat behind the per-IP **browser** protections:
- `rl:general` limiter: **1000 req / 15 min / IP** (`middleware/security.ts`)
- `bruteForceProtection` slowDown: **+500ms/req after 100/15min/IP**

All of Mention's outbound federation egresses **one NAT IP**, so:
- **Sustained load** (a ~25 req/s author backfill) blew the 1000/15min budget in ~40s → every subsequent `/federation/sign` **429'd** for the rest of the window. Measured: **11,798 of 11,967** signs failed. The 429 is invisible in oxy-api logs.
- **Steady state**: the slowDown penalty added **1–3.3s** latency to `/sign` in a *quiet* window (**46 of 92** calls flagged `Slow request`), intermittently timing out remote-actor fetches / outbox sync / delivery → the live federation degradation.

## Fix
Mirrors the existing IdP service-to-service precedent (`isIdpServiceToServicePath`):
- Skip both the general limiter **and** slowDown for the `/federation/*` prefix (every route there is `serviceAuth`-gated).
- Add a dedicated, uniquely-prefixed `federationServiceLimiter` (`rl:federation:service:`, **60000/15min ≈ 66 req/s** — 2.6× the observed peak, still bounds a runaway/compromised credential), mounted **before** the router so unauthenticated floods stay bounded.

## Tests
- New `federationServiceRateLimit.test.ts` (general limiter skips `/federation/*`; dedicated limiter enforces the ceiling; path predicate).
- Updated `idpServiceRateLimitPrefix.test.ts` (asserts `rl:federation:service:` present + all prefixes distinct).
- 18 touched tests pass; `tsc --noEmit` clean.

## Verify post-deploy
The `"Slow request: POST /federation/sign"` warnings should vanish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)