### PR TITLE
feat(sdk): instant cross-app session sync via user-room socket event (Phase A)

### DIFF
--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -9,6 +9,7 @@ const mockSwitchActive = jest.fn();
 const mockSignout = jest.fn();
 const mockResolveActiveToken = jest.fn();
 const mockBroadcast = jest.fn();
+const mockBroadcastAccounts = jest.fn();
 const mockDecodeToken = jest.fn();
 const mockGetSession = jest.fn();
 const mockGetStateBySecret = jest.fn();
@@ -51,7 +52,10 @@ jest.mock('../../services/loginLockout.service', () => ({
   recordFailure: (...a: unknown[]) => mockRecordFailure(...a),
   clearFailures: (...a: unknown[]) => mockClearFailures(...a),
 }));
-jest.mock('../../utils/socket', () => ({ broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a) }));
+jest.mock('../../utils/socket', () => ({
+  broadcastDeviceState: (...a: unknown[]) => mockBroadcast(...a),
+  broadcastSessionAccountsChanged: (...a: unknown[]) => mockBroadcastAccounts(...a),
+}));
 jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
 
 import sessionDeviceRouter from '../sessionDevice';
@@ -88,6 +92,9 @@ afterAll((done) => { server.close(done); });
 beforeEach(() => {
   jest.clearAllMocks();
   mockResolveActiveToken.mockResolvedValue({ accessToken: 'jwt-active', expiresAt: '2026-07-07T00:00:00.000Z' });
+  // The signout route pre-reads the device state (to diff which users were
+  // removed) before signing out — default it to the single-account STATE.
+  mockGetState.mockResolvedValue(STATE);
   // Default to an active first-party session; individual tests override this
   // to exercise managed sessions or the expired/revoked (null) 401 path.
   mockGetSession.mockResolvedValue({ operatedByUserId: null });
@@ -115,6 +122,8 @@ describe('POST /session/device/switch', () => {
     expect(res.status).toBe(200);
     expect(mockSwitchActive).toHaveBeenCalledWith('d1', 'a1');
     expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+    // A1: cross-device signal to the switched-to account's user room.
+    expect(mockBroadcastAccounts).toHaveBeenCalledWith('a1', STATE.revision, 'switch');
     expect(res.body.data.state).toEqual(STATE);
     expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
   });
@@ -124,6 +133,7 @@ describe('POST /session/device/switch', () => {
     const res = await requestJson(server, 'POST', '/session/device/switch', { accountId: 'ghost' });
     expect(res.status).toBe(404);
     expect(mockBroadcast).not.toHaveBeenCalled();
+    expect(mockBroadcastAccounts).not.toHaveBeenCalled();
   });
 
   it('403 and broadcasts the healed state when the target session is revoked (act_as membership pulled)', async () => {
@@ -135,6 +145,8 @@ describe('POST /session/device/switch', () => {
     // switchActive healed the device set (dropped the revoked account); the
     // route broadcasts that healed state so the device's other tabs converge.
     expect(mockBroadcast).toHaveBeenCalledWith(healed);
+    // A1: the revoked account's user is signalled to refetch.
+    expect(mockBroadcastAccounts).toHaveBeenCalledWith('org1', healed.revision, 'revoke');
   });
 });
 
@@ -146,15 +158,27 @@ describe('POST /session/device/signout', () => {
     expect(res.status).toBe(200);
     expect(mockSignout).toHaveBeenCalledWith('d1', { accountId: 'a1' });
     expect(mockBroadcast).toHaveBeenCalledWith(after);
+    // A1: the removed account (present before, gone after) is signalled.
+    expect(mockBroadcastAccounts).toHaveBeenCalledWith(['a1'], after.revision, 'signout');
     expect(res.body.data.state).toEqual(after);
   });
 
-  it('signs out all when { all: true }', async () => {
+  it('signs out all when { all: true } and signals every removed user', async () => {
+    // Two accounts on the device before; all removed.
+    const before = {
+      ...STATE,
+      accounts: [
+        { accountId: 'a1', sessionId: 's1', authuser: 0 },
+        { accountId: 'a2', sessionId: 's2', authuser: 1 },
+      ],
+    };
+    mockGetState.mockResolvedValueOnce(before);
     const after = { ...STATE, accounts: [], activeAccountId: null, revision: 2 };
     mockSignout.mockResolvedValueOnce(after);
     const res = await requestJson(server, 'POST', '/session/device/signout', { all: true });
     expect(res.status).toBe(200);
     expect(mockSignout).toHaveBeenCalledWith('d1', { all: true });
+    expect(mockBroadcastAccounts).toHaveBeenCalledWith(['a1', 'a2'], after.revision, 'signout');
   });
 });
 
@@ -166,6 +190,8 @@ describe('POST /session/device/add', () => {
     expect(mockGetSession).toHaveBeenCalledWith('s1', true);
     expect(mockAddAccount).toHaveBeenCalledWith('d1', { accountId: '64b0000000000000000000aa', sessionId: 's1' });
     expect(mockBroadcast).toHaveBeenCalledWith(STATE);
+    // A1: the added account's user is signalled to refetch.
+    expect(mockBroadcastAccounts).toHaveBeenCalledWith('64b0000000000000000000aa', STATE.revision, 'add');
     expect(res.body.data.state).toEqual(STATE);
     expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
   });
@@ -175,6 +201,8 @@ describe('POST /session/device/add', () => {
     const res = await requestJson(server, 'POST', '/session/device/add', {});
     expect(res.status).toBe(200);
     expect(mockBroadcast).not.toHaveBeenCalled();
+    // No change → no cross-device signal either.
+    expect(mockBroadcastAccounts).not.toHaveBeenCalled();
     expect(res.body.data.state).toEqual(STATE);
     expect(res.body.data.activeToken.accessToken).toBe('jwt-active');
   });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -27,6 +27,7 @@ import { BadRequestError, NotFoundError, UnauthorizedError, ForbiddenError } fro
 import { logger } from '../utils/logger';
 import SignatureService from '../services/signature.service';
 import { emitAuthSessionUpdate } from '../utils/authSessionSocket';
+import { broadcastSessionAccountsChanged } from '../utils/socket';
 import socialAuthRouter from './socialAuth';
 import { validate } from '../middleware/validate';
 import sessionService from '../services/session.service';
@@ -1343,6 +1344,11 @@ router.post('/session/authorize/:sessionToken', authMiddleware, validate({ param
     username: authenticatedUser.username,
   });
 
+  // A1: a brand-new session was minted for this user — signal all of their other
+  // connected sockets (across devices/origins) to refetch. No device mutation
+  // happens here, so the revision hint is 0.
+  broadcastSessionAccountsChanged(authenticatedUserId, 0, 'login');
+
   sendSuccess(res, {
     success: true,
     sessionId: newSession.sessionId,
@@ -1689,6 +1695,11 @@ router.post(
       userId: outcome.userId,
       username: outcome.username,
     });
+
+    // A1: a brand-new session was minted for the signer via the QR handoff —
+    // signal all of their other connected sockets to refetch. No device mutation
+    // happens here, so the revision hint is 0.
+    broadcastSessionAccountsChanged(outcome.userId, 0, 'login');
 
     sendSuccess(res, {
       success: true,

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -13,7 +13,7 @@ import { rateLimit } from '../middleware/rateLimiter';
 import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
 import deviceSessionService from '../services/deviceSession.service';
 import sessionService from '../services/session.service';
-import { broadcastDeviceState } from '../utils/socket';
+import { broadcastDeviceState, broadcastSessionAccountsChanged } from '../utils/socket';
 import { asyncHandler } from '../utils/asyncHandler';
 import { logger } from '../utils/logger';
 
@@ -238,7 +238,11 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
     ...(operatedByUserId ? { operatedByUserId } : {}),
   });
   // An idempotent re-register (reload handoff) changes nothing — do not broadcast.
-  if (changed) broadcastDeviceState(state);
+  if (changed) {
+    broadcastDeviceState(state);
+    // Also signal the added account's user across their other apps/devices.
+    broadcastSessionAccountsChanged(accountId, state.revision, 'add');
+  }
   res.json({ data: await withActiveToken(state) });
 }));
 
@@ -254,6 +258,8 @@ router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
       // removing the dead account. Broadcast the healed state so the device's
       // other tabs drop it too, then reject the switch.
       broadcastDeviceState(outcome.state);
+      // The dropped account was revoked — signal its user to refetch.
+      broadcastSessionAccountsChanged(accountId, outcome.state.revision, 'revoke');
       res.status(403).json({ error: 'Account not authorized' });
       return;
     }
