### PR TITLE
feat(api): accept hardware/U2F security keys — residentKey/UV preferred, username-first login (Fase B)

### DIFF
--- a/packages/api/src/models/WebauthnCredential.ts
+++ b/packages/api/src/models/WebauthnCredential.ts
@@ -14,6 +14,13 @@ import mongoose, { type Document, Schema, type Types } from 'mongoose';
  * signature counter, persisted on every successful assertion for replay
  * detection (platform authenticators keep it at 0 and never increment — that is
  * NOT a regression, see the login/verify route).
+ *
+ * `userVerified` records the ASSURANCE LEVEL of the most recent ceremony: `true`
+ * when the authenticator performed real user verification (PIN/biometric),
+ * `false` for a possession-only assertion (a U2F/CTAP1 security key with no PIN,
+ * accepted under the owner's possession-credential policy). It is stamped at
+ * enrollment and refreshed on every successful login, so a future step-up can
+ * gate sensitive actions on UV-backed credentials without re-running a ceremony.
  */
 export interface IWebauthnCredential extends Document {
   userId: Types.ObjectId;
@@ -23,6 +30,7 @@ export interface IWebauthnCredential extends Document {
   transports?: string[];
   deviceType: 'singleDevice' | 'multiDevice';
   backedUp: boolean;
+  userVerified: boolean;
   name: string;
   createdAt: Date;
   lastUsedAt?: Date;
@@ -60,6 +68,11 @@ const WebauthnCredentialSchema: Schema = new Schema(
       required: true,
     },
     backedUp: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+    userVerified: {
       type: Boolean,
       required: true,
       default: false,

--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -230,36 +230,94 @@ beforeEach(() => {
   mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 6 } });
 });
 
+interface AuthOptionsArg {
+  allowCredentials: { id: string; transports?: string[] }[];
+  userVerification?: string;
+}
+
 describe('POST /webauthn/login/options', () => {
-  it('a supplied username does NOT leak the account: empty allowCredentials, unbound challenge, no DB lookup', async () => {
-    // Arrange the store so that IF the handler looked the user up it would find a
-    // matching account with a credential — proving the handler ignores it.
+  it('username-first (KNOWN username): returns that user\'s allowCredentials + a challenge bound to the account', async () => {
     mockUserFindOne.mockReturnValue(selectLean({ _id: USER_ID }));
-    mockCredFind.mockReturnValue(selectLean([{ credentialID: CRED_ID, transports: ['internal'] }]));
+    mockCredFind.mockReturnValue(selectLean([{ credentialID: CRED_ID, transports: ['usb', 'nfc'] }]));
 
     const res = await request(server, 'POST', '/webauthn/login/options', { username: 'loginuser' });
 
     expect(res.status).toBe(200);
-    // Discoverable-only: never emit the user's credentialIDs.
-    const opts = mockGenerateAuthOptions.mock.calls[0][0] as { allowCredentials: unknown[]; userVerification?: string };
-    expect(opts.allowCredentials).toHaveLength(0);
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg;
+    // The user's real credential id is surfaced so a non-discoverable hardware key
+    // can be invoked by the browser.
+    expect(opts.allowCredentials).toEqual([{ id: CRED_ID, transports: ['usb', 'nfc'] }]);
     expect(opts.userVerification).toBe('required');
-    // Challenge is not bound to any account.
-    const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: string };
+    // Challenge is bound to the resolved account (so verify can reject a foreign key).
+    const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: unknown };
     expect(stored.type).toBe('authentication');
-    expect(stored.userId).toBeUndefined();
-    // No account-existence-dependent branching or timing: the user/credential
-    // lookups must NOT run at all.
-    expect(mockUserFindOne).not.toHaveBeenCalled();
-    expect(mockCredFind).not.toHaveBeenCalled();
+    expect(String(stored.userId)).toBe(USER_ID);
+    // The user + credential lookups both ran (same work as the not-found path).
+    expect(mockUserFindOne).toHaveBeenCalledTimes(1);
+    expect(mockCredFind).toHaveBeenCalledTimes(1);
   });
 
-  it('usernameless (discoverable): empty allowCredentials and an unbound challenge', async () => {
+  it('username-first (UNKNOWN username): returns a decoy allowCredential of the same shape — never empty, never the real user\'s id, no non-existence tell', async () => {
+    // The account does not exist and the (throwaway-id) credential query returns none.
+    mockUserFindOne.mockReturnValue(selectLean(null));
+    mockCredFind.mockReturnValue(selectLean([]));
+
+    const res = await request(server, 'POST', '/webauthn/login/options', { username: 'ghostuser' });
+
+    expect(res.status).toBe(200);
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg;
+    // Same SHAPE as the known-username response: exactly one non-empty allowCredential.
+    expect(opts.allowCredentials).toHaveLength(1);
+    expect(typeof opts.allowCredentials[0].id).toBe('string');
+    expect(opts.allowCredentials[0].id.length).toBeGreaterThan(0);
+    // The decoy is NOT any real credential id.
+    expect(opts.allowCredentials[0].id).not.toBe(CRED_ID);
+    // Structurally identical (transports present, like a real allow-list entry).
+    expect(Array.isArray(opts.allowCredentials[0].transports)).toBe(true);
+    // A bound challenge is still stored (non-null userId), so nothing about the
+    // response reveals that the account does not exist.
+    const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: unknown };
+    expect(stored.type).toBe('authentication');
+    expect(stored.userId).toBeDefined();
+    // SAME work as the found path: user lookup + one credential query both ran (no
+    // account-existence-dependent early return / timing oracle).
+    expect(mockUserFindOne).toHaveBeenCalledTimes(1);
+    expect(mockCredFind).toHaveBeenCalledTimes(1);
+  });
+
+  it('the decoy is DETERMINISTIC: the same unknown username yields the same decoy id across requests', async () => {
+    mockUserFindOne.mockReturnValue(selectLean(null));
+    mockCredFind.mockReturnValue(selectLean([]));
+
+    await request(server, 'POST', '/webauthn/login/options', { username: 'ghostuser' });
+    await request(server, 'POST', '/webauthn/login/options', { username: 'ghostuser' });
+
+    const first = (mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg).allowCredentials[0].id;
+    const second = (mockGenerateAuthOptions.mock.calls[1][0] as AuthOptionsArg).allowCredentials[0].id;
+    // Stable across polls (a per-request-random decoy would itself be the tell).
+    expect(second).toBe(first);
+  });
+
+  it('username-first (KNOWN account with NO passkey): returns a decoy, not an empty allow-list', async () => {
+    // A real account that simply has not enrolled a passkey must look identical to
+    // an unknown username — otherwise the empty allow-list would leak "exists".
+    mockUserFindOne.mockReturnValue(selectLean({ _id: USER_ID }));
+    mockCredFind.mockReturnValue(selectLean([]));
+
+    const res = await request(server, 'POST', '/webauthn/login/options', { username: 'loginuser' });
+
+    expect(res.status).toBe(200);
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg;
+    expect(opts.allowCredentials).toHaveLength(1);
+    expect(opts.allowCredentials[0].id).not.toBe(CRED_ID);
+  });
+
+  it('usernameless (discoverable): empty allowCredentials and an unbound challenge, no lookups', async () => {
     const res = await request(server, 'POST', '/webauthn/login/options', {});
     expect(res.status).toBe(200);
-    const opts = mockGenerateAuthOptions.mock.calls[0][0] as { allowCredentials: unknown[] };
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg;
     expect(opts.allowCredentials).toHaveLength(0);
-    const stored = mockChallengeCreate.mock.calls[0][0] as { userId?: string };
+    const stored = mockChallengeCreate.mock.calls[0][0] as { userId?: unknown };
     expect(stored.userId).toBeUndefined();
     expect(mockUserFindOne).not.toHaveBeenCalled();
     expect(mockCredFind).not.toHaveBeenCalled();
@@ -330,6 +388,29 @@ describe('POST /webauthn/login/verify', () => {
     mockChallengeFindOneAndUpdate.mockImplementation(() => leanValue(null));
     const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
     expect(res.status).toBe(401);
+    expect(mockVerifyAuthentication).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a credential whose owner does NOT match a username-bound challenge (cross-user)', async () => {
+    // The stored challenge was issued for a DIFFERENT account (OTHER_USER). The
+    // presented credential is owned by USER_ID. The owner-bound burn only matches
+    // when its queried userId equals the stored owner, so neither the owner-bound
+    // attempt (USER_ID) nor the discoverable fallback (null) can burn it.
+    const OTHER_USER = '507f1f77bcf86cd7994390ff';
+    mockChallengeFindOneAndUpdate.mockImplementation((query: { userId?: unknown }) =>
+      leanValue(query.userId === OTHER_USER ? { _id: 'ch-other', challenge: AUTH_CHALLENGE } : null),
+    );
+
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+
+    expect(res.status).toBe(401);
+    // The handler DID attempt an owner-bound burn keyed on the credential's owner…
+    const ownerBoundQuery = mockChallengeFindOneAndUpdate.mock.calls[0][0] as { userId?: unknown };
+    expect(ownerBoundQuery.userId).toBe(USER_ID);
+    // …and a discoverable (userId:null) fallback — both missed the OTHER_USER row.
+    const discoverableQuery = mockChallengeFindOneAndUpdate.mock.calls[1][0] as { userId?: unknown };
+    expect(discoverableQuery.userId).toBeNull();
     expect(mockVerifyAuthentication).not.toHaveBeenCalled();
     expect(mockCreateSession).not.toHaveBeenCalled();
   });

--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -30,6 +30,7 @@ let mockCredDoc: {
   counter: number;
   userId: string;
   transports?: string[];
+  userVerified?: boolean;
   lastUsedAt?: Date;
   save: jest.Mock;
 } | null;
@@ -205,6 +206,7 @@ beforeEach(() => {
     counter: 5,
     userId: USER_ID,
     transports: ['internal'],
+    userVerified: false,
     save: jest.fn().mockResolvedValue(undefined),
   };
 
@@ -227,7 +229,7 @@ beforeEach(() => {
   mockFinalizeDeviceLogin.mockResolvedValue({ deviceSecret: 'device-secret-1' });
   mockLogSignIn.mockResolvedValue(undefined);
   mockLogSuspicious.mockResolvedValue(undefined);
-  mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 6 } });
+  mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 6, userVerified: true } });
 });
 
 interface AuthOptionsArg {
@@ -247,7 +249,7 @@ describe('POST /webauthn/login/options', () => {
     // The user's real credential id is surfaced so a non-discoverable hardware key
     // can be invoked by the browser.
     expect(opts.allowCredentials).toEqual([{ id: CRED_ID, transports: ['usb', 'nfc'] }]);
-    expect(opts.userVerification).toBe('required');
+    expect(opts.userVerification).toBe('preferred');
     // Challenge is bound to the resolved account (so verify can reject a foreign key).
     const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: unknown };
     expect(stored.type).toBe('authentication');
@@ -335,13 +337,32 @@ describe('POST /webauthn/login/verify', () => {
     expect(res.body.user).toMatchObject({ id: USER_ID, username: 'loginuser' });
     // Counter advanced and persisted.
     expect(mockCredDoc?.counter).toBe(6);
+    // Assurance level refreshed from this ceremony (stored false → verified true).
+    expect(mockCredDoc?.userVerified).toBe(true);
+    expect(mockCredDoc?.save).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    // Possession-only assertions are accepted — UV is not required at verify.
+    const verifyArg = mockVerifyAuthentication.mock.calls[0][0] as { requireUserVerification: boolean };
+    expect(verifyArg.requireUserVerification).toBe(false);
+  });
+
+  it('accepts a possession-only (userVerified:false) assertion and records the flag', async () => {
+    // A stored credential that had verified previously authenticates presence-only
+    // now (e.g. a U2F key with no PIN) → still succeeds, flag refreshed to false.
+    if (mockCredDoc) mockCredDoc.userVerified = true;
+    mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 6, userVerified: false } });
+
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+
+    expect(res.status).toBe(200);
+    expect(mockCredDoc?.userVerified).toBe(false);
     expect(mockCredDoc?.save).toHaveBeenCalledTimes(1);
     expect(mockCreateSession).toHaveBeenCalledTimes(1);
   });
 
   it('accepts a platform authenticator that never increments (newCounter === 0, stored 0)', async () => {
     if (mockCredDoc) mockCredDoc.counter = 0;
-    mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 0 } });
+    mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 0, userVerified: true } });
 
     const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
 

