### PR TITLE
fix(sdk): gate cross-origin silent-restore to official origins + env-configurable authorize URL

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -558,6 +558,7 @@ export {
     buildIdpHubOrigin,
     buildHubSyncUrl,
     isIdpHubOrigin,
+    isLoopbackOrigin,
     isOfficialWebOrigin,
     isAllowedDeviceJoinOrigin,
     normalizeOfficialReturnOrigin,

--- a/packages/core/src/utils/__tests__/officialOrigins.test.ts
+++ b/packages/core/src/utils/__tests__/officialOrigins.test.ts
@@ -3,6 +3,7 @@ import {
   buildIdpHubOrigin,
   isAllowedDeviceJoinOrigin,
   isIdpHubOrigin,
+  isLoopbackOrigin,
   isOfficialWebOrigin,
   normalizeOfficialReturnOrigin,
   parseHubSyncReturnUrl,
@@ -17,6 +18,19 @@ describe('officialOrigins', () => {
     expect(isOfficialWebOrigin('https://inbox.oxy.so')).toBe(true);
     expect(isOfficialWebOrigin('https://mention.earth')).toBe(true);
     expect(isOfficialWebOrigin('https://evil.example')).toBe(false);
+  });
+
+  it('flags loopback / local-dev origins on any port', () => {
+    expect(isLoopbackOrigin('http://localhost:3000')).toBe(true);
+    expect(isLoopbackOrigin('http://127.0.0.1:8081')).toBe(true);
+    expect(isLoopbackOrigin('http://[::1]:19006')).toBe(true);
+    expect(isLoopbackOrigin('https://localhost')).toBe(true);
+    expect(isLoopbackOrigin('https://accounts.oxy.so')).toBe(false);
+    expect(isLoopbackOrigin('https://evil.example')).toBe(false);
+  });
+
+  it('treats loopback as an official origin (loopback dev is trusted)', () => {
+    expect(isOfficialWebOrigin('http://localhost:3000')).toBe(true);
   });
 
   it('keeps the deprecated alias in sync with isOfficialWebOrigin', () => {

--- a/packages/core/src/utils/officialOrigins.ts
+++ b/packages/core/src/utils/officialOrigins.ts
@@ -41,7 +41,12 @@ export function isIdpHubOrigin(): boolean {
   }
 }
 
-function isLoopbackOrigin(origin: string): boolean {
+/**
+ * Whether an origin is a loopback / local-dev origin (`localhost`, `127.0.0.1`,
+ * or `[::1]` on any port, http or https). Local dev must never be bounced to a
+ * hosted IdP for cross-origin session restore.
+ */
+export function isLoopbackOrigin(origin: string): boolean {
   try {
     const parsed = new URL(origin);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {

--- a/packages/services/src/ui/boot/runProviderColdBoot.ts
+++ b/packages/services/src/ui/boot/runProviderColdBoot.ts
@@ -8,6 +8,7 @@ import type { SessionClient } from '@oxyhq/core';
 import { loadPersistedDeviceCredential } from '../utils/deviceCredential';
 import {
   consumeSilentOAuthError,
+  isSilentRestoreEligibleOrigin,
   maybeStartSilentOAuthRestore,
 } from '../utils/crossOriginRestore';
 import { tryCompleteOAuthReturn, consumeHubSyncFailure } from '../utils/oauthReturn';
@@ -22,6 +23,12 @@ export interface RunProviderColdBootOptions {
   authStore: AuthStateStore;
   clientId?: string;
   authRedirectUri?: string;
+  /**
+   * Authorize endpoint override for silent cross-origin restore. Defaults to
+   * the production Oxy IdP when unset; a local/staging deployment sets it so the
+   * silent-restore redirect targets its own IdP, never production.
+   */
+  authorizeBaseUrl?: string;
   sessionClient: SessionClient;
   syncDeviceCredentialToHost: () => Promise<void>;
   commitSession: (
@@ -46,6 +53,7 @@ export async function runProviderColdBoot(opts: RunProviderColdBootOptions): Pro
     authStore,
     clientId,
     authRedirectUri,
+    authorizeBaseUrl,
     sessionClient,
     syncDeviceCredentialToHost,
     commitSession,
@@ -129,11 +137,26 @@ export async function runProviderColdBoot(opts: RunProviderColdBootOptions): Pro
       },
     });
 
-    if (isWebBrowser() && clientId && outcome.kind !== 'session') {
+    // Silent cross-origin OAuth restore (web cross-app SSO). Gate it the SAME
+    // way the hub-sync WRITE side (`syncHubAfterSignIn`) gates: official web
+    // origins only, never the IdP hub itself, and — unlike the write side —
+    // never a loopback / local-dev origin (which must not be bounced to a hosted
+    // IdP on cold boot). The authorize endpoint is env-configurable so a
+    // local/staging app targets its own IdP instead of production.
+    const webOrigin = isWebBrowser()
+      ? (globalThis as { location?: Location }).location?.origin
+      : undefined;
+    if (
+      clientId &&
+      outcome.kind !== 'session' &&
+      webOrigin &&
+      isSilentRestoreEligibleOrigin(webOrigin)
+    ) {
       const redirected = await maybeStartSilentOAuthRestore({
         oxyServices,
         clientId,
         redirectUri: authRedirectUri,
+        authorizeBaseUrl,
       });
       if (redirected) {
         return;

--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -114,6 +114,7 @@ const OxyProvider: FC<OxyProviderProps> = ({
     baseURL,
     authWebUrl,
     authRedirectUri,
+    authorizeBaseUrl,
     queryClient: providedQueryClient,
     requireAuth = 'off',
     hubSync = true,
@@ -309,6 +310,7 @@ const OxyProvider: FC<OxyProviderProps> = ({
                     baseURL={baseURL}
                     authWebUrl={authWebUrl}
                     authRedirectUri={authRedirectUri}
+                    authorizeBaseUrl={authorizeBaseUrl}
                     storageKeyPrefix={storageKeyPrefix}
                     clientId={clientId}
                     hubSync={hubSync}

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -84,6 +84,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   baseURL,
   authWebUrl,
   authRedirectUri,
+  authorizeBaseUrl,
   storageKeyPrefix = 'oxy_session',
   clientId: clientIdProp,
   hubSync = true,
@@ -825,6 +826,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       authStore,
       clientId: clientIdProp,
       authRedirectUri,
+      authorizeBaseUrl,
       sessionClient,
       syncDeviceCredentialToHost,
       commitSession: (input, options) => commitSessionRef.current(input, options),
@@ -836,6 +838,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     authStore,
     clientIdProp,
     authRedirectUri,
+    authorizeBaseUrl,
     syncDeviceCredentialToHost,
     sessionClient,
   ]);

--- a/packages/services/src/ui/context/oxyContextTypes.ts
+++ b/packages/services/src/ui/context/oxyContextTypes.ts
@@ -145,6 +145,13 @@ export interface OxyContextProviderProps {
   baseURL?: string;
   authWebUrl?: string;
   authRedirectUri?: string;
+  /**
+   * Authorize endpoint override for silent cross-origin session restore
+   * (web cross-app SSO). Defaults to the production Oxy IdP when unset; a
+   * local/staging deployment points it at its own IdP so cold boot never
+   * bounces the tab to production `auth.oxy.so`.
+   */
+  authorizeBaseUrl?: string;
   storageKeyPrefix?: string;
   clientId?: string;
   /** Sync device credentials to auth.oxy.so after interactive sign-in. @default true */

--- a/packages/services/src/ui/types/navigation.ts
+++ b/packages/services/src/ui/types/navigation.ts
@@ -62,6 +62,14 @@ export interface OxyProviderProps {
     baseURL?: string;
     authWebUrl?: string;
     authRedirectUri?: string;
+    /**
+     * Authorize endpoint override for silent cross-origin session restore
+     * (web cross-app SSO on cold boot). Defaults to the production Oxy IdP
+     * (`https://auth.oxy.so/authorize`) when unset. Set this from an env var
+     * (e.g. Vite `VITE_OXY_AUTHORIZE_URL`, Expo `EXPO_PUBLIC_OXY_AUTHORIZE_URL`)
+     * so a local/staging deployment targets its own IdP instead of production.
+     */
+    authorizeBaseUrl?: string;
     queryClient?: QueryClient;
     /** Sync device credentials to auth.oxy.so after interactive sign-in. @default true */
     hubSync?: boolean;

--- a/packages/services/src/ui/utils/__tests__/crossOriginRestore.test.ts
+++ b/packages/services/src/ui/utils/__tests__/crossOriginRestore.test.ts
@@ -1,0 +1,143 @@
+import type { OxyServices } from '@oxyhq/core';
+
+// Spy on the platform redirect so no real navigation happens and we can assert
+// the authorize URL the silent-restore flow hands to the browser.
+jest.mock('../../components/oauthNavigation', () => ({
+  redirectToAuthorize: jest.fn(),
+}));
+
+// jsdom's `location` is non-configurable, so the origin the code reads cannot be
+// reassigned per-test. Instead, drive the ORIGIN-CLASSIFICATION predicates
+// (whose real behaviour is covered by core's officialOrigins.test.ts) and keep
+// every other core helper real (PKCE, authorize-URL builder, handshake store).
+jest.mock('@oxyhq/core', () => {
+  const actual = jest.requireActual('@oxyhq/core');
+  return {
+    __esModule: true,
+    ...actual,
+    isLoopbackOrigin: jest.fn(),
+    isOfficialWebOrigin: jest.fn(),
+    isIdpHubOrigin: jest.fn(),
+  };
+});
+
+import {
+  isLoopbackOrigin,
+  isOfficialWebOrigin,
+  isIdpHubOrigin,
+} from '@oxyhq/core';
+import { redirectToAuthorize } from '../../components/oauthNavigation';
+import {
+  isSilentRestoreEligibleOrigin,
+  maybeStartSilentOAuthRestore,
+  clearCrossOriginRestoreGuards,
+} from '../crossOriginRestore';
+
+const mockRedirect = redirectToAuthorize as jest.Mock;
+const mockIsLoopback = isLoopbackOrigin as jest.Mock;
+const mockIsOfficial = isOfficialWebOrigin as jest.Mock;
+const mockIsIdpHub = isIdpHubOrigin as jest.Mock;
+
+const OXY_SERVICES_STUB = {} as OxyServices;
+
+/** Default to an eligible official origin; individual tests narrow this. */
+function makeOriginEligible(): void {
+  mockIsLoopback.mockReturnValue(false);
+  mockIsIdpHub.mockReturnValue(false);
+  mockIsOfficial.mockReturnValue(true);
+}
+
+describe('crossOriginRestore', () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+    mockIsLoopback.mockReset();
+    mockIsOfficial.mockReset();
+    mockIsIdpHub.mockReset();
+    globalThis.sessionStorage?.clear();
+    clearCrossOriginRestoreGuards();
+  });
+
+  describe('isSilentRestoreEligibleOrigin', () => {
+    it('rejects loopback / local-dev origins', () => {
+      mockIsLoopback.mockReturnValue(true);
+      mockIsIdpHub.mockReturnValue(false);
+      mockIsOfficial.mockReturnValue(true);
+      expect(isSilentRestoreEligibleOrigin('http://localhost:3000')).toBe(false);
+    });
+
+    it('rejects the central IdP hub origin (no self-hop)', () => {
+      mockIsLoopback.mockReturnValue(false);
+      mockIsIdpHub.mockReturnValue(true);
+      mockIsOfficial.mockReturnValue(true);
+      expect(isSilentRestoreEligibleOrigin('https://auth.oxy.so')).toBe(false);
+    });
+
+    it('rejects non-official origins', () => {
+      mockIsLoopback.mockReturnValue(false);
+      mockIsIdpHub.mockReturnValue(false);
+      mockIsOfficial.mockReturnValue(false);
+      expect(isSilentRestoreEligibleOrigin('https://evil.example')).toBe(false);
+    });
+
+    it('accepts official, non-loopback, non-IdP origins', () => {
+      makeOriginEligible();
+      expect(isSilentRestoreEligibleOrigin('https://accounts.oxy.so')).toBe(true);
+    });
+  });
+
+  describe('maybeStartSilentOAuthRestore', () => {
+    it('is SKIPPED on a loopback origin (no redirect)', async () => {
+      mockIsLoopback.mockReturnValue(true);
+      mockIsIdpHub.mockReturnValue(false);
+      mockIsOfficial.mockReturnValue(true);
+      const redirected = await maybeStartSilentOAuthRestore({
+        oxyServices: OXY_SERVICES_STUB,
+        clientId: 'oxy_dk_test',
+      });
+      expect(redirected).toBe(false);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('is SKIPPED on a non-official origin (no redirect)', async () => {
+      mockIsLoopback.mockReturnValue(false);
+      mockIsIdpHub.mockReturnValue(false);
+      mockIsOfficial.mockReturnValue(false);
+      const redirected = await maybeStartSilentOAuthRestore({
+        oxyServices: OXY_SERVICES_STUB,
+        clientId: 'oxy_dk_test',
+      });
+      expect(redirected).toBe(false);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the PROD IdP by default on an eligible origin', async () => {
+      makeOriginEligible();
+      const redirected = await maybeStartSilentOAuthRestore({
+        oxyServices: OXY_SERVICES_STUB,
+        clientId: 'oxy_dk_test',
+      });
+      expect(redirected).toBe(true);
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const url = mockRedirect.mock.calls[0][0] as string;
+      expect(url.startsWith('https://auth.oxy.so/authorize?')).toBe(true);
+      const params = new URL(url).searchParams;
+      expect(params.get('client_id')).toBe('oxy_dk_test');
+      expect(params.get('prompt')).toBe('none');
+    });
+
+    it('honors an authorizeBaseUrl override (self-hosted / staging IdP)', async () => {
+      makeOriginEligible();
+      const redirected = await maybeStartSilentOAuthRestore({
+        oxyServices: OXY_SERVICES_STUB,
+        clientId: 'oxy_dk_test',
+        authorizeBaseUrl: 'https://auth.staging.oxy.so/authorize',
+      });
+      expect(redirected).toBe(true);
+      const url = mockRedirect.mock.calls[0][0] as string;
+      expect(url.startsWith('https://auth.staging.oxy.so/authorize?')).toBe(true);
+      const params = new URL(url).searchParams;
+      expect(params.get('client_id')).toBe('oxy_dk_test');
+      expect(params.get('prompt')).toBe('none');
+    });
+  });
+});

--- a/packages/services/src/ui/utils/crossOriginRestore.ts
+++ b/packages/services/src/ui/utils/crossOriginRestore.ts
@@ -3,6 +3,9 @@ import {
   buildOAuthAuthorizeUrl,
   generateOAuthState,
   generatePkcePair,
+  isIdpHubOrigin,
+  isLoopbackOrigin,
+  isOfficialWebOrigin,
   OXY_CROSS_ORIGIN_RESTORE_ATTEMPTED_KEY,
   OXY_SILENT_OAUTH_ATTEMPTED_KEY,
   persistOAuthHandshake,
@@ -43,11 +46,35 @@ export function clearCrossOriginRestoreGuards(): void {
   }
 }
 
+/**
+ * Whether cold boot should attempt silent cross-origin OAuth restore for the
+ * given web origin.
+ *
+ * Mirrors the hub-sync WRITE gate (`syncHubAfterSignIn`): only OFFICIAL Oxy web
+ * origins participate in cross-app SSO — a random third-party / preview origin
+ * must never have its tab bounced to the IdP. Additionally, loopback / local-dev
+ * origins are EXCLUDED here even though {@link isOfficialWebOrigin} treats them
+ * as official: a developer's local app must never be redirected to a hosted IdP
+ * on cold boot (it signs in through the in-app dialog instead). The central IdP
+ * hub's own origin is excluded to avoid a wasteful self-hop.
+ */
+export function isSilentRestoreEligibleOrigin(origin: string): boolean {
+  if (isLoopbackOrigin(origin)) return false;
+  if (isIdpHubOrigin()) return false;
+  return isOfficialWebOrigin(origin);
+}
+
 export interface SilentOAuthRestoreOptions {
   oxyServices: OxyServices;
   clientId: string;
   redirectUri?: string;
   scope?: string;
+  /**
+   * Authorize endpoint override (env-configurable per deployment). Defaults to
+   * the production Oxy IdP when unset, so a local/staging app points silent
+   * restore at its OWN IdP instead of production `auth.oxy.so`.
+   */
+  authorizeBaseUrl?: string;
 }
 
 /**
@@ -61,6 +88,12 @@ export async function maybeStartSilentOAuthRestore(
 
   const location = (globalThis as { location?: Location }).location;
   if (!location) return false;
+
+  // Defense-in-depth: never bounce a loopback / non-official / IdP-hub origin to
+  // a hosted authorize endpoint (the caller gates on this too).
+  if (!isSilentRestoreEligibleOrigin(location.origin)) {
+    return false;
+  }
 
   if (isCrossOriginRestoreBlocked()) {
     return false;
@@ -83,6 +116,7 @@ export async function maybeStartSilentOAuthRestore(
     );
 
     const authorizeUrl = buildOAuthAuthorizeUrl({
+      authorizeBaseUrl: opts.authorizeBaseUrl,
       clientId: opts.clientId,
       redirectUri,
       state,


### PR DESCRIPTION
## Summary
- Adds an official-origin/loopback gate on the cold-boot silent cross-origin OAuth restore path (`isSilentRestoreEligibleOrigin` in `packages/services/src/ui/utils/crossOriginRestore.ts`), mirroring the existing hub-sync WRITE gate but additionally excluding loopback/local-dev origins and the IdP hub's own origin — so a developer's localhost app is never silently bounced to production `auth.oxy.so`.
- New `isLoopbackOrigin` export from `@oxyhq/core` (`packages/core/src/utils/officialOrigins.ts` — was already implemented internally, now exported) used by the gate.
- Threads a new optional `authorizeBaseUrl` prop through `OxyProvider` → `OxyContext` → `runProviderColdBoot` → `maybeStartSilentOAuthRestore` → `buildOAuthAuthorizeUrl`, so a local/staging deployment can point silent restore at its own IdP via an env var (e.g. Vite `VITE_OXY_AUTHORIZE_URL`, Expo `EXPO_PUBLIC_OXY_AUTHORIZE_URL`) instead of defaulting to production.
- Production behavior is unchanged (official origins still silently restore via `auth.oxy.so` by default).
- New unit tests: `packages/core/src/utils/__tests__/officialOrigins.test.ts` (isLoopbackOrigin export coverage) and `packages/services/src/ui/utils/__tests__/crossOriginRestore.test.ts` (gate + authorizeBaseUrl override coverage).
- This is a core+services change that batches with the next SDK republish (not published to npm by this PR).

## Test plan
- [x] `bun run --filter @oxyhq/contracts build`
- [x] `bun run --filter @oxyhq/core build`
- [x] `bun run services:build`
- [x] `packages/core`: `bunx tsc --noEmit` clean
- [x] `packages/core`: `bun run test` — 70 suites / 878 tests passed
- [x] `packages/services`: `bunx tsc --noEmit` clean
- [x] `packages/services`: `bun run test` — 32 suites / 225 tests passed
- [x] repo-root `bun install` (no lockfile changes)
- [x] repo-root `bun install --frozen-lockfile` passes

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>