### PR TITLE
fix(api): public user rows were missing bio, verified and remote-actor info

### DIFF
--- a/packages/api/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/users.controller.test.ts
@@ -21,6 +21,7 @@ jest.mock('../../utils/asyncHandler', () => ({
 
 import { UsersController } from '../users.controller';
 import { BadRequestError, InternalServerError } from '../../utils/error';
+import { PUBLIC_USER_PROFILE_SELECT } from '../../utils/publicUserProjection';
 
 describe('UsersController', () => {
   let usersController: UsersController;
@@ -84,9 +85,35 @@ describe('UsersController', () => {
           { 'name.last': { $regex: 'test', $options: 'i' } },
         ],
       });
-      expect(mockQuery.select).toHaveBeenCalledWith('username name avatar email description color');
+      // Search rows are PUBLIC user rows — same shared projection the
+      // follower/following/mutual lists use, asserted against the exported
+      // constant so the two cannot drift apart again.
+      expect(mockQuery.select).toHaveBeenCalledWith(PUBLIC_USER_PROFILE_SELECT);
       expect(mockQuery.limit).toHaveBeenCalledWith(5);
       expect(mockQuery.lean).toHaveBeenCalled();
+    });
+
+    it('never projects the searched users\' email addresses', async () => {
+      mockRequest.body = { query: 'test' };
+
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+      mockFind.mockReturnValue(mockQuery);
+
+      await usersController.searchUsers(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext
+      );
+
+      // This projection used to include `email`, so a public user search
+      // returned every match's email address. The shared projection is
+      // inclusion-only: `email` is simply never loaded.
+      const projection = mockQuery.select.mock.calls[0]?.[0] as string;
+      expect(projection.split(' ')).not.toContain('email');
     });
 
     it('should throw InternalServerError on database errors', async () => {

--- a/packages/api/src/controllers/users.controller.ts
+++ b/packages/api/src/controllers/users.controller.ts
@@ -11,6 +11,7 @@ import { logger } from '../utils/logger';
 import { BadRequestError, InternalServerError } from '../utils/error';
 import { sendSuccess } from '../utils/asyncHandler';
 import { sanitizeSearchQuery } from '../utils/sanitize';
+import { PUBLIC_USER_PROFILE_SELECT } from '../utils/publicUserProjection';
 
 export class UsersController {
   /**
@@ -40,7 +41,7 @@ export class UsersController {
           { 'name.last': { $regex: sanitizedQuery, $options: 'i' } },
         ],
       })
-        .select('username name avatar email description color')
+        .select(PUBLIC_USER_PROFILE_SELECT)
         .limit(5)
         .lean();
 

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger';
 import { sanitizeSearchQuery } from '../utils/sanitize';
 import { validate } from '../middleware/validate';
 import { searchQuerySchema } from '../schemas/search.schemas';
+import { PUBLIC_USER_PROFILE_SELECT } from '../utils/publicUserProjection';
 
 const router = express.Router();
 
@@ -34,7 +35,7 @@ router.get("/", validate({ query: searchQuerySchema }), async (req: Request, res
           { location: searchQuery }
         ]
       })
-      .select('username name description avatar location color')
+      .select(PUBLIC_USER_PROFILE_SELECT)
       .skip(skip)
       .limit(limit);
 

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -737,7 +737,7 @@ router.get(
  * @param {string} userId - User ID
  * @query {number} limit - Number of results (max 100, default 50)
  * @query {number} offset - Pagination offset (default 0)
- * @returns {PaginatedResponse<UserProfile>} Paginated list of followers
+ * @returns {PaginatedResponse<PublicUserProfile>} Paginated list of followers
  */
 router.get(
   '/:userId/followers',
@@ -776,7 +776,7 @@ router.get(
  * @param {string} userId - User ID
  * @query {number} limit - Number of results (max 100, default 50)
  * @query {number} offset - Pagination offset (default 0)
- * @returns {PaginatedResponse<UserProfile>} Paginated list of following
+ * @returns {PaginatedResponse<PublicUserProfile>} Paginated list of following
  */
 router.get(
   '/:userId/following',
@@ -825,7 +825,7 @@ router.get(
  * @param {string} userId - Target user ID (ObjectId or publicKey; resolved first)
  * @query {number} limit - Number of results (max 100, default 50)
  * @query {number} offset - Pagination offset (default 0)
- * @returns {PaginatedResponse<UserProfile>} Paginated list of mutual followers
+ * @returns {PaginatedResponse<PublicUserProfile>} Paginated list of mutual followers
  */
 router.get(
   '/:userId/mutuals',

--- a/packages/api/src/services/__tests__/user.service.publicUserRows.test.ts
+++ b/packages/api/src/services/__tests__/user.service.publicUserRows.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The PUBLIC user row contract of the follower / following / mutual lists.
+ *
+ * These three endpoints feed the same UI row across the ecosystem (avatar,
+ * display name, handle, bio, verified badge, federated badge). They each used
+ * to carry their own hand-written `.select('username name avatar color -email')`
+ * projection, which omitted `bio`, `verified` and `federation` — so the API
+ * emitted `bio: undefined` on every row while the model, the serializer and the
+ * wire contract all had the field. These tests lock the fix: all three query
+ * with the ONE shared projection, and the DTO carries the public row fields.
+ *
+ * Same harness as `user.service.getUserMutuals`: restore the real `mongoose`
+ * (the global setup mocks it wholesale, stripping `Types`) and mock the models
+ * as chainable query builders. `formatUserResponse` runs for real, so what is
+ * asserted below is the exact payload the route returns.
+ */
+
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import { Types } from 'mongoose';
+
+const mockFollowLean = jest.fn();
+const followQuery = {
+  select: jest.fn(() => followQuery),
+  limit: jest.fn(() => followQuery),
+  skip: jest.fn(() => followQuery),
+  sort: jest.fn(() => followQuery),
+  lean: mockFollowLean,
+};
+const mockFollowFind = jest.fn(() => followQuery);
+const mockFollowCountDocuments = jest.fn();
+
+const mockUserExec = jest.fn();
+const mockUserSelect = jest.fn(() => userQuery);
+const userQuery = {
+  select: mockUserSelect,
+  lean: jest.fn(() => userQuery),
+  exec: mockUserExec,
+};
+const mockUserFind = jest.fn(() => userQuery);
+
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  default: {
+    find: mockFollowFind,
+    countDocuments: mockFollowCountDocuments,
+  },
+  FollowType: {
+    USER: 'user',
+    HASHTAG: 'hashtag',
+    TOPIC: 'topic',
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    find: mockUserFind,
+  },
+}));
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../securityActivityService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { UserService } from '../user.service';
+import { PUBLIC_USER_PROFILE_SELECT } from '../../utils/publicUserProjection';
+
+/** A federated row: bio + verified + remote-actor info must all survive. */
+function federatedUserDoc(id: Types.ObjectId) {
+  return {
+    _id: id,
+    username: 'remote',
+    name: { first: 'Remote', last: 'Friend' },
+    avatar: 'https://mastodon.social/avatars/remote.png',
+    color: 'blue',
+    bio: 'Bio that the rows never used to receive.',
+    description: 'A longer public description.',
+    verified: true,
+    type: 'federated',
+    federation: { actorUri: 'https://mastodon.social/users/remote', domain: 'mastodon.social' },
+    privacySettings: { fediverseSharing: true },
+  };
+}
+
+describe('public user row projection (followers / following / mutuals)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('projects the shared public-row field set on getUserFollowers and emits the full DTO', async () => {
+    const targetId = new Types.ObjectId().toHexString();
+    const followerId = new Types.ObjectId();
+
+    mockFollowCountDocuments.mockResolvedValueOnce(1);
+    mockFollowLean.mockResolvedValueOnce([{ followerUserId: followerId }]);
+    mockUserExec.mockResolvedValueOnce([federatedUserDoc(followerId)]);
+
+    const result = await new UserService().getUserFollowers(targetId, { limit: 50, offset: 0 });
+
+    expect(mockUserSelect).toHaveBeenCalledWith(PUBLIC_USER_PROFILE_SELECT);
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0]).toMatchObject({
+      id: followerId.toHexString(),
+      username: 'remote',
+      bio: 'Bio that the rows never used to receive.',
+      description: 'A longer public description.',
+      verified: true,
+      isFederated: true,
+      federation: { domain: 'mastodon.social' },
+    });
+  });
+
+  it('projects the shared public-row field set on getUserFollowing and emits the full DTO', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+    const followedId = new Types.ObjectId();
+
+    mockFollowCountDocuments.mockResolvedValueOnce(1);
+    mockFollowLean.mockResolvedValueOnce([{ followedId }]);
+    mockUserExec.mockResolvedValueOnce([federatedUserDoc(followedId)]);
+
+    const result = await new UserService().getUserFollowing(viewerId, { limit: 50, offset: 0 });
+
+    expect(mockUserSelect).toHaveBeenCalledWith(PUBLIC_USER_PROFILE_SELECT);
+    expect(result.data[0]).toMatchObject({
+      id: followedId.toHexString(),
+      bio: 'Bio that the rows never used to receive.',
+      verified: true,
+      isFederated: true,
+    });
+  });
+
+  it('projects the shared public-row field set on getUserMutuals and emits the full DTO', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+    const targetId = new Types.ObjectId().toHexString();
+    const mutualId = new Types.ObjectId();
+
+    mockFollowLean
+      .mockResolvedValueOnce([{ followedId: mutualId }])
+      .mockResolvedValueOnce([{ followerUserId: mutualId }]);
+    mockFollowCountDocuments.mockResolvedValueOnce(1);
+    mockUserExec.mockResolvedValueOnce([federatedUserDoc(mutualId)]);
+
+    const result = await new UserService().getUserMutuals(viewerId, targetId, {
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(mockUserSelect).toHaveBeenCalledWith(PUBLIC_USER_PROFILE_SELECT);
+    expect(result.data[0]).toMatchObject({
+      id: mutualId.toHexString(),
+      bio: 'Bio that the rows never used to receive.',
+      verified: true,
+      isFederated: true,
+    });
+  });
+
+  it('keeps private fields out of the projection', () => {
+    const paths = PUBLIC_USER_PROFILE_SELECT.split(' ');
+
+    // Inclusion-only projection: anything not listed cannot reach the row.
+    expect(paths).not.toContain('email');
+    expect(paths).not.toContain('phone');
+    expect(paths).not.toContain('password');
+    expect(paths).not.toContain('refreshToken');
+    // Only the public, derived consent flag — never the whole settings subdoc.
+    expect(paths).not.toContain('privacySettings');
+    expect(paths).toContain('privacySettings.fediverseSharing');
+  });
+});

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -21,11 +21,14 @@ import {
   PaginatedResponse,
   PublicUserProfile,
   ProfileUpdateInput,
-  UserProfile,
   UserStatistics,
   FollowActionResult,
   ViewerGraph,
 } from '../types/user.types';
+import {
+  PUBLIC_USER_PROFILE_SELECT,
+  type PublicUserDocument,
+} from '../utils/publicUserProjection';
 import Subscription from '../models/Subscription';
 import { formatUserNameResponse, type NameParts } from '../utils/displayName';
 import { normalizeLocale } from '@oxyhq/core';
@@ -462,9 +465,9 @@ export class UserService {
     const followers = await User.find({
       _id: { $in: followerIds },
     })
-      .select('username name avatar color -email')
-      .lean()
-      .exec() as UserProfile[];
+      .select(PUBLIC_USER_PROFILE_SELECT)
+      .lean<PublicUserDocument[]>()
+      .exec();
 
     // Maintain order from original follow relationships
     const followersMap = new Map(
@@ -472,7 +475,7 @@ export class UserService {
     );
     const orderedFollowers = followerIds
       .map((id) => followersMap.get(id))
-      .filter((user): user is UserProfile => user !== undefined)
+      .filter((user): user is PublicUserDocument => user !== undefined)
       .map((user) => this.formatUserResponse(user));
 
     return {
@@ -523,9 +526,9 @@ export class UserService {
     const following = await User.find({
       _id: { $in: followingIds },
     })
-      .select('username name avatar color -email')
-      .lean()
-      .exec() as UserProfile[];
+      .select(PUBLIC_USER_PROFILE_SELECT)
+      .lean<PublicUserDocument[]>()
+      .exec();
 
     // Maintain order from original follow relationships
     const followingMap = new Map(
@@ -533,7 +536,7 @@ export class UserService {
     );
     const orderedFollowing = followingIds
       .map((id) => followingMap.get(id))
-      .filter((user): user is UserProfile => user !== undefined)
+      .filter((user): user is PublicUserDocument => user !== undefined)
       .map((user) => this.formatUserResponse(user));
 
     return {
@@ -632,9 +635,9 @@ export class UserService {
     const mutuals = await User.find({
       _id: { $in: mutualIds },
     })
-      .select('username name avatar color -email')
-      .lean()
-      .exec() as UserProfile[];
+      .select(PUBLIC_USER_PROFILE_SELECT)
+      .lean<PublicUserDocument[]>()
+      .exec();
 
     // Maintain order from the original follow relationships (most-recent first)
     const mutualsMap = new Map(
@@ -642,7 +645,7 @@ export class UserService {
     );
     const orderedMutuals = mutualIds
       .map((id) => mutualsMap.get(id))
-      .filter((user): user is UserProfile => user !== undefined)
+      .filter((user): user is PublicUserDocument => user !== undefined)
       .map((user) => this.formatUserResponse(user));
 
     return {
@@ -1525,10 +1528,15 @@ export class UserService {
   }
 
   /**
-   * Format user response with stats
+   * Format user response with stats.
+   *
+   * Reads only PUBLIC profile fields. A source document must therefore be loaded
+   * with a projection that covers them — `PUBLIC_USER_PROFILE_SELECT` for list
+   * queries, `-password -refreshToken` for the single-user reads — otherwise the
+   * unprojected fields serialize as `undefined` with no error anywhere.
    */
   formatUserResponse(
-    user: IUser | UserProfile,
+    user: IUser | PublicUserDocument,
     stats?: UserStatistics,
     options: { includePrivateFields?: boolean } = {}
   ): PublicUserProfile {

--- a/packages/api/src/types/user.types.ts
+++ b/packages/api/src/types/user.types.ts
@@ -5,29 +5,15 @@
  * Reuses model types to avoid duplication.
  */
 
-import { Types } from 'mongoose';
 import type { IUser } from '../models/User';
 import type { UserProfileUpdate, UserResponse } from '@oxyhq/contracts';
 
 // Reuse name structure from IUser
 export type UserName = IUser['name'];
 
-// User profile data for API responses (read-only, excludes sensitive fields)
-export type UserProfile = Pick<
-  IUser,
-  | '_id'
-  | 'username'
-  | 'name'
-  | 'avatar'
-  | 'color'
-  | 'bio'
-  | 'description'
-  | 'links'
-  | 'linksMetadata'
-  | 'verified'
-  | 'createdAt'
-  | 'updatedAt'
->;
+// The raw user document a public list query reads is `PublicUserDocument` in
+// `utils/publicUserProjection.ts` — it lives next to the projection that
+// produces it so the two cannot drift.
 
 export type PublicUserProfile = UserResponse;
 

--- a/packages/api/src/utils/publicUserProjection.ts
+++ b/packages/api/src/utils/publicUserProjection.ts
@@ -1,0 +1,86 @@
+/**
+ * The Mongo projection for a PUBLIC user row.
+ *
+ * SINGLE source of truth for every endpoint that returns a list of other
+ * people's user documents (followers, following, mutuals, user search). Those
+ * lists render the same row everywhere in the ecosystem — avatar, display name,
+ * handle, bio, verified badge, federated/remote-instance badge — so they all
+ * need the same field set, and repeating a hand-written `.select('username name
+ * avatar color …')` per query is exactly how they drifted apart: the follower /
+ * following / mutual queries silently omitted `bio`, `verified` and
+ * `federation`, so the API emitted `bio: undefined` on every row while the
+ * model, the serializer (`UserService.formatUserResponse`) and the wire contract
+ * (`userResponseSchema`) all carried the field.
+ *
+ * INVARIANT: this projection must cover every field
+ * `UserService.formatUserResponse` reads. A field it reads but this does not
+ * project is not an error anywhere — it just silently serializes as `undefined`.
+ *
+ * Inclusion-only on purpose: every unlisted path (`email`, `phone`, `password`,
+ * `refreshToken`, hashed contacts, the private half of `privacySettings`, …) is
+ * dropped by MongoDB itself, instead of relying on an easily-forgotten `-field`
+ * exclusion to keep a private field off a public row.
+ *
+ * `publicKey` is deliberately NOT projected. `formatUserResponse` prefers it as
+ * the DTO `id`, and the social graph these lists feed (follow edges, the viewer
+ * graph id lists, client-side follow-state maps) is keyed by the ObjectId —
+ * projecting it here would flip the `id` of key-based accounts on these
+ * endpoints only, which is a graph change, not a profile-row change.
+ */
+
+import type { IUser } from '../models/User';
+
+/**
+ * Public profile paths. Nested paths are allowed (MongoDB projects the single
+ * leaf), which is how the public, derived `fediverseSharing` consent flag is
+ * exposed without dragging in the rest of `privacySettings`.
+ */
+const PUBLIC_USER_PROFILE_PATHS = [
+  'username',
+  'name',
+  'avatar',
+  'color',
+  'bio',
+  'description',
+  'links',
+  'linksMetadata',
+  'verified',
+  // Account type + remote-actor info: the row renders a verified badge, a
+  // federated badge and the `@user@instance` handle from these.
+  'type',
+  'federation',
+  // ONLY the public, derived consent flag — the rest of `privacySettings` is
+  // private and must never reach a public row.
+  'privacySettings.fediverseSharing',
+  'createdAt',
+  'updatedAt',
+] as const;
+
+/** `.select(...)` argument for a public user row. */
+export const PUBLIC_USER_PROFILE_SELECT = PUBLIC_USER_PROFILE_PATHS.join(' ');
+
+/**
+ * The lean document shape {@link PUBLIC_USER_PROFILE_SELECT} yields. Declared
+ * from `IUser` so the projection and the type cannot drift: a path added to the
+ * projection is a compile error here until it is a real `User` field.
+ */
+export type PublicUserDocument = Pick<
+  IUser,
+  | '_id'
+  | 'username'
+  | 'name'
+  | 'avatar'
+  | 'color'
+  | 'bio'
+  | 'description'
+  | 'links'
+  | 'linksMetadata'
+  | 'verified'
+  | 'type'
+  | 'federation'
+  | 'createdAt'
+  | 'updatedAt'
+> & {
+  /** Only the projected leaf — see {@link PUBLIC_USER_PROFILE_SELECT}. */
+  privacySettings?: Pick<IUser['privacySettings'], 'fediverseSharing'>;
+};

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -103,6 +103,12 @@ export interface User {
    */
   name: UserNameResponse;
   bio?: string;
+  /**
+   * Longer public profile text. Emitted alongside `bio` by every user DTO the
+   * API produces (single profile, `getUsersByIds`, follower/following/mutual
+   * lists, profile search) — the two are separate fields on the User document.
+   */
+  description?: string;
   phone?: string;
   address?: string;
   birthday?: string;


### PR DESCRIPTION
## Summary
Mention's followers / following / mutuals screens render a user row with the user's **bio** — and it was always empty. It looked like a UI bug, but the API simply never sent the field.

**Root cause:** followers, following, mutuals and user search all fetched users with the projection

```ts
.select('username name avatar color -email')
```

so `bio` **never left the database**. The verified badge and remote-actor (federation) info were missing for the same reason. The projection was a **string literal duplicated across the query sites**, which is exactly how it silently drifted from what a public user row actually needs.

## The fix (at the root)
- **New `utils/publicUserProjection.ts`** exporting ONE shared `PUBLIC_USER_PROFILE_SELECT`, now used by **every** query that returns a public user row (followers, following, mutuals, user search, and the users controller/routes). One source of truth instead of four literals.
- The projection now carries **`bio`, `description`, `links`, `verified`, account type and federation info** alongside the existing identity fields.
- 🔒 **Privacy fix:** the old user-**search** projection selected **`email`** — public user search was returning email addresses. It no longer does (verified nothing read it).
- The controller test now asserts against the **exported constant** rather than a hardcoded select string, so the projection can't drift unnoticed again.
- Added a service test covering the fields a public user row must carry.

## Test plan
- `bun run core:build` and `bun run api:build` — clean
- `cd packages/api && bun run test` — **154 suites / 1390 tests, 0 failures** (was 1 failing: the controller test asserting the old select string, which included `email`)

## Note
This needs an **API deploy** for consumers (Mention) to actually receive the bio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)