--- a/packages/api/src/routes/__tests__/webauthnRegister.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnRegister.test.ts
@@ -28,6 +28,7 @@ const NEW_USER_ID = '507f1f77bcf86cd7994390aa';
 let mockBearerUserId: string | null = null;
 let mockBurnResult: unknown = { _id: 'c1', challenge: REG_CHALLENGE, type: 'registration' };
 let mockCredCreateError: { code?: number } | null = null;
+let mockRegisterUserVerified = true;
 
 const mockChallengeCreate = jest.fn();
 const mockChallengeFindOneAndUpdate = jest.fn();
@@ -227,6 +228,7 @@ beforeEach(() => {
   mockBearerUserId = null;
   mockBurnResult = { _id: 'c1', challenge: REG_CHALLENGE, type: 'registration' };
   mockCredCreateError = null;
+  mockRegisterUserVerified = true;
 
   mockGenerateRegistration.mockResolvedValue({
     challenge: REG_CHALLENGE,
@@ -256,14 +258,15 @@ beforeEach(() => {
   });
   mockFinalizeDeviceLogin.mockResolvedValue({ deviceSecret: 'device-secret-1' });
   mockLogSignIn.mockResolvedValue(undefined);
-  mockVerifyRegistration.mockResolvedValue({
+  mockVerifyRegistration.mockImplementation(async () => ({
     verified: true,
     registrationInfo: {
       credential: { id: NEW_CRED_ID, publicKey: new Uint8Array([1, 2, 3, 4]), counter: 0, transports: ['internal'] },
       credentialDeviceType: 'multiDevice',
       credentialBackedUp: true,
+      userVerified: mockRegisterUserVerified,
     },
-  });
+  }));
 });
 
 describe('POST /webauthn/register/options', () => {
@@ -289,7 +292,7 @@ describe('POST /webauthn/register/options', () => {
     expect(res.status).toBe(400);
   });
 
-  it('offers residentKey:preferred + UV:required and does NOT pin authenticatorAttachment (roaming/hardware keys can enrol)', async () => {
+  it('offers residentKey:preferred + UV:preferred and does NOT pin authenticatorAttachment (roaming/hardware keys can enrol)', async () => {
     const res = await request(server, 'POST', '/webauthn/register/options', { username: 'freshuser' });
     expect(res.status).toBe(200);
     const opts = mockGenerateRegistration.mock.calls[0][0] as {
@@ -302,8 +305,9 @@ describe('POST /webauthn/register/options', () => {
     // `preferred` (not `required`) is what lets a Google Titan / roaming key with no
     // resident-key support still register a non-discoverable credential.
     expect(opts.authenticatorSelection.residentKey).toBe('preferred');
-    // UV stays mandatory (passwordless plan requires user verification).
-    expect(opts.authenticatorSelection.userVerification).toBe('required');
+    // UV is `preferred` (owner possession-credential policy): UV-capable keys still
+    // verify; a UV-incapable U2F key falls back to presence-only.
+    expect(opts.authenticatorSelection.userVerification).toBe('preferred');
     // Attachment is unpinned so both platform and cross-platform authenticators show.
     expect(opts.authenticatorSelection.authenticatorAttachment).toBeUndefined();
   });
@@ -328,11 +332,37 @@ describe('POST /webauthn/register/verify — signup branch', () => {
     // Account + credential were created; a webauthn authMethod was stamped.
     expect(mockUserSave).toHaveBeenCalledTimes(1);
     expect(mockCredCreate).toHaveBeenCalledTimes(1);
-    const credArg = mockCredCreate.mock.calls[0][0] as { credentialID: string; name: string; deviceType: string };
+    const credArg = mockCredCreate.mock.calls[0][0] as {
+      credentialID: string;
+      name: string;
+      deviceType: string;
+      userVerified: boolean;
+    };
     expect(credArg.credentialID).toBe(NEW_CRED_ID);
     expect(credArg.name).toBe('My Laptop');
+    // Assurance level captured at enrollment (this ceremony did real UV).
+    expect(credArg.userVerified).toBe(true);
     expect(mockNewUserDoc.authMethods).toHaveLength(1);
     expect((mockNewUserDoc.authMethods[0] as { type: string }).type).toBe('webauthn');
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    // Possession-only credentials are accepted — UV is not required at verify.
+    const verifyArg = mockVerifyRegistration.mock.calls[0][0] as { requireUserVerification: boolean };
+    expect(verifyArg.requireUserVerification).toBe(false);
+  });
+
+  it('records userVerified:false for a possession-only (no-UV) enrollment and still creates the account', async () => {
+    mockRegisterUserVerified = false;
+    const res = await request(server, 'POST', '/webauthn/register/verify', {
+      username: 'freshuser',
+      deviceName: 'Titan Key',
+      response: registrationResponse(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockCredCreate).toHaveBeenCalledTimes(1);
+    const credArg = mockCredCreate.mock.calls[0][0] as { userVerified: boolean };
+    // Presence-only assertion → recorded as an unverified (possession-only) credential.
+    expect(credArg.userVerified).toBe(false);
     expect(mockCreateSession).toHaveBeenCalledTimes(1);
   });
 
@@ -386,6 +416,9 @@ describe('POST /webauthn/register/verify — linking branch', () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(mockCredCreate).toHaveBeenCalledTimes(1);
+    // The linked credential records its enrollment assurance level.
+    const credArg = mockCredCreate.mock.calls[0][0] as { userVerified: boolean };
+    expect(credArg.userVerified).toBe(true);
     expect(linkDoc.authMethods).toHaveLength(1);
     expect((linkDoc.authMethods[0] as { type: string }).type).toBe('webauthn');
     expect(mockInvalidate).toHaveBeenCalledWith(LINK_USER_ID);

--- a/packages/api/src/routes/__tests__/webauthnRegister.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnRegister.test.ts
@@ -42,6 +42,7 @@ const mockCreateSession = jest.fn();
 const mockFinalizeDeviceLogin = jest.fn();
 const mockLogSignIn = jest.fn();
 const mockVerifyRegistration = jest.fn();
+const mockGenerateRegistration = jest.fn();
 
 let mockNewUserDoc: { _id: string; username?: string; avatar?: string; authMethods: unknown[]; save: jest.Mock };
 
@@ -54,13 +55,7 @@ function selectLean(value: unknown) {
 
 // ---- module mocks ----------------------------------------------------------
 jest.mock('@simplewebauthn/server', () => ({
-  generateRegistrationOptions: jest.fn(async () => ({
-    challenge: REG_CHALLENGE,
-    rp: { name: 'Oxy', id: 'localhost' },
-    user: { id: 'x', name: 'x', displayName: '' },
-    pubKeyCredParams: [],
-    excludeCredentials: [],
-  })),
+  generateRegistrationOptions: (...args: unknown[]) => mockGenerateRegistration(...args),
   verifyRegistrationResponse: (...args: unknown[]) => mockVerifyRegistration(...args),
 }));
 
@@ -233,6 +228,13 @@ beforeEach(() => {
   mockBurnResult = { _id: 'c1', challenge: REG_CHALLENGE, type: 'registration' };
   mockCredCreateError = null;
 
+  mockGenerateRegistration.mockResolvedValue({
+    challenge: REG_CHALLENGE,
+    rp: { name: 'Oxy', id: 'localhost' },
+    user: { id: 'x', name: 'x', displayName: '' },
+    pubKeyCredParams: [],
+    excludeCredentials: [],
+  });
   mockChallengeCreate.mockResolvedValue({});
   mockChallengeFindOneAndUpdate.mockImplementation(() => leanValue(mockBurnResult));
   mockCredFind.mockReturnValue(selectLean([]));
@@ -285,6 +287,25 @@ describe('POST /webauthn/register/options', () => {
   it('requires a username in the signup branch', async () => {
     const res = await request(server, 'POST', '/webauthn/register/options', {});
     expect(res.status).toBe(400);
+  });
+
+  it('offers residentKey:preferred + UV:required and does NOT pin authenticatorAttachment (roaming/hardware keys can enrol)', async () => {
+    const res = await request(server, 'POST', '/webauthn/register/options', { username: 'freshuser' });
+    expect(res.status).toBe(200);
+    const opts = mockGenerateRegistration.mock.calls[0][0] as {
+      authenticatorSelection: {
+        residentKey?: string;
+        userVerification?: string;
+        authenticatorAttachment?: string;
+      };
+    };
+    // `preferred` (not `required`) is what lets a Google Titan / roaming key with no
+    // resident-key support still register a non-discoverable credential.
+    expect(opts.authenticatorSelection.residentKey).toBe('preferred');
+    // UV stays mandatory (passwordless plan requires user verification).
+    expect(opts.authenticatorSelection.userVerification).toBe('required');
+    // Attachment is unpinned so both platform and cross-platform authenticators show.
+    expect(opts.authenticatorSelection.authenticatorAttachment).toBeUndefined();
   });
 });
 

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -22,6 +22,7 @@
 
 import { Router, type Request, type Response } from 'express';
 import crypto from 'crypto';
+import { Types } from 'mongoose';
 import {
   generateRegistrationOptions,
   verifyRegistrationResponse,
@@ -170,6 +171,55 @@ async function burnChallenge(
 }
 
 /**
+ * Realistic transport spreads a decoy credential can advertise. A real
+ * credential's `transports` vary widely by authenticator (platform passkey →
+ * `['internal']`, hybrid/QR → `['internal','hybrid']`, security key →
+ * `['usb','nfc']`), so a deterministic pick from this pool sits inside the natural
+ * distribution and is not, by itself, an existence signal.
+ */
+const DECOY_TRANSPORT_POOL: AuthenticatorTransportFuture[][] = [
+  ['internal'],
+  ['internal', 'hybrid'],
+  ['usb', 'nfc'],
+  ['usb'],
+];
+
+/**
+ * A DETERMINISTIC decoy allow-credential for a username-first `login/options`
+ * request that does NOT resolve to an account with a passkey — i.e. the username
+ * is unknown OR belongs to a real account that has no WebAuthn credential. Its
+ * only job is anti-enumeration: the "no real credential" response must be
+ * INDISTINGUISHABLE from the "here are your credential ids" response so an
+ * unauthenticated caller cannot probe which usernames exist / have a passkey.
+ *
+ * - **Stable per username.** The id is `HMAC(DEVICE_ID_SALT, username)` — the SAME
+ *   username always yields the SAME id across requests, exactly as a real user's
+ *   credential ids are stable. A per-request-random decoy would itself be the tell
+ *   (a real allow-list does not change between two polls of the same username).
+ * - **Unforgeable.** Keying on the server-side salt (never a raw hash of the
+ *   username) stops an attacker precomputing "the decoy id for X" and matching it
+ *   against a response to classify fake vs real.
+ * - **Natural shape.** Length (16–31 bytes → 22–42 base64url chars) and transports
+ *   are derived from the same digest so they land within the spread of real
+ *   authenticator credential ids/transports rather than at a fixed tell-tale size.
+ *
+ * The paired challenge is bound by the caller to a throwaway ObjectId that maps to
+ * no user, so no real assertion can ever satisfy it: `login/verify` then fails with
+ * the same generic error a wrong/unknown passkey produces.
+ */
+function decoyAllowCredentials(
+  normalizedUsername: string,
+): { id: string; transports: AuthenticatorTransportFuture[] }[] {
+  const salt = process.env.DEVICE_ID_SALT ?? '';
+  const digest = crypto.createHmac('sha256', salt).update(`webauthn-decoy|${normalizedUsername}`).digest();
+  // Realistic, stable-per-username credential-id length (16–31 bytes).
+  const idByteLength = 16 + (digest[0] % 16);
+  const id = digest.subarray(1, 1 + idByteLength).toString('base64url');
+  const transports = DECOY_TRANSPORT_POOL[digest[digest.length - 1] % DECOY_TRANSPORT_POOL.length];
+  return [{ id, transports }];
+}
+
+/**
  * The shared session-mint finalisation. Identical to the `/auth/signup` /
  * `/auth/verify` tail: create the session, format the standard auth response,
  * register the session into its device set + mint the rotating `deviceSecret`,
@@ -291,8 +341,20 @@ router.post(
       attestationType: 'none',
       excludeCredentials,
       authenticatorSelection: {
-        residentKey: 'required',
+        // `preferred`, not `required`: a discoverable (resident) credential is still
+        // asked for so usernameless login keeps working on platform authenticators
+        // and modern security keys, but a roaming/hardware key with no resident-key
+        // support (or full resident slots) can STILL register — it just enrolls a
+        // non-discoverable credential, which the username-first login/options path
+        // serves via an explicit allow-list. `required` here is exactly what made a
+        // Google Titan fail Chrome's "device can't be used with this site" gate.
+        residentKey: 'preferred',
+        // Keep UV mandatory (the passwordless plan requires user verification): a key
+        // with no PIN/biometric legitimately cannot enrol — that is correct, not a bug.
         userVerification: 'required',
+        // `authenticatorAttachment` is deliberately UNPINNED so both platform (Face ID /
+        // Touch ID / Windows Hello) and cross-platform/roaming (USB-C / NFC security key)
+        // authenticators are offered.
       },
     });
 
@@ -484,13 +546,26 @@ router.post(
 /**
  * POST /webauthn/login/options
  *
- * ALWAYS discoverable-credential (usernameless) login: the allow-list is empty
- * regardless of any supplied `username`, and no user lookup is performed. Emitting
- * a user's `credentialID`s (a non-empty allow-list) — or even branching the
- * response/timing on whether a username resolves — would leak account existence
- * and let an unauthenticated caller enumerate a user's passkeys, so neither is
- * done. The authenticator returns the credentialID at verify time, which is where
- * the user is resolved. The challenge carries no `userId` (discoverable flow).
+ * Two flows, selected by whether the body carries a `username`:
+ *
+ *  - **No username → usernameless/discoverable.** Empty allow-list, unbound
+ *    challenge, no user lookup. The authenticator surfaces its resident credential
+ *    and the user is resolved by credentialID at verify time. (Unchanged.)
+ *
+ *  - **Username present → username-first.** Returns THAT user's credentialIDs in
+ *    `allowCredentials`, so a roaming/hardware key that did NOT store a resident
+ *    (discoverable) credential can still be used — the browser needs the explicit
+ *    id to invoke it. The challenge is bound to the resolved account so
+ *    `login/verify` can reject a credential owned by a different user.
+ *
+ * ANTI-ENUMERATION (this is why the M1 empty-allow-list existed — do NOT regress
+ * it): a username that does NOT resolve to an account-with-a-passkey (unknown, or a
+ * real account with no credential) returns a DETERMINISTIC decoy allow-credential
+ * of the same shape (see `decoyAllowCredentials`), bound to a throwaway id that
+ * maps to no user. Every branch does the SAME work — resolve the user, compute the
+ * decoy, run one credential query — and returns the SAME response shape, so an
+ * unknown username is indistinguishable from a known one by RESPONSE CONTENT and by
+ * TIMING. There are no account-existence-dependent early returns.
  */
 router.post(
   '/login/options',
@@ -502,16 +577,54 @@ router.post(
     }
 
     const rpID = getWebauthnRpId();
+    const requestedUsername = parsed.data.username;
+
+    let allowCredentials: { id: string; transports?: AuthenticatorTransportFuture[] }[] = [];
+    let challengeUserId: Types.ObjectId | undefined;
+
+    if (requestedUsername) {
+      const normalizedUsername = normalizeUsername(requestedUsername);
+      // Always resolve the user (an unparseable/nonexistent username simply finds
+      // nothing — never a distinct rejection that would leak "no such account").
+      const user = await User.findOne({ username: exactCaseInsensitiveUsernameRegex(normalizedUsername) })
+        .select('_id')
+        .lean();
+      // Always compute the decoy, whether or not it is ultimately used, so the
+      // found and not-found paths do the same work.
+      const decoy = decoyAllowCredentials(normalizedUsername);
+      // Always issue exactly one credential query. For a missing user a throwaway
+      // id keeps the query shape/cost identical while returning no rows.
+      const probeUserId = user?._id ?? new Types.ObjectId();
+      const credentials = await WebauthnCredential.find({ userId: probeUserId })
+        .select('credentialID transports')
+        .lean();
+
+      if (user && credentials.length > 0) {
+        allowCredentials = credentials.map((cred) => ({
+          id: cred.credentialID,
+          transports: cred.transports as AuthenticatorTransportFuture[] | undefined,
+        }));
+        // Bind the challenge to the resolved account — verify asserts the presented
+        // credential's owner equals this id (user A's challenge ≠ user B's key).
+        challengeUserId = user._id;
+      } else {
+        // Unknown username OR an account with no passkey → decoy. Bind the challenge
+        // to a throwaway id that maps to no user, so it can never be satisfied.
+        allowCredentials = decoy;
+        challengeUserId = new Types.ObjectId();
+      }
+    }
 
     const options = await generateAuthenticationOptions({
       rpID,
-      allowCredentials: [],
+      allowCredentials,
       userVerification: 'required',
     });
 
     await WebauthnChallenge.create({
       challenge: options.challenge,
       type: 'authentication',
+      ...(challengeUserId ? { userId: challengeUserId } : {}),
       expiresAt: new Date(Date.now() + CHALLENGE_TTL_MS),
       used: false,
     });
@@ -553,9 +666,17 @@ router.post(
 
     const { origin, challenge } = decodeAndGuardClientData(response.response.clientDataJSON);
 
-    // Burn the challenge. A username-first challenge carries the account id; it
-    // must match the credential's owner. A discoverable challenge carries none
-    // (`{ userId: null }` matches the missing field).
+    // Burn the challenge, and in doing so ENFORCE the challenge↔owner binding
+    // atomically. Two mutually-exclusive shapes are accepted:
+    //   1. Username-first: the challenge was stored bound to an account id, so it is
+    //      only burned when that id EQUALS this credential's owner. A challenge
+    //      issued for user A is therefore unusable by user B's credential (the match
+    //      fails), and a decoy challenge (bound to a throwaway id that maps to no
+    //      user) is unusable by anyone — both fall through to the same generic error.
+    //   2. Discoverable: the challenge carries no account id (`{ userId: null }`
+    //      matches the missing field); any owner may satisfy it. (Unchanged.)
+    // Because the owner constraint lives INSIDE the atomic `findOneAndUpdate`, the
+    // cross-user rejection cannot race the burn.
     const owner = credential.userId.toString();
     const usernameFirstBurned = await burnChallenge(challenge, 'authentication', { userId: owner });
     const discoverableBurned = usernameFirstBurned

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -349,9 +349,13 @@ router.post(
         // serves via an explicit allow-list. `required` here is exactly what made a
         // Google Titan fail Chrome's "device can't be used with this site" gate.
         residentKey: 'preferred',
-        // Keep UV mandatory (the passwordless plan requires user verification): a key
-        // with no PIN/biometric legitimately cannot enrol — that is correct, not a bug.
-        userVerification: 'required',
+        // `preferred`, not `required` (owner possession-credential policy): a
+        // UV-capable authenticator (platform Face ID / Windows Hello, FIDO2-with-PIN)
+        // STILL performs user verification unchanged; only a UV-incapable key (a
+        // U2F/CTAP1 Titan with no PIN) falls back to presence-only. The assurance
+        // level of each ceremony is captured on the credential's `userVerified` flag
+        // (see register/verify) so a future step-up can gate on UV-backed credentials.
+        userVerification: 'preferred',
         // `authenticatorAttachment` is deliberately UNPINNED so both platform (Face ID /
         // Touch ID / Windows Hello) and cross-platform/roaming (USB-C / NFC security key)
         // authenticators are offered.
@@ -410,7 +414,10 @@ router.post(
         expectedChallenge: challenge,
         expectedOrigin: origin,
         expectedRPID: rpID,
-        requireUserVerification: true,
+        // Possession-only credentials are accepted (owner policy): a presence-only
+        // U2F/CTAP1 key would fail here if UV were required. The actual assurance
+        // level is recorded per-credential via `registrationInfo.userVerified`.
+        requireUserVerification: false,
       });
     } catch (error) {
       logger.warn('webauthn register verification threw', {
@@ -424,7 +431,7 @@ router.post(
       throw new BadRequestError('Passkey registration could not be verified');
     }
 
-    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+    const { credential, credentialDeviceType, credentialBackedUp, userVerified } = verification.registrationInfo;
     const credentialName = envelope.deviceName?.trim() || DEFAULT_CREDENTIAL_NAME;
 
     if (bearerUserId) {
@@ -443,6 +450,7 @@ router.post(
           transports: credential.transports,
           deviceType: credentialDeviceType,
           backedUp: credentialBackedUp,
+          userVerified,
           name: credentialName,
         });
       } catch (error) {
@@ -501,6 +509,7 @@ router.post(
         transports: credential.transports,
         deviceType: credentialDeviceType,
         backedUp: credentialBackedUp,
+        userVerified,
         name: credentialName,
       });
     } catch (error) {
@@ -618,7 +627,11 @@ router.post(
     const options = await generateAuthenticationOptions({
       rpID,
       allowCredentials,
-      userVerification: 'required',
+      // `preferred` (owner possession-credential policy): UV-capable authenticators
+      // still verify; a UV-incapable U2F key authenticates presence-only. The
+      // ceremony's real assurance level is refreshed onto the credential's
+      // `userVerified` flag at verify time.
+      userVerification: 'preferred',
     });
 
     await WebauthnChallenge.create({
@@ -693,7 +706,9 @@ router.post(
         expectedChallenge: challenge,
         expectedOrigin: origin,
         expectedRPID: rpID,
-        requireUserVerification: true,
+        // Possession-only assertions are accepted (owner policy); the actual
+        // assurance level is refreshed onto `credential.userVerified` below.
+        requireUserVerification: false,
         credential: {
           id: credential.credentialID,
           publicKey: new Uint8Array(credential.credentialPublicKey),
@@ -713,7 +728,7 @@ router.post(
       throw new UnauthorizedError('Passkey authentication could not be verified');
     }
 
-    const { newCounter } = verification.authenticationInfo;
+    const { newCounter, userVerified } = verification.authenticationInfo;
     // Counter regression = replay/cloned authenticator. `newCounter === 0` is NOT
     // a regression: platform authenticators keep the counter at 0 and never
     // increment, so a stored 0 and a fresh 0 are legitimate.
@@ -737,6 +752,9 @@ router.post(
 
     credential.counter = newCounter;
     credential.lastUsedAt = new Date();
+    // Refresh the assurance level: a credential that enrolled UV-capable but
+    // authenticated presence-only (or vice versa) reflects its most recent ceremony.
+    credential.userVerified = userVerified;
     await credential.save();
 
     const user = await User.findById(owner);


### PR DESCRIPTION
## Summary

- Relaxes WebAuthn registration/auth requirements to accept possession-only hardware/U2F security keys (e.g. a no-PIN Google Titan) as bound credentials: `residentKey` changed `'required'` → `'preferred'`, `userVerification` changed `'required'` → `'preferred'`, and `requireUserVerification: false` on verification. This relaxation is an explicit owner decision, not an oversight — the goal is to support the full range of real-world hardware keys, not only platform authenticators with PIN/biometric UV.
- Adds a username-first login/options flow, including an HMAC-based anti-enumeration decoy response (so probing for valid usernames doesn't leak account existence) and cross-user challenge binding.
- Adds a new `WebauthnCredential.userVerified` field that records the per-credential assurance level actually achieved at registration/auth time — independent of the now-relaxed requirement, so we retain a signal of which credentials had real UV even though it's no longer mandatory.

## Security review

Reviewed separately. **Verdict: SAFE TO MERGE AS-IS** — no Critical or High findings.

Documented non-blocking fast-follows (Medium/Low residuals), tracked for later:
- Mask the decoy response's credential count to better match a real account's response shape.
- Widen the decoy challenge length for a tighter timing/format match against real challenges.
- Note in code/docs that `userVerified` is an assurance *signal*, not an enforced requirement — callers must not treat it as a guarantee.
- Confirm fail-closed behavior for the anti-enumeration HMAC salt (missing/misconfigured salt must not silently degrade anti-enumeration protection).

## Test plan

- [x] `@oxyhq/contracts` + `@oxyhq/core` build clean
- [x] `packages/api` — `tsc --noEmit` clean
- [x] `packages/api` test suite green: 170 suites / 1560 tests (includes 26 WebAuthn tests covering hardware-key + username-first anti-enumeration flows)
- [x] Lockfile gate: `bun install` produced zero lockfile changes; `bun install --frozen-lockfile` passes (no drift, no new deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)