### PR TITLE
fix(api): exempt service-to-service /users/resolve + /assets/service/* from browser rate-limit

### DIFF
--- a/packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts
+++ b/packages/api/src/middleware/__tests__/optionalAuth.dualAuth.test.ts
@@ -2,7 +2,7 @@
  * optionalUserOrServiceAuth + resolveViewerId — the dual-auth viewer resolution
  * for the recommendation surface.
  *
- * The token-verification primitives (`verifyServiceToken` from ./auth,
+ * The token-verification primitives (`verifyServiceToken` from ./serviceToken,
  * `authenticateRequestNonBlocking` from ./authUtils) are mocked so we exercise
  * the REAL middleware/resolver branching without a DB or real JWTs.
  *
@@ -24,7 +24,7 @@ import { Types } from 'mongoose';
 import type { Response } from 'express';
 
 const mockVerifyServiceToken = jest.fn();
-jest.mock('../auth', () => ({
+jest.mock('../serviceToken', () => ({
   __esModule: true,
   verifyServiceToken: (...args: unknown[]) => mockVerifyServiceToken(...args),
 }));

--- a/packages/api/src/middleware/__tests__/serviceBulkRateLimit.test.ts
+++ b/packages/api/src/middleware/__tests__/serviceBulkRateLimit.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Token-gated service-to-service BULK-path rate-limit exemption.
+ *
+ * Some oxy-api endpoints are EXCLUSIVELY service-to-service (serviceAuth-gated)
+ * yet live under a user-facing prefix, and a relying app's federation backfill
+ * calls them in BULK through ONE NAT egress IP:
+ *   - PUT  /users/resolve             (find-or-create a federated/agent user)
+ *   - POST /assets/service/cache      (mirror remote media into the cache ns)
+ *   - POST /assets/service/federation (persist durable federated media)
+ *   - POST /assets/service/user-media (persist media for a local user; MCP)
+ *
+ * Like `/federation/*` (#604), these must NOT share the per-IP browser budget
+ * (`rl:general`, 1000/15min) — a backfill exhausts it and 429s legitimate bulk
+ * resolves/uploads. But UNLIKE `/federation/*` (whose whole prefix is
+ * service-only), these share a prefix with browser routes, so the exemption is
+ * gated on the request carrying a VALID service token: `isServiceToServiceBulkRequest`.
+ * This suite proves (a) the predicate only exempts an exempt path WITH a valid
+ * service token, (b) the general limiter honours that, and — critically —
+ * (c) sibling user-facing routes and unauthenticated/user-token traffic KEEP the
+ * per-IP protection.
+ */
+
+// This file needs the REAL jsonwebtoken (the global jest.setup.cjs mocks it) so
+// `verifyServiceToken` actually validates a minted service token.
+jest.mock('jsonwebtoken', () => jest.requireActual('jsonwebtoken'));
+
+import express from 'express';
+import http from 'http';
+import jwt from 'jsonwebtoken';
+import type { AddressInfo } from 'net';
+import type { Request } from 'express';
+
+const ACCESS_TOKEN_SECRET = 'test_access_token_secret_minimum_32_characters';
+process.env.ACCESS_TOKEN_SECRET = ACCESS_TOKEN_SECRET;
+
+import { rateLimiter, isServiceToServiceBulkRequest } from '../security';
+
+function serviceToken(overrides: Record<string, unknown> = {}): string {
+  return jwt.sign(
+    {
+      type: 'service',
+      appId: 'app-1',
+      appName: 'Mention',
+      credentialId: 'cred-1',
+      scopes: ['federation:write'],
+      ...overrides,
+    },
+    ACCESS_TOKEN_SECRET,
+    { expiresIn: '5m' }
+  );
+}
+
+function userSessionToken(): string {
+  return jwt.sign({ userId: 'u-1', sessionId: 's-1' }, ACCESS_TOKEN_SECRET, { expiresIn: '5m' });
+}
+
+function makeReq(path: string, authorization?: string): Request {
+  return { path, headers: authorization ? { authorization } : {} } as unknown as Request;
+}
+
+interface Probe {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+}
+
+function request(
+  server: http.Server,
+  opts: { method: string; path: string; authorization?: string }
+): Promise<Probe> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string> = {};
+    if (opts.authorization) headers.authorization = opts.authorization;
+    const req = http.request(
+      { method: opts.method, host: '127.0.0.1', port: address.port, path: opts.path, headers },
+      (res) => {
+        res.on('data', () => undefined);
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers }));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function hasRateLimitHeaders(headers: http.IncomingHttpHeaders): boolean {
+  return Object.keys(headers).some((h) => h.toLowerCase().startsWith('ratelimit'));
+}
+
+describe('isServiceToServiceBulkRequest', () => {
+  it('exempts an exempt path WITH a valid service token', () => {
+    for (const path of [
+      '/users/resolve',
+      '/assets/service/cache',
+      '/assets/service/federation',
+      '/assets/service/user-media',
+    ]) {
+      expect(isServiceToServiceBulkRequest(makeReq(path, `Bearer ${serviceToken()}`))).toBe(true);
+    }
+  });
+
+  it('does NOT exempt an exempt path WITHOUT a token (unauthenticated flood stays capped)', () => {
+    expect(isServiceToServiceBulkRequest(makeReq('/users/resolve'))).toBe(false);
+  });
+
+  it('does NOT exempt an exempt path carrying a USER session token', () => {
+    expect(isServiceToServiceBulkRequest(makeReq('/users/resolve', `Bearer ${userSessionToken()}`))).toBe(false);
+  });
+
+  it('does NOT exempt an exempt path carrying a garbage/invalid token', () => {
+    expect(isServiceToServiceBulkRequest(makeReq('/users/resolve', 'Bearer not-a-jwt'))).toBe(false);
+  });
+
+  it('does NOT exempt a sibling USER-FACING route even WITH a valid service token', () => {
+    // The exemption is an exact-path allow-list: /users/me keeps browser protection.
+    expect(isServiceToServiceBulkRequest(makeReq('/users/me', `Bearer ${serviceToken()}`))).toBe(false);
+    expect(isServiceToServiceBulkRequest(makeReq('/users/app-1', `Bearer ${serviceToken()}`))).toBe(false);
+    expect(isServiceToServiceBulkRequest(makeReq('/assets/upload', `Bearer ${serviceToken()}`))).toBe(false);
+  });
+});
+
+describe('general limiter (rl:general) honours the token-gated exemption', () => {
+  let server: http.Server;
+
+  beforeAll(async () => {
+    const app = express();
+    app.use(rateLimiter);
+    app.all('*', (_req, res) => res.json({ ok: true }));
+    server = await new Promise<http.Server>((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('SKIPS /users/resolve when a valid service token is present (no budget drawdown)', async () => {
+    const res = await request(server, {
+      method: 'PUT',
+      path: '/users/resolve',
+      authorization: `Bearer ${serviceToken()}`,
+    });
+    expect(res.status).toBe(200);
+    expect(hasRateLimitHeaders(res.headers)).toBe(false);
+  });
+
+  it('STILL enforces /users/resolve for an unauthenticated request', async () => {
+    const res = await request(server, { method: 'PUT', path: '/users/resolve' });
+    expect(res.status).toBe(200);
+    expect(hasRateLimitHeaders(res.headers)).toBe(true);
+    // NODE_ENV is not "development" under jest → production ceiling of 1000.
+    expect(res.headers['ratelimit-limit']).toBe('1000');
+  });
+
+  it('STILL enforces a sibling user-facing route (/users/me) even with a service token', async () => {
+    const res = await request(server, {
+      method: 'GET',
+      path: '/users/me',
+      authorization: `Bearer ${serviceToken()}`,
+    });
+    expect(res.status).toBe(200);
+    expect(hasRateLimitHeaders(res.headers)).toBe(true);
+    expect(res.headers['ratelimit-limit']).toBe('1000');
+  });
+
+  it('SKIPS the /assets/service/* upload paths with a valid service token', async () => {
+    for (const path of [
+      '/assets/service/cache',
+      '/assets/service/federation',
+      '/assets/service/user-media',
+    ]) {
+      const res = await request(server, { method: 'POST', path, authorization: `Bearer ${serviceToken()}` });
+      expect(res.status).toBe(200);
+      expect(hasRateLimitHeaders(res.headers)).toBe(false);
+    }
+  });
+});

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import { logger } from '../utils/logger';
 import type { Document } from 'mongoose';
 import sessionService from '../services/session.service';
+import { verifyServiceToken, type ServiceTokenPayload } from './serviceToken';
 import {
   extractTokenFromRequest,
   decodeToken,
@@ -199,23 +200,6 @@ export const authMiddleware = async (req: AuthRequest, res: Response, next: Next
 };
 
 /**
- * Decoded payload for service-to-service JWTs minted via
- * `POST /auth/service-token`. Carries the `scopes` granted to the
- * Application so downstream middleware can do per-scope authorisation.
- * The `appId` claim is the Application `_id`.
- */
-export interface ServiceTokenPayload {
-  type: 'service';
-  appId: string;
-  appName: string;
-  /** The specific ApplicationCredential `_id` that minted this token. */
-  credentialId: string;
-  scopes: string[];
-  iat?: number;
-  exp?: number;
-}
-
-/**
  * Request augmented by `serviceAuthMiddleware` with the verified service
  * principal. Routes can read `req.serviceApp.scopes` to gate sensitive
  * actions.
@@ -239,81 +223,6 @@ export interface ServiceAuthRequest extends Request {
  * @param res - Express response object
  * @param next - Express next function
  */
-/**
- * Outcome of {@link verifyServiceToken}. The verification is deliberately
- * tri-state so callers can produce the precise 4xx (blocking middleware) or
- * silently fall back to anonymous (non-blocking optional auth):
- *  - `{ ok: true, payload }` — a valid `service`-type token.
- *  - `{ ok: false, reason: 'not_service' }` — verified, but not a service token
- *    (a user session token, or missing required service claims).
- *  - `{ ok: false, reason: 'expired' | 'invalid' }` — verification failed.
- */
-export type ServiceTokenVerification =
-  | { ok: true; payload: ServiceTokenPayload }
-  | { ok: false; reason: 'not_service' | 'expired' | 'invalid' };
-
-/**
- * Pure verification of a service JWT. SINGLE SOURCE OF TRUTH for the service
- * token contract — both the blocking `serviceAuthMiddleware` and any optional /
- * dual-auth path verify through here so they cannot drift. Performs the full
- * `jwt.verify` (signature + expiry) and the required-claim checks; never throws.
- */
-export function verifyServiceToken(token: string): ServiceTokenVerification {
-  if (!process.env.ACCESS_TOKEN_SECRET) {
-    logger.error('ACCESS_TOKEN_SECRET not configured');
-    return { ok: false, reason: 'invalid' };
-  }
-
-  let decoded: {
-    type?: string;
-    appId?: string;
-    appName?: string;
-    credentialId?: string;
-    scopes?: unknown;
-    iat?: number;
-    exp?: number;
-    [key: string]: unknown;
-  };
-  try {
-    decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET) as typeof decoded;
-  } catch (error) {
-    if (error instanceof jwt.TokenExpiredError) {
-      return { ok: false, reason: 'expired' };
-    }
-    return { ok: false, reason: 'invalid' };
-  }
-
-  if (decoded.type !== 'service') {
-    return { ok: false, reason: 'not_service' };
-  }
-
-  if (
-    typeof decoded.appId !== 'string' ||
-    typeof decoded.appName !== 'string' ||
-    typeof decoded.credentialId !== 'string' ||
-    decoded.credentialId.length === 0
-  ) {
-    return { ok: false, reason: 'not_service' };
-  }
-
-  const scopes = Array.isArray(decoded.scopes)
-    ? decoded.scopes.filter((s): s is string => typeof s === 'string')
-    : [];
-
-  return {
-    ok: true,
-    payload: {
-      type: 'service',
-      appId: decoded.appId,
-      appName: decoded.appName,
-      credentialId: decoded.credentialId,
-      scopes,
-      iat: decoded.iat,
-      exp: decoded.exp,
-    },
-  };
-}
-
 export const serviceAuthMiddleware = (req: ServiceAuthRequest, res: Response, next: NextFunction) => {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {

--- a/packages/api/src/middleware/optionalAuth.ts
+++ b/packages/api/src/middleware/optionalAuth.ts
@@ -10,7 +10,7 @@ import type { Response, NextFunction } from 'express';
 import { Types } from 'mongoose';
 import { logger } from '../utils/logger';
 import { authenticateRequestNonBlocking, type AuthenticatedRequest, extractTokenFromRequest, decodeToken, validateSessionToken } from './authUtils';
-import { verifyServiceToken, type ServiceTokenPayload } from './auth';
+import { verifyServiceToken, type ServiceTokenPayload } from './serviceToken';
 
 /**
  * Optional authentication middleware

--- a/packages/api/src/middleware/security.ts
+++ b/packages/api/src/middleware/security.ts
@@ -6,6 +6,7 @@ import { RedisStore } from "rate-limit-redis";
 import type { RedisReply } from "rate-limit-redis";
 import { getRedisClient } from "../config/redis";
 import type { AuthRequest } from "./auth";
+import { verifyServiceToken } from "./serviceToken";
 
 const isProd = process.env.NODE_ENV !== 'development';
 
@@ -78,6 +79,53 @@ export function isFederationServiceToServicePath(path: string): boolean {
   return path.startsWith('/federation/');
 }
 
+/**
+ * Exact paths that are EXCLUSIVELY service-to-service (each gated by
+ * `serviceAuthMiddleware`) yet live UNDER a user-facing prefix, and that a
+ * relying app's federation/connectors backfill calls in BULK — all fanned
+ * through ONE NAT egress IP:
+ *   - PUT  /users/resolve             (find-or-create a federated/agent user)
+ *   - POST /assets/service/cache      (mirror remote media into the cache ns)
+ *   - POST /assets/service/federation (persist durable federated media)
+ *   - POST /assets/service/user-media (persist media for a local user; MCP)
+ *
+ * Because these share a prefix with genuine browser/user routes (`/users/*`,
+ * `/assets/*`), a PURE path match — as used for the IdP worker / federation
+ * paths, whose whole prefix is service-only — is unsafe here: it could exempt a
+ * future sibling browser route and would leave UNauthenticated floods of the
+ * path unbounded. The exemption is therefore additionally gated on the request
+ * carrying a VALID service token (see {@link isServiceToServiceBulkRequest}).
+ *
+ * The `/api/` prefix is already stripped by the time the limiters run (the strip
+ * middleware is mounted before them), so the bare forms suffice.
+ */
+const SERVICE_TO_SERVICE_BULK_PATHS: ReadonlySet<string> = new Set([
+  '/users/resolve',
+  '/assets/service/cache',
+  '/assets/service/federation',
+  '/assets/service/user-media',
+]);
+
+/**
+ * True when the request targets a {@link SERVICE_TO_SERVICE_BULK_PATHS} path AND
+ * carries a valid `service`-type token. Used to exempt genuine internal backfill
+ * traffic from the per-IP BROWSER protections (rl:general + slowDown) WITHOUT
+ * weakening them for user-facing traffic or unauthenticated floods — anything
+ * lacking a valid service token is NOT exempted and stays under the general
+ * per-IP budget.
+ *
+ * MOUNT-ORDER INVARIANT: every exempt path MUST carry its own dedicated service
+ * limiter at its route — `/users/resolve` → `userResolveServiceLimiter`
+ * (routes/users.ts), `/assets/service/*` → `cacheUploadLimiter` (routes/assets.ts).
+ * The path set here and those route limiters must be kept in sync.
+ */
+export function isServiceToServiceBulkRequest(req: Request): boolean {
+  if (!SERVICE_TO_SERVICE_BULK_PATHS.has(req.path)) return false;
+  const authHeader = req.headers.authorization;
+  if (!authHeader?.startsWith('Bearer ')) return false;
+  return verifyServiceToken(authHeader.slice('Bearer '.length)).ok;
+}
+
 // General rate limiting middleware (exclude file uploads). The previous
 // ceiling of 150/15min was below what a single signed-in user generates
 // against the API in normal usage (feed scrolling, profile loads, sockets'
@@ -95,7 +143,8 @@ const rateLimiter = rateLimit({
   skip: (req: Request) =>
     req.path.startsWith('/files/upload') ||
     isIdpServiceToServicePath(req.path) ||
-    isFederationServiceToServicePath(req.path),
+    isFederationServiceToServicePath(req.path) ||
+    isServiceToServiceBulkRequest(req),
 });
 
 // Dedicated high-ceiling limiter for the federation sign-on-behalf surface
@@ -186,7 +235,8 @@ const bruteForceProtection = slowDown({
   skip: (req: Request) =>
     req.path.startsWith('/files/upload') ||
     isIdpServiceToServicePath(req.path) ||
-    isFederationServiceToServicePath(req.path),
+    isFederationServiceToServicePath(req.path) ||
+    isServiceToServiceBulkRequest(req),
 });
 
 /**

--- a/packages/api/src/middleware/serviceToken.ts
+++ b/packages/api/src/middleware/serviceToken.ts
@@ -1,0 +1,106 @@
+import jwt from 'jsonwebtoken';
+import { logger } from '../utils/logger';
+
+/**
+ * Service-token verification — the pure JWT half of the service-auth contract.
+ *
+ * Kept in its OWN module (importing only `jsonwebtoken` + `logger`) so it can be
+ * reused by request-path code — the blocking `serviceAuthMiddleware`, the
+ * optional/dual-auth path, and the rate-limiter's service-to-service exemption
+ * predicate — WITHOUT dragging in the session-service / Mongoose model graph
+ * that `middleware/auth.ts` pulls in. `verifyServiceToken` is the SINGLE SOURCE
+ * OF TRUTH for the service-token contract; every consumer verifies through here.
+ */
+
+/**
+ * Decoded payload for service-to-service JWTs minted via
+ * `POST /auth/service-token`. Carries the `scopes` granted to the Application so
+ * downstream middleware can do per-scope authorisation. The `appId` claim is the
+ * Application `_id`.
+ */
+export interface ServiceTokenPayload {
+  type: 'service';
+  appId: string;
+  appName: string;
+  /** The specific ApplicationCredential `_id` that minted this token. */
+  credentialId: string;
+  scopes: string[];
+  iat?: number;
+  exp?: number;
+}
+
+/**
+ * Outcome of {@link verifyServiceToken}. The verification is deliberately
+ * tri-state so callers can produce the precise 4xx (blocking middleware) or
+ * silently fall back to anonymous (non-blocking optional auth):
+ *  - `{ ok: true, payload }` — a valid `service`-type token.
+ *  - `{ ok: false, reason: 'not_service' }` — verified, but not a service token
+ *    (a user session token, or missing required service claims).
+ *  - `{ ok: false, reason: 'expired' | 'invalid' }` — verification failed.
+ */
+export type ServiceTokenVerification =
+  | { ok: true; payload: ServiceTokenPayload }
+  | { ok: false; reason: 'not_service' | 'expired' | 'invalid' };
+
+/**
+ * Pure verification of a service JWT. SINGLE SOURCE OF TRUTH for the service
+ * token contract — the blocking `serviceAuthMiddleware`, any optional /
+ * dual-auth path, and the rate-limiter exemption verify through here so they
+ * cannot drift. Performs the full `jwt.verify` (signature + expiry) and the
+ * required-claim checks; never throws.
+ */
+export function verifyServiceToken(token: string): ServiceTokenVerification {
+  if (!process.env.ACCESS_TOKEN_SECRET) {
+    logger.error('ACCESS_TOKEN_SECRET not configured');
+    return { ok: false, reason: 'invalid' };
+  }
+
+  let decoded: {
+    type?: string;
+    appId?: string;
+    appName?: string;
+    credentialId?: string;
+    scopes?: unknown;
+    iat?: number;
+    exp?: number;
+    [key: string]: unknown;
+  };
+  try {
+    decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET) as typeof decoded;
+  } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      return { ok: false, reason: 'expired' };
+    }
+    return { ok: false, reason: 'invalid' };
+  }
+
+  if (decoded.type !== 'service') {
+    return { ok: false, reason: 'not_service' };
+  }
+
+  if (
+    typeof decoded.appId !== 'string' ||
+    typeof decoded.appName !== 'string' ||
+    typeof decoded.credentialId !== 'string' ||
+    decoded.credentialId.length === 0
+  ) {
+    return { ok: false, reason: 'not_service' };
+  }
+
+  const scopes = Array.isArray(decoded.scopes)
+    ? decoded.scopes.filter((s): s is string => typeof s === 'string')
+    : [];
+
+  return {
+    ok: true,
+    payload: {
+      type: 'service',
+      appId: decoded.appId,
+      appName: decoded.appName,
+      credentialId: decoded.credentialId,
+      scopes,
+      iat: decoded.iat,
+      exp: decoded.exp,
+    },
+  };
+}

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -1526,9 +1526,36 @@ async function verifyFederatedWebFingerBinding(username: string, actorUri: strin
   }
 }
 
+/**
+ * Dedicated per-app limiter for PUT /users/resolve — the federated/agent user
+ * find-or-create that a relying app's connectors call in BULK during a backfill
+ * (one resolve per unique external author), all through a single NAT egress IP.
+ *
+ * This path is EXEMPT from the global browser per-IP limiter (rl:general) and the
+ * slowDown penalty (see `isServiceToServiceBulkRequest` in middleware/security),
+ * because that per-IP browser budget — shared across ALL of the app's oxy-api
+ * calls from one NAT IP — 429'd bulk resolves (the same failure mode as the
+ * federation sign surface). This is therefore its dedicated budget. Keyed by the
+ * calling service app id (never the shared NAT IP), sized like
+ * `federationServiceLimiter` (60000/15min ≈ 66 req/s): generous enough for a
+ * large author backfill, still bounding a runaway or compromised credential.
+ * Applied AFTER serviceAuthMiddleware so `req.serviceApp` is populated for the key.
+ */
+const userResolveServiceLimiter = rateLimit({
+  prefix: 'rl:user-resolve:service:',
+  windowMs: 15 * 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 120000 : 60000,
+  message: 'Too many federated-user resolve requests, please slow down.',
+  keyGenerator: (req: Request) => {
+    const appId = (req as ServiceAuthRequest).serviceApp?.appId;
+    return appId ? `app:${appId}` : (req.ip ?? 'unknown');
+  },
+});
+
 router.put(
   '/resolve',
   serviceAuthMiddleware,
+  userResolveServiceLimiter,
   asyncHandler(async (req: ServiceAuthRequest, res: Response) => {
     // Scope gate — only service tokens explicitly granted `federation:write`
     // may create or update federated/agent/automated users.


### PR DESCRIPTION
## Why
Follow-up to #604 (`/federation/sign`). The federated-author backfill — and normal bulk federation — also call two other **service-token-only** oxy-api routes at volume, both of which sat behind the per-IP **browser** protections (`rl:general` 1000/15min + `bruteForceProtection` slowDown). All of Mention's outbound traffic egresses **one NAT IP**, so under bulk load:
- `PUT /users/resolve` (federated-user find-or-create, one per unique remote author) **429'd** — 306 in a 12k-post backfill pass.
- `/assets/service/{cache,federation,user-media}` (banner/media mirroring) ate the 500ms slowDown penalty on top of their own `cacheUploadLimiter`.

## Fix — same proven pattern as #604, **token-gated** (these live under user-facing prefixes)
- `SERVICE_TO_SERVICE_BULK_PATHS` exact allow-list + `isServiceToServiceBulkRequest(req)` = path in the set **AND** a valid service token (`verifyServiceToken`). Skips `rl:general` + slowDown for **genuine service calls only**:
  - a browser / user-token / unauthenticated hit to `/users/resolve` is **not** exempted (stays 1000/15min),
  - a sibling like `/users/me` is **never** exempted even with a service token.
  No blanket "service token ⇒ exempt".
- Dedicated `userResolveServiceLimiter` (`rl:user-resolve:service:`, 60000/15min, keyed by service **appId** not the shared IP) after `serviceAuthMiddleware` on `/users/resolve`. `/assets/service/*` already have `cacheUploadLimiter`, so exemption only there.

## Refactor (required)
Extracted the pure `verifyServiceToken` + types out of `auth.ts` into a lightweight `middleware/serviceToken.ts` (imports only `jsonwebtoken` + `logger`) so pulling it into `security.ts` doesn't drag the Session-model graph into the limiter module. All 3 importers updated — **clean cut, no re-export shim**, behavior byte-identical.

## Tests
- New `serviceBulkRateLimit.test.ts`: the token-gated predicate (exempt path + valid service token ⇒ true; no/user/garbage token or sibling path ⇒ false) + integration (rl:general skips `/users/resolve` & `/assets/service/*` with a valid service token; STILL enforces `/users/resolve` unauthenticated and `/users/me` even with a service token — proves no user-facing route loses protection).
- Retargeted `optionalAuth.dualAuth.test.ts`'s `verifyServiceToken` mock to the new module.
- Full suite: 154 suites / 1394 tests pass. `tsc` + lint clean.

## Verify post-deploy
The federated-author backfill apply run should show `/users/resolve` 429s → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)