### PR TITLE
fix(commons): local-first identity gate — offline cold-launch loads the vault, not create-identity (identity-loss hazard)

### DIFF
--- a/packages/commons/__tests__/hooks/useOnboardingStatus.test.tsx
+++ b/packages/commons/__tests__/hooks/useOnboardingStatus.test.tsx
@@ -19,9 +19,31 @@ jest.mock('@oxyhq/core', () => {
   };
 });
 
-// Imported AFTER jest.mock so the hook sees the patched KeyManager.
+// Deterministic control over the LOCAL, offline-safe "onboarding complete"
+// milestone. The hook reads it via `getOnboardingCompleteFromStorage` (a plain
+// secure-store read) and writes it via `persistOnboardingComplete`. Mocking
+// both here (backed by a plain in-memory flag) decouples the test from the
+// platform storage-singleton selection and lets us simulate a RETURNING user
+// (`mockOnboardingCompleteFlag = true`) vs. a first-time onboarding
+// (`= false`). `mock`-prefixed so jest's hoisted factory may reference it.
+let mockOnboardingCompleteFlag = false;
+jest.mock('@/hooks/identity/identityStore', () => {
+  const actual = jest.requireActual('@/hooks/identity/identityStore');
+  return {
+    ...actual,
+    getOnboardingCompleteFromStorage: jest.fn(async () => mockOnboardingCompleteFlag),
+    persistOnboardingComplete: jest.fn(async (complete: boolean) => {
+      mockOnboardingCompleteFlag = complete;
+    }),
+  };
+});
+
+// Imported AFTER jest.mock so the hook sees the patched KeyManager +
+// identityStore.
 // eslint-disable-next-line import/first
 import { useOnboardingStatus } from '@/hooks/useOnboardingStatus';
+// eslint-disable-next-line import/first
+import { persistOnboardingComplete } from '@/hooks/identity/identityStore';
 
 // The hook now reads the shared identity probe via React Query, so each render
 // needs its own QueryClient. A fresh client per render keeps the
