### PR TITLE
feat: remove all user IP persistence (privacy: no IPs at rest)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -455,6 +455,15 @@ All limiters use `rate-limit-redis` with a shared ioredis client. The factory `r
 
 **General limiter threshold** (commit `641cea67`): raised 150 → **1000 / 15min**. The 150 ceiling was below a single authenticated user's normal traffic (feed scroll + socket fallback polling + profile loads + device-secret token mints). Per-endpoint limiters (`authRateLimiter` 300, `userRateLimiter` 200, `checkLimiter` 10/min, etc.) remain the relevant defense-in-depth. **Do NOT lower the general limiter below 1000 without measuring real production traffic.**
 
+## No User IPs At Rest (privacy invariant, owner-mandated 2026-07-14)
+
+Threat model: state-actor harassment of users. The platform must **never persist a user IP address** — raw, hashed, or geo-derived (country included, e.g. `cf-ipcountry`) — in MongoDB, logs (pino fields), metrics metadata, or response DTOs. Salted hashes of the IPv4 space are brute-forceable by anyone with server access, so hashing is NOT an acceptable at-rest form.
+
+- Removed entirely: `SecurityActivity.ipAddress`, `Session.deviceInfo.{ipAddress,location}`, `ApiKeyUsage.ipAddress`, the IP input to `deriveStableDeviceId`, IP-based anomaly detection (`detectRapidIPChanges`), and the civic `shared_ip` anti-sybil signal (`graphExclusion.ts` — device-fingerprint/interaction-history/affinity-throttle only now).
+- **Anonymous rate-limit keys are the one place IPs may be touched, and only transiently:** they MUST go through `hashedIpKey` (`packages/api/src/utils/ipKey.ts` — HMAC(`DEVICE_ID_SALT`), IPv6 /56-bucketed) and live only as a Redis key with the limiter's normal TTL. Never key a limiter on raw `req.ip`.
+- **The one sanctioned exception:** inbound-email `Received:` headers (third-party SMTP sender IPs, not Oxy users) stored in `Message.headers` — standard email practice, owner-approved.
+- Do NOT re-add IP capture "for security" (audit trails, anomaly detection, sybil resistance, etc.) — this was a deliberate trade-off, not an oversight. Design + rollout: `docs/superpowers/specs/2026-07-14-no-ip-storage-design.md`.
+
 ## useCurrentUser Pattern (services)
 
 - `queryFn` must be pure — never call `useAuthStore.setUser()` inside a `queryFn`.

--- a/docs/superpowers/plans/2026-07-14-no-ip-storage.md
+++ b/docs/superpowers/plans/2026-07-14-no-ip-storage.md
@@ -1,0 +1,587 @@
+# No IP Storage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove all user IP persistence (raw, hashed at rest, geo-derived) from oxy-api; hash the transient rate-limit keys; scrub logs; purge historical prod data.
+
+**Architecture:** Deletion-heavy change across `packages/api` (models, services, middleware, routes), one type removal in `@oxyhq/core`, IP rendering removal in `packages/accounts`, plus a one-shot purge script. One NEW module: `packages/api/src/utils/ipKey.ts` (HMAC-hashed rate-limit key).
+
+**Tech Stack:** Express + Mongoose + express-rate-limit@^7.5 (exports `ipKeyGenerator`) + rate-limit-redis. Tests: Jest (ts-jest) — run per-package `bun run test`, NEVER blanket `bun test`.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-no-ip-storage-design.md`
+
+## Global Constraints
+
+- Package manager: `bun` only. Tests: `cd packages/api && bun run test` (Jest). Core build: `bun run core:build` from repo root.
+- NO `as any`, no `@ts-ignore`, no `!` non-null assertions, no TODO comments, no silent catch.
+- Clean cuts: remove identifiers entirely + update every call site. No back-compat aliases.
+- Email inbound `Message.headers` is OUT OF SCOPE (owner decision: keep).
+- Path-scope all `git add` calls (shared package).
+- Test baselines before change: api 1322, core 722. Expect small deltas from removed IP-specific tests.
+
+---
+
+### Task 1: `hashedIpKey` helper + hashed rate-limit keys everywhere
+
+**Files:**
+- Create: `packages/api/src/utils/ipKey.ts`
+- Create: `packages/api/src/utils/__tests__/ipKey.test.ts`
+- Modify: `packages/api/src/middleware/rateLimiter.ts` (default keyGenerator)
+- Modify: `packages/api/src/middleware/security.ts` (limiters at ~136, 165, 183, 200, 211, 231)
+- Modify route keyGenerators: `routes/links.ts:51`, `routes/assets.ts:555,569`, `routes/contacts.ts:73`, `routes/nodes.ts:33,79`, `routes/identity.ts:59`, `routes/accounts.ts:78`, `routes/userData.ts:97`, `routes/civic.ts:65-160` (9 sites), `routes/users.ts:1178,1551`
+
+**Interfaces:**
+- Produces: `hashedIpKey(req: Request): string` — HMAC-sha256(DEVICE_ID_SALT, 'rl|' + IPv6-normalized IP), 24 hex chars, `'unknown'` when no IP. Used by every anonymous rate-limit key from here on.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// packages/api/src/utils/__tests__/ipKey.test.ts
+import type { Request } from 'express';
+import { hashedIpKey } from '../ipKey';
+
+function reqWithIp(ip: string | undefined): Request {
+  return { ip } as Request;
+}
+
+describe('hashedIpKey', () => {
+  const OLD_SALT = process.env.DEVICE_ID_SALT;
+  beforeEach(() => {
+    process.env.DEVICE_ID_SALT = 'test-salt-0123456789abcdef';
+  });
+  afterAll(() => {
+    process.env.DEVICE_ID_SALT = OLD_SALT;
+  });
+
+  it('is deterministic for the same IP', () => {
+    expect(hashedIpKey(reqWithIp('203.0.113.7'))).toBe(hashedIpKey(reqWithIp('203.0.113.7')));
+  });
+
+  it('differs across IPs', () => {
+    expect(hashedIpKey(reqWithIp('203.0.113.7'))).not.toBe(hashedIpKey(reqWithIp('203.0.113.8')));
+  });
+
+  it('never contains the raw IP and is fixed-length hex', () => {
+    const key = hashedIpKey(reqWithIp('203.0.113.7'));
+    expect(key).not.toContain('203.0.113.7');
+    expect(key).toMatch(/^[a-f0-9]{24}$/);
+  });
+
+  it('changes with the salt', () => {
+    const a = hashedIpKey(reqWithIp('203.0.113.7'));
+    process.env.DEVICE_ID_SALT = 'other-salt-0123456789abcdef';
+    expect(hashedIpKey(reqWithIp('203.0.113.7'))).not.toBe(a);
+  });
+
+  it('buckets IPv6 addresses (same /56 → same key)', () => {
+    const a = hashedIpKey(reqWithIp('2001:db8:0:1::1'));
+    const b = hashedIpKey(reqWithIp('2001:db8:0:1::2'));
+    expect(a).toBe(b);
+  });
+
+  it('returns "unknown" when no IP is resolvable', () => {
+    expect(hashedIpKey(reqWithIp(undefined))).toBe('unknown');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/api && bunx jest src/utils/__tests__/ipKey.test.ts`
+Expected: FAIL — `Cannot find module '../ipKey'`
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// packages/api/src/utils/ipKey.ts
+import crypto from 'crypto';
+import type { Request } from 'express';
+import { ipKeyGenerator } from 'express-rate-limit';
+
+/**
+ * Privacy-preserving rate-limit key: the raw client IP must never reach a
+ * store at rest (Redis included). IPv6 is bucketed via express-rate-limit's
+ * `ipKeyGenerator` (/56 by default) BEFORE hashing so a single v6 host can't
+ * rotate through 2^72 keys; the result is then HMAC'd with the server-side
+ * DEVICE_ID_SALT (namespaced with 'rl|' so rate-limit keys can never be
+ * correlated with deviceId derivations that use the same salt).
+ */
+export function hashedIpKey(req: Request): string {
+  const ip = req.ip;
+  if (!ip) {
+    return 'unknown';
+  }
+  const normalized = ipKeyGenerator(ip);
+  const salt = process.env.DEVICE_ID_SALT ?? '';
+  return crypto.createHmac('sha256', salt).update(`rl|${normalized}`).digest('hex').slice(0, 24);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/api && bunx jest src/utils/__tests__/ipKey.test.ts`
+Expected: PASS (6 tests). If `ipKeyGenerator`'s import name differs in the installed express-rate-limit version, check `node_modules/express-rate-limit/dist/index.d.ts` — v7.5 exports `ipKeyGenerator(ip: string, ipv6Subnet?: number | false): string`.
+
+- [ ] **Step 5: Wire the factory default (`middleware/rateLimiter.ts`)**
+
+Replace the option spread so limiters WITHOUT a custom keyGenerator hash the IP:
+
+```typescript
+import { hashedIpKey } from '../utils/ipKey';
+// ...
+export function rateLimit(options: RateLimitOptions) {
+  return expressRateLimit({
+    ...makeStore(options.prefix),
+    windowMs: options.windowMs,
+    max: options.max,
+    message: options.message || 'Too many requests, please try again later.',
+    standardHeaders: true,
+    legacyHeaders: false,
+    keyGenerator: options.keyGenerator ?? hashedIpKey,
+  });
+}
+```
+
+- [ ] **Step 6: Wire `middleware/security.ts`**
+
+Add `import { hashedIpKey } from '../utils/ipKey';`. Add `keyGenerator: hashedIpKey,` to the four direct `rateLimit({...})` limiters (`rl:general:` ~line 136, `rl:federation:service:` ~165, `rl:idp:service:` ~183, `rl:auth:` ~200) and to `slowDown({...})` (~231). Change `userRateLimiter`'s keyGenerator (~219) to:
+
+```typescript
+keyGenerator: (req: Request) => {
+  return (req as AuthRequest).user?.id || hashedIpKey(req);
+},
+```
+
+- [ ] **Step 7: Wire every route-level keyGenerator**
+
+In each site, add `import { hashedIpKey } from '../utils/ipKey';` and replace the fallback expression `req.ip ?? 'unknown'` with `hashedIpKey(req)`. Exact sites (pattern is identical — shown once, apply everywhere):
+
+```typescript
+// BEFORE (routes/civic.ts:65 and 8 siblings; links/assets/contacts/nodes/identity/accounts/userData/users)
+return userId ? `civic:attest:${userId}` : `civic:attest:ip:${req.ip ?? 'unknown'}`;
+// AFTER
+return userId ? `civic:attest:${userId}` : `civic:attest:ip:${hashedIpKey(req)}`;
+```
+
+Full site list: `routes/links.ts:51`, `routes/assets.ts:555`, `routes/assets.ts:569`, `routes/contacts.ts:73`, `routes/nodes.ts:33`, `routes/nodes.ts:79`, `routes/identity.ts:59`, `routes/accounts.ts:78`, `routes/userData.ts:97`, `routes/civic.ts:65,76,88,100,112,124,136,148,160`, `routes/users.ts:1178`, `routes/users.ts:1551` (this one is `appId ? \`app:${appId}\` : hashedIpKey(req)`).
+
+Verify no stragglers: `grep -rn "req\.ip" packages/api/src --include='*.ts' | grep -v __tests__ | grep -v ipKey.ts` — remaining hits after this task must only be the ones Tasks 2–5 remove (securityActivityService, deviceUtils, anomalyDetection, csrf, performance, auth.ts:2732).
+
+- [ ] **Step 8: Run the api suite + commit**
+
+Run: `cd packages/api && bun run test`
+Expected: green (any failure here is a rate-limit test asserting raw-IP keys — update it to assert the hashed shape).
+
+```bash
+git add packages/api/src/utils/ipKey.ts packages/api/src/utils/__tests__/ipKey.test.ts packages/api/src/middleware/rateLimiter.ts packages/api/src/middleware/security.ts packages/api/src/routes/links.ts packages/api/src/routes/assets.ts packages/api/src/routes/contacts.ts packages/api/src/routes/nodes.ts packages/api/src/routes/identity.ts packages/api/src/routes/accounts.ts packages/api/src/routes/userData.ts packages/api/src/routes/civic.ts packages/api/src/routes/users.ts
+git commit -m "feat(api): hash anonymous rate-limit keys — no raw IPs in Redis"
+```
+
+---
+
+### Task 2: SecurityActivity — stop capturing/serving IP
+
+**Files:**
+- Modify: `packages/api/src/models/SecurityActivity.ts:53,84-86`
+- Modify: `packages/api/src/services/securityActivityService.ts:35,152-154,196,211`
+- Modify: `packages/api/src/controllers/securityActivity.controller.ts:106`
+- Test: any existing suite touching these (grep `ipAddress` under `packages/api/src/**/__tests__`)
+
+**Interfaces:**
+- Produces: `ISecurityActivity` WITHOUT `ipAddress`; `GET /security/activity` DTO WITHOUT `ipAddress`. Task 6 (core type) and Task 7 (accounts UI) depend on this shape.
+
+- [ ] **Step 1: Model — delete the field**
+
+In `models/SecurityActivity.ts` remove `ipAddress?: string;` from `ISecurityActivity` (line 53) and the schema block (lines 84-86):
+
+```typescript
+    ipAddress: {
+      type: String,
+    },
+```
+
+- [ ] **Step 2: Service — stop reading req.ip**
+
+In `services/securityActivityService.ts`:
+- Line 35: `ACTIVITY_SELECT_FIELDS` becomes `'_id userId eventType eventDescription metadata userAgent deviceId timestamp severity createdAt'`.
+- Delete lines 152-154 (`rawIpAddress` + `ipAddress` extraction); keep the `userAgent` extraction and update the stale comment above it to `// Extract and sanitize user agent`.
+- Remove `ipAddress,` from the duplicate-placeholder object (line 196) and from `new SecurityActivity({...})` (line 211).
+
+- [ ] **Step 3: Controller — drop from DTO**
+
+In `controllers/securityActivity.controller.ts` delete line 106 (`ipAddress: activity.ipAddress,`).
+
+- [ ] **Step 4: Run tests, fix IP-specific assertions by deletion**
+
+Run: `cd packages/api && bun run test`
+Expected: failures ONLY in tests asserting `ipAddress` on security activity — delete those assertions (do not re-add the field).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/models/SecurityActivity.ts packages/api/src/services/securityActivityService.ts packages/api/src/controllers/securityActivity.controller.ts
+git commit -m "feat(api): SecurityActivity no longer captures or serves IP addresses"
+```
+
+---
+
+### Task 3: Session + deviceUtils — no IP, no geo, IP out of deviceId hash
+
+**Files:**
+- Modify: `packages/api/src/models/Session.ts:14,16,62,64`
+- Modify: `packages/api/src/utils/deviceUtils.ts` (DeviceFingerprint, DeviceInfo, UNRESOLVABLE_IPS, deriveStableDeviceId, extractDeviceInfo)
+- Modify: `packages/api/src/services/session.service.ts:522,581,583`
+- Test: `packages/api/src/utils/__tests__/deviceUtils.test.ts`, `packages/api/src/services/__tests__/session.service.test.ts`, `packages/api/src/services/__tests__/session.service.managedSwitch.test.ts`
+
+**Interfaces:**
+- Produces: `deriveStableDeviceId(userAgent: string, acceptLanguage: string, userId?: string | null): string | null` (IP parameter REMOVED — update every caller; find them with `grep -rn "deriveStableDeviceId(" packages/api/src`). `DeviceInfo` loses `ipAddress` and `location`. `DeviceFingerprint` loses `ipAddress`.
+
+- [ ] **Step 1: Update deviceUtils tests first (TDD on the new signature)**
+
+In `deviceUtils.test.ts`: change every `deriveStableDeviceId(ua, ip, lang, userId)` call to `deriveStableDeviceId(ua, lang, userId)`. DELETE test cases that assert IP-driven behavior (null on `'127.0.0.1'`/`'::1'`/missing IP; different id per IP). ADD:
+
+```typescript
+it('derives the same deviceId regardless of network (no IP input)', () => {
+  process.env.DEVICE_ID_SALT = 'test-salt-0123456789abcdef';
+  const a = deriveStableDeviceId('Mozilla/5.0 (X11; Linux x86_64)', 'en-US', 'user1');
+  expect(a).toMatch(/^[a-f0-9]{32}$/);
+  expect(deriveStableDeviceId('Mozilla/5.0 (X11; Linux x86_64)', 'en-US', 'user1')).toBe(a);
+});
+
+it('extractDeviceInfo returns no ipAddress and no location', () => {
+  const req = {
+    headers: { 'user-agent': 'Mozilla/5.0', 'accept-language': 'en', 'cf-ipcountry': 'ES' },
+    ip: '203.0.113.7',
+    connection: { remoteAddress: '203.0.113.7' },
+  } as unknown as Request;
+  const info = extractDeviceInfo(req);
+  expect('ipAddress' in info).toBe(false);
+  expect('location' in info).toBe(false);
+});
+```
+
+Run: `cd packages/api && bunx jest src/utils/__tests__/deviceUtils.test.ts` → FAIL (old signature).
+
+- [ ] **Step 2: Rewrite deviceUtils.ts**
+
+- `DeviceFingerprint`: delete `ipAddress: string;` (line 18).
+- `DeviceInfo`: delete `ipAddress?: string;` (32) and `location?: string;` (34).
+- Delete `const UNRESOLVABLE_IPS ...` (line 43).
+- `deriveStableDeviceId` — new signature and body (doc comment: replace the IP mentions; state that IP is deliberately NOT an input because a salted hash over the IPv4 space is brute-forceable and IP-churn made ids unstable):
+
+```typescript
+export function deriveStableDeviceId(
+  userAgent: string,
+  acceptLanguage: string,
+  userId?: string | null
+): string | null {
+  if (!userAgent || userAgent === 'unknown') {
+    return null;
+  }
+  const salt = getDeviceIdSalt();
+  if (!salt) {
+    return null;
+  }
+  const userScope = userId && userId.length > 0 ? userId : PRE_AUTH_USER_SCOPE;
+  return crypto
+    .createHash('sha256')
+    .update(`${salt}|${userScope}|${userAgent}|${acceptLanguage}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+```
+
+- `extractDeviceInfo`: delete `const ipAddress = req.ip || req.connection.remoteAddress;` (219); change the derive call (230) to `deriveStableDeviceId(userAgent, acceptLanguage, userId)`; delete `ipAddress,` (247) and the `location: req.headers['cf-ipcountry'] ...` line (249) from the returned object.
+- Update ALL other `deriveStableDeviceId(` callers found by grep to the 3-arg form.
+
+- [ ] **Step 3: Session model + service writes**
+
+`models/Session.ts`: delete `ipAddress?: string;` (14) and `location?: string; // General location...` (16) from `ISession`; delete `ipAddress: String,` (62) and `location: String,` (64) from the schema.
+
+`services/session.service.ts`: delete `'deviceInfo.ipAddress': deviceInfo.ipAddress,` (line 522) and `ipAddress: deviceInfo.ipAddress,` / `location: deviceInfo.location,` (581, 583). Then sweep the whole package: `grep -rn "deviceInfo\.ipAddress\|deviceInfo\.location\|deviceInfo\['ipAddress'\]" packages/api/src --include='*.ts'` — every remaining source hit (outside civic/anomaly, handled in Tasks 4-5) must be removed.
+
+- [ ] **Step 4: Run tests, fix session fixtures**
+
+Run: `cd packages/api && bun run test`
+Expected: `session.service.test.ts` / `session.service.managedSwitch.test.ts` fixtures that set or assert `deviceInfo.ipAddress`/`location` fail — delete those properties/assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/api/src/models/Session.ts packages/api/src/utils/deviceUtils.ts packages/api/src/services/session.service.ts packages/api/src/utils/__tests__/deviceUtils.test.ts packages/api/src/services/__tests__/session.service.test.ts packages/api/src/services/__tests__/session.service.managedSwitch.test.ts
+git commit -m "feat(api): sessions store no IP or geo; deviceId hash no longer mixes IP"
+```
+
+---
+
+### Task 4: Anomaly detection — remove the IP-change detector
+
+**Files:**
+- Modify: `packages/api/src/services/anomalyDetection.service.ts`
+
+- [ ] **Step 1: Delete `detectRapidIPChanges`** (lines 108-145) entirely.
+
+- [ ] **Step 2: Update `checkForAnomalies`** — remove `rapidIP` from the parallel array and its anomaly push:
+
+```typescript
+const [newLocation, newDevice, impossibleTravel] = await Promise.all([
+  this.detectNewLocation(userId, location),
+  this.detectNewDevice(userId, deviceInfo),
+  this.detectImpossibleTravel(userId, location),
+]);
+```
+
+Delete the `if (rapidIP.isAnomaly) { ... 'rapid_ip_change' ... }` block (lines 193-198).
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `cd packages/api && bun run test` → green (grep first for `rapid_ip_change`/`detectRapidIPChanges` in tests; delete matching cases).
+
+```bash
+git add packages/api/src/services/anomalyDetection.service.ts
+git commit -m "feat(api): drop IP-based anomaly detection"
+```
+
+---
+
+### Task 5: Civic anti-sybil — device-only signal; logs scrubbed
+
+**Files:**
+- Modify: `packages/api/src/services/civic/graphExclusion.ts`
+- Modify: `packages/api/src/services/civic/sybil.service.ts:66-99`
+- Modify: every `isSockPuppetRelation`/`sessionFingerprints`/`shareDeviceOrIp` caller (`grep -rn "ignoreSharedIp\|sessionFingerprints\|shareDeviceOrIp\|shared_ip" packages/api/src --include='*.ts'`) — includes `services/civic/validator.service.ts` and the attestation service that passes `ignoreSharedIp: true`
+- Modify: `packages/api/src/middleware/csrf.ts` (5× `ip: req.ip`), `packages/api/src/middleware/performance.ts:23`, `packages/api/src/routes/auth.ts:2732`
+- Test: `packages/api/src/services/__tests__/civic.graphExclusion.test.ts`
+
+**Interfaces:**
+- Produces (clean renames, update all callers): `sessionDeviceIds(userId: string): Promise<Set<string>>` (replaces `sessionFingerprints` — devices only), `shareDevice(a: string, b: string): Promise<boolean>` (replaces `shareDeviceOrIp`), `ExclusionReason = 'self' | 'graph_neighbor' | 'shared_device'`, `isSockPuppetRelation(a, b, opts?: { hops?: number })` (no `ignoreSharedIp`).
+
+- [ ] **Step 1: Update `civic.graphExclusion.test.ts` first** — delete `shared_ip` / `ignoreSharedIp` cases; rename helpers to the new names; keep shared-device cases. Run: `cd packages/api && bunx jest src/services/__tests__/civic.graphExclusion.test.ts` → FAIL.
+
+- [ ] **Step 2: Rewrite `graphExclusion.ts`**
+
+```typescript
+export type ExclusionReason = 'self' | 'graph_neighbor' | 'shared_device';
+
+/** Collect a user's active-session device ids. IPs are deliberately NOT a
+ * signal: the platform stores no user IPs (privacy invariant — see
+ * docs/superpowers/specs/2026-07-14-no-ip-storage-design.md). `deviceId` is
+ * the high-confidence per-install identifier (fingerprint rationale below). */
+export async function sessionDeviceIds(userId: string): Promise<Set<string>> {
+  const sessions = await Session.find({ userId, isActive: true })
+    .select('deviceId')
+    .lean();
+  const devices = new Set<string>();
+  for (const session of sessions) {
+    const record = session as { deviceId?: string };
+    if (record.deviceId) devices.add(record.deviceId);
+  }
+  return devices;
+}
+
+/** True when `a` and `b` share an active-session deviceId. */
+export async function shareDevice(a: string, b: string): Promise<boolean> {
+  const [da, db] = await Promise.all([sessionDeviceIds(a), sessionDeviceIds(b)]);
+  for (const device of da) {
+    if (db.has(device)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function isSockPuppetRelation(
+  a: string,
+  b: string,
+  opts: { hops?: number } = {},
+): Promise<ExclusionResult> {
+  if (a === b) {
+    return { excluded: true, reason: 'self' };
+  }
+  if (await areGraphRelated(a, b, opts.hops ?? 1)) {
+    return { excluded: true, reason: 'graph_neighbor' };
+  }
+  if (await shareDevice(a, b)) {
+    return { excluded: true, reason: 'shared_device' };
+  }
+  return { excluded: false };
+}
+```
+
+Preserve the existing fingerprint-exclusion doc comment on the device-id rationale; delete the header-comment's "SHARED DEVICE / IP" mention of IP, the `ignoreSharedIp` doc, and the `logger` import if now unused.
+
+- [ ] **Step 3: Update `sybil.service.ts`** — `computeSharedFingerprintSignal` uses devices only:
+
+```typescript
+for (const accountId of accounts) {
+  const devices = await sessionDeviceIds(accountId);
+  const prints = [...devices].map((d) => `d:${d}`);
+  // ... rest unchanged
+```
+
+Update the function doc from "Shared-device/IP cluster signal" to "Shared-device cluster signal". Update the import.
+
+- [ ] **Step 4: Update remaining callers** — validator.service.ts needs no code change (only its doc comment: "shared device/IP" → "shared device"); the attestation caller drops `ignoreSharedIp: true` and its comment. Grep to confirm zero remaining references: `grep -rn "ignoreSharedIp\|shared_ip\|shareDeviceOrIp\|sessionFingerprints" packages/api/src --include='*.ts'` → empty.
+
+- [ ] **Step 5: Scrub logs** — delete the `ip: req.ip,` line in: `middleware/csrf.ts` (5 sites: ~99, ~112, ~127, ~151, ~169), `middleware/performance.ts:23`, `routes/auth.ts:2732`. Then `grep -rn "req\.ip" packages/api/src --include='*.ts' | grep -v __tests__` must return ONLY `utils/ipKey.ts`.
+
+- [ ] **Step 6: Run + commit**
+
+Run: `cd packages/api && bun run test` → green.
+
+```bash
+git add packages/api/src/services/civic/ packages/api/src/services/__tests__/civic.graphExclusion.test.ts packages/api/src/middleware/csrf.ts packages/api/src/middleware/performance.ts packages/api/src/routes/auth.ts
+git commit -m "feat(api): civic anti-sybil is device-only; logs carry no IPs"
+```
+
+---
+
+### Task 6: Dormant `ApiKeyUsage.ipAddress` + `@oxyhq/core` type
+
+**Files:**
+- Modify: `packages/api/src/models/ApiKeyUsage.ts:15,72-74`
+- Modify: `packages/core/src/models/interfaces.ts:651`
+
+- [ ] **Step 1:** Delete `ipAddress?: string;` from `IApiKeyUsage` and the `ipAddress: { type: String },` schema block in `ApiKeyUsage.ts`.
+
+- [ ] **Step 2:** Delete `ipAddress?: string;` from the `SecurityActivity` interface in `packages/core/src/models/interfaces.ts` (line 651).
+
+- [ ] **Step 3:** Rebuild core so downstream workspaces resolve the new type: `bun run core:build` (repo root). Then `cd packages/core && bun run test` → green (722 ± removed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/api/src/models/ApiKeyUsage.ts packages/core/src/models/interfaces.ts
+git commit -m "feat(core+api): remove ipAddress from SecurityActivity type and dormant ApiKeyUsage field"
+```
+
+NOTE: this is an SDK type removal — `@oxyhq/core` gets its version bump + npm publish with the next release train (do NOT publish from this branch; see AGENTS.md publish rules).
+
+---
+
+### Task 7: Accounts UI — stop rendering IP
+
+**Files:**
+- Modify: `packages/accounts/utils/activity-format.ts:162-182`
+- Modify: `packages/accounts/components/security/useSecurityActivityItems.ts:52-65`
+- Modify: `packages/accounts/components/activity/activity-details-panel.tsx:57-62`
+- Modify: i18n locales containing `detailIp` (`grep -rn "detailIp" packages/accounts`)
+
+- [ ] **Step 1:** `getEventSubtitle` — remove the IP branches:
+
+```typescript
+/** Row subtitle (relative time + optional device name). */
+export function getEventSubtitle(
+    event: SecurityActivity,
+    formatters: DayFormatters,
+    t: TranslateFn,
+): string {
+    const relative = formatRelativeTime(event.timestamp, formatters, t);
+    const deviceName =
+        event.metadata && typeof event.metadata === 'object'
+            ? (event.metadata as { deviceName?: unknown }).deviceName
+            : undefined;
+    const deviceLabel = typeof deviceName === 'string' ? deviceName : null;
+
+    if (deviceLabel) return `${relative} • ${deviceLabel}`;
+    return relative;
+}
+```
+
+- [ ] **Step 2:** `useSecurityActivityItems.ts` — delete the `activity.ipAddress ? ... detailIp ... : null,` entry (line 57) from the details array; update the comment on line 52 (`// Show details on press - include device info, etc.`).
+
+- [ ] **Step 3:** `activity-details-panel.tsx` — delete the `if (event.ipAddress) { ... }` block (~lines 57-62).
+
+- [ ] **Step 4:** Remove the now-unused `security.activity.detailIp` key from every locale file that has it.
+
+- [ ] **Step 5:** Typecheck + commit. Run accounts typecheck (`cd packages/accounts && bunx tsc --noEmit`) — core was rebuilt in Task 6, so any lingering `ipAddress` usage fails here.
+
+```bash
+git add packages/accounts/utils/activity-format.ts packages/accounts/components/security/useSecurityActivityItems.ts packages/accounts/components/activity/activity-details-panel.tsx packages/accounts/lib/i18n/
+git commit -m "feat(accounts): security activity UI no longer shows IP addresses"
+```
+
+---
+
+### Task 8: Purge script (historical prod data)
+
+**Files:**
+- Create: `packages/api/scripts/purge-ip-data.ts`
+
+- [ ] **Step 1: Write the script** (mirrors the existing one-shot script pattern in `packages/api/scripts/`; supports `DRY_RUN`):
+
+```typescript
+/**
+ * One-shot purge of historical IP data (privacy invariant: no user IPs at rest).
+ * Removes: securityactivities.ipAddress, sessions.deviceInfo.{ipAddress,location},
+ * apikeyusages.ipAddress. Idempotent. DRY_RUN=1 counts without writing.
+ * Run as a one-shot ECS task AFTER deploying the api that stops new IP writes.
+ */
+import mongoose from 'mongoose';
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error('MONGODB_URI is required');
+  }
+  const dryRun = process.env.DRY_RUN === '1';
+  await mongoose.connect(uri);
+  const db = mongoose.connection.db;
+  if (!db) {
+    throw new Error('No database handle after connect');
+  }
+
+  const targets = [
+    { collection: 'securityactivities', filter: { ipAddress: { $exists: true } }, unset: { ipAddress: 1 } },
+    {
+      collection: 'sessions',
+      filter: { $or: [{ 'deviceInfo.ipAddress': { $exists: true } }, { 'deviceInfo.location': { $exists: true } }] },
+      unset: { 'deviceInfo.ipAddress': 1, 'deviceInfo.location': 1 },
+    },
+    { collection: 'apikeyusages', filter: { ipAddress: { $exists: true } }, unset: { ipAddress: 1 } },
+  ] as const;
+
+  for (const target of targets) {
+    if (dryRun) {
+      const count = await db.collection(target.collection).countDocuments(target.filter);
+      console.log(`[DRY_RUN] ${target.collection}: ${count} docs would be updated`);
+    } else {
+      const result = await db.collection(target.collection).updateMany(target.filter, { $unset: target.unset });
+      console.log(`${target.collection}: ${result.modifiedCount} docs purged`);
+    }
+  }
+
+  await mongoose.disconnect();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Dry-run locally** (needs local mongod; skip if not running): `cd packages/api && DRY_RUN=1 MONGODB_URI=mongodb://127.0.0.1:27017/oxy-dev bunx ts-node scripts/purge-ip-data.ts` — match the invocation style of the sibling scripts (check how `backfill-contact-hashes.ts` is documented/run and use the same runner).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/api/scripts/purge-ip-data.ts
+git commit -m "feat(api): one-shot purge script for historical IP data"
+```
+
+---
+
+### Task 9: Full verification gate
+
+- [ ] **Step 1:** Final IP sweep — each must return ONLY sanctioned hits (`ipKey.ts`, email-inbound header storage, tests):
+
+```bash
+grep -rn "req\.ip\b\|remoteAddress\|x-forwarded-for\|cf-ipcountry" packages/api/src --include='*.ts' | grep -v __tests__
+grep -rn "ipAddress" packages/api/src packages/core/src packages/accounts --include='*.ts' --include='*.tsx' | grep -v __tests__
+```
+
+- [ ] **Step 2:** Full test-build gate (per-package correct runners + builds): api `bun run test`, core `bun run test`, contracts/services unaffected but run root `bun run test` via turbo, plus `bun run build:all`. All green before push.
+
+- [ ] **Step 3:** Add the durable rule to `packages/api`'s governing docs: in `/home/nate/Oxy/OxyHQServices/AGENTS.md` (Auth/Session or Coding Standards section) add — "**No user IPs at rest (privacy invariant):** never persist user IP addresses — raw, hashed, or geo-derived (country included) — in MongoDB, logs, or metrics. Anonymous rate-limit keys must go through `hashedIpKey` (`packages/api/src/utils/ipKey.ts`). Inbound-email `Received:` headers (third-party sender IPs) are the one sanctioned exception."
+
+- [ ] **Step 4:** Push branch, open PR, check CI + bot reviews (gemini/CodeQL), merge on green, deploy, THEN run the purge script as a one-shot ECS task (Task 8 rollout order).

--- a/docs/superpowers/specs/2026-07-14-no-ip-storage-design.md
+++ b/docs/superpowers/specs/2026-07-14-no-ip-storage-design.md
@@ -1,0 +1,68 @@
+# No IP Storage — Privacy Design
+
+**Date:** 2026-07-14
+**Status:** Approved
+**Owner requirement:** user privacy is paramount (threat model includes state-actor harassment of users). Zero user IP addresses at rest — raw, hashed, or geo-derived. Salted hashes of IPv4 addresses are brute-forceable by anyone with server access, so hashing is NOT an acceptable at-rest form for historical data.
+
+## Scope
+
+`packages/api` (primary), `packages/accounts` (UI rendering of IP), one-shot prod purge script. Inbound email `Received:` headers (third-party sender IPs) are explicitly **kept** (owner decision — standard email practice, not Oxy-user IPs).
+
+## Changes
+
+### 1. SecurityActivity — no IP capture
+- Remove `ipAddress` field from `packages/api/src/models/SecurityActivity.ts`.
+- `services/securityActivityService.ts`: stop reading `req.ip` / `req.socket.remoteAddress`; remove sanitize/truncate logic; remove `ipAddress` from `ACTIVITY_SELECT_FIELDS`.
+- `controllers/securityActivity.controller.ts`: remove `ipAddress` from the `GET /security/activity` DTO.
+- No location substitute: **no country either** (owner decision — no location signal of any kind in the security feed). Feed shows device + action + timestamp only.
+
+### 2. Session — no IP, no geo
+- Remove `deviceInfo.ipAddress` and `deviceInfo.location` from `packages/api/src/models/Session.ts`.
+- `utils/deviceUtils.ts` `getDeviceInfo`: stop reading `req.ip` and `cf-ipcountry`.
+- `services/session.service.ts`: remove the `deviceInfo.ipAddress` / `deviceInfo.location` writes (new-session and session-reuse paths).
+
+### 3. deviceId derivation — IP removed from hash
+- `utils/deviceUtils.ts` `deriveStableDeviceId`: drop the IP input (hash = salt|userScope|ua|lang). Rationale: sha256 with a known salt is reversible over the IPv4 space by brute force.
+- Accepted trade-offs: (a) same user + same UA + same language on two devices dedupe to one deviceId — acceptable because device-first auth uses the client-persisted deviceId as authority; (b) existing derived deviceIds change once after deploy — stale session rows expire via the 7-day sliding TTL.
+- `UNRESOLVABLE_IPS` sentinel handling goes away with the IP input.
+
+### 4. Anomaly detection — IP-change detector removed
+- Delete `detectRapidIPChanges` from `services/anomalyDetection.service.ts` and its trigger. Signal is moot: password login is being phased out in favor of Commons key identity.
+
+### 5. Civic anti-sybil — IP signal removed
+- `services/civic/graphExclusion.ts`: remove IP sets from `sessionFingerprints()`, the `shared_ip` exclusion reason, and the `ignoreSharedIp` option.
+- `services/civic/sybil.service.ts`: remove `i:<ip>` inverted-index prints.
+- `services/civic/validator.service.ts`: jury exclusion keeps device-fingerprint + interaction-history + affinity throttle. Accepted trade-off: weaker detection of multi-accounts behind one network.
+
+### 6. Rate limiting — HMAC-truncated Redis keys (transient only)
+- Anonymous rate limiting stays keyed per client, but the Redis key stores `hmac-sha256(salt, normalizedIp)` truncated — never the raw IP. TTL unchanged (windowMs). Hashing is acceptable HERE because keys live minutes, not history.
+- One shared helper in `packages/api` (e.g. `utils/ipKey.ts` `hashedIpKey(req)`), reusing the existing required `DEVICE_ID_SALT`; IPv6-normalize via express-rate-limit's `ipKeyGenerator` before hashing.
+- Apply to: default keyGenerators in `middleware/security.ts` (rl:general, rl:auth, rl:idp:service, rl:federation:service, rl:user anonymous fallback) and every route-level `…:ip:<ip>` keyGenerator (civic, links, contacts, userData, users, assets, accounts, nodes, identity routes).
+- Follow-up (separate change): same treatment in `@oxyhq/core/server` `rateLimit.ts` for the other Oxy backends.
+
+### 7. Logs — no IP fields
+- Remove `ip: req.ip` from `middleware/csrf.ts` warn calls, `routes/auth.ts` service-token issue log, and `middleware/performance.ts` metric metadata.
+
+### 8. Email inbound — unchanged
+- `Message.headers` (incl. `Received:` chains with third-party sender IPs) kept as-is per owner decision.
+
+### 9. Data purge (prod, irreversible — owner-confirmed)
+- One-shot script `packages/api/scripts/purge-ip-data.ts`:
+  - `securityactivities`: `$unset: { ipAddress: 1 }` (730-day TTL means live history exists)
+  - `sessions`: `$unset: { 'deviceInfo.ipAddress': 1, 'deviceInfo.location': 1 }`
+- Run as one-shot ECS task after the API deploy.
+
+### 10. Cleanup + UI + docs
+- Remove dormant `ApiKeyUsage.ipAddress` field (no writer exists).
+- `packages/accounts`: remove IP rendering from `utils/activity-format.ts` and `components/security/useSecurityActivityItems.ts`; drop `ipAddress` from any activity type the UI/SDK declares.
+- AGENTS.md gains the durable rule: never persist user IPs (raw, hashed, or geo-derived); transient anonymous rate-limit keys must be HMAC-hashed.
+
+## Testing
+- Update existing Jest suites touching securityActivity, session.service, deviceUtils, anomalyDetection, civic graphExclusion/sybil/validator, csrf, rate limiters.
+- New assertions: security-activity DTO has no `ipAddress`; session docs persist no `deviceInfo.ipAddress`/`location`; rate-limit key for an anonymous request is a hash, not the IP.
+- Baselines (correct runner per package): contracts 130, core 722, api 1322, services 195, auth 45 — counts may shift where IP-specific tests are removed.
+
+## Rollout order
+1. Land + deploy `packages/api` (stops new IP writes).
+2. Run purge script (deletes historical IPs).
+3. Accounts UI change ships with the same PR (renders nothing even if old field present).

--- a/packages/accounts/components/activity/activity-details-panel.tsx
+++ b/packages/accounts/components/activity/activity-details-panel.tsx
@@ -54,13 +54,6 @@ export function ActivityDetailsPanel({
             )} — ${formatters.time.format(timestamp)}`,
         });
     }
-    if (event.ipAddress) {
-        rows.push({
-            key: 'ip',
-            label: t('activity.details.ip'),
-            value: event.ipAddress,
-        });
-    }
     if (event.userAgent) {
         rows.push({
             key: 'ua',

--- a/packages/accounts/components/security/useSecurityActivityItems.ts
+++ b/packages/accounts/components/security/useSecurityActivityItems.ts
@@ -25,7 +25,7 @@ interface UseSecurityActivityItemsArgs {
 
 /**
  * Builds the recent-activity `GroupedSection` rows for the security screen.
- * Each row opens a detail alert (type, severity, IP, device, browser, time)
+ * Each row opens a detail alert (type, severity, device, browser, time)
  * with an optional "view device" navigation action for device/sign-in events.
  *
  * Extracted verbatim from the security screen's inline `useMemo`.
@@ -49,12 +49,11 @@ export function useSecurityActivityItems({
       const description = formatEventDescription(activity);
       const deviceId = activity.deviceId;
 
-      // Show details on press - include IP, device info, etc.
+      // Show details on press - include device info, etc.
       const onPress = () => {
         const details = [
           `${t('security.activity.detailType')}: ${activity.eventType}`,
           `${t('security.activity.detailSeverity')}: ${severity}`,
-          activity.ipAddress ? `${t('security.activity.detailIp')}: ${activity.ipAddress}` : null,
           activity.deviceId && activity.metadata?.deviceName
             ? `${t('security.activity.detailDevice')}: ${activity.metadata.deviceName}`
             : activity.deviceId

--- a/packages/accounts/lib/i18n/locales/en.json
+++ b/packages/accounts/lib/i18n/locales/en.json
@@ -180,7 +180,6 @@
       "viewDevice": "View Device",
       "detailType": "Type",
       "detailSeverity": "Severity",
-      "detailIp": "IP",
       "detailDevice": "Device",
       "detailDeviceId": "Device ID",
       "detailBrowser": "Browser",
@@ -330,7 +329,6 @@
       "type": "Event type",
       "severity": "Severity",
       "time": "Time",
-      "ip": "IP address",
       "browser": "Browser",
       "device": "Device",
       "deviceId": "Device ID"

--- a/packages/accounts/lib/i18n/locales/es.json
+++ b/packages/accounts/lib/i18n/locales/es.json
@@ -180,7 +180,6 @@
       "viewDevice": "Ver dispositivo",
       "detailType": "Tipo",
       "detailSeverity": "Severidad",
-      "detailIp": "IP",
       "detailDevice": "Dispositivo",
       "detailDeviceId": "ID de dispositivo",
       "detailBrowser": "Navegador",
@@ -330,7 +329,6 @@
       "type": "Tipo de evento",
       "severity": "Gravedad",
       "time": "Hora",
-      "ip": "Dirección IP",
       "browser": "Navegador",
       "device": "Dispositivo",
       "deviceId": "ID del dispositivo"

--- a/packages/accounts/utils/activity-format.ts
+++ b/packages/accounts/utils/activity-format.ts
@@ -159,24 +159,19 @@ export function getEventTitle(event: SecurityActivity, t: TranslateFn): string {
     return localized;
 }
 
-/** Row subtitle (relative time + optional device name / IP). */
+/** Row subtitle (relative time + optional device name). */
 export function getEventSubtitle(
     event: SecurityActivity,
     formatters: DayFormatters,
     t: TranslateFn,
 ): string {
     const relative = formatRelativeTime(event.timestamp, formatters, t);
-    const ip = event.ipAddress;
     const deviceName =
         event.metadata && typeof event.metadata === 'object'
             ? (event.metadata as { deviceName?: unknown }).deviceName
             : undefined;
     const deviceLabel = typeof deviceName === 'string' ? deviceName : null;
 
-    if (deviceLabel && ip) {
-        return `${relative} • ${deviceLabel} • ${ip}`;
-    }
     if (deviceLabel) return `${relative} • ${deviceLabel}`;
-    if (ip) return `${relative} • ${ip}`;
     return relative;
 }

--- a/packages/api/scripts/purge-ip-data.ts
+++ b/packages/api/scripts/purge-ip-data.ts
@@ -1,0 +1,65 @@
+#!/usr/bin/env bun
+/**
+ * One-shot purge of historical IP data (privacy invariant: no user IPs at rest).
+ *
+ * Removes: securityactivities.ipAddress, sessions.deviceInfo.{ipAddress,location},
+ * apikeyusages.ipAddress. Idempotent. DRY_RUN=1 counts without writing.
+ *
+ * A salted hash of an IPv4 address is brute-forceable by anyone with server
+ * access, so historical IPs (even where hashed) are removed outright rather than
+ * re-hashed. Run as a one-shot ECS task AFTER deploying the api that stops new
+ * IP writes (see docs/superpowers/specs/2026-07-14-no-ip-storage-design.md,
+ * "Rollout order").
+ *
+ * Run:
+ *   cd packages/api && bun run scripts/purge-ip-data.ts
+ *
+ * Env:
+ *   MONGODB_URI   Mongo connection string (required)
+ *   DRY_RUN=1     Report counts without writing
+ */
+
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+
+dotenv.config();
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error('MONGODB_URI is required');
+  }
+  const dryRun = process.env.DRY_RUN === '1';
+  await mongoose.connect(uri);
+  const db = mongoose.connection.db;
+  if (!db) {
+    throw new Error('No database handle after connect');
+  }
+
+  const targets = [
+    { collection: 'securityactivities', filter: { ipAddress: { $exists: true } }, unset: { ipAddress: 1 } },
+    {
+      collection: 'sessions',
+      filter: { $or: [{ 'deviceInfo.ipAddress': { $exists: true } }, { 'deviceInfo.location': { $exists: true } }] },
+      unset: { 'deviceInfo.ipAddress': 1, 'deviceInfo.location': 1 },
+    },
+    { collection: 'apikeyusages', filter: { ipAddress: { $exists: true } }, unset: { ipAddress: 1 } },
+  ] as const;
+
+  for (const target of targets) {
+    if (dryRun) {
+      const count = await db.collection(target.collection).countDocuments(target.filter);
+      console.log(`[DRY_RUN] ${target.collection}: ${count} docs would be updated`);
+    } else {
+      const result = await db.collection(target.collection).updateMany(target.filter, { $unset: target.unset });
+      console.log(`${target.collection}: ${result.modifiedCount} docs purged`);
+    }
+  }
+
+  await mongoose.disconnect();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/api/src/controllers/securityActivity.controller.ts
+++ b/packages/api/src/controllers/securityActivity.controller.ts
@@ -103,7 +103,6 @@ export const getSecurityActivity = async (req: AuthRequest, res: Response): Prom
       eventType: activity.eventType,
       eventDescription: activity.eventDescription,
       metadata: activity.metadata || {},
-      ipAddress: activity.ipAddress,
       userAgent: activity.userAgent,
       deviceId: activity.deviceId,
       timestamp: activity.timestamp,

--- a/packages/api/src/middleware/csrf.ts
+++ b/packages/api/src/middleware/csrf.ts
@@ -96,7 +96,6 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
       logger.warn('Native app CSRF bypass without auth', {
         method: req.method,
         path: req.path,
-        ip: req.ip,
       });
 
       return res.status(403).json({
@@ -109,7 +108,6 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
       logger.warn('CSRF token missing (native app)', {
         method: req.method,
         path: req.path,
-        ip: req.ip,
       });
 
       return res.status(403).json({
@@ -124,7 +122,6 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
       logger.warn('CSRF token invalid format (native app)', {
         method: req.method,
         path: req.path,
-        ip: req.ip,
       });
 
       return res.status(403).json({
@@ -148,7 +145,6 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
       path: req.path,
       hasCookie: !!cookieToken,
       hasHeader: !!headerToken,
-      ip: req.ip,
     });
 
     return res.status(403).json({
@@ -166,7 +162,6 @@ export function verifyCsrfToken(req: Request, res: Response, next: NextFunction)
     logger.warn('CSRF token mismatch', {
       method: req.method,
       path: req.path,
-      ip: req.ip,
     });
 
     return res.status(403).json({

--- a/packages/api/src/middleware/performance.ts
+++ b/packages/api/src/middleware/performance.ts
@@ -20,7 +20,6 @@ export const performanceMiddleware = (req: Request, res: Response, next: NextFun
       path: req.path,
       statusCode: res.statusCode,
       userAgent: req.get('user-agent'),
-      ip: req.ip,
     });
 
     // Log slow requests

--- a/packages/api/src/middleware/rateLimiter.ts
+++ b/packages/api/src/middleware/rateLimiter.ts
@@ -3,6 +3,7 @@ import { RedisStore } from 'rate-limit-redis';
 import type { RedisReply } from 'rate-limit-redis';
 import { getRedisClient } from '../config/redis';
 import type { Request } from 'express';
+import { hashedIpKey } from '../utils/ipKey';
 
 interface RateLimitOptions {
   /**
@@ -40,6 +41,6 @@ export function rateLimit(options: RateLimitOptions) {
     message: options.message || 'Too many requests, please try again later.',
     standardHeaders: true,
     legacyHeaders: false,
-    ...(options.keyGenerator ? { keyGenerator: options.keyGenerator } : {}),
+    keyGenerator: options.keyGenerator ?? hashedIpKey,
   });
 }

--- a/packages/api/src/middleware/security.ts
+++ b/packages/api/src/middleware/security.ts
@@ -7,6 +7,7 @@ import type { RedisReply } from "rate-limit-redis";
 import { getRedisClient } from "../config/redis";
 import type { AuthRequest } from "./auth";
 import { verifyServiceToken } from "./serviceToken";
+import { hashedIpKey } from "../utils/ipKey";
 
 const isProd = process.env.NODE_ENV !== 'development';
 
@@ -140,6 +141,7 @@ const rateLimiter = rateLimit({
   message: "Too many requests from this IP, please try again later.",
   standardHeaders: true,
   legacyHeaders: false,
+  keyGenerator: hashedIpKey,
   skip: (req: Request) =>
     req.path.startsWith('/files/upload') ||
     isIdpServiceToServicePath(req.path) ||
@@ -169,6 +171,7 @@ const federationServiceLimiter = rateLimit({
   message: "Too many federation signing requests, please slow down.",
   standardHeaders: true,
   legacyHeaders: false,
+  keyGenerator: hashedIpKey,
   skip: (req: Request) => req.path.startsWith('/files/upload'),
 });
 
@@ -187,6 +190,7 @@ const idpServiceLimiter = rateLimit({
   message: "Too many requests, please try again later.",
   standardHeaders: true,
   legacyHeaders: false,
+  keyGenerator: hashedIpKey,
   skip: (req: Request) => req.path.startsWith('/files/upload'),
 });
 
@@ -204,6 +208,7 @@ const authRateLimiter = rateLimit({
   message: "Too many authentication attempts from this IP, please try again later.",
   standardHeaders: true,
   legacyHeaders: false,
+  keyGenerator: hashedIpKey,
   skip: (req: Request) => req.path.startsWith('/files/upload'),
 });
 
@@ -216,7 +221,7 @@ const userRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: (req: Request) => {
-    return (req as AuthRequest).user?.id || req.ip || 'unknown';
+    return (req as AuthRequest).user?.id || hashedIpKey(req);
   },
   skip: (req: Request) => {
     return req.path.startsWith('/files/upload') || !(req as AuthRequest).user;
@@ -232,6 +237,7 @@ const bruteForceProtection = slowDown({
   windowMs: 15 * 60 * 1000,
   delayAfter: isProd ? 100 : 1000,
   delayMs: () => isProd ? 500 : 100,
+  keyGenerator: hashedIpKey,
   skip: (req: Request) =>
     req.path.startsWith('/files/upload') ||
     isIdpServiceToServicePath(req.path) ||

--- a/packages/api/src/models/ApiKeyUsage.ts
+++ b/packages/api/src/models/ApiKeyUsage.ts
@@ -12,7 +12,6 @@ export interface IApiKeyUsage extends Document {
   creditsUsed?: number;
   responseTime?: number;
   userAgent?: string;
-  ipAddress?: string;
   timestamp: Date;
   authType: 'api_key' | 'session' | 'internal';
   serviceApp?: string;
@@ -67,9 +66,6 @@ const ApiKeyUsageSchema = new Schema<IApiKeyUsage>(
       type: Number,
     },
     userAgent: {
-      type: String,
-    },
-    ipAddress: {
       type: String,
     },
     timestamp: {

--- a/packages/api/src/models/SecurityActivity.ts
+++ b/packages/api/src/models/SecurityActivity.ts
@@ -50,7 +50,6 @@ export interface ISecurityActivity extends Document {
   eventType: SecurityEventType;
   eventDescription: string;
   metadata?: Record<string, any>; // Additional event-specific data
-  ipAddress?: string;
   userAgent?: string;
   deviceId?: string;
   timestamp: Date;
@@ -80,9 +79,6 @@ const SecurityActivitySchema: Schema = new Schema(
     metadata: {
       type: Schema.Types.Mixed,
       default: {},
-    },
-    ipAddress: {
-      type: String,
     },
     userAgent: {
       type: String,

--- a/packages/api/src/models/Session.ts
+++ b/packages/api/src/models/Session.ts
@@ -11,9 +11,7 @@ export interface ISession extends Document {
     browser?: string;
     os?: string;
     lastActive: Date;
-    ipAddress?: string;
     userAgent?: string;
-    location?: string; // General location for security purposes
     fingerprint?: string; // Device fingerprint for identification
   };
   accessToken: string; // Current access token for this session
@@ -59,9 +57,7 @@ const SessionSchema: Schema = new Schema(
       browser: String,
       os: String,
       lastActive: { type: Date, default: Date.now },
-      ipAddress: String,
       userAgent: String,
-      location: String,
       fingerprint: String, // Device fingerprint for identification
     },
     accessToken: {

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -6,6 +6,7 @@ import { authMiddleware, type AuthRequest } from '../middleware/auth';
 import { isStaffUser } from '../middleware/requireStaff';
 import { validate } from '../middleware/validate';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { asyncHandler } from '../utils/asyncHandler';
 import { BadRequestError, ForbiddenError, NotFoundError, UnauthorizedError } from '../utils/error';
 import { accountService, type AccountNode, type EffectiveAccess } from '../services/account.service';
@@ -75,7 +76,7 @@ function resolveCallerDeviceId(req: AuthRequest): string | null {
 function userScopedKey(scope: string) {
   return (req: Request): string => {
     const userId = (req as AuthRequest).user?._id?.toString();
-    return userId ? `${scope}:${userId}` : `${scope}:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `${scope}:${userId}` : `${scope}:ip:${hashedIpKey(req)}`;
   };
 }
 

--- a/packages/api/src/routes/assets.ts
+++ b/packages/api/src/routes/assets.ts
@@ -5,6 +5,7 @@ import { authMiddleware, serviceAuthMiddleware, type ServiceAuthRequest } from '
 import { optionalAuthMiddleware, getMediaViewerUserId } from '../middleware/optionalAuth';
 import { mediaHeadersMiddleware } from '../middleware/mediaHeaders';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { logger } from '../utils/logger';
 import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
 import { ApiError, BadRequestError, NotFoundError, UnauthorizedError, ForbiddenError, ValidationError, ConflictError } from '../utils/error';
@@ -552,7 +553,7 @@ const cacheUploadLimiter = rateLimit({
     if (serviceApp?.appId) {
       return `asset-cache:upload:${serviceApp.appId}`;
     }
-    return `asset-cache:upload:ip:${req.ip ?? 'unknown'}`;
+    return `asset-cache:upload:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -566,7 +567,7 @@ const cacheDeleteLimiter = rateLimit({
     if (serviceApp?.appId) {
       return `asset-cache:delete:${serviceApp.appId}`;
     }
-    return `asset-cache:delete:ip:${req.ip ?? 'unknown'}`;
+    return `asset-cache:delete:ip:${hashedIpKey(req)}`;
   },
 });
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2729,7 +2729,6 @@ router.post('/service-token', serviceTokenLimiter, validate({ body: serviceToken
     applicationId: app._id.toString(),
     appName: app.name,
     expiresIn: SERVICE_TOKEN_EXPIRY,
-    ip: req.ip,
   });
 
   sendSuccess(res, {

--- a/packages/api/src/routes/civic.ts
+++ b/packages/api/src/routes/civic.ts
@@ -16,6 +16,7 @@ import { Router, type Request, type Response } from 'express';
 import { authMiddleware, serviceAuthMiddleware, type AuthRequest, type ServiceAuthRequest } from '../middleware/auth';
 import { validate } from '../middleware/validate';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { asyncHandler } from '../utils/asyncHandler';
 import { BadRequestError, ConflictError, ForbiddenError, NotFoundError, UnauthorizedError } from '../utils/error';
 import { isValidObjectId } from '../utils/validation';
@@ -62,7 +63,7 @@ const attestationLimiter = rateLimit({
   message: 'Too many attestation submissions. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:attest:${userId}` : `civic:attest:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:attest:${userId}` : `civic:attest:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -73,7 +74,7 @@ const validationLimiter = rateLimit({
   message: 'Too many validation requests. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:validate:${userId}` : `civic:validate:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:validate:${userId}` : `civic:validate:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -85,7 +86,7 @@ const vouchLimiter = rateLimit({
   message: 'Too many vouch operations. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:vouch:${userId}` : `civic:vouch:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:vouch:${userId}` : `civic:vouch:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -97,7 +98,7 @@ const personhoodReadLimiter = rateLimit({
   message: 'Too many personhood status requests. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:personhood:read:${userId}` : `civic:personhood:read:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:personhood:read:${userId}` : `civic:personhood:read:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -109,7 +110,7 @@ const personhoodAdminLimiter = rateLimit({
   message: 'Too many personhood admin operations. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:personhood:admin:${userId}` : `civic:personhood:admin:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:personhood:admin:${userId}` : `civic:personhood:admin:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -121,7 +122,7 @@ const credentialIssueLimiter = rateLimit({
   message: 'Too many credential issuance requests. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:credential:issue:${userId}` : `civic:credential:issue:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:credential:issue:${userId}` : `civic:credential:issue:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -133,7 +134,7 @@ const credentialReadLimiter = rateLimit({
   message: 'Too many credential requests. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:credential:read:${userId}` : `civic:credential:read:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:credential:read:${userId}` : `civic:credential:read:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -145,7 +146,7 @@ const credentialVerifyLimiter = rateLimit({
   message: 'Too many credential verification requests. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:credential:verify:${userId}` : `civic:credential:verify:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:credential:verify:${userId}` : `civic:credential:verify:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -157,7 +158,7 @@ const credentialRevokeLimiter = rateLimit({
   message: 'Too many credential revocation requests. Please slow down.',
   keyGenerator: (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `civic:credential:revoke:${userId}` : `civic:credential:revoke:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `civic:credential:revoke:${userId}` : `civic:credential:revoke:ip:${hashedIpKey(req)}`;
   },
 });
 

--- a/packages/api/src/routes/civic.ts
+++ b/packages/api/src/routes/civic.ts
@@ -216,7 +216,6 @@ function throwForRealLifeReason(reason: RealLifeRejectionReason): never {
     case 'self_attestation':
     case 'excluded_graph_neighbor':
     case 'excluded_shared_device':
-    case 'excluded_shared_ip':
       throw new ForbiddenError(`Attestation rejected: ${reason}`);
     default:
       throw new BadRequestError(`Attestation rejected: ${reason}`);
@@ -240,7 +239,6 @@ function throwForVouchReason(reason: VouchRejectionReason): never {
     case 'excluded_self':
     case 'excluded_graph_neighbor':
     case 'excluded_shared_device':
-    case 'excluded_shared_ip':
       throw new ForbiddenError(`Vouch rejected: ${reason}`);
     default:
       throw new BadRequestError(`Vouch rejected: ${reason}`);

--- a/packages/api/src/routes/contacts.ts
+++ b/packages/api/src/routes/contacts.ts
@@ -28,6 +28,7 @@ import { Router, type Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { authMiddleware, type AuthRequest } from '../middleware/auth';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { validate } from '../middleware/validate';
 import { asyncHandler } from '../utils/asyncHandler';
 import { ForbiddenError, UnauthorizedError } from '../utils/error';
@@ -70,7 +71,7 @@ const discoverLimiter = rateLimit({
         });
       }
     }
-    return `contacts:discover:ip:${req.ip ?? 'unknown'}`;
+    return `contacts:discover:ip:${hashedIpKey(req)}`;
   },
 });
 

--- a/packages/api/src/routes/identity.ts
+++ b/packages/api/src/routes/identity.ts
@@ -24,6 +24,7 @@ import { BadRequestError, NotFoundError, UnauthorizedError } from '../utils/erro
 import { validate } from '../middleware/validate';
 import { isValidObjectId } from '../utils/validation';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { logger } from '../utils/logger';
 import { safeFetch } from '@oxyhq/core/server';
 import {
@@ -56,7 +57,7 @@ const router = Router();
 function userScopedKey(scope: string) {
   return (req: Request): string => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `${scope}:${userId}` : `${scope}:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `${scope}:${userId}` : `${scope}:ip:${hashedIpKey(req)}`;
   };
 }
 

--- a/packages/api/src/routes/links.ts
+++ b/packages/api/src/routes/links.ts
@@ -31,6 +31,7 @@ import {
   type OptionalUserOrServiceRequest,
 } from '../middleware/optionalAuth';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { validate } from '../middleware/validate';
 import { asyncHandler } from '../utils/asyncHandler';
 import { linkPreviewService } from '../services/linkPreview/linkPreviewService';
@@ -48,7 +49,7 @@ function principalKey(req: Request): string {
   const r = req as OptionalUserOrServiceRequest;
   if (r.user?._id) return `u:${r.user._id}`;
   if (r.serviceApp?.appId) return `s:${r.serviceApp.appId}`;
-  return `ip:${req.ip ?? 'unknown'}`;
+  return `ip:${hashedIpKey(req)}`;
 }
 
 // Reads are cheap (cache-backed) and every app calls them with ONE shared

--- a/packages/api/src/routes/nodes.ts
+++ b/packages/api/src/routes/nodes.ts
@@ -19,6 +19,7 @@ import { authMiddleware, type AuthRequest } from '../middleware/auth';
 import { asyncHandler } from '../utils/asyncHandler';
 import { ApiError, ErrorCodes, InternalServerError, NotFoundError, UnauthorizedError } from '../utils/error';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { isValidObjectId } from '../utils/validation';
 import { getUserNode, removeNode, provisionManagedVault } from '../services/nodeRegistry.service';
 import { enqueueNodeIngest } from '../queue/nodeIngest.queue';
@@ -30,7 +31,7 @@ const router = Router();
 function userScopedKey(scope: string) {
   return (req: AuthRequest): string => {
     const userId = req.user?.id;
-    return userId ? `${scope}:${userId}` : `${scope}:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `${scope}:${userId}` : `${scope}:ip:${hashedIpKey(req)}`;
   };
 }
 
@@ -76,7 +77,7 @@ const nodeIngestNotifyLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 30,
   message: 'Too many ingest notifications. Please slow down.',
-  keyGenerator: (req: Request): string => `nodes:ingest:ip:${req.ip ?? 'unknown'}`,
+  keyGenerator: (req: Request): string => `nodes:ingest:ip:${hashedIpKey(req)}`,
 });
 
 /** Public projection of a node row (drops Mongo internals). */

--- a/packages/api/src/routes/platform-stats.ts
+++ b/packages/api/src/routes/platform-stats.ts
@@ -48,8 +48,6 @@ async function refreshStats(now: number) {
     totalTransactions,
     totalApplications,
     totalFollows,
-    topCountries,
-    regionCount,
   ] = await Promise.all([
     User.countDocuments(),
     Session.countDocuments({ isActive: true }),
@@ -59,16 +57,6 @@ async function refreshStats(now: number) {
     Transaction.countDocuments(),
     Application.countDocuments({ status: 'active' }),
     Follow.countDocuments(),
-    Session.aggregate([
-      { $match: { isActive: true, 'deviceInfo.location': { $exists: true, $ne: '' } } },
-      { $group: { _id: '$deviceInfo.location', count: { $sum: 1 } } },
-      { $sort: { count: -1 } },
-      { $limit: 7 },
-    ]).catch(() => []),
-    Session.distinct('deviceInfo.location', {
-      isActive: true,
-      'deviceInfo.location': { $exists: true, $ne: '' },
-    }).then((locations) => locations.length).catch(() => 0),
   ]);
 
   const stats = {
@@ -81,11 +69,6 @@ async function refreshStats(now: number) {
     totalApplications,
     totalFollows,
     aiModels: 4,
-    topCountries: topCountries.map((c: any) => ({
-      location: c._id,
-      count: c.count,
-    })),
-    regions: regionCount,
     timestamp: new Date().toISOString(),
   };
 

--- a/packages/api/src/routes/userData.ts
+++ b/packages/api/src/routes/userData.ts
@@ -21,6 +21,7 @@ import { Router, type Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { authMiddleware, type AuthRequest } from '../middleware/auth';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { validate } from '../middleware/validate';
 import { asyncHandler } from '../utils/asyncHandler';
 import { ApiError, ConflictError, UnauthorizedError } from '../utils/error';
@@ -94,7 +95,7 @@ const writeLimiter = rateLimit({
         });
       }
     }
-    return `userAppData:write:ip:${req.ip ?? 'unknown'}`;
+    return `userAppData:write:ip:${hashedIpKey(req)}`;
   },
 });
 

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -50,6 +50,7 @@ import {
 import { sanitizePlainText } from '../utils/sanitize';
 import { cleanDisplayName } from '../utils/displayNameSanitize';
 import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
 import { buildExportBundle } from '../services/identityExport.service';
 import { exportBundleSchema } from '@oxyhq/contracts';
 
@@ -1175,7 +1176,7 @@ const identityExportLimiter = rateLimit({
   message: 'Too many export requests. Please try again later.',
   keyGenerator: (req) => {
     const userId = (req as AuthRequest).user?.id;
-    return userId ? `identity:export:${userId}` : `identity:export:ip:${req.ip ?? 'unknown'}`;
+    return userId ? `identity:export:${userId}` : `identity:export:ip:${hashedIpKey(req)}`;
   },
 });
 
@@ -1548,7 +1549,7 @@ const userResolveServiceLimiter = rateLimit({
   message: 'Too many federated-user resolve requests, please slow down.',
   keyGenerator: (req: Request) => {
     const appId = (req as ServiceAuthRequest).serviceApp?.appId;
-    return appId ? `app:${appId}` : (req.ip ?? 'unknown');
+    return appId ? `app:${appId}` : hashedIpKey(req);
   },
 });
 

--- a/packages/api/src/services/__tests__/civic.graphExclusion.test.ts
+++ b/packages/api/src/services/__tests__/civic.graphExclusion.test.ts
@@ -3,9 +3,10 @@
  *
  * Asserts the shared sock-puppet test used by BOTH the real-life flow and the
  * jury selection: related users (follow/block edge, common neighbour at 2 hops,
- * shared device/IP) are EXCLUDED; unrelated users are not. The Follow/Block/
- * Session models are driven by a tiny in-memory graph fixture so the rules are
- * exercised deterministically.
+ * shared device) are EXCLUDED; unrelated users are not. IP is NOT a signal
+ * (privacy invariant — no user IPs at rest). The Follow/Block/Session models are
+ * driven by a tiny in-memory graph fixture so the rules are exercised
+ * deterministically.
  */
 
 interface GraphEntry {
@@ -17,7 +18,6 @@ interface GraphEntry {
   /** Coarse client-supplied `deviceInfo.fingerprint` values (environment hash,
    * NOT device-unique — must never produce a `shared_device` verdict). */
   fingerprints: string[];
-  ips: string[];
 }
 
 const graph: Record<string, Partial<GraphEntry>> = {};
@@ -31,7 +31,6 @@ function entry(id: string): GraphEntry {
     blockedBy: e.blockedBy ?? [],
     devices: e.devices ?? [],
     fingerprints: e.fingerprints ?? [],
-    ips: e.ips ?? [],
   };
 }
 
@@ -70,7 +69,6 @@ jest.mock('../../models/Session', () => ({
       const rows = [
         ...e.devices.map((d, i) => ({ deviceId: d, deviceInfo: { fingerprint: e.fingerprints[i] } })),
         ...e.fingerprints.slice(e.devices.length).map((fp) => ({ deviceInfo: { fingerprint: fp } })),
-        ...e.ips.map((ip) => ({ deviceInfo: { ipAddress: ip } })),
       ];
       return chain(rows);
     },
@@ -110,37 +108,13 @@ describe('isSockPuppetRelation', () => {
     expect(await isSockPuppetRelation(A, B)).toEqual({ excluded: true, reason: 'shared_device' });
   });
 
-  it('excludes a shared IP by default (jury behaviour unchanged)', async () => {
-    graph[A] = { ips: ['1.2.3.4'] };
-    graph[B] = { ips: ['1.2.3.4'] };
-    expect(await isSockPuppetRelation(A, B)).toEqual({ excluded: true, reason: 'shared_ip' });
-  });
-
-  it('does NOT exclude a shared-ONLY-IP pair when ignoreSharedIp is set (attestation)', async () => {
-    // Real-life attestation: meeting in person implies a shared network, so a
-    // shared IP (with distinct deviceIds, no graph edge) must be a SOFT signal.
-    graph[A] = { devices: ['dev-a'], ips: ['1.2.3.4'] };
-    graph[B] = { devices: ['dev-b'], ips: ['1.2.3.4'] };
-    expect(await isSockPuppetRelation(A, B, { ignoreSharedIp: true })).toEqual({ excluded: false });
-  });
-
-  it('still excludes a shared deviceId even when ignoreSharedIp is set', async () => {
-    graph[A] = { devices: ['dev-1'], ips: ['1.2.3.4'] };
-    graph[B] = { devices: ['dev-1'], ips: ['1.2.3.4'] };
-    expect(await isSockPuppetRelation(A, B, { ignoreSharedIp: true })).toEqual({
-      excluded: true,
-      reason: 'shared_device',
-    });
-  });
-
   it('does NOT exclude two distinct installs that share only the coarse environment fingerprint', async () => {
     // Regression (prod incident): two DISTINCT physical phones — separate
-    // per-install deviceIds, separate IPs — produced the IDENTICAL client
-    // `deviceInfo.fingerprint` (environment hash of ua/platform/language/
-    // timezone: no device-unique input on React Native). The fingerprint must
-    // NOT yield a `shared_device` verdict.
-    graph[A] = { devices: ['dev-a'], fingerprints: ['same-env-fp'], ips: ['9.9.9.9'] };
-    graph[B] = { devices: ['dev-b'], fingerprints: ['same-env-fp'], ips: ['8.8.8.8'] };
+    // per-install deviceIds — produced the IDENTICAL client `deviceInfo.fingerprint`
+    // (environment hash of ua/platform/language/timezone: no device-unique input
+    // on React Native). The fingerprint must NOT yield a `shared_device` verdict.
+    graph[A] = { devices: ['dev-a'], fingerprints: ['same-env-fp'] };
+    graph[B] = { devices: ['dev-b'], fingerprints: ['same-env-fp'] };
     expect(await isSockPuppetRelation(A, B)).toEqual({ excluded: false });
   });
 
@@ -151,8 +125,8 @@ describe('isSockPuppetRelation', () => {
   });
 
   it('does NOT exclude unrelated users', async () => {
-    graph[A] = { follows: [X], devices: ['dev-a'], ips: ['9.9.9.9'] };
-    graph[B] = { follows: ['z'.repeat(24)], devices: ['dev-b'], ips: ['8.8.8.8'] };
+    graph[A] = { follows: [X], devices: ['dev-a'] };
+    graph[B] = { follows: ['z'.repeat(24)], devices: ['dev-b'] };
     expect(await isSockPuppetRelation(A, B)).toEqual({ excluded: false });
   });
 });

--- a/packages/api/src/services/__tests__/civic.realLife.test.ts
+++ b/packages/api/src/services/__tests__/civic.realLife.test.ts
@@ -153,13 +153,14 @@ describe('submitRealLifeAttestation', () => {
     });
   });
 
-  it('runs the sock-puppet check with ignoreSharedIp so a shared IP does not hard-block', async () => {
-    // A shared IP is a soft signal for attestation: `isSockPuppetRelation`
-    // resolves `excluded:false` (IP downgraded) and the attestation proceeds.
+  it('runs the sock-puppet check with only the hop radius (IP is not a signal)', async () => {
+    // IP is never a signal (no user IPs at rest): the sock-puppet check is
+    // driven by deviceId + social graph, so it is called with only `hops` and
+    // must NOT carry an `ignoreSharedIp` flag. A not-excluded pair proceeds.
     const result = await submitRealLifeAttestation(envelope(), B);
 
     expect(result).toEqual({ ok: true, recordId: 'rec-1', subjectUserId: A, attestorUserId: B, points: 25 });
-    expect(mockIsSockPuppet).toHaveBeenCalledWith(A, B, expect.objectContaining({ ignoreSharedIp: true }));
+    expect(mockIsSockPuppet).toHaveBeenCalledWith(A, B, { hops: 1 });
   });
 
   it('is idempotent for a repeat of the same pair: returns the original award, no second +25', async () => {

--- a/packages/api/src/services/__tests__/civic.sybil.test.ts
+++ b/packages/api/src/services/__tests__/civic.sybil.test.ts
@@ -1,19 +1,19 @@
 /**
  * Sybil heuristics tests (civic / Fase 3).
  *
- * `computeSybilPenalty` is driven with PersonhoodVouch + session-fingerprint
+ * `computeSybilPenalty` is driven with PersonhoodVouch + session-device
  * reads mocked, so the two heuristics are exercised in isolation:
- *  - SHARED DEVICE/IP CLUSTER — vouchers that share a fingerprint with one
- *    another raise the penalty.
+ *  - SHARED DEVICE CLUSTER — vouchers that share a deviceId with one
+ *    another raise the penalty. (IP is not a signal — no user IPs at rest.)
  *  - VOUCH-RING DENSITY — a reciprocal (subject vouches back) edge raises it.
  * No vouchers ⇒ no penalty.
  */
 
-const mockFingerprints = jest.fn();
+const mockDeviceIds = jest.fn();
 const mockVouchFind = jest.fn();
 
 jest.mock('../civic/graphExclusion', () => ({
-  sessionFingerprints: (...a: unknown[]) => mockFingerprints(...a),
+  sessionDeviceIds: (...a: unknown[]) => mockDeviceIds(...a),
 }));
 jest.mock('../../models/PersonhoodVouch', () => ({
   __esModule: true,
@@ -43,11 +43,8 @@ interface VouchQuery {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  // Default: no overlapping fingerprints for any account.
-  mockFingerprints.mockImplementation(async (id: string) => ({
-    devices: new Set([`dev-${id}`]),
-    ips: new Set([`ip-${id}`]),
-  }));
+  // Default: no overlapping deviceIds for any account.
+  mockDeviceIds.mockImplementation(async (id: string) => new Set([`dev-${id}`]));
 });
 
 describe('computeSybilPenalty', () => {
@@ -67,11 +64,11 @@ describe('computeSybilPenalty', () => {
       return chain([]);
     });
     // A and B share the same device → both are "clustered".
-    mockFingerprints.mockImplementation(async (id: string) => {
+    mockDeviceIds.mockImplementation(async (id: string) => {
       if (id === A || id === B) {
-        return { devices: new Set(['shared-device']), ips: new Set([`ip-${id}`]) };
+        return new Set(['shared-device']);
       }
-      return { devices: new Set([`dev-${id}`]), ips: new Set([`ip-${id}`]) };
+      return new Set([`dev-${id}`]);
     });
 
     const signal = await computeSybilPenalty(SUBJECT);

--- a/packages/api/src/services/__tests__/session.service.managedSwitch.test.ts
+++ b/packages/api/src/services/__tests__/session.service.managedSwitch.test.ts
@@ -91,7 +91,7 @@ jest.mock('../../utils/sessionUtils', () => ({
 jest.mock('../../utils/deviceUtils', () => ({
   extractDeviceInfo: jest.fn().mockReturnValue({
     deviceId: 'device-x', deviceName: 'Dev', deviceType: 'desktop', platform: 'web',
-    browser: 'Chrome', os: 'Linux', ipAddress: '127.0.0.1', userAgent: 'ua',
+    browser: 'Chrome', os: 'Linux', userAgent: 'ua',
   }),
   generateDeviceFingerprint: jest.fn(),
   registerDevice: jest.fn(),

--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -116,9 +116,7 @@ jest.mock('../../utils/deviceUtils', () => ({
       platform: 'web',
       browser: 'Chrome',
       os: 'Linux',
-      ipAddress: '127.0.0.1',
       userAgent: 'test-agent',
-      location: undefined,
       fingerprint: undefined,
     })),
   generateDeviceFingerprint: jest.fn().mockReturnValue('fingerprint-hash'),
@@ -169,7 +167,6 @@ function createMockSession(overrides: Record<string, unknown> = {}) {
       platform: 'web',
       browser: 'Chrome',
       os: 'Linux',
-      ipAddress: '127.0.0.1',
       userAgent: 'test-agent',
       lastActive: new Date(),
     },
@@ -237,7 +234,6 @@ describe('Session Service', () => {
       expect(result.deviceInfo.deviceType).toBe('desktop');
       expect(result.deviceInfo.platform).toBe('web');
       expect(result.deviceInfo.browser).toBe('Chrome');
-      expect(result.deviceInfo.ipAddress).toBe('127.0.0.1');
       expect(result.deviceId).toBe('device-123');
     });
   });

--- a/packages/api/src/services/anomalyDetection.service.ts
+++ b/packages/api/src/services/anomalyDetection.service.ts
@@ -106,45 +106,6 @@ class AnomalyDetectionService {
   }
 
   /**
-   * Detect rapid login attempts from different IPs
-   */
-  async detectRapidIPChanges(
-    userId: string,
-    currentIp: string
-  ): Promise<{ isAnomaly: boolean; reason?: string }> {
-    try {
-      // Get sessions from last hour
-      const recentSessions = await Session.find({
-        userId,
-        createdAt: { $gt: new Date(Date.now() - 60 * 60 * 1000) },
-      })
-        .sort({ createdAt: -1 })
-        .limit(10)
-        .lean();
-
-      const uniqueIps = new Set<string>();
-      recentSessions.forEach(session => {
-        if (session.deviceInfo?.ipAddress) {
-          uniqueIps.add(session.deviceInfo.ipAddress);
-        }
-      });
-
-      // If more than 3 different IPs in last hour
-      if (uniqueIps.size > 3 && !uniqueIps.has(currentIp)) {
-        return {
-          isAnomaly: true,
-          reason: 'Multiple IPs detected in short time',
-        };
-      }
-
-      return { isAnomaly: false };
-    } catch (error) {
-      logger.error('Error detecting rapid IP changes:', error);
-      return { isAnomaly: false };
-    }
-  }
-
-  /**
    * Run all anomaly checks and alert if suspicious
    */
   async checkForAnomalies(
@@ -160,11 +121,10 @@ class AnomalyDetectionService {
     const location = deviceInfo?.location?.coordinates;
 
     // Run all detection checks in parallel
-    const [newLocation, newDevice, impossibleTravel, rapidIP] = await Promise.all([
+    const [newLocation, newDevice, impossibleTravel] = await Promise.all([
       this.detectNewLocation(userId, location),
       this.detectNewDevice(userId, deviceInfo),
       this.detectImpossibleTravel(userId, location),
-      this.detectRapidIPChanges(userId, req.ip || ''),
     ]);
 
     if (newLocation.isAnomaly) {
@@ -187,13 +147,6 @@ class AnomalyDetectionService {
         type: 'impossible_travel',
         reason: impossibleTravel.reason!,
         details: impossibleTravel.details,
-      });
-    }
-
-    if (rapidIP.isAnomaly) {
-      anomalies.push({
-        type: 'rapid_ip_change',
-        reason: rapidIP.reason!,
       });
     }
 

--- a/packages/api/src/services/civic/graphExclusion.ts
+++ b/packages/api/src/services/civic/graphExclusion.ts
@@ -12,9 +12,12 @@
  *     neighbour; 2 = shares a common neighbour). Two-hop is computed as the
  *     intersection of the two users' direct-neighbour sets (bounded, no BFS
  *     blow-up).
- *  2. SHARED DEVICE / IP — an overlap in the `deviceId` / IP of the two users'
- *     active sessions (a classic multi-account signal). `deviceInfo.fingerprint`
- *     is deliberately NOT a device signal here — see `sessionFingerprints`.
+ *  2. SHARED DEVICE — an overlap in the `deviceId` of the two users' active
+ *     sessions (a classic multi-account signal). IP is deliberately NOT a
+ *     signal: the platform stores no user IP addresses at rest (privacy
+ *     invariant — see docs/superpowers/specs/2026-07-14-no-ip-storage-design.md).
+ *     `deviceInfo.fingerprint` is also NOT a device signal here — see
+ *     `sessionDeviceIds`.
  *
  * `Contact` is intentionally NOT used: it keys on email, not a resolved Oxy
  * user id, so it does not yield a user↔user edge without a privacy-sensitive
@@ -24,10 +27,9 @@
 import Follow, { FollowType } from '../../models/Follow';
 import Block from '../../models/Block';
 import Session from '../../models/Session';
-import { logger } from '../../utils/logger';
 
 /** Why two users were judged related (for audit + a machine-readable reason). */
-export type ExclusionReason = 'self' | 'graph_neighbor' | 'shared_device' | 'shared_ip';
+export type ExclusionReason = 'self' | 'graph_neighbor' | 'shared_device';
 
 export type ExclusionResult =
   | { excluded: false }
@@ -80,9 +82,13 @@ export async function areGraphRelated(a: string, b: string, hops = 1): Promise<b
   return false;
 }
 
-/** Collect a user's active-session device ids + IPs. Exported so the Fase 3
- * sybil heuristics can cluster accounts by shared identifiers without
- * re-implementing the (deviceId / IP) extraction.
+/** Collect a user's active-session device ids. Exported so the Fase 3 sybil
+ * heuristics can cluster accounts by shared deviceId without re-implementing the
+ * extraction.
+ *
+ * IPs are deliberately NOT collected: the platform stores no user IP addresses
+ * at rest (privacy invariant — see
+ * docs/superpowers/specs/2026-07-14-no-ip-storage-design.md).
  *
  * `deviceInfo.fingerprint` is deliberately EXCLUDED from the device set: it is
  * the sha256 of a client-supplied environment blob ({userAgent, platform,
@@ -97,60 +103,38 @@ export async function areGraphRelated(a: string, b: string, hops = 1): Promise<b
  * additional sign-in), while the server-derived fallback is salted +
  * user-scoped and can never collide across users — so a genuine
  * multi-account-on-one-device pair still overlaps on `deviceId`. */
-export async function sessionFingerprints(
-  userId: string,
-): Promise<{ devices: Set<string>; ips: Set<string> }> {
+export async function sessionDeviceIds(userId: string): Promise<Set<string>> {
   const sessions = await Session.find({ userId, isActive: true })
-    .select('deviceId deviceInfo.ipAddress')
+    .select('deviceId')
     .lean();
   const devices = new Set<string>();
-  const ips = new Set<string>();
   for (const session of sessions) {
-    const record = session as { deviceId?: string; deviceInfo?: { ipAddress?: string } };
+    const record = session as { deviceId?: string };
     if (record.deviceId) devices.add(record.deviceId);
-    if (record.deviceInfo?.ipAddress) ips.add(record.deviceInfo.ipAddress);
   }
-  return { devices, ips };
+  return devices;
 }
 
-/** True (with kind) when `a` and `b` share an active-session deviceId or IP. */
-export async function shareDeviceOrIp(
-  a: string,
-  b: string,
-): Promise<{ shared: false } | { shared: true; kind: 'device' | 'ip' }> {
-  const [fa, fb] = await Promise.all([sessionFingerprints(a), sessionFingerprints(b)]);
-  for (const device of fa.devices) {
-    if (fb.devices.has(device)) {
-      return { shared: true, kind: 'device' };
+/** True when `a` and `b` share an active-session deviceId. */
+export async function shareDevice(a: string, b: string): Promise<boolean> {
+  const [da, db] = await Promise.all([sessionDeviceIds(a), sessionDeviceIds(b)]);
+  for (const device of da) {
+    if (db.has(device)) {
+      return true;
     }
   }
-  for (const ip of fa.ips) {
-    if (fb.ips.has(ip)) {
-      return { shared: true, kind: 'ip' };
-    }
-  }
-  return { shared: false };
+  return false;
 }
 
 /**
  * The shared sock-puppet test: `a` and `b` are excluded from attesting/judging
  * each other when they are the same account, within `hops` graph hops, or share
- * an active device/IP. Returns the FIRST matching reason.
- *
- * `ignoreSharedIp` DOWNGRADES the IP overlap from a hard exclusion to a SOFT
- * (logged-only) signal for the caller. The real-life attestation flow sets it:
- * people who genuinely meet in person almost always share a network (home /
- * café / CGNAT), so a shared IP contradicts — rather than confirms — sock-puppet
- * suspicion there. `deviceId` (per-install), the social graph, and the jury
- * carry the anti-sybil weight for attestation. A shared `deviceId` still
- * hard-excludes regardless of this flag (it wins over IP inside
- * `shareDeviceOrIp`). Jury selection does NOT pass the flag and keeps IP as a
- * hard exclusion.
+ * an active-session deviceId. Returns the FIRST matching reason.
  */
 export async function isSockPuppetRelation(
   a: string,
   b: string,
-  opts: { hops?: number; ignoreSharedIp?: boolean } = {},
+  opts: { hops?: number } = {},
 ): Promise<ExclusionResult> {
   if (a === b) {
     return { excluded: true, reason: 'self' };
@@ -158,18 +142,8 @@ export async function isSockPuppetRelation(
   if (await areGraphRelated(a, b, opts.hops ?? 1)) {
     return { excluded: true, reason: 'graph_neighbor' };
   }
-  const device = await shareDeviceOrIp(a, b);
-  if (device.shared) {
-    if (device.kind === 'ip' && opts.ignoreSharedIp) {
-      // Soft signal: record the shared-IP overlap for telemetry but do NOT
-      // exclude — no shared deviceId was found (that check wins above), so the
-      // pair is treated as unrelated for this caller.
-      logger.info('civic.sockpuppet shared IP downgraded to soft signal', {
-        component: 'civic.graphExclusion',
-      });
-      return { excluded: false };
-    }
-    return { excluded: true, reason: device.kind === 'ip' ? 'shared_ip' : 'shared_device' };
+  if (await shareDevice(a, b)) {
+    return { excluded: true, reason: 'shared_device' };
   }
   return { excluded: false };
 }

--- a/packages/api/src/services/civic/personhood.service.ts
+++ b/packages/api/src/services/civic/personhood.service.ts
@@ -78,7 +78,6 @@ export type VouchRejectionReason =
   | 'excluded_self'
   | 'excluded_graph_neighbor'
   | 'excluded_shared_device'
-  | 'excluded_shared_ip'
   | RejectionReason;
 
 export type VouchResult =
@@ -92,15 +91,13 @@ function isDuplicateKeyError(error: unknown): boolean {
 
 /** Map a sock-puppet exclusion reason to the matching vouch rejection reason. */
 function exclusionReason(
-  reason: 'self' | 'graph_neighbor' | 'shared_device' | 'shared_ip',
+  reason: 'self' | 'graph_neighbor' | 'shared_device',
 ): VouchRejectionReason {
   switch (reason) {
     case 'self':
       return 'excluded_self';
     case 'shared_device':
       return 'excluded_shared_device';
-    case 'shared_ip':
-      return 'excluded_shared_ip';
     default:
       return 'excluded_graph_neighbor';
   }

--- a/packages/api/src/services/civic/realLife.service.ts
+++ b/packages/api/src/services/civic/realLife.service.ts
@@ -58,7 +58,6 @@ export type RealLifeRejectionReason =
   | 'nonce_used'
   | 'excluded_graph_neighbor'
   | 'excluded_shared_device'
-  | 'excluded_shared_ip'
   | RejectionReason;
 
 export type RealLifeResult =
@@ -102,13 +101,11 @@ async function claimNonce(nonce: string, subjectUserId: string, exp: number): Pr
 
 /** Map a graph-exclusion reason to the matching rejection reason. */
 function exclusionReason(
-  reason: 'self' | 'graph_neighbor' | 'shared_device' | 'shared_ip',
+  reason: 'self' | 'graph_neighbor' | 'shared_device',
 ): RealLifeRejectionReason {
   switch (reason) {
     case 'shared_device':
       return 'excluded_shared_device';
-    case 'shared_ip':
-      return 'excluded_shared_ip';
     case 'self':
       return 'self_attestation';
     default:
@@ -168,12 +165,10 @@ export async function submitRealLifeAttestation(
   }
 
   // Anti-sybil: B must not be A's puppet (no graph edge, no shared deviceId).
-  // A shared IP is a SOFT signal here (`ignoreSharedIp`): meeting in person
-  // almost always implies a shared network, so it must not hard-block a
-  // real-life attestation. deviceId + social graph + the jury carry the weight.
+  // IP is not a signal (no user IPs at rest); deviceId + social graph + the
+  // jury carry the anti-sybil weight for real-life attestation.
   const relation = await isSockPuppetRelation(subjectUserId, attestorUserId, {
     hops: REAL_LIFE_EXCLUSION_HOPS,
-    ignoreSharedIp: true,
   });
   if (relation.excluded) {
     return { ok: false, reason: exclusionReason(relation.reason) };

--- a/packages/api/src/services/civic/sybil.service.ts
+++ b/packages/api/src/services/civic/sybil.service.ts
@@ -10,12 +10,12 @@
  * the {@link computeVouchRingSignal} boundary without changing this function's
  * return contract):
  *
- *  1. SHARED DEVICE / IP CLUSTER — the fraction of a subject's active vouchers
- *     that share an active-session device id or IP with the subject or with one
+ *  1. SHARED DEVICE CLUSTER — the fraction of a subject's active vouchers
+ *     that share an active-session device id with the subject or with one
  *     another. Real vouchers are independent people on independent devices; a
  *     multi-account farm shows a dense identifier overlap. (The coarse
  *     `deviceInfo.fingerprint` is NOT part of the print set — see
- *     `sessionFingerprints`.)
+ *     `sessionDeviceIds`. IP is NOT a signal — no user IPs at rest.)
  *
  *  2. VOUCH-RING DENSITY — reciprocal (A↔B) and short-cycle (A→B→C→A) vouch
  *     edges around the subject. An organic web-of-trust is broadly acyclic
@@ -25,7 +25,7 @@
  * bounded by `SYBIL_VOUCHER_SCAN_CAP` so the cost stays O(vouchers).
  */
 
-import { sessionFingerprints } from './graphExclusion';
+import { sessionDeviceIds } from './graphExclusion';
 import PersonhoodVouch from '../../models/PersonhoodVouch';
 import { clamp } from '../../utils/reputation.constants';
 import {
@@ -57,10 +57,10 @@ async function activeVoucherIds(subjectUserId: string): Promise<string[]> {
 }
 
 /**
- * Shared-device/IP cluster signal: the fraction of {subject ∪ vouchers} whose
- * active-session fingerprints overlap with at least one OTHER account in the
- * set. Each account's fingerprint set is fetched once; overlap is computed by an
- * in-memory inverted index (fingerprint → owning accounts), so the cost is
+ * Shared-device cluster signal: the fraction of {subject ∪ vouchers} whose
+ * active-session deviceIds overlap with at least one OTHER account in the
+ * set. Each account's device set is fetched once; overlap is computed by an
+ * in-memory inverted index (deviceId → owning accounts), so the cost is
  * O(accounts) queries with no pairwise blow-up.
  */
 async function computeSharedFingerprintSignal(
@@ -73,8 +73,8 @@ async function computeSharedFingerprintSignal(
   const accountPrints = new Map<string, string[]>();
 
   for (const accountId of accounts) {
-    const { devices, ips } = await sessionFingerprints(accountId);
-    const prints = [...[...devices].map((d) => `d:${d}`), ...[...ips].map((ip) => `i:${ip}`)];
+    const devices = await sessionDeviceIds(accountId);
+    const prints = [...devices].map((d) => `d:${d}`);
     accountPrints.set(accountId, prints);
     for (const print of prints) {
       const set = owners.get(print) ?? new Set<string>();

--- a/packages/api/src/services/civic/validator.service.ts
+++ b/packages/api/src/services/civic/validator.service.ts
@@ -7,7 +7,7 @@
  *  - RANDOM selection — weighted reservoir sampling keyed by a per-request RNG
  *    seed (stored for audit), so a subject cannot predict or pack their jury.
  *  - GRAPH EXCLUSION — the shared `isSockPuppetRelation` (2 hops + shared
- *    device/IP) drops the subject's neighbours from the pool.
+ *    device) drops the subject's neighbours from the pool.
  *  - AFFINITY THROTTLE — a candidate that has co-voted heavily with an
  *    already-selected juror is skipped (breaks up voting rings).
  *  - SLASHING — if the resulting award is later reversed (dispute/fraud), the
@@ -93,7 +93,7 @@ export interface ValidatorSelection {
  * Select the jury for `subjectUserId`. Eligible pool = balances with a
  * jury-eligible trust tier, minus the subject and anyone the shared exclusion
  * test flags (graph neighbour within {@link VALIDATION_EXCLUSION_HOPS} or shared
- * device/IP). The remaining candidates are ranked by a seeded weighted-reservoir
+ * device). The remaining candidates are ranked by a seeded weighted-reservoir
  * key; the top `VALIDATOR_COUNT` are taken, skipping any candidate with high
  * co-vote affinity to an already-selected juror.
  */

--- a/packages/api/src/services/securityActivityService.ts
+++ b/packages/api/src/services/securityActivityService.ts
@@ -32,7 +32,7 @@ const MAX_USER_AGENT_LENGTH = 500;
 const DEDUPLICATION_WINDOW_MS = 5000; // 5 seconds - prevent duplicate events
 
 // Field selection for queries (single source of truth)
-const ACTIVITY_SELECT_FIELDS = '_id userId eventType eventDescription metadata ipAddress userAgent deviceId timestamp severity createdAt';
+const ACTIVITY_SELECT_FIELDS = '_id userId eventType eventDescription metadata userAgent deviceId timestamp severity createdAt';
 
 class SecurityActivityService {
   /**
@@ -149,9 +149,7 @@ class SecurityActivityService {
       sanitizedDescription = `Security event: ${eventType}`;
     }
 
-    // Extract and sanitize IP address and user agent
-    const rawIpAddress = req?.ip || req?.socket?.remoteAddress || undefined;
-    const ipAddress = rawIpAddress ? this.sanitizeString(rawIpAddress, 45) : undefined; // IPv6 max length is 45 chars
+    // Extract and sanitize user agent
     const rawUserAgent = req?.headers['user-agent'];
     const userAgent = rawUserAgent ? this.sanitizeString(rawUserAgent, MAX_USER_AGENT_LENGTH) : undefined;
 
@@ -193,7 +191,6 @@ class SecurityActivityService {
         eventType,
         eventDescription: sanitizedDescription,
         metadata: sanitizedMetadata,
-        ipAddress,
         userAgent,
         deviceId: finalDeviceId,
         timestamp: new Date(),
@@ -208,7 +205,6 @@ class SecurityActivityService {
       eventType,
       eventDescription: sanitizedDescription,
       metadata: sanitizedMetadata,
-      ipAddress,
       userAgent,
       deviceId: finalDeviceId,
       timestamp: new Date(),

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -519,7 +519,6 @@ class SessionService {
               ...(migrateToDeviceId ? { deviceId: migrateToDeviceId } : {}),
               'deviceInfo.lastActive': now,
               'deviceInfo.deviceName': deviceName || existingSession.deviceInfo?.deviceName,
-              'deviceInfo.ipAddress': deviceInfo.ipAddress,
               'deviceInfo.userAgent': deviceInfo.userAgent,
               // Bind the reused session to the CURRENT operator when this is an
               // account switch (keeps the act_as re-check pointed at whoever just
@@ -578,9 +577,7 @@ class SessionService {
           platform: deviceInfo.platform,
           browser: deviceInfo.browser,
           os: deviceInfo.os,
-          ipAddress: deviceInfo.ipAddress,
           userAgent: deviceInfo.userAgent,
-          location: deviceInfo.location,
           fingerprint: deviceInfo.fingerprint,
           lastActive: now
         },

--- a/packages/api/src/utils/__tests__/deviceUtils.test.ts
+++ b/packages/api/src/utils/__tests__/deviceUtils.test.ts
@@ -2,8 +2,9 @@
  * deviceUtils — `deriveStableDeviceId` tests (security review H1).
  *
  * The derived deviceId scopes session-grouping per (server-salt + user) so
- * two distinct users behind the same NAT/proxy on the same browser do NOT
- * collide on the same id. These tests pin that contract.
+ * two distinct users on the same browser do NOT collide on the same id. IP is
+ * deliberately NOT an input (privacy invariant — no user IPs at rest). These
+ * tests pin that contract.
  */
 
 jest.mock('../logger', () => ({
@@ -19,9 +20,11 @@ jest.mock('../sessionCache', () => ({ __esModule: true, default: { invalidate: j
 jest.mock('../userTransform', () => ({ formatUserResponse: jest.fn() }));
 
 import crypto from 'crypto';
+import type { Request } from 'express';
 import {
   deriveStableDeviceId,
   deriveServiceDeviceId,
+  extractDeviceInfo,
   generateDeviceFingerprint,
 } from '../deviceUtils';
 
@@ -29,7 +32,6 @@ const STRONG_SALT_A = 'a'.repeat(48);
 const STRONG_SALT_B = 'b'.repeat(48);
 
 const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/120.0.0.0 Safari/537.36';
-const IP = '203.0.113.42';
 const LANG = 'en-US,en;q=0.9';
 
 const ORIGINAL_ENV = process.env;
@@ -45,29 +47,36 @@ describe('deriveStableDeviceId', () => {
   });
 
   it('returns a 32-char hex string for valid inputs', () => {
-    const id = deriveStableDeviceId(UA, IP, LANG, 'user-1');
+    const id = deriveStableDeviceId(UA, LANG, 'user-1');
     expect(id).not.toBeNull();
     expect(id).toMatch(/^[0-9a-f]{32}$/);
   });
 
-  it('is deterministic for the same (ua, ip, lang, userId) inputs', () => {
-    const a = deriveStableDeviceId(UA, IP, LANG, 'user-1');
-    const b = deriveStableDeviceId(UA, IP, LANG, 'user-1');
+  it('is deterministic for the same (ua, lang, userId) inputs', () => {
+    const a = deriveStableDeviceId(UA, LANG, 'user-1');
+    const b = deriveStableDeviceId(UA, LANG, 'user-1');
     expect(a).toBe(b);
   });
 
-  it('produces DIFFERENT ids for two distinct users on the same browser/IP', () => {
-    const userA = deriveStableDeviceId(UA, IP, LANG, 'user-A');
-    const userB = deriveStableDeviceId(UA, IP, LANG, 'user-B');
+  it('derives the same deviceId regardless of network (no IP input)', () => {
+    process.env.DEVICE_ID_SALT = 'test-salt-0123456789abcdef';
+    const a = deriveStableDeviceId('Mozilla/5.0 (X11; Linux x86_64)', 'en-US', 'user1');
+    expect(a).toMatch(/^[a-f0-9]{32}$/);
+    expect(deriveStableDeviceId('Mozilla/5.0 (X11; Linux x86_64)', 'en-US', 'user1')).toBe(a);
+  });
+
+  it('produces DIFFERENT ids for two distinct users on the same browser', () => {
+    const userA = deriveStableDeviceId(UA, LANG, 'user-A');
+    const userB = deriveStableDeviceId(UA, LANG, 'user-B');
     expect(userA).not.toBeNull();
     expect(userB).not.toBeNull();
     expect(userA).not.toBe(userB);
   });
 
   it('produces a DIFFERENT id when the server salt changes (defends against salt-guessing)', () => {
-    const withSaltA = deriveStableDeviceId(UA, IP, LANG, 'user-1');
+    const withSaltA = deriveStableDeviceId(UA, LANG, 'user-1');
     process.env.DEVICE_ID_SALT = STRONG_SALT_B;
-    const withSaltB = deriveStableDeviceId(UA, IP, LANG, 'user-1');
+    const withSaltB = deriveStableDeviceId(UA, LANG, 'user-1');
     expect(withSaltA).not.toBeNull();
     expect(withSaltB).not.toBeNull();
     expect(withSaltA).not.toBe(withSaltB);
@@ -75,25 +84,25 @@ describe('deriveStableDeviceId', () => {
 
   describe('pre-auth (userId omitted / null)', () => {
     it('still returns a stable id (deterministic with itself)', () => {
-      const a = deriveStableDeviceId(UA, IP, LANG, null);
-      const b = deriveStableDeviceId(UA, IP, LANG, null);
-      const c = deriveStableDeviceId(UA, IP, LANG);
+      const a = deriveStableDeviceId(UA, LANG, null);
+      const b = deriveStableDeviceId(UA, LANG, null);
+      const c = deriveStableDeviceId(UA, LANG);
       expect(a).not.toBeNull();
       expect(a).toBe(b);
       expect(a).toBe(c);
     });
 
     it('produces a DIFFERENT id from any post-auth id derived from the same inputs', () => {
-      const preAuth = deriveStableDeviceId(UA, IP, LANG, null);
-      const postAuth = deriveStableDeviceId(UA, IP, LANG, 'user-1');
+      const preAuth = deriveStableDeviceId(UA, LANG, null);
+      const postAuth = deriveStableDeviceId(UA, LANG, 'user-1');
       expect(preAuth).not.toBeNull();
       expect(postAuth).not.toBeNull();
       expect(preAuth).not.toBe(postAuth);
     });
 
     it('treats empty-string userId as pre-auth', () => {
-      const empty = deriveStableDeviceId(UA, IP, LANG, '');
-      const preAuth = deriveStableDeviceId(UA, IP, LANG, null);
+      const empty = deriveStableDeviceId(UA, LANG, '');
+      const preAuth = deriveStableDeviceId(UA, LANG, null);
       expect(empty).toBe(preAuth);
     });
   });
@@ -101,32 +110,55 @@ describe('deriveStableDeviceId', () => {
   describe('unresolvable inputs', () => {
     it('returns null when DEVICE_ID_SALT is unset', () => {
       delete process.env.DEVICE_ID_SALT;
-      expect(deriveStableDeviceId(UA, IP, LANG, 'user-1')).toBeNull();
+      expect(deriveStableDeviceId(UA, LANG, 'user-1')).toBeNull();
     });
 
     it('returns null when DEVICE_ID_SALT is empty', () => {
       process.env.DEVICE_ID_SALT = '';
-      expect(deriveStableDeviceId(UA, IP, LANG, 'user-1')).toBeNull();
+      expect(deriveStableDeviceId(UA, LANG, 'user-1')).toBeNull();
     });
 
     it.each([
-      ['empty UA', '', IP],
-      ['literal "unknown" UA', 'unknown', IP],
-      ['undefined IP', UA, undefined],
-      ['"unknown" IP', UA, 'unknown'],
-      ['loopback v4', UA, '127.0.0.1'],
-      ['loopback v6', UA, '::1'],
-    ])('returns null for %s', (_label, ua, ip) => {
-      expect(deriveStableDeviceId(ua, ip, LANG, 'user-1')).toBeNull();
+      ['empty UA', ''],
+      ['literal "unknown" UA', 'unknown'],
+    ])('returns null for %s', (_label, ua) => {
+      expect(deriveStableDeviceId(ua, LANG, 'user-1')).toBeNull();
     });
+  });
+});
+
+describe('extractDeviceInfo', () => {
+  const SAVED_SALT = process.env.DEVICE_ID_SALT;
+
+  beforeEach(() => {
+    process.env.DEVICE_ID_SALT = STRONG_SALT_A;
+  });
+
+  afterEach(() => {
+    if (SAVED_SALT === undefined) {
+      delete process.env.DEVICE_ID_SALT;
+    } else {
+      process.env.DEVICE_ID_SALT = SAVED_SALT;
+    }
+  });
+
+  it('returns no ipAddress and no location', () => {
+    const req = {
+      headers: { 'user-agent': 'Mozilla/5.0', 'accept-language': 'en', 'cf-ipcountry': 'ES' },
+      ip: '203.0.113.7',
+      connection: { remoteAddress: '203.0.113.7' },
+    } as unknown as Request;
+    const info = extractDeviceInfo(req);
+    expect('ipAddress' in info).toBe(false);
+    expect('location' in info).toBe(false);
   });
 });
 
 /**
  * deviceUtils — `deriveServiceDeviceId` tests.
  *
- * The IdP/FedCM-issued device id is keyed by (server-salt + userId + RP key),
- * NOT by the IdP worker's UA/IP. These tests pin: determinism (so one
+ * The server-minted device id is keyed by (server-salt + userId + RP key),
+ * NOT by the caller's UA/IP. These tests pin: determinism (so one
  * (user, RP) reuses one session), per-user scoping (security review H1),
  * per-RP scoping, and fail-closed behaviour when the salt is unset.
  */
@@ -177,9 +209,9 @@ describe('deriveServiceDeviceId', () => {
     expect(withSaltA).not.toBe(withSaltB);
   });
 
-  it('can never collide with a UA/IP-derived id (distinct "idp" namespace)', () => {
+  it('can never collide with a UA-derived id (distinct "idp" namespace)', () => {
     const serviceId = deriveServiceDeviceId('user-1', RP_A);
-    const stableId = deriveStableDeviceId(UA, IP, LANG, 'user-1');
+    const stableId = deriveStableDeviceId(UA, LANG, 'user-1');
     expect(serviceId).not.toBe(stableId);
   });
 
@@ -221,7 +253,6 @@ describe('generateDeviceFingerprint', () => {
         language: 'en-US',
         timezone: 'America/Los_Angeles',
         screen: { width: 1440, height: 900, colorDepth: 24 },
-        ipAddress: '203.0.113.10',
       })
     ).toBe(
       crypto

--- a/packages/api/src/utils/__tests__/ipKey.test.ts
+++ b/packages/api/src/utils/__tests__/ipKey.test.ts
@@ -1,0 +1,46 @@
+import type { Request } from 'express';
+import { hashedIpKey } from '../ipKey';
+
+function reqWithIp(ip: string | undefined): Request {
+  return { ip } as Request;
+}
+
+describe('hashedIpKey', () => {
+  const OLD_SALT = process.env.DEVICE_ID_SALT;
+  beforeEach(() => {
+    process.env.DEVICE_ID_SALT = 'test-salt-0123456789abcdef';
+  });
+  afterAll(() => {
+    process.env.DEVICE_ID_SALT = OLD_SALT;
+  });
+
+  it('is deterministic for the same IP', () => {
+    expect(hashedIpKey(reqWithIp('203.0.113.7'))).toBe(hashedIpKey(reqWithIp('203.0.113.7')));
+  });
+
+  it('differs across IPs', () => {
+    expect(hashedIpKey(reqWithIp('203.0.113.7'))).not.toBe(hashedIpKey(reqWithIp('203.0.113.8')));
+  });
+
+  it('never contains the raw IP and is fixed-length hex', () => {
+    const key = hashedIpKey(reqWithIp('203.0.113.7'));
+    expect(key).not.toContain('203.0.113.7');
+    expect(key).toMatch(/^[a-f0-9]{24}$/);
+  });
+
+  it('changes with the salt', () => {
+    const a = hashedIpKey(reqWithIp('203.0.113.7'));
+    process.env.DEVICE_ID_SALT = 'other-salt-0123456789abcdef';
+    expect(hashedIpKey(reqWithIp('203.0.113.7'))).not.toBe(a);
+  });
+
+  it('buckets IPv6 addresses (same /56 → same key)', () => {
+    const a = hashedIpKey(reqWithIp('2001:db8:0:1::1'));
+    const b = hashedIpKey(reqWithIp('2001:db8:0:1::2'));
+    expect(a).toBe(b);
+  });
+
+  it('returns "unknown" when no IP is resolvable', () => {
+    expect(hashedIpKey(reqWithIp(undefined))).toBe('unknown');
+  });
+});

--- a/packages/api/src/utils/deviceUtils.ts
+++ b/packages/api/src/utils/deviceUtils.ts
@@ -15,7 +15,6 @@ export interface DeviceFingerprint {
     height: number;
     colorDepth: number;
   };
-  ipAddress: string;
 }
 
 export type DeviceFingerprintInput = DeviceFingerprint | string;
@@ -29,9 +28,7 @@ export interface DeviceInfo {
   platform: string;
   browser?: string;
   os?: string;
-  ipAddress?: string;
   userAgent?: string;
-  location?: string;
   fingerprint?: string;
   /**
    * How `deviceId` was sourced. Diagnostic only — never persisted on the
@@ -39,8 +36,6 @@ export interface DeviceInfo {
    */
   deviceIdSource?: 'provided' | 'fingerprint-derived' | 'random';
 }
-
-const UNRESOLVABLE_IPS: ReadonlySet<string> = new Set(['unknown', '127.0.0.1', '::1']);
 
 const PRE_AUTH_USER_SCOPE = 'pre-auth';
 
@@ -64,42 +59,44 @@ function getDeviceIdSalt(): string | null {
 }
 
 /**
- * Derive a stable, non-PII deviceId from a request's User-Agent + IP +
+ * Derive a stable, non-PII deviceId from a request's User-Agent +
  * Accept-Language, scoped by a server-side salt and (optionally) the
  * authenticated `userId`. The output is the first 32 hex chars of
- * `sha256("${salt}|${userScope}|${ua}|${ip}|${lang}")`, which gives roughly
+ * `sha256("${salt}|${userScope}|${ua}|${lang}")`, which gives roughly
  * 128 bits of entropy in the digest space.
  *
- * **Why salt + userId?** Without them, two distinct users behind the same
- * NAT/proxy/office using the same Chrome version + Accept-Language would
- * derive the SAME deviceId — leaking the existence of one user's sessions
- * to the other via `getDeviceActiveSessions`, and enabling cross-tenant
- * session termination via `logoutAllDeviceSessions`. Scoping by `userId`
- * makes the device-grouping per-user (the multi-account browser-switcher
- * is driven separately by indexed refresh cookies, not by this id).
+ * **IP is deliberately NOT an input.** The platform stores no user IP addresses
+ * at rest (privacy invariant — see
+ * docs/superpowers/specs/2026-07-14-no-ip-storage-design.md). Beyond the privacy
+ * requirement, a salted hash over the tiny IPv4 space is brute-forceable by
+ * anyone with server access, and IP churn (mobile networks, NAT re-lease) made
+ * IP-seeded ids unstable — a single physical device kept minting fresh session
+ * rows as its IP rotated. Dropping IP fixes both.
+ *
+ * **Why salt + userId?** Without them, two distinct users on the same browser
+ * (same Chrome version + Accept-Language) would derive the SAME deviceId —
+ * leaking the existence of one user's sessions to the other via
+ * `getDeviceActiveSessions`, and enabling cross-tenant session termination via
+ * `logoutAllDeviceSessions`. Scoping by `userId` makes the device-grouping
+ * per-user. The accepted trade-off is that the same user + same UA + same
+ * language on two physical devices dedupe to one deviceId — acceptable because
+ * device-first auth uses the client-persisted deviceId as the authority.
  *
  * Pre-auth callers (e.g. signup, before the user record exists) MAY pass
  * `userId = null`; the resulting id is stable for the pre-auth phase but
  * deterministically distinct from any post-auth id derived from the same
- * UA/IP/lang.
+ * UA/lang.
  *
  * Falls back to `null` when:
  *   - the server-side salt is unset (caller should fall back to a random id);
- *   - the User-Agent is missing or the literal string `'unknown'`;
- *   - the IP is missing or one of the unresolvable sentinels
- *     (`'unknown'`, `'127.0.0.1'`, `'::1'`) — those would deterministically
- *     collide across totally unrelated requests.
+ *   - the User-Agent is missing or the literal string `'unknown'`.
  */
 export function deriveStableDeviceId(
   userAgent: string,
-  ip: string | undefined,
   acceptLanguage: string,
   userId?: string | null
 ): string | null {
   if (!userAgent || userAgent === 'unknown') {
-    return null;
-  }
-  if (!ip || UNRESOLVABLE_IPS.has(ip)) {
     return null;
   }
   const salt = getDeviceIdSalt();
@@ -109,7 +106,7 @@ export function deriveStableDeviceId(
   const userScope = userId && userId.length > 0 ? userId : PRE_AUTH_USER_SCOPE;
   return crypto
     .createHash('sha256')
-    .update(`${salt}|${userScope}|${userAgent}|${ip}|${acceptLanguage}`)
+    .update(`${salt}|${userScope}|${userAgent}|${acceptLanguage}`)
     .digest('hex')
     .slice(0, 32);
 }
@@ -122,16 +119,15 @@ export function deriveStableDeviceId(
  * segment is FIXED cryptographic derivation material for server-minted sessions.
  *
  * **Why a separate helper?** A server-to-server mint has no meaningful
- * User-Agent (`'unknown'`) and a per-call egress IP. Feeding those into
- * `deriveStableDeviceId` would yield a fresh random id every call → a
- * brand-new session row each time. Keying off a stable per-caller key (`key`)
- * instead makes one `(user, RP)` reuse a single session that simply refreshes
- * its tokens/expiry.
+ * User-Agent (`'unknown'`), so `deriveStableDeviceId` returns null for it → the
+ * caller would fall back to a fresh random id every call → a brand-new session
+ * row each time. Keying off a stable per-caller key (`key`) instead makes one
+ * `(user, RP)` reuse a single session that simply refreshes its tokens/expiry.
  *
  * **Why the `'idp'` namespace segment?** It guarantees the output can never
- * collide with an IP/UA-derived id from `deriveStableDeviceId` (whose hash
- * input never contains the literal `idp` in that position), so the two
- * device-id spaces stay disjoint.
+ * collide with a UA-derived id from `deriveStableDeviceId` (whose hash input
+ * never contains the literal `idp` in that position), so the two device-id
+ * spaces stay disjoint.
  *
  * **Per-user scoping is MANDATORY (security review H1):** `userId` is mixed
  * into the hash so two users with the same RP `key` can never derive the same
@@ -192,14 +188,13 @@ export const generateDeviceFingerprint = (fingerprint: DeviceFingerprintInput): 
 /**
  * Extract device information from request.
  *
- * @param req - Express request to read headers/IP from.
+ * @param req - Express request to read headers from.
  * @param providedDeviceId - Optional explicit deviceId supplied by the client.
  * @param deviceName - Optional explicit device name supplied by the client.
  * @param userId - Optional authenticated user id. When set, the derived
- *   deviceId is scoped to this user so two distinct users behind the same
- *   NAT/proxy on the same browser do NOT collide on the same id. Pre-auth
- *   callers (signup, device bootstrap before a session exists) should pass
- *   `null` / omit.
+ *   deviceId is scoped to this user so two distinct users on the same browser
+ *   do NOT collide on the same id. Pre-auth callers (signup, device bootstrap
+ *   before a session exists) should pass `null` / omit.
  */
 export const extractDeviceInfo = (
   req: Request,
@@ -216,18 +211,17 @@ export const extractDeviceInfo = (
   const os = parseUserAgentOS(userAgent);
   const deviceType = parseDeviceType(userAgent);
 
-  const ipAddress = req.ip || req.connection.remoteAddress;
   const acceptLanguageHeader = req.headers['accept-language'];
   const acceptLanguage = typeof acceptLanguageHeader === 'string' ? acceptLanguageHeader : '';
 
   // Stable deviceId fallback. The derived id is salted + user-scoped (see
   // `deriveStableDeviceId`) so device-grouping is per-user; the multi-account
   // browser switcher is driven by indexed refresh cookies, not by this id.
-  // We fall back to a random id when ANY of the inputs is unresolvable.
+  // We fall back to a random id when the UA is unresolvable or the salt is unset.
   let resolvedDeviceId = providedDeviceId;
   let deviceIdSource: DeviceInfo['deviceIdSource'] = providedDeviceId ? 'provided' : 'random';
   if (!resolvedDeviceId) {
-    const derived = deriveStableDeviceId(userAgent, ipAddress, acceptLanguage, userId);
+    const derived = deriveStableDeviceId(userAgent, acceptLanguage, userId);
     if (derived) {
       resolvedDeviceId = derived;
       deviceIdSource = 'fingerprint-derived';
@@ -244,9 +238,7 @@ export const extractDeviceInfo = (
     platform,
     browser,
     os,
-    ipAddress,
     userAgent,
-    location: req.headers['cf-ipcountry'] as string || undefined, // Cloudflare country header
     deviceIdSource,
   };
 };

--- a/packages/api/src/utils/ipKey.ts
+++ b/packages/api/src/utils/ipKey.ts
@@ -1,0 +1,100 @@
+import crypto from 'crypto';
+import net from 'net';
+import type { Request } from 'express';
+
+/**
+ * IPv6 hosts are typically handed an entire /64 (often a /56), so a single host
+ * can rotate through an enormous address space and evade a per-address rate
+ * limit. We therefore bucket IPv6 to its /56 prefix BEFORE hashing. IPv4 (and
+ * IPv4-mapped IPv6) addresses are used as-is — each is a single host.
+ *
+ * NOTE: express-rate-limit only exposes an `ipKeyGenerator` helper for this from
+ * v8 onwards; this package is pinned to v7, so the /56 masking is implemented
+ * here rather than pulling a major-version bump of a security-critical dependency
+ * (and its rate-limit-redis compatibility) into an unrelated privacy change.
+ */
+const IPV6_SUBNET_BITS = 56;
+
+/** Expand an IPv6 literal (handling `::` and embedded IPv4) to 8 numeric hextets, or null if unparseable. */
+function ipv6Hextets(ip: string): number[] | null {
+  let addr = ip;
+  const zone = addr.indexOf('%');
+  if (zone !== -1) {
+    addr = addr.slice(0, zone);
+  }
+
+  // Embedded IPv4 tail (e.g. `::ffff:203.0.113.7`) → fold the dotted quad into two hextets.
+  const lastColon = addr.lastIndexOf(':');
+  if (lastColon !== -1 && addr.slice(lastColon + 1).includes('.')) {
+    const v4 = addr.slice(lastColon + 1);
+    if (!net.isIPv4(v4)) {
+      return null;
+    }
+    const octets = v4.split('.').map((part) => Number.parseInt(part, 10));
+    const high = ((octets[0] << 8) | octets[1]).toString(16);
+    const low = ((octets[2] << 8) | octets[3]).toString(16);
+    addr = `${addr.slice(0, lastColon + 1)}${high}:${low}`;
+  }
+
+  const halves = addr.split('::');
+  if (halves.length > 2) {
+    return null;
+  }
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  let groups: string[];
+  if (halves.length === 1) {
+    groups = head;
+  } else {
+    const missing = 8 - (head.length + tail.length);
+    if (missing < 0) {
+      return null;
+    }
+    groups = [...head, ...new Array(missing).fill('0'), ...tail];
+  }
+  if (groups.length !== 8) {
+    return null;
+  }
+  const hextets = groups.map((group) => Number.parseInt(group || '0', 16));
+  if (hextets.some((value) => Number.isNaN(value) || value < 0 || value > 0xffff)) {
+    return null;
+  }
+  return hextets;
+}
+
+/** Mask an IPv6 address to its /{bits} prefix, returned as a canonical hex string. */
+function maskIPv6(ip: string, bits: number): string {
+  const hextets = ipv6Hextets(ip);
+  if (!hextets) {
+    return ip;
+  }
+  const masked = hextets.map((hextet, index) => {
+    const groupStart = index * 16;
+    if (groupStart >= bits) {
+      return 0;
+    }
+    const keepBits = Math.min(16, bits - groupStart);
+    const mask = keepBits >= 16 ? 0xffff : (0xffff << (16 - keepBits)) & 0xffff;
+    return hextet & mask;
+  });
+  return `${masked.map((hextet) => hextet.toString(16)).join(':')}/${bits}`;
+}
+
+/**
+ * Privacy-preserving rate-limit key: the raw client IP must never reach a store
+ * at rest (Redis included). IPv6 is bucketed to its /56 prefix BEFORE hashing so
+ * a single v6 host can't rotate through its allocation to mint fresh keys; the
+ * result is then HMAC'd with the server-side DEVICE_ID_SALT (namespaced with
+ * 'rl|' so rate-limit keys can never be correlated with deviceId derivations
+ * that use the same salt). Returns 'unknown' when no IP is resolvable.
+ */
+export function hashedIpKey(req: Request): string {
+  const ip = req.ip;
+  if (!ip) {
+    return 'unknown';
+  }
+  const normalized =
+    net.isIPv6(ip) && !ip.startsWith('::ffff:') ? maskIPv6(ip, IPV6_SUBNET_BITS) : ip;
+  const salt = process.env.DEVICE_ID_SALT ?? '';
+  return crypto.createHmac('sha256', salt).update(`rl|${normalized}`).digest('hex').slice(0, 24);
+}

--- a/packages/core/src/models/interfaces.ts
+++ b/packages/core/src/models/interfaces.ts
@@ -648,7 +648,6 @@ export interface SecurityActivity {
   eventType: SecurityEventType;
   eventDescription: string;
   metadata?: Record<string, any>;
-  ipAddress?: string;
   userAgent?: string;
   deviceId?: string;
   timestamp: string;


### PR DESCRIPTION
## Summary

This PR removes all persistence of user IP addresses across the Oxy platform. The goal is a hard privacy invariant: **no user IP address is ever written to disk or long-term storage.**

- Zero user IPs at rest: removed from `SecurityActivity`, `Session.deviceInfo` (`ip` + `location`), `ApiKeyUsage`, the `deviceId` hash input, IP-based anomaly detection, and the civic anti-sybil `shared_ip` signal
- Anonymous rate-limit Redis keys are now HMAC-hashed via a new `hashedIpKey` helper (IPv6 bucketed at /56) instead of storing raw IPs as Redis keys
- Logs scrubbed of IPs (CSRF middleware, performance logging, service-token middleware/logging)
- Accounts UI (`packages/accounts`) no longer renders IP addresses in security/activity views
- A one-shot purge script `scripts/purge-ip-data.ts` (in `packages/api`) is included to scrub historical prod data — **this must be run as an ECS one-shot task AFTER the deploy, not before**
- Email inbound `Received:` headers are intentionally **kept** — this is an explicit owner decision, not an oversight (RFC 5322 headers are part of the message content, not a tracking mechanism)
- Design spec + implementation plan docs added under `docs/superpowers/`:
  - `2026-07-14-no-ip-storage-design.md`
  - `2026-07-14-no-ip-storage.md`

## Test plan

- [x] `bun run test` — full workspace suite green: contracts 130/130, core 785/785, api 1400/1400, services 201/201, auth 45/45 (0 failures)
- [x] `bun run build:all` — 11/11 tasks successful
- [x] `cd packages/accounts && bunx tsc --noEmit` — clean, zero errors
- [ ] Note: `commons#test` has 3 failing suites (StandingHero, ActivityList, CompositionCard) — confirmed **pre-existing on `main`** (missing component files exist on main too) and unrelated to this branch (`git diff --stat main...fix/no-ip-storage` shows zero `packages/commons` changes). Not a blocker for this PR.
- [ ] Post-merge/deploy: run `scripts/purge-ip-data.ts` as a one-shot ECS task to scrub historical IP data from prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)