### PR TITLE
feat(accounts): passkey management — add/list/revoke on accounts.oxy.so (Fase B/b1-fe)

### DIFF
--- a/packages/accounts/app/(tabs)/security.tsx
+++ b/packages/accounts/app/(tabs)/security.tsx
@@ -14,6 +14,7 @@ import { SecurityActivitySection } from '@/components/security/security-activity
 import { useSecurityActivityItems } from '@/components/security/useSecurityActivityItems';
 import { SignInSection } from '@/components/security/sign-in-section';
 import { useSignInItems } from '@/components/security/useSignInItems';
+import { usePasskeyItems } from '@/components/security/usePasskeyItems';
 import { LanguageSection } from '@/components/security/language-section';
 import { DevicesSection } from '@/components/security/devices-section';
 import { useDeviceItems } from '@/components/security/useDeviceItems';
@@ -73,6 +74,10 @@ export default function SecurityScreen() {
         toggleBiometricLogin,
     });
 
+    // Passkey rows (web-only, Oxy RP origin) appended to "How you sign in".
+    // Returns [] on native / non-Oxy origins, so the spread below is a no-op there.
+    const passkeyItems = usePasskeyItems();
+
     const deviceItems = useDeviceItems({ devices });
 
     const { items: activeSessionsItems } = useActiveSessions({ sessions, logoutAll });
