### PR TITLE
feat(auth): passkey signup + sign-in on auth.oxy.so (Fase B/b1-fe)

### DIFF
--- a/packages/auth/components/__tests__/login-form-passkey.test.tsx
+++ b/packages/auth/components/__tests__/login-form-passkey.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * The login form offers a "Sign in with a passkey" affordance on the identifier
+ * step (first-party Oxy web origins only — the jsdom test host is `localhost`, a
+ * loopback RP origin, so it renders). Selecting it runs the discoverable WebAuthn
+ * ceremony via `useOxy().signInWithPasskey()`; on success the SDK has already
+ * committed the device-first session, so the form just redirects. A dismissed /
+ * aborted browser prompt surfaces a calm inline message instead of crashing.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { BrowserRouter } from "react-router-dom"
+
+const signInWithPasskey = mock(async () => undefined)
+
+// `mock.module` is process-global in bun (last writer wins across files), so
+// expose the full services surface both auth forms consume — including the
+// signup-only `handleWebSession`/`registerWithPasskey` — to stay leak-safe.
+mock.module("@oxyhq/services", () => ({
+    useOxy: () => ({
+        openAccountDialog: () => undefined,
+        oxyServices: { lookupUsername: async () => ({ username: "", name: {}, avatar: null, color: null }) },
+        signInWithPassword: async () => ({ status: "ok" as const }),
+        signInWithPasskey,
+        completeTwoFactorSignIn: async () => ({}),
+        revokeSuspiciousSignIn: async () => undefined,
+        switchToAccount: async () => undefined,
+        handleWebSession: async () => undefined,
+        registerWithPasskey: async () => undefined,
+    }),
+    useSwitchableAccounts: () => ({ isLoading: false, currentSessionId: null, accounts: [] }),
+}))
+
+const { LoginForm } = await import("@/components/login-form")
+
+function renderForm(): { container: HTMLDivElement; unmount: () => void } {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root: Root = createRoot(container)
+    act(() => {
+        root.render(
+            <BrowserRouter>
+                <LoginForm />
+            </BrowserRouter>,
+        )
+    })
+    return {
+        container,
+        unmount: () => {
+            act(() => root.unmount())
+            container.remove()
+        },
+    }
+}
+
+function findButton(container: HTMLElement, label: RegExp): HTMLButtonElement | undefined {
+    return Array.from(container.querySelectorAll("button")).find((b) =>
+        label.test(b.textContent ?? ""),
+    )
+}
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+}
+
+describe("LoginForm — passkey sign-in", () => {
+    beforeEach(() => {
+        signInWithPasskey.mockClear()
+        signInWithPasskey.mockImplementation(async () => undefined)
+    })
+
+    test("shows the passkey button on the identifier step (loopback RP origin)", () => {
+        const { container, unmount } = renderForm()
+        expect(findButton(container, /sign in with a passkey/i)).toBeDefined()
+        unmount()
+    })
+
+    test("clicking it invokes signInWithPasskey", async () => {
+        const { container, unmount } = renderForm()
+        const button = findButton(container, /sign in with a passkey/i)
+        expect(button).toBeDefined()
+
+        act(() => {
+            button?.dispatchEvent(new (window.MouseEvent || Event)("click", { bubbles: true }))
+        })
+        await flush()
+
+        expect(signInWithPasskey).toHaveBeenCalledTimes(1)
+        unmount()
+    })
+
+    test("a cancelled ceremony surfaces an inline message and does not crash", async () => {
+        const cancel = Object.assign(new Error("The operation was aborted."), { name: "NotAllowedError" })
+        signInWithPasskey.mockImplementation(async () => { throw cancel })
+
+        const { container, unmount } = renderForm()
+        const button = findButton(container, /sign in with a passkey/i)
+
+        act(() => {
+            button?.dispatchEvent(new (window.MouseEvent || Event)("click", { bubbles: true }))
+        })
+        await flush()
+
+        expect(signInWithPasskey).toHaveBeenCalledTimes(1)
+        // The form is still mounted on the identifier step and shows the friendly
+        // "dismissed" copy rather than the raw DOMException text.
+        expect(container.textContent).toMatch(/dismissed/i)
+        unmount()
+    })
+})

