### PR TITLE
fix(commons): CreatingStep shows error + retry instead of endless loading

### DIFF
--- a/packages/commons/app/(auth)/create-identity/index.tsx
+++ b/packages/commons/app/(auth)/create-identity/index.tsx
@@ -50,6 +50,20 @@ export default function CreateIdentityScreen() {
   // protection against a remount-induced bounce relies on the SDK-side
   // cache invalidation in `updateProfile` keeping `hasUsername` stable.
   const hasNavigatedResumeRef = useRef(false);
+  // A hard create failure (e.g. key generation/persistence failed) used to set
+  // an auth error that nothing rendered, leaving the user stuck on the endless
+  // "Setting up your account…" screen. Track it locally so `CreatingStep` can
+  // show the reason + a Retry (issue #605).
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
+
+  const handleRetry = useCallback(() => {
+    setCreateError(null);
+    hasStartedCreateRef.current = false;
+    hasNavigatedResumeRef.current = false;
+    setCreatingProgress(0);
+    setRetryNonce((n) => n + 1);
+  }, []);
 
   // Cleanup function for all timers
   const cleanupTimers = useCallback(() => {
@@ -191,6 +205,9 @@ export default function CreateIdentityScreen() {
           const errorMessage = extractAuthErrorMessage(err);
           setAuthError(errorMessage);
           setCreatingProgress(0);
+          // Surface the failure in the UI (with a Retry) instead of leaving the
+          // user on an endless loading screen.
+          setCreateError(errorMessage);
         }
       };
       create();
@@ -207,6 +224,7 @@ export default function CreateIdentityScreen() {
     setAuthError,
     cleanupTimers,
     recoveryPhraseRef,
+    retryNonce,
   ]);
 
   // While onboarding status is still resolving on this screen's own mount,
@@ -225,6 +243,8 @@ export default function CreateIdentityScreen() {
       isSyncing={isResuming}
       backgroundColor={backgroundColor}
       textColor={textColor}
+      error={createError}
+      onRetry={handleRetry}
     />
   );
 }