@@ -261,6 +267,7 @@ router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
     return;
   }
   broadcastDeviceState(outcome.state);
+  broadcastSessionAccountsChanged(accountId, outcome.state.revision, 'switch');
   res.json({ data: await withActiveToken(outcome.state) });
 }));
 
@@ -270,8 +277,17 @@ router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => 
   const { accountId, all } = req.body ?? {};
   const target = all === true ? { all: true as const } : accountId ? { accountId } : null;
   if (!target) { res.status(400).json({ error: 'accountId or all required' }); return; }
+  // Capture the account set BEFORE signout so we can signal every user actually
+  // removed — this covers `all`, a single account, AND the operator-cascade
+  // (signing out an operator removes their managed accounts too).
+  const before = await deviceSessionService.getState(deviceId);
   const state = await deviceSessionService.signout(deviceId, target);
   broadcastDeviceState(state);
+  const remaining = new Set(state.accounts.map((a) => a.accountId));
+  const removedUserIds = before.accounts
+    .map((a) => a.accountId)
+    .filter((id) => !remaining.has(id));
+  broadcastSessionAccountsChanged(removedUserIds, state.revision, 'signout');
   res.json({ data: await withActiveToken(state) });
 }));
 

--- a/packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts
+++ b/packages/api/src/utils/__tests__/deviceStateBroadcast.test.ts
@@ -1,6 +1,7 @@
 jest.mock('../logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
-import { initializeIO, closeIO, broadcastDeviceState } from '../socket';
+import { initializeIO, closeIO, broadcastDeviceState, broadcastSessionAccountsChanged } from '../socket';
 import type { DeviceSessionState } from '@oxyhq/contracts';
+import { SESSION_ACCOUNTS_CHANGED_EVENT } from '@oxyhq/contracts';
 
 const state: DeviceSessionState = { deviceId: 'd1', accounts: [], activeAccountId: null, revision: 5, updatedAt: 1720000000000 };
 
@@ -19,5 +20,34 @@ describe('broadcastDeviceState', () => {
   it('is a no-op when io is not initialised', () => {
     closeIO();
     expect(() => broadcastDeviceState(state)).not.toThrow();
+  });
+});
+
+describe('broadcastSessionAccountsChanged', () => {
+  it('emits the token-free signal to a single user room', () => {
+    const emit = jest.fn();
+    const to = jest.fn().mockReturnValue({ emit });
+    initializeIO({ to } as never);
+    broadcastSessionAccountsChanged('user-1', 7, 'add');
+    expect(to).toHaveBeenCalledWith('user:user-1');
+    expect(emit).toHaveBeenCalledWith(SESSION_ACCOUNTS_CHANGED_EVENT, { userId: 'user-1', revision: 7, reason: 'add' });
+    // Signal only — never carries a token/secret.
+    const payload = emit.mock.calls[0][1] as Record<string, unknown>;
+    expect(Object.keys(payload).sort()).toEqual(['reason', 'revision', 'userId']);
+  });
+
+  it('de-duplicates and drops blank ids across an array of users', () => {
+    const emit = jest.fn();
+    const to = jest.fn().mockReturnValue({ emit });
+    initializeIO({ to } as never);
+    broadcastSessionAccountsChanged(['user-1', 'user-1', '', 'user-2'], 3, 'signout');
+    expect(to).toHaveBeenCalledTimes(2);
+    expect(to).toHaveBeenCalledWith('user:user-1');
+    expect(to).toHaveBeenCalledWith('user:user-2');
+  });
+
+  it('is a no-op when io is not initialised', () => {
+    closeIO();
+    expect(() => broadcastSessionAccountsChanged('user-1', 1, 'login')).not.toThrow();
   });
 });

--- a/packages/api/src/utils/socket.ts
+++ b/packages/api/src/utils/socket.ts
@@ -1,5 +1,6 @@
 import type { Server as SocketIOServer } from 'socket.io';
-import type { DeviceSessionState } from '@oxyhq/contracts';
+import type { DeviceSessionState, SessionAccountsChangedReason } from '@oxyhq/contracts';
+import { SESSION_ACCOUNTS_CHANGED_EVENT } from '@oxyhq/contracts';
 import { logger } from './logger';
 
 let io: SocketIOServer | null = null;
@@ -26,6 +27,31 @@ export function broadcastDeviceState(state: DeviceSessionState): void {
     return;
   }
   server.to(`device:${state.deviceId}`).emit('session_state', state);
+}
+
+/**
+ * Emit the token-free `session_accounts_changed` signal to `user:<userId>` for
+ * each affected user. Unlike {@link broadcastDeviceState} (scoped to a single
+ * device/origin), this reaches ALL of a user's connected sockets across their
+ * devices/origins so every Oxy app refetches its authenticated session/account
+ * state instantly. The payload carries NO token/secret — it is a signal only.
+ *
+ * `revision` is the mutated DeviceSession revision for device-scoped reasons; for
+ * `login` (no device mutation) callers pass 0. Empty / blank ids are dropped, and
+ * duplicate ids are de-duplicated so a user is signalled at most once per call.
+ */
+export function broadcastSessionAccountsChanged(
+  userIds: string | readonly string[],
+  revision: number,
+  reason: SessionAccountsChangedReason,
+): void {
+  const server = getIO();
+  if (!server) return;
+  const list = Array.isArray(userIds) ? userIds : [userIds as string];
+  const unique = new Set(list.filter((id): id is string => typeof id === 'string' && id.length > 0));
+  for (const userId of unique) {
+    server.to(`user:${userId}`).emit(SESSION_ACCOUNTS_CHANGED_EVENT, { userId, revision, reason });
+  }
 }
 
 export function deviceRoomFor(decoded: { deviceId?: string | null }): string | null {

--- a/packages/contracts/src/__tests__/deviceSession.test.ts
+++ b/packages/contracts/src/__tests__/deviceSession.test.ts
@@ -1,4 +1,13 @@
-import { deviceSessionStateSchema, sessionAccountSchema, deviceSessionSyncSchema, deviceTokenMintRequestSchema, deviceTokenMintResponseSchema, safeParseContract } from '../index';
+import {
+  deviceSessionStateSchema,
+  sessionAccountSchema,
+  deviceSessionSyncSchema,
+  deviceTokenMintRequestSchema,
+  deviceTokenMintResponseSchema,
+  sessionAccountsChangedEventSchema,
+  SESSION_ACCOUNTS_CHANGED_EVENT,
+  safeParseContract,
+} from '../index';
 
 describe('deviceSessionStateSchema', () => {
   const account = { accountId: 'a1', sessionId: 's1', authuser: 0 };
@@ -78,5 +87,30 @@ describe('deviceTokenMintResponseSchema', () => {
   it('rejects a response with an invalid nested state', () => {
     const v = { accessToken: 'a', expiresAt: 'e', nextDeviceSecret: 'n', state: { deviceId: 'd1' } };
     expect(safeParseContract(deviceTokenMintResponseSchema, v)).toBeNull();
+  });
+});
+
+describe('sessionAccountsChangedEventSchema', () => {
+  it('parses a valid token-free signal', () => {
+    const v = { userId: 'u1', revision: 4, reason: 'add' as const };
+    expect(safeParseContract(sessionAccountsChangedEventSchema, v)).toEqual(v);
+  });
+
+  it('accepts every documented reason', () => {
+    for (const reason of ['login', 'add', 'switch', 'signout', 'revoke'] as const) {
+      expect(safeParseContract(sessionAccountsChangedEventSchema, { userId: 'u1', revision: 0, reason })).not.toBeNull();
+    }
+  });
+
+  it('rejects an unknown reason', () => {
+    expect(safeParseContract(sessionAccountsChangedEventSchema, { userId: 'u1', revision: 0, reason: 'nope' })).toBeNull();
+  });
+
+  it('rejects a negative revision', () => {
+    expect(safeParseContract(sessionAccountsChangedEventSchema, { userId: 'u1', revision: -1, reason: 'add' })).toBeNull();
+  });
+
+  it('exposes the canonical event name', () => {
+    expect(SESSION_ACCOUNTS_CHANGED_EVENT).toBe('session_accounts_changed');
   });
 });

--- a/packages/contracts/src/deviceSession.ts
+++ b/packages/contracts/src/deviceSession.ts
@@ -94,3 +94,51 @@ export type DeviceHubTicketIssueRequest = z.infer<typeof deviceHubTicketIssueReq
 export type DeviceHubTicketIssueResponse = z.infer<typeof deviceHubTicketIssueResponseSchema>;
 export type DeviceHubTicketRedeemRequest = z.infer<typeof deviceHubTicketRedeemRequestSchema>;
 export type DeviceHubTicketRedeemResponse = z.infer<typeof deviceHubTicketRedeemResponseSchema>;
+
+/* -------------------------------------------------------------------------- */
+/*  Instant cross-app session sync (token-free socket signal)                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Name of the token-free Socket.IO event emitted to room `user:<userId>` on
+ * every DeviceSession mutation that changes what is signed in for that user.
+ *
+ * This is a pure SIGNAL — it carries NO access token, NO deviceSecret and NO
+ * account bodies. A client that receives it re-fetches its authenticated
+ * session/account state (`GET /session/device/state`, `GET /accounts`). Unlike
+ * `session_state` (scoped to `device:<deviceId>`, i.e. a single origin), this
+ * reaches ALL of a user's connected sockets across their devices/origins so
+ * every Oxy app reflects an add / switch / signout instantly.
+ */
+export const SESSION_ACCOUNTS_CHANGED_EVENT = 'session_accounts_changed';
+
+/**
+ * Why the signed-in set changed:
+ *  - `login`   — a brand-new session was minted for the user (QR / cross-app authorize)
+ *  - `add`     — an account was registered onto a device set
+ *  - `switch`  — the active account on a device changed
+ *  - `signout` — one or all accounts were signed out of a device
+ *  - `revoke`  — a dead/revoked account was healed out of a device set
+ */
+export const sessionAccountsChangedReasonSchema = z.enum([
+  'login',
+  'add',
+  'switch',
+  'signout',
+  'revoke',
+]);
+
+/**
+ * Payload of {@link SESSION_ACCOUNTS_CHANGED_EVENT}. `revision` is the mutated
+ * DeviceSession revision for device-scoped reasons (`add`/`switch`/`signout`/
+ * `revoke`); for `login` (no device mutation at emit time) it is `0`. The
+ * payload is deliberately minimal and secret-free — the client refetches.
+ */
+export const sessionAccountsChangedEventSchema = z.object({
+  userId: z.string(),
+  revision: z.number().int().nonnegative(),
+  reason: sessionAccountsChangedReasonSchema,
+});
+
+export type SessionAccountsChangedReason = z.infer<typeof sessionAccountsChangedReasonSchema>;
+export type SessionAccountsChangedEvent = z.infer<typeof sessionAccountsChangedEventSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -217,6 +217,9 @@ export {
     deviceHubTicketIssueResponseSchema,
     deviceHubTicketRedeemRequestSchema,
     deviceHubTicketRedeemResponseSchema,
+    SESSION_ACCOUNTS_CHANGED_EVENT,
+    sessionAccountsChangedReasonSchema,
+    sessionAccountsChangedEventSchema,
 } from './deviceSession';
 
 export type {
@@ -230,6 +233,8 @@ export type {
     DeviceHubTicketIssueResponse,
     DeviceHubTicketRedeemRequest,
     DeviceHubTicketRedeemResponse,
+    SessionAccountsChangedReason,
+    SessionAccountsChangedEvent,
 } from './deviceSession';
 
 export {

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -2,6 +2,8 @@ import {
   deviceSessionStateSchema,
   deviceSessionSyncSchema,
   safeParseContract,
+  SESSION_ACCOUNTS_CHANGED_EVENT,
+  sessionAccountsChangedEventSchema,
   type DeviceSessionState,
 } from '@oxyhq/contracts';
 import { logger } from '../utils/loggerUtils';
@@ -407,12 +409,46 @@ export class SessionClient {
         });
       }
     });
+    socket.on(SESSION_ACCOUNTS_CHANGED_EVENT, (payload: unknown) => {
+      this.onSessionAccountsChanged(payload);
+    });
     this.socket = socket;
     // (Re)bind app-facing server-event subscriptions on the fresh socket.
     this.boundServerEvents.clear();
     for (const event of this.serverEvents.keys()) {
       this.bindServerEvent(event);
     }
+  }
+
+  /**
+   * Handle the token-free `session_accounts_changed` signal (room `user:<userId>`).
+   *
+   * Unlike `session_state` (device-scoped, carries the new state to APPLY), this
+   * reaches ALL of a user's connected sockets across their devices/origins and is
+   * a pure SIGNAL: it carries no token, no secret, and no account bodies. The only
+   * trustworthy bit is "something changed for this user", so — matching the
+   * `session_state` contract's guidance — we re-fetch our OWN authoritative device
+   * state (`bootstrap` → `GET /session/device/state`) and let the existing
+   * `applyState` revision guard reconcile it. We never trust any field on the event
+   * beyond routing it to the current user.
+   *
+   * The refetch is a private (bearer) call: the socket only joins `user:<userId>`
+   * when authenticated, so a signed-out client never receives this — but we guard
+   * the bearer anyway so a race at sign-out can't 401.
+   */
+  private onSessionAccountsChanged(payload: unknown): void {
+    const event = safeParseContract(sessionAccountsChangedEventSchema, payload);
+    if (!event) {
+      logger.warn('[SessionClient] discarded invalid session_accounts_changed', { component: 'SessionClient' });
+      return;
+    }
+    // The socket is in `user:<activeUserId>` for the planted bearer, so this should
+    // always be the current user; ignore a foreign id defensively (out-of-band relay).
+    if (event.userId !== this.host.getCurrentAccountId()) return;
+    if (!this.host.getAccessToken()) return;
+    void this.bootstrap().catch((error) => {
+      logger.warn('[SessionClient] session_accounts_changed refetch failed', { component: 'SessionClient' }, error);
+    });
   }
 
   /**

--- a/packages/core/src/session/__tests__/SessionClient.serverEvents.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.serverEvents.test.ts
@@ -8,6 +8,7 @@ class FakeSocket implements MinimalSocket {
   handlers = new Map<string, Handler[]>();
   on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
   off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+  emit(_event: string, ..._args: unknown[]) { /* client→server emit, unused here */ }
   connect() { this.connected = true; }
   disconnect() { this.connected = false; }
   emitServer(event: string, payload: unknown) { for (const h of this.handlers.get(event) ?? []) h(payload); }

