### PR TITLE
feat(sdk): WebAuthn passkey client — core methods + services ceremony/dialog (Fase B/b1-fe)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -602,6 +602,7 @@
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "^11.0.0",
+        "@simplewebauthn/browser": "^13.3.0",
         "color": "^4.2.3",
       },
       "devDependencies": {
@@ -1960,6 +1961,8 @@
     "@simple-libs/child-process-utils": ["@simple-libs/child-process-utils@1.0.1", "", { "dependencies": { "@simple-libs/stream-utils": "^1.1.0", "@types/node": "^22.0.0" } }, ""],
 
     "@simple-libs/stream-utils": ["@simple-libs/stream-utils@1.1.0", "", { "dependencies": { "@types/node": "^22.0.0" } }, ""],
+
+    "@simplewebauthn/browser": ["@simplewebauthn/browser@13.3.0", "", {}, "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ=="],
 
     "@simplewebauthn/server": ["@simplewebauthn/server@13.3.2", "", { "dependencies": { "@hexagon/base64": "^1.1.27", "@levischuck/tiny-cbor": "^0.2.2", "@peculiar/asn1-android": "^2.6.0", "@peculiar/asn1-ecc": "^2.6.1", "@peculiar/asn1-rsa": "^2.6.1", "@peculiar/asn1-schema": "^2.6.0", "@peculiar/asn1-x509": "^2.6.1", "@peculiar/x509": "^1.14.3" } }, "sha512-KEDhfcGP1PAKRVSDjA3npTQFqS2b/srm+ipoNBNHdkzrHAlaRQUTE+a5f4ywsx6thxAw1NU2rYcLEY1949RGbQ=="],
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -517,6 +517,11 @@ export type { QuickAccount, DisplayNameUserShape } from './utils/accountUtils';
 export { registrableApex } from './utils/registrableApex';
 export { CENTRAL_IDP_APEX } from './utils/authWebUrl';
 
+// WebAuthn relying-party origin guard (client side). Mirrors the server's
+// `isOxyApexOrigin` so consumers can decide whether to offer passkey UI on the
+// current page (first-party Oxy origin / loopback only).
+export { isOxyRpOrigin } from './utils/webauthnOrigin';
+
 export { runColdBoot } from './utils/coldBoot';
 export type {
     ColdBootStep,

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -1197,6 +1197,139 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
     }
 
     /**
+     * Begin a WebAuthn / passkey REGISTRATION ceremony. Requests the
+     * `PublicKeyCredentialCreationOptions` the browser's `navigator.credentials
+     * .create()` (or `@simplewebauthn/browser`'s `startRegistration`) needs.
+     *
+     * With a bearer token planted this links a passkey to the signed-in account
+     * (`username` ignored); without one it is a prospective signup and `username`
+     * is the desired handle. The returned options are OPAQUE — Oxy does not own
+     * their shape (the browser / `@simplewebauthn` does), so they pass through
+     * as `unknown` for the caller to hand straight to the ceremony.
+     */
+    async webauthnRegisterOptions(username?: string): Promise<unknown> {
+      try {
+        return await this.makeRequest<unknown>(
+          'POST',
+          '/auth/webauthn/register/options',
+          { ...(username !== undefined ? { username } : {}) },
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Finish a WebAuthn / passkey REGISTRATION ceremony. Forwards the opaque
+     * browser `RegistrationResponseJSON` (`response`) alongside the Oxy envelope
+     * (desired `username` for signup + the device-session naming fields).
+     *
+     * Two server branches, disambiguated by the response shape:
+     *  - **Signup** (no bearer): the account is created and a session minted —
+     *    the response carries `sessionId`, is the SAME {@link LoginResult}
+     *    contract as `POST /auth/verify`, and its access token is planted here.
+     *  - **Link** (bearer present): the passkey is attached to the signed-in
+     *    account and the server returns `{ success, message }` with no session,
+     *    which is returned verbatim (no token planting).
+     */
+    async webauthnRegisterVerify(
+      response: unknown,
+      envelope: {
+        username?: string;
+        deviceName?: string;
+        deviceFingerprint?: string;
+        deviceId?: string;
+      } = {},
+    ): Promise<{ success: true; message: string } | LoginResult> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          '/auth/webauthn/register/verify',
+          { response, ...envelope },
+          { cache: false },
+        );
+        if (res && typeof res === 'object') {
+          const record = res as Record<string, unknown>;
+          // Signup branch: mints a session (LoginSessionResult, carries
+          // `sessionId`). Parse against the login contract and plant the token.
+          if ('sessionId' in record) {
+            const parsed = safeParseContract(loginResultSchema, record);
+            if (!parsed) {
+              throw new Error('auth/webauthn/register/verify returned an unexpected response shape');
+            }
+            if (!('twoFactorRequired' in parsed) && parsed.accessToken) {
+              this.setTokens(parsed.accessToken);
+            }
+            return parsed;
+          }
+          // Link branch: passkey attached to the signed-in account, no session.
+          if (record.success === true && typeof record.message === 'string') {
+            return { success: true, message: record.message };
+          }
+        }
+        throw new Error('auth/webauthn/register/verify returned an unexpected response shape');
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Begin a WebAuthn / passkey AUTHENTICATION ceremony. Requests the
+     * `PublicKeyCredentialRequestOptions` the browser's `navigator.credentials
+     * .get()` (or `@simplewebauthn/browser`'s `startAuthentication`) needs.
+     *
+     * When `username` is present the server scopes `allowCredentials` to that
+     * user's passkeys (username-first); when omitted it returns an empty
+     * allow-list for the usernameless / discoverable-credential flow. The
+     * returned options are OPAQUE and pass through as `unknown`.
+     */
+    async webauthnLoginOptions(username?: string): Promise<unknown> {
+      try {
+        return await this.makeRequest<unknown>(
+          'POST',
+          '/auth/webauthn/login/options',
+          { ...(username !== undefined ? { username } : {}) },
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Finish a WebAuthn / passkey AUTHENTICATION ceremony. Forwards the opaque
+     * browser `AuthenticationResponseJSON` (`response`) alongside the
+     * device-session envelope. Resolves to the SAME {@link LoginResult} contract
+     * as `POST /auth/verify`; on the session arm the access token is planted
+     * immediately (mirroring {@link passwordSignIn}), and the response's
+     * `deviceId` + `deviceSecret` are the zero-cookie restore credential.
+     */
+    async webauthnLoginVerify(
+      response: unknown,
+      envelope: { deviceName?: string; deviceFingerprint?: string; deviceId?: string } = {},
+    ): Promise<LoginResult> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          '/auth/webauthn/login/verify',
+          { response, ...envelope },
+          { cache: false },
+        );
+        const parsed = safeParseContract(loginResultSchema, res);
+        if (!parsed) {
+          throw new Error('auth/webauthn/login/verify returned an unexpected response shape');
+        }
+        if (!('twoFactorRequired' in parsed) && parsed.accessToken) {
+          this.setTokens(parsed.accessToken);
+        }
+        return parsed;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
      * Exchange an OAuth authorization code (returned to the RP redirect URI
      * after password sign-in at auth.oxy.so) for a device-first session.
      * Public first-party clients use PKCE (`codeVerifier`); the access token is

--- a/packages/core/src/mixins/__tests__/webauthnAuth.test.ts
+++ b/packages/core/src/mixins/__tests__/webauthnAuth.test.ts
@@ -1,0 +1,206 @@
+/**
+ * WebAuthn / passkey auth methods on OxyServices
+ * (`webauthnRegisterOptions` / `webauthnRegisterVerify` /
+ * `webauthnLoginOptions` / `webauthnLoginVerify`).
+ *
+ * Stubs `makeRequest` (HTTP-mock style, like `passwordSignIn.test.ts`) and
+ * asserts: each method hits the right endpoint with the right body; the opaque
+ * ceremony `response` is forwarded verbatim; the login/verify + register/verify
+ * (signup) paths parse the login contract and plant the access token on the
+ * session arm; register/verify (link) returns `{ success, message }` WITHOUT
+ * planting a token.
+ */
+import type { LoginResult } from '@oxyhq/contracts';
+import { OxyServices } from '../../OxyServices';
+
+const SESSION_ARM: LoginResult = {
+  sessionId: 'sess-1',
+  deviceId: 'dev-1',
+  expiresAt: '2030-01-01T00:00:00.000Z',
+  accessToken: 'access-1',
+  deviceSecret: 'ds-secret-1',
+  user: { id: 'user-1', username: 'u' },
+};
+
+const LINK_RESULT = { success: true as const, message: 'Passkey registered successfully' };
+
+// Opaque browser ceremony payloads — Oxy never inspects these, so shape is
+// irrelevant beyond "forwarded verbatim under `response`".
+const CREATE_RESPONSE = { id: 'cred-abc', rawId: 'cred-abc', response: { attestationObject: 'ao' }, type: 'public-key' };
+const GET_RESPONSE = { id: 'cred-abc', rawId: 'cred-abc', response: { signature: 'sig' }, type: 'public-key' };
+
+describe('webauthnRegisterOptions', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequest = jest.spyOn(oxy, 'makeRequest');
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('POSTs to /auth/webauthn/register/options with the username', async () => {
+    const options = { challenge: 'c', rp: { id: 'oxy.so' } };
+    makeRequest.mockResolvedValueOnce(options);
+    const result = await oxy.webauthnRegisterOptions('alice');
+    expect(result).toBe(options);
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/register/options',
+      { username: 'alice' },
+      { cache: false },
+    );
+  });
+
+  it('omits username from the body when not provided (link flow)', async () => {
+    makeRequest.mockResolvedValueOnce({ challenge: 'c' });
+    await oxy.webauthnRegisterOptions();
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/register/options',
+      {},
+      { cache: false },
+    );
+  });
+});
+
+describe('webauthnLoginOptions', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequest = jest.spyOn(oxy, 'makeRequest');
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('POSTs to /auth/webauthn/login/options with the username (username-first)', async () => {
+    const options = { challenge: 'c', allowCredentials: [{ id: 'cred-abc' }] };
+    makeRequest.mockResolvedValueOnce(options);
+    const result = await oxy.webauthnLoginOptions('alice');
+    expect(result).toBe(options);
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/login/options',
+      { username: 'alice' },
+      { cache: false },
+    );
+  });
+
+  it('omits username for the usernameless / discoverable flow', async () => {
+    makeRequest.mockResolvedValueOnce({ challenge: 'c', allowCredentials: [] });
+    await oxy.webauthnLoginOptions();
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/login/options',
+      {},
+      { cache: false },
+    );
+  });
+});
+
+describe('webauthnRegisterVerify', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+  let setTokens: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequest = jest.spyOn(oxy, 'makeRequest');
+    setTokens = jest.spyOn(oxy, 'setTokens').mockImplementation(() => undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('signup branch: parses LoginSessionResult, plants the token, threads the envelope', async () => {
+    makeRequest.mockResolvedValueOnce(SESSION_ARM);
+    const result = await oxy.webauthnRegisterVerify(CREATE_RESPONSE, {
+      username: 'alice',
+      deviceName: 'Phone',
+      deviceFingerprint: 'fp-1',
+    });
+    expect(result).toEqual(SESSION_ARM);
+    expect('twoFactorRequired' in result).toBe(false);
+    if (!('twoFactorRequired' in result) && 'sessionId' in result) {
+      expect(result.deviceId).toBe('dev-1');
+      expect(result.deviceSecret).toBe('ds-secret-1');
+    }
+    expect(setTokens).toHaveBeenCalledWith('access-1');
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/register/verify',
+      { response: CREATE_RESPONSE, username: 'alice', deviceName: 'Phone', deviceFingerprint: 'fp-1' },
+      { cache: false },
+    );
+  });
+
+  it('link branch: returns { success, message } WITHOUT planting a token', async () => {
+    makeRequest.mockResolvedValueOnce(LINK_RESULT);
+    const result = await oxy.webauthnRegisterVerify(CREATE_RESPONSE, { deviceName: 'Laptop' });
+    expect(result).toEqual(LINK_RESULT);
+    expect(setTokens).not.toHaveBeenCalled();
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/register/verify',
+      { response: CREATE_RESPONSE, deviceName: 'Laptop' },
+      { cache: false },
+    );
+  });
+
+  it('throws on an unexpected response shape', async () => {
+    makeRequest.mockResolvedValueOnce({ nope: true });
+    await expect(oxy.webauthnRegisterVerify(CREATE_RESPONSE)).rejects.toThrow();
+    expect(setTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe('webauthnLoginVerify', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+  let setTokens: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequest = jest.spyOn(oxy, 'makeRequest');
+    setTokens = jest.spyOn(oxy, 'setTokens').mockImplementation(() => undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('parses LoginSessionResult, plants the token, and threads the device envelope', async () => {
+    makeRequest.mockResolvedValueOnce(SESSION_ARM);
+    const result = await oxy.webauthnLoginVerify(GET_RESPONSE, {
+      deviceName: 'Phone',
+      deviceFingerprint: 'fp-1',
+      deviceId: 'dev-persisted',
+    });
+    expect(result).toEqual(SESSION_ARM);
+    expect('twoFactorRequired' in result).toBe(false);
+    if (!('twoFactorRequired' in result)) {
+      expect(result.deviceId).toBe('dev-1');
+      expect(result.deviceSecret).toBe('ds-secret-1');
+    }
+    expect(setTokens).toHaveBeenCalledWith('access-1');
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/login/verify',
+      { response: GET_RESPONSE, deviceName: 'Phone', deviceFingerprint: 'fp-1', deviceId: 'dev-persisted' },
+      { cache: false },
+    );
+  });
+
+  it('POSTs the bare response body when no envelope is passed', async () => {
+    makeRequest.mockResolvedValueOnce(SESSION_ARM);
+    await oxy.webauthnLoginVerify(GET_RESPONSE);
+    expect(makeRequest).toHaveBeenCalledWith(
+      'POST',
+      '/auth/webauthn/login/verify',
+      { response: GET_RESPONSE },
+      { cache: false },
+    );
+  });
+
+  it('throws on an unexpected response shape', async () => {
+    makeRequest.mockResolvedValueOnce({ nope: true });
+    await expect(oxy.webauthnLoginVerify(GET_RESPONSE)).rejects.toThrow();
+    expect(setTokens).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/utils/__tests__/webauthnOrigin.test.ts
+++ b/packages/core/src/utils/__tests__/webauthnOrigin.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `isOxyRpOrigin()` — client-side WebAuthn relying-party origin guard.
+ *
+ * Runs under the `node` test environment, where `globalThis.location` is
+ * genuinely absent by default (mirroring native/SSR). Each case defines a fake
+ * `location` with the host under test and restores the original afterwards.
+ */
+import { isOxyRpOrigin } from '../webauthnOrigin';
+
+describe('isOxyRpOrigin', () => {
+  const originalLocation = globalThis.location;
+
+  const setHostname = (hostname: unknown): void => {
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: hostname === undefined ? undefined : { hostname },
+    });
+  };
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('returns true on the apex oxy.so', () => {
+    setHostname('oxy.so');
+    expect(isOxyRpOrigin()).toBe(true);
+  });
+
+  it('returns true on an oxy.so subdomain', () => {
+    setHostname('accounts.oxy.so');
+    expect(isOxyRpOrigin()).toBe(true);
+  });
+
+  it('returns true on a deep oxy.so subdomain', () => {
+    setHostname('sub.accounts.oxy.so');
+    expect(isOxyRpOrigin()).toBe(true);
+  });
+
+  it('returns true on loopback hosts', () => {
+    for (const host of ['localhost', '127.0.0.1', '[::1]']) {
+      setHostname(host);
+      expect(isOxyRpOrigin()).toBe(true);
+    }
+  });
+
+  it('is case-insensitive on the host', () => {
+    setHostname('Accounts.OXY.So');
+    expect(isOxyRpOrigin()).toBe(true);
+  });
+
+  it('returns false on an unrelated origin', () => {
+    setHostname('evil.com');
+    expect(isOxyRpOrigin()).toBe(false);
+  });
+
+  it('returns false on a look-alike suffix without the dot boundary', () => {
+    setHostname('evil-oxy.so');
+    expect(isOxyRpOrigin()).toBe(false);
+  });
+
+  it('returns false when oxy.so is only a subdomain label of an attacker apex', () => {
+    setHostname('oxy.so.evil.com');
+    expect(isOxyRpOrigin()).toBe(false);
+  });
+
+  it('returns false when there is no location (native / SSR)', () => {
+    setHostname(undefined);
+    expect(isOxyRpOrigin()).toBe(false);
+  });
+
+  it('returns false when the hostname is not a string', () => {
+    setHostname(123);
+    expect(isOxyRpOrigin()).toBe(false);
+  });
+
+  it('returns false when the hostname is empty', () => {
+    setHostname('');
+    expect(isOxyRpOrigin()).toBe(false);
+  });
+});

--- a/packages/core/src/utils/webauthnOrigin.ts
+++ b/packages/core/src/utils/webauthnOrigin.ts
@@ -1,0 +1,52 @@
+/**
+ * WebAuthn relying-party origin guard (client side).
+ *
+ * The passkey ceremonies (`OxyServices.webauthn*`) are only meaningful when the
+ * page is served from a first-party Oxy web origin: a credential minted with
+ * `WEBAUTHN_RP_ID=oxy.so` can only be created/asserted from `oxy.so`, one of its
+ * subdomains, or a loopback dev server. This is the browser-side mirror of the
+ * server's `isOxyApexOrigin` (`packages/api/src/utils/origin.ts`), which forms
+ * the server's `expectedOrigin` allow-set — consumers use it to decide whether to
+ * even offer the passkey UI on the current page.
+ *
+ * It reads `globalThis.location` directly (no argument) because that is the only
+ * origin the browser will let a WebAuthn ceremony run against. On native / SSR /
+ * any environment without a DOM `location`, it returns `false` (there is no
+ * relying-party origin, so passkeys are not applicable).
+ */
+
+/**
+ * True iff the current page's host is a first-party Oxy relying-party origin:
+ * `oxy.so`, any `*.oxy.so` subdomain, or a loopback dev host
+ * (`localhost` / `127.0.0.1` / `[::1]`).
+ *
+ * Fails closed: no `location` (native/SSR), a non-string/empty hostname, or a
+ * host that merely ends in the literal `oxy.so` without the dot boundary
+ * (`evil-oxy.so`, `oxy.so.evil.com`) all return `false`.
+ *
+ * @example
+ *   isOxyRpOrigin() // true  on https://accounts.oxy.so
+ *   isOxyRpOrigin() // true  on http://localhost:8081
+ *   isOxyRpOrigin() // false on https://evil.com
+ *   isOxyRpOrigin() // false in a React Native / SSR context (no location)
+ */
+export function isOxyRpOrigin(): boolean {
+  // `globalThis.location` is typed `Location` by the DOM lib, but is genuinely
+  // `undefined` on native/SSR — widen to a nullable local so the guard is a real
+  // runtime check, not a type-level no-op.
+  const location: Location | undefined = globalThis.location;
+  if (!location || typeof location.hostname !== 'string') {
+    return false;
+  }
+
+  const hostname = location.hostname.toLowerCase();
+  if (hostname.length === 0) {
+    return false;
+  }
+
+  if (hostname === 'oxy.so' || hostname.endsWith('.oxy.so')) {
+    return true;
+  }
+
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}

--- a/packages/services/__tests__/components/OxyAccountDialogPasskey.test.tsx
+++ b/packages/services/__tests__/components/OxyAccountDialogPasskey.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * `OxyAccountDialog` — the "Sign in with a passkey" button gating.
+ *
+ * The button is offered ONLY on a first-party Oxy web origin
+ * (`isWebBrowser() && isOxyRpOrigin()`); on a non-Oxy web origin or on native it
+ * is hidden entirely. When shown, a press drives `useOxy().signInWithPasskey()`
+ * and — on success — closes the dialog. These tests toggle the two gate probes
+ * directly rather than depending on the jsdom URL.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { AccountDialogSnapshot } from '@oxyhq/core';
+
+const signInWithPasskey = jest.fn(async () => undefined);
+const closeAccountDialog = jest.fn();
+
+const signInSnapshot: AccountDialogSnapshot = {
+  view: 'signin',
+  accounts: [],
+  activeAccountId: null,
+  loading: false,
+  error: null,
+  switchingAccountId: null,
+  signIn: { phase: 'idle', authorizeCode: null, qrPayload: null, expiresAt: null, error: null },
+};
+
+const controller = {
+  subscribe: (_l: () => void) => () => undefined,
+  getSnapshot: () => signInSnapshot,
+  switchTo: jest.fn(async () => undefined),
+  add: jest.fn(),
+  showQr: jest.fn(),
+  signInWithOxy: jest.fn(),
+  setView: jest.fn(),
+  cancelSignIn: jest.fn(),
+  openPasswordAtOxyAuth: jest.fn(() => 'https://auth.oxy.so/login'),
+};
+
+jest.mock('../../src/ui/context/OxyContext', () => ({
+  __esModule: true,
+  useOxy: () => ({
+    accountDialogController: controller,
+    isAccountDialogOpen: true,
+    closeAccountDialog,
+    showBottomSheet: jest.fn(),
+    logoutAll: jest.fn(async () => undefined),
+    refreshAccounts: jest.fn(async () => undefined),
+    signInWithPasskey,
+  }),
+}));
+
+jest.mock('../../src/ui/hooks/useI18n', () => ({
+  __esModule: true,
+  useI18n: () => ({ t: () => '', locale: 'en' }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  __esModule: true,
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+jest.mock('react-native-qrcode-svg', () => ({ __esModule: true, default: () => null }));
+jest.mock('@expo/vector-icons', () => ({ __esModule: true, MaterialCommunityIcons: () => null }));
+jest.mock('../../src/ui/components/logo/LogoIcon', () => ({ LogoIcon: () => null }));
+
+// The two environment gate probes, toggled per test.
+const isWebBrowserMock = jest.fn(() => true);
+jest.mock('../../src/ui/utils/isWebBrowser', () => ({
+  __esModule: true,
+  isWebBrowser: () => isWebBrowserMock(),
+}));
+
+const isOxyRpOriginMock = jest.fn(() => true);
+jest.mock('@oxyhq/core', () => {
+  const actual = jest.requireActual('@oxyhq/core');
+  return { __esModule: true, ...actual, isOxyRpOrigin: () => isOxyRpOriginMock() };
+});
+
+// eslint-disable-next-line import/first
+import OxyAccountDialog from '../../src/ui/components/OxyAccountDialog';
+
+describe('OxyAccountDialog — passkey button gating', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    isWebBrowserMock.mockReturnValue(true);
+    isOxyRpOriginMock.mockReturnValue(true);
+  });
+
+  it('renders the passkey button on a first-party Oxy web origin', () => {
+    render(<OxyAccountDialog />);
+
+    const button = screen.getByTestId('passkey-signin-button');
+    expect(button).toBeTruthy();
+    expect(button.textContent).toContain('Sign in with a passkey');
+    // The primary device flow is still present.
+    expect(screen.getByRole('button', { name: 'Sign in with Oxy' })).toBeTruthy();
+  });
+
+  it('drives signInWithPasskey and closes the dialog on a successful press', async () => {
+    render(<OxyAccountDialog />);
+
+    fireEvent.click(screen.getByTestId('passkey-signin-button'));
+
+    await waitFor(() => expect(signInWithPasskey).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(closeAccountDialog).toHaveBeenCalledTimes(1));
+  });
+
+  it('hides the passkey button on a non-Oxy web origin', () => {
+    isOxyRpOriginMock.mockReturnValue(false);
+
+    render(<OxyAccountDialog />);
+
+    expect(screen.queryByTestId('passkey-signin-button')).toBeNull();
+    // Sign-in itself is unaffected — only the passkey affordance is gated.
+    expect(screen.getByRole('button', { name: 'Sign in with Oxy' })).toBeTruthy();
+  });
+
+  it('hides the passkey button on native (not a web browser)', () => {
+    isWebBrowserMock.mockReturnValue(false);
+
+    render(<OxyAccountDialog />);
+
+    expect(screen.queryByTestId('passkey-signin-button')).toBeNull();
+  });
+});

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -128,6 +128,7 @@
   "dependencies": {
     "@oxyhq/contracts": "workspace:*",
     "@oxyhq/core": "^11.0.0",
+    "@simplewebauthn/browser": "^13.3.0",
     "color": "^4.2.3"
   },
   "devDependencies": {

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -95,6 +95,7 @@ export {
     useRecentSecurityActivity,
     useInfiniteSecurityActivity,
 } from './ui/hooks/queries/useSecurityQueries';
+export { useAuthMethods } from './ui/hooks/queries/useAuthMethods';
 export {
     useUserSubscription,
     useUserPayments,
@@ -166,6 +167,7 @@ export {
     invalidateStorageQueries,
     invalidatePaymentsQueries,
     invalidateConnectedAppsQueries,
+    invalidateAuthMethodsQueries,
 } from './ui/hooks/queries/queryKeys';
 
 // Mutation status aggregator (for "Syncing..." indicators)

--- a/packages/services/src/ui/components/OxyAccountDialog.tsx
+++ b/packages/services/src/ui/components/OxyAccountDialog.tsx
@@ -62,9 +62,11 @@ import {
   type AppColorName,
 } from '@oxyhq/bloom/theme';
 import type { SwitchableAccount, AccountDialogSnapshot } from '@oxyhq/core';
+import { isOxyRpOrigin } from '@oxyhq/core';
 import { useQueryClient } from '@tanstack/react-query';
 import { useOxy } from '../context/OxyContext';
 import { useI18n } from '../hooks/useI18n';
+import { isWebBrowser } from '../utils/isWebBrowser';
 import { LogoIcon } from './logo/LogoIcon';
 
 /** Diameter of a row avatar. */
@@ -112,10 +114,37 @@ const OxyAccountDialog: React.FC = () => {
     showBottomSheet,
     logoutAll,
     refreshAccounts,
+    signInWithPasskey,
   } = useOxy();
   const theme = useTheme();
   const { t } = useI18n();
   const queryClient = useQueryClient();
+
+  // Passkey sign-in is offered ONLY on a first-party Oxy web origin (a credential
+  // minted for `oxy.so` can only be asserted there or on a loopback dev host).
+  // Off the web / on a non-Oxy origin the button is hidden entirely (a hub popup
+  // for arbitrary web origins is a later phase). This is environment-static.
+  const passkeyAvailable = useMemo(() => isWebBrowser() && isOxyRpOrigin(), []);
+  const [passkeyPending, setPasskeyPending] = useState(false);
+  const [passkeyError, setPasskeyError] = useState<string | null>(null);
+
+  const handleSignInWithPasskey = useCallback(async () => {
+    if (passkeyPending) return;
+    setPasskeyPending(true);
+    setPasskeyError(null);
+    try {
+      await signInWithPasskey();
+      closeAccountDialog();
+    } catch (error) {
+      // A cancelled/failed ceremony keeps the dialog open so the user can retry
+      // or fall back to another method — surface a concise message, never swallow.
+      setPasskeyError(
+        error instanceof Error && error.message ? error.message : 'Passkey sign-in failed.',
+      );
+    } finally {
+      setPasskeyPending(false);
+    }
+  }, [passkeyPending, signInWithPasskey, closeAccountDialog]);
 
   // Bind the headless controller. `getSnapshot` returns a stable reference
   // between changes, so it is `useSyncExternalStore`-safe. Guard the no-provider
@@ -222,6 +251,9 @@ const OxyAccountDialog: React.FC = () => {
             onSignInWithOxy={() => void controller.signInWithOxy()}
             onScanQr={() => void controller.showQr()}
             onUsePassword={() => void controller.openPasswordAtOxyAuth()}
+            onSignInWithPasskey={passkeyAvailable ? () => void handleSignInWithPasskey() : undefined}
+            passkeyPending={passkeyPending}
+            passkeyError={passkeyError}
           />
         )}
       </ScrollView>
@@ -416,6 +448,10 @@ interface SignInViewProps {
   onSignInWithOxy: () => void;
   onScanQr: () => void;
   onUsePassword: () => void;
+  /** When present, offer a "Sign in with a passkey" button (first-party Oxy web only). */
+  onSignInWithPasskey?: () => void;
+  passkeyPending: boolean;
+  passkeyError: string | null;
 }
 
 const SignInView: React.FC<SignInViewProps> = ({
@@ -426,6 +462,9 @@ const SignInView: React.FC<SignInViewProps> = ({
   onSignInWithOxy,
   onScanQr,
   onUsePassword,
+  onSignInWithPasskey,
+  passkeyPending,
+  passkeyError,
 }) => (
   <View style={styles.signInBlock}>
     {snapshot.accounts.length > 0 ? (
@@ -447,6 +486,24 @@ const SignInView: React.FC<SignInViewProps> = ({
     <Button variant="primary" onPress={onSignInWithOxy} style={styles.primaryButton}>
       Sign in with Oxy
     </Button>
+
+    {onSignInWithPasskey ? (
+      <Button
+        variant="secondary"
+        onPress={onSignInWithPasskey}
+        disabled={passkeyPending}
+        style={styles.secondaryButton}
+        testID="passkey-signin-button"
+      >
+        {passkeyPending
+          ? t('accountSwitcher.passkeySigningIn') || 'Signing in…'
+          : t('accountSwitcher.signInWithPasskey') || 'Sign in with a passkey'}
+      </Button>
+    ) : null}
+
+    {passkeyError ? (
+      <Text style={[styles.errorText, { color: theme.colors.error }]}>{passkeyError}</Text>
+    ) : null}
 
     <Button variant="secondary" onPress={onScanQr} style={styles.secondaryButton}>
       {t('accountSwitcher.scanQr') || 'Scan a QR from another device'}

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -65,6 +65,13 @@ import type {
 } from './oxyContextTypes';
 import { DEFAULT_SESSION_VALIDITY_MS, loadUseFollowHook } from './oxyContextHelpers';
 import { commitDeviceSetAndResolve } from './commitSessionFlow';
+import { runPasskeyLogin, runPasskeyRegister, runPasskeyAdd } from './passkeyFlow';
+import {
+  isPasskeySupported,
+  runRegistrationCeremony,
+  runAuthenticationCeremony,
+} from '../../webauthn/passkeyClient';
+import { queryKeys } from '../hooks/queries/queryKeys';
 import { useOxyAccountGraph } from './useOxyAccountGraph';
 
 export type { OxyContextState, PasswordSignInResult, OxyContextProviderProps } from './oxyContextTypes';
@@ -735,6 +742,66 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     [oxyServices, commitSession],
   );
 
+  // ── Passkey (WebAuthn) ─────────────────────────────────────────────────────
+  // Web-only sign-in / registration via the browser WebAuthn ceremony. The fixed
+  // `options → ceremony → verify → commit` ordering lives in the pure
+  // `passkeyFlow` helpers (deps-injected, unit-tested); these wrappers supply the
+  // real deps (core `webauthn*` methods, the platform ceremony client, and the
+  // `commitSession` funnel). All three GATE on `isPasskeySupported()` so a native
+  // / unsupported surface throws loudly instead of stalling in a ceremony.
+
+  // Usernameless (discoverable) passkey sign-in.
+  const signInWithPasskey = useCallback(
+    async (opts?: { deviceName?: string; deviceFingerprint?: string }): Promise<void> => {
+      const persisted = await authStore.load();
+      await runPasskeyLogin({
+        isSupported: isPasskeySupported,
+        getLoginOptions: () => oxyServices.webauthnLoginOptions(),
+        runCeremony: runAuthenticationCeremony,
+        loginVerify: (response, envelope) => oxyServices.webauthnLoginVerify(response, envelope),
+        commit: (input) => commitSession(input, { activate: true, hubSync: true }),
+        deviceId: persisted?.deviceId,
+        deviceName: opts?.deviceName,
+        deviceFingerprint: opts?.deviceFingerprint,
+      });
+    },
+    [oxyServices, authStore, commitSession],
+  );
+
+  // Create a brand-new account whose first auth method is a passkey.
+  const registerWithPasskey = useCallback(
+    async (params: { username: string; deviceName?: string }): Promise<void> => {
+      await runPasskeyRegister({
+        isSupported: isPasskeySupported,
+        getRegisterOptions: (username) => oxyServices.webauthnRegisterOptions(username),
+        runCeremony: runRegistrationCeremony,
+        registerVerify: (response, envelope) => oxyServices.webauthnRegisterVerify(response, envelope),
+        commit: (input) => commitSession(input, { activate: true, hubSync: true }),
+        username: params.username,
+        deviceName: params.deviceName,
+      });
+    },
+    [oxyServices, commitSession],
+  );
+
+  // Add a passkey to the already-signed-in account (bearer present). No new
+  // session is committed — just refresh the linked auth-methods list.
+  const addPasskey = useCallback(
+    async (params?: { deviceName?: string }): Promise<void> => {
+      await runPasskeyAdd({
+        isSupported: isPasskeySupported,
+        getRegisterOptions: () => oxyServices.webauthnRegisterOptions(),
+        runCeremony: runRegistrationCeremony,
+        registerVerify: (response, envelope) => oxyServices.webauthnRegisterVerify(response, envelope),
+        onLinked: () => {
+          void queryClient.invalidateQueries({ queryKey: queryKeys.authMethods.all });
+        },
+        deviceName: params?.deviceName,
+      });
+    },
+    [oxyServices, queryClient],
+  );
+
   // ── Cold boot ────────────────────────────────────────────────────────────
   // Device-first session restore via `runProviderColdBoot` (see boot/runProviderColdBoot.ts).
   const runColdBoot = useCallback(async (): Promise<void> => {
@@ -885,6 +952,9 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       signIn,
       signInWithPassword,
       completeTwoFactorSignIn,
+      signInWithPasskey,
+      registerWithPasskey,
+      addPasskey,
       revokeSuspiciousSignIn,
       handleWebSession,
       logout,
@@ -937,6 +1007,9 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       signIn,
       signInWithPassword,
       completeTwoFactorSignIn,
+      signInWithPasskey,
+      registerWithPasskey,
+      addPasskey,
       revokeSuspiciousSignIn,
       handleWebSession,
       logout,
@@ -1007,6 +1080,9 @@ const LOADING_STATE: OxyContextState = {
   signIn: () => rejectMissingProvider<User>(),
   signInWithPassword: () => rejectMissingProvider<PasswordSignInResult>(),
   completeTwoFactorSignIn: () => rejectMissingProvider<{ securityAlert?: SecurityAlert }>(),
+  signInWithPasskey: () => rejectMissingProvider<void>(),
+  registerWithPasskey: () => rejectMissingProvider<void>(),
+  addPasskey: () => rejectMissingProvider<void>(),
   revokeSuspiciousSignIn: () => rejectMissingProvider<void>(),
   handleWebSession: () => rejectMissingProvider<void>(),
   logout: () => rejectMissingProvider<void>(),

--- a/packages/services/src/ui/context/__tests__/passkeyFlow.test.ts
+++ b/packages/services/src/ui/context/__tests__/passkeyFlow.test.ts
@@ -1,0 +1,237 @@
+/**
+ * `passkeyFlow` — the pure, deps-injected passkey (WebAuthn) orchestration that
+ * backs `useOxy().signInWithPasskey` / `registerWithPasskey` / `addPasskey`.
+ *
+ * These tests assert the fixed `options → ceremony → verify → commit` ordering,
+ * the exact `commitSession` input projected from a session-arm login result, the
+ * `isSupported()` gate, and the branch discipline (sign-in/register commit a
+ * session; add links WITHOUT committing and fires `onLinked`) — the same
+ * deps-injection style `commitSessionFlow.test.ts` uses.
+ */
+
+import type { LoginResult, LoginSessionResult } from '@oxyhq/contracts';
+import {
+  runPasskeyLogin,
+  runPasskeyRegister,
+  runPasskeyAdd,
+  PASSKEY_UNSUPPORTED_MESSAGE,
+  type RunPasskeyLoginDeps,
+  type RunPasskeyRegisterDeps,
+  type RunPasskeyAddDeps,
+  type PasskeyRegisterVerifyResult,
+} from '../passkeyFlow';
+import type { CommitInput } from '../oxyContextTypes';
+
+const SESSION_USER_ID = 'user_pk_1';
+
+/** A full session arm of the login contract (mirrors `webauthn*Verify`'s signup/login output). */
+const sessionResult: LoginSessionResult = {
+  sessionId: 'sess_pk',
+  deviceId: 'dev_pk',
+  accessToken: 'pk.access.token',
+  deviceSecret: 'pk.device.secret',
+  expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  user: { id: SESSION_USER_ID, username: 'pkuser' },
+};
+
+/** The `commitSession` input the flow projects from `sessionResult`. */
+const expectedCommitInput: CommitInput = {
+  sessionId: 'sess_pk',
+  accessToken: 'pk.access.token',
+  deviceSecret: 'pk.device.secret',
+  deviceId: 'dev_pk',
+  expiresAt: sessionResult.expiresAt,
+  userId: SESSION_USER_ID,
+  user: { id: SESSION_USER_ID, username: 'pkuser' },
+};
+
+const twoFactorResult: LoginResult = { twoFactorRequired: true, loginToken: 'lt_should_not_happen' };
+const linkResult: PasskeyRegisterVerifyResult = { success: true, message: 'Passkey added' };
+
+describe('runPasskeyLogin', () => {
+  const buildDeps = (
+    order: string[],
+    overrides: Partial<RunPasskeyLoginDeps> = {},
+  ): RunPasskeyLoginDeps => ({
+    isSupported: jest.fn(() => true),
+    getLoginOptions: jest.fn(async () => {
+      order.push('getLoginOptions');
+      return { challenge: 'login-opts' };
+    }),
+    runCeremony: jest.fn(async (options) => {
+      order.push('runCeremony');
+      expect(options).toEqual({ challenge: 'login-opts' });
+      return { id: 'assertion' };
+    }),
+    loginVerify: jest.fn(async () => {
+      order.push('loginVerify');
+      return sessionResult;
+    }),
+    commit: jest.fn(async () => {
+      order.push('commit');
+    }),
+    deviceId: 'persisted-dev',
+    deviceName: 'My Laptop',
+    deviceFingerprint: 'fp-123',
+    ...overrides,
+  });
+
+  it('drives options → ceremony → verify → commit and threads the device envelope', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order);
+
+    await runPasskeyLogin(deps);
+
+    expect(order).toEqual(['getLoginOptions', 'runCeremony', 'loginVerify', 'commit']);
+    // The assertion response is forwarded to verify with the device envelope.
+    expect(deps.loginVerify).toHaveBeenCalledWith(
+      { id: 'assertion' },
+      { deviceName: 'My Laptop', deviceFingerprint: 'fp-123', deviceId: 'persisted-dev' },
+    );
+    // The session arm is projected onto the exact commitSession input.
+    expect(deps.commit).toHaveBeenCalledWith(expectedCommitInput);
+  });
+
+  it('throws and touches nothing when passkeys are unsupported', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order, { isSupported: jest.fn(() => false) });
+
+    await expect(runPasskeyLogin(deps)).rejects.toThrow(PASSKEY_UNSUPPORTED_MESSAGE);
+    expect(deps.getLoginOptions).not.toHaveBeenCalled();
+    expect(deps.commit).not.toHaveBeenCalled();
+  });
+
+  it('refuses a 2FA arm (a passkey assertion is the strong factor) and never commits', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order, {
+      loginVerify: jest.fn(async () => {
+        order.push('loginVerify');
+        return twoFactorResult;
+      }),
+    });
+
+    await expect(runPasskeyLogin(deps)).rejects.toThrow(/second factor/i);
+    expect(deps.commit).not.toHaveBeenCalled();
+  });
+});
+
+describe('runPasskeyRegister', () => {
+  const buildDeps = (
+    order: string[],
+    overrides: Partial<RunPasskeyRegisterDeps> = {},
+  ): RunPasskeyRegisterDeps => ({
+    isSupported: jest.fn(() => true),
+    getRegisterOptions: jest.fn(async (username) => {
+      order.push('getRegisterOptions');
+      expect(username).toBe('newuser');
+      return { challenge: 'reg-opts' };
+    }),
+    runCeremony: jest.fn(async () => {
+      order.push('runCeremony');
+      return { id: 'attestation' };
+    }),
+    registerVerify: jest.fn(async () => {
+      order.push('registerVerify');
+      return sessionResult;
+    }),
+    commit: jest.fn(async () => {
+      order.push('commit');
+    }),
+    username: 'newuser',
+    deviceName: 'My Laptop',
+    ...overrides,
+  });
+
+  it('creates the account (signup branch) and commits the minted session', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order);
+
+    await runPasskeyRegister(deps);
+
+    expect(order).toEqual(['getRegisterOptions', 'runCeremony', 'registerVerify', 'commit']);
+    expect(deps.registerVerify).toHaveBeenCalledWith(
+      { id: 'attestation' },
+      { username: 'newuser', deviceName: 'My Laptop' },
+    );
+    expect(deps.commit).toHaveBeenCalledWith(expectedCommitInput);
+  });
+
+  it('throws (no commit) when verify returns a link branch instead of a session', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order, {
+      registerVerify: jest.fn(async () => linkResult),
+    });
+
+    await expect(runPasskeyRegister(deps)).rejects.toThrow(/did not establish a session/i);
+    expect(deps.commit).not.toHaveBeenCalled();
+  });
+
+  it('throws and touches nothing when passkeys are unsupported', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order, { isSupported: jest.fn(() => false) });
+
+    await expect(runPasskeyRegister(deps)).rejects.toThrow(PASSKEY_UNSUPPORTED_MESSAGE);
+    expect(deps.getRegisterOptions).not.toHaveBeenCalled();
+    expect(deps.commit).not.toHaveBeenCalled();
+  });
+});
+
+describe('runPasskeyAdd', () => {
+  const buildDeps = (
+    order: string[],
+    overrides: Partial<RunPasskeyAddDeps> = {},
+  ): RunPasskeyAddDeps => ({
+    isSupported: jest.fn(() => true),
+    getRegisterOptions: jest.fn(async () => {
+      order.push('getRegisterOptions');
+      return { challenge: 'add-opts' };
+    }),
+    runCeremony: jest.fn(async () => {
+      order.push('runCeremony');
+      return { id: 'attestation' };
+    }),
+    registerVerify: jest.fn(async () => {
+      order.push('registerVerify');
+      return linkResult;
+    }),
+    onLinked: jest.fn(() => {
+      order.push('onLinked');
+    }),
+    deviceName: 'My Laptop',
+    ...overrides,
+  });
+
+  it('links the passkey WITHOUT committing a session and fires onLinked', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order);
+
+    await runPasskeyAdd(deps);
+
+    expect(order).toEqual(['getRegisterOptions', 'runCeremony', 'registerVerify', 'onLinked']);
+    // Add requests options with NO username (bearer scopes it to the signed-in user).
+    expect(deps.getRegisterOptions).toHaveBeenCalledWith();
+    expect(deps.registerVerify).toHaveBeenCalledWith({ id: 'attestation' }, { deviceName: 'My Laptop' });
+    expect(deps.onLinked).toHaveBeenCalledTimes(1);
+    // There is no `commit` dependency at all — structurally cannot commit a session.
+    expect('commit' in deps).toBe(false);
+  });
+
+  it('throws (no onLinked) if verify unexpectedly mints a session', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order, {
+      registerVerify: jest.fn(async () => sessionResult),
+    });
+
+    await expect(runPasskeyAdd(deps)).rejects.toThrow(/instead of linking/i);
+    expect(deps.onLinked).not.toHaveBeenCalled();
+  });
+
+  it('throws and touches nothing when passkeys are unsupported', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order, { isSupported: jest.fn(() => false) });
+
+    await expect(runPasskeyAdd(deps)).rejects.toThrow(PASSKEY_UNSUPPORTED_MESSAGE);
+    expect(deps.getRegisterOptions).not.toHaveBeenCalled();
+    expect(deps.onLinked).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/ui/context/oxyContextTypes.ts
+++ b/packages/services/src/ui/context/oxyContextTypes.ts
@@ -54,6 +54,27 @@ export interface OxyContextState {
     deviceName?: string;
   }) => Promise<{ securityAlert?: SecurityAlert }>;
 
+  /**
+   * Sign in with a passkey (WebAuthn). Usernameless / discoverable-credential
+   * flow: the browser prompts for any resident Oxy passkey. WEB-ONLY — throws on
+   * native or an unsupported browser (native passkeys are Commons' job). On
+   * `useOxy()`, NOT re-exposed on `useAuth()`.
+   */
+  signInWithPasskey: (opts?: { deviceName?: string; deviceFingerprint?: string }) => Promise<void>;
+
+  /**
+   * Create a brand-new account whose first authentication method is a passkey.
+   * WEB-ONLY — throws on native or an unsupported browser.
+   */
+  registerWithPasskey: (params: { username: string; deviceName?: string }) => Promise<void>;
+
+  /**
+   * Add a passkey to the already-signed-in account (bearer present). Does NOT
+   * commit a new session; refreshes the linked auth-methods list on success.
+   * WEB-ONLY — throws on native or an unsupported browser.
+   */
+  addPasskey: (params?: { deviceName?: string }) => Promise<void>;
+
   revokeSuspiciousSignIn: () => Promise<void>;
   handleWebSession: (session: SessionLoginResponse) => Promise<void>;
 

--- a/packages/services/src/ui/context/passkeyFlow.ts
+++ b/packages/services/src/ui/context/passkeyFlow.ts
@@ -1,0 +1,146 @@
+/**
+ * Pure passkey (WebAuthn) sign-in / registration orchestration.
+ *
+ * Extracted from `OxyContext` so the fixed `options → ceremony → verify → commit`
+ * ordering is unit-testable with injected deps — the exact pattern
+ * `commitSessionFlow.ts` (`commitDeviceSetAndResolve`) uses. The context methods
+ * (`signInWithPasskey` / `registerWithPasskey` / `addPasskey`) are thin wrappers
+ * that supply the real deps: the core `webauthn*` methods, the platform ceremony
+ * client (`webauthn/passkeyClient`), and the internal `commitSession` funnel.
+ *
+ * All three GATE on `isSupported()` first (the platform client returns `false`
+ * off the web) so an unsupported surface fails loudly before touching a ceremony.
+ */
+
+import type { LoginResult, LoginSessionResult } from '@oxyhq/contracts';
+import type { CommitInput } from './oxyContextTypes';
+
+/**
+ * The result of `OxyServices.webauthnRegisterVerify` — either the LINK branch
+ * (`{ success, message }`, bearer present, no session) or the SIGNUP branch (a
+ * full {@link LoginResult}, which carries a `sessionId` on its session arm).
+ */
+export type PasskeyRegisterVerifyResult = { success: true; message: string } | LoginResult;
+
+/** Thrown when a passkey flow is attempted on a surface that cannot run WebAuthn. */
+export const PASSKEY_UNSUPPORTED_MESSAGE =
+  'Passkeys are not available in this environment. Use another sign-in method.';
+
+/** Project a session-arm login result onto the internal `commitSession` input. */
+function toCommitInput(result: LoginSessionResult): CommitInput {
+  return {
+    sessionId: result.sessionId,
+    accessToken: result.accessToken,
+    deviceSecret: result.deviceSecret,
+    deviceId: result.deviceId,
+    expiresAt: result.expiresAt,
+    userId: result.user.id,
+    user: result.user,
+  };
+}
+
+/** Injected dependencies for {@link runPasskeyLogin}. */
+export interface RunPasskeyLoginDeps {
+  isSupported: () => boolean;
+  getLoginOptions: () => Promise<unknown>;
+  runCeremony: (optionsJSON: unknown) => Promise<unknown>;
+  loginVerify: (
+    response: unknown,
+    envelope: { deviceName?: string; deviceFingerprint?: string; deviceId?: string },
+  ) => Promise<LoginResult>;
+  commit: (input: CommitInput) => Promise<void>;
+  deviceId?: string;
+  deviceName?: string;
+  deviceFingerprint?: string;
+}
+
+/**
+ * Usernameless (discoverable-credential) passkey SIGN-IN: request login options,
+ * run the authentication ceremony, verify, then commit the session. A passkey
+ * assertion is itself the strong factor, so a 2FA arm here is a protocol error.
+ */
+export async function runPasskeyLogin(deps: RunPasskeyLoginDeps): Promise<void> {
+  if (!deps.isSupported()) {
+    throw new Error(PASSKEY_UNSUPPORTED_MESSAGE);
+  }
+  const options = await deps.getLoginOptions();
+  const response = await deps.runCeremony(options);
+  const result = await deps.loginVerify(response, {
+    deviceName: deps.deviceName,
+    deviceFingerprint: deps.deviceFingerprint,
+    deviceId: deps.deviceId,
+  });
+  if ('twoFactorRequired' in result) {
+    throw new Error('Passkey sign-in unexpectedly required a second factor.');
+  }
+  await deps.commit(toCommitInput(result));
+}
+
+/** Injected dependencies for {@link runPasskeyRegister}. */
+export interface RunPasskeyRegisterDeps {
+  isSupported: () => boolean;
+  getRegisterOptions: (username: string) => Promise<unknown>;
+  runCeremony: (optionsJSON: unknown) => Promise<unknown>;
+  registerVerify: (
+    response: unknown,
+    envelope: { username: string; deviceName?: string },
+  ) => Promise<PasskeyRegisterVerifyResult>;
+  commit: (input: CommitInput) => Promise<void>;
+  username: string;
+  deviceName?: string;
+}
+
+/**
+ * Passkey SIGNUP: create a brand-new account whose first auth method is a
+ * passkey. The verify signup branch mints a session (a {@link LoginSessionResult}
+ * carrying `sessionId`), which is committed exactly like a password signup.
+ */
+export async function runPasskeyRegister(deps: RunPasskeyRegisterDeps): Promise<void> {
+  if (!deps.isSupported()) {
+    throw new Error(PASSKEY_UNSUPPORTED_MESSAGE);
+  }
+  const options = await deps.getRegisterOptions(deps.username);
+  const response = await deps.runCeremony(options);
+  const result = await deps.registerVerify(response, {
+    username: deps.username,
+    deviceName: deps.deviceName,
+  });
+  // Only the signup session arm carries `sessionId`; the link branch
+  // (`{ success, message }`) and any 2FA arm do not.
+  if (!('sessionId' in result)) {
+    throw new Error('Passkey registration did not establish a session.');
+  }
+  await deps.commit(toCommitInput(result));
+}
+
+/** Injected dependencies for {@link runPasskeyAdd}. */
+export interface RunPasskeyAddDeps {
+  isSupported: () => boolean;
+  getRegisterOptions: () => Promise<unknown>;
+  runCeremony: (optionsJSON: unknown) => Promise<unknown>;
+  registerVerify: (
+    response: unknown,
+    envelope: { deviceName?: string },
+  ) => Promise<PasskeyRegisterVerifyResult>;
+  onLinked: () => void;
+  deviceName?: string;
+}
+
+/**
+ * ADD a passkey to the already-signed-in account (bearer present). The verify
+ * link branch returns `{ success, message }` with NO session — so this never
+ * commits a session; it just fires `onLinked` (which invalidates the
+ * auth-methods query). A session arm here would be a server contract violation.
+ */
+export async function runPasskeyAdd(deps: RunPasskeyAddDeps): Promise<void> {
+  if (!deps.isSupported()) {
+    throw new Error(PASSKEY_UNSUPPORTED_MESSAGE);
+  }
+  const options = await deps.getRegisterOptions();
+  const response = await deps.runCeremony(options);
+  const result = await deps.registerVerify(response, { deviceName: deps.deviceName });
+  if ('sessionId' in result) {
+    throw new Error('addPasskey unexpectedly minted a new session instead of linking.');
+  }
+  deps.onLinked();
+}

--- a/packages/services/src/ui/hooks/queries/queryKeys.ts
+++ b/packages/services/src/ui/hooks/queries/queryKeys.ts
@@ -71,6 +71,12 @@ export const queryKeys = {
       [...queryKeys.security.all, 'infinite', limit, eventType] as const,
   },
 
+  // Linked authentication methods (passwords, identity keys, passkeys, social)
+  authMethods: {
+    all: ['authMethods'] as const,
+    list: (userId?: string) => [...queryKeys.authMethods.all, 'list', userId || 'current'] as const,
+  },
+
   // Storage usage queries
   storage: {
     all: ['storage'] as const,
@@ -157,6 +163,14 @@ export const invalidateSecurityQueries = (queryClient: QueryClient): void => {
  */
 export const invalidateStorageQueries = (queryClient: QueryClient): void => {
   queryClient.invalidateQueries({ queryKey: queryKeys.storage.all });
+};
+
+/**
+ * Helper to invalidate the user's linked auth-methods list (call after linking
+ * or removing a passkey / password / identity key).
+ */
+export const invalidateAuthMethodsQueries = (queryClient: QueryClient): void => {
+  queryClient.invalidateQueries({ queryKey: queryKeys.authMethods.all });
 };
 
 /**

--- a/packages/services/src/ui/hooks/queries/useAuthMethods.ts
+++ b/packages/services/src/ui/hooks/queries/useAuthMethods.ts
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { AuthMethodEntry, AuthMethodsResponse } from '@oxyhq/contracts';
+import { queryKeys } from './queryKeys';
+import { useOxy } from '../../context/OxyContext';
+
+/** Stable empty list so the derived selectors keep a stable reference while loading. */
+const EMPTY_METHODS: readonly AuthMethodEntry[] = Object.freeze([]);
+
+/**
+ * The current account's linked authentication methods (`GET /auth/methods`),
+ * plus convenience projections. Backs the security / account surfaces that let a
+ * user see and manage their passwords, identity key, social logins, and passkeys.
+ *
+ * `passkeys` is the `type === 'webauthn'` subset — one entry per registered
+ * credential. Invalidate via `queryKeys.authMethods.all` after linking a passkey
+ * (`useOxy().addPasskey()` does this) or removing one.
+ */
+export const useAuthMethods = (options?: { enabled?: boolean }) => {
+  const { oxyServices, activeSessionId } = useOxy();
+
+  const query = useQuery<AuthMethodsResponse>({
+    queryKey: queryKeys.authMethods.list(),
+    queryFn: () => oxyServices.listAuthMethods(),
+    enabled: options?.enabled !== false && !!activeSessionId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+  });
+
+  const methods = query.data?.methods ?? EMPTY_METHODS;
+  const passkeys = useMemo(
+    () => methods.filter((method) => method.type === 'webauthn'),
+    [methods],
+  );
+
+  return {
+    ...query,
+    /** Every linked auth method. Empty while loading. */
+    methods,
+    /** The registered passkeys (a `type === 'webauthn'` subset of `methods`). */
+    passkeys,
+    /** The account's DID, or `null` while loading. */
+    did: query.data?.did ?? null,
+  };
+};

--- a/packages/services/src/webauthn/passkeyClient.native.ts
+++ b/packages/services/src/webauthn/passkeyClient.native.ts
@@ -1,0 +1,26 @@
+/**
+ * Passkey / WebAuthn ceremony client — NATIVE implementation.
+ *
+ * React Native has no browser WebAuthn API, and Oxy's native passkey story is
+ * Commons (shared-keychain / QR handoff), NOT `navigator.credentials`. So this
+ * variant imports NOTHING browser-specific and mirrors the clean default:
+ * unsupported, and the ceremony helpers throw if a caller skipped the gate.
+ */
+
+const WEBAUTHN_WEB_ONLY_MESSAGE =
+  'WebAuthn is web-only; native uses Commons. Passkeys are not available on this platform.';
+
+/** Always `false` on native — there is no browser WebAuthn API. */
+export function isPasskeySupported(): boolean {
+  return false;
+}
+
+/** Not available on native — throws. Guard with {@link isPasskeySupported} first. */
+export async function runRegistrationCeremony(_optionsJSON: unknown): Promise<unknown> {
+  throw new Error(WEBAUTHN_WEB_ONLY_MESSAGE);
+}
+
+/** Not available on native — throws. Guard with {@link isPasskeySupported} first. */
+export async function runAuthenticationCeremony(_optionsJSON: unknown): Promise<unknown> {
+  throw new Error(WEBAUTHN_WEB_ONLY_MESSAGE);
+}

--- a/packages/services/src/webauthn/passkeyClient.ts
+++ b/packages/services/src/webauthn/passkeyClient.ts
@@ -1,0 +1,31 @@
+/**
+ * Passkey / WebAuthn ceremony client — clean default (non-web) implementation.
+ *
+ * This is the base module TypeScript resolves for TYPES and any bundler that
+ * does not pick a platform variant. It intentionally imports NOTHING browser-
+ * specific (no `@simplewebauthn/browser`) so it stays safe for Metro, native
+ * builds, and SSR. The real ceremony lives in `passkeyClient.web.ts`; native
+ * passkeys are Commons' job, so there is no WebAuthn ceremony here.
+ *
+ * `isPasskeySupported()` returns `false` (no relying-party origin / no browser
+ * WebAuthn API), and the ceremony helpers throw a clear error so a caller that
+ * skipped the support gate fails loudly instead of silently.
+ */
+
+const WEBAUTHN_WEB_ONLY_MESSAGE =
+  'WebAuthn is web-only; native uses Commons. Passkeys are not available on this platform.';
+
+/** Always `false` off the web — there is no relying-party origin or WebAuthn API. */
+export function isPasskeySupported(): boolean {
+  return false;
+}
+
+/** Not available off the web — throws. Guard with {@link isPasskeySupported} first. */
+export async function runRegistrationCeremony(_optionsJSON: unknown): Promise<unknown> {
+  throw new Error(WEBAUTHN_WEB_ONLY_MESSAGE);
+}
+
+/** Not available off the web — throws. Guard with {@link isPasskeySupported} first. */
+export async function runAuthenticationCeremony(_optionsJSON: unknown): Promise<unknown> {
+  throw new Error(WEBAUTHN_WEB_ONLY_MESSAGE);
+}

--- a/packages/services/src/webauthn/passkeyClient.web.ts
+++ b/packages/services/src/webauthn/passkeyClient.web.ts
@@ -1,0 +1,56 @@
+/**
+ * Passkey / WebAuthn ceremony client — WEB implementation.
+ *
+ * The browser half of the passkey flow: it drives `navigator.credentials`
+ * through `@simplewebauthn/browser`, turning the OPAQUE options the server
+ * emitted (`OxyServices.webauthn{Register,Login}Options`) into the opaque
+ * response the matching `verify` endpoint consumes. Oxy never owns those wire
+ * shapes — `@simplewebauthn/browser` does — so options flow in as `unknown` and
+ * the single cast at this boundary hands them to the library's own types.
+ *
+ * This file is selected ONLY on web (react-native-web / Vite RNW): the sibling
+ * `passkeyClient.native.ts` + the clean default `passkeyClient.ts` deliberately
+ * do NOT import `@simplewebauthn/browser` (a browser-only dependency), per the
+ * platform-split rule. Native passkeys are Commons' job — there is no WebAuthn
+ * ceremony off the web.
+ */
+
+import {
+  startRegistration,
+  startAuthentication,
+  type PublicKeyCredentialCreationOptionsJSON,
+  type PublicKeyCredentialRequestOptionsJSON,
+  type RegistrationResponseJSON,
+  type AuthenticationResponseJSON,
+} from '@simplewebauthn/browser';
+
+/**
+ * True iff this browser can run a WebAuthn ceremony (exposes the
+ * `PublicKeyCredential` global). Gate all passkey UI/entrypoints on this so an
+ * unsupported browser fails loudly rather than throwing mid-ceremony.
+ */
+export function isPasskeySupported(): boolean {
+  return typeof window !== 'undefined' && typeof window.PublicKeyCredential !== 'undefined';
+}
+
+/**
+ * Run the WebAuthn REGISTRATION ceremony (`navigator.credentials.create`) from
+ * the server's opaque creation options, returning the opaque attestation
+ * response for `OxyServices.webauthnRegisterVerify`.
+ */
+export async function runRegistrationCeremony(
+  optionsJSON: unknown,
+): Promise<RegistrationResponseJSON> {
+  return startRegistration({ optionsJSON: optionsJSON as PublicKeyCredentialCreationOptionsJSON });
+}
+
+/**
+ * Run the WebAuthn AUTHENTICATION ceremony (`navigator.credentials.get`) from
+ * the server's opaque request options, returning the opaque assertion response
+ * for `OxyServices.webauthnLoginVerify`.
+ */
+export async function runAuthenticationCeremony(
+  optionsJSON: unknown,
+): Promise<AuthenticationResponseJSON> {
+  return startAuthentication({ optionsJSON: optionsJSON as PublicKeyCredentialRequestOptionsJSON });
+}


### PR DESCRIPTION
## Summary

- **`@oxyhq/core`**: 4 new `webauthn*` methods on `OxyServices` (register/login begin+finish), reusing the same token-planting pattern as `completeTwoFactorSignIn`. New `isOxyRpOrigin()` WebAuthn relying-party origin guard.
- **`@oxyhq/services`**: platform-split `passkeyClient.{web,native,ts}` (native funnels through Commons). New `@simplewebauthn/browser@^13.3.0` dependency. `signInWithPasskey` / `registerWithPasskey` / `addPasskey` added to `useOxy()`, funneled through `commitSession`. New `useAuthMethods()` query hook. A gated "Sign in with a passkey" button added to `OxyAccountDialog`.
- **Test coverage**: new unit tests for all of the above — `webauthnAuth.test.ts`, `webauthnOrigin.test.ts`, `passkeyFlow.test.ts`, `OxyAccountDialogPasskey.test.tsx`.

**Status: additive only — nothing consumes this yet.** No app (accounts, auth IdP, etc.) wires up passkey sign-in/registration UI yet, and there is no browser E2E coverage of the real WebAuthn ceremony. Those are the next phase.

## Test plan

- [x] `bun run build:all` — 12/12 tasks green (contracts → core → services → rest order)
- [x] `bun install` + `bun install --frozen-lockfile` — no drift, lockfile gate passes
- [x] `@oxyhq/contracts` tests — 135/135
- [x] `@oxyhq/core` tests — 874/874
- [x] `@oxyhq/services` tests — 215/215
- [x] `@oxyhq/api` tests — 1508/1508
- [x] `packages/commons` tests — 45/48 (3 pre-existing, unrelated failures: `StandingHero.test.tsx`, `ActivityList.test.tsx`, `CompositionCard.test.tsx` — this branch touches zero commons files, confirmed via `git diff --stat`)
- [x] `tsc --noEmit` clean on `packages/core` and `packages/services`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>