### PR TITLE
fix(commons): don't fire username update without a session (no infinite spinner)

### DIFF
--- a/packages/commons/app/(auth)/create-identity/username.tsx
+++ b/packages/commons/app/(auth)/create-identity/username.tsx
@@ -69,6 +69,25 @@ export default function CreateIdentityUsernameScreen() {
 
     setUpdateError(null);
 
+    // The username write is an AUTHENTICATED call. If the create-sync hasn't
+    // established a session yet — an offline create, or a signIn that hasn't
+    // finished re-syncing after reconnect — `oxyServices` has no access token.
+    // Firing updateProfile then throws "No active access token", and because
+    // mutations run with networkMode:'offlineFirst' + retry, the retry is
+    // PAUSED, leaving the Confirm button spinning forever with no way out
+    // (issue #605). Guard it: surface a clear, actionable state instead. The
+    // session self-establishes via the reconnect/sync handler, so tapping
+    // Continue again once it's ready succeeds.
+    if (!oxyServices.getAccessToken()) {
+      const offline = await checkIfOffline();
+      setUpdateError(
+        offline
+          ? 'You are offline. Reconnect and tap continue to save your username.'
+          : 'Finishing setting up your account — tap continue again in a moment.',
+      );
+      return;
+    }
+
     try {
       // mutateAsync triggers the optimistic onMutate FIRST, which:
       //  - cancels in-flight queries on accounts.current()


### PR DESCRIPTION
Fixes the **online variant of #605** — the actual real-device failure reported on a Pixel 10 Pro.

## Reproduced (emulator)
Create an identity with no session yet (offline create, or a `signIn` that hasn't finished re-syncing after reconnect) → reach the username step → tap Continue. `updateProfile` (authenticated) throws **"No active access token is available. Sync the session before calling authenticated APIs."**, and because mutations run with `networkMode:'offlineFirst'` + `retry:1`, the retry is **PAUSED** — so `updateProfile.isPending` stays `true` and the **Confirm button spins forever** with the error shown beneath it, no way out.

## Fix
Guard `handleContinue`: if `oxyServices.getAccessToken()` is null, surface a clear, actionable message (offline vs "finishing setup — tap continue again in a moment") and **return before calling `updateProfile`**. The session self-establishes via the reconnect/sync handler, so tapping Continue again once it's ready succeeds. The authenticated call never fires without a session, so the spinner can't get stuck.

## Verified (emulator, release build)
- Reproduced the stuck spinner + "No active access token" pre-fix.
- Post-fix: online create still reaches the ID card (guard passes when the session exists), boot clean, no erroneous guard firing online.

Closes the remaining item in #605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)