--- a/packages/commons/components/auth/CreatingStep.tsx
+++ b/packages/commons/components/auth/CreatingStep.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
 import LottieView from 'lottie-react-native';
 import Animated, {
   FadeIn,
@@ -19,6 +19,14 @@ interface CreatingStepProps {
   textColor: string;
   isSyncing?: boolean;
   isSigningIn?: boolean;
+  /**
+   * When set, the step renders a recoverable error state (message + Retry)
+   * instead of the loading animation. Without this, a failed `createIdentity()`
+   * left the user stuck on an endless "Setting up your account…" screen with no
+   * feedback and no way forward (see issue #605).
+   */
+  error?: string | null;
+  onRetry?: () => void;
 }
 
 const TOTAL_PROGRESS_STEPS = 3; // 0, 1, 2
@@ -31,7 +39,7 @@ const PROGRESS_MESSAGE_KEYS = [
 /**
  * Creating step component showing progress during identity creation, sync, and sign-in
  */
-export function CreatingStep({ progress, backgroundColor, textColor, isSyncing, isSigningIn }: CreatingStepProps) {
+export function CreatingStep({ progress, backgroundColor, textColor, isSyncing, isSigningIn, error, onRetry }: CreatingStepProps) {
   const { t } = useTranslation();
   // Determine message based on current state
   let currentMessage: string;
@@ -78,6 +86,32 @@ export function CreatingStep({ progress, backgroundColor, textColor, isSyncing, 
       opacity: progressValue.value > 0 ? 1 : 0.5,
     };
   });
+
+  // Recoverable failure: show the reason + a Retry instead of an endless
+  // "Setting up your account…" with no way forward (issue #605).
+  if (error) {
+    return (
+      <View style={[styles.container, { backgroundColor }]}>
+        <View style={styles.centeredContainer}>
+          <Text style={[styles.creatingTitle, { color: textColor }]}>
+            {t('auth.creating.errorTitle')}
+          </Text>
+          <Text style={[styles.creatingSubtitle, { color: textColor, opacity: 0.7 }]}>
+            {error}
+          </Text>
+          {onRetry ? (
+            <Pressable
+              onPress={onRetry}
+              accessibilityRole="button"
+              style={({ pressed }) => [styles.retryButton, { opacity: pressed ? 0.7 : 1 }]}
+            >
+              <Text style={styles.retryButtonText}>{t('auth.creating.retry')}</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.container, { backgroundColor }]}>
@@ -171,6 +205,18 @@ const styles = StyleSheet.create({
     borderRadius: 2,
     // Ensure minimum width for visibility even at 0%
     minWidth: 1,
+  },
+  retryButton: {
+    marginTop: 28,
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 24,
+    backgroundColor: '#8B5CF6',
+  },
+  retryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
   },
 });
 

--- a/packages/commons/lib/i18n/locales/en.json
+++ b/packages/commons/lib/i18n/locales/en.json
@@ -94,7 +94,9 @@
       "signingIn": "Signing in...",
       "signingInSubtitle": "Almost there!",
       "syncing": "Syncing your identity...",
-      "syncingSubtitle": "Connecting to Oxy servers"
+      "syncingSubtitle": "Connecting to Oxy servers",
+      "errorTitle": "Couldn't finish setting up",
+      "retry": "Try again"
     },
     "usernameRequired": {
       "title": "Username Required",
@@ -1324,8 +1326,29 @@
       "activity": {
         "title": "Recent activity",
         "heatmapTitle": "Activity",
-        "months": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-        "weekdays": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+        "months": [
+          "Jan",
+          "Feb",
+          "Mar",
+          "Apr",
+          "May",
+          "Jun",
+          "Jul",
+          "Aug",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dec"
+        ],
+        "weekdays": [
+          "Sun",
+          "Mon",
+          "Tue",
+          "Wed",
+          "Thu",
+          "Fri",
+          "Sat"
+        ],
         "loading": "Loading activity…",
         "error": "Couldn't load recent activity.",
         "empty": "No reputation activity yet — your verified actions will appear here.",

--- a/packages/commons/lib/i18n/locales/es.json
+++ b/packages/commons/lib/i18n/locales/es.json
@@ -94,7 +94,9 @@
       "signingIn": "Iniciando sesión...",
       "signingInSubtitle": "¡Casi listo!",
       "syncing": "Sincronizando tu identidad...",
-      "syncingSubtitle": "Conectando con los servidores de Oxy"
+      "syncingSubtitle": "Conectando con los servidores de Oxy",
+      "errorTitle": "No se pudo terminar la configuración",
+      "retry": "Reintentar"
     },
     "usernameRequired": {
       "title": "Nombre de usuario requerido",
@@ -1324,8 +1326,29 @@
       "activity": {
         "title": "Actividad reciente",
         "heatmapTitle": "Actividad",
-        "months": ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"],
-        "weekdays": ["Dom", "Lun", "Mar", "Mié", "Jue", "Vie", "Sáb"],
+        "months": [
+          "Ene",
+          "Feb",
+          "Mar",
+          "Abr",
+          "May",
+          "Jun",
+          "Jul",
+          "Ago",
+          "Sep",
+          "Oct",
+          "Nov",
+          "Dic"
+        ],
+        "weekdays": [
+          "Dom",
+          "Lun",
+          "Mar",
+          "Mié",
+          "Jue",
+          "Vie",
+          "Sáb"
+        ],
         "loading": "Cargando actividad…",
         "error": "No se pudo cargar la actividad reciente.",
         "empty": "Aún no hay actividad de reputación: tus acciones verificadas aparecerán aquí.",


### PR DESCRIPTION
Closes the second half of #605.

## Problem
A hard `createIdentity()` failure (e.g. key generation/persistence) set an auth error that **nothing rendered** — `CreatingStep` only ever showed the loading animation. The user was left stuck on an endless "Setting up your account…" with no feedback and no way forward.

## Fix
- `CreatingStep` gains optional `error` + `onRetry` props; when `error` is set it renders the reason + a **Retry** button instead of the loading animation.
- `create-identity/index.tsx` surfaces a hard-failure error into `CreatingStep` and wires Retry (resets the run guards + bumps a retry nonce to re-run the effect).
- Added `auth.creating.errorTitle` / `auth.creating.retry` to en + es locales (other locales fall back to en).

## Risk
Additive — the error branch only renders when `error` is set; the happy/offline paths are unchanged.

## Verified on emulator (release build)
- **Boot:** clean, no crash.
- **Online create:** still reaches the ID card (happy path unchanged).
- (Offline fast-fail from #607 also intact in this build.)

Note: the **online sync-failure variant** in #605 (the original real-device report — sync failing while connected, stranding the *username* step) is still open and needs a live logcat capture from the affected device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)