@@ -39,6 +61,9 @@ describe('useOnboardingStatus', () => {
   beforeEach(() => {
     __resetOxyState();
     hasIdentityMock.mockReset();
+    // Default: a first-time device that has NOT finished onboarding, so the
+    // legacy expectations (identity-but-no-session → "in_progress") still hold.
+    mockOnboardingCompleteFlag = false;
     Platform.OS = 'ios';
   });
 
@@ -192,5 +217,132 @@ describe('useOnboardingStatus', () => {
       expect(result.current.status).toBe('in_progress');
     });
     expect(result.current.isLoading).toBe(false);
+  });
+
+  // ── OFFLINE / device-first identity-loss guard ────────────────────────────
+  // These simulate the exact hazard: a returning user opens Commons with NO
+  // network. The device-first cold boot cannot mint a session, so
+  // `isAuthenticated` stays false even though cold boot HAS concluded
+  // (`isAuthResolved: true`). The local keystore still holds the identity
+  // (`hasIdentity()` is a pure local read → true) and the local onboarding
+  // milestone is set. The gate MUST route to the vault, NEVER to create-identity.
+  describe('offline returning user (no session)', () => {
+    it('routes a previously-onboarded identity to the vault OFFLINE (status "complete", needsAuth false)', async () => {
+      // hasIdentity true (local, offline-safe) + onboarding-complete milestone
+      // set + NO session (cold boot concluded signed-out because the network is
+      // down). This is the identity-loss bug: it must resolve to the vault.
+      hasIdentityMock.mockResolvedValue(true);
+      mockOnboardingCompleteFlag = true;
+      __setOxyState({ isAuthResolved: true, isAuthenticated: false, user: null });
+
+      const { result } = renderHook(() => useOnboardingStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('complete');
+      });
+      expect(result.current.needsAuth).toBe(false);
+      expect(result.current.hasIdentity).toBe(true);
+    });
+
+    it('NEVER downgrades an existing offline identity into the create flow ("none")', async () => {
+      // Explicit guard: with a local identity present, status can never be
+      // "none" (the only path that shows "create identity"), regardless of the
+      // absent session.
+      hasIdentityMock.mockResolvedValue(true);
+      mockOnboardingCompleteFlag = true;
+      __setOxyState({ isAuthResolved: true, isAuthenticated: false, user: null });
+
+      const { result } = renderHook(() => useOnboardingStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.status).not.toBe('checking');
+      });
+      expect(result.current.status).not.toBe('none');
+      expect(result.current.status).toBe('complete');
+    });
+
+    it('keeps a never-completed identity in the wizard OFFLINE (status "in_progress")', async () => {
+      // Counterpart: an identity generated but whose onboarding never finished
+      // (e.g. an offline create) has NO completion milestone. Offline it must
+      // stay in the wizard to finish, NOT jump to the vault — and still never
+      // fall through to "none"/create.
+      hasIdentityMock.mockResolvedValue(true);
+      mockOnboardingCompleteFlag = false;
+      __setOxyState({ isAuthResolved: true, isAuthenticated: false, user: null });
+
+      const { result } = renderHook(() => useOnboardingStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('in_progress');
+      });
+      expect(result.current.needsAuth).toBe(true);
+    });
+
+    it('stays "checking" until the local onboarding milestone resolves', async () => {
+      // The milestone read is part of the "resolving" gate: we must not flash a
+      // premature verdict before the local flag is known.
+      hasIdentityMock.mockResolvedValue(true);
+      let releaseComplete: (value: boolean) => void = () => undefined;
+      (persistOnboardingComplete as jest.Mock).mockClear();
+      const { getOnboardingCompleteFromStorage } = jest.requireMock(
+        '@/hooks/identity/identityStore',
+      ) as { getOnboardingCompleteFromStorage: jest.Mock };
+      getOnboardingCompleteFromStorage.mockImplementationOnce(
+        () => new Promise<boolean>((resolve) => {
+          releaseComplete = resolve;
+        }),
+      );
+      __setOxyState({ isAuthResolved: true, isAuthenticated: false, user: null });
+
+      const { result } = renderHook(() => useOnboardingStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(hasIdentityMock).toHaveBeenCalled();
+      });
+      expect(result.current.status).toBe('checking');
+
+      await act(async () => {
+        releaseComplete(true);
+      });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('complete');
+      });
+      // Restore the default resolver for subsequent cases.
+      getOnboardingCompleteFromStorage.mockImplementation(async () => mockOnboardingCompleteFlag);
+    });
+  });
+
+  describe('onboarding-complete milestone persistence', () => {
+    it('persists the milestone when onboarding genuinely completes online', async () => {
+      // A live session whose user has a username is the single genuine
+      // completion event — the hook writes the local milestone so the NEXT cold
+      // start can route to the vault with no network.
+      (persistOnboardingComplete as jest.Mock).mockClear();
+      hasIdentityMock.mockResolvedValue(true);
+      __setOxyState({ isAuthResolved: true, isAuthenticated: true, user: { username: 'alice' } });
+
+      const { result } = renderHook(() => useOnboardingStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('complete');
+      });
+      await waitFor(() => {
+        expect(persistOnboardingComplete).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('does NOT persist the milestone while onboarding is still incomplete (no username)', async () => {
+      (persistOnboardingComplete as jest.Mock).mockClear();
+      hasIdentityMock.mockResolvedValue(true);
+      __setOxyState({ isAuthResolved: true, isAuthenticated: true, user: {} });
+
+      const { result } = renderHook(() => useOnboardingStatus(), { wrapper: createWrapper() });
+
+      await waitFor(() => {
+        expect(result.current.status).toBe('in_progress');
+      });
+      expect(persistOnboardingComplete).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/commons/app/(tabs)/(settings)/delete-account.tsx
+++ b/packages/commons/app/(tabs)/(settings)/delete-account.tsx
@@ -13,7 +13,8 @@ import { alert, toast } from '@oxyhq/bloom';
 import { KeyManager } from '@oxyhq/core';
 import { useTranslation } from '@/lib/i18n';
 import { runAccountDeletion } from '@/lib/account/delete-account-flow';
-import { ONBOARDING_IDENTITY_QUERY_KEY } from '@/hooks/useOnboardingStatus';
+import { ONBOARDING_IDENTITY_QUERY_KEY, ONBOARDING_COMPLETE_QUERY_KEY } from '@/hooks/useOnboardingStatus';
+import { persistOnboardingComplete } from '@/hooks/identity/identityStore';
 
 /**
  * Account Deletion Screen.
@@ -67,8 +68,12 @@ export default function DeleteAccountScreen() {
 
       // The local identity has been purged (or the purge was attempted) — re-sync
       // the shared onboarding probe to ground truth so routing doesn't resume a
-      // deleted account's stale identity.
+      // deleted account's stale identity. Also clear the local onboarding-complete
+      // milestone so a subsequent re-onboard on this device starts fresh (the
+      // identity-presence check gates first, but keep storage coherent).
+      await persistOnboardingComplete(false);
       queryClient.invalidateQueries({ queryKey: ONBOARDING_IDENTITY_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ONBOARDING_COMPLETE_QUERY_KEY });
 
       // The account is gone server-side regardless. If the local key purge
       // failed, surface a non-fatal warning so the user knows to reinstall to

--- a/packages/commons/hooks/identity/identityStore.ts
+++ b/packages/commons/hooks/identity/identityStore.ts
@@ -114,6 +114,26 @@ export const IDENTITY_SYNC_STORAGE_KEY = 'oxy_identity_synced';
  * The phrase itself is NEVER stored — only this acknowledgement flag.
  */
 export const RECOVERY_PHRASE_ACK_STORAGE_KEY = 'oxy_recovery_phrase_acknowledged';
+/**
+ * Storage key for the monotonic "this device finished Commons onboarding for the
+ * current identity" milestone.
+ *
+ * Set to `'true'` exactly once — when onboarding genuinely completes (a live
+ * server session whose user has a username). It is read on EVERY cold start so a
+ * RETURNING user who has a local identity routes straight to the vault even with
+ * ZERO network: the local keystore + this flag are the authority, and session
+ * restore/mint is a background concern that must never hide the local identity.
+ *
+ * Reset to `'false'` whenever a NEW identity is created or imported (see
+ * `useIdentity`), so the milestone can never leak across a delete → re-onboard on
+ * the same device. The identity-presence check in `useOnboardingStatus` gates
+ * BEFORE this flag anyway, so a stale `'true'` after deletion can never route a
+ * keyless device into the vault — the reset is belt-and-suspenders for the
+ * delete-then-import-on-the-same-device case.
+ *
+ * Offline-safe: a plain local secure-store read, never a network call.
+ */
+export const ONBOARDING_COMPLETE_STORAGE_KEY = 'oxy_onboarding_complete';
 
 /** Canonical serialized truthy value. Only this literal is treated as set. */
 const STORED_TRUE = 'true';
@@ -233,6 +253,32 @@ export const getIdentitySyncStateFromStorage = async (): Promise<boolean> => {
   } catch (error) {
     console.error('[IdentityStore] Failed to read sync state', error);
     return false; // Not synced on error
+  }
+};
+
+/**
+ * Persist the monotonic onboarding-complete milestone (see
+ * {@link ONBOARDING_COMPLETE_STORAGE_KEY}).
+ */
+export const persistOnboardingComplete = async (complete: boolean): Promise<void> => {
+  try {
+    await storage.setItem(ONBOARDING_COMPLETE_STORAGE_KEY, complete ? STORED_TRUE : STORED_FALSE);
+  } catch (error) {
+    console.error('[IdentityStore] Failed to persist onboarding-complete flag', error);
+  }
+};
+
+/**
+ * Read the onboarding-complete milestone directly (offline-safe local read).
+ * Returns `false` by default — only `true` when explicitly stored as `'true'`.
+ */
+export const getOnboardingCompleteFromStorage = async (): Promise<boolean> => {
+  try {
+    const complete = await storage.getItem(ONBOARDING_COMPLETE_STORAGE_KEY);
+    return complete === STORED_TRUE;
+  } catch (error) {
+    console.error('[IdentityStore] Failed to read onboarding-complete flag', error);
+    return false;
   }
 };
 

--- a/packages/commons/hooks/useIdentity.ts
+++ b/packages/commons/hooks/useIdentity.ts
@@ -11,12 +11,12 @@ import {
 } from '@oxyhq/core';
 import type { User } from '@oxyhq/core';
 import { useBiometricSignIn } from './useBiometricSignIn';
-import { useIdentityStore, persistIdentitySyncState, getIdentitySyncStateFromStorage } from './identity/identityStore';
+import { useIdentityStore, persistIdentitySyncState, getIdentitySyncStateFromStorage, persistOnboardingComplete } from './identity/identityStore';
 import { syncIdentityWithServer } from './identity/syncService';
 import { acquireSyncLock, isSyncLockAborted } from './identity/syncLock';
 import { useNetworkReconnect } from './identity/useNetworkReconnect';
 import { isAlreadyRegisteredError } from './identity/errorUtils';
-import { ONBOARDING_IDENTITY_QUERY_KEY } from './useOnboardingStatus';
+import { ONBOARDING_IDENTITY_QUERY_KEY, ONBOARDING_COMPLETE_QUERY_KEY } from './useOnboardingStatus';
 
 const REGISTER_ERROR_CODE = 'REGISTER_ERROR';
 
@@ -177,6 +177,13 @@ export const useIdentity = (): UseIdentityResult => {
         // the next time they wipe the app.
         setSynced(false);
         await persistIdentitySyncState(false);
+        // A brand-new identity has NOT finished onboarding yet. Reset the
+        // local milestone so this identity starts fresh — otherwise a stale
+        // `true` left by a prior (deleted) identity on the same device would
+        // route the new one straight to the vault, skipping its onboarding
+        // wizard. It flips back to `true` only when THIS identity genuinely
+        // completes (username + session) in `useOnboardingStatus`.
+        await persistOnboardingComplete(false);
 
         // Caller detected no connectivity: skip the register + signIn round-trip
         // rather than stalling the "Setting up your account…" screen on a ~19s
@@ -231,10 +238,11 @@ export const useIdentity = (): UseIdentityResult => {
       inFlightCreateIdentity = run();
       try {
         const result = await inFlightCreateIdentity;
-        // Identity now exists on-device → refresh the shared onboarding probe so
-        // routing (`useOnboardingStatus`) reflects it without a per-component
-        // re-check.
+        // Identity now exists on-device → refresh the shared onboarding probes so
+        // routing (`useOnboardingStatus`) reflects both the new identity AND its
+        // reset onboarding-complete milestone without a per-component re-check.
         queryClient.invalidateQueries({ queryKey: ONBOARDING_IDENTITY_QUERY_KEY });
+        queryClient.invalidateQueries({ queryKey: ONBOARDING_COMPLETE_QUERY_KEY });
         return result;
       } catch (error) {
         if (!(error instanceof IdentityAlreadyExistsError)) {
@@ -279,6 +287,10 @@ export const useIdentity = (): UseIdentityResult => {
 
         setSynced(false);
         await persistIdentitySyncState(false);
+        // Reset the local onboarding milestone for the freshly-imported identity
+        // (see the matching reset in `createIdentity`). It flips back to `true`
+        // only when this identity completes onboarding in `useOnboardingStatus`.
+        await persistOnboardingComplete(false);
 
         try {
           const { registered } = await oxyServices.checkPublicKeyRegistered(publicKey);
@@ -311,10 +323,11 @@ export const useIdentity = (): UseIdentityResult => {
       inFlightImportIdentity = run();
       try {
         const result = await inFlightImportIdentity;
-        // Identity now exists on-device → refresh the shared onboarding probe so
-        // routing (`useOnboardingStatus`) reflects it without a per-component
-        // re-check.
+        // Identity now exists on-device → refresh the shared onboarding probes so
+        // routing (`useOnboardingStatus`) reflects both the new identity AND its
+        // reset onboarding-complete milestone without a per-component re-check.
         queryClient.invalidateQueries({ queryKey: ONBOARDING_IDENTITY_QUERY_KEY });
+        queryClient.invalidateQueries({ queryKey: ONBOARDING_COMPLETE_QUERY_KEY });
         return result;
       } catch (error) {
         if (!(error instanceof IdentityAlreadyExistsError) && !(error instanceof IdentityPersistError)) {

--- a/packages/commons/hooks/useOnboardingStatus.ts
+++ b/packages/commons/hooks/useOnboardingStatus.ts
@@ -1,7 +1,11 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useOxy } from '@oxyhq/services';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { KeyManager, logger } from '@oxyhq/core';
+import {
+  getOnboardingCompleteFromStorage,
+  persistOnboardingComplete,
+} from './identity/identityStore';
 
 export type OnboardingStatus = 'checking' | 'none' | 'in_progress' | 'complete';
 
@@ -23,12 +27,32 @@ export interface OnboardingState {
 export const ONBOARDING_IDENTITY_QUERY_KEY = ['onboarding', 'identity'] as const;
 
 /**
+ * React Query key for the LOCAL, offline-safe "onboarding complete" milestone
+ * (`getOnboardingCompleteFromStorage`). Read once per app session and shared by
+ * every consumer. Identity mutations (create / import) invalidate it so it
+ * re-reads exactly when the answer can change; genuine online completion writes
+ * it directly via `queryClient.setQueryData` below.
+ */
+export const ONBOARDING_COMPLETE_QUERY_KEY = ['onboarding', 'complete'] as const;
+
+/**
  * Centralized hook for managing onboarding state.
  *
- * Combines three signals into a single resolved status:
- *   - `KeyManager.hasIdentity()`: identity material in secure storage
+ * Combines four signals into a single resolved status:
+ *   - `KeyManager.hasIdentity()`: identity material in secure storage (LOCAL,
+ *     offline-safe — a returning user's identity is detected with no network)
+ *   - `getOnboardingCompleteFromStorage()`: the LOCAL, offline-safe milestone
+ *     that this device finished onboarding for the current identity
  *   - `isAuthenticated`: an active server session exists
  *   - `user.username`: the user has completed the username step
+ *
+ * LOCAL-FIRST / OFFLINE-SAFE ROUTING (identity-loss guard): identity presence is
+ * decided ONLY from the local keystore, and a returning user (local identity +
+ * local completion milestone) routes to the vault EVEN WITH ZERO NETWORK. A
+ * failed/absent session mint (offline, expired) can NEVER downgrade an existing
+ * identity into the "create identity" flow — the create path is reachable only
+ * when the local keystore genuinely has no identity. Session restore/mint is a
+ * strictly background concern.
  *
  * Used by:
  *   - `_layout.tsx` for routing decisions (`needsAuth`) and splash readiness
@@ -37,8 +61,9 @@ export const ONBOARDING_IDENTITY_QUERY_KEY = ['onboarding', 'identity'] as const
  *   - `create-identity.tsx` for flow initialization
  *   - `useOnboardingFlow.ts`
  *
- * The `KeyManager.hasIdentity()` probe is a SHARED React Query read
- * (`ONBOARDING_IDENTITY_QUERY_KEY`), so every consumer above shares ONE deduped
+ * The `KeyManager.hasIdentity()` probe and the onboarding-complete milestone are
+ * SHARED React Query reads (`ONBOARDING_IDENTITY_QUERY_KEY` /
+ * `ONBOARDING_COMPLETE_QUERY_KEY`), so every consumer above shares ONE deduped
  * result and one loading state — no per-component re-probe flashing.
  *
  * Correctness invariants:
@@ -59,6 +84,7 @@ export const ONBOARDING_IDENTITY_QUERY_KEY = ['onboarding', 'identity'] as const
  */
 export function useOnboardingStatus(): OnboardingState {
   const { user, isAuthenticated, isAuthResolved, isLoading: oxyLoading } = useOxy();
+  const queryClient = useQueryClient();
 
   const identityQuery = useQuery({
     queryKey: ONBOARDING_IDENTITY_QUERY_KEY,
@@ -87,6 +113,22 @@ export function useOnboardingStatus(): OnboardingState {
     retry: false,
   });
 
+  // The LOCAL, offline-safe "onboarding complete" milestone. This is the signal
+  // that lets a RETURNING user reach the vault with ZERO network: it is a plain
+  // secure-store read (never a network call), so an existing identity is never
+  // hidden behind a failed session mint. `getOnboardingCompleteFromStorage`
+  // catches its own storage errors (→ `false`), so no wrapper is needed here.
+  const completeQuery = useQuery({
+    queryKey: ONBOARDING_COMPLETE_QUERY_KEY,
+    queryFn: getOnboardingCompleteFromStorage,
+    // Mirror the identity probe: defer until the SDK provider settles, and never
+    // auto-refetch — the answer only moves on explicit identity mutations (which
+    // invalidate the key) or genuine completion (which sets the data directly).
+    enabled: !oxyLoading,
+    staleTime: Infinity,
+    retry: false,
+  });
+
   // Map React Query state onto the prior local-probe semantics:
   //   - `identityExists`: `boolean` once resolved, `null` while still unknown.
   //     React Query keeps the previous value across invalidation refetches, so
@@ -94,6 +136,24 @@ export function useOnboardingStatus(): OnboardingState {
   //   - `isResolving`: `true` only until the FIRST probe resolves.
   const identityExists: boolean | null = identityQuery.data ?? null;
   const isResolving = identityQuery.data === undefined;
+
+  // Once resolved this is a stable boolean; `undefined` only while the initial
+  // local read is in flight (mirrors `isResolving` above).
+  const onboardingComplete: boolean = completeQuery.data ?? false;
+  const isCompleteResolving = completeQuery.data === undefined;
+
+  // Persist the monotonic onboarding-complete milestone the moment onboarding
+  // genuinely completes ONLINE (a live session whose user has a username). This
+  // is what lets the NEXT cold start route a returning user to the vault with no
+  // network. Guarded on the cached flag so it writes at most once per identity;
+  // `setQueryData` reflects it immediately for the current session. Never clears
+  // it here — creation/import own the reset (see `useIdentity`).
+  useEffect(() => {
+    if (!isAuthenticated || !user?.username) return;
+    if (completeQuery.data === true) return;
+    void persistOnboardingComplete(true);
+    queryClient.setQueryData(ONBOARDING_COMPLETE_QUERY_KEY, true);
+  }, [isAuthenticated, user?.username, completeQuery.data, queryClient]);
 
   const status = useMemo<OnboardingStatus>(() => {
     // Genuinely unknown — still resolving the initial answer. `isAuthResolved`
@@ -104,7 +164,7 @@ export function useOnboardingStatus(): OnboardingState {
     // session will restore, so we stay `'checking'` (neutral backdrop) rather
     // than prematurely reporting `'in_progress'` and bouncing the user through
     // create-identity.
-    if (oxyLoading || !isAuthResolved || isResolving) {
+    if (oxyLoading || !isAuthResolved || isResolving || isCompleteResolving) {
       return 'checking';
     }
 
@@ -116,13 +176,38 @@ export function useOnboardingStatus(): OnboardingState {
       return user.username ? 'complete' : 'in_progress';
     }
 
+    // No local identity → genuinely a fresh device. This is the ONLY path to
+    // "create identity", and it is decided purely from the LOCAL keystore
+    // (`hasIdentity()`), never from a network call.
     if (!identityExists) {
       return 'none';
     }
 
-    // Identity exists locally but no active session — resume onboarding.
+    // Identity EXISTS locally but there is no live session (e.g. the device is
+    // OFFLINE, or the device session simply hasn't restored/minted yet). Decide
+    // from the LOCAL onboarding milestone — NEVER from the network:
+    //   - onboarding completed before on this device → this is a RETURNING user
+    //     whose session is merely absent. Route them to the vault; the
+    //     session restore/mint proceeds in the background and must not hide the
+    //     local identity. This is the offline-loss fix: a fully-onboarded user
+    //     with no connectivity reaches their vault, never the create flow.
+    //   - never completed → a first-time onboarding still in progress (identity
+    //     generated but username/sync not finished, e.g. an offline create) →
+    //     resume the wizard.
+    if (onboardingComplete) {
+      return 'complete';
+    }
     return 'in_progress';
-  }, [identityExists, isResolving, isAuthenticated, isAuthResolved, user, oxyLoading]);
+  }, [
+    identityExists,
+    isResolving,
+    isCompleteResolving,
+    onboardingComplete,
+    isAuthenticated,
+    isAuthResolved,
+    user,
+    oxyLoading,
+  ]);
 
   const needsAuth = useMemo(() => {
     // While the device-first cold boot is unresolved (`status === 'checking'`)
@@ -141,7 +226,7 @@ export function useOnboardingStatus(): OnboardingState {
   return {
     status,
     needsAuth,
-    isLoading: isResolving || oxyLoading || !isAuthResolved,
+    isLoading: isResolving || isCompleteResolving || oxyLoading || !isAuthResolved,
     // An active session implies identity exists — keep this in lockstep
     // with the `status` invariant above so consumers that gate on
     // `hasIdentity` (e.g. the redirect in `(auth)/index.tsx`) don't fall


### PR DESCRIPTION
## Root cause

`useOnboardingStatus` previously required a LIVE server session to resolve to "complete". When a returning user's device had a real local identity but was offline (or the session simply hadn't remounted yet), the hook fell through to "in_progress" and routed the user toward the **create-identity** flow — even though the user's real identity was sitting right there in secure storage.

This is an **identity-loss hazard**: a confused user could create a redundant second identity while offline, get confused about which one is real, or worse, end up overwriting/orphaning the existing one.

## The fix

A new local-first, offline-safe milestone (`oxy_onboarding_complete`, secure-storage only, **never** a network read) is set exactly once — the moment onboarding genuinely completes online (live session + username present).

On every cold start, `useOnboardingStatus` now checks local identity presence (`KeyManager.hasIdentity()`, already offline-safe) **first**. If an identity exists but there's no live session, it decides purely from this local milestone:
- **"complete"** (route to vault) if previously onboarded
- **"in_progress"** (resume wizard) only if never completed before

A failed/absent/slow session mint can never downgrade an existing identity into the create flow. Session restore/mint remains a strictly background concern.

The milestone is reset on new identity create/import (so it can't leak across devices/identities) and cleared on account deletion (so a fresh re-onboard on the same device starts clean).

**Files touched:**
- `packages/commons/hooks/identity/identityStore.ts` — new `ONBOARDING_COMPLETE_STORAGE_KEY` + `persistOnboardingComplete`/`getOnboardingCompleteFromStorage` helpers
- `packages/commons/hooks/useIdentity.ts` — resets the milestone on new identity create/import
- `packages/commons/hooks/useOnboardingStatus.ts` — the core routing fix
- `packages/commons/app/(tabs)/(settings)/delete-account.tsx` — clears the milestone on account deletion
- `__tests__/hooks/useOnboardingStatus.test.tsx` — new tests

## Tests added

6 new tests in `useOnboardingStatus.test.tsx` (4 covering offline routing behavior, 2 covering milestone persistence timing), all passing.

**Full verification summary (all green, zero regressions):**
1. `bun run --filter @oxyhq/core build` — passed.
2. tsc: `packages/core` clean. `packages/commons` has exactly 3 KNOWN PRE-EXISTING errors (unbuilt `@oxyhq/expo-splash`, missing `global.css` type decl, `constants/styles.ts` web `'fixed'` style value) — confirmed byte-for-byte identical to `origin/main` (diffed tsc output from both branches). **Zero new tsc errors introduced.**
3. Tests: `packages/core` **868/868** pass. `packages/commons` **387/387** pass; 3 test suites fail to even *load* (`CompositionCard.test.tsx`, `StandingHero.test.tsx`, `ActivityList.test.tsx`) — confirmed pre-existing and unrelated: the first two reference component files (`StandingHero.tsx`, `CompositionCard.tsx`) that don't exist anywhere in the repo, not even on `origin/main` (dead tests from an earlier refactor); the third fails on a `react-native-keyboard-controller` ESM import under Jest, also pre-existing. None of these 3 files are touched by this branch's diff. The new/extended `__tests__/hooks/useOnboardingStatus.test.tsx` passes **18/18**, including the 6 new tests above.
4. Lockfile: root `bun install` → no changes (already in sync); `bun install --frozen-lockfile` passes clean. No new deps added.

## ⚠️ Manual verification required before shipping to real users

**Automated tests cover the logic, but this is a safety-critical identity-routing path. Final sign-off REQUIRES manual verification on a REAL device or emulator in AIRPLANE MODE before this ships to real users.**

Manual steps:
1. On a device/emulator with an **existing** Commons identity and completed onboarding, enable airplane mode, force-quit and relaunch the app, confirm it opens directly to the **vault** (not create-identity).
2. With airplane mode still on, confirm no data loss / no prompt to create a new identity.
3. Disable airplane mode, confirm normal session restore proceeds in the background without disrupting the already-loaded vault.

This ships via **EAS** (per repo convention) and must **NOT** be dev-installed (`adb install -r` or similar) over any device holding a REAL identity — per the repo's Commons on-device-testing safety rule, doing so risks orphaning the AndroidKeyStore key and permanently deleting the identity (both primary and backup) with no recovery except the user's 12-word recovery phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
