### PR TITLE
feat(services): responsive bottom-sheet OxyAccountDialog on web via Bloom 0.30.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@oxyhq/sdk",
       "dependencies": {
         "@expo/metro-runtime": "~57.0.3",
-        "@oxyhq/bloom": "^0.30.3",
+        "@oxyhq/bloom": "^0.30.8",
         "expo-contacts": "~57.0.0",
         "expo-splash-screen": "~57.0.2",
         "is-arrayish": "^0.3.2",
@@ -27,7 +27,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@lottiefiles/dotlottie-react": "^0.19.5",
-        "@oxyhq/bloom": "^0.29.3",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/core": "*",
         "@oxyhq/expo-splash": "workspace:*",
         "@oxyhq/services": "*",
@@ -180,7 +180,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@hugeicons/core-free-icons": "^3.1.1",
         "@hugeicons/react": "^1.1.9",
-        "@oxyhq/bloom": "^0.29.3",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "workspace:*",
         "@oxyhq/services": "workspace:*",
@@ -235,7 +235,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@lottiefiles/dotlottie-react": "^0.19.5",
-        "@oxyhq/bloom": "^0.30.0",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/core": "*",
         "@oxyhq/expo-splash": "workspace:*",
         "@oxyhq/services": "*",
@@ -313,7 +313,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@hugeicons/core-free-icons": "^3.1.1",
         "@hugeicons/react": "^1.1.9",
-        "@oxyhq/bloom": "^0.29.3",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/core": "*",
         "@oxyhq/services": "*",
         "@tailwindcss/vite": "^4.3.2",
@@ -453,7 +453,7 @@
         "@hugeicons/react": "^1.1.9",
         "@lottiefiles/dotlottie-react": "^0.19.5",
         "@lottiefiles/dotlottie-react-native": "^0.11.0",
-        "@oxyhq/bloom": "^0.29.3",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/core": "*",
         "@oxyhq/services": "*",
         "@radix-ui/react-dropdown-menu": "^2.1.18",
@@ -703,7 +703,7 @@
         "@expo/vector-icons": "^15.1.1",
         "@gorhom/bottom-sheet": "^5.2.14",
         "@lottiefiles/dotlottie-react": "^0.19.5",
-        "@oxyhq/bloom": "^0.30.0",
+        "@oxyhq/bloom": "^0.30.8",
         "@oxyhq/services": "*",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native/virtualized-lists": "0.86.0",
@@ -765,7 +765,7 @@
     "react-native-hce@0.3.0": "patches/react-native-hce@0.3.0.patch",
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.30.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@radix-ui/react-slot": "1.2.3",
     "ioredis": "5.11.1",
     "lightningcss": "1.30.1",
@@ -1627,7 +1627,7 @@
 
     "@oxyhq/api": ["@oxyhq/api@workspace:packages/api"],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.30.3", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-9F9H98lnIZ+zasXOROogLDoAioxguoKaczZLac30lXzQxNmJy4LpfAPb6HbJXdGThW3rS9HayY/IIkLy/v7BJA=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.30.8", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-font": "*", "expo-haptics": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-+0LJhWefPicQV7GzmU/QZYd+5vvygsyOLJQR0tlPDCfXWemLu4EsnN1VrI8QjsqDJ2fBEFh5MEYT5Ici4KbGWA=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@workspace:packages/contracts"],
 

