### PR TITLE
fix(api): make the backfill produce what the write path produces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -380,7 +380,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "10.1.3",
+      "version": "10.1.4",
       "dependencies": {
         "@oxyhq/contracts": "workspace:^",
         "@oxyhq/protocol": "workspace:^",

--- a/packages/api/src/models/File.ts
+++ b/packages/api/src/models/File.ts
@@ -10,11 +10,15 @@ import { normalizeInlineText } from '@oxyhq/core';
  * mirrored onto `Message` attachments). It is a single-line display value, so it
  * gets the canonical inline normalization.
  *
- * This is a schema setter rather than a call in `assetService` because there are
- * four independent upload paths (direct, streamed, chunked-complete, media-cache)
- * that all write this one leaf field; normalizing at the field is the only place
- * none of them can bypass. Non-string values pass through so Mongoose reports the
- * cast error itself.
+ * The API's rule is to normalize in the WRITE SERVICE, never in a schema setter
+ * (stated once, in `utils/profileTextNormalization.ts`). THIS FIELD IS THE ONE
+ * NAMED EXCEPTION to it, because it is the one case the rule carves out: there is
+ * no single write chokepoint to put the call in. Four independent upload paths
+ * (direct, streamed, chunked-complete, media-cache) write this one leaf field, so
+ * the schema field itself is the only place none of them can bypass. Do not read
+ * this as a competing convention — a new field gets a setter only with the same
+ * argument. Non-string values pass through so Mongoose reports the cast error
+ * itself.
  */
 function normalizeFileName(value: unknown): unknown {
   return typeof value === 'string' ? normalizeInlineText(value) : value;

--- a/packages/api/src/scripts/__tests__/normalizeUserTextFields.test.ts
+++ b/packages/api/src/scripts/__tests__/normalizeUserTextFields.test.ts
@@ -7,6 +7,10 @@
  * function. What matters is the IDEMPOTENCE contract — the script must produce an
  * empty `$set` for a document that is already clean, so a re-run performs zero
  * writes.
+ *
+ * The other half of the contract — that what it writes is byte-identical to what
+ * the profile write path would persist — is pinned in
+ * `normalizeUserTextFields.writePathParity.test.ts`.
  */
 
 import mongoose from 'mongoose';
@@ -91,6 +95,25 @@ describe('buildUserTextUpdate', () => {
     const update = buildUserTextUpdate(storedUser({ links: [' https://a.example ', '  '] }));
 
     expect(update).toEqual({ links: ['https://a.example'] });
+  });
+
+  it('drops a stored link card with no usable URL instead of persisting an invalid one', () => {
+    // `linksMetadata.url` is `required` in the User schema, and this script writes
+    // through the raw driver, which runs no validators. Keeping the entry with an
+    // empty `url` would plant a document that fails to save the next time the user
+    // edits their profile — over a link card they can neither see nor fix.
+    const update = buildUserTextUpdate(
+      storedUser({
+        linksMetadata: [
+          { url: '  \n ', title: 'T', description: 'D' },
+          { url: 'https://example.com', title: 'T', description: 'D' },
+        ],
+      })
+    );
+
+    expect(update).toEqual({
+      linksMetadata: [{ url: 'https://example.com', title: 'T', description: 'D' }],
+    });
   });
 
   it('touches ONLY the fields that actually change', () => {

--- a/packages/api/src/scripts/__tests__/normalizeUserTextFields.writePathParity.test.ts
+++ b/packages/api/src/scripts/__tests__/normalizeUserTextFields.writePathParity.test.ts
@@ -1,0 +1,229 @@
+/**
+ * THE INVARIANT of the backfill script, pinned.
+ *
+ * `scripts/normalize-user-text-fields.ts` exists to bring documents written
+ * BEFORE the text-normalization fix into the state the fixed write path produces.
+ * That is only true if it normalizes by the same rules — so this suite runs the
+ * SAME input through both and asserts the persisted result is byte-identical:
+ *
+ *   write path  → `userService.updateUserProfile` (what `user.set(field, value)`
+ *                 receives is exactly what Mongoose will save)
+ *   backfill    → `buildUserTextUpdate` (the `$set` payload)
+ *
+ * Why this matters beyond tidiness: the backfill writes with the RAW driver
+ * (`collection.bulkWrite`), which does not run Mongoose validators. A second,
+ * hand-written copy of the normalization policy that drifts from the real one can
+ * therefore persist a sub-document the schema forbids — e.g. a `linksMetadata`
+ * entry whose `url` normalized to `''`, when `url`/`title`/`description` are
+ * `required: true` — and the breakage surfaces later, as a validation error on the
+ * user's next profile save, over a link card they cannot see or fix. The parity
+ * asserted here is what makes that impossible.
+ *
+ * SCOPE. `bio` / `description` / `address` are compared with markup-free input:
+ * the backfill deliberately replays only the WHITESPACE half of the write path's
+ * `sanitizePlainText` (see the SCOPE note in the script header), and the two agree
+ * byte for byte over exactly that domain — which is the whole domain of the bug it
+ * cleans up.
+ */
+
+// The global jest.setup.cjs mocks `mongoose` wholesale, stripping `Schema.Types`.
+// `user.service.ts` imports the real `Follow` model, whose schema references
+// `Schema.Types.ObjectId` at module load — so restore the actual mongoose module.
+// The User/Subscription models ARE mocked below.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    findById: jest.fn(),
+    findOne: jest.fn(),
+  },
+}));
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {
+    findOne: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: jest.fn() },
+}));
+
+jest.mock('../../services/securityActivityService', () => ({
+  __esModule: true,
+  default: { logEmailChange: jest.fn(), logProfileUpdate: jest.fn() },
+}));
+
+import mongoose from 'mongoose';
+import User from '../../models/User';
+import { userService } from '../../services/user.service';
+import type { ProfileUpdateInput } from '../../types/user.types';
+import {
+  MAX_LINK_TITLE_LENGTH,
+  MAX_LOCATION_TEXT_LENGTH,
+} from '../../utils/profileTextNormalization';
+import { buildUserTextUpdate } from '../normalize-user-text-fields';
+
+const mockUser = User as jest.Mocked<typeof User>;
+
+const OBJECT_ID = new mongoose.Types.ObjectId();
+
+/**
+ * The fields under test, typed as the WRITE PATH's own input. A stored document is
+ * the same shape with `unknown` leaves, so one case object drives both paths.
+ */
+type ProfileFields = ProfileUpdateInput;
+
+/**
+ * Run the REAL write path and return what it would persist, field by field:
+ * `updateUserProfile` applies its result with `user.set(key, value)`, so the mock's
+ * `set` calls ARE the document state that `save()` is about to write.
+ */
+async function persistedByWritePath(fields: ProfileFields): Promise<Record<string, unknown>> {
+  const set = jest.fn<(key: string, value: unknown) => void>();
+  (mockUser.findById as jest.Mock).mockReturnValueOnce({
+    select: jest.fn().mockReturnValue({
+      _id: 'user-1',
+      username: 'alice',
+      email: 'user@example.com',
+      set,
+      save: jest.fn().mockResolvedValue(undefined),
+      toObject: jest.fn().mockReturnValue({ _id: 'user-1' }),
+    }),
+  });
+
+  await userService.updateUserProfile('user-1', fields);
+
+  const persisted: Record<string, unknown> = {};
+  for (const [key, value] of set.mock.calls) {
+    persisted[key] = value;
+  }
+  return persisted;
+}
+
+/**
+ * Run the backfill and return the resulting document state: the `$set` value for
+ * every field it rewrites, and the STORED value for every field it leaves alone
+ * (an absent key means "already clean", which must equal what is on disk).
+ */
+function persistedByBackfill(fields: ProfileFields): Record<string, unknown> {
+  const update = buildUserTextUpdate({ _id: OBJECT_ID, ...fields });
+
+  const persisted: Record<string, unknown> = {};
+  for (const key of Object.keys(fields)) {
+    persisted[key] = key in update ? update[key] : fields[key as keyof ProfileFields];
+  }
+  return persisted;
+}
+
+/** The reported bug: a remote `<title>` served across indented source lines. */
+const INDENTED_REMOTE_TITLE = '\n      Mi título\n    ';
+
+const PARITY_CASES: Array<{ label: string; fields: ProfileFields }> = [
+  {
+    label: 'an indented remote <title> and a multi-line description',
+    fields: {
+      linksMetadata: [
+        {
+          url: ' https://example.com ',
+          title: INDENTED_REMOTE_TITLE,
+          description: 'Una   descripción\ncon salto',
+          image: 'file-id',
+        },
+      ],
+    },
+  },
+  {
+    label: 'a link card whose URL normalizes to nothing (the schema requires `url`)',
+    fields: {
+      linksMetadata: [
+        { url: '   ', title: 'Sin URL', description: 'D' },
+        { url: 'https://example.com', title: 'Con URL', description: 'D' },
+      ],
+    },
+  },
+  {
+    label: 'an over-long scraped title (length cap)',
+    fields: {
+      linksMetadata: [
+        {
+          url: 'https://example.com',
+          title: `${'a'.repeat(MAX_LINK_TITLE_LENGTH)} desbordado`,
+          description: 'D',
+        },
+      ],
+    },
+  },
+  {
+    label: 'a Nominatim display_name and an over-long place name',
+    fields: {
+      locations: [
+        {
+          id: 'loc-1',
+          name: `  Plaça   de Catalunya ${'!'.repeat(MAX_LOCATION_TEXT_LENGTH)}`,
+          label: 'Home\noffice',
+          address: { city: ' Barcelona ', formattedAddress: 'Plaça de Catalunya,\n  Barcelona' },
+          coordinates: { lat: 41.3, lon: 2.1 },
+        },
+      ],
+    },
+  },
+  {
+    label: 'profile links with padding and an empty entry',
+    fields: { links: [' https://a.example ', '   ', 'https://b.example'] },
+  },
+  {
+    label: 'a display name padded with a run of spaces',
+    fields: { name: { first: `Ana${' '.repeat(20)}`, last: ' Gómez ' } },
+  },
+  {
+    label: 'free text with blank lines made of spaces (markup-free — see SCOPE)',
+    fields: {
+      bio: 'Primera línea\n   \n   \nSegunda línea',
+      description: 'Descripción   sucia',
+      address: '  12 Baker St  ',
+    },
+  },
+];
+
+describe('backfill / write-path parity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(PARITY_CASES)(
+    'the backfill persists exactly what the write path persists: $label',
+    async ({ fields }) => {
+      const fromWritePath = await persistedByWritePath(fields);
+      const fromBackfill = persistedByBackfill(fields);
+
+      expect(fromBackfill).toEqual(fromWritePath);
+    }
+  );
+
+  it('never emits a link card the User schema would reject (`url` is required)', () => {
+    const update = buildUserTextUpdate({
+      _id: OBJECT_ID,
+      linksMetadata: [
+        { url: '', title: 'T', description: 'D' },
+        { url: '\n  \n', title: 'T', description: 'D' },
+        { title: 'Sin url', description: 'D' },
+        'not-an-object',
+        { url: ' https://ok.example ', title: 'T', description: 'D' },
+      ],
+    });
+
+    // The backfill writes with the raw driver, which runs NO Mongoose validators:
+    // an entry with an empty `url` would be persisted and would then fail the
+    // `required` validator on the user's next profile save.
+    expect(update.linksMetadata).toEqual([
+      { url: 'https://ok.example', title: 'T', description: 'D' },
+    ]);
+  });
+});