--- a/packages/auth/components/__tests__/sign-up-form-passkey.test.tsx
+++ b/packages/auth/components/__tests__/sign-up-form-passkey.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * The sign-up form offers a username-only "Sign up with a passkey" sub-flow
+ * (first-party Oxy web origins only — the jsdom host is loopback `localhost`).
+ * The passkey signup backend reads ONLY `envelope.username` (no email/password),
+ * so the sub-flow collects just a username and calls
+ * `useOxy().registerWithPasskey({ username })`; on success the SDK has committed
+ * the device-first session and the form redirects like a password signup.
+ */
+import { beforeEach, afterEach, describe, expect, mock, test } from "bun:test"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { BrowserRouter } from "react-router-dom"
+
+const registerWithPasskey = mock(async (_params: { username: string }) => undefined)
+
+// `mock.module` is process-global in bun (last writer wins across files), so
+// expose the full services surface both auth forms consume — not just the two
+// signup needs — to stay leak-safe if another test file's mock is registered
+// later in the same run.
+mock.module("@oxyhq/services", () => ({
+    useOxy: () => ({
+        handleWebSession: async () => undefined,
+        registerWithPasskey,
+        openAccountDialog: () => undefined,
+        oxyServices: { lookupUsername: async () => ({ username: "", name: {}, avatar: null, color: null }) },
+        signInWithPassword: async () => ({ status: "ok" as const }),
+        signInWithPasskey: async () => undefined,
+        completeTwoFactorSignIn: async () => ({}),
+        revokeSuspiciousSignIn: async () => undefined,
+        switchToAccount: async () => undefined,
+    }),
+    useSwitchableAccounts: () => ({ isLoading: false, currentSessionId: null, accounts: [] }),
+}))
+
+const { SignUpForm } = await import("@/components/sign-up-form")
+
+// The username availability check debounces a `fetch` to /auth/check-username.
+// Stub it so typing a username never touches the network.
+const originalFetch = globalThis.fetch
+beforeEach(() => {
+    globalThis.fetch = (async () =>
+        new Response(JSON.stringify({ data: { available: true } }), {
+            headers: { "content-type": "application/json" },
+        })) as typeof fetch
+})
+afterEach(() => {
+    globalThis.fetch = originalFetch
+})
+
+function renderForm(): { container: HTMLDivElement; unmount: () => void } {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root: Root = createRoot(container)
+    act(() => {
+        root.render(
+            <BrowserRouter>
+                <SignUpForm redirectUri="https://app.example.com/cb" clientId="oxy_dk_test" />
+            </BrowserRouter>,
+        )
+    })
+    return {
+        container,
+        unmount: () => {
+            act(() => root.unmount())
+            container.remove()
+        },
+    }
+}
+
+function findButton(container: HTMLElement, label: RegExp): HTMLButtonElement | undefined {
+    return Array.from(container.querySelectorAll("button")).find((b) =>
+        label.test(b.textContent ?? ""),
+    )
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+    )?.set
+    setter?.call(input, value)
+    input.dispatchEvent(new (window.Event)("input", { bubbles: true }))
+}
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+}
+
+describe("SignUpForm — passkey signup", () => {
+    beforeEach(() => {
+        registerWithPasskey.mockClear()
+        registerWithPasskey.mockImplementation(async () => undefined)
+    })
+
+    test("offers the passkey option in password mode", () => {
+        const { container, unmount } = renderForm()
+        expect(findButton(container, /sign up with a passkey/i)).toBeDefined()
+        unmount()
+    })
+
+    test("switching to passkey mode shows a username-only form (no password field)", () => {
+        const { container, unmount } = renderForm()
+        act(() => {
+            findButton(container, /sign up with a passkey/i)?.dispatchEvent(
+                new (window.MouseEvent)("click", { bubbles: true }),
+            )
+        })
+        expect(container.querySelector("#passkey-username")).not.toBeNull()
+        expect(container.querySelector('input[type="password"]')).toBeNull()
+        unmount()
+    })
+
+    test("submitting the username-only form calls registerWithPasskey", async () => {
+        const { container, unmount } = renderForm()
+        act(() => {
+            findButton(container, /sign up with a passkey/i)?.dispatchEvent(
+                new (window.MouseEvent)("click", { bubbles: true }),
+            )
+        })
+
+        const input = container.querySelector<HTMLInputElement>("#passkey-username")
+        expect(input).not.toBeNull()
+        act(() => {
+            if (input) setInputValue(input, "newhuman")
+        })
+
+        const form = container.querySelector("form")
+        act(() => {
+            form?.dispatchEvent(new (window.Event)("submit", { bubbles: true, cancelable: true }))
+        })
+        await flush()
+
+        expect(registerWithPasskey).toHaveBeenCalledTimes(1)
+        expect(registerWithPasskey).toHaveBeenCalledWith({ username: "newhuman" })
+        unmount()
+    })
+
+    test("a cancelled ceremony surfaces an inline message and stays on the passkey form", async () => {
+        const cancel = Object.assign(new Error("timed out or was not allowed"), { name: "NotAllowedError" })
+        registerWithPasskey.mockImplementation(async () => { throw cancel })
+
+        const { container, unmount } = renderForm()
+        act(() => {
+            findButton(container, /sign up with a passkey/i)?.dispatchEvent(
+                new (window.MouseEvent)("click", { bubbles: true }),
+            )
+        })
+        const input = container.querySelector<HTMLInputElement>("#passkey-username")
+        act(() => {
+            if (input) setInputValue(input, "newhuman")
+        })
+        const form = container.querySelector("form")
+        act(() => {
+            form?.dispatchEvent(new (window.Event)("submit", { bubbles: true, cancelable: true }))
+        })
+        await flush()
+
+        expect(registerWithPasskey).toHaveBeenCalledTimes(1)
+        expect(container.querySelector("#passkey-username")).not.toBeNull()
+        expect(container.textContent).toMatch(/dismissed/i)
+        unmount()
+    })
+})