--- a/package.json
+++ b/package.json
@@ -81,13 +81,13 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "@radix-ui/react-slot": "1.2.3",
-    "@oxyhq/bloom": "^0.30.3",
+    "@oxyhq/bloom": "^0.30.8",
     "markdown-it": "12.3.2",
     "lightningcss": "1.30.1"
   },
   "dependencies": {
     "@expo/metro-runtime": "~57.0.3",
-    "@oxyhq/bloom": "^0.30.3",
+    "@oxyhq/bloom": "^0.30.8",
     "expo-contacts": "~57.0.0",
     "expo-splash-screen": "~57.0.2",
     "is-arrayish": "^0.3.2",

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
     "@lottiefiles/dotlottie-react": "^0.19.5",
-    "@oxyhq/bloom": "^0.29.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/core": "*",
     "@oxyhq/expo-splash": "workspace:*",
     "@oxyhq/services": "*",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@oxyhq/bloom": "^0.29.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/contracts": "workspace:*",
     "@oxyhq/core": "workspace:*",
     "@oxyhq/services": "workspace:*",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
     "@lottiefiles/dotlottie-react": "^0.19.5",
-    "@oxyhq/bloom": "^0.30.0",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/core": "*",
     "@oxyhq/expo-splash": "workspace:*",
     "@oxyhq/services": "*",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -16,7 +16,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@hugeicons/core-free-icons": "^3.1.1",
     "@hugeicons/react": "^1.1.9",
-    "@oxyhq/bloom": "^0.29.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/core": "*",
     "@oxyhq/services": "*",
     "@tailwindcss/vite": "^4.3.2",

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -18,7 +18,7 @@
     "@hugeicons/react": "^1.1.9",
     "@lottiefiles/dotlottie-react": "^0.19.5",
     "@lottiefiles/dotlottie-react-native": "^0.11.0",
-    "@oxyhq/bloom": "^0.29.3",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/core": "*",
     "@oxyhq/services": "*",
     "@radix-ui/react-dropdown-menu": "^2.1.18",

--- a/packages/services/src/ui/components/OxyAccountDialog.tsx
+++ b/packages/services/src/ui/components/OxyAccountDialog.tsx
@@ -41,7 +41,6 @@
 import type React from 'react';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import {
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -74,8 +73,6 @@ const ROW_AVATAR_SIZE = 40;
 const QR_PLATE_BG = '#FFFFFF';
 const QR_FOREGROUND = '#000000';
 const QR_SIZE = 196;
-
-const isWeb = Platform.OS === 'web';
 
 /**
  * Resolve an account's stored color (a named Bloom preset, e.g. `'purple'`) to
@@ -194,17 +191,7 @@ const OxyAccountDialog: React.FC = () => {
     <Dialog
       open={isAccountDialogOpen}
       onClose={closeAccountDialog}
-      // On web ALWAYS use the centered placement. Bloom's `bottom` placement
-      // routes through its `BottomSheet`, which on web is built on
-      // react-native-web's `Modal`. That `Modal` creates its `ModalPortal` host
-      // node as a side effect during render and removes it in an effect cleanup;
-      // under React 19 concurrent rendering (and StrictMode's dev double-invoke)
-      // the host is orphaned and never re-attached, so the sheet never paints on
-      // narrow web viewports (reproduced on console.oxy.so / auth.oxy.so, Pixel-7
-      // width). The `center` placement uses Bloom's react-dom Portal (no RN
-      // Modal) and paints reliably at every width. Native keeps the real bottom
-      // sheet on narrow screens.
-      placement={isWeb ? 'center' : { base: 'bottom', md: 'center' }}
+      placement={{ base: 'bottom', md: 'center' }}
       dismissOnBackdrop={false}
       maxWidth={420}
       label={headerCopy(view, snapshot.accounts.length, t).title}

--- a/packages/test-app-expo/package.json
+++ b/packages/test-app-expo/package.json
@@ -17,7 +17,7 @@
     "@expo/vector-icons": "^15.1.1",
     "@gorhom/bottom-sheet": "^5.2.14",
     "@lottiefiles/dotlottie-react": "^0.19.5",
-    "@oxyhq/bloom": "^0.30.0",
+    "@oxyhq/bloom": "^0.30.8",
     "@oxyhq/services": "*",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native/virtualized-lists": "0.86.0",


### PR DESCRIPTION
## Summary
`OxyAccountDialog` now uses Bloom's responsive `placement={{ base: 'bottom', md: 'center' }}` on **web** as well as native — removing the previous web-only `isWeb ? 'center'` workaround and its now-unused `Platform` import. On narrow web viewports the dialog renders as a real bottom sheet; at ≥768px it stays a centered card.

### Why the workaround existed
Bloom's `bottom` placement routes through react-native-web's `Modal`, which froze off-screen on narrow web viewports under React 19 concurrent rendering (orphaned `ModalPortal` host). The dialog therefore forced `center` on web. **Bloom 0.30.6** fixed the RN-Web bottom-sheet entrance animation (lists shared values in `useAnimatedStyle` deps so it ticks on web without the worklets babel plugin). **0.30.8** is the strict final superset — 0.30.6 sheet fix + 0.30.7 avatar-thumb fix + 0.30.8 PressableScale/AnimatedCheck web-anim-deps fixes — so the workaround is no longer needed and the whole consumer wave lands on one version.

## Changes
- `packages/services/src/ui/components/OxyAccountDialog.tsx` — drop `isWeb` branch + `Platform` import; `placement={{ base: 'bottom', md: 'center' }}` unconditionally.
- Bump `@oxyhq/bloom` `→ ^0.30.8` monorepo-wide: root `overrides` + `dependencies`, and the `accounts`, `auth`, `commons`, `console`, `inbox`, `test-app-expo` apps. Lockfile regenerated; `bun install --frozen-lockfile` passes.

## Verification (real foregrounded Chrome, faithful RN-Web pipeline)
Reproduced against rolldown-vite + `vite-plugin-react-native-web`, **no** worklets babel plugin (matches production), sampling computed transform / bounding rect over ~1.5s. The bottom-sheet code is byte-identical across 0.30.6 → 0.30.8, so this carries forward:

- **390px (base → bottom sheet):** sheet animates in from off-screen — `translateY 844 → 0`, title `rect.top 1561 → 714` (settles at the bottom of an 844px viewport) — over a dark backdrop; **dismiss works** (marker gone after close). No frozen/off-screen sheet.
- **900px (md → centered card):** no bottom translate; card vertically centered (center ratio ≈ 0.45).

> Note: headless Chrome defaults to `prefers-reduced-motion: reduce`, which mounts the sheet at its final frame and masks the entrance; the run above emulates `no-preference`.

## Gates
- `bun run build:all` — clean (11/11).
- `packages/services` tests — **202 passed** / 29 suites.
- `packages/core` tests — **830 passed** / 67 suites.
- `bun install --frozen-lockfile` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