--- a/packages/api/src/scripts/normalize-user-text-fields.ts
+++ b/packages/api/src/scripts/normalize-user-text-fields.ts
@@ -24,21 +24,42 @@
  * canonical `@oxyhq/core` normalizers). This script cleans the documents that
  * were written BEFORE the fix.
  *
- * WHAT IT NORMALIZES (per user document)
- *   - `name.first` / `name.last`        → cleanDisplayName (inline + char policy + cap)
- *   - `bio` / `description`             → normalizeMultilineText (paragraphs survive)
- *   - `address`                         → normalizeInlineText
- *   - `linksMetadata[].url/.title/.description` → normalizeInlineText (+ length caps)
- *   - `locations[].name/.label` and every string leaf of `locations[].address`
- *                                       → normalizeInlineText (+ length cap)
- *   - `links[]`                         → normalizeInlineText, empty entries dropped
+ * THE INVARIANT: what this script writes is byte-identical to what the profile
+ * write path (`user.service.updateUserProfile`) would persist for the same input.
+ * It holds because the script CALLS the write path's own normalizers instead of
+ * restating their rules — a second copy of the policy is exactly how the backfill
+ * would come to fabricate a document the write path would have rejected (e.g. a
+ * `linksMetadata` entry with an empty `url`, which the schema marks `required`).
+ * `scripts/__tests__/normalizeUserTextFields.writePathParity.test.ts` pins it.
+ *
+ * WHAT IT NORMALIZES (per user document), all via the write path's normalizers
+ *   - `name`                            → normalizeProfileName (+ drops the stale
+ *                                         `full` virtual if a copy was persisted)
+ *   - `bio` / `description` / `address` → normalizeMultilineText (paragraphs survive)
+ *   - `linksMetadata[]`                 → normalizeLinksMetadata
+ *   - `locations[]`                     → normalizeLocations
+ *   - `links[]`                         → normalizeLinks
+ *
+ * SCOPE — whitespace only. The free-text fields (`bio`, `description`, `address`)
+ * are normalized with `normalizeMultilineText`, which is the WHITESPACE half of
+ * the write path's `sanitizePlainText`; its other half (HTML-entity decoding + tag
+ * stripping) is deliberately NOT replayed over historical documents. It is a
+ * content transform, not a whitespace fix, and `decodeHtmlEntities` is not
+ * idempotent for double-encoded input (`&amp;amp;` → `&amp;` → `&`), so folding it
+ * in would break the "a re-run writes nothing" guarantee below. For any value
+ * carrying no markup — the whole domain of the bug being fixed — the two agree
+ * byte for byte.
  *
  * `LinkPreview` documents are deliberately NOT touched: bumping
  * `LINK_PREVIEW_RESOLVER_VERSION` to 2 already marks every cached preview stale,
  * so they re-resolve through the fixed resolver on their own.
  *
  * Safety:
- *   - No deletes, no drops, no schema changes.
+ *   - No document deletes, no drops, no schema changes. Within an array, an entry
+ *     that cannot be the thing it claims to be — a link card with no URL, an empty
+ *     `links[]` string, a non-object entry — IS dropped, because that is what the
+ *     write path does with it and keeping it would persist a document that fails
+ *     the `required` validators on the user's next profile save.
  *   - Reads through a CURSOR and writes in bounded `bulkWrite` batches — a large
  *     `users` collection is never loaded into memory.
  *   - Writes ONLY the documents whose normalized value actually differs, and only
@@ -59,16 +80,14 @@
 
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
-import { normalizeInlineText, normalizeMultilineText } from '@oxyhq/core';
+import { normalizeMultilineText } from '@oxyhq/core';
 import { getDbName } from '../config/db.js';
 import { logger } from '../utils/logger.js';
-import { cleanDisplayName } from '../utils/displayNameSanitize.js';
 import {
-  MAX_LINK_DESCRIPTION_LENGTH,
-  MAX_LINK_TITLE_LENGTH,
-  MAX_LINK_URL_LENGTH,
-  MAX_LOCATION_TEXT_LENGTH,
-  normalizeDisplayValue,
+  normalizeLinks,
+  normalizeLinksMetadata,
+  normalizeLocations,
+  normalizeProfileName,
 } from '../utils/profileTextNormalization.js';
 
 dotenv.config();
@@ -96,22 +115,54 @@ export interface StoredUserDoc {
   locations?: unknown;
 }
 
