### PR TITLE
fix(commons): skip create-identity server-sync when offline (no ~19s DNS hang)

### DIFF
--- a/packages/commons/app/(auth)/create-identity/index.tsx
+++ b/packages/commons/app/(auth)/create-identity/index.tsx
@@ -131,7 +131,15 @@ export default function CreateIdentityScreen() {
 
           creatingProgressRef.current = progressInterval as unknown as NodeJS.Timeout;
 
-          const result = await createIdentity();
+          // Detect connectivity up front so createIdentity can skip the ~19s
+          // DNS-timeout on the register/signIn round-trip when offline (the
+          // identity is still created locally; sync is deferred). `checkIfOffline`
+          // is already imported here safely — do NOT move this probe into
+          // `useIdentity`: it loads early in the provider tree and importing
+          // `networkUtils` there triggers a circular import that crashes
+          // OxyProvider at boot (see issue #605).
+          const offline = await checkIfOffline();
+          const result = await createIdentity({ skipSync: offline });
 
           cleanupTimers();
 

--- a/packages/commons/hooks/useIdentity.ts
+++ b/packages/commons/hooks/useIdentity.ts
@@ -34,8 +34,14 @@ let inFlightCreateIdentity: Promise<{ recoveryPhrase: string[]; synced: boolean;
 let inFlightImportIdentity: Promise<{ synced: boolean }> | null = null;
 
 export interface UseIdentityResult {
-  /** Create a new identity locally (offline-first) and optionally sync with server */
-  createIdentity: () => Promise<{ recoveryPhrase: string[]; synced: boolean; user?: User }>;
+  /**
+   * Create a new identity locally (offline-first) and optionally sync with server.
+   * Pass `{ skipSync: true }` (e.g. when the caller already detected no
+   * connectivity) to skip the register + signIn round-trip entirely instead of
+   * blocking on a ~19s DNS timeout — the identity is still created locally and
+   * the sync is deferred to the reconnect handler / username step.
+   */
+  createIdentity: (opts?: { skipSync?: boolean }) => Promise<{ recoveryPhrase: string[]; synced: boolean; user?: User }>;
   /** Import an existing identity from recovery phrase */
   importIdentity: (phrase: string) => Promise<{ synced: boolean }>;
   /** Sync local identity with server (when online) */
@@ -124,7 +130,7 @@ export const useIdentity = (): UseIdentityResult => {
   );
 
   const createIdentity = useCallback(
-    async (): Promise<{ recoveryPhrase: string[]; synced: boolean; user?: User }> => {
+    async (opts?: { skipSync?: boolean }): Promise<{ recoveryPhrase: string[]; synced: boolean; user?: User }> => {
       if (!oxyServices) throw new Error('OxyServices not initialized');
       if (!signIn) throw new Error('signIn not available');
 
@@ -171,6 +177,15 @@ export const useIdentity = (): UseIdentityResult => {
         // the next time they wipe the app.
         setSynced(false);
         await persistIdentitySyncState(false);
+
+        // Caller detected no connectivity: skip the register + signIn round-trip
+        // rather than stalling the "Setting up your account…" screen on a ~19s
+        // DNS timeout. The identity already exists locally (keys generated
+        // above); sync is deferred to the reconnect handler / username step.
+        if (opts?.skipSync) {
+          console.warn('[useIdentity] Offline during create — identity stored locally, server sync deferred');
+          return { recoveryPhrase: words, synced: false };
+        }
 
         try {
           const { signature, timestamp } = await SignatureService.createRegistrationSignature();


### PR DESCRIPTION
Partial fix for #605.

## Problem
Offline, `createIdentity` generated keys locally but then blocked **~19s** on a DNS timeout for `register`/`signIn` before returning `{synced:false}`, showing a "Setting up your account…" screen indistinguishable from a hang.

## Fix
Detect connectivity in `create-identity/index.tsx` (which already imports `checkIfOffline`) and pass `{ skipSync }` into `createIdentity` so it defers the network round-trip immediately when offline. Identity is still created locally; sync is deferred to the reconnect handler / username step.

## ⚠️ Why the offline probe is NOT in `useIdentity`
An earlier attempt that added `import { checkIfOffline } from '@/utils/auth/networkUtils'` **into `useIdentity.ts`** crashed the app at boot (`TypeError: undefined is not a function` in `OxyProvider`) — `useIdentity` loads early in the provider tree and pulling in `networkUtils` (→ expo-network) created a circular import. So the probe stays in `create-identity/index.tsx` and is passed as a flag. Do not move it.

## Verified on emulator (release build)
- **Boot:** clean onboarding, no crash.
- **Offline create:** `skipSync` fires in **~1s** (was ~19s); "Offline during create — identity stored locally, server sync deferred".
- **Online create:** full flow works, no `deferred` log, identity created + synced, reaches the ID card.

## Still open in #605 (needs real-device repro)
- The **online** infinite-loading variant (session-sync failing while connected) — needs a live logcat capture from the affected device.
- `CreatingStep` has no error/retry state for hard `createIdentity` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)