### PR TITLE
feat(api): WebAuthn/passkey backend — 4 ceremony endpoints, session-mint reuse (Fase B/b1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -104,6 +104,7 @@
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "workspace:*",
         "@oxyhq/protocol": "workspace:*",
+        "@simplewebauthn/server": "13.3.2",
         "@socket.io/redis-adapter": "^8.3.0",
         "@types/cheerio": "^0.22.35",
         "@types/compression": "^1.8.1",
@@ -1367,6 +1368,8 @@
 
     "@gorhom/portal": ["@gorhom/portal@1.0.14", "", { "dependencies": { "nanoid": "^3.3.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, ""],
 
+    "@hexagon/base64": ["@hexagon/base64@1.1.28", "", {}, "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, ""],
 
     "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@3.1.1", "", {}, ""],
@@ -1529,6 +1532,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, ""],
 
+    "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
+
     "@livekit/mutex": ["@livekit/mutex@1.1.1", "", {}, ""],
 
     "@livekit/protocol": ["@livekit/protocol@1.46.6", "", { "dependencies": { "@bufbuild/protobuf": "^1.10.0" } }, "sha512-upzlHP1vi/kZ/QqALZTFskQ0ifqc2f15RKucHYOsIHJsaXvEYanG75mAb7o+Yomfs4XhQ4BaRsdY+TFHXpaqrg=="],
@@ -1642,6 +1647,32 @@
     "@oxyhq/services": ["@oxyhq/services@workspace:packages/services"],
 
     "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
+
+    "@peculiar/asn1-android": ["@peculiar/asn1-android@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-skLbS+IOGv1lUgDqtChr8xvtvEr3HMse/JGBaL2r1J1o/n7a8wqOrovMtlRq/UXLhxvmLaONP67hwtshgzwfzA=="],
+
+    "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA=="],
+
+    "@peculiar/asn1-csr": ["@peculiar/asn1-csr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg=="],
+
+    "@peculiar/asn1-ecc": ["@peculiar/asn1-ecc@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ=="],
+
+    "@peculiar/asn1-pfx": ["@peculiar/asn1-pfx@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-rsa": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg=="],
+
+    "@peculiar/asn1-pkcs8": ["@peculiar/asn1-pkcs8@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA=="],
+
+    "@peculiar/asn1-pkcs9": ["@peculiar/asn1-pkcs9@2.8.0", "", { "dependencies": { "@peculiar/asn1-cms": "^2.8.0", "@peculiar/asn1-pfx": "^2.8.0", "@peculiar/asn1-pkcs8": "^2.8.0", "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "@peculiar/asn1-x509-attr": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ=="],
+
+    "@peculiar/asn1-rsa": ["@peculiar/asn1-rsa@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg=="],
+
+    "@peculiar/asn1-schema": ["@peculiar/asn1-schema@2.8.0", "", { "dependencies": { "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q=="],
+
+    "@peculiar/asn1-x509": ["@peculiar/asn1-x509@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/utils": "^2.0.2", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg=="],
+
+    "@peculiar/asn1-x509-attr": ["@peculiar/asn1-x509-attr@2.8.0", "", { "dependencies": { "@peculiar/asn1-schema": "^2.8.0", "@peculiar/asn1-x509": "^2.8.0", "asn1js": "^3.0.10", "tslib": "^2.8.1" } }, "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA=="],
+
+    "@peculiar/utils": ["@peculiar/utils@2.0.3", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ=="],
+
+    "@peculiar/x509": ["@peculiar/x509@1.14.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.6.0", "@peculiar/asn1-csr": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.0", "@peculiar/asn1-pkcs9": "^2.6.0", "@peculiar/asn1-rsa": "^2.6.0", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.0", "pvtsutils": "^1.3.6", "reflect-metadata": "^0.2.2", "tslib": "^2.8.1", "tsyringe": "^4.10.0" } }, "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA=="],
 
     "@phun-ky/typeof": ["@phun-ky/typeof@2.0.3", "", {}, ""],
 
@@ -1880,6 +1911,8 @@
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.1", "", { "dependencies": { "@simple-libs/stream-utils": "^1.1.0", "@types/node": "^22.0.0" } }, ""],
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.1.0", "", { "dependencies": { "@types/node": "^22.0.0" } }, ""],
+
+    "@simplewebauthn/server": ["@simplewebauthn/server@13.3.2", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
@@ -2366,6 +2399,8 @@
     "arrify": ["arrify@1.0.1", "", {}, ""],
 
     "asap": ["asap@2.0.6", "", {}, ""],
+
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, ""],
 
@@ -4073,6 +4108,10 @@
 
     "pure-rand": ["pure-rand@6.1.0", "", {}, ""],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "qrcode": ["qrcode@1.5.4", "", { "dependencies": { "dijkstrajs": "^1.0.1", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": "bin/qrcode" }, ""],
 
     "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, ""],
@@ -4200,6 +4239,8 @@
     "redis-errors": ["redis-errors@1.2.0", "", {}, ""],
 
     "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, ""],
+
+    "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, ""],
 
@@ -4616,6 +4657,8 @@
     "tslib": ["tslib@2.8.1", "", {}, ""],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "bin": "dist/cli.mjs" }, ""],
+
+    "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -6238,6 +6281,8 @@
     "ts-jest/semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "tsx/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/linux-x64": "0.27.2" }, "bin": "bin/esbuild" }, ""],
+
+    "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, ""],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -54,6 +54,7 @@
     "@oxyhq/contracts": "workspace:*",
     "@oxyhq/core": "workspace:*",
     "@oxyhq/protocol": "workspace:*",
+    "@simplewebauthn/server": "13.3.2",
     "@socket.io/redis-adapter": "^8.3.0",
     "@types/cheerio": "^0.22.35",
     "@types/compression": "^1.8.1",

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -287,6 +287,24 @@ export function isDevelopment(): boolean {
 }
 
 /**
+ * The WebAuthn Relying Party ID — the registrable domain a passkey is scoped to.
+ * Defaults to the Oxy apex `oxy.so` in production (so a single passkey works
+ * across every `*.oxy.so` first-party origin) and to `localhost` in development
+ * (matching a loopback dev server). Overridable via `WEBAUTHN_RP_ID`, mirroring
+ * the other domain-override envs (`FEDERATION_DOMAIN`, `DID_WEB_DOMAIN`) that are
+ * read inline at their call sites. The RP ID is a bare hostname — never a scheme,
+ * port, or path — so `verifyRegistrationResponse`/`verifyAuthenticationResponse`
+ * can match it against the ceremony's `rpIdHash`.
+ */
+export function getWebauthnRpId(): string {
+  const configured = process.env.WEBAUTHN_RP_ID?.trim();
+  if (configured) {
+    return configured;
+  }
+  return isDevelopment() ? 'localhost' : 'oxy.so';
+}
+
+/**
  * Get sanitized configuration for logging (without sensitive data)
  */
 export function getSanitizedConfig(): Record<string, string> {

--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -64,12 +64,14 @@ export function isValidUserColor(value: unknown): boolean {
  * Users can have multiple auth methods (identity, password, social) linked to the same account.
  */
 export interface AuthMethod {
-  type: 'identity' | 'password' | 'google' | 'apple' | 'github';
+  type: 'identity' | 'password' | 'google' | 'apple' | 'github' | 'webauthn';
   linkedAt: Date;
   metadata?: {
     publicKey?: string;      // For identity type
     email?: string;          // For password/social types
     providerId?: string;     // For social types (Google ID, Apple ID, etc.)
+    credentialID?: string;   // For webauthn type — the passkey's base64url credential id
+    name?: string;           // For webauthn type — the passkey's user-facing label
   };
 }
 
@@ -487,7 +489,7 @@ const UserSchema: Schema = new Schema(
       type: [{
         type: {
           type: String,
-          enum: ['identity', 'password', 'google', 'apple', 'github'],
+          enum: ['identity', 'password', 'google', 'apple', 'github', 'webauthn'],
           required: true,
         },
         linkedAt: { type: Date, default: Date.now },
@@ -495,6 +497,8 @@ const UserSchema: Schema = new Schema(
           publicKey: { type: String },
           email: { type: String },
           providerId: { type: String },
+          credentialID: { type: String },
+          name: { type: String },
         },
       }],
       default: [],

--- a/packages/api/src/models/WebauthnChallenge.ts
+++ b/packages/api/src/models/WebauthnChallenge.ts
@@ -1,0 +1,63 @@
+import mongoose, { type Document, Schema, type Types } from 'mongoose';
+
+/**
+ * WebauthnChallenge Model
+ *
+ * Stores the single-use challenge issued by `generateRegistrationOptions` /
+ * `generateAuthenticationOptions` for a WebAuthn ceremony. Mirrors
+ * `AuthChallenge`: the `challenge` is unique, a TTL index reaps expired rows,
+ * and `used` is flipped atomically the moment the ceremony's verify step burns
+ * it (so a challenge can never be replayed).
+ *
+ * `type` distinguishes the registration ceremony from the authentication one.
+ * `userId` is present when the ceremony is bound to a known account
+ * (linking a passkey to a signed-in user, or a username-first login); it is
+ * absent for prospective signups and usernameless/discoverable logins.
+ */
+export interface IWebauthnChallenge extends Document {
+  challenge: string;
+  type: 'registration' | 'authentication';
+  userId?: Types.ObjectId;
+  expiresAt: Date;
+  used: boolean;
+  createdAt: Date;
+}
+
+const WebauthnChallengeSchema: Schema = new Schema(
+  {
+    challenge: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    type: {
+      type: String,
+      enum: ['registration', 'authentication'],
+      required: true,
+    },
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+    used: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// TTL index to automatically delete expired challenges.
+WebauthnChallengeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const WebauthnChallenge = mongoose.model<IWebauthnChallenge>(
+  'WebauthnChallenge',
+  WebauthnChallengeSchema
+);
+export default WebauthnChallenge;

--- a/packages/api/src/models/WebauthnCredential.ts
+++ b/packages/api/src/models/WebauthnCredential.ts
@@ -1,0 +1,84 @@
+import mongoose, { type Document, Schema, type Types } from 'mongoose';
+
+/**
+ * WebauthnCredential Model
+ *
+ * One registered WebAuthn/passkey credential for a user. A user may have many.
+ * The `credentialID` is the browser-supplied base64url credential id — it is a
+ * PUBLIC handle (returned to any RP the authenticator talks to), not a secret,
+ * so it is looked up with plain equality and carries a UNIQUE index.
+ *
+ * `credentialPublicKey` is the COSE-encoded public key bytes returned by
+ * `verifyRegistrationResponse` — stored as a Buffer and fed back to
+ * `verifyAuthenticationResponse` on each login. `counter` is the authenticator's
+ * signature counter, persisted on every successful assertion for replay
+ * detection (platform authenticators keep it at 0 and never increment — that is
+ * NOT a regression, see the login/verify route).
+ */
+export interface IWebauthnCredential extends Document {
+  userId: Types.ObjectId;
+  credentialID: string;
+  credentialPublicKey: Buffer;
+  counter: number;
+  transports?: string[];
+  deviceType: 'singleDevice' | 'multiDevice';
+  backedUp: boolean;
+  name: string;
+  createdAt: Date;
+  lastUsedAt?: Date;
+}
+
+const WebauthnCredentialSchema: Schema = new Schema(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    credentialID: {
+      type: String,
+      required: true,
+      unique: true,
+    },
+    credentialPublicKey: {
+      type: Buffer,
+      required: true,
+    },
+    counter: {
+      type: Number,
+      required: true,
+      default: 0,
+    },
+    transports: {
+      type: [String],
+      default: undefined,
+    },
+    deviceType: {
+      type: String,
+      enum: ['singleDevice', 'multiDevice'],
+      required: true,
+    },
+    backedUp: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    lastUsedAt: {
+      type: Date,
+    },
+  },
+  {
+    timestamps: { createdAt: true, updatedAt: false },
+  }
+);
+
+export const WebauthnCredential = mongoose.model<IWebauthnCredential>(
+  'WebauthnCredential',
+  WebauthnCredentialSchema
+);
+export default WebauthnCredential;

--- a/packages/api/src/routes/__tests__/authLinking.reversibility.test.ts
+++ b/packages/api/src/routes/__tests__/authLinking.reversibility.test.ts
@@ -30,6 +30,8 @@ interface MockUserDoc {
 
 let mockUserDoc: MockUserDoc;
 const mockInvalidate = jest.fn();
+const mockWacFindOne = jest.fn();
+const mockWacDeleteOne = jest.fn();
 
 function selectable(doc: unknown) {
   return {
@@ -61,6 +63,14 @@ jest.mock('../../utils/userCache', () => ({
 }));
 
 jest.mock('../../services/socialAuth.service', () => ({ __esModule: true, default: {} }));
+
+jest.mock('../../models/WebauthnCredential', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: unknown[]) => mockWacFindOne(...args),
+    deleteOne: (...args: unknown[]) => mockWacDeleteOne(...args),
+  },
+}));
 
 import authLinkingRouter from '../authLinking';
 import SignatureService from '../../services/signature.service';
@@ -123,6 +133,8 @@ beforeEach(() => {
     authMethods: [{ type: 'password', linkedAt: new Date('2026-01-01T00:00:00.000Z') }],
     save: jest.fn().mockResolvedValue(undefined),
   };
+  mockWacFindOne.mockResolvedValue({ _id: 'wac-1', credentialID: 'passkey-1', userId: USER_ID });
+  mockWacDeleteOne.mockResolvedValue({ acknowledged: true, deletedCount: 1 });
 });
 
 describe('identity link/unlink reversibility', () => {
@@ -172,6 +184,53 @@ describe('identity link/unlink reversibility', () => {
     expect(res.status).toBe(400);
     expect(mockUserDoc.save).not.toHaveBeenCalled();
     expect(mockInvalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /auth/link/webauthn/:credentialID (keep ≥1 auth method)', () => {
+  it('unlinks a passkey when other auth methods remain (removes row + credential + invalidates cache)', async () => {
+    // password + one passkey → two methods; unlinking the passkey is allowed.
+    mockUserDoc.authMethods = [
+      { type: 'password', linkedAt: new Date('2026-01-01T00:00:00.000Z') },
+      { type: 'webauthn', linkedAt: new Date('2026-02-01T00:00:00.000Z'), metadata: { credentialID: 'passkey-1', name: 'Laptop' } },
+    ];
+
+    const res = await request(server, 'DELETE', '/auth/link/webauthn/passkey-1');
+
+    expect(res.status).toBe(200);
+    expect(mockUserDoc.authMethods.some((m) => m.type === 'webauthn')).toBe(false);
+    expect(mockUserDoc.save).toHaveBeenCalledTimes(1);
+    expect(mockWacDeleteOne).toHaveBeenCalledTimes(1);
+    expect(mockInvalidate).toHaveBeenCalledWith(USER_ID);
+  });
+
+  it('refuses to unlink the LAST auth method — a passkey-only account (no write, no delete)', async () => {
+    // The passkey is the ONLY auth method: no password, no publicKey, no social.
+    mockUserDoc.password = undefined;
+    mockUserDoc.publicKey = undefined;
+    mockUserDoc.authMethods = [
+      { type: 'webauthn', linkedAt: new Date('2026-02-01T00:00:00.000Z'), metadata: { credentialID: 'passkey-1', name: 'Laptop' } },
+    ];
+
+    const res = await request(server, 'DELETE', '/auth/link/webauthn/passkey-1');
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+    expect(mockWacDeleteOne).not.toHaveBeenCalled();
+    expect(mockInvalidate).not.toHaveBeenCalled();
+  });
+
+  it('rejects unlinking a passkey the account does not own (404-style 400)', async () => {
+    mockUserDoc.authMethods = [
+      { type: 'password', linkedAt: new Date('2026-01-01T00:00:00.000Z') },
+      { type: 'webauthn', linkedAt: new Date('2026-02-01T00:00:00.000Z'), metadata: { credentialID: 'passkey-1' } },
+    ];
+    mockWacFindOne.mockResolvedValue(null);
+
+    const res = await request(server, 'DELETE', '/auth/link/webauthn/passkey-1');
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -313,6 +313,19 @@ describe('POST /webauthn/login/verify', () => {
     expect(mockCreateSession).not.toHaveBeenCalled();
   });
 
+  it('rejects a non-string credential id (NoSQL operator injection) with 400 before any query runs', async () => {
+    const malicious = authenticationResponse();
+    // Attacker sends a Mongo operator object instead of the base64url id.
+    (malicious as { id: unknown }).id = { $ne: null };
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: malicious });
+    expect(res.status).toBe(400);
+    // The value must be rejected BEFORE it can reach a query — no credential
+    // lookup, no challenge burn, no session.
+    expect(mockCredFindOne).not.toHaveBeenCalled();
+    expect(mockChallengeFindOneAndUpdate).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
   it('rejects an expired/burned challenge with 401', async () => {
     mockChallengeFindOneAndUpdate.mockImplementation(() => leanValue(null));
     const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });

--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -1,0 +1,319 @@
+/**
+ * WebAuthn authentication ceremony tests (Fase B/b1).
+ *
+ * Covers login/options (username-first vs usernameless) and login/verify: the
+ * credential resolution by public id, the atomic challenge burn, the signature
+ * counter-regression guard (including the `newCounter === 0` NON-regression), the
+ * unknown-credential / expired-challenge rejections, and the assertion that a
+ * successful login mints a session whose response shape is byte-identical to
+ * `POST /auth/verify`.
+ *
+ * `@simplewebauthn/server` is mocked at the module boundary to drive the verify
+ * RESULT — real assertion verification is NOT weakened (production calls the real
+ * verifier). The session mint is mocked to the SAME `buildSessionAuthResponse`
+ * shape `/auth/verify` returns.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const AUTH_CHALLENGE = 'authentication-challenge-abc';
+const OXY_ORIGIN = 'https://accounts.oxy.so';
+const CRED_ID = 'existing-credential-id';
+const USER_ID = '507f1f77bcf86cd799439011';
+
+let mockCredDoc: {
+  _id: string;
+  credentialID: string;
+  credentialPublicKey: Buffer;
+  counter: number;
+  userId: string;
+  transports?: string[];
+  lastUsedAt?: Date;
+  save: jest.Mock;
+} | null;
+
+const mockChallengeCreate = jest.fn();
+const mockChallengeFindOneAndUpdate = jest.fn();
+const mockCredFindOne = jest.fn();
+const mockCredFind = jest.fn();
+const mockUserFindOne = jest.fn();
+const mockUserFindById = jest.fn();
+const mockCreateSession = jest.fn();
+const mockFinalizeDeviceLogin = jest.fn();
+const mockLogSignIn = jest.fn();
+const mockLogSuspicious = jest.fn();
+const mockVerifyAuthentication = jest.fn();
+const mockGenerateAuthOptions = jest.fn();
+
+function leanValue(value: unknown) {
+  return { lean: () => Promise.resolve(value) };
+}
+function selectLean(value: unknown) {
+  return { select: () => leanValue(value) };
+}
+
+jest.mock('@simplewebauthn/server', () => ({
+  generateAuthenticationOptions: (...args: unknown[]) => mockGenerateAuthOptions(...args),
+  verifyAuthenticationResponse: (...args: unknown[]) => mockVerifyAuthentication(...args),
+}));
+
+jest.mock('@simplewebauthn/server/helpers', () => ({
+  decodeClientDataJSON: () => ({ origin: OXY_ORIGIN, challenge: AUTH_CHALLENGE, type: 'webauthn.get' }),
+  isoUint8Array: { fromUTF8String: (s: string) => new TextEncoder().encode(s) },
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/authUtils', () => ({
+  extractTokenFromRequest: () => undefined,
+  decodeToken: () => null,
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: {
+    findOne: (...args: unknown[]) => mockUserFindOne(...args),
+    findById: (...args: unknown[]) => mockUserFindById(...args),
+  },
+  buildAuthMethod: (type: string, metadata?: Record<string, unknown>) => ({ type, linkedAt: new Date(), metadata }),
+}));
+
+jest.mock('../../models/WebauthnCredential', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: unknown[]) => mockCredFindOne(...args),
+    find: (...args: unknown[]) => mockCredFind(...args),
+  },
+}));
+
+jest.mock('../../models/WebauthnChallenge', () => ({
+  __esModule: true,
+  default: {
+    create: (...args: unknown[]) => mockChallengeCreate(...args),
+    findOneAndUpdate: (...args: unknown[]) => mockChallengeFindOneAndUpdate(...args),
+  },
+}));
+
+jest.mock('../../models/Notification', () => ({ __esModule: true, default: class { save = jest.fn(); } }));
+
+jest.mock('../../utils/userCache', () => ({ __esModule: true, default: { invalidate: jest.fn() } }));
+
+jest.mock('../../controllers/session.controller', () => ({
+  __esModule: true,
+  buildSessionAuthResponse: (
+    session: { sessionId: string; deviceId: string; expiresAt: Date; accessToken?: string },
+    user: { _id: { toString(): string }; username?: string; avatar?: string },
+  ) => ({
+    sessionId: session.sessionId,
+    deviceId: session.deviceId,
+    expiresAt: session.expiresAt.toISOString(),
+    accessToken: session.accessToken,
+    user: { id: user._id.toString(), username: user.username, avatar: user.avatar },
+  }),
+  sessionCreateOptionsFromBody: (body: { deviceName?: string; deviceFingerprint?: string; deviceId?: string }) => ({
+    deviceName: body.deviceName,
+    deviceFingerprint: body.deviceFingerprint,
+    ...(body.deviceId ? { deviceId: body.deviceId } : {}),
+  }),
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: (...args: unknown[]) => mockCreateSession(...args) },
+}));
+
+jest.mock('../../services/deviceLogin.service', () => ({
+  __esModule: true,
+  finalizeDeviceLogin: (...args: unknown[]) => mockFinalizeDeviceLogin(...args),
+}));
+
+jest.mock('../../services/securityActivityService', () => ({
+  __esModule: true,
+  default: {
+    logSignIn: (...args: unknown[]) => mockLogSignIn(...args),
+    logSuspiciousActivity: (...args: unknown[]) => mockLogSuspicious(...args),
+  },
+}));
+
+import webauthnRouter from '../webauthn';
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function request(server: http.Server, method: string, path: string, payload?: unknown): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? undefined : JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: body !== undefined
+          ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) }
+          : {},
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }));
+      },
+    );
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+/** A minimal AuthenticationResponseJSON-shaped payload; the verifier is mocked. */
+function authenticationResponse() {
+  return {
+    id: CRED_ID,
+    rawId: CRED_ID,
+    type: 'public-key',
+    clientExtensionResults: {},
+    response: { clientDataJSON: 'stub', authenticatorData: 'stub', signature: 'stub' },
+  };
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/webauthn', webauthnRouter);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockCredDoc = {
+    _id: 'cred-doc-1',
+    credentialID: CRED_ID,
+    credentialPublicKey: Buffer.from([1, 2, 3, 4]),
+    counter: 5,
+    userId: USER_ID,
+    transports: ['internal'],
+    save: jest.fn().mockResolvedValue(undefined),
+  };
+
+  mockGenerateAuthOptions.mockResolvedValue({ challenge: AUTH_CHALLENGE, allowCredentials: [], rpId: 'localhost' });
+  mockChallengeCreate.mockResolvedValue({});
+  // Default: challenge burns successfully (username-first / first attempt matches).
+  mockChallengeFindOneAndUpdate.mockImplementation(() => leanValue({ _id: 'ch1', challenge: AUTH_CHALLENGE }));
+  mockCredFindOne.mockImplementation(() => Promise.resolve(mockCredDoc));
+  mockCredFind.mockReturnValue(selectLean([]));
+  mockUserFindOne.mockReturnValue(selectLean(null));
+  mockUserFindById.mockResolvedValue({ _id: USER_ID, username: 'loginuser', avatar: undefined });
+  mockCreateSession.mockResolvedValue({
+    sessionId: 'sess-1',
+    deviceId: 'dev-1',
+    accessToken: 'access-token-1',
+    expiresAt: new Date('2026-08-01T00:00:00.000Z'),
+    createdAt: new Date(),
+    deviceInfo: { deviceName: 'Test Device', deviceType: 'web', platform: 'web' },
+  });
+  mockFinalizeDeviceLogin.mockResolvedValue({ deviceSecret: 'device-secret-1' });
+  mockLogSignIn.mockResolvedValue(undefined);
+  mockLogSuspicious.mockResolvedValue(undefined);
+  mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 6 } });
+});
+
+describe('POST /webauthn/login/options', () => {
+  it('username-first: scopes allowCredentials to the user and binds the challenge to their id', async () => {
+    mockUserFindOne.mockReturnValue(selectLean({ _id: USER_ID }));
+    mockCredFind.mockReturnValue(selectLean([{ credentialID: CRED_ID, transports: ['internal'] }]));
+
+    const res = await request(server, 'POST', '/webauthn/login/options', { username: 'loginuser' });
+
+    expect(res.status).toBe(200);
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as { allowCredentials: unknown[] };
+    expect(opts.allowCredentials).toHaveLength(1);
+    const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: string };
+    expect(stored.type).toBe('authentication');
+    expect(stored.userId).toBe(USER_ID);
+  });
+
+  it('usernameless (discoverable): empty allowCredentials and an unbound challenge', async () => {
+    const res = await request(server, 'POST', '/webauthn/login/options', {});
+    expect(res.status).toBe(200);
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as { allowCredentials: unknown[] };
+    expect(opts.allowCredentials).toHaveLength(0);
+    const stored = mockChallengeCreate.mock.calls[0][0] as { userId?: string };
+    expect(stored.userId).toBeUndefined();
+  });
+});
+
+describe('POST /webauthn/login/verify', () => {
+  it('mints a session with the byte-identical AuthSuccess shape of /auth/verify', async () => {
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+
+    expect(res.status).toBe(200);
+    expect(Object.keys(res.body).sort()).toEqual(['accessToken', 'deviceId', 'deviceSecret', 'expiresAt', 'sessionId', 'user']);
+    expect(res.body.deviceSecret).toBe('device-secret-1');
+    expect(res.body.accessToken).toBe('access-token-1');
+    expect(res.body.user).toMatchObject({ id: USER_ID, username: 'loginuser' });
+    // Counter advanced and persisted.
+    expect(mockCredDoc?.counter).toBe(6);
+    expect(mockCredDoc?.save).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a platform authenticator that never increments (newCounter === 0, stored 0)', async () => {
+    if (mockCredDoc) mockCredDoc.counter = 0;
+    mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 0 } });
+
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+
+    expect(res.status).toBe(200);
+    expect(mockCredDoc?.counter).toBe(0);
+    expect(mockLogSuspicious).not.toHaveBeenCalled();
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a genuine counter regression (401 + security log, no session)', async () => {
+    if (mockCredDoc) mockCredDoc.counter = 10;
+    mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 4 } });
+
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+
+    expect(res.status).toBe(401);
+    expect(mockLogSuspicious).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockCredDoc?.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown credential with 401', async () => {
+    mockCredDoc = null;
+    mockCredFindOne.mockResolvedValue(null);
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+    expect(res.status).toBe(401);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects an expired/burned challenge with 401', async () => {
+    mockChallengeFindOneAndUpdate.mockImplementation(() => leanValue(null));
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+    expect(res.status).toBe(401);
+    expect(mockVerifyAuthentication).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the assertion does not verify', async () => {
+    mockVerifyAuthentication.mockResolvedValue({ verified: false, authenticationInfo: { newCounter: 6 } });
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+    expect(res.status).toBe(401);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -231,18 +231,27 @@ beforeEach(() => {
 });
 
 describe('POST /webauthn/login/options', () => {
-  it('username-first: scopes allowCredentials to the user and binds the challenge to their id', async () => {
+  it('a supplied username does NOT leak the account: empty allowCredentials, unbound challenge, no DB lookup', async () => {
+    // Arrange the store so that IF the handler looked the user up it would find a
+    // matching account with a credential — proving the handler ignores it.
     mockUserFindOne.mockReturnValue(selectLean({ _id: USER_ID }));
     mockCredFind.mockReturnValue(selectLean([{ credentialID: CRED_ID, transports: ['internal'] }]));
 
     const res = await request(server, 'POST', '/webauthn/login/options', { username: 'loginuser' });
 
     expect(res.status).toBe(200);
-    const opts = mockGenerateAuthOptions.mock.calls[0][0] as { allowCredentials: unknown[] };
-    expect(opts.allowCredentials).toHaveLength(1);
+    // Discoverable-only: never emit the user's credentialIDs.
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as { allowCredentials: unknown[]; userVerification?: string };
+    expect(opts.allowCredentials).toHaveLength(0);
+    expect(opts.userVerification).toBe('required');
+    // Challenge is not bound to any account.
     const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: string };
     expect(stored.type).toBe('authentication');
-    expect(stored.userId).toBe(USER_ID);
+    expect(stored.userId).toBeUndefined();
+    // No account-existence-dependent branching or timing: the user/credential
+    // lookups must NOT run at all.
+    expect(mockUserFindOne).not.toHaveBeenCalled();
+    expect(mockCredFind).not.toHaveBeenCalled();
   });
 
   it('usernameless (discoverable): empty allowCredentials and an unbound challenge', async () => {
@@ -252,6 +261,8 @@ describe('POST /webauthn/login/options', () => {
     expect(opts.allowCredentials).toHaveLength(0);
     const stored = mockChallengeCreate.mock.calls[0][0] as { userId?: string };
     expect(stored.userId).toBeUndefined();
+    expect(mockUserFindOne).not.toHaveBeenCalled();
+    expect(mockCredFind).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/api/src/routes/__tests__/webauthnRegister.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnRegister.test.ts
@@ -1,0 +1,402 @@
+/**
+ * WebAuthn registration ceremony tests (Fase B/b1).
+ *
+ * Exercises the Oxy orchestration around `@simplewebauthn/server`: username
+ * availability at options time, the atomic (flow-bound) challenge burn, the
+ * linking branch (push credential + authMethods + invalidate cache), the signup
+ * branch (create account + credential, run the shared session mint), and the
+ * duplicate-credential / expired-challenge rejections.
+ *
+ * `@simplewebauthn/server` is mocked at the MODULE BOUNDARY so the test can drive
+ * the verification RESULT — production still calls the real verifier; nothing
+ * about real attestation verification is weakened here. The session mint is
+ * mocked to the SAME `AuthSuccess` shape `/auth/verify` returns (see
+ * `buildSessionAuthResponse`), so the signup branch's response shape is locked.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const REG_CHALLENGE = 'registration-challenge-abc';
+const OXY_ORIGIN = 'https://accounts.oxy.so';
+const NEW_CRED_ID = 'new-credential-id-xyz';
+const LINK_USER_ID = '507f1f77bcf86cd799439011';
+const NEW_USER_ID = '507f1f77bcf86cd7994390aa';
+
+// ---- controllable mock state ----------------------------------------------
+let mockBearerUserId: string | null = null;
+let mockBurnResult: unknown = { _id: 'c1', challenge: REG_CHALLENGE, type: 'registration' };
+let mockCredCreateError: { code?: number } | null = null;
+
+const mockChallengeCreate = jest.fn();
+const mockChallengeFindOneAndUpdate = jest.fn();
+const mockCredFind = jest.fn();
+const mockCredCreate = jest.fn();
+const mockUserFindById = jest.fn();
+const mockUserFindOne = jest.fn();
+const mockUserFindByIdAndDelete = jest.fn();
+const mockUserSave = jest.fn();
+const mockInvalidate = jest.fn();
+const mockCreateSession = jest.fn();
+const mockFinalizeDeviceLogin = jest.fn();
+const mockLogSignIn = jest.fn();
+const mockVerifyRegistration = jest.fn();
+
+let mockNewUserDoc: { _id: string; username?: string; avatar?: string; authMethods: unknown[]; save: jest.Mock };
+
+function leanValue(value: unknown) {
+  return { lean: () => Promise.resolve(value) };
+}
+function selectLean(value: unknown) {
+  return { select: () => leanValue(value) };
+}
+
+// ---- module mocks ----------------------------------------------------------
+jest.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: jest.fn(async () => ({
+    challenge: REG_CHALLENGE,
+    rp: { name: 'Oxy', id: 'localhost' },
+    user: { id: 'x', name: 'x', displayName: '' },
+    pubKeyCredParams: [],
+    excludeCredentials: [],
+  })),
+  verifyRegistrationResponse: (...args: unknown[]) => mockVerifyRegistration(...args),
+}));
+
+jest.mock('@simplewebauthn/server/helpers', () => ({
+  decodeClientDataJSON: () => ({ origin: OXY_ORIGIN, challenge: REG_CHALLENGE, type: 'webauthn.create' }),
+  isoUint8Array: { fromUTF8String: (s: string) => new TextEncoder().encode(s) },
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/authUtils', () => ({
+  extractTokenFromRequest: (req: { headers: Record<string, string> }) =>
+    req.headers.authorization?.startsWith('Bearer ') ? req.headers.authorization.slice(7) : undefined,
+  decodeToken: () => (mockBearerUserId ? { userId: mockBearerUserId, type: 'access' } : null),
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: class {
+    _id = NEW_USER_ID;
+    username?: string;
+    avatar?: string;
+    authMethods: unknown[] = [];
+    constructor(init: { username?: string; authMethods?: unknown[] }) {
+      this.username = init.username;
+      this.authMethods = init.authMethods ?? [];
+      mockNewUserDoc = this as unknown as typeof mockNewUserDoc;
+    }
+    save = mockUserSave;
+    static findById = (...args: unknown[]) => mockUserFindById(...args);
+    static findOne = (...args: unknown[]) => mockUserFindOne(...args);
+    static findByIdAndDelete = (...args: unknown[]) => mockUserFindByIdAndDelete(...args);
+  },
+  buildAuthMethod: (type: string, metadata?: Record<string, unknown>) => ({ type, linkedAt: new Date(), metadata }),
+}));
+
+jest.mock('../../models/WebauthnCredential', () => ({
+  __esModule: true,
+  default: {
+    find: (...args: unknown[]) => mockCredFind(...args),
+    create: (...args: unknown[]) => mockCredCreate(...args),
+  },
+}));
+
+jest.mock('../../models/WebauthnChallenge', () => ({
+  __esModule: true,
+  default: {
+    create: (...args: unknown[]) => mockChallengeCreate(...args),
+    findOneAndUpdate: (...args: unknown[]) => mockChallengeFindOneAndUpdate(...args),
+  },
+}));
+
+jest.mock('../../models/Notification', () => ({
+  __esModule: true,
+  default: class {
+    save = jest.fn().mockResolvedValue(undefined);
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: (...args: unknown[]) => mockInvalidate(...args) },
+}));
+
+jest.mock('../../controllers/session.controller', () => ({
+  __esModule: true,
+  buildSessionAuthResponse: (
+    session: { sessionId: string; deviceId: string; expiresAt: Date; accessToken?: string },
+    user: { _id: { toString(): string }; username?: string; avatar?: string },
+  ) => ({
+    sessionId: session.sessionId,
+    deviceId: session.deviceId,
+    expiresAt: session.expiresAt.toISOString(),
+    accessToken: session.accessToken,
+    user: { id: user._id.toString(), username: user.username, avatar: user.avatar },
+  }),
+  sessionCreateOptionsFromBody: (body: { deviceName?: string; deviceFingerprint?: string; deviceId?: string }) => ({
+    deviceName: body.deviceName,
+    deviceFingerprint: body.deviceFingerprint,
+    ...(body.deviceId ? { deviceId: body.deviceId } : {}),
+  }),
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: (...args: unknown[]) => mockCreateSession(...args) },
+}));
+
+jest.mock('../../services/deviceLogin.service', () => ({
+  __esModule: true,
+  finalizeDeviceLogin: (...args: unknown[]) => mockFinalizeDeviceLogin(...args),
+}));
+
+jest.mock('../../services/securityActivityService', () => ({
+  __esModule: true,
+  default: { logSignIn: (...args: unknown[]) => mockLogSignIn(...args), logSuspiciousActivity: jest.fn() },
+}));
+
+import webauthnRouter from '../webauthn';
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function request(
+  server: http.Server,
+  method: string,
+  path: string,
+  payload?: unknown,
+  headers: Record<string, string> = {},
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? undefined : JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: {
+          ...(body !== undefined
+            ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) }
+            : {}),
+          ...headers,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }));
+      },
+    );
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+/** A minimal RegistrationResponseJSON-shaped payload; the verifier is mocked. */
+function registrationResponse() {
+  return {
+    id: NEW_CRED_ID,
+    rawId: NEW_CRED_ID,
+    type: 'public-key',
+    clientExtensionResults: {},
+    response: { clientDataJSON: 'stub', attestationObject: 'stub' },
+  };
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/webauthn', webauthnRouter);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBearerUserId = null;
+  mockBurnResult = { _id: 'c1', challenge: REG_CHALLENGE, type: 'registration' };
+  mockCredCreateError = null;
+
+  mockChallengeCreate.mockResolvedValue({});
+  mockChallengeFindOneAndUpdate.mockImplementation(() => leanValue(mockBurnResult));
+  mockCredFind.mockReturnValue(selectLean([]));
+  mockCredCreate.mockImplementation(async () => {
+    if (mockCredCreateError) throw mockCredCreateError;
+    return {};
+  });
+  mockUserSave.mockResolvedValue(undefined);
+  mockUserFindById.mockReturnValue({ _id: LINK_USER_ID, username: 'linker', authMethods: [], save: mockUserSave });
+  mockUserFindOne.mockReturnValue(selectLean(null));
+  mockUserFindByIdAndDelete.mockResolvedValue(undefined);
+  mockCreateSession.mockResolvedValue({
+    sessionId: 'sess-1',
+    deviceId: 'dev-1',
+    accessToken: 'access-token-1',
+    expiresAt: new Date('2026-08-01T00:00:00.000Z'),
+    createdAt: new Date(),
+    deviceInfo: { deviceName: 'Test Device', deviceType: 'web', platform: 'web' },
+  });
+  mockFinalizeDeviceLogin.mockResolvedValue({ deviceSecret: 'device-secret-1' });
+  mockLogSignIn.mockResolvedValue(undefined);
+  mockVerifyRegistration.mockResolvedValue({
+    verified: true,
+    registrationInfo: {
+      credential: { id: NEW_CRED_ID, publicKey: new Uint8Array([1, 2, 3, 4]), counter: 0, transports: ['internal'] },
+      credentialDeviceType: 'multiDevice',
+      credentialBackedUp: true,
+    },
+  });
+});
+
+describe('POST /webauthn/register/options', () => {
+  it('signup branch: validates username availability and persists a registration challenge', async () => {
+    const res = await request(server, 'POST', '/webauthn/register/options', { username: 'freshuser' });
+    expect(res.status).toBe(200);
+    expect(res.body.challenge).toBe(REG_CHALLENGE);
+    expect(mockChallengeCreate).toHaveBeenCalledTimes(1);
+    const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: string };
+    expect(stored.type).toBe('registration');
+    expect(stored.userId).toBeUndefined(); // signup challenge is not bound to a user
+  });
+
+  it('rejects a taken username with 409 (no challenge stored)', async () => {
+    mockUserFindOne.mockReturnValue(selectLean({ _id: 'someone' }));
+    const res = await request(server, 'POST', '/webauthn/register/options', { username: 'taken' });
+    expect(res.status).toBe(409);
+    expect(mockChallengeCreate).not.toHaveBeenCalled();
+  });
+
+  it('requires a username in the signup branch', async () => {
+    const res = await request(server, 'POST', '/webauthn/register/options', {});
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /webauthn/register/verify — signup branch', () => {
+  it('creates the account + credential + webauthn authMethod and returns the AuthSuccess mint shape', async () => {
+    const res = await request(server, 'POST', '/webauthn/register/verify', {
+      username: 'freshuser',
+      deviceName: 'My Laptop',
+      response: registrationResponse(),
+    });
+
+    expect(res.status).toBe(200);
+    // Byte-identical shape to POST /auth/verify: buildSessionAuthResponse + deviceSecret.
+    expect(Object.keys(res.body).sort()).toEqual(['accessToken', 'deviceId', 'deviceSecret', 'expiresAt', 'sessionId', 'user']);
+    expect(res.body.deviceSecret).toBe('device-secret-1');
+    expect(res.body.accessToken).toBe('access-token-1');
+    // Same nested user shape as /auth/verify (avatar omitted when undefined, as JSON does).
+    expect(res.body.user).toMatchObject({ id: NEW_USER_ID, username: 'freshuser' });
+
+    // Account + credential were created; a webauthn authMethod was stamped.
+    expect(mockUserSave).toHaveBeenCalledTimes(1);
+    expect(mockCredCreate).toHaveBeenCalledTimes(1);
+    const credArg = mockCredCreate.mock.calls[0][0] as { credentialID: string; name: string; deviceType: string };
+    expect(credArg.credentialID).toBe(NEW_CRED_ID);
+    expect(credArg.name).toBe('My Laptop');
+    expect(mockNewUserDoc.authMethods).toHaveLength(1);
+    expect((mockNewUserDoc.authMethods[0] as { type: string }).type).toBe('webauthn');
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back the account when the credential insert collides (duplicate) → 409', async () => {
+    mockCredCreateError = { code: 11000 };
+    const res = await request(server, 'POST', '/webauthn/register/verify', {
+      username: 'freshuser',
+      response: registrationResponse(),
+    });
+    expect(res.status).toBe(409);
+    expect(mockUserFindByIdAndDelete).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a burned/expired challenge with 401 (no account created)', async () => {
+    mockBurnResult = null; // findOneAndUpdate matches nothing
+    const res = await request(server, 'POST', '/webauthn/register/verify', {
+      username: 'freshuser',
+      response: registrationResponse(),
+    });
+    expect(res.status).toBe(401);
+    expect(mockUserSave).not.toHaveBeenCalled();
+    expect(mockCredCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the attestation does not verify', async () => {
+    mockVerifyRegistration.mockResolvedValue({ verified: false });
+    const res = await request(server, 'POST', '/webauthn/register/verify', {
+      username: 'freshuser',
+      response: registrationResponse(),
+    });
+    expect(res.status).toBe(400);
+    expect(mockCredCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /webauthn/register/verify — linking branch', () => {
+  it('links the passkey to the bearer account (credential + authMethod + cache invalidate)', async () => {
+    mockBearerUserId = LINK_USER_ID;
+    const linkDoc = { _id: LINK_USER_ID, username: 'linker', authMethods: [] as unknown[], save: mockUserSave };
+    mockUserFindById.mockReturnValue(linkDoc);
+
+    const res = await request(
+      server,
+      'POST',
+      '/webauthn/register/verify',
+      { deviceName: 'YubiKey', response: registrationResponse() },
+      { authorization: 'Bearer valid-token' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(mockCredCreate).toHaveBeenCalledTimes(1);
+    expect(linkDoc.authMethods).toHaveLength(1);
+    expect((linkDoc.authMethods[0] as { type: string }).type).toBe('webauthn');
+    expect(mockInvalidate).toHaveBeenCalledWith(LINK_USER_ID);
+    // Linking does NOT mint a new session.
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('binds the burn to the caller: a linking challenge query carries the user id', async () => {
+    mockBearerUserId = LINK_USER_ID;
+    mockUserFindById.mockReturnValue({ _id: LINK_USER_ID, username: 'linker', authMethods: [], save: mockUserSave });
+    await request(
+      server,
+      'POST',
+      '/webauthn/register/verify',
+      { response: registrationResponse() },
+      { authorization: 'Bearer valid-token' },
+    );
+    const query = mockChallengeFindOneAndUpdate.mock.calls[0][0] as { userId: unknown };
+    expect(query.userId).toBe(LINK_USER_ID);
+  });
+
+  it('rejects a duplicate passkey on link with 409', async () => {
+    mockBearerUserId = LINK_USER_ID;
+    mockUserFindById.mockReturnValue({ _id: LINK_USER_ID, username: 'linker', authMethods: [], save: mockUserSave });
+    mockCredCreateError = { code: 11000 };
+    const res = await request(
+      server,
+      'POST',
+      '/webauthn/register/verify',
+      { response: registrationResponse() },
+      { authorization: 'Bearer valid-token' },
+    );
+    expect(res.status).toBe(409);
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -29,6 +29,7 @@ import SignatureService from '../services/signature.service';
 import { emitAuthSessionUpdate } from '../utils/authSessionSocket';
 import { broadcastSessionAccountsChanged } from '../utils/socket';
 import socialAuthRouter from './socialAuth';
+import webauthnRouter from './webauthn';
 import { validate } from '../middleware/validate';
 import sessionService from '../services/session.service';
 import { finalizeDeviceLogin } from '../services/deviceLogin.service';
@@ -452,6 +453,22 @@ router.post(
  * POST /auth/social/github  - body: { code }
  */
 router.use('/social', socialAuthRouter);
+
+// ============================================
+// WebAuthn / Passkey Routes
+// ============================================
+
+/**
+ * POST /auth/webauthn/register/options  - begin passkey registration (link OR signup)
+ * POST /auth/webauthn/register/verify   - finish passkey registration
+ * POST /auth/webauthn/login/options     - begin passkey authentication
+ * POST /auth/webauthn/login/verify      - finish passkey authentication
+ *
+ * Each reads an OPTIONAL bearer (link when signed in, signup/usernameless
+ * otherwise). The verify handlers reuse the standard session mint and return the
+ * same AuthSuccess shape as POST /auth/verify.
+ */
+router.use('/webauthn', webauthnRouter);
 
 // ============================================
 // Public Key Authentication Routes

--- a/packages/api/src/routes/authLinking.ts
+++ b/packages/api/src/routes/authLinking.ts
@@ -18,7 +18,8 @@ import SignatureService from '../services/signature.service.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
 import { BadRequestError, ConflictError, UnauthorizedError } from '../utils/error.js';
 import { validate } from '../middleware/validate.js';
-import { linkAuthMethodSchema, unlinkTypeParams } from '../schemas/authLinking.schemas.js';
+import { linkAuthMethodSchema, unlinkTypeParams, unlinkWebauthnParams } from '../schemas/authLinking.schemas.js';
+import WebauthnCredential from '../models/WebauthnCredential.js';
 import socialAuthService from '../services/socialAuth.service.js';
 import type { SocialProfile } from '../services/socialAuth.service.js';
 import userCache from '../utils/userCache.js';
@@ -47,6 +48,26 @@ async function verifySocialLinkToken(type: SocialAuthMethodType, providerToken: 
   }
 
   return profile;
+}
+
+/**
+ * Count the account's distinct authentication methods: the identity key, a
+ * password, each linked social provider, AND each registered passkey. Used by
+ * the unlink guards to keep every account with at least ONE usable auth method
+ * (removing the last would lock the user out).
+ */
+function countAuthMethods(user: {
+  publicKey?: string | null;
+  password?: string | null;
+  authMethods?: Array<{ type: string }> | null;
+}): number {
+  let count = 0;
+  if (user.publicKey) count++;
+  if (user.password) count++;
+  const methods = user.authMethods ?? [];
+  count += methods.filter((m) => ['google', 'apple', 'github'].includes(m.type)).length;
+  count += methods.filter((m) => m.type === 'webauthn').length;
+  return count;
 }
 
 // All routes require authentication
@@ -263,6 +284,51 @@ router.post('/link', validate({ body: linkAuthMethodSchema }), asyncHandler(asyn
 }));
 
 /**
+ * DELETE /api/auth/link/webauthn/:credentialID
+ * Unlink ONE passkey (by its public credential id) from the current account.
+ * Passkeys are per-credential, so this needs the specific id rather than the
+ * generic per-type unlink. Removes the `authMethods[]` row AND the
+ * WebauthnCredential document, keeping at least one usable auth method overall.
+ *
+ * Registered BEFORE `DELETE /link/:type` so the two-segment webauthn path is not
+ * shadowed by the single-segment `:type` route.
+ */
+router.delete('/link/webauthn/:credentialID', validate({ params: unlinkWebauthnParams }), asyncHandler(async (req: AuthRequest, res: Response) => {
+  const userId = req.user?._id;
+  if (!userId) {
+    throw new BadRequestError('User not authenticated');
+  }
+
+  const { credentialID } = req.params;
+
+  const user = await User.findById(userId).select('+password');
+  if (!user) {
+    throw new BadRequestError('User not found');
+  }
+
+  // The passkey must belong to the caller (its public id alone is not proof of
+  // ownership — scope the lookup by userId).
+  const credential = await WebauthnCredential.findOne({ credentialID, userId });
+  if (!credential) {
+    throw new BadRequestError('No such passkey is linked to this account');
+  }
+
+  // Removing the last remaining auth method would lock the account out.
+  if (countAuthMethods(user) <= 1) {
+    throw new BadRequestError('Cannot unlink last authentication method - account would become inaccessible');
+  }
+
+  user.authMethods = user.authMethods?.filter(
+    (m) => !(m.type === 'webauthn' && m.metadata?.credentialID === credentialID)
+  );
+  await user.save();
+  await WebauthnCredential.deleteOne({ _id: credential._id });
+  userCache.invalidate(userId.toString());
+
+  res.json({ success: true, message: 'Passkey unlinked successfully' });
+}));
+
+/**
  * DELETE /api/auth/link/:type
  * Unlink an authentication method from the current user account
  * Must keep at least one auth method
@@ -285,13 +351,7 @@ router.delete('/link/:type', validate({ params: unlinkTypeParams }), asyncHandle
   }
 
   // Count current auth methods
-  let methodCount = 0;
-  if (user.publicKey) methodCount++;
-  if (user.password) methodCount++;
-  const socialMethods = user.authMethods?.filter(m =>
-    ['google', 'apple', 'github'].includes(m.type)
-  ) || [];
-  methodCount += socialMethods.length;
+  const methodCount = countAuthMethods(user);
 
   if (methodCount <= 1) {
     throw new BadRequestError('Cannot unlink last authentication method - account would become inaccessible');

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -109,6 +109,20 @@ function readCeremonyResponse<T>(body: unknown): T {
 }
 
 /**
+ * Guard that a value pulled from the (Zod-unvalidated) browser ceremony response
+ * is a string before it reaches a MongoDB query. Browser response fields are
+ * attacker-controlled; without this a caller could pass an object such as
+ * `{ $ne: null }` and inject a Mongo query operator. Throwing here makes every
+ * value that reaches a query provably a plain string.
+ */
+function requireString(value: unknown, label: string): string {
+  if (typeof value !== 'string') {
+    throw new BadRequestError(`WebAuthn ${label} must be a string`);
+  }
+  return value;
+}
+
+/**
  * Decode the ceremony's `clientDataJSON` and return the origin (validated to be
  * an Oxy apex origin) plus the challenge the authenticator signed. The origin
  * gate is the WebAuthn `expectedOrigin` allow-set: `@simplewebauthn/server`'s
@@ -116,17 +130,22 @@ function readCeremonyResponse<T>(body: unknown): T {
  * validate the reported origin against `isOxyApexOrigin` here and then pass that
  * exact origin back in — the security boundary is this gate.
  */
-function decodeAndGuardClientData(clientDataJSON: string): { origin: string; challenge: string } {
+function decodeAndGuardClientData(clientDataJSON: unknown): { origin: string; challenge: string } {
+  const raw = requireString(clientDataJSON, 'clientDataJSON');
   let clientData: { origin: string; challenge: string };
   try {
-    clientData = decodeClientDataJSON(clientDataJSON);
+    clientData = decodeClientDataJSON(raw);
   } catch {
     throw new BadRequestError('Malformed WebAuthn clientDataJSON');
   }
-  if (!isOxyApexOrigin(clientData.origin)) {
+  // `clientData` is attacker-controlled JSON; both fields flow into Mongo queries
+  // (the origin gate below and the challenge burn), so pin them to strings first.
+  const origin = requireString(clientData.origin, 'ceremony origin');
+  const challenge = requireString(clientData.challenge, 'ceremony challenge');
+  if (!isOxyApexOrigin(origin)) {
     throw new BadRequestError('WebAuthn ceremony origin is not allowed');
   }
-  return { origin: clientData.origin, challenge: clientData.challenge };
+  return { origin, challenge };
 }
 
 /**
@@ -524,7 +543,10 @@ router.post(
     const rpID = getWebauthnRpId();
 
     // Resolve the credential by its PUBLIC base64url id (plain equality).
-    const credential = await WebauthnCredential.findOne({ credentialID: response.id });
+    // `response.id` is attacker-controlled and Zod-unvalidated; pin it to a
+    // string so an object like `{ $ne: null }` cannot inject a query operator.
+    const credentialId = requireString(response.id, 'credential id');
+    const credential = await WebauthnCredential.findOne({ credentialID: credentialId });
     if (!credential) {
       throw new UnauthorizedError('Unknown passkey');
     }

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -273,7 +273,7 @@ router.post(
       excludeCredentials,
       authenticatorSelection: {
         residentKey: 'required',
-        userVerification: 'preferred',
+        userVerification: 'required',
       },
     });
 
@@ -329,6 +329,7 @@ router.post(
         expectedChallenge: challenge,
         expectedOrigin: origin,
         expectedRPID: rpID,
+        requireUserVerification: true,
       });
     } catch (error) {
       logger.warn('webauthn register verification threw', {
@@ -464,11 +465,13 @@ router.post(
 /**
  * POST /webauthn/login/options
  *
- * With a `username` the returned allow-list is scoped to that user's passkeys
- * (username-first) and the challenge is bound to their account. Without one the
- * allow-list is empty for the usernameless / discoverable-credential flow (the
- * default). A username that resolves to no user still returns options (empty
- * allow-list) so account existence is not leaked.
+ * ALWAYS discoverable-credential (usernameless) login: the allow-list is empty
+ * regardless of any supplied `username`, and no user lookup is performed. Emitting
+ * a user's `credentialID`s (a non-empty allow-list) — or even branching the
+ * response/timing on whether a username resolves — would leak account existence
+ * and let an unauthenticated caller enumerate a user's passkeys, so neither is
+ * done. The authenticator returns the credentialID at verify time, which is where
+ * the user is resolved. The challenge carries no `userId` (discoverable flow).
  */
 router.post(
   '/login/options',
@@ -481,36 +484,15 @@ router.post(
 
     const rpID = getWebauthnRpId();
 
-    let allowCredentials: { id: string; transports?: AuthenticatorTransportFuture[] }[] = [];
-    let challengeUserId: string | undefined;
-
-    if (parsed.data.username) {
-      const normalizedUsername = normalizeUsername(parsed.data.username);
-      const user = await User.findOne({ username: exactCaseInsensitiveUsernameRegex(normalizedUsername) })
-        .select('_id')
-        .lean();
-      if (user) {
-        const creds = await WebauthnCredential.find({ userId: user._id })
-          .select('credentialID transports')
-          .lean();
-        allowCredentials = creds.map((cred) => ({
-          id: cred.credentialID,
-          transports: cred.transports as AuthenticatorTransportFuture[] | undefined,
-        }));
-        challengeUserId = user._id.toString();
-      }
-    }
-
     const options = await generateAuthenticationOptions({
       rpID,
-      allowCredentials,
-      userVerification: 'preferred',
+      allowCredentials: [],
+      userVerification: 'required',
     });
 
     await WebauthnChallenge.create({
       challenge: options.challenge,
       type: 'authentication',
-      ...(challengeUserId ? { userId: challengeUserId } : {}),
       expiresAt: new Date(Date.now() + CHALLENGE_TTL_MS),
       used: false,
     });
@@ -568,6 +550,7 @@ router.post(
         expectedChallenge: challenge,
         expectedOrigin: origin,
         expectedRPID: rpID,
+        requireUserVerification: true,
         credential: {
           id: credential.credentialID,
           publicKey: new Uint8Array(credential.credentialPublicKey),

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -1,0 +1,638 @@
+/**
+ * WebAuthn / passkey ceremony routes (Fase B/b1).
+ *
+ * Four endpoints implement the two WebAuthn ceremonies:
+ *   POST /webauthn/register/options   — begin registration (link OR signup)
+ *   POST /webauthn/register/verify    — finish registration
+ *   POST /webauthn/login/options      — begin authentication
+ *   POST /webauthn/login/verify       — finish authentication
+ *
+ * All four read an OPTIONAL bearer (like `sessionDevice.ts`'s
+ * `resolveCallerDeviceId`) rather than mounting `authMiddleware`: a bearer means
+ * "link a passkey to THIS signed-in account", its absence means "prospective
+ * signup / usernameless login".
+ *
+ * CORE PRINCIPLE — reuse the session mint. The verify handlers do ONLY: verify
+ * the assertion via `@simplewebauthn/server` → resolve the userId → run the exact
+ * same finalisation the password/2FA paths run (`sessionService.createSession` →
+ * `buildSessionAuthResponse` → `finalizeDeviceLogin`) → return the same
+ * `AuthSuccess` shape as `POST /auth/verify`. No session/device-secret minting is
+ * reinvented here.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import crypto from 'crypto';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+  type RegistrationResponseJSON,
+  type AuthenticationResponseJSON,
+  type AuthenticatorTransportFuture,
+} from '@simplewebauthn/server';
+import { decodeClientDataJSON, isoUint8Array } from '@simplewebauthn/server/helpers';
+import {
+  webauthnRegisterOptionsRequestSchema,
+  webauthnLoginOptionsRequestSchema,
+  webauthnRegisterVerifyRequestSchema,
+  webauthnLoginVerifyRequestSchema,
+} from '@oxyhq/contracts';
+import { User, buildAuthMethod } from '../models/User';
+import WebauthnCredential from '../models/WebauthnCredential';
+import WebauthnChallenge from '../models/WebauthnChallenge';
+import Notification from '../models/Notification';
+import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils';
+import { rateLimit } from '../middleware/rateLimiter';
+import { asyncHandler } from '../utils/asyncHandler';
+import { BadRequestError, ConflictError, UnauthorizedError, InternalServerError } from '../utils/error';
+import { logger } from '../utils/logger';
+import userCache from '../utils/userCache';
+import { isOxyApexOrigin } from '../utils/origin';
+import { getWebauthnRpId } from '../config/env';
+import { normalizeUsername, USERNAME_PATTERN, INVALID_USERNAME_MESSAGE } from '../utils/username';
+import { exactCaseInsensitiveUsernameRegex } from '../utils/resolveUserIdentifier';
+import { buildSessionAuthResponse, sessionCreateOptionsFromBody } from '../controllers/session.controller';
+import sessionService from '../services/session.service';
+import { finalizeDeviceLogin } from '../services/deviceLogin.service';
+import securityActivityService from '../services/securityActivityService';
+import type { SessionAuthResponse } from '../types/session';
+import type { UserLike } from '../utils/userTransform';
+
+const router = Router();
+
+const RP_NAME = 'Oxy';
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CREDENTIAL_NAME = 'Passkey';
+
+const registerOptionsLimiter = rateLimit({ prefix: 'rl:webauthn:register-options:', windowMs: 60_000, max: 20 });
+const registerVerifyLimiter = rateLimit({ prefix: 'rl:webauthn:register-verify:', windowMs: 60_000, max: 10 });
+const loginOptionsLimiter = rateLimit({ prefix: 'rl:webauthn:login-options:', windowMs: 60_000, max: 30 });
+const loginVerifyLimiter = rateLimit({ prefix: 'rl:webauthn:login-verify:', windowMs: 60_000, max: 10 });
+
+/** The device-session options every first-party sign-in body carries. */
+interface DeviceEnvelope {
+  deviceName?: string;
+  deviceFingerprint?: string;
+  deviceId?: string;
+}
+
+/**
+ * Resolve the authenticated userId from an OPTIONAL bearer, mirroring
+ * `sessionDevice.ts`'s `resolveCallerDeviceId`: decode the access JWT and read
+ * its `userId` claim. Returns null when there is no valid `access` bearer — the
+ * caller then treats the request as unauthenticated (signup / usernameless).
+ */
+function resolveOptionalBearerUserId(req: Request): string | null {
+  const token = extractTokenFromRequest(req);
+  const decoded = token ? decodeToken(token) : null;
+  if (!decoded || decoded.type !== 'access') {
+    return null;
+  }
+  return typeof decoded.userId === 'string' && decoded.userId.length > 0 ? decoded.userId : null;
+}
+
+/**
+ * Pull the browser ceremony response out of the raw request body. The outer Oxy
+ * envelope is validated by Zod separately; the `response` object is validated by
+ * `@simplewebauthn/server`, so here we only assert it is present and object-shaped.
+ */
+function readCeremonyResponse<T>(body: unknown): T {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw new BadRequestError('WebAuthn ceremony response is required');
+  }
+  const response = (body as Record<string, unknown>).response;
+  if (!response || typeof response !== 'object' || Array.isArray(response)) {
+    throw new BadRequestError('WebAuthn ceremony response is required');
+  }
+  return response as T;
+}
+
+/**
+ * Decode the ceremony's `clientDataJSON` and return the origin (validated to be
+ * an Oxy apex origin) plus the challenge the authenticator signed. The origin
+ * gate is the WebAuthn `expectedOrigin` allow-set: `@simplewebauthn/server`'s
+ * `expectedOrigin` only accepts a concrete string/array, not a predicate, so we
+ * validate the reported origin against `isOxyApexOrigin` here and then pass that
+ * exact origin back in — the security boundary is this gate.
+ */
+function decodeAndGuardClientData(clientDataJSON: string): { origin: string; challenge: string } {
+  let clientData: { origin: string; challenge: string };
+  try {
+    clientData = decodeClientDataJSON(clientDataJSON);
+  } catch {
+    throw new BadRequestError('Malformed WebAuthn clientDataJSON');
+  }
+  if (!isOxyApexOrigin(clientData.origin)) {
+    throw new BadRequestError('WebAuthn ceremony origin is not allowed');
+  }
+  return { origin: clientData.origin, challenge: clientData.challenge };
+}
+
+/**
+ * Atomically burn the ceremony's stored challenge. A single `findOneAndUpdate`
+ * flips `used` only if the row is still unused and unexpired — a burned/expired/
+ * unknown challenge returns null so the ceremony is rejected (no replay). `match`
+ * additionally binds the challenge to its intended flow (a linking challenge to
+ * its user, a signup challenge to no user) so one flow's challenge cannot be
+ * redirected into another.
+ */
+async function burnChallenge(
+  challenge: string,
+  type: 'registration' | 'authentication',
+  match: Record<string, unknown>,
+): Promise<boolean> {
+  const burned = await WebauthnChallenge.findOneAndUpdate(
+    { challenge, type, used: false, expiresAt: { $gt: new Date() }, ...match },
+    { $set: { used: true } },
+    { new: false },
+  ).lean();
+  return burned !== null;
+}
+
+/**
+ * The shared session-mint finalisation. Identical to the `/auth/signup` /
+ * `/auth/verify` tail: create the session, format the standard auth response,
+ * register the session into its device set + mint the rotating `deviceSecret`,
+ * and best-effort log the sign-in. Produces the SAME `AuthSuccess` shape as
+ * `POST /auth/verify`.
+ */
+async function mintWebauthnSession(
+  req: Request,
+  res: Response,
+  user: UserLike & { _id: { toString(): string } },
+  envelope: DeviceEnvelope,
+): Promise<void> {
+  const userId = user._id.toString();
+  const session = await sessionService.createSession(
+    userId,
+    req,
+    sessionCreateOptionsFromBody(envelope),
+  );
+
+  const baseResponse = buildSessionAuthResponse(session, user);
+  if (!baseResponse) {
+    throw new InternalServerError('Failed to format user data');
+  }
+  const response: SessionAuthResponse & { deviceSecret?: string } = baseResponse;
+
+  const deviceExtras = await finalizeDeviceLogin({ session, userId });
+  if (deviceExtras.deviceSecret) {
+    response.deviceSecret = deviceExtras.deviceSecret;
+  }
+
+  try {
+    await securityActivityService.logSignIn(userId, req, session.deviceId, {
+      deviceName: envelope.deviceName || session.deviceInfo?.deviceName,
+      deviceType: session.deviceInfo?.deviceType,
+      platform: session.deviceInfo?.platform,
+    });
+  } catch (error) {
+    logger.error(
+      'Failed to log security event for webauthn sign-in',
+      error instanceof Error ? error : new Error(String(error)),
+      { component: 'webauthn', method: 'mintWebauthnSession', userId },
+    );
+  }
+
+  res.json(response);
+}
+
+/**
+ * POST /webauthn/register/options
+ *
+ * Bearer → link a passkey to the signed-in account (excludes existing passkeys).
+ * No bearer → prospective signup: validate the requested username is available
+ * WITHOUT creating the user yet (a throwaway userID handle is used for the
+ * ceremony). Either way the returned `challenge` is persisted as a
+ * `registration` challenge and burned exactly once at verify time.
+ */
+router.post(
+  '/register/options',
+  registerOptionsLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = webauthnRegisterOptionsRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new BadRequestError('Invalid request body');
+    }
+
+    const rpID = getWebauthnRpId();
+    const bearerUserId = resolveOptionalBearerUserId(req);
+
+    let userName: string;
+    let userHandle: string;
+    let challengeUserId: string | undefined;
+    let excludeCredentials: { id: string; transports?: AuthenticatorTransportFuture[] }[] = [];
+
+    if (bearerUserId) {
+      // Linking branch: the signed-in account adds another passkey.
+      const user = await User.findById(bearerUserId).select('username').lean();
+      if (!user) {
+        throw new UnauthorizedError('User not found');
+      }
+      userName = user.username || bearerUserId;
+      userHandle = bearerUserId;
+      challengeUserId = bearerUserId;
+
+      const existing = await WebauthnCredential.find({ userId: bearerUserId })
+        .select('credentialID transports')
+        .lean();
+      excludeCredentials = existing.map((cred) => ({
+        id: cred.credentialID,
+        transports: cred.transports as AuthenticatorTransportFuture[] | undefined,
+      }));
+    } else {
+      // Signup branch: validate username availability but DON'T create the user.
+      const requestedUsername = parsed.data.username;
+      if (!requestedUsername) {
+        throw new BadRequestError('username is required to register a new account');
+      }
+      const normalizedUsername = normalizeUsername(requestedUsername);
+      if (!USERNAME_PATTERN.test(normalizedUsername)) {
+        throw new BadRequestError(INVALID_USERNAME_MESSAGE);
+      }
+      const taken = await User.findOne({ username: exactCaseInsensitiveUsernameRegex(normalizedUsername) })
+        .select('_id')
+        .lean();
+      if (taken) {
+        throw new ConflictError('Username already taken');
+      }
+      userName = normalizedUsername;
+      // Throwaway per-ceremony handle: the real account id does not exist yet and
+      // the credential is resolved by its own id at login, so this is opaque.
+      userHandle = crypto.randomUUID();
+      challengeUserId = undefined;
+    }
+
+    const options = await generateRegistrationOptions({
+      rpName: RP_NAME,
+      rpID,
+      userName,
+      userID: isoUint8Array.fromUTF8String(userHandle),
+      attestationType: 'none',
+      excludeCredentials,
+      authenticatorSelection: {
+        residentKey: 'required',
+        userVerification: 'preferred',
+      },
+    });
+
+    await WebauthnChallenge.create({
+      challenge: options.challenge,
+      type: 'registration',
+      ...(challengeUserId ? { userId: challengeUserId } : {}),
+      expiresAt: new Date(Date.now() + CHALLENGE_TTL_MS),
+      used: false,
+    });
+
+    res.json(options);
+  }),
+);
+
+/**
+ * POST /webauthn/register/verify
+ *
+ * Verifies the attestation, atomically burns the matching `registration`
+ * challenge, then either LINKS the passkey to the bearer's account (returns
+ * `{ success: true }`) or, for a signup, CREATES the account + credential and
+ * runs the shared session mint (returns the `/auth/verify` `AuthSuccess` shape).
+ */
+router.post(
+  '/register/verify',
+  registerVerifyLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsedEnvelope = webauthnRegisterVerifyRequestSchema.safeParse(req.body);
+    if (!parsedEnvelope.success) {
+      throw new BadRequestError('Invalid request body');
+    }
+    const envelope = parsedEnvelope.data;
+    const response = readCeremonyResponse<RegistrationResponseJSON>(req.body);
+
+    const rpID = getWebauthnRpId();
+    const bearerUserId = resolveOptionalBearerUserId(req);
+
+    const { origin, challenge } = decodeAndGuardClientData(response.response.clientDataJSON);
+
+    // Bind the challenge to its flow: a linking challenge to its user, a signup
+    // challenge to no user (`{ userId: null }` also matches a missing field).
+    const burned = await burnChallenge(challenge, 'registration', {
+      userId: bearerUserId ?? null,
+    });
+    if (!burned) {
+      throw new UnauthorizedError('Invalid or expired registration challenge');
+    }
+
+    let verification: Awaited<ReturnType<typeof verifyRegistrationResponse>>;
+    try {
+      verification = await verifyRegistrationResponse({
+        response,
+        expectedChallenge: challenge,
+        expectedOrigin: origin,
+        expectedRPID: rpID,
+      });
+    } catch (error) {
+      logger.warn('webauthn register verification threw', {
+        component: 'webauthn',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new BadRequestError('Passkey registration could not be verified');
+    }
+
+    if (!verification.verified || !verification.registrationInfo) {
+      throw new BadRequestError('Passkey registration could not be verified');
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+    const credentialName = envelope.deviceName?.trim() || DEFAULT_CREDENTIAL_NAME;
+
+    if (bearerUserId) {
+      // ---- Linking branch --------------------------------------------------
+      const user = await User.findById(bearerUserId);
+      if (!user) {
+        throw new UnauthorizedError('User not found');
+      }
+
+      try {
+        await WebauthnCredential.create({
+          userId: user._id,
+          credentialID: credential.id,
+          credentialPublicKey: Buffer.from(credential.publicKey),
+          counter: credential.counter,
+          transports: credential.transports,
+          deviceType: credentialDeviceType,
+          backedUp: credentialBackedUp,
+          name: credentialName,
+        });
+      } catch (error) {
+        if (isDuplicateKeyError(error)) {
+          throw new ConflictError('This passkey is already registered');
+        }
+        throw error;
+      }
+
+      if (!user.authMethods) {
+        user.authMethods = [];
+      }
+      user.authMethods.push(buildAuthMethod('webauthn', { credentialID: credential.id, name: credentialName }));
+      await user.save();
+      userCache.invalidate(user._id.toString());
+
+      res.json({ success: true, message: 'Passkey registered successfully' });
+      return;
+    }
+
+    // ---- Signup branch -----------------------------------------------------
+    const requestedUsername = envelope.username;
+    if (!requestedUsername) {
+      throw new BadRequestError('username is required to register a new account');
+    }
+    const normalizedUsername = normalizeUsername(requestedUsername);
+    if (!USERNAME_PATTERN.test(normalizedUsername)) {
+      throw new BadRequestError(INVALID_USERNAME_MESSAGE);
+    }
+    const taken = await User.findOne({ username: exactCaseInsensitiveUsernameRegex(normalizedUsername) })
+      .select('_id')
+      .lean();
+    if (taken) {
+      throw new ConflictError('Username already taken');
+    }
+
+    const user = new User({
+      username: normalizedUsername,
+      authMethods: [buildAuthMethod('webauthn', { credentialID: credential.id, name: credentialName })],
+    });
+    try {
+      await user.save();
+    } catch (error) {
+      if (isDuplicateKeyError(error)) {
+        throw new ConflictError('Username already taken');
+      }
+      throw error;
+    }
+
+    try {
+      await WebauthnCredential.create({
+        userId: user._id,
+        credentialID: credential.id,
+        credentialPublicKey: Buffer.from(credential.publicKey),
+        counter: credential.counter,
+        transports: credential.transports,
+        deviceType: credentialDeviceType,
+        backedUp: credentialBackedUp,
+        name: credentialName,
+      });
+    } catch (error) {
+      // Roll back the just-created account so a failed credential insert never
+      // orphans a username with no usable auth method.
+      try {
+        await User.findByIdAndDelete(user._id);
+      } catch (cleanupError) {
+        logger.error(
+          'Failed to roll back user after webauthn credential insert failure',
+          cleanupError instanceof Error ? cleanupError : new Error(String(cleanupError)),
+          { component: 'webauthn', method: 'register/verify', userId: user._id.toString() },
+        );
+      }
+      if (isDuplicateKeyError(error)) {
+        throw new ConflictError('This passkey is already registered');
+      }
+      throw error;
+    }
+
+    // Welcome notification — best-effort, mirrors SessionController.signUp.
+    try {
+      await new Notification({
+        recipientId: user._id,
+        actorId: user._id,
+        type: 'welcome',
+        entityId: user._id,
+        entityType: 'profile',
+        read: false,
+      }).save();
+    } catch (notificationError) {
+      logger.error(
+        'Failed to create welcome notification during webauthn signup',
+        notificationError instanceof Error ? notificationError : new Error(String(notificationError)),
+        { component: 'webauthn', method: 'register/verify', userId: user._id.toString() },
+      );
+    }
+
+    await mintWebauthnSession(req, res, user, envelope);
+  }),
+);
+
+/**
+ * POST /webauthn/login/options
+ *
+ * With a `username` the returned allow-list is scoped to that user's passkeys
+ * (username-first) and the challenge is bound to their account. Without one the
+ * allow-list is empty for the usernameless / discoverable-credential flow (the
+ * default). A username that resolves to no user still returns options (empty
+ * allow-list) so account existence is not leaked.
+ */
+router.post(
+  '/login/options',
+  loginOptionsLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = webauthnLoginOptionsRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new BadRequestError('Invalid request body');
+    }
+
+    const rpID = getWebauthnRpId();
+
+    let allowCredentials: { id: string; transports?: AuthenticatorTransportFuture[] }[] = [];
+    let challengeUserId: string | undefined;
+
+    if (parsed.data.username) {
+      const normalizedUsername = normalizeUsername(parsed.data.username);
+      const user = await User.findOne({ username: exactCaseInsensitiveUsernameRegex(normalizedUsername) })
+        .select('_id')
+        .lean();
+      if (user) {
+        const creds = await WebauthnCredential.find({ userId: user._id })
+          .select('credentialID transports')
+          .lean();
+        allowCredentials = creds.map((cred) => ({
+          id: cred.credentialID,
+          transports: cred.transports as AuthenticatorTransportFuture[] | undefined,
+        }));
+        challengeUserId = user._id.toString();
+      }
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID,
+      allowCredentials,
+      userVerification: 'preferred',
+    });
+
+    await WebauthnChallenge.create({
+      challenge: options.challenge,
+      type: 'authentication',
+      ...(challengeUserId ? { userId: challengeUserId } : {}),
+      expiresAt: new Date(Date.now() + CHALLENGE_TTL_MS),
+      used: false,
+    });
+
+    res.json(options);
+  }),
+);
+
+/**
+ * POST /webauthn/login/verify
+ *
+ * Resolves the credential by its public id, atomically burns the matching
+ * `authentication` challenge, verifies the assertion, enforces the signature
+ * counter (rejecting a genuine regression), persists the new counter, and runs
+ * the shared session mint — returning the SAME `AuthSuccess` shape as
+ * `POST /auth/verify`.
+ */
+router.post(
+  '/login/verify',
+  loginVerifyLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsedEnvelope = webauthnLoginVerifyRequestSchema.safeParse(req.body);
+    if (!parsedEnvelope.success) {
+      throw new BadRequestError('Invalid request body');
+    }
+    const envelope = parsedEnvelope.data;
+    const response = readCeremonyResponse<AuthenticationResponseJSON>(req.body);
+
+    const rpID = getWebauthnRpId();
+
+    // Resolve the credential by its PUBLIC base64url id (plain equality).
+    const credential = await WebauthnCredential.findOne({ credentialID: response.id });
+    if (!credential) {
+      throw new UnauthorizedError('Unknown passkey');
+    }
+
+    const { origin, challenge } = decodeAndGuardClientData(response.response.clientDataJSON);
+
+    // Burn the challenge. A username-first challenge carries the account id; it
+    // must match the credential's owner. A discoverable challenge carries none
+    // (`{ userId: null }` matches the missing field).
+    const owner = credential.userId.toString();
+    const usernameFirstBurned = await burnChallenge(challenge, 'authentication', { userId: owner });
+    const discoverableBurned = usernameFirstBurned
+      ? false
+      : await burnChallenge(challenge, 'authentication', { userId: null });
+    if (!usernameFirstBurned && !discoverableBurned) {
+      throw new UnauthorizedError('Invalid or expired authentication challenge');
+    }
+
+    let verification: Awaited<ReturnType<typeof verifyAuthenticationResponse>>;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge: challenge,
+        expectedOrigin: origin,
+        expectedRPID: rpID,
+        credential: {
+          id: credential.credentialID,
+          publicKey: new Uint8Array(credential.credentialPublicKey),
+          counter: credential.counter,
+          transports: credential.transports as AuthenticatorTransportFuture[] | undefined,
+        },
+      });
+    } catch (error) {
+      logger.warn('webauthn authentication verification threw', {
+        component: 'webauthn',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw new UnauthorizedError('Passkey authentication could not be verified');
+    }
+
+    if (!verification.verified) {
+      throw new UnauthorizedError('Passkey authentication could not be verified');
+    }
+
+    const { newCounter } = verification.authenticationInfo;
+    // Counter regression = replay/cloned authenticator. `newCounter === 0` is NOT
+    // a regression: platform authenticators keep the counter at 0 and never
+    // increment, so a stored 0 and a fresh 0 are legitimate.
+    if (newCounter !== 0 && newCounter <= credential.counter) {
+      try {
+        await securityActivityService.logSuspiciousActivity(
+          owner,
+          'WebAuthn signature counter regression detected — possible cloned authenticator',
+          { credentialId: credential.credentialID, storedCounter: credential.counter, presentedCounter: newCounter },
+          req,
+        );
+      } catch (error) {
+        logger.error(
+          'Failed to log webauthn counter-regression security event',
+          error instanceof Error ? error : new Error(String(error)),
+          { component: 'webauthn', method: 'login/verify', userId: owner },
+        );
+      }
+      throw new UnauthorizedError('Passkey authentication rejected');
+    }
+
+    credential.counter = newCounter;
+    credential.lastUsedAt = new Date();
+    await credential.save();
+
+    const user = await User.findById(owner);
+    if (!user) {
+      throw new UnauthorizedError('User not found');
+    }
+
+    await mintWebauthnSession(req, res, user, envelope);
+  }),
+);
+
+/**
+ * Narrow a thrown value to a MongoDB duplicate-key (E11000) error without an
+ * `any` cast — used to translate a unique-index collision into a 409.
+ */
+function isDuplicateKeyError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 11000
+  );
+}
+
+export default router;

--- a/packages/api/src/schemas/authLinking.schemas.ts
+++ b/packages/api/src/schemas/authLinking.schemas.ts
@@ -16,3 +16,8 @@ export const linkAuthMethodSchema = z.object({
 export const unlinkTypeParams = z.object({
   type: z.enum(['identity', 'password', 'google', 'apple', 'github']),
 });
+
+// DELETE /auth/link/webauthn/:credentialID
+export const unlinkWebauthnParams = z.object({
+  credentialID: z.string().trim().min(1),
+});

--- a/packages/api/src/services/__tests__/did.service.test.ts
+++ b/packages/api/src/services/__tests__/did.service.test.ts
@@ -123,6 +123,49 @@ describe('buildDidDocument — custodial (password-only) account', () => {
   });
 });
 
+describe('buildDidDocument — webauthn stays CUSTODIAL (Fase B/b1)', () => {
+  // A passkey is NOT a DID verification method: `collectIdentityKeys` must never
+  // read a `webauthn` auth-method row, so a passkey-only account remains
+  // custodial (controlled solely by OXY_DID), exactly like a password-only one.
+  const webauthnOnlyUser = {
+    _id: '507f1f77bcf86cd799439013',
+    username: 'wren',
+    authMethods: [{ type: 'webauthn', metadata: { credentialID: 'passkey-abc', name: 'Laptop' } }],
+    type: 'local',
+  };
+
+  it('is controlled solely by OXY_DID and derives NO self-key verification method from the passkey', () => {
+    delete process.env.OXY_PUBLIC_KEY;
+    const doc = buildDidDocument(webauthnOnlyUser);
+    const did = buildUserDid(webauthnOnlyUser._id);
+
+    expect(() => didDocumentSchema.parse(doc)).not.toThrow();
+    expect(doc.controller).toEqual([OXY_DID]);
+    // No verification method carries the passkey (no #key-1, no credential id).
+    expect(doc.verificationMethod).toEqual([]);
+    expect(doc.verificationMethod.some((vm) => vm.id === `${did}#key-1`)).toBe(false);
+    expect(JSON.stringify(doc)).not.toContain('passkey-abc');
+  });
+
+  it('a password + passkey account is still custodial (the passkey adds no key)', () => {
+    process.env.OXY_PUBLIC_KEY = newPublicKey();
+    const doc = buildDidDocument({
+      _id: '507f1f77bcf86cd799439014',
+      username: 'pax',
+      authMethods: [
+        { type: 'password', metadata: { email: 'pax@oxy.so' } },
+        { type: 'webauthn', metadata: { credentialID: 'passkey-def' } },
+      ],
+      type: 'local',
+    });
+
+    expect(doc.controller).toEqual([OXY_DID]);
+    // Only the Oxy custodial key — nothing derived from the passkey.
+    expect(doc.verificationMethod).toHaveLength(1);
+    expect(doc.verificationMethod[0]?.id).toBe(`${OXY_DID}#oxy-custodial-key`);
+  });
+});
+
 describe('buildOxyDidDocument', () => {
   it('returns the Oxy organisation DID document', () => {
     process.env.OXY_PUBLIC_KEY = newPublicKey();

--- a/packages/api/src/utils/authMethodEntries.ts
+++ b/packages/api/src/utils/authMethodEntries.ts
@@ -25,7 +25,11 @@ export interface AuthMethodEntriesInput {
   email?: string | null;
   /** Whether a usable password credential exists (resolved by the caller). */
   hasPassword: boolean;
-  authMethods?: Array<{ type?: string | null; linkedAt?: Date | null } | null> | null;
+  authMethods?: Array<{
+    type?: string | null;
+    linkedAt?: Date | null;
+    metadata?: { credentialID?: string | null; name?: string | null } | null;
+  } | null> | null;
   /** Fallback `linkedAt` for methods predating the `authMethods[]` stamp. */
   createdAt: Date;
 }
@@ -34,7 +38,10 @@ export interface AuthMethodEntriesInput {
  * Build the contract-shaped list of linked authentication methods for an
  * account. The identity entry is present when the account holds a `publicKey`;
  * the password entry when `hasPassword` and an `email` exist; one social entry
- * per linked social `authMethods[]` row.
+ * per linked social `authMethods[]` row; and one `webauthn` entry per registered
+ * passkey row (carrying its `credentialId` + `name`). A passkey is NOT a DID
+ * verification method, so its entry has no `verificationMethodId` — a
+ * passkey-only account stays custodial.
  */
 export function buildAuthMethodEntries(input: AuthMethodEntriesInput): AuthMethodEntry[] {
   const entries: AuthMethodEntry[] = [];
@@ -57,6 +64,11 @@ export function buildAuthMethodEntries(input: AuthMethodEntriesInput): AuthMetho
   for (const method of methods) {
     if (method?.type && isSocialType(method.type)) {
       entries.push({ type: method.type, linkedAt: method.linkedAt ?? input.createdAt });
+    } else if (method?.type === 'webauthn') {
+      const entry: AuthMethodEntry = { type: 'webauthn', linkedAt: method.linkedAt ?? input.createdAt };
+      if (method.metadata?.credentialID) entry.credentialId = method.metadata.credentialID;
+      if (method.metadata?.name) entry.name = method.metadata.name;
+      entries.push(entry);
     }
   }
 

--- a/packages/api/src/utils/origin.ts
+++ b/packages/api/src/utils/origin.ts
@@ -54,3 +54,37 @@ export function isLoopbackOrigin(origin: string): boolean {
   }
   return LOOPBACK_ORIGIN_PATTERN.test(normalised);
 }
+
+/**
+ * True when `origin` belongs to the Oxy apex ecosystem — the `oxy.so` registrable
+ * domain (`oxy.so` itself or any `*.oxy.so` subdomain over any scheme/port) OR a
+ * loopback dev origin (see {@link isLoopbackOrigin}). This is the WebAuthn
+ * `expectedOrigin` allow-set: a passkey minted with `WEBAUTHN_RP_ID=oxy.so` may be
+ * used from any first-party Oxy web origin, and a `localhost` dev server may
+ * exercise the ceremony locally. Fails closed: any unparseable origin, or a host
+ * merely ending in the literal `oxy.so` without the dot boundary
+ * (`notoxy.so`, `evil-oxy.so`), returns `false`.
+ *
+ * @example
+ *   isOxyApexOrigin('https://accounts.oxy.so') // true
+ *   isOxyApexOrigin('https://oxy.so')          // true
+ *   isOxyApexOrigin('http://localhost:8081')   // true
+ *   isOxyApexOrigin('https://evil-oxy.so')     // false
+ *   isOxyApexOrigin('https://oxy.so.evil.com') // false
+ */
+export function isOxyApexOrigin(origin: string): boolean {
+  if (isLoopbackOrigin(origin)) {
+    return true;
+  }
+  const normalised = normaliseOrigin(origin);
+  if (normalised === null) {
+    return false;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(normalised).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  return hostname === 'oxy.so' || hostname.endsWith('.oxy.so');
+}

--- a/packages/contracts/src/identity.ts
+++ b/packages/contracts/src/identity.ts
@@ -367,18 +367,25 @@ export type DomainVerificationInstructions = z.infer<
  * One linked authentication method. Mirrors a `User.authMethods[]` entry.
  * `verificationMethodId` is present for `identity` methods (a key) and absent
  * for `password`/social methods, linking the auth method to its DID
- * verification-method fragment.
+ * verification-method fragment. For `webauthn` methods `credentialId` identifies
+ * the specific passkey (one entry per registered credential) and `name` is its
+ * user-facing label; a passkey is NOT a DID verification method, so it carries
+ * no `verificationMethodId` (a passkey-only account stays custodial).
  */
 export interface AuthMethodEntry {
-    type: 'identity' | 'password' | 'google' | 'apple' | 'github';
+    type: 'identity' | 'password' | 'google' | 'apple' | 'github' | 'webauthn';
     linkedAt: string | Date;
     verificationMethodId?: string;
+    credentialId?: string;
+    name?: string;
 }
 
 export const authMethodEntrySchema: z.ZodType<AuthMethodEntry> = z.object({
-    type: z.enum(['identity', 'password', 'google', 'apple', 'github']),
+    type: z.enum(['identity', 'password', 'google', 'apple', 'github', 'webauthn']),
     linkedAt: z.union([z.string(), z.date()]),
     verificationMethodId: z.string().optional(),
+    credentialId: z.string().optional(),
+    name: z.string().optional(),
 });
 
 /**

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -249,3 +249,18 @@ export type {
     SecurityAlert,
     SecurityAlertAnomaly,
 } from './deviceBoot';
+
+export {
+    // Schemas
+    webauthnRegisterOptionsRequestSchema,
+    webauthnLoginOptionsRequestSchema,
+    webauthnRegisterVerifyRequestSchema,
+    webauthnLoginVerifyRequestSchema,
+} from './webauthn';
+
+export type {
+    WebauthnRegisterOptionsRequest,
+    WebauthnLoginOptionsRequest,
+    WebauthnRegisterVerifyRequest,
+    WebauthnLoginVerifyRequest,
+} from './webauthn';

--- a/packages/contracts/src/webauthn.ts
+++ b/packages/contracts/src/webauthn.ts
@@ -1,0 +1,70 @@
+/**
+ * WebAuthn / passkey ceremony contracts (Fase B/b1).
+ *
+ * These schemas describe ONLY the outer Oxy envelope that wraps a WebAuthn
+ * ceremony request — the username the client is registering/authenticating as,
+ * plus the device-session options every first-party sign-in accepts. The browser
+ * `RegistrationResponseJSON` / `AuthenticationResponseJSON` payloads are NOT
+ * mirrored here: they are validated by `@simplewebauthn/server` inside the route
+ * (`verifyRegistrationResponse` / `verifyAuthenticationResponse`), which is the
+ * single source of truth for their structure. Re-encoding them in Zod would just
+ * create a second, drift-prone definition of a shape we do not own.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Device-session options shared by every first-party sign-in body
+ * (`deviceName`/`deviceFingerprint`/`deviceId`). Mirrors what
+ * `sessionCreateOptionsFromBody` reads in the API so a WebAuthn login/verify can
+ * name and pin its resulting session exactly like `/auth/login` or `/auth/verify`.
+ */
+const deviceSessionEnvelope = {
+  deviceName: z.string().trim().min(1).max(120).optional(),
+  deviceFingerprint: z.string().trim().min(1).max(256).optional(),
+  deviceId: z.string().trim().min(1).max(256).optional(),
+} as const;
+
+/**
+ * `POST /webauthn/register/options` — request registration options. With a bearer
+ * token the caller links a passkey to their signed-in account and `username` is
+ * ignored; without one it is a prospective signup and `username` is the desired
+ * (not-yet-created) handle.
+ */
+export const webauthnRegisterOptionsRequestSchema = z.object({
+  username: z.string().trim().min(1).max(60).optional(),
+});
+export type WebauthnRegisterOptionsRequest = z.infer<typeof webauthnRegisterOptionsRequestSchema>;
+
+/**
+ * `POST /webauthn/login/options` — request authentication options. When
+ * `username` is present the server scopes `allowCredentials` to that user's
+ * passkeys (username-first); when omitted it returns an empty allow-list for the
+ * usernameless / discoverable-credential flow (the default).
+ */
+export const webauthnLoginOptionsRequestSchema = z.object({
+  username: z.string().trim().min(1).max(60).optional(),
+});
+export type WebauthnLoginOptionsRequest = z.infer<typeof webauthnLoginOptionsRequestSchema>;
+
+/**
+ * `POST /webauthn/register/verify` — the outer envelope. The browser
+ * `RegistrationResponseJSON` travels alongside these fields under `response` and
+ * is validated by `@simplewebauthn/server`, not here. `username` is required only
+ * for the prospective-signup branch (no bearer); the linking branch ignores it.
+ */
+export const webauthnRegisterVerifyRequestSchema = z.object({
+  username: z.string().trim().min(1).max(60).optional(),
+  ...deviceSessionEnvelope,
+});
+export type WebauthnRegisterVerifyRequest = z.infer<typeof webauthnRegisterVerifyRequestSchema>;
+
+/**
+ * `POST /webauthn/login/verify` — the outer envelope. The browser
+ * `AuthenticationResponseJSON` travels alongside these fields under `response`
+ * and is validated by `@simplewebauthn/server`, not here.
+ */
+export const webauthnLoginVerifyRequestSchema = z.object({
+  ...deviceSessionEnvelope,
+});
+export type WebauthnLoginVerifyRequest = z.infer<typeof webauthnLoginVerifyRequestSchema>;


### PR DESCRIPTION
## Summary
- Adds 4 new `/auth/webauthn/*` endpoints: register options, register verify, login options, login verify (passkey ceremony backend).
- New `WebauthnCredential` and `WebauthnChallenge` models back the ceremony state and stored credentials.
- `authMethods` gains a `webauthn` verification-method type (link/unlink supported).
- RP ID is `oxy.so`, resolved via `isOxyApexOrigin`.
- Session minting reuses the existing chain (`createSession` → `buildSessionAuthResponse` → `finalizeDeviceLogin`) — byte-identical to `/auth/verify`, no parallel session logic.
- Login is discoverable-credential-only — no username enumeration / account-existence leak.
- User verification is mandatory (no UV-optional downgrade).
- New dependency: `@simplewebauthn/server@13.3.2`.

**Note:** passkeys remain custodial (no DID/self-sovereign change) — this is backend-only. Frontend ceremony UI (WebAuthn browser/native API calls) is a later phase.

## Test plan
- [x] `build:all` — 11/11 packages
- [x] Lockfile frozen-install check — clean, no drift
- [x] Full test suite: api 1507/1507 (incl. 18 webauthn tests), core 830/830, contracts 135/135, services 202/202, accounts 135/135, auth bun-test 45/45, node 40/40, protocol 99/99 (commons has only 3 pre-existing unrelated failures)
- [x] `tsc --noEmit` clean on `packages/api` and `packages/contracts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)