-/** The address leaves of a stored `locations[]` entry — all single-line values. */
-const LOCATION_ADDRESS_TEXT_KEYS = [
-  'street',
-  'streetNumber',
-  'streetDetails',
-  'postalCode',
-  'city',
-  'state',
-  'country',
-  'formattedAddress',
-] as const;
-
 type UnknownRecord = Record<string, unknown>;
 
-function isUnknownRecord(value: unknown): value is UnknownRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+/**
+ * A JSON object as the driver deserializes it. BSON leaves (ObjectId, Date,
+ * Binary) are class instances, not plain objects, and are compared by identity /
+ * by value in {@link deepEquals} rather than key by key.
+ */
+function isPlainObject(value: unknown): value is UnknownRecord {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * Structural equality between a stored value and its normalized counterpart.
+ *
+ * This is the ONLY thing the script adds on top of the write path's normalizers:
+ * "did the value change?" is a diffing question, orthogonal to the normalization
+ * POLICY, which lives entirely in `utils/profileTextNormalization.ts`. Deciding it
+ * generically is what lets the script own zero copies of that policy.
+ *
+ * The normalizers rebuild only the containers they touch (arrays, entry objects)
+ * and pass every other leaf through BY REFERENCE, so the `a === b` fast path
+ * covers the BSON leaves (ObjectId, Binary) that have no meaningful structural
+ * comparison here. `Date` is compared by value anyway, defensively.
+ */
+function deepEquals(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, index) => deepEquals(item, b[index]));
+  }
+
+  if (a instanceof Date || b instanceof Date) {
+    return a instanceof Date && b instanceof Date && a.getTime() === b.getTime();
+  }
+
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (key) => Object.prototype.hasOwnProperty.call(b, key) && deepEquals(a[key], b[key])
+    );
+  }
+
+  return false;
 }
 
 /**
@@ -133,169 +184,61 @@ interface BulkUpdateOne {
 type FieldCounters = Record<string, number>;
 
 /**
- * Normalize the `name` sub-document. Returns `undefined` when nothing changes.
- * Uses the same `cleanDisplayName` the write paths use, so a backfilled name is
- * byte-identical to one written today.
+ * Add `key` to the `$set` only when the normalized value differs from what is on
+ * disk. This is the script's single decision point: the VALUE always comes from a
+ * write-path normalizer, and all this adds is "has it changed?".
  */