@@ -99,7 +104,7 @@ export default function SecurityScreen() {
                 isLoading={securityActivityLoading}
             />
 
-            <SignInSection items={signInItems} />
+            <SignInSection items={[...signInItems, ...passkeyItems]} />
 
             <LanguageSection />
 

--- a/packages/accounts/components/security/usePasskeyItems.tsx
+++ b/packages/accounts/components/security/usePasskeyItems.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, Platform, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { alert, toast } from '@oxyhq/bloom';
+import { isOxyRpOrigin } from '@oxyhq/core';
+import { useAuthMethods, useOxy } from '@oxyhq/services';
+import { useColors } from '@/hooks/useColors';
+import { useTranslation, useLocale } from '@/lib/i18n';
+import type { GroupedItem } from '@/components/sections/types';
+
+/** A single registered passkey, as projected by `useAuthMethods().passkeys`. */
+type PasskeyMethod = ReturnType<typeof useAuthMethods>['passkeys'][number];
+
+/**
+ * WebAuthn ceremony errors that mean the user simply dismissed / cancelled the
+ * browser prompt — not a real failure. `@simplewebauthn/browser` wraps the raw
+ * `DOMException` (`NotAllowedError` on dismiss) as the thrown error's `cause`,
+ * and reports an aborted ceremony via `code: 'ERROR_CEREMONY_ABORTED'`. Detect
+ * all three shapes so a cancel shows a friendly toast instead of a scary error.
+ */
+const CANCELLED_CEREMONY_NAMES = new Set(['NotAllowedError', 'AbortError']);
+
+function isCancelledPasskeyCeremony(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (CANCELLED_CEREMONY_NAMES.has(error.name)) return true;
+  const { code, cause } = error as { code?: unknown; cause?: unknown };
+  if (code === 'ERROR_CEREMONY_ABORTED') return true;
+  return cause instanceof Error && CANCELLED_CEREMONY_NAMES.has(cause.name);
+}
+
+/**
+ * Builds the passkey rows for the "How you sign in" section: one row per
+ * registered passkey (name + added date + a trailing remove button) followed by
+ * an "Add a passkey" CTA that runs the browser WebAuthn ceremony.
+ *
+ * WEB-ONLY and gated on {@link isOxyRpOrigin} — passkeys minted with Oxy's RP id
+ * can only be created/asserted from a first-party Oxy web origin. Returns `[]`
+ * on native or a non-Oxy origin, mirroring the native-only biometric block in
+ * `useSignInItems`. A `.tsx` file because the rows embed JSX (the remove button
+ * / activity indicators).
+ */
+export function usePasskeyItems(): GroupedItem[] {
+  const colors = useColors();
+  const { t } = useTranslation();
+  const { locale } = useLocale();
+  const { addPasskey, removePasskey } = useOxy();
+
+  const enabled = Platform.OS === 'web' && isOxyRpOrigin();
+  const { passkeys } = useAuthMethods({ enabled });
+
+  const [isAdding, setIsAdding] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }),
+    [locale],
+  );
+
+  const handleAdd = useCallback(async () => {
+    setIsAdding(true);
+    try {
+      await addPasskey();
+      toast.success(t('security.passkeys.addSuccess'));
+    } catch (error: unknown) {
+      if (isCancelledPasskeyCeremony(error)) {
+        toast.info(t('security.passkeys.addCancelled'));
+      } else {
+        const message = error instanceof Error ? error.message : '';
+        toast.error(message || t('security.passkeys.addFailed'));
+      }
+    } finally {
+      setIsAdding(false);
+    }
+  }, [addPasskey, t]);
+
+  const handleRemove = useCallback(
+    (passkey: PasskeyMethod) => {
+      const credentialId = passkey.credentialId;
+      if (!credentialId) return;
+      alert(
+        t('security.passkeys.removeConfirmTitle'),
+        t('security.passkeys.removeConfirmMessage'),
+        [
+          { text: t('common.cancel'), style: 'cancel' },
+          {
+            text: t('security.passkeys.removeAction'),
+            style: 'destructive',
+            onPress: async () => {
+              setRemovingId(credentialId);
+              try {
+                await removePasskey(credentialId);
+                toast.success(t('security.passkeys.removeSuccess'));
+              } catch (error: unknown) {
+                const message = error instanceof Error ? error.message : '';
+                toast.error(message || t('security.passkeys.removeFailed'));
+              } finally {
+                setRemovingId(null);
+              }
+            },
+          },
+        ],
+      );
+    },
+    [removePasskey, t],
+  );
+
+  return useMemo(() => {
+    if (!enabled) return [];
+
+    const items: GroupedItem[] = [];
+
+    for (const passkey of passkeys) {
+      const credentialId = passkey.credentialId;
+      if (!credentialId) continue;
+
+      const addedDate = passkey.linkedAt ? new Date(passkey.linkedAt) : null;
+      const subtitle =
+        addedDate && !Number.isNaN(addedDate.getTime())
+          ? t('security.passkeys.addedOn', { date: dateFormatter.format(addedDate) })
+          : undefined;
+      const isRemoving = removingId === credentialId;
+
+      items.push({
+        id: `passkey-${credentialId}`,
+        icon: 'key-variant',
+        iconColor: colors.sidebarIconSecurity,
+        title: passkey.name?.trim() || t('security.passkeys.unnamed'),
+        subtitle,
+        showChevron: false,
+        customContent: isRemoving ? (
+          <ActivityIndicator size="small" color={colors.error} />
+        ) : (
+          <TouchableOpacity
+            onPress={() => handleRemove(passkey)}
+            accessibilityRole="button"
+            accessibilityLabel={t('security.passkeys.removeA11yLabel')}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Ionicons name="trash-outline" size={20} color={colors.error} />
+          </TouchableOpacity>
+        ),
+      });
+    }
+
+    // "Add a passkey" CTA — always last. Disabled (and shows a spinner) while a
+    // ceremony is in flight so a double-tap can't launch two prompts.
+    items.push({
+      id: 'add-passkey',
+      icon: 'key-plus',
+      iconColor: colors.success,
+      title: t('security.passkeys.addTitle'),
+      subtitle: t('security.passkeys.addSubtitle'),
+      onPress: isAdding ? undefined : handleAdd,
+      disabled: isAdding,
+      showChevron: false,
+      customContent: isAdding ? (
+        <ActivityIndicator size="small" color={colors.success} />
+      ) : undefined,
+    });
+
+    return items;
+  }, [enabled, passkeys, removingId, isAdding, colors, dateFormatter, handleAdd, handleRemove, t]);
+}

--- a/packages/accounts/lib/i18n/locales/en.json
+++ b/packages/accounts/lib/i18n/locales/en.json
@@ -198,6 +198,21 @@
       "publicKeyAuth": "Public key authentication",
       "publicKeyAuthSubtitle": "Your account uses cryptographic keys for secure sign-in"
     },
