### PR TITLE
feat(auth+sdk): username-first passkey login for hardware/U2F keys (Fase B)

### DIFF
--- a/packages/auth/components/__tests__/login-form-security-key.test.tsx
+++ b/packages/auth/components/__tests__/login-form-security-key.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * The login form offers a "Sign in with a security key" affordance on the
+ * identifier step (first-party Oxy web origins only — the jsdom host is
+ * `localhost`, a loopback RP origin, so it renders). Unlike the discoverable
+ * "Sign in with a passkey" button, this one reveals a handle step first: a
+ * NON-discoverable hardware key (U2F, e.g. a Google Titan) can't be located by a
+ * usernameless ceremony, so the typed username scopes the server's WebAuthn
+ * `allowCredentials` to that user's registered keys. Selecting it and submitting
+ * a handle calls `useOxy().signInWithPasskey({ username })`.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { BrowserRouter } from "react-router-dom"
+
+const signInWithPasskey = mock(async () => undefined)
+
+// `mock.module` is process-global in bun (last writer wins across files), so
+// expose the full services surface both auth forms consume — including the
+// signup-only `handleWebSession`/`registerWithPasskey` — to stay leak-safe.
+mock.module("@oxyhq/services", () => ({
+    useOxy: () => ({
+        openAccountDialog: () => undefined,
+        oxyServices: { lookupUsername: async () => ({ username: "", name: {}, avatar: null, color: null }) },
+        signInWithPassword: async () => ({ status: "ok" as const }),
+        signInWithPasskey,
+        completeTwoFactorSignIn: async () => ({}),
+        revokeSuspiciousSignIn: async () => undefined,
+        switchToAccount: async () => undefined,
+        handleWebSession: async () => undefined,
+        registerWithPasskey: async () => undefined,
+    }),
+    useSwitchableAccounts: () => ({ isLoading: false, currentSessionId: null, accounts: [] }),
+}))
+
+const { LoginForm } = await import("@/components/login-form")
+
+function renderForm(): { container: HTMLDivElement; unmount: () => void } {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root: Root = createRoot(container)
+    act(() => {
+        root.render(
+            <BrowserRouter>
+                <LoginForm />
+            </BrowserRouter>,
+        )
+    })
+    return {
+        container,
+        unmount: () => {
+            act(() => root.unmount())
+            container.remove()
+        },
+    }
+}
+
+function findButton(container: HTMLElement, label: RegExp): HTMLButtonElement | undefined {
+    return Array.from(container.querySelectorAll("button")).find((b) =>
+        label.test(b.textContent ?? ""),
+    )
+}
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+    )?.set
+    setter?.call(input, value)
+    input.dispatchEvent(new (window.Event)("input", { bubbles: true }))
+}
+
+async function flush(): Promise<void> {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+}
+
+describe("LoginForm — security-key sign-in", () => {
+    beforeEach(() => {
+        signInWithPasskey.mockClear()
+        signInWithPasskey.mockImplementation(async () => undefined)
+    })
+
+    test("shows the security-key button on the identifier step (loopback RP origin)", () => {
+        const { container, unmount } = renderForm()
+        expect(findButton(container, /sign in with a security key/i)).toBeDefined()
+        unmount()
+    })
+
+    test("selecting it reveals a handle input and does not fire the ceremony yet", () => {
+        const { container, unmount } = renderForm()
+        act(() => {
+            findButton(container, /sign in with a security key/i)?.dispatchEvent(
+                new (window.MouseEvent)("click", { bubbles: true }),
+            )
+        })
+        // The handle step is now shown; the ceremony has NOT been invoked (it
+        // only fires on submit, once the user supplies a username).
+        expect(container.querySelector("#security-key-identifier")).not.toBeNull()
+        expect(signInWithPasskey).not.toHaveBeenCalled()
+        unmount()
+    })
+
+    test("submitting the handle calls signInWithPasskey with the typed username", async () => {
+        const { container, unmount } = renderForm()
+        act(() => {
+            findButton(container, /sign in with a security key/i)?.dispatchEvent(
+                new (window.MouseEvent)("click", { bubbles: true }),
+            )
+        })
+
+        const input = container.querySelector<HTMLInputElement>("#security-key-identifier")
+        expect(input).not.toBeNull()
+        act(() => {
+            if (input) setInputValue(input, "titanuser")
+        })
+
+        const form = container.querySelector("form")
+        act(() => {
+            form?.dispatchEvent(new (window.Event)("submit", { bubbles: true, cancelable: true }))
+        })
+        await flush()
+
+        expect(signInWithPasskey).toHaveBeenCalledTimes(1)
+        // Username-first: the handle is forwarded so the server scopes
+        // allowCredentials to that user's keys (the U2F path).
+        expect(signInWithPasskey).toHaveBeenCalledWith(
+            expect.objectContaining({ username: "titanuser" }),
+        )
+        unmount()
+    })
+
+    test("an empty handle does not fire the ceremony", async () => {
+        const { container, unmount } = renderForm()
+        act(() => {
+            findButton(container, /sign in with a security key/i)?.dispatchEvent(
+                new (window.MouseEvent)("click", { bubbles: true }),
+            )
+        })
+
+        const form = container.querySelector("form")
+        act(() => {
+            form?.dispatchEvent(new (window.Event)("submit", { bubbles: true, cancelable: true }))
+        })
+        await flush()
+
+        expect(signInWithPasskey).not.toHaveBeenCalled()
+        unmount()
+    })
+
+    test("a cancelled ceremony surfaces an inline message and stays on the handle step", async () => {
+        const cancel = Object.assign(new Error("The operation was aborted."), { name: "NotAllowedError" })
+        signInWithPasskey.mockImplementation(async () => { throw cancel })
+
+        const { container, unmount } = renderForm()
+        act(() => {
+            findButton(container, /sign in with a security key/i)?.dispatchEvent(
+                new (window.MouseEvent)("click", { bubbles: true }),
+            )
+        })
+        const input = container.querySelector<HTMLInputElement>("#security-key-identifier")
+        act(() => {
+            if (input) setInputValue(input, "titanuser")
+        })
+        const form = container.querySelector("form")
+        act(() => {
+            form?.dispatchEvent(new (window.Event)("submit", { bubbles: true, cancelable: true }))
+        })
+        await flush()
+
+        expect(signInWithPasskey).toHaveBeenCalledTimes(1)
+        // Still on the handle step, showing the calm "dismissed" copy.
+        expect(container.querySelector("#security-key-identifier")).not.toBeNull()
+        expect(container.textContent).toMatch(/dismissed/i)
+        unmount()
+    })
+})