--- a/packages/core/src/session/__tests__/SessionClient.socket.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.socket.test.ts
@@ -132,6 +132,42 @@ describe('SessionClient socket', () => {
     expect(fakeSocket.connected).toBe(false);
   });
 
+  it('session_accounts_changed for the current user refetches device state (GET /session/device/state)', async () => {
+    const makeRequest = jest.fn().mockResolvedValue(SYNC(1));
+    const host = makeHost({ makeRequest, getCurrentAccountId: () => 'a1' });
+    const c = new SessionClient(host);
+    await c.start();
+    makeRequest.mockClear();
+    fakeSocket.trigger('session_accounts_changed', { userId: 'a1', revision: 5, reason: 'add' });
+    await Promise.resolve();
+    expect(makeRequest).toHaveBeenCalledWith('GET', '/session/device/state', undefined, { cache: false });
+    c.stop();
+  });
+
+  it('session_accounts_changed for a DIFFERENT user is ignored (no refetch)', async () => {
+    const makeRequest = jest.fn().mockResolvedValue(SYNC(1));
+    const host = makeHost({ makeRequest, getCurrentAccountId: () => 'a1' });
+    const c = new SessionClient(host);
+    await c.start();
+    makeRequest.mockClear();
+    fakeSocket.trigger('session_accounts_changed', { userId: 'someone-else', revision: 5, reason: 'switch' });
+    await Promise.resolve();
+    expect(makeRequest).not.toHaveBeenCalled();
+    c.stop();
+  });
+
+  it('session_accounts_changed drops a malformed payload without refetching', async () => {
+    const makeRequest = jest.fn().mockResolvedValue(SYNC(1));
+    const host = makeHost({ makeRequest, getCurrentAccountId: () => 'a1' });
+    const c = new SessionClient(host);
+    await c.start();
+    makeRequest.mockClear();
+    fakeSocket.trigger('session_accounts_changed', { userId: 'a1', reason: 'not-a-real-reason' });
+    await Promise.resolve();
+    expect(makeRequest).not.toHaveBeenCalled();
+    c.stop();
+  });
+
   it('a socket-pushed empty state fires onUnauthenticated with the PUSH origin (bug #4)', async () => {
     const onUnauthenticated = jest.fn();
     const c = new SessionClient(makeHost(), { onUnauthenticated });

--- a/packages/core/src/session/__tests__/SessionClient.socketFactory.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.socketFactory.test.ts
@@ -20,6 +20,7 @@ class FakeSocket implements MinimalSocket {
   handlers = new Map<string, Handler[]>();
   on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
   off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+  emit(_event: string, ..._args: unknown[]) { /* no-op: device socket never emits */ }
   connect() { this.connected = true; }
   disconnect() { this.connected = false; }
 }

--- a/packages/core/src/session/__tests__/accountDialogController.test.ts
+++ b/packages/core/src/session/__tests__/accountDialogController.test.ts
@@ -4,6 +4,7 @@ import type { User } from '../../models/interfaces';
 import type { SessionLoginResponse, MinimalUserData } from '../../models/session';
 import type { AccountNode } from '../../mixins/OxyServices.accounts';
 import { SessionClient, type SessionClientHost } from '../SessionClient';
+import type { MinimalSocket, SocketIOFactory } from '../socketLoader';
 import { logger } from '../../utils/loggerUtils';
 import {
   AccountDialogController,
@@ -68,6 +69,7 @@ function graphNode(id: string, over: Partial<AccountNode> = {}): AccountNode {
 
 interface OxyMock {
   getAccessToken: jest.Mock;
+  getBaseURL: jest.Mock;
   onTokensChanged: jest.Mock;
   listAccounts: jest.Mock;
   getUsersByIds: jest.Mock;
@@ -91,6 +93,7 @@ function makeOxy(): OxyMock {
   let currentToken: string | null = 'access-token';
   return {
     getAccessToken: jest.fn(() => currentToken),
+    getBaseURL: jest.fn(() => 'http://test.invalid'),
     onTokensChanged: jest.fn((listener: (token: string | null) => void) => {
       tokenListeners.add(listener);
       return () => tokenListeners.delete(listener);
@@ -724,6 +727,110 @@ describe('AccountDialogController — openPasswordAtOxyAuth', () => {
     });
     const url = await controller.openPasswordAtOxyAuth({ returnUrl: 'https://alia.onl/' });
     expect(new URL(url).origin).toBe('https://auth.alia.onl');
+  });
+});
+
+describe('AccountDialogController — /auth-session socket (instant QR wake)', () => {
+  type Handler = (...args: unknown[]) => void;
+  class FakeAuthSocket implements MinimalSocket {
+    connected = false;
+    disconnected = false;
+    handlers = new Map<string, Handler[]>();
+    emitted: Array<{ event: string; args: unknown[] }> = [];
+    on(event: string, cb: Handler) { const l = this.handlers.get(event) ?? []; l.push(cb); this.handlers.set(event, l); }
+    off(event: string, cb?: Handler) { if (!cb) { this.handlers.delete(event); return; } this.handlers.set(event, (this.handlers.get(event) ?? []).filter((h) => h !== cb)); }
+    emit(event: string, ...args: unknown[]) { this.emitted.push({ event, args }); }
+    connect() { this.connected = true; }
+    disconnect() { this.connected = false; this.disconnected = true; }
+    /** Simulate a server→client push on this socket. */
+    server(event: string, payload?: unknown) { for (const h of this.handlers.get(event) ?? []) h(payload); }
+  }
+
+  const START_HANDLE = {
+    sessionToken: 'secret-tok',
+    authorizeCode: 'AUTH-CODE',
+    qrPayload: 'oxycommons://approve?v=1&code=AUTH-CODE',
+    expiresAt: Date.now() + 600_000,
+    status: 'pending' as const,
+  };
+
+  function makeSocketHarness(): { controller: AccountDialogController; oxy: OxyMock; created: () => FakeAuthSocket | null; factory: jest.Mock; commitSession: jest.Mock } {
+    const oxy = makeOxy();
+    oxy.startCommonsSignIn.mockResolvedValue(START_HANDLE);
+    let socket: FakeAuthSocket | null = null;
+    const factory = jest.fn((_uri: string, _opts?: Record<string, unknown>): MinimalSocket => {
+      socket = new FakeAuthSocket();
+      socket.connected = true; // real io autoConnect resolves before we inspect
+      return socket;
+    });
+    const commitSession = jest.fn().mockResolvedValue(undefined);
+    const controller = new AccountDialogController({
+      oxyServices: oxy as unknown as OxyServices,
+      sessionClient: new TestSessionClient(host()),
+      clientId: 'oxy_dk_test',
+      commitSession,
+      socketFactory: factory as unknown as SocketIOFactory,
+    });
+    return { controller, oxy, created: () => socket, factory, commitSession };
+  }
+
+  it('connects to /auth-session, joins the flow room, and wakes the claim on auth_update — no timer advance', async () => {
+    const { controller, oxy, created, factory, commitSession } = makeSocketHarness();
+    oxy.pollCommonsSignIn.mockResolvedValue({ authorized: true, sessionId: 'sess-1', status: 'authorized' });
+    oxy.claimSessionByToken.mockResolvedValue({
+      accessToken: 'access-1', sessionId: 'sess-1', deviceId: 'device-1', expiresAt: '2030-01-01T00:00:00Z', user: user('a1'),
+    });
+
+    await controller.showQr();
+
+    expect(factory).toHaveBeenCalledWith('http://test.invalid/auth-session', expect.any(Object));
+    const sock = created();
+    if (!sock) throw new Error('socket not created');
+    expect(sock.emitted).toContainEqual({ event: 'join', args: ['secret-tok'] });
+
+    // The server pushes auth_update → immediate status check + claim, without any poll timer firing.
+    sock.server('auth_update', { status: 'authorized', sessionId: 'sess-1' });
+    await flush();
+
+    expect(oxy.pollCommonsSignIn).toHaveBeenCalledWith('secret-tok');
+    expect(oxy.claimSessionByToken).toHaveBeenCalledWith('secret-tok');
+    expect(commitSession).toHaveBeenCalled();
+    expect(controller.getSnapshot().view).toBe('accounts');
+    expect(sock.disconnected).toBe(true); // torn down on completion
+  });
+
+  it('re-joins the room on reconnect (connect event) and tears the socket down on cancelSignIn', async () => {
+    const { controller, oxy, created } = makeSocketHarness();
+    oxy.pollCommonsSignIn.mockResolvedValue({ authorized: false, status: 'pending' });
+
+    await controller.showQr();
+    const sock = created();
+    if (!sock) throw new Error('socket not created');
+    expect(sock.emitted.filter((e) => e.event === 'join')).toHaveLength(1);
+
+    // A reconnect fires `connect` again → the join is re-issued so it survives drops.
+    sock.server('connect');
+    expect(sock.emitted.filter((e) => e.event === 'join')).toHaveLength(2);
+
+    controller.cancelSignIn();
+    expect(sock.disconnected).toBe(true);
+  });
+
+  it('a stale auth_update after the flow was cancelled does not re-poll', async () => {
+    const { controller, oxy, created } = makeSocketHarness();
+    oxy.pollCommonsSignIn.mockResolvedValue({ authorized: false, status: 'pending' });
+
+    await controller.showQr();
+    const sock = created();
+    if (!sock) throw new Error('socket not created');
+    oxy.pollCommonsSignIn.mockClear();
+
+    controller.cancelSignIn();
+    // Even if a late auth_update slips through on the (now-detached) socket, the
+    // superseded-token guard drops it.
+    sock.server('auth_update', { status: 'authorized' });
+    await flush();
+    expect(oxy.pollCommonsSignIn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/session/accountDialogController.ts
+++ b/packages/core/src/session/accountDialogController.ts
@@ -39,6 +39,7 @@ import {
   persistOAuthHandshake,
 } from '../utils/oauthPkce';
 import type { SessionClient } from './SessionClient';
+import type { MinimalSocket, SocketIOFactory } from './socketLoader';
 import {
   projectSwitchableAccounts,
   switchableAccountIds,
@@ -124,8 +125,20 @@ export interface AccountDialogControllerOptions {
    * `location.origin` normalization in {@link openPasswordAtOxyAuth}.
    */
   authRedirectUri?: string | null;
-  /** QR device-flow poll interval in ms (default 3000). */
+  /**
+   * QR device-flow FALLBACK poll interval in ms (default 12000). The primary
+   * approval signal is the `/auth-session` socket's `auth_update` event (instant);
+   * this slow poll is only the safety net for when the socket can't connect.
+   */
   pollIntervalMs?: number;
+  /**
+   * Statically-injected `socket.io-client` factory (its `io` export), same as
+   * {@link SessionClient}'s. When provided, the QR flow subscribes to the
+   * `/auth-session` namespace for an INSTANT `auth_update` wake instead of relying
+   * on the slow fallback poll. Absent on web builds without a bundled `io` and in
+   * headless/core usage → the controller silently degrades to poll-only.
+   */
+  socketFactory?: SocketIOFactory;
   /**
    * Optional URL opener. When provided, `openPasswordAtOxyAuth` invokes it with
    * the built URL in addition to returning it (web: `location.assign`; native:
@@ -144,7 +157,16 @@ export interface AccountDialogControllerOptions {
   canOpenApp?: (url: string) => Promise<boolean>;
 }
 
-const DEFAULT_POLL_INTERVAL_MS = 3000;
+/**
+ * Slow FALLBACK poll cadence for the QR flow. The `/auth-session` socket delivers
+ * the approval instantly via `auth_update`; this poll only covers the case where
+ * the socket can't connect, so it is deliberately slow (was 3000 when polling was
+ * the sole mechanism).
+ */
+const DEFAULT_POLL_INTERVAL_MS = 12000;
+
+/** Socket.IO namespace the API emits QR-flow approval (`auth_update`) events on. */
+const AUTH_SESSION_NAMESPACE = '/auth-session';
 
 /**
  * Commons's custom URL scheme. Probed via the injected `canOpenApp` to detect an
@@ -179,6 +201,7 @@ export class AccountDialogController {
   private readonly pollIntervalMs: number;
   private readonly openUrl?: (url: string) => void;
   private readonly canOpenApp?: (url: string) => Promise<boolean>;
+  private readonly socketFactory?: SocketIOFactory;
 
   private readonly listeners = new Set<SnapshotListener>();
 
@@ -195,6 +218,18 @@ export class AccountDialogController {
   /** The secret device-flow token of the active QR flow (never surfaced). */
   private signInToken: string | null = null;
   private pollTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * The `/auth-session` socket for the active QR flow, or null (poll-only). Its
+   * `auth_update` event wakes {@link pollOnce} instantly instead of waiting for the
+   * slow fallback timer.
+   */
+  private authSessionSocket: MinimalSocket | null = null;
+  /**
+   * Guards {@link pollOnce} against re-entrancy: the fallback timer and a socket
+   * `auth_update` wake can fire together — without this both could claim the
+   * single-use token concurrently.
+   */
+  private pollInFlight = false;
 
   // --- Store plumbing ---
   private unsubscribeSession: (() => void) | null = null;
@@ -217,6 +252,7 @@ export class AccountDialogController {
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.openUrl = options.openUrl;
     this.canOpenApp = options.canOpenApp;
+    this.socketFactory = options.socketFactory;
     this.snapshot = this.computeSnapshot();
   }
 
@@ -289,6 +325,8 @@ export class AccountDialogController {
       this.unsubscribeTokens = null;
     }
     this.clearPollTimer();
+    this.closeAuthSessionSocket();
+    this.signInToken = null;
     this.listeners.clear();
   }
 
@@ -568,6 +606,10 @@ export class AccountDialogController {
         expiresAt: handle.expiresAt,
         error: null,
       });
+      // Primary path: an instant `auth_update` wake over the `/auth-session`
+      // socket. The poll below is only the fallback for when the socket can't
+      // connect, so it now runs at the slow fallback cadence.
+      this.openAuthSessionSocket(handle.sessionToken);
       this.scheduleNextPoll(handle.sessionToken);
       // Same-device convenience: if Commons is installed (native only — `canOpenApp`
       // is undefined/false on web), deep-link straight into its approve screen with
@@ -600,9 +642,10 @@ export class AccountDialogController {
     }
   }
 
-  /** Tear down the active sign-in device flow (timers + token) and reset to idle. */
+  /** Tear down the active sign-in device flow (timers + socket + token) and reset to idle. */
   cancelSignIn(): void {
     this.clearPollTimer();
+    this.closeAuthSessionSocket();
     this.signInToken = null;
     if (this.signIn !== IDLE_SIGN_IN) {
       this.setSignIn(IDLE_SIGN_IN);
@@ -664,36 +707,48 @@ export class AccountDialogController {
     }, this.pollIntervalMs);
   }
 
+  /**
+   * Run one status check + (on approval) claim. Triggered by the fallback timer
+   * AND by the `/auth-session` socket's `auth_update` wake, so it is guarded
+   * against concurrent entry: whichever fires first claims the single-use token;
+   * the other no-ops. The `auth_update` payload is never trusted — this always
+   * re-checks the authoritative status via `pollCommonsSignIn`.
+   */
   private async pollOnce(sessionToken: string): Promise<void> {
-    // A superseded / cancelled flow must not act.
-    if (this.signInToken !== sessionToken) return;
-    const expiresAt = this.signIn.expiresAt;
-    if (typeof expiresAt === 'number' && Date.now() > expiresAt) {
-      this.failSignIn('Session expired. Please try again.');
-      return;
-    }
+    // A superseded / cancelled flow must not act; a poll already running owns the claim.
+    if (this.signInToken !== sessionToken || this.pollInFlight) return;
+    this.pollInFlight = true;
     try {
-      const status = await this.oxyServices.pollCommonsSignIn(sessionToken);
-      if (this.signInToken !== sessionToken) return; // cancelled mid-request
-      if (status.authorized && status.sessionId) {
-        this.clearPollTimer();
-        await this.claimAndComplete(status.sessionId, sessionToken);
-        return;
-      }
-      if (status.status === 'cancelled') {
-        this.failSignIn('Authorization was denied.');
-        return;
-      }
-      if (status.status === 'expired') {
+      const expiresAt = this.signIn.expiresAt;
+      if (typeof expiresAt === 'number' && Date.now() > expiresAt) {
         this.failSignIn('Session expired. Please try again.');
         return;
       }
-    } catch (error) {
-      // Transient poll error — the next tick retries. Logged, never thrown.
-      logger.debug('[AccountDialogController] poll error (will retry)', { component: 'AccountDialogController' }, error);
-    }
-    if (this.signInToken === sessionToken) {
-      this.scheduleNextPoll(sessionToken);
+      try {
+        const status = await this.oxyServices.pollCommonsSignIn(sessionToken);
+        if (this.signInToken !== sessionToken) return; // cancelled mid-request
+        if (status.authorized && status.sessionId) {
+          this.clearPollTimer();
+          await this.claimAndComplete(status.sessionId, sessionToken);
+          return;
+        }
+        if (status.status === 'cancelled') {
+          this.failSignIn('Authorization was denied.');
+          return;
+        }
+        if (status.status === 'expired') {
+          this.failSignIn('Session expired. Please try again.');
+          return;
+        }
+      } catch (error) {
+        // Transient poll error — the next tick retries. Logged, never thrown.
+        logger.debug('[AccountDialogController] poll error (will retry)', { component: 'AccountDialogController' }, error);
+      }
+      if (this.signInToken === sessionToken) {
+        this.scheduleNextPoll(sessionToken);
+      }
+    } finally {
+      this.pollInFlight = false;
     }
   }
 
@@ -754,6 +809,7 @@ export class AccountDialogController {
     await this.commitAuthorizedSession(session, user);
     this.signInToken = null;
     this.clearPollTimer();
+    this.closeAuthSessionSocket();
     this.signIn = IDLE_SIGN_IN;
     this.view = 'accounts';
     this.emit();
@@ -779,6 +835,7 @@ export class AccountDialogController {
 
   private failSignIn(message: string): void {
     this.clearPollTimer();
+    this.closeAuthSessionSocket();
     this.signInToken = null;
     this.setSignIn({ ...IDLE_SIGN_IN, phase: 'error', error: message });
   }
@@ -787,6 +844,72 @@ export class AccountDialogController {
     if (this.pollTimer !== null) {
       clearTimeout(this.pollTimer);
       this.pollTimer = null;
+    }
+  }
+
+  // =========================================================================
+  // /auth-session socket (instant QR approval wake — replaces 3s polling)
+  // =========================================================================
+
+  /**
+   * Subscribe the active QR flow to the `/auth-session` namespace so the API's
+   * `auth_update` event wakes {@link pollOnce} the instant the approval lands.
+   *
+   * The join is keyed by the secret `sessionToken` (the server's `auth:<token>`
+   * room, joined by emitting `join`) and re-issued on every (re)connect so it
+   * survives socket drops. `auth_update` is treated as a pure SIGNAL — the payload
+   * is never trusted; `pollOnce` re-checks the authoritative status and claims.
+   *
+   * No-op (poll-only) when no `socketFactory` was injected (web without a bundled
+   * `io`, headless/core usage, tests). The namespace needs no auth.
+   */
+  private openAuthSessionSocket(sessionToken: string): void {
+    this.closeAuthSessionSocket();
+    if (!this.socketFactory) return;
+    let socket: MinimalSocket;
+    try {
+      socket = this.socketFactory(`${this.oxyServices.getBaseURL()}${AUTH_SESSION_NAMESPACE}`, {
+        transports: ['websocket'],
+        autoConnect: true,
+        reconnection: true,
+        reconnectionAttempts: Number.POSITIVE_INFINITY,
+        reconnectionDelay: 1000,
+        reconnectionDelayMax: 10000,
+      });
+    } catch (error) {
+      // Socket unavailable — the fallback poll still completes the flow.
+      logger.debug('[AccountDialogController] auth-session socket create failed (poll fallback)', { component: 'AccountDialogController' }, error);
+      return;
+    }
+    const join = (): void => {
+      if (this.signInToken !== sessionToken) return;
+      try {
+        socket.emit('join', sessionToken);
+      } catch (error) {
+        logger.debug('[AccountDialogController] auth-session join failed', { component: 'AccountDialogController' }, error);
+      }
+    };
+    socket.on('connect', join);
+    if (socket.connected) join();
+    socket.on('auth_update', () => {
+      if (this.signInToken !== sessionToken) return;
+      // Pure wake signal — re-check the authoritative status + claim the poll would have.
+      void this.pollOnce(sessionToken);
+    });
+    this.authSessionSocket = socket;
+  }
+
+  /** Tear down the `/auth-session` socket, if any. Idempotent. */
+  private closeAuthSessionSocket(): void {
+    const socket = this.authSessionSocket;
+    if (!socket) return;
+    this.authSessionSocket = null;
+    try {
+      socket.off('auth_update');
+      socket.off('connect');
+      socket.disconnect();
+    } catch (error) {
+      logger.debug('[AccountDialogController] auth-session socket close failed', { component: 'AccountDialogController' }, error);
     }
   }
 

--- a/packages/core/src/session/socketLoader.ts
+++ b/packages/core/src/session/socketLoader.ts
@@ -4,6 +4,8 @@ export interface MinimalSocket {
   connected: boolean;
   on(event: string, handler: (...args: unknown[]) => void): void;
   off(event: string, handler?: (...args: unknown[]) => void): void;
+  /** Client→server emit (e.g. joining the `/auth-session` room for a QR flow). */
+  emit(event: string, ...args: unknown[]): void;
   connect(): void;
   disconnect(): void;
 }

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react';
 import { Linking } from 'react-native';
+import { io } from 'socket.io-client';
 import { OxyServices, oxyClient } from '@oxyhq/core';
 import type {
   User,
@@ -616,6 +617,9 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       clientId,
       authRedirectUri,
       locale: currentLanguage,
+      // Same statically-injected `io` as the SessionClient: gives the QR flow an
+      // instant `/auth-session` `auth_update` wake instead of a slow poll.
+      socketFactory: io,
       commitSession: (session) => handleWebSessionRef.current(session),
       onSignedIn: () => setAccountDialogOpen(false),
       openUrl: (url) => {


### PR DESCRIPTION
## Summary
- New token-free `session_accounts_changed` Socket.IO event broadcast to room `user:<userId>` on every `DeviceSession` mutation (add/switch/signout/revoke) and on new login (QR + bearer authorize) — so every connected socket for that user, across devices/origins, refetches session/account state instantly, not just the single device-scoped origin that `session_state` already covered.
- **contracts:** new `SESSION_ACCOUNTS_CHANGED_EVENT` constant + reason/event schemas.
- **api:** `broadcastSessionAccountsChanged` util wired into `sessionDevice` routes and both authorize routes; payload is signal-only, carries no token/secret.
- **core:** `SessionClient` subscribes to the event and refetches device state through the existing revision-guarded `applyState`; `accountDialogController` now joins the `/auth-session` socket namespace for instant QR-approval wake, demoting the old 3s poll to a 12s fallback (re-entrancy guarded so the socket path and the timer fallback can't double-claim the same approval).
- **services:** `OxyProvider` now injects the io factory needed for the `/auth-session` socket.
- No behavior change beyond the sync itself; this branch is intentionally scoped to just the sync mechanism (a separate QR-origin-hardening branch is being retained apart from this one).

Note: root-level `bun run test` will show 3 pre-existing failing suites in `packages/commons` (module-resolution/ESM-transform issues) — confirmed identical on `main`, unrelated to this change, not introduced by this PR.

## Test plan
- [x] `bun run build:all` — 11/11 packages built clean
- [x] contracts 9/9 suites, 135/135 tests
- [x] core 67/67 suites, 823/823 tests
- [x] services 29/29 suites, 202/202 tests
- [x] api 161/161 suites, 1472/1472 tests
- [x] `tsc --noEmit` clean on contracts, core, api, services
- [x] Lockfile gate: `bun install --frozen-lockfile` clean, no diff

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->