+    "passkeys": {
+      "unnamed": "Passkey",
+      "addedOn": "Added {{date}}",
+      "addTitle": "Add a passkey",
+      "addSubtitle": "Sign in with your fingerprint, face, or device PIN",
+      "addSuccess": "Passkey added",
+      "addCancelled": "Passkey setup cancelled",
+      "addFailed": "Could not add a passkey",
+      "removeA11yLabel": "Remove passkey",
+      "removeConfirmTitle": "Remove this passkey?",
+      "removeConfirmMessage": "You will no longer be able to sign in with this passkey. Make sure you have another way to sign in.",
+      "removeAction": "Remove",
+      "removeSuccess": "Passkey removed",
+      "removeFailed": "Could not remove the passkey"
+    },
     "recoveryWarning": {
       "title": "No recovery phrase backup",
       "subtitle": "If you have not written down your 12-word recovery phrase, you cannot restore your account on a new device. Create an encrypted backup or note your phrase now.",

--- a/packages/accounts/lib/i18n/locales/es.json
+++ b/packages/accounts/lib/i18n/locales/es.json
@@ -198,6 +198,21 @@
       "publicKeyAuth": "Autenticación por clave pública",
       "publicKeyAuthSubtitle": "Tu cuenta usa claves criptográficas para iniciar sesión de forma segura"
     },
+    "passkeys": {
+      "unnamed": "Llave de acceso",
+      "addedOn": "Añadida el {{date}}",
+      "addTitle": "Añadir una llave de acceso",
+      "addSubtitle": "Inicia sesión con tu huella, tu cara o el PIN del dispositivo",
+      "addSuccess": "Llave de acceso añadida",
+      "addCancelled": "Configuración de la llave de acceso cancelada",
+      "addFailed": "No se pudo añadir la llave de acceso",
+      "removeA11yLabel": "Eliminar llave de acceso",
+      "removeConfirmTitle": "¿Eliminar esta llave de acceso?",
+      "removeConfirmMessage": "Ya no podrás iniciar sesión con esta llave de acceso. Asegúrate de tener otra forma de iniciar sesión.",
+      "removeAction": "Eliminar",
+      "removeSuccess": "Llave de acceso eliminada",
+      "removeFailed": "No se pudo eliminar la llave de acceso"
+    },
     "recoveryWarning": {
       "title": "Sin copia de la frase de recuperación",
       "subtitle": "Si no has anotado tu frase de recuperación de 12 palabras, no podrás restaurar tu cuenta en otro dispositivo. Crea una copia cifrada o anota tu frase ahora.",

--- a/packages/core/src/mixins/OxyServices.identity.ts
+++ b/packages/core/src/mixins/OxyServices.identity.ts
@@ -251,6 +251,32 @@ export function OxyServicesIdentityMixin<T extends typeof OxyServicesBase>(Base:
     }
 
     /**
+     * Remove ONE passkey (WebAuthn credential) from the current account.
+     *
+     * Passkeys are per-credential, so unlike {@link unlinkAuthMethod} (which
+     * removes an auth method by type) this targets a specific credential id.
+     * The server refuses to remove the last remaining auth method (the account
+     * would become inaccessible) and deletes the stored `WebauthnCredential`.
+     *
+     * @param credentialId - The passkey's public credential id
+     *   (`AuthMethodEntry.credentialId`).
+     */
+    async removePasskey(credentialId: string): Promise<LinkAuthMethodResult> {
+      try {
+        const result = await this.makeRequest<LinkAuthMethodResult>(
+          'DELETE',
+          `/auth/link/webauthn/${encodeURIComponent(credentialId)}`,
+          undefined,
+          { cache: false },
+        );
+        this._invalidateIdentityCaches(this.getCurrentUserId());
+        return result;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
      * Sign a record with the on-device identity key, WITHOUT publishing it.
      * The subject is the current user's DID. NATIVE-ONLY (requires a stored
      * key). Use {@link publishRecord} to sign and store in one step.

--- a/packages/core/src/mixins/__tests__/OxyServices.identity.test.ts
+++ b/packages/core/src/mixins/__tests__/OxyServices.identity.test.ts
@@ -219,6 +219,35 @@ describe('OxyServices.identity', () => {
     });
   });
 