-function normalizeStoredName(value: unknown): UnknownRecord | undefined {
-  if (!isUnknownRecord(value)) return undefined;
-
-  let changed = false;
-  const result: UnknownRecord = { ...value };
-  for (const part of ['first', 'last'] as const) {
-    const partValue = result[part];
-    if (typeof partValue !== 'string') continue;
-    const cleaned = cleanDisplayName(partValue);
-    if (cleaned !== partValue) {
-      result[part] = cleaned;
-      changed = true;
-    }
+function setIfChanged(update: UpdateSet, key: string, current: unknown, next: unknown): void {
+  if (!deepEquals(current, next)) {
+    update[key] = next;
   }
-  // `full` is a schema virtual; a stored copy would go stale the moment first/last
-  // change, so it is dropped from the persisted sub-document if present.
-  if ('full' in result) {
-    delete result.full;
-    changed = true;
-  }
-  return changed ? result : undefined;
 }
 
-/** Normalize `linksMetadata[]`. Returns `undefined` when nothing changes. */
-function normalizeStoredLinksMetadata(value: unknown): unknown[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-
-  let changed = false;
-  const result: unknown[] = [];
-  for (const entry of value) {
-    if (!isUnknownRecord(entry)) {
-      // A non-object entry is unusable as a link card; dropping it IS a change.
-      changed = true;
-      continue;
-    }
-
-    const next: UnknownRecord = { ...entry };
-    const caps: Array<[key: string, max: number]> = [
-      ['url', MAX_LINK_URL_LENGTH],
-      ['title', MAX_LINK_TITLE_LENGTH],
-      ['description', MAX_LINK_DESCRIPTION_LENGTH],
-    ];
-    for (const [key, max] of caps) {
-      const current = next[key];
-      if (typeof current !== 'string') continue;
-      const normalized = normalizeDisplayValue(current, max);
-      if (normalized !== current) {
-        next[key] = normalized;
-        changed = true;
-      }
-    }
-    result.push(next);
+/**
+ * The write path's `normalizeProfileName`, plus the one thing that is specific to
+ * a STORED document: `name.full` is a schema virtual, so a persisted copy of it
+ * (written by an older code path) goes stale the moment first/last change and is
+ * dropped here. The write path never receives it — it only ever sees a client
+ * payload — which is why this sits on top of the shared normalizer instead of
+ * inside it.
+ */
+function normalizeStoredName(value: unknown): unknown {
+  const normalized = normalizeProfileName(value);
+  if (!isPlainObject(normalized) || !('full' in normalized)) {
+    return normalized;
   }
-  return changed ? result : undefined;
-}
-
-/** Normalize `locations[]`. Returns `undefined` when nothing changes. */
-function normalizeStoredLocations(value: unknown): unknown[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-
-  let changed = false;
-  const result: unknown[] = [];
-  for (const entry of value) {
-    if (!isUnknownRecord(entry)) {
-      changed = true;
-      continue;
-    }
-
-    const next: UnknownRecord = { ...entry };
-    for (const key of ['name', 'label'] as const) {
-      const current = next[key];
-      if (typeof current !== 'string') continue;
-      const normalized = normalizeDisplayValue(current, MAX_LOCATION_TEXT_LENGTH);
-      if (normalized !== current) {
-        next[key] = normalized;
-        changed = true;
-      }
-    }
-
-    if (isUnknownRecord(next.address)) {
-      const address: UnknownRecord = { ...next.address };
-      let addressChanged = false;
-      for (const key of LOCATION_ADDRESS_TEXT_KEYS) {
-        const current = address[key];
-        if (typeof current !== 'string') continue;
-        const normalized = normalizeDisplayValue(current, MAX_LOCATION_TEXT_LENGTH);
-        if (normalized !== current) {
-          address[key] = normalized;
-          addressChanged = true;
-        }
-      }
-      if (addressChanged) {
-        next.address = address;
-        changed = true;
-      }
-    }
-
-    result.push(next);
-  }
-  return changed ? result : undefined;
-}
-
-/** Normalize `links[]` (plain URLs). Returns `undefined` when nothing changes. */
-function normalizeStoredLinks(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-
-  let changed = false;
-  const result: string[] = [];
-  for (const entry of value) {
-    if (typeof entry !== 'string') {
-      changed = true;
-      continue;
-    }
-    const url = normalizeDisplayValue(entry, MAX_LINK_URL_LENGTH);
-    if (url !== entry) changed = true;
-    if (url) {
-      result.push(url);
-    } else {
-      changed = true;
-    }
-  }
-  return changed ? result : undefined;
+  const withoutVirtual: UnknownRecord = { ...normalized };
+  delete withoutVirtual.full;
+  return withoutVirtual;
 }
 
 /**
  * Build the `$set` for one stored user, containing ONLY the fields whose
  * normalized value differs from what is on disk. An empty object means the
  * document is already clean and must not be written.
+ *
+ * Every value in the result is produced by the SAME normalizer the profile write
+ * path runs, so a backfilled document is byte-identical to one written today.
  */
 export function buildUserTextUpdate(doc: StoredUserDoc): UpdateSet {
   const update: UpdateSet = {};
 
-  const name = normalizeStoredName(doc.name);
-  if (name) update.name = name;
+  setIfChanged(update, 'name', doc.name, normalizeStoredName(doc.name));
 
-  // Bodies: the author's line breaks are meaningful, so these use the MULTILINE
-  // normalizer — it strips the trailing spaces that turn a "blank" line into an
-  // uncollapsible one, without flattening real paragraphs.
-  for (const key of ['bio', 'description'] as const) {
+  // Free text: the author's line breaks are meaningful, so these use the MULTILINE
+  // normalizer — the same one `sanitizePlainText` delegates its whitespace pass to.
+  // It strips the trailing spaces that turn a "blank" line into an uncollapsible
+  // one, without flattening real paragraphs. See SCOPE in the header for why the
+  // entity-decoding / tag-stripping half of `sanitizePlainText` is not replayed.
+  for (const key of ['bio', 'description', 'address'] as const) {
     const current = doc[key];
     if (typeof current !== 'string') continue;
-    const normalized = normalizeMultilineText(current);
-    if (normalized !== current) update[key] = normalized;
+    setIfChanged(update, key, current, normalizeMultilineText(current));
   }
 
-  // A postal address is one line of display text.
-  if (typeof doc.address === 'string') {
-    const normalized = normalizeInlineText(doc.address);
-    if (normalized !== doc.address) update.address = normalized;
-  }
-
-  const linksMetadata = normalizeStoredLinksMetadata(doc.linksMetadata);
-  if (linksMetadata) update.linksMetadata = linksMetadata;
-
-  const locations = normalizeStoredLocations(doc.locations);
-  if (locations) update.locations = locations;
-
-  const links = normalizeStoredLinks(doc.links);
-  if (links) update.links = links;
+  setIfChanged(update, 'linksMetadata', doc.linksMetadata, normalizeLinksMetadata(doc.linksMetadata));
+  setIfChanged(update, 'locations', doc.locations, normalizeLocations(doc.locations));
+  setIfChanged(update, 'links', doc.links, normalizeLinks(doc.links));
 
   return update;
 }

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -13,11 +13,12 @@ import { Types } from 'mongoose';
 import userCache from '../utils/userCache';
 import securityActivityService from './securityActivityService';
 import { sanitizeProfileUpdate } from '../utils/sanitize';
-import { cleanDisplayName, isValidDisplayName } from '../utils/displayNameSanitize';
+import { isValidDisplayName } from '../utils/displayNameSanitize';
 import {
   normalizeLinks,
   normalizeLinksMetadata,
   normalizeLocations,
+  normalizeProfileName,
 } from '../utils/profileTextNormalization';
 import { INVALID_USERNAME_MESSAGE, USERNAME_PATTERN, normalizeUsername } from '../utils/username';
 import { BadRequestError } from '../utils/error';
@@ -178,35 +179,6 @@ function isBulkWriteLikeError(error: unknown): error is BulkWriteLikeError {
  */
 function normalizeProfileColor(value: unknown): unknown {
   return typeof value === 'string' ? value.trim().toLowerCase() : value;
-}
-
-/**
- * Canonicalize the `name` sub-document of a profile update with the SAME cleaner
- * the FEDERATED write paths use (`cleanDisplayName`): NFC, the display-name
- * character policy, whitespace collapse, length cap.
- *
- * Before this, the native path was the odd one out. `sanitizeProfileUpdate`
- * skips `name`, the `NameSchema` has no `trim`, and `isValidDisplayName` only
- * checks the CHARACTER SET — a space is a legal display-name character, so
- * `"Ana" + 20 spaces + "Gómez"` passed validation and was stored verbatim, while
- * the exact same string arriving from a federated actor was collapsed. The
- * character policy is validated (and rejected with a 400) BEFORE this runs, so
- * the cleaner here only ever has whitespace and length left to fix.
- *
- * Non-string parts are passed through untouched for the caller's own handling.
- */
-function normalizeProfileName(value: unknown): unknown {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return value;
-  }
-  const result: Record<string, unknown> = { ...(value as Record<string, unknown>) };
-  for (const part of ['first', 'last'] as const) {
-    const partValue = result[part];
-    if (typeof partValue === 'string') {
-      result[part] = cleanDisplayName(partValue);
-    }
-  }
-  return result;
 }
 
 /**

--- a/packages/api/src/utils/__tests__/username.test.ts
+++ b/packages/api/src/utils/__tests__/username.test.ts
@@ -1,12 +1,18 @@
-import {
-  INVALID_USERNAME_MESSAGE,
-  USERNAME_PATTERN,
-  isValidUsername,
-  normalizeUsername,
-} from '../username';
+import { INVALID_USERNAME_MESSAGE, USERNAME_PATTERN, normalizeUsername } from '../username';
 
 /** Non-breaking space, spelled with an escape so the code point is unambiguous. */
 const NBSP = '\u00A0';
+
+/**
+ * The composition every write path applies: normalize the submitted value, then
+ * test the normalized form. Spelled out here rather than exported as a helper \u2014
+ * an `isValidUsername` in this module would collide by name with the LOOSER
+ * `isValidUsername` of `@oxyhq/core` (which admits `_` and `-`), and a caller
+ * reaching for the wrong import would silently widen the server's policy.
+ */
+function accepts(raw: string): boolean {
+  return USERNAME_PATTERN.test(normalizeUsername(raw));
+}
 
 describe('username policy', () => {
   describe('normalizeUsername', () => {
@@ -19,14 +25,14 @@ describe('username policy', () => {
       // under a name they never chose. It collapses to a single space, which the
       // pattern then rejects.
       expect(normalizeUsername('al   ice')).toBe('al ice');
-      expect(isValidUsername('al   ice')).toBe(false);
+      expect(accepts('al   ice')).toBe(false);
     });
 
     it('normalizes a non-breaking space (the invisible-collision case)', () => {
       // A trailing NBSP would otherwise store a second "alice" that no human can
       // tell apart from the first.
       expect(normalizeUsername(`alice${NBSP}`)).toBe('alice');
-      expect(isValidUsername(`ali${NBSP}ce`)).toBe(false);
+      expect(accepts(`ali${NBSP}ce`)).toBe(false);
     });
   });
 

--- a/packages/api/src/utils/profileTextNormalization.ts
+++ b/packages/api/src/utils/profileTextNormalization.ts
@@ -1,6 +1,6 @@
 /**
- * Whitespace normalization for the STRUCTURED profile fields — `linksMetadata`,
- * `locations`, `links`.
+ * Whitespace normalization for the STRUCTURED profile fields — `name`,
+ * `linksMetadata`, `locations`, `links`.
  *
  * WHY THESE NEED THEIR OWN PASS
  * -----------------------------
@@ -28,12 +28,25 @@
  * line break in any of them is always an artifact of the source, never authored
  * intent.
  *
- * These normalizers run in the profile WRITE SERVICE (`user.service`), not in a
- * Mongoose setter: the write service is where the rest of the profile's
- * boundary validation already lives (display-name policy, locale canonicalization,
- * premium-color gate), and it is the layer that can reject a malformed payload
- * with a structured 400. A setter would silently fix up documents from every
- * internal caller and hide the same class of bug from tests.
+ * WHERE NORMALIZATION RUNS — the one rule for the whole API
+ * ---------------------------------------------------------
+ * Normalize in the WRITE SERVICE, not in a Mongoose setter. The write service is
+ * where the rest of the field's boundary validation already lives (display-name
+ * policy, locale canonicalization, premium-color gate); it is the layer that can
+ * reject a malformed payload with a structured 400, and it keeps the
+ * transformation visible to the tests that cover that boundary. A setter instead
+ * fixes up documents from every internal caller silently, which hides that same
+ * class of bug.
+ *
+ * The rule has exactly ONE named exception: a field with NO single write
+ * chokepoint. `File.originalName` (`models/File.ts`) is written by four
+ * independent upload paths, so the schema field itself is the only place none of
+ * them can bypass, and it therefore normalizes in a setter. A new normalized
+ * field needs either a chokepoint or that same argument — nothing else.
+ *
+ * The BACKFILL for these fields (`scripts/normalize-user-text-fields.ts`) calls
+ * the functions below rather than restating their rules, so a normalized-in-place
+ * document is byte-identical to one written through the service today.
  *
  * Length caps are applied here too: these are display strings coming from a
  * remote origin that we do not control, so an unbounded `og:description` cannot
@@ -41,6 +54,7 @@
  */
 
 import { normalizeInlineText } from '@oxyhq/core';
+import { cleanDisplayName } from './displayNameSanitize';
 
 /** Max stored length of a link card's title, in code units after normalization. */
 export const MAX_LINK_TITLE_LENGTH = 200;
@@ -90,23 +104,52 @@ export function normalizeDisplayValue(value: string, maxLength: number): string 
 
 /**
  * Normalize the string leaves of an object IN PLACE-free fashion: returns a new
- * object with `keys` normalized and every other key passed through untouched.
- * Keys that are absent, or hold a non-string, are left exactly as they were —
- * this function normalizes text, it does not validate shape.
+ * object with `keys` run through `normalize` and every other key passed through
+ * untouched (by reference). Keys that are absent, or hold a non-string, are left
+ * exactly as they were — this function normalizes text, it does not validate shape.
  */
 function withNormalizedKeys(
   source: UnknownRecord,
   keys: readonly string[],
-  maxLength: number
+  normalize: (value: string) => string
 ): UnknownRecord {
   const result: UnknownRecord = { ...source };
   for (const key of keys) {
     const value = result[key];
     if (typeof value === 'string') {
-      result[key] = normalizeDisplayValue(value, maxLength);
+      result[key] = normalize(value);
     }
   }
   return result;
+}
+
+/** The `normalize` argument of {@link withNormalizedKeys} for a capped display value. */
+function inlineTextNormalizer(maxLength: number): (value: string) => string {
+  return (value: string) => normalizeDisplayValue(value, maxLength);
+}
+
+/** The text leaves of the `name` sub-document. `full` is a schema VIRTUAL. */
+const NAME_TEXT_KEYS = ['first', 'last'] as const;
+
+/**
+ * Canonicalize the `name` sub-document with the SAME cleaner the FEDERATED write
+ * paths use (`cleanDisplayName`): NFC, the display-name character policy,
+ * whitespace collapse, length cap.
+ *
+ * Before this, the native path was the odd one out. `sanitizeProfileUpdate` skips
+ * `name`, the `NameSchema` has no `trim`, and `isValidDisplayName` only checks the
+ * CHARACTER SET — a space is a legal display-name character, so `"Ana"` + 20
+ * spaces + `"Gómez"` passed validation and was stored verbatim, while the exact
+ * same string arriving from a federated actor was collapsed. In `user.service` the
+ * character policy is validated (and rejected with a 400) BEFORE this runs, so
+ * there the cleaner only ever has whitespace and length left to fix.
+ *
+ * Non-object values, and non-string parts, are passed through untouched for the
+ * caller's own handling.
+ */
+export function normalizeProfileName(value: unknown): unknown {
+  if (!isUnknownRecord(value)) return value;
+  return withNormalizedKeys(value, NAME_TEXT_KEYS, cleanDisplayName);
 }
 
 /**
@@ -159,12 +202,13 @@ export function normalizeLocations(value: unknown): unknown {
   for (const entry of value) {
     if (!isUnknownRecord(entry)) continue;
 
-    const next = withNormalizedKeys(entry, ['name', 'label'], MAX_LOCATION_TEXT_LENGTH);
+    const normalizeLocationText = inlineTextNormalizer(MAX_LOCATION_TEXT_LENGTH);
+    const next = withNormalizedKeys(entry, ['name', 'label'], normalizeLocationText);
     if (isUnknownRecord(next.address)) {
       next.address = withNormalizedKeys(
         next.address,
         LOCATION_ADDRESS_TEXT_KEYS,
-        MAX_LOCATION_TEXT_LENGTH
+        normalizeLocationText
       );
     }
     normalized.push(next);

--- a/packages/api/src/utils/username.ts
+++ b/packages/api/src/utils/username.ts
@@ -1,5 +1,5 @@
 /**
- * Username policy — the single source of truth.
+ * Username policy — THE ENFORCED ONE, for the API's write paths.
  *
  * A username is a HANDLE, not prose: it is the routing key of a profile URL
  * (`/@alice`), a webfinger `acct:` local part, and a login identifier. It
@@ -11,6 +11,19 @@
  * public-key registration controllers, each with its own copy of the regex. It
  * now lives here so every write path — signup, registration, the availability
  * check, and `PUT /users/me` — validates against the SAME rule.
+ *
+ * WHERE THE OTHER TWO LIVE (this file is NOT the ecosystem-wide source of truth,
+ * it is the SERVER-SIDE one — the only one that decides what gets stored):
+ *
+ *   - `@oxyhq/core` `utils/validationUtils.ts` — `/^[a-zA-Z0-9_-]{3,30}$/`. Also
+ *     admits `_` and `-`. It is the SDK's client-side pre-check; a value it
+ *     accepts can still be rejected here, and this rule is the one that wins.
+ *   - `@oxyhq/commons` `utils/auth/usernameUtils.ts` — `/^[a-z0-9]+$/i` plus a
+ *     `USERNAME_MIN_LENGTH` bound, used by the signup UI's suggestion/validation
+ *     helpers.
+ *
+ * Loosening any of the three without the others produces a username that a client
+ * accepts and the server 400s (or worse, the reverse). Change this one first.
  */
 
 import { normalizeInlineText } from '@oxyhq/core';
@@ -32,9 +45,4 @@ export const INVALID_USERNAME_MESSAGE =
  */
 export function normalizeUsername(raw: string): string {
   return normalizeInlineText(raw);
-}
-
-/** Whether `value` is a syntactically valid username (already normalized or not). */
-export function isValidUsername(value: string): boolean {
-  return USERNAME_PATTERN.test(normalizeUsername(value));
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "10.1.3",
+  "version": "10.1.4",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/utils/textNormalization.ts
+++ b/packages/core/src/utils/textNormalization.ts
@@ -43,30 +43,6 @@
  * normalize whitespace and Unicode form.
  */
 
-/**
- * Characters that make a value ineligible for the zero-work fast path, and the
- * whitespace shapes that a normalized INLINE value can never contain.
- *
- * A value that matches nothing here is, by construction, already normalized:
- * it holds only printable ASCII (which is NFC-stable, so `normalize('NFC')`
- * would be a no-op), its only whitespace is the plain space, it has no leading
- * or trailing space, and no run of two spaces. Returning it untouched skips
- * three string allocations — worth it because the common case in the feed
- * hydration hot path is text that is already clean.
- *
- * Non-global (safe for repeated `.test()`; a global regex is stateful).
- */
-const INLINE_NEEDS_NORMALIZATION = /[^\x20-\x7E]|^ | $| {2}/;
-
-/**
- * Same idea as {@link INLINE_NEEDS_NORMALIZATION}, for MULTILINE values: `\n`
- * joins the printable-ASCII fast-path alphabet, and the additional shapes a
- * normalized body can never contain are a space adjacent to a line break — on
- * either side, since every line is trimmed — and a run of three line breaks
- * (more than one blank line).
- */
-const MULTILINE_NEEDS_NORMALIZATION = /[^\x20-\x7E\n]|^[ \n]|[ \n]$| {2}| \n|\n |\n{3}/;
-
 /** Any run of whitespace, including tabs, line breaks and Unicode spaces. */
 const ANY_WHITESPACE_RUN = /\s+/g;
 
@@ -134,9 +110,6 @@ const EXCESS_BLANK_LINES = /\n{3,}/g;
  * Idempotent: `f(f(x)) === f(x)`.
  */
 export function normalizeInlineText(value: string): string {
-  if (!INLINE_NEEDS_NORMALIZATION.test(value)) {
-    return value;
-  }
   return value.normalize('NFC').replace(ANY_WHITESPACE_RUN, ' ').trim();
 }
 
@@ -173,9 +146,6 @@ export function normalizeInlineText(value: string): string {
  * Idempotent: `f(f(x)) === f(x)`.
  */
 export function normalizeMultilineText(value: string): string {
-  if (!MULTILINE_NEEDS_NORMALIZATION.test(value)) {
-    return value;
-  }
   return value
     .normalize('NFC')
     .replace(LINE_BREAK_FORMS, '\n')


### PR DESCRIPTION
## Summary

Quality pass on #612 (whitespace normalization), before the backfill is pointed at production.

**The backfill script reimplemented the profile normalizers instead of calling the ones the write path uses — and the two had already drifted apart.**

`normalizeLinksMetadata` **drops** a link entry whose url normalizes to empty. The script's copy **kept** it and `$set` an empty `url`. And the script writes through the **raw driver**, which runs no validators, while `url` / `title` / `description` are `required: true` on the `linksMetadata` subdocument.

So the cleanup script could persist a link card the write path considers invalid — and the next time that user saved their profile through the normal path (which *does* validate), `save()` would throw on a card they can neither see nor fix. **The script fabricated the breakage it claims to fix.**

## What changed

- The script now calls `normalizeLinksMetadata` / `normalizeLocations` / `normalizeLinks` and diffs the result against what is stored. Change detection is orthogonal to the normalization rules, so it is one `setIfChanged` helper rather than three reimplemented policies.
- `normalizeProfileName` moves to the shared module both sides already import.
- A **parity test** pins the invariant the script's own docstring claimed but did not hold: what the backfill writes is byte-identical to what the write path would write for the same input.
- Delete the dead `isValidUsername`. Nothing called it, and it collided by name with `@oxyhq/core`'s — which has a **different** rule (it allows `_` and `-`). An autoimport picking the wrong one would silently accept usernames this path is meant to reject. Its docstring claimed to be "the single source of truth" and was not; there is a third policy in `packages/commons`.
- State **one** rule for where normalization lives (write service; a schema setter only where no single write chokepoint exists), so `File.ts` reads as the named exception it is rather than as a flat contradiction of `profileTextNormalization`.
- `@oxyhq/core` → `10.1.4`: the fast-path guards are gone from the normalizers. They were a second, hand-derived encoding of the pipeline's contract, and the failure mode when the two drift is a **false negative** — waving through text that is *not* normalized, which is precisely the bug class this whole change exists to kill. The hot path they were justified by does not exist (1 of 9 call sites is on a read path; the rest sit behind an HTTP round trip or a Mongo write), and they never fire on accented or non-ASCII text anyway.

## Test plan

`bun run build` + `bun run test` in `packages/api`: **1468 tests green**, including the new parity suite.

Two suites (`sessionAccess.controller`, `authLinking.reversibility`) fail to *load* in a fresh worktree with `Failed to load native binding` (`@node-rs/argon2`). Verified this reproduces on a **pristine checkout of `main` with zero changes** — it is an environment artifact of a clean install, not this diff. In the main tree, where the binding is present, the full suite is 162 suites / 1477 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)