### PR TITLE
fix(accounts): operator-anchored switcher + in-place switch (no redirect) + surfaced errors

### DIFF
--- a/packages/api/src/routes/__tests__/accountsSwitch.test.ts
+++ b/packages/api/src/routes/__tests__/accountsSwitch.test.ts
@@ -30,9 +30,13 @@ const OPERATOR_ID = '6a0000000000000000000001';
 const ORG_ID = '6a0000000000000000000010';
 
 const mockVerifyActingAs = jest.fn();
+const mockListAccessibleAccounts = jest.fn();
 jest.mock('../../services/account.service', () => ({
   __esModule: true,
-  accountService: { verifyActingAs: (...args: unknown[]) => mockVerifyActingAs(...args) },
+  accountService: {
+    verifyActingAs: (...args: unknown[]) => mockVerifyActingAs(...args),
+    listAccessibleAccounts: (...args: unknown[]) => mockListAccessibleAccounts(...args),
+  },
 }));
 
 const mockFindById = jest.fn();
@@ -43,9 +47,15 @@ jest.mock('../../models/User', () => ({
 }));
 
 const mockCreateSession = jest.fn();
+const mockGetSession = jest.fn();
 jest.mock('../../services/session.service', () => ({
   __esModule: true,
-  default: { createSession: (...args: unknown[]) => mockCreateSession(...args) },
+  default: {
+    createSession: (...args: unknown[]) => mockCreateSession(...args),
+    // Used by the route's `resolveOperatorId` to read `operatedByUserId` off the
+    // session doc (the JWT does not carry it).
+    getSession: (...args: unknown[]) => mockGetSession(...args),
+  },
 }));
 
 // The switch now registers the managed session into the operator's device set.
@@ -134,6 +144,37 @@ function post(srv: http.Server, path: string): Promise<JsonResponse> {
   });
 }
 