--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react"
 import { useNavigate, Link } from "react-router-dom"
 import { toast } from "sonner"
-import { ArrowLeft, KeyRound, QrCode, ShieldAlert } from "lucide-react"
+import { ArrowLeft, KeyRound, QrCode, ShieldAlert, Usb } from "lucide-react"
 import { isOxyRpOrigin, type SwitchableAccount } from "@oxyhq/core"
 import type { SecurityAlert } from "@oxyhq/contracts"
 import { useOxy, useSwitchableAccounts } from "@oxyhq/services"
@@ -40,7 +40,7 @@ type LoginFormProps = React.ComponentProps<"div"> & {
     loginHint?: string
 }
 
-type LoginStep = "identifier" | "password" | "2fa" | "security-alert"
+type LoginStep = "identifier" | "password" | "2fa" | "security-alert" | "security-key"
 
 type LookupResult = {
     username: string
@@ -206,7 +206,7 @@ export function LoginForm({
         setStepState({ step: next, direction: dir })
         requestAnimationFrame(() => {
             if (next === "password") passwordRef.current?.focus()
-            else if (next === "identifier") identifierRef.current?.focus()
+            else if (next === "identifier" || next === "security-key") identifierRef.current?.focus()
         })
     }
 
@@ -362,6 +362,33 @@ export function LoginForm({
         }
     }
 
+    /**
+     * Username-first passkey sign-in for a NON-discoverable hardware key (e.g. a
+     * U2F/security key like a Google Titan). The typed handle scopes the server's
+     * WebAuthn `allowCredentials` to that user's registered keys, so a key that
+     * stores no resident credential — and therefore can't be found by the
+     * usernameless ceremony above — can still be selected. On success the SDK has
+     * committed the device-first session, so we reuse `redirectAfterLogin`; a
+     * dismissed prompt surfaces the same calm inline message.
+     */
+    async function handleSecurityKeySignIn(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault()
+        const username = identifier.trim()
+        if (!username || passkeyPending || rateLimitSeconds > 0) return
+        setLocalError(undefined)
+        setPasskeyPending(true)
+        try {
+            const deviceFingerprint = await getOrCreateDeviceFingerprint()
+            await signInWithPasskey({ username, deviceFingerprint: deviceFingerprint ?? undefined })
+            redirectAfterLogin()
+        } catch (err) {
+            const message = describePasskeyError(err)
+            setLocalError(message)
+            toast.error("Security key sign-in failed", { description: message })
+            setPasskeyPending(false)
+        }
+    }
+
     async function handlePasswordSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault()
         setLocalError(undefined)
@@ -512,6 +539,23 @@ export function LoginForm({
                             Sign in with a passkey
                         </Button>
                     )}
+                    {/* Security-key option: a non-discoverable hardware key (U2F,
+                        e.g. a Google Titan) can't be located by the usernameless
+                        prompt above, so this reveals a handle step that scopes the
+                        WebAuthn allow-list to that user's registered keys. */}
+                    {passkeyAvailable && (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="lg"
+                            className="w-full"
+                            disabled={passkeyPending || rateLimitSeconds > 0}
+                            onClick={() => goToStep("security-key", "forward")}
+                        >
+                            <Usb className="size-4" />
+                            Sign in with a security key
+                        </Button>
+                    )}
                     {/* Cross-device "Sign in with Oxy" (QR). The user approves in
                         their Oxy app on their phone — no password here. */}
                     <Button
@@ -599,6 +643,48 @@ export function LoginForm({
                             </Button>
                             <Button type="submit" size="lg" className="flex-1 min-w-0" loading={isSubmitting} disabled={isSubmitting || rateLimitSeconds > 0}>
                                 Sign in
+                            </Button>
+                        </div>
+                    </FieldGroup>
+                </form>
+            )}
+
+            {/* Security-key step: username-first passkey for a NON-discoverable
+                hardware key (U2F, e.g. a Google Titan). The handle scopes the
+                server's `allowCredentials` to that user's registered keys so a
+                key with no resident credential can still assert. Reuses the
+                identifier field + state. */}
+            {step === "security-key" && (
+                <form onSubmit={handleSecurityKeySignIn} key="security-key" className={animationClass}>
+                    <FieldGroup>
+                        <AuthFormHeader title="Sign in with a security key" description="Enter your username, then tap your security key." />
+                        <Field data-invalid={displayError ? true : undefined}>
+                            <FieldLabel htmlFor="security-key-identifier">Username</FieldLabel>
+                            <Input
+                                ref={identifierRef}
+                                id="security-key-identifier"
+                                name="identifier"
+                                type="text"
+                                placeholder="yourname"
+                                autoComplete="username"
+                                value={identifier}
+                                onChange={(e) => {
+                                    setIdentifier(e.target.value)
+                                    if (localError) setLocalError(undefined)
+                                }}
+                                required
+                                autoFocus
+                                disabled={passkeyPending || rateLimitSeconds > 0}
+                            />
+                            {displayError && <FieldError>{displayError}</FieldError>}
+                        </Field>
+                        <div className="flex gap-3">
+                            <Button type="button" variant="outline" size="lg" onClick={() => goToStep("identifier", "back")} className="shrink-0" aria-label="Go back" disabled={passkeyPending}>
+                                <ArrowLeft className="size-4" />
+                            </Button>
+                            <Button type="submit" size="lg" className="flex-1 min-w-0" loading={passkeyPending} disabled={passkeyPending || rateLimitSeconds > 0}>
+                                <Usb className="size-4" />
+                                Continue
                             </Button>
                         </div>
                     </FieldGroup>

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -750,16 +750,20 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   // `commitSession` funnel). All three GATE on `isPasskeySupported()` so a native
   // / unsupported surface throws loudly instead of stalling in a ceremony.
 
-  // Usernameless (discoverable) passkey sign-in.
+  // Passkey sign-in. No `username` → usernameless (discoverable) flow. With a
+  // `username` → username-first: the server scopes `allowCredentials` to that
+  // user's passkeys so a non-discoverable hardware key (U2F/security key) can
+  // be selected.
   const signInWithPasskey = useCallback(
-    async (opts?: { deviceName?: string; deviceFingerprint?: string }): Promise<void> => {
+    async (opts?: { username?: string; deviceName?: string; deviceFingerprint?: string }): Promise<void> => {
       const persisted = await authStore.load();
       await runPasskeyLogin({
         isSupported: isPasskeySupported,
-        getLoginOptions: () => oxyServices.webauthnLoginOptions(),
+        getLoginOptions: (username) => oxyServices.webauthnLoginOptions(username),
         runCeremony: runAuthenticationCeremony,
         loginVerify: (response, envelope) => oxyServices.webauthnLoginVerify(response, envelope),
         commit: (input) => commitSession(input, { activate: true, hubSync: true }),
+        username: opts?.username,
         deviceId: persisted?.deviceId,
         deviceName: opts?.deviceName,
         deviceFingerprint: opts?.deviceFingerprint,

--- a/packages/services/src/ui/context/__tests__/passkeyFlow.test.ts
+++ b/packages/services/src/ui/context/__tests__/passkeyFlow.test.ts
@@ -92,6 +92,27 @@ describe('runPasskeyLogin', () => {
     expect(deps.commit).toHaveBeenCalledWith(expectedCommitInput);
   });
 
+  it('forwards the username to getLoginOptions for the username-first (hardware-key) path', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order, { username: 'alice' });
+
+    await runPasskeyLogin(deps);
+
+    // The username scopes login options to that user's passkeys — the path a
+    // non-discoverable U2F/security key needs.
+    expect(deps.getLoginOptions).toHaveBeenCalledWith('alice');
+  });
+
+  it('passes undefined to getLoginOptions for the usernameless (discoverable) path', async () => {
+    const order: string[] = [];
+    const deps = buildDeps(order);
+
+    await runPasskeyLogin(deps);
+
+    // No username → discoverable-credential ceremony (server returns an empty allow-list).
+    expect(deps.getLoginOptions).toHaveBeenCalledWith(undefined);
+  });
+
   it('throws and touches nothing when passkeys are unsupported', async () => {
     const order: string[] = [];
     const deps = buildDeps(order, { isSupported: jest.fn(() => false) });

--- a/packages/services/src/ui/context/oxyContextTypes.ts
+++ b/packages/services/src/ui/context/oxyContextTypes.ts
@@ -55,12 +55,19 @@ export interface OxyContextState {
   }) => Promise<{ securityAlert?: SecurityAlert }>;
 
   /**
-   * Sign in with a passkey (WebAuthn). Usernameless / discoverable-credential
-   * flow: the browser prompts for any resident Oxy passkey. WEB-ONLY — throws on
-   * native or an unsupported browser (native passkeys are Commons' job). On
-   * `useOxy()`, NOT re-exposed on `useAuth()`.
+   * Sign in with a passkey (WebAuthn). With no `username` this is the
+   * usernameless / discoverable-credential flow: the browser prompts for any
+   * resident Oxy passkey. Pass `username` for the username-first flow — the
+   * server scopes `allowCredentials` to that user's passkeys so a
+   * NON-discoverable hardware key (e.g. a U2F/security key) can be used.
+   * WEB-ONLY — throws on native or an unsupported browser (native passkeys are
+   * Commons' job). On `useOxy()`, NOT re-exposed on `useAuth()`.
    */
-  signInWithPasskey: (opts?: { deviceName?: string; deviceFingerprint?: string }) => Promise<void>;
+  signInWithPasskey: (opts?: {
+    username?: string;
+    deviceName?: string;
+    deviceFingerprint?: string;
+  }) => Promise<void>;
 
   /**
    * Create a brand-new account whose first authentication method is a passkey.

--- a/packages/services/src/ui/context/passkeyFlow.ts
+++ b/packages/services/src/ui/context/passkeyFlow.ts
@@ -42,28 +42,39 @@ function toCommitInput(result: LoginSessionResult): CommitInput {
 /** Injected dependencies for {@link runPasskeyLogin}. */
 export interface RunPasskeyLoginDeps {
   isSupported: () => boolean;
-  getLoginOptions: () => Promise<unknown>;
+  getLoginOptions: (username?: string) => Promise<unknown>;
   runCeremony: (optionsJSON: unknown) => Promise<unknown>;
   loginVerify: (
     response: unknown,
     envelope: { deviceName?: string; deviceFingerprint?: string; deviceId?: string },
   ) => Promise<LoginResult>;
   commit: (input: CommitInput) => Promise<void>;
+  /**
+   * When present, scopes login options to that user's registered passkeys
+   * (username-first) — the path a NON-discoverable hardware key (e.g. a U2F
+   * security key) needs, since it can't be found by a usernameless ceremony.
+   * Omit for the discoverable / resident-credential path.
+   */
+  username?: string;
   deviceId?: string;
   deviceName?: string;
   deviceFingerprint?: string;
 }
 
 /**
- * Usernameless (discoverable-credential) passkey SIGN-IN: request login options,
- * run the authentication ceremony, verify, then commit the session. A passkey
- * assertion is itself the strong factor, so a 2FA arm here is a protocol error.
+ * Passkey SIGN-IN. With no `username` this is the usernameless
+ * (discoverable-credential) flow; with a `username` it is username-first —
+ * the server scopes `allowCredentials` to that user's passkeys so a
+ * non-discoverable hardware key (U2F/security key) can be selected. Either way:
+ * request login options, run the authentication ceremony, verify, then commit
+ * the session. A passkey assertion is itself the strong factor, so a 2FA arm
+ * here is a protocol error.
  */
 export async function runPasskeyLogin(deps: RunPasskeyLoginDeps): Promise<void> {
   if (!deps.isSupported()) {
     throw new Error(PASSKEY_UNSUPPORTED_MESSAGE);
   }
-  const options = await deps.getLoginOptions();
+  const options = await deps.getLoginOptions(deps.username);
   const response = await deps.runCeremony(options);
   const result = await deps.loginVerify(response, {
     deviceName: deps.deviceName,


### PR DESCRIPTION
## Summary
- `signInWithPasskey({ username })` in `@oxyhq/services` now forwards the username to `webauthnLoginOptions(username)` so the server scopes `allowCredentials` to that user's registered passkeys — the path a non-discoverable hardware/U2F key (e.g. a Google Titan) needs, since it can't be located by a usernameless discoverable ceremony. Omitting `username` keeps the existing discoverable/resident-credential flow unchanged.
- auth.oxy.so login form adds a gated (`isOxyRpOrigin`) "Sign in with a security key" affordance on the identifier step, reusing the identifier field/state, that drives `signInWithPasskey({ username })`.
- Browser E2E already verified with a U2F virtual authenticator (non-resident + presence-only): username-first assertion → JWT planted → `GET /users/me` returns 200.

## Test plan
- [x] `bun run --filter @oxyhq/contracts build && bun run --filter @oxyhq/core build && bun run services:build` — clean
- [x] `packages/services`: `bunx tsc --noEmit` — clean
- [x] `packages/auth`: `bunx tsc --noEmit` — clean
- [x] `packages/services`: `bun run test` — 217/217 passed
- [x] `packages/auth`: `bun run test` — 57/57 passed (bun test)
- [x] Root `bun install` + `bun install --frozen-lockfile` — no lockfile changes, gate passes
- [x] Browser E2E with U2F virtual authenticator (non-resident + presence-only) — username-first assertion succeeds end to end

Note: this PR and the parallel `feat/passkey-accounts-ui` both touch `OxyContext.tsx`/`oxyContextTypes.ts`; the additions are localized to different methods and the overlap is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>