--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -1,13 +1,14 @@
 import { useState, useRef, useEffect } from "react"
 import { useNavigate, Link } from "react-router-dom"
 import { toast } from "sonner"
-import { ArrowLeft, QrCode, ShieldAlert } from "lucide-react"
-import type { SwitchableAccount } from "@oxyhq/core"
+import { ArrowLeft, KeyRound, QrCode, ShieldAlert } from "lucide-react"
+import { isOxyRpOrigin, type SwitchableAccount } from "@oxyhq/core"
 import type { SecurityAlert } from "@oxyhq/contracts"
 import { useOxy, useSwitchableAccounts } from "@oxyhq/services"
 import { Avatar } from "@oxyhq/bloom/avatar"
 import { getAvatarUrl } from "@/lib/oxy-api-client"
 import { buildPostLoginRedirect } from "@/lib/auth-utils"
+import { describePasskeyError } from "@/lib/passkey-error"
 import { setBasePreset } from "@/lib/bloom-css"
 import { useLayoutContext } from "@/lib/layout-context"
 import { getOrCreateDeviceFingerprint } from "@/lib/device-fingerprint"
@@ -93,12 +94,22 @@ export function LoginForm({
     const {
         oxyServices,
         signInWithPassword,
+        signInWithPasskey,
         completeTwoFactorSignIn,
         revokeSuspiciousSignIn,
         switchToAccount,
         openAccountDialog,
     } = useOxy()
     const { setLogoSlot } = useLayoutContext()
+
+    // Passkey (WebAuthn) sign-in is only meaningful on a first-party Oxy web
+    // origin — a credential minted with `WEBAUTHN_RP_ID=oxy.so` can only be
+    // asserted from `oxy.so`, a subdomain, or a loopback dev host. On any other
+    // origin (or native/SSR) the browser would reject the ceremony, so we hide
+    // the affordance entirely. `isOxyRpOrigin()` reads `location` once and is
+    // stable for the page's lifetime, so it needs no reactive state.
+    const passkeyAvailable = isOxyRpOrigin()
+    const [passkeyPending, setPasskeyPending] = useState(false)
 
     const [localError, setLocalError] = useState<string | undefined>()
     const [rateLimitSeconds, setRateLimitSeconds] = useState(0)
@@ -327,6 +338,30 @@ export function LoginForm({
         toast.error("Sign in failed", { description: message })
     }
 
+    /**
+     * Discoverable (usernameless) passkey sign-in. The SDK drives the WebAuthn
+     * assertion ceremony, verifies it, and commits the device-first session
+     * (token planted, `{deviceId, deviceSecret}` persisted, account activated) —
+     * exactly like the password path — so on success we reuse `redirectAfterLogin`.
+     * A dismissed/aborted browser prompt is a normal user action, not a crash:
+     * surface a calm inline message and let them retry.
+     */
+    async function handlePasskeySignIn() {
+        if (passkeyPending || rateLimitSeconds > 0) return
+        setLocalError(undefined)
+        setPasskeyPending(true)
+        try {
+            const deviceFingerprint = await getOrCreateDeviceFingerprint()
+            await signInWithPasskey({ deviceFingerprint: deviceFingerprint ?? undefined })
+            redirectAfterLogin()
+        } catch (err) {
+            const message = describePasskeyError(err)
+            setLocalError(message)
+            toast.error("Passkey sign-in failed", { description: message })
+            setPasskeyPending(false)
+        }
+    }
+
     async function handlePasswordSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault()
         setLocalError(undefined)
@@ -459,8 +494,26 @@ export function LoginForm({
             className={className}
             footer={step === "identifier" ? (
                 <div className="flex flex-col gap-4">
-                    {/* Third option: cross-device "Sign in with Oxy" (QR). The user
-                        approves in their Oxy app on their phone — no password here. */}
+                    {/* Passkey option: a single tap runs the browser's WebAuthn
+                        prompt (discoverable credential — no username needed) and
+                        the SDK commits the session on success. First-party Oxy web
+                        origins only. */}
+                    {passkeyAvailable && (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="lg"
+                            className="w-full"
+                            loading={passkeyPending}
+                            disabled={passkeyPending || rateLimitSeconds > 0}
+                            onClick={() => { void handlePasskeySignIn() }}
+                        >
+                            <KeyRound className="size-4" />
+                            Sign in with a passkey
+                        </Button>
+                    )}
+                    {/* Cross-device "Sign in with Oxy" (QR). The user approves in
+                        their Oxy app on their phone — no password here. */}
                     <Button
                         type="button"
                         variant="outline"

--- a/packages/auth/components/sign-up-form.tsx
+++ b/packages/auth/components/sign-up-form.tsx
@@ -1,15 +1,16 @@
 import { useState, useRef, useCallback } from "react"
 import { useNavigate, Link } from "react-router-dom"
 import { toast } from "sonner"
-import { Check, X, Loader2 } from "lucide-react"
+import { ArrowLeft, Check, KeyRound, X, Loader2 } from "lucide-react"
 import { useOxy } from "@oxyhq/services"
-import type { SessionLoginResponse } from "@oxyhq/core"
+import { isOxyRpOrigin, type SessionLoginResponse } from "@oxyhq/core"
 import { loginResultSchema, safeParseContract } from "@oxyhq/contracts"
 
 import { buildAuthUrl, buildApiUrl } from "@/lib/oxy-api-client"
 import { buildPostLoginRedirect } from "@/lib/auth-utils"
+import { describePasskeyError } from "@/lib/passkey-error"
 import { Button } from "@oxyhq/bloom/button"
-import { Field, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
+import { Field, FieldDescription, FieldError, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { PasswordInput } from "@/components/password-input"
 import { PasswordRequirements } from "@/components/password-requirements"
@@ -90,26 +91,84 @@ export function SignUpForm({
 }: SignUpFormProps) {
     const navigate = useNavigate()
     // Sign-up commits its session through the SAME device-first SDK funnel every
-    // Oxy app uses (`handleWebSession`): it plants the access token, persists the
-    // zero-cookie `{deviceId, deviceSecret}` credential, and registers the new
-    // account into the device set as the active account — so `/authorize` targets
-    // it with no first-party device cookie.
-    const { handleWebSession } = useOxy()
+    // Oxy app uses (`handleWebSession` for password; `registerWithPasskey` for the
+    // passkey path): it plants the access token, persists the zero-cookie
+    // `{deviceId, deviceSecret}` credential, and registers the new account into
+    // the device set as the active account — so `/authorize` targets it with no
+    // first-party device cookie.
+    const { handleWebSession, registerWithPasskey } = useOxy()
     const [localError, setLocalError] = useState<string | undefined>()
     const [serverErrors, setServerErrors] = useState<string[]>([])
     const [isSubmitting, setIsSubmitting] = useState(false)
     const [password, setPassword] = useState("")
     const [passwordTouched, setPasswordTouched] = useState(false)
 
+    // The passkey signup branch collects ONLY a username — the backend
+    // register/verify path reads `envelope.username` and nothing else (no email,
+    // no password). `mode` toggles between the classic password form and the
+    // username-only passkey sub-flow. Offered on first-party Oxy web origins only.
+    const passkeyAvailable = isOxyRpOrigin()
+    const [mode, setMode] = useState<"password" | "passkey">("password")
+    const [passkeyUsername, setPasskeyUsername] = useState("")
+
     const displayError = localError ?? error
 
     const username = useAvailabilityCheck("/auth/check-username")
     const email = useAvailabilityCheck("/auth/check-email")
+    const passkeyUsernameCheck = useAvailabilityCheck("/auth/check-username")
 
     const errorShownRef = useRef(false)
     if (error && !errorShownRef.current) {
         errorShownRef.current = true
         queueMicrotask(() => toast.error("Sign up failed", { description: error }))
+    }
+
+    function switchToPasskeyMode() {
+        setLocalError(undefined)
+        setServerErrors([])
+        setMode("passkey")
+    }
+
+    function switchToPasswordMode() {
+        setLocalError(undefined)
+        passkeyUsernameCheck.reset()
+        setMode("password")
+    }
+
+    /**
+     * Passkey signup: register a brand-new account whose FIRST auth method is a
+     * passkey. Only a username is collected — the SDK runs the WebAuthn creation
+     * ceremony, verifies it, and commits the device-first session exactly like a
+     * password signup, so on success we reuse the same post-signup redirect. A
+     * dismissed/aborted browser prompt is a normal user action: surface a calm
+     * inline message and let them retry.
+     */
+    async function handlePasskeySubmit(event: React.FormEvent<HTMLFormElement>) {
+        event.preventDefault()
+        const usernameValue = passkeyUsername.trim()
+        if (!usernameValue || passkeyUsernameCheck.status === "taken" || isSubmitting) return
+        setLocalError(undefined)
+        setIsSubmitting(true)
+        let didRedirect = false
+        try {
+            await registerWithPasskey({ username: usernameValue })
+            didRedirect = true
+            navigate(buildPostLoginRedirect({
+                sessionToken,
+                redirectUri,
+                state,
+                clientId,
+                codeChallenge,
+                codeChallengeMethod,
+                scope,
+            }))
+        } catch (err) {
+            const message = describePasskeyError(err)
+            setLocalError(message)
+            toast.error("Passkey signup failed", { description: message })
+        } finally {
+            if (!didRedirect) setIsSubmitting(false)
+        }
     }
 
     async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -203,18 +262,89 @@ export function SignUpForm({
         }
     }
 
+    // Username-only passkey signup sub-flow.
+    if (mode === "passkey") {
+        return (
+            <AuthFormLayout className={className} {...props}>
+                <form onSubmit={handlePasskeySubmit}>
+                    <FieldGroup>
+                        <AuthFormHeader
+                            title="Sign up with a passkey"
+                            description="Pick a username — no password needed. Your device will create a passkey."
+                        />
+                        <Field data-invalid={displayError ? true : undefined}>
+                            <FieldLabel htmlFor="passkey-username">Username</FieldLabel>
+                            <Input
+                                id="passkey-username"
+                                name="passkey-username"
+                                type="text"
+                                placeholder="yourname"
+                                autoComplete="username webauthn"
+                                required
+                                autoFocus
+                                value={passkeyUsername}
+                                onChange={(e) => {
+                                    const value = e.target.value
+                                    setPasskeyUsername(value)
+                                    if (localError) setLocalError(undefined)
+                                    passkeyUsernameCheck.check(value.trim())
+                                }}
+                            />
+                            <AvailabilityIndicator status={passkeyUsernameCheck.status} takenMessage="This username is taken" />
+                            {displayError && <FieldError>{displayError}</FieldError>}
+                        </Field>
+                        <div className="flex gap-3">
+                            <Button type="button" variant="outline" size="lg" onClick={switchToPasswordMode} className="shrink-0" aria-label="Go back">
+                                <ArrowLeft className="size-4" />
+                            </Button>
+                            <Button
+                                type="submit"
+                                size="lg"
+                                className="flex-1 min-w-0"
+                                loading={isSubmitting}
+                                disabled={isSubmitting || passkeyUsernameCheck.status === "taken"}
+                            >
+                                <KeyRound className="size-4" />
+                                Create passkey
+                            </Button>
+                        </div>
+                        <FieldDescription>
+                            Already have an account? <Link to="/login">Sign in</Link>
+                        </FieldDescription>
+                    </FieldGroup>
+                </form>
+            </AuthFormLayout>
+        )
+    }
+
     return (
         <AuthFormLayout
             className={className}
-            footer={<SocialLoginButtons
-                sessionToken={sessionToken}
-                redirectUri={redirectUri}
-                state={state}
-                clientId={clientId}
-                codeChallenge={codeChallenge}
-                codeChallengeMethod={codeChallengeMethod}
-                scope={scope}
-            />}
+            footer={
+                <div className="flex flex-col gap-4">
+                    {passkeyAvailable && (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="lg"
+                            className="w-full"
+                            onClick={switchToPasskeyMode}
+                        >
+                            <KeyRound className="size-4" />
+                            Sign up with a passkey
+                        </Button>
+                    )}
+                    <SocialLoginButtons
+                        sessionToken={sessionToken}
+                        redirectUri={redirectUri}
+                        state={state}
+                        clientId={clientId}
+                        codeChallenge={codeChallenge}
+                        codeChallengeMethod={codeChallengeMethod}
+                        scope={scope}
+                    />
+                </div>
+            }
             {...props}
         >
             <form onSubmit={handleSubmit}>

--- a/packages/auth/lib/__tests__/setup-dom.ts
+++ b/packages/auth/lib/__tests__/setup-dom.ts
@@ -12,9 +12,11 @@ const dom = new JSDOM(
 type GlobalWithDOM = typeof globalThis & {
     window: JSDOM["window"]
     document: Document
+    location: Location
     HTMLElement: typeof HTMLElement
     HTMLStyleElement: typeof HTMLStyleElement
     HTMLButtonElement: typeof HTMLButtonElement
+    HTMLInputElement: typeof HTMLInputElement
     Element: typeof Element
     Node: typeof Node
     navigator: Navigator
@@ -32,9 +34,14 @@ const w = dom.window
 
 g.window = w
 g.document = w.document
+// Browsers expose `location` on `globalThis` (`globalThis.location === window.location`);
+// mirror that so code reading `globalThis.location` directly (e.g. the SDK's
+// `isOxyRpOrigin` WebAuthn origin guard) sees the jsdom `http://localhost/` URL.
+g.location = w.location
 g.HTMLElement = w.HTMLElement
 g.HTMLStyleElement = w.HTMLStyleElement
 g.HTMLButtonElement = w.HTMLButtonElement
+g.HTMLInputElement = w.HTMLInputElement
 g.Element = w.Element
 g.Node = w.Node
 g.navigator = w.navigator

--- a/packages/auth/lib/passkey-error.ts
+++ b/packages/auth/lib/passkey-error.ts
@@ -1,0 +1,62 @@
+/**
+ * Turn a thrown WebAuthn passkey ceremony error into a friendly, user-facing
+ * message for the auth (IdP) forms.
+ *
+ * The passkey handlers call the SDK's `signInWithPasskey` / `registerWithPasskey`,
+ * which run a `navigator.credentials` ceremony through `@simplewebauthn/browser`.
+ * When the user dismisses the browser's system prompt (or it times out) the
+ * ceremony rejects with a `NotAllowedError` / `AbortError` DOMException — often
+ * re-wrapped by `@simplewebauthn/browser` as a `WebAuthnError` carrying the
+ * original as its `cause`. Those raw messages are noisy and alarming ("The
+ * operation either timed out or was not allowed…"), so we detect the
+ * cancellation shape anywhere in the cause chain and return a calm message
+ * instead of crashing or leaking the DOMException text.
+ */
+
+/** Friendly copy shown when the user dismisses / cancels the browser prompt. */
+export const PASSKEY_CANCELLED_MESSAGE =
+    "Passkey prompt dismissed. Try again when you're ready."
+
+/** Generic fallback when a ceremony fails for a non-cancellation reason. */
+const PASSKEY_GENERIC_FAILURE = "Couldn't complete the passkey. Please try again."
+
+/**
+ * Walk an error's `cause` chain (bounded) looking for the DOMException `name`
+ * WebAuthn raises on a user-dismissed / aborted prompt. `@simplewebauthn/browser`
+ * wraps the original DOMException as `cause`, so the top-level error is a
+ * `WebAuthnError` while the meaningful `name` lives one level down.
+ */
+function isCancellation(error: unknown): boolean {
+    let current: unknown = error
+    for (let depth = 0; depth < 5 && current; depth += 1) {
+        if (current instanceof Error) {
+            if (current.name === "NotAllowedError" || current.name === "AbortError") {
+                return true
+            }
+            // `@simplewebauthn/browser` sets a stable `code` for an aborted ceremony.
+            const code = (current as { code?: unknown }).code
+            if (code === "ERROR_CEREMONY_ABORTED") {
+                return true
+            }
+            current = (current as { cause?: unknown }).cause
+        } else {
+            break
+        }
+    }
+    return false
+}
+
+/**
+ * Resolve a passkey ceremony error to a message suitable for inline display.
+ * Cancellations get the calm {@link PASSKEY_CANCELLED_MESSAGE}; anything else
+ * falls back to the error's own message, then a generic failure string.
+ */
+export function describePasskeyError(error: unknown): string {
+    if (isCancellation(error)) {
+        return PASSKEY_CANCELLED_MESSAGE
+    }
+    if (error instanceof Error && error.message.trim().length > 0) {
+        return error.message
+    }
+    return PASSKEY_GENERIC_FAILURE
+}


### PR DESCRIPTION
## Summary
- Adds "Create account with a passkey" to the sign-up form on auth.oxy.so — a username-only registration branch (no email/password required) that runs the WebAuthn registration ceremony and completes the SDK's verify-signup flow.
- Adds "Sign in with a passkey" to the login form — a discoverable-credential WebAuthn authentication flow (no username typed up front).
- Both entry points are gated by `isOxyRpOrigin` — passkey UI is only offered on trusted Oxy origins.
- New `lib/passkey-error.ts` gives friendly handling for cancelled/aborted WebAuthn ceremonies (e.g. user dismisses the platform authenticator prompt) instead of surfacing a raw `NotAllowedError`.
- Both flows plant a session via the SDK the same way password sign-in does (no bespoke token handling in the auth app).

## Evidence
- Browser E2E was run manually against a real virtual authenticator via CDP (already completed by another agent prior to this PR):
  - Passkey sign-in flow: successfully plants a session.
  - Passkey sign-up flow: successfully plants a session, and the newly created user ends up with `authMethods: [webauthn]` — fully passwordless.

## Test plan (CI-covered parts)
- [x] `bunx tsc --noEmit` in `packages/auth` — clean
- [x] `bun run test` in `packages/auth` (bun test runner) — 52 pass, 0 fail (baseline 45 + 7 new passkey tests: `login-form-passkey.test.tsx`, `sign-up-form-passkey.test.tsx`)
- [x] `bun install` at repo root — no lockfile changes (already in sync)
- [x] `bun install --frozen-lockfile` — passes
- [x] Manual browser E2E via CDP virtual authenticator (see Evidence above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>