+function get(srv: http.Server, path: string): Promise<JsonResponse> {
+  const address = srv.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: 'GET',
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: { Authorization: 'Bearer t' },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (c) => { raw += c; });
+        res.on('end', () => {
+          try {
+            const setCookie = res.headers['set-cookie'] ?? [];
+            resolve({
+              status: res.statusCode ?? 0,
+              setCookie: Array.isArray(setCookie) ? setCookie : [setCookie],
+              body: raw.length > 0 ? JSON.parse(raw) : {},
+            });
+          } catch (err) { reject(err); }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
 let server: http.Server;
 
 beforeAll((done) => {
@@ -158,6 +199,12 @@ beforeEach(() => {
   // inherit it so the org session lands on the SAME device doc as the operator.
   mockDecodeToken.mockReset();
   mockDecodeToken.mockReturnValue({ sessionId: 'op-sess', deviceId: 'dev-op' });
+  // Default: an ordinary (non-operated) session → the operator IS the active
+  // account. Operated-session cases override with an `operatedByUserId`.
+  mockGetSession.mockReset();
+  mockGetSession.mockResolvedValue({ operatedByUserId: null });
+  mockListAccessibleAccounts.mockReset();
+  mockListAccessibleAccounts.mockResolvedValue([]);
 });
 
 describe('POST /accounts/:id/switch', () => {
@@ -225,6 +272,44 @@ describe('POST /accounts/:id/switch', () => {
     );
   });
 
+  it('anchors on the OPERATOR when acting-as a sub-account (sibling switch works, operator never nests)', async () => {
+    // The active session is an OPERATED sub-account: the human operator is the
+    // recorded `operatedByUserId`, NOT the active account (OPERATOR_ID here plays
+    // the acted-as sub-account). A switch out of it must authorise + record the
+    // HUMAN, so the operator can reach their sibling accounts.
+    const HUMAN_ID = '6a0000000000000000000099';
+    mockGetSession.mockResolvedValue({ operatedByUserId: { toString: () => HUMAN_ID } });
+    mockVerifyActingAs.mockResolvedValue('owner');
+    mockFindById.mockResolvedValue({
+      _id: new Types.ObjectId(ORG_ID),
+      username: 'sibling-org',
+      kind: 'organization',
+      accountStatus: 'active',
+    });
+    mockCreateSession.mockResolvedValue({
+      sessionId: 'sess-2',
+      deviceId: 'dev-op',
+      expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+      accessToken: 'acc-2',
+    });
+
+    const res = await post(server, `/accounts/${ORG_ID}/switch`);
+
+    expect(res.status).toBe(200);
+    // Authorised as the human operator — NOT the acted-as sub-account.
+    expect(mockVerifyActingAs).toHaveBeenCalledWith(HUMAN_ID, ORG_ID);
+    // The minted session records the human operator (flat chain, never the sub-account).
+    expect(mockCreateSession).toHaveBeenCalledWith(ORG_ID, expect.anything(), {
+      operatedByUserId: HUMAN_ID,
+      deviceId: 'dev-op',
+    });
+    expect(mockAddAccount).toHaveBeenCalledWith(
+      'dev-op',
+      { accountId: ORG_ID, sessionId: 'sess-2', operatedByUserId: HUMAN_ID },
+      { activate: 'always' },
+    );
+  });
+
   it('falls back to a fresh device when the bearer has no resolvable deviceId', async () => {
     // No decodable deviceId on the caller's bearer → keep today's behavior
     // (let createSession derive/allocate a device) rather than passing undefined.
@@ -285,5 +370,29 @@ describe('POST /accounts/:id/switch', () => {
 
     expect(res.status).toBe(404);
     expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /accounts (operator-anchored switchable graph)', () => {
+  it('anchors an ordinary session on the authenticated account', async () => {
+    // No operatedByUserId → the operator IS the active account.
+    const res = await get(server, '/accounts');
+
+    expect(res.status).toBe(200);
+    expect(mockListAccessibleAccounts).toHaveBeenCalledWith(OPERATOR_ID);
+  });
+
+  it('anchors an OPERATED (sub-account) session on the human operator, not the active account', async () => {
+    // Acting-as a leaf sub-account must still return the OPERATOR's full forest
+    // (their personal account + every sibling they can act_as), so the switcher
+    // never collapses to just the active sub-account.
+    const HUMAN_ID = '6a0000000000000000000099';
+    mockGetSession.mockResolvedValue({ operatedByUserId: { toString: () => HUMAN_ID } });
+
+    const res = await get(server, '/accounts');
+
+    expect(res.status).toBe(200);
+    expect(mockListAccessibleAccounts).toHaveBeenCalledWith(HUMAN_ID);
+    expect(mockListAccessibleAccounts).not.toHaveBeenCalledWith(OPERATOR_ID);
   });
 });

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -72,6 +72,45 @@ function resolveCallerDeviceId(req: AuthRequest): string | null {
   return decoded?.deviceId ?? null;
 }
 
+/**
+ * Resolve the OPERATOR anchoring the caller's account graph and switches — the
+ * HUMAN behind the request, NOT the account currently being acted-as.
+ *
+ * For an ordinary session the operator IS the authenticated account. For an
+ * operated (managed / sub-account) session — one minted by `POST /:id/switch`
+ * and carrying `operatedByUserId` — the operator is that recorded human, so
+ * every switcher surface stays anchored on the person no matter which of their
+ * accounts is currently active. Without this, acting-as a leaf sub-account
+ * (which has no children/memberships of its own) collapses the switchable set to
+ * just that account and makes sibling switches fail `verifyActingAs`.
+ *
+ * `operatedByUserId` is authoritative and server-set at switch time (bound to
+ * the operator's `account:act_as` membership, re-verified on validate/refresh),
+ * so trusting it here escalates nothing. The bearer JWT does not carry it
+ * (session-doc-only), so it is read from the (request-cached) session record; a
+ * missing/unreadable session degrades safely to the authenticated account.
+ */
+async function resolveOperatorId(req: AuthRequest): Promise<string> {
+  const authedUserId = requireUserId(req);
+  const token = extractTokenFromRequest(req);
+  const sessionId = token ? decodeToken(token)?.sessionId : undefined;
+  if (!sessionId) {
+    return authedUserId;
+  }
+  try {
+    const sessionDoc = await sessionService.getSession(sessionId, true);
+    const operator = sessionDoc?.operatedByUserId ? sessionDoc.operatedByUserId.toString() : null;
+    return operator ?? authedUserId;
+  } catch (error) {
+    logger.debug('[accounts] resolveOperatorId: session lookup failed, using active account', {
+      component: 'accounts',
+      method: 'resolveOperatorId',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return authedUserId;
+  }
+}
+
 /** Per-user (or per-IP when anonymous) rate-limit key for a scope. */
 function userScopedKey(scope: string) {
   return (req: Request): string => {
@@ -267,16 +306,22 @@ function requireAccountPermission(permission: AccountPermission) {
 // ============================================================================
 
 /**
- * The caller's accessible account forest: their own personal account plus every
+ * The OPERATOR's accessible account forest: their own personal account plus every
  * account they can reach (direct membership + inherited subtree). Flat by
  * default; `?tree=true` nests children under parents.
+ *
+ * Anchored on the operator (the human), NOT the currently-active account, so the
+ * switchable set is IDENTICAL regardless of which of the operator's accounts is
+ * active — switching only flips which account is marked current, never which are
+ * listed. (When acting-as a leaf sub-account, anchoring on the active account
+ * would collapse the list to just that account.)
  */
 router.get(
   '/',
   readLimiter,
   validate({ query: listAccountsQuerySchema }),
   asyncHandler(async (req: AuthRequest, res) => {
-    const userId = requireUserId(req);
+    const userId = await resolveOperatorId(req);
     const nodes = await accountService.listAccessibleAccounts(userId);
     const serialized = nodes.map(serializeAccountNode);
 
@@ -310,7 +355,13 @@ router.post(
   writeLimiter,
   validate({ params: accountIdRouteParams }),
   asyncHandler(async (req: AuthRequest, res) => {
-    const operatorId = requireUserId(req);
+    // Anchor on the OPERATOR (the human), not the active account: acting-as a
+    // sub-account must still let the operator switch into their SIBLING accounts.
+    // For an ordinary session this is the authenticated account itself; for an
+    // operated session it is the recorded `operatedByUserId`, so the operator
+    // chain never nests (a switch out of a sub-account is still authorised as,
+    // and recorded against, the human — never the sub-account).
+    const operatorId = await resolveOperatorId(req);
     const id = req.params.id;
     if (!mongoose.isValidObjectId(id)) {
       throw new NotFoundError('Account not found');

--- a/packages/core/src/session/__tests__/accountDialogController.test.ts
+++ b/packages/core/src/session/__tests__/accountDialogController.test.ts
@@ -391,6 +391,54 @@ describe('AccountDialogController — switchTo (uniform switch)', () => {
     expect(commitSession.mock.calls[0][0]).toMatchObject({ sessionId: 'sess-org', accessToken: 'access-org' });
   });
 
+  it('commits a graph switch via the IN-PLACE commitSwitchedSession — never the hub-syncing commitSession', async () => {
+    // PROBLEM 2: an account switch must not run the cross-origin hub-sync
+    // full-page redirect. When both funnels are wired, the mint-switch must use
+    // commitSwitchedSession (in-place) and NEVER commitSession (which may
+    // redirect on an official web origin).
+    const oxy = makeOxy();
+    const sc = new TestSessionClient(host());
+    sc.set(state([{ accountId: 'a1', sessionId: 's1' }], 'a1'));
+    jest.spyOn(sc, 'switchAccount').mockResolvedValue(undefined);
+    oxy.switchToAccount.mockResolvedValue({
+      sessionId: 'sess-org',
+      deviceId: 'device-1',
+      expiresAt: '2030-01-01T00:00:00Z',
+      accessToken: 'access-org',
+      user: user('org1'),
+    });
+    const commitSession = jest.fn().mockResolvedValue(undefined);
+    const commitSwitchedSession = jest.fn().mockResolvedValue(undefined);
+    const controller = new AccountDialogController({
+      oxyServices: oxy as unknown as OxyServices,
+      sessionClient: sc,
+      clientId: 'oxy_dk_test',
+      commitSession,
+      commitSwitchedSession,
+    });
+
+    await controller.switchTo('org1');
+
+    expect(commitSwitchedSession).toHaveBeenCalledTimes(1);
+    expect(commitSwitchedSession.mock.calls[0][0]).toMatchObject({ sessionId: 'sess-org', accessToken: 'access-org' });
+    expect(commitSession).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed switch as snapshot.error instead of silently no-op\'ing', async () => {
+    // PROBLEM 1: switching into an account the server refuses (e.g. a 403 for a
+    // personal-kind target) must tell the user why — the error is recorded on
+    // the snapshot, the switch does not throw, and switchingAccountId resets.
+    const { controller, oxy, sc } = makeHarness();
+    sc.set(state([{ accountId: 'a1', sessionId: 's1' }], 'a1'));
+    oxy.switchToAccount.mockRejectedValue(new Error('Cannot switch into a personal account'));
+
+    await expect(controller.switchTo('org1')).resolves.toBeUndefined();
+
+    const snap = controller.getSnapshot();
+    expect(snap.error).toBe('Cannot switch into a personal account');
+    expect(snap.switchingAccountId).toBeNull();
+  });
+
   it('falls back to SessionClient.registerAndActivate when no commitSession is supplied', async () => {
     const oxy = makeOxy();
     const sc = new TestSessionClient(host());

--- a/packages/core/src/session/__tests__/accountProjection.test.ts
+++ b/packages/core/src/session/__tests__/accountProjection.test.ts
@@ -164,6 +164,36 @@ describe('projectSwitchableAccounts', () => {
     });
     expect(rows.every((r) => !r.isCurrent)).toBe(true);
   });
+
+  it('keeps the OPERATOR full set when acting-as a sub-account (no collapse to the active account)', () => {
+    // nate operates albert: albert is the active on-device account, nate is also
+    // on-device, and the graph is OPERATOR-anchored (the server returns nate's
+    // full forest regardless of which account is active). The projection must
+    // faithfully union — switching in only changes which row is `isCurrent`,
+    // never which accounts are listed. This is the switcher-collapse regression.
+    const rows = projectSwitchableAccounts({
+      state: state([{ accountId: 'nate', sessionId: 's-nate' }, { accountId: 'albert', sessionId: 's-albert' }], 'albert'),
+      graph: [
+        graphNode('nate', { kind: 'personal', relationship: 'self' }),
+        graphNode('albert', { relationship: 'owner' }),
+        graphNode('oxy', { relationship: 'owner' }),
+        graphNode('faircoin', { relationship: 'owner' }),
+      ],
+      profilesById: mapOf(user('nate'), user('albert'), user('oxy'), user('faircoin')),
+      resolveAvatarUrl: noAvatar,
+    });
+
+    // The full operable set is present even though a leaf sub-account is active.
+    expect(rows.map((r) => r.accountId).sort()).toEqual(['albert', 'faircoin', 'nate', 'oxy']);
+    // Exactly the active sub-account is flagged current; operator + siblings stay.
+    expect(rows.find((r) => r.accountId === 'albert')?.isCurrent).toBe(true);
+    expect(rows.filter((r) => r.isCurrent)).toHaveLength(1);
+    // The operator's own personal account is not dropped by acting-as.
+    expect(rows.find((r) => r.accountId === 'nate')).toBeDefined();
+    // Graph-only siblings (operable but not yet on this device) still appear.
+    expect(rows.find((r) => r.accountId === 'oxy')?.onDevice).toBe(false);
+    expect(rows.find((r) => r.accountId === 'faircoin')?.onDevice).toBe(false);
+  });
 });
 
 describe('switchableAccountIds', () => {

--- a/packages/core/src/session/accountDialogController.ts
+++ b/packages/core/src/session/accountDialogController.ts
@@ -98,15 +98,36 @@ export interface AccountDialogControllerOptions {
   /** Locale for display-name resolution. */
   locale?: string;
   /**
-   * Commit a freshly-authorized session (device flow / shared identity / minted
-   * graph switch) into the host's session set — device-first registration +
-   * durable persist + profile hydration. The consumer supplies its provider's
-   * commit path (`useOxy().handleWebSession` / the auth-sdk equivalent). Called
-   * AFTER the SDK has planted the access token. When omitted the controller
-   * falls back to `SessionClient.registerAndActivate` (registration + activation
-   * only — no provider-side durable persist/hydration).
+   * Commit a freshly-authorized SIGN-IN session (device flow / shared identity)
+   * into the host's session set — device-first registration + durable persist +
+   * profile hydration. The consumer supplies its provider's commit path
+   * (`useOxy().handleWebSession` / the auth-sdk equivalent). Called AFTER the SDK
+   * has planted the access token. When omitted the controller falls back to
+   * `SessionClient.registerAndActivate` (registration + activation only — no
+   * provider-side durable persist/hydration).
+   *
+   * This is the SIGN-IN commit: on an official web origin it may run the
+   * cross-origin hub-sync (a full-page redirect to `auth.oxy.so/sync`) that
+   * bootstraps silent OAuth restore on OTHER origins. A first sign-in on a web
+   * origin legitimately needs that. An account SWITCH does NOT — see
+   * {@link commitSwitchedSession}.
    */
   commitSession?: (session: SessionLoginResponse) => Promise<void>;
+  /**
+   * Commit a minted graph SWITCH session into the host's session set — same
+   * device-first registration + durable persist + profile hydration as
+   * {@link commitSession}, but IN-PLACE: it must NOT trigger the cross-origin
+   * hub-sync redirect. Switching into an account you already operate reuses the
+   * device credential that was already hub-synced at the original sign-in, so
+   * re-syncing is redundant and a full-page redirect on switch is the exact
+   * regression this separation prevents. Cross-tab/app propagation of the switch
+   * still happens instantly via the server's device-scoped `session_state` /
+   * `session_accounts_changed` socket broadcast — no navigation required.
+   *
+   * When omitted the controller falls back to {@link commitSession} (if wired)
+   * and then to `SessionClient.registerAndActivate`.
+   */
+  commitSwitchedSession?: (session: SessionLoginResponse) => Promise<void>;
   /** Notified after a completed sign-in (bearer planted + session committed). */
   onSignedIn?: (user: MinimalUserData) => void;
   /**
@@ -179,6 +200,7 @@ export class AccountDialogController {
   private readonly clientId: string | null;
   private readonly locale?: string;
   private readonly commitSession?: (session: SessionLoginResponse) => Promise<void>;
+  private readonly commitSwitchedSession?: (session: SessionLoginResponse) => Promise<void>;
   private readonly onSignedIn?: (user: MinimalUserData) => void;
   private readonly pollIntervalMs: number;
   private readonly openUrl?: (url: string) => void;
@@ -228,6 +250,7 @@ export class AccountDialogController {
     this.clientId = options.clientId ?? null;
     this.locale = options.locale;
     this.commitSession = options.commitSession;
+    this.commitSwitchedSession = options.commitSwitchedSession;
     this.onSignedIn = options.onSignedIn;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.openUrl = options.openUrl;
@@ -523,6 +546,10 @@ export class AccountDialogController {
             accessToken: result.accessToken,
           },
           result.user,
+          // A switch is IN-PLACE: commit without the hub-sync redirect (the
+          // device is already known/synced). Cross-tab/app propagation rides the
+          // server's `session_state` socket broadcast, not a navigation.
+          { fromSwitch: true },
         );
       }
       // Re-project + refetch immediately; the subscription also fires.
@@ -755,15 +782,25 @@ export class AccountDialogController {
 
   /**
    * Register a token-planted session into the device set. Prefers the
-   * consumer's `commitSession` (durable persist + hydration); falls back to
+   * consumer's commit funnel (durable persist + hydration); falls back to
    * `SessionClient.registerAndActivate` (registration + activation only).
+   *
+   * A SWITCH (`opts.fromSwitch`) uses the IN-PLACE `commitSwitchedSession` funnel
+   * so it never runs the cross-origin hub-sync redirect; a SIGN-IN uses
+   * `commitSession` (which may hub-sync on an official web origin). When the
+   * switch funnel is not wired it falls back to the sign-in funnel, then to
+   * `registerAndActivate`.
    */
   private async commitAuthorizedSession(
     session: SessionLoginResponse,
     user: MinimalUserData,
+    opts?: { fromSwitch?: boolean },
   ): Promise<void> {
-    if (this.commitSession) {
-      await this.commitSession(session);
+    const commit = opts?.fromSwitch
+      ? this.commitSwitchedSession ?? this.commitSession
+      : this.commitSession;
+    if (commit) {
+      await commit(session);
     } else {
       await this.sessionClient.registerAndActivate(user.id);
     }

--- a/packages/services/__tests__/components/OxyAccountDialog.test.tsx
+++ b/packages/services/__tests__/components/OxyAccountDialog.test.tsx
@@ -132,6 +132,18 @@ describe('OxyAccountDialog', () => {
     expect(controller.signInWithOxy).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces snapshot.error as a banner in the accounts view (failed switch is not silent)', () => {
+    snapshot = makeSnapshot({
+      error: 'Cannot switch into a personal account',
+      activeAccountId: 'a',
+      accounts: [makeAccount({ accountId: 'a', displayName: 'Alice', isCurrent: true, sessionId: 's-a' })],
+    });
+
+    render(<OxyAccountDialog />);
+
+    expect(screen.getByText('Cannot switch into a personal account')).toBeTruthy();
+  });
+
   it('renders the QR payload while awaiting approval', () => {
     snapshot = makeSnapshot({
       view: 'qr',

--- a/packages/services/src/ui/components/OxyAccountDialog.tsx
+++ b/packages/services/src/ui/components/OxyAccountDialog.tsx
@@ -238,6 +238,16 @@ const OxyAccountDialog: React.FC = () => {
         contentContainerStyle={styles.bodyContent}
         showsVerticalScrollIndicator={false}
       >
+        {snapshot.error && view !== 'qr' ? (
+          // A failed switch (or account-list load) records `snapshot.error`.
+          // Surface it here — the `qr` view renders its own sign-in error — so a
+          // switch that can't proceed tells the user why instead of silently
+          // no-op'ing.
+          <View style={[styles.errorBanner, { backgroundColor: theme.colors.negativeSubtle }]}>
+            <MaterialCommunityIcons name="alert-circle-outline" size={18} color={theme.colors.error} />
+            <Text style={[styles.errorBannerText, { color: theme.colors.error }]}>{snapshot.error}</Text>
+          </View>
+        ) : null}
         {view === 'accounts' ? (
           <AccountsView snapshot={snapshot} theme={theme} t={t} handlers={handlers} />
         ) : view === 'qr' ? (
@@ -756,6 +766,20 @@ const styles = StyleSheet.create({
   errorText: {
     fontSize: 14,
     textAlign: 'center',
+  },
+  errorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 12,
+  },
+  errorBannerText: {
+    flex: 1,
+    fontSize: 13.5,
+    lineHeight: 18,
   },
   qrPlate: {
     padding: 16,

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -606,14 +606,41 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     [commitSession],
   );
 
+  // Commit a minted graph-SWITCH session. Same funnel as `handleWebSession` but
+  // IN-PLACE: `hubSync: false` so switching accounts never triggers the
+  // cross-origin hub-sync full-page redirect. The switch already propagates
+  // across tabs/apps via the server's `session_state` socket broadcast.
+  const commitSwitchedSession = useCallback(
+    async (session: SessionLoginResponse): Promise<void> => {
+      if (!session?.user || !session?.sessionId || !session.accessToken) {
+        throw new Error('Session response did not include a usable session');
+      }
+      await commitSession(
+        {
+          sessionId: session.sessionId,
+          accessToken: session.accessToken,
+          deviceSecret: session.deviceSecret,
+          deviceId: session.deviceId,
+          expiresAt: session.expiresAt,
+          userId: session.user.id,
+          user: session.user,
+        },
+        { activate: true, hubSync: false },
+      );
+    },
+    [commitSession],
+  );
+
   // ── Unified account dialog ─────────────────────────────────────────────────
   // The single account-chooser + sign-in surface. Built ONCE per provider mount
   // and bound to the live `oxyServices` + `sessionClient` + this provider's
-  // `handleWebSession` commit funnel. `handleWebSession` is threaded through a ref
-  // so the controller keeps a STABLE `commitSession` (rebuilding the controller
-  // on every commit-identity change would drop its subscription + state).
+  // commit funnels. Both funnels are threaded through refs so the controller
+  // keeps STABLE commit callbacks (rebuilding the controller on every
+  // commit-identity change would drop its subscription + state).
   const handleWebSessionRef = useRef(handleWebSession);
   handleWebSessionRef.current = handleWebSession;
+  const commitSwitchedSessionRef = useRef(commitSwitchedSession);
+  commitSwitchedSessionRef.current = commitSwitchedSession;
 
   const accountDialogControllerRef = useRef<AccountDialogController | null>(null);
   if (!accountDialogControllerRef.current) {
@@ -626,6 +653,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       // instant `/auth-session` `auth_update` wake instead of a slow poll.
       socketFactory: io,
       commitSession: (session) => handleWebSessionRef.current(session),
+      commitSwitchedSession: (session) => commitSwitchedSessionRef.current(session),
       onSignedIn: () => setAccountDialogOpen(false),
       openUrl: (url) => {
         if (isWebBrowser()) {

--- a/packages/services/src/ui/context/useOxyAccountGraph.ts
+++ b/packages/services/src/ui/context/useOxyAccountGraph.ts
@@ -13,7 +13,7 @@ interface UseOxyAccountGraphParams {
   oxyServices: OxyServices;
   sessionClient: SessionClient;
   syncFromClient: () => Promise<void>;
-  commitSession: (input: CommitInput, options: { activate: boolean }) => Promise<void>;
+  commitSession: (input: CommitInput, options: { activate: boolean; hubSync?: boolean }) => Promise<void>;
   queryClient: QueryClient;
   accountDialogControllerRef: RefObject<AccountDialogController | null>;
   clearSessionStateRef: RefObject<() => Promise<void>>;
@@ -89,7 +89,9 @@ export function useOxyAccountGraph({
           userId: result.user.id,
           user: result.user,
         },
-        { activate: true },
+        // A switch is IN-PLACE: never run the cross-origin hub-sync full-page
+        // redirect. Cross-tab/app propagation rides the `session_state` socket.
+        { activate: true, hubSync: false },
       );
       await runPostAccountSwitchSideEffects();
     },


### PR DESCRIPTION
## Summary

Three account-switch symptoms, one root cause: the switchable-accounts graph and the switch route were anchored on the **currently active account** instead of the **human operator** behind the session.

- **Symptom 1 — silent failure on a refused switch.** Switching into an account the server rejects (e.g. a 403 for a personal-kind target) recorded the error on the controller snapshot, but `OxyAccountDialog` only rendered errors in the `qr` view — the accounts view showed nothing.
- **Symptom 2 — full-page redirect on web switch.** Switching accounts committed through `handleWebSession` with `hubSync: true`, which on an official web origin triggers `window.location.assign(auth.oxy.so/sync)`. A switch into an account you already operate reuses a device credential that was already hub-synced at sign-in, so re-syncing is redundant and the redirect was a regression.
- **Symptom 3 — switcher collapse after switching into a sub-account.** After switching into a sub-account (e.g. `albert`, operated by `nate`), the account switcher lost the operator and sibling accounts, leaving only the active sub-account. `GET /accounts` called `listAccessibleAccounts(requireUserId(req))` = the *active* account, which has no children/memberships of its own — the forest collapsed. `POST /accounts/:id/switch` resolved the operator the same wrong way, so switching out of a sub-account into a sibling would `verifyActingAs(albert, …)` and 403.

## Changes

- **`packages/api`** — new `resolveOperatorId(req)` helper resolves the HUMAN behind the request (the session's `operatedByUserId` for an operated session, else the authenticated account). Both `GET /accounts` (list, anchored on the operator) and `POST /:id/switch` (authorizes + records against the operator) now use it, so the switchable set is identical no matter which of the operator's accounts is currently active — switching only flips which row is current. `operatedByUserId` is server-set at switch time and re-verified, so trusting it escalates nothing; the impersonation guard (can't switch INTO a personal account) is untouched.
- **`packages/core`** — `accountDialogController` gets a distinct in-place `commitSwitchedSession` funnel (`hubSync: false`) for the mint-switch path, instead of routing through the hub-syncing `commitSession`. Cross-tab/app propagation still rides the server's `session_state` / `session_accounts_changed` socket broadcast — no navigation. `projectSwitchableAccounts` needed no change — it was already a pure, operator-agnostic union; the operator authority correctly lives server-side (the client can't authoritatively determine the operator). Added a projection test locking in that a leaf-sub-account-active projection still lists the operator + full set.
- **`packages/services`** — `OxyContext` and `useOxyAccountGraph` route the mint-switch through the new in-place funnel with explicit `hubSync: false`; `OxyAccountDialog` gets an error banner on the account-list / sign-in views so a refused switch surfaces why.

A prod DB fix (`oxy` → `organization` account kind) is **already live** and is **not** part of this branch.

## Test plan

All suites run per-package with their own runner (`bun run test`), never a blanket `bun test`, per repo convention.

- [x] `bun install --frozen-lockfile` — clean, no lockfile drift
- [x] `@oxyhq/contracts`, `@oxyhq/protocol`, `@oxyhq/core`, `@oxyhq/services` build clean
- [x] `packages/api` `tsc --noEmit` — clean
- [x] `@oxyhq/core` tests: **871/871 passed** (69 suites)
- [x] `@oxyhq/services` tests: **222/222 passed** (31 suites)
- [x] `@oxyhq/api` tests: **1545/1545 passed** (166 suites), including `routes/__tests__/accountsSwitch.test.ts`, `services/__tests__/account.service.test.ts`, `services/__tests__/session.service.managedSwitch.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>