### PR TITLE
fix(api): harden WebAuthn username-first decoy (mask count/length, fail-closed salt)

### DIFF
--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -23,6 +23,17 @@ const OXY_ORIGIN = 'https://accounts.oxy.so';
 const CRED_ID = 'existing-credential-id';
 const USER_ID = '507f1f77bcf86cd799439011';
 
+// The username-first decoy is keyed on DEVICE_ID_SALT (fail-closed if empty — see
+// `decoyAllowCredentials`). Pin a fixed, non-empty salt so the decoy is
+// deterministic under test and the count/length/transports assertions below are
+// stable rather than dependent on the ambient environment.
+process.env.DEVICE_ID_SALT = 'test-device-id-salt-for-webauthn-decoy-anti-enum';
+
+/** Decoded byte length of a base64url credential id. */
+function decodedByteLength(id: string): number {
+  return Buffer.from(id, 'base64url').length;
+}
+
 let mockCredDoc: {
   _id: string;
   credentialID: string;
@@ -259,7 +270,7 @@ describe('POST /webauthn/login/options', () => {
     expect(mockCredFind).toHaveBeenCalledTimes(1);
   });
 
-  it('username-first (UNKNOWN username): returns a decoy allowCredential of the same shape — never empty, never the real user\'s id, no non-existence tell', async () => {
+  it('username-first (UNKNOWN username): returns a decoy allow-list of the same shape — never empty, never the real user\'s id, no non-existence tell', async () => {
     // The account does not exist and the (throwaway-id) credential query returns none.
     mockUserFindOne.mockReturnValue(selectLean(null));
     mockCredFind.mockReturnValue(selectLean([]));
@@ -268,14 +279,30 @@ describe('POST /webauthn/login/options', () => {
 
     expect(res.status).toBe(200);
     const opts = mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg;
-    // Same SHAPE as the known-username response: exactly one non-empty allowCredential.
-    expect(opts.allowCredentials).toHaveLength(1);
-    expect(typeof opts.allowCredentials[0].id).toBe('string');
-    expect(opts.allowCredentials[0].id.length).toBeGreaterThan(0);
-    // The decoy is NOT any real credential id.
-    expect(opts.allowCredentials[0].id).not.toBe(CRED_ID);
-    // Structurally identical (transports present, like a real allow-list entry).
-    expect(Array.isArray(opts.allowCredentials[0].transports)).toBe(true);
+    // Non-empty and masked to 1 OR 2 entries (a real account with 1–2 passkeys must
+    // be indistinguishable — a fixed count-of-1 would leak "≥2 passkeys" via count).
+    expect(opts.allowCredentials.length).toBeGreaterThanOrEqual(1);
+    expect(opts.allowCredentials.length).toBeLessThanOrEqual(2);
+    for (const cred of opts.allowCredentials) {
+      expect(typeof cred.id).toBe('string');
+      expect(cred.id.length).toBeGreaterThan(0);
+      // NOT any real credential id.
+      expect(cred.id).not.toBe(CRED_ID);
+      // Realistic credential-id length (16–64 bytes), covering both short platform
+      // passkeys and long roaming/hardware-key ids — no fixed tell-tale size.
+      expect(decodedByteLength(cred.id)).toBeGreaterThanOrEqual(16);
+      expect(decodedByteLength(cred.id)).toBeLessThanOrEqual(64);
+      // transports is either a real-looking array or omitted entirely (like real
+      // credentials that advertise none) — never some other shape.
+      if (cred.transports !== undefined) {
+        expect(Array.isArray(cred.transports)).toBe(true);
+        expect(cred.transports.length).toBeGreaterThan(0);
+      }
+    }
+    // Distinct ids when the decoy has two entries (like a real multi-passkey account).
+    if (opts.allowCredentials.length === 2) {
+      expect(opts.allowCredentials[0].id).not.toBe(opts.allowCredentials[1].id);
+    }
     // A bound challenge is still stored (non-null userId), so nothing about the
     // response reveals that the account does not exist.
     const stored = mockChallengeCreate.mock.calls[0][0] as { type: string; userId?: unknown };
@@ -285,6 +312,60 @@ describe('POST /webauthn/login/options', () => {
     // account-existence-dependent early return / timing oracle).
     expect(mockUserFindOne).toHaveBeenCalledTimes(1);
     expect(mockCredFind).toHaveBeenCalledTimes(1);
+  });
+
+  it('the decoy COUNT is masked (not always 1): across a spread of usernames both 1- and 2-entry decoys appear', async () => {
+    // A fixed count-of-1 decoy made `count === 2` a clean "this public username has
+    // ≥2 passkeys" oracle. The count is now a deterministic 1 OR 2 keyed on the salt,
+    // so surveying enough usernames must surface BOTH lengths.
+    mockUserFindOne.mockReturnValue(selectLean(null));
+    mockCredFind.mockReturnValue(selectLean([]));
+
+    const observedCounts = new Set<number>();
+    for (let i = 0; i < 16; i += 1) {
+      await request(server, 'POST', '/webauthn/login/options', { username: `probe${i}` });
+    }
+    for (const call of mockGenerateAuthOptions.mock.calls) {
+      observedCounts.add((call[0] as AuthOptionsArg).allowCredentials.length);
+    }
+    // Deterministic under the fixed test salt: probe0..15 yield both 1 and 2.
+    expect(observedCounts.has(1)).toBe(true);
+    expect(observedCounts.has(2)).toBe(true);
+  });
+
+  it('the decoy sometimes OMITS transports (deterministically) so [{id}] vs [{id,transports}] is not a tell', async () => {
+    mockUserFindOne.mockReturnValue(selectLean(null));
+    mockCredFind.mockReturnValue(selectLean([]));
+
+    let sawOmitted = false;
+    let sawPresent = false;
+    for (let i = 0; i < 30 && !(sawOmitted && sawPresent); i += 1) {
+      await request(server, 'POST', '/webauthn/login/options', { username: `shape${i}` });
+    }
+    for (const call of mockGenerateAuthOptions.mock.calls) {
+      for (const cred of (call[0] as AuthOptionsArg).allowCredentials) {
+        if (cred.transports === undefined) sawOmitted = true;
+        else sawPresent = true;
+      }
+    }
+    expect(sawOmitted).toBe(true);
+    expect(sawPresent).toBe(true);
+  });
+
+  it('fails closed (500) when DEVICE_ID_SALT is empty — never emits an attacker-computable decoy', async () => {
+    // An empty salt would make the decoy precomputable, defeating anti-enumeration.
+    mockUserFindOne.mockReturnValue(selectLean(null));
+    mockCredFind.mockReturnValue(selectLean([]));
+    const original = process.env.DEVICE_ID_SALT;
+    delete process.env.DEVICE_ID_SALT;
+    try {
+      const res = await request(server, 'POST', '/webauthn/login/options', { username: 'ghostuser' });
+      expect(res.status).toBe(500);
+      // No challenge is stored on the fail-closed path.
+      expect(mockChallengeCreate).not.toHaveBeenCalled();
+    } finally {
+      process.env.DEVICE_ID_SALT = original;
+    }
   });
 
   it('the decoy is DETERMINISTIC: the same unknown username yields the same decoy id across requests', async () => {
@@ -310,8 +391,12 @@ describe('POST /webauthn/login/options', () => {
 
     expect(res.status).toBe(200);
     const opts = mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg;
-    expect(opts.allowCredentials).toHaveLength(1);
-    expect(opts.allowCredentials[0].id).not.toBe(CRED_ID);
+    // Masked decoy (1–2 entries), never the empty allow-list that would leak "exists".
+    expect(opts.allowCredentials.length).toBeGreaterThanOrEqual(1);
+    expect(opts.allowCredentials.length).toBeLessThanOrEqual(2);
+    for (const cred of opts.allowCredentials) {
+      expect(cred.id).not.toBe(CRED_ID);
+    }
   });
 
   it('usernameless (discoverable): empty allowCredentials and an unbound challenge, no lookups', async () => {

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -484,6 +484,14 @@ router.post(
       throw new BadRequestError('Passkey registration could not be verified');
     }
 
+    // CAVEAT — `userVerified` is authenticator-SELF-ASSERTED, not attestation-proven.
+    // We register with `attestationType: 'none'` and verify with
+    // `requireUserVerification: false`, so this flag is only the UV bit the
+    // authenticator reported for THIS ceremony; nothing cryptographically attests the
+    // authenticator's UV capability or that UV actually happened. Treat it as an
+    // assurance/telemetry marker ONLY — it must NOT be used as a hard security
+    // boundary for step-up (e.g. "require a UV-backed credential for sensitive
+    // actions"). A real step-up gate needs attestation.
     const { credential, credentialDeviceType, credentialBackedUp, userVerified } = verification.registrationInfo;
     const credentialName = envelope.deviceName?.trim() || DEFAULT_CREDENTIAL_NAME;
 
@@ -807,6 +815,11 @@ router.post(
     credential.lastUsedAt = new Date();
     // Refresh the assurance level: a credential that enrolled UV-capable but
     // authenticated presence-only (or vice versa) reflects its most recent ceremony.
+    // CAVEAT (same as register/verify): `userVerified` is authenticator-SELF-ASSERTED
+    // — verify runs with `requireUserVerification: false` and no attestation, so this
+    // is only the UV bit the authenticator reported for this assertion. It is an
+    // assurance/telemetry marker, NOT an attestation-proven fact, and must NOT gate a
+    // hard step-up boundary without attestation.
     credential.userVerified = userVerified;
     await credential.save();
 

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -185,23 +185,53 @@ const DECOY_TRANSPORT_POOL: AuthenticatorTransportFuture[][] = [
 ];
 
 /**
- * A DETERMINISTIC decoy allow-credential for a username-first `login/options`
+ * Deterministic keystream over the server salt: HMAC(salt, `${message}|blk${n}`)
+ * concatenated across as many 32-byte SHA-256 blocks as `byteLength` needs. A single
+ * HMAC digest is only 32 bytes, but a realistic roaming-key credential id can reach
+ * ~64 bytes, so a decoy id that long must span more than one block. Every byte stays
+ * keyed on the server secret, so no decoy field is attacker-computable.
+ */
+function decoyKeystream(salt: string, message: string, byteLength: number): Buffer {
+  const blocks: Buffer[] = [];
+  for (let block = 0, produced = 0; produced < byteLength; block += 1) {
+    const digest = crypto.createHmac('sha256', salt).update(`${message}|blk${block}`).digest();
+    blocks.push(digest);
+    produced += digest.length;
+  }
+  return Buffer.concat(blocks).subarray(0, byteLength);
+}
+
+/**
+ * DETERMINISTIC decoy allow-credentials for a username-first `login/options`
  * request that does NOT resolve to an account with a passkey — i.e. the username
  * is unknown OR belongs to a real account that has no WebAuthn credential. Its
  * only job is anti-enumeration: the "no real credential" response must be
  * INDISTINGUISHABLE from the "here are your credential ids" response so an
  * unauthenticated caller cannot probe which usernames exist / have a passkey.
  *
- * - **Stable per username.** The id is `HMAC(DEVICE_ID_SALT, username)` — the SAME
- *   username always yields the SAME id across requests, exactly as a real user's
- *   credential ids are stable. A per-request-random decoy would itself be the tell
- *   (a real allow-list does not change between two polls of the same username).
- * - **Unforgeable.** Keying on the server-side salt (never a raw hash of the
- *   username) stops an attacker precomputing "the decoy id for X" and matching it
- *   against a response to classify fake vs real.
- * - **Natural shape.** Length (16–31 bytes → 22–42 base64url chars) and transports
- *   are derived from the same digest so they land within the spread of real
- *   authenticator credential ids/transports rather than at a fixed tell-tale size.
+ * - **Stable per username.** Each id derives from `HMAC(DEVICE_ID_SALT, …)` — the
+ *   SAME username always yields the SAME decoy across requests, exactly as a real
+ *   user's credential ids are stable. A per-request-random decoy (count, id, length,
+ *   or transports) would itself be the tell (a real allow-list does not change
+ *   between two polls of the same username).
+ * - **Unforgeable / fail-closed.** Keying on the server-side salt (never a raw hash
+ *   of the username) stops an attacker precomputing "the decoy for X" and matching
+ *   it against a response to classify fake vs real. If the salt is empty (misconfig)
+ *   the decoy would become attacker-computable, so this throws (500) rather than
+ *   silently emitting a computable decoy.
+ * - **Masked COUNT (1 or 2).** A fixed count-of-1 decoy made `count === 2` a clean
+ *   "this public username has ≥2 passkeys" posture oracle (a real account with two
+ *   passkeys returns two entries). The count is now a deterministic 1 or 2, so the
+ *   common 1–2-passkey case is indistinguishable between a decoy and a real
+ *   allow-list. RESIDUAL: a real account with ≥3 passkeys still exceeds the decoy
+ *   max of 2 — accepted, since that posture is rarer and account EXISTENCE is
+ *   already public (`GET /auth/lookup`); this closes the clean 1-vs-2 oracle, not
+ *   every conceivable posture signal.
+ * - **Natural shape.** Id length (16–64 bytes → 22–86 base64url chars, covering both
+ *   short platform passkeys and long roaming/hardware-key ids) and transports
+ *   (sometimes omitted, like real credentials that advertise none) are derived from
+ *   the same keystream so they land within the spread of real authenticator
+ *   credential ids/transports rather than at a fixed tell-tale size/shape.
  *
  * The paired challenge is bound by the caller to a throwaway ObjectId that maps to
  * no user, so no real assertion can ever satisfy it: `login/verify` then fails with
@@ -209,14 +239,37 @@ const DECOY_TRANSPORT_POOL: AuthenticatorTransportFuture[][] = [
  */
 function decoyAllowCredentials(
   normalizedUsername: string,
-): { id: string; transports: AuthenticatorTransportFuture[] }[] {
-  const salt = process.env.DEVICE_ID_SALT ?? '';
-  const digest = crypto.createHmac('sha256', salt).update(`webauthn-decoy|${normalizedUsername}`).digest();
-  // Realistic, stable-per-username credential-id length (16–31 bytes).
-  const idByteLength = 16 + (digest[0] % 16);
-  const id = digest.subarray(1, 1 + idByteLength).toString('base64url');
-  const transports = DECOY_TRANSPORT_POOL[digest[digest.length - 1] % DECOY_TRANSPORT_POOL.length];
-  return [{ id, transports }];
+): { id: string; transports?: AuthenticatorTransportFuture[] }[] {
+  const salt = process.env.DEVICE_ID_SALT;
+  // FAIL CLOSED. An empty salt makes every decoy attacker-computable, defeating the
+  // whole anti-enumeration point. Prod already fail-fasts on the salt at boot
+  // (`config/env.ts`); this is defense-in-depth so a misconfigured/empty salt can
+  // NEVER silently downgrade the decoy to a computable value — it 500s instead.
+  if (!salt) {
+    throw new InternalServerError('WebAuthn anti-enumeration is not configured');
+  }
+
+  // Deterministic COUNT of 1 or 2 (never always 1) — see the "Masked COUNT" note above.
+  const count = 1 + (decoyKeystream(salt, `webauthn-decoy|${normalizedUsername}`, 2)[1] % 2);
+
+  const credentials: { id: string; transports?: AuthenticatorTransportFuture[] }[] = [];
+  for (let index = 0; index < count; index += 1) {
+    // Key each decoy on its index so the ids differ (like a real account's do) while
+    // staying stable per (username, index) across polls. 66 bytes = 1 length byte +
+    // up to 64 id bytes + 1 transports-selector byte.
+    const material = decoyKeystream(salt, `webauthn-decoy|${normalizedUsername}|${index}`, 66);
+    const idByteLength = 16 + (material[0] % 49); // 16–64 bytes → 22–86 base64url chars
+    const id = material.subarray(1, 1 + idByteLength).toString('base64url');
+    const transportSelector = material[65];
+    // Omit transports ~1-in-4 deterministically so `[{ id }]` vs `[{ id, transports }]`
+    // is not a fake-vs-real tell (some real credentials advertise no transports).
+    if (transportSelector % 4 === 0) {
+      credentials.push({ id });
+    } else {
+      credentials.push({ id, transports: DECOY_TRANSPORT_POOL[transportSelector % DECOY_TRANSPORT_POOL.length] });
+    }
+  }
+  return credentials;
 }
 
 /**


### PR DESCRIPTION
## Summary

Non-blocking security fast-follows hardening the WebAuthn username-first hardware-key decoy in `packages/api/src/routes/webauthn.ts`:

- **Masked decoy credential count**: the decoy `allowCredentials` list now deterministically returns 1 or 2 entries (previously always exactly 1), closing a "≥2 passkeys" posture oracle that let an attacker distinguish real multi-credential accounts from decoys by credential count alone.
- **Widened decoy id length + transports variance**: decoy credential ids now span 16–64 bytes (previously a narrow 16–31 byte range), and `transports` is sometimes omitted, so the decoy shape better matches the real spread of authenticator credentials (including hardware/roaming keys) instead of being a fixed, fingerprintable tell.
- **`userVerified` caveat documented**: added a comment noting `userVerified` is authenticator-self-asserted (registration uses `attestationType: 'none'`, verification uses `requireUserVerification: false`), NOT attestation-proven — it must not be treated as a hard step-up security boundary without real attestation.
- **Fail-closed on misconfigured salt**: `decoyAllowCredentials` now throws `InternalServerError` (500) if `DEVICE_ID_SALT` is empty/misconfigured, instead of silently falling back to an empty-salt HMAC that would make decoy credentials attacker-computable.

## Test plan

- [x] `bun run --filter @oxyhq/contracts build` — passes
- [x] `bun run --filter @oxyhq/core build` — passes
- [x] `packages/api` `bunx tsc --noEmit` — clean
- [x] `packages/api` `bun run test` — 170/170 suites, 1563/1563 tests green
- [x] Repo-root `bun install` — no lockfile changes; `bun install --frozen-lockfile` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)