+  describe('removePasskey', () => {
+    it('DELETEs /auth/link/webauthn/:credentialID and sweeps cache', async () => {
+      makeRequestSpy.mockResolvedValue({ success: true, message: 'Passkey unlinked successfully' });
+
+      await oxy.removePasskey('cred-abc');
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'DELETE',
+        '/auth/link/webauthn/cred-abc',
+        undefined,
+        expect.objectContaining({ cache: false }),
+      );
+      expect(clearEntrySpy).toHaveBeenCalledWith('GET:/u/user-123/did.json');
+    });
+
+    it('URL-encodes the credential id', async () => {
+      makeRequestSpy.mockResolvedValue({ success: true, message: 'Passkey unlinked successfully' });
+
+      await oxy.removePasskey('a/b+c=');
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'DELETE',
+        '/auth/link/webauthn/a%2Fb%2Bc%3D',
+        undefined,
+        expect.objectContaining({ cache: false }),
+      );
+    });
+  });
+
   describe('signRecord (client-only)', () => {
     it('signs with the current user DID as subject and does not hit the network', async () => {
       const signRecordSpy = jest

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -802,6 +802,17 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     [oxyServices, queryClient],
   );
 
+  // Remove a passkey from the already-signed-in account by credential id. Not a
+  // ceremony — a plain unlink — so it needs no `isPasskeySupported` gate; it just
+  // refreshes the linked auth-methods list on success.
+  const removePasskey = useCallback(
+    async (credentialId: string): Promise<void> => {
+      await oxyServices.removePasskey(credentialId);
+      void queryClient.invalidateQueries({ queryKey: queryKeys.authMethods.all });
+    },
+    [oxyServices, queryClient],
+  );
+
   // ── Cold boot ────────────────────────────────────────────────────────────
   // Device-first session restore via `runProviderColdBoot` (see boot/runProviderColdBoot.ts).
   const runColdBoot = useCallback(async (): Promise<void> => {
@@ -955,6 +966,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       signInWithPasskey,
       registerWithPasskey,
       addPasskey,
+      removePasskey,
       revokeSuspiciousSignIn,
       handleWebSession,
       logout,
@@ -1010,6 +1022,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       signInWithPasskey,
       registerWithPasskey,
       addPasskey,
+      removePasskey,
       revokeSuspiciousSignIn,
       handleWebSession,
       logout,
@@ -1083,6 +1096,7 @@ const LOADING_STATE: OxyContextState = {
   signInWithPasskey: () => rejectMissingProvider<void>(),
   registerWithPasskey: () => rejectMissingProvider<void>(),
   addPasskey: () => rejectMissingProvider<void>(),
+  removePasskey: () => rejectMissingProvider<void>(),
   revokeSuspiciousSignIn: () => rejectMissingProvider<void>(),
   handleWebSession: () => rejectMissingProvider<void>(),
   logout: () => rejectMissingProvider<void>(),

--- a/packages/services/src/ui/context/oxyContextTypes.ts
+++ b/packages/services/src/ui/context/oxyContextTypes.ts
@@ -75,6 +75,14 @@ export interface OxyContextState {
    */
   addPasskey: (params?: { deviceName?: string }) => Promise<void>;
 
+  /**
+   * Remove a passkey from the current account by its credential id
+   * (`AuthMethodEntry.credentialId`). Refreshes the linked auth-methods list on
+   * success. Works on any platform (it is a plain unlink, not a WebAuthn
+   * ceremony) but is only reachable from surfaces that list passkeys.
+   */
+  removePasskey: (credentialId: string) => Promise<void>;
+
   revokeSuspiciousSignIn: () => Promise<void>;
   handleWebSession: (session: SessionLoginResponse) => Promise<void>;
 


### PR DESCRIPTION
## Summary
- `@oxyhq/core`: new `OxyServices.removePasskey(credentialId)` → `DELETE /auth/link/webauthn/:credentialID`
- `@oxyhq/services`: new `useOxy().removePasskey` — invalidates the cached authMethods after removal
- `packages/accounts`: new `usePasskeyItems` hook wired into the Security screen (web-only, gated on `isOxyRpOrigin`) — add via the existing `addPasskey`, list via `useAuthMethods`, revoke via the new `removePasskey`; new en/es i18n strings

## Verification
- Builds green (contracts → core → services)
- `bunx tsc --noEmit` clean in `packages/core`; clean in `packages/accounts` except one pre-existing, unmodified-by-this-branch error in `constants/styles.ts` (documented `Platform.select` "fixed" typing issue, present on `main` too)
- `bun run test` green: core 876/876 (incl. 2 new `removePasskey` tests), accounts 135/135
- Lockfile gate clean (`bun install --frozen-lockfile`, no drift)
- Browser-E2E DB-verified: adding a passkey creates a doc, revoking removes it

## Note
`@oxyhq/core` and `@oxyhq/services` changed — a later SDK republish (`@oxyhq/core`, `@oxyhq/services`) will be needed to deliver `removePasskey` to any EXTERNAL consumer. `packages/accounts` already consumes both via `workspace:*`, so it works immediately in this repo without a republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)