### PR TITLE
fix(api): shared identity base for the three user-DTO serializers (Option 1)

### DIFF
--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -26,7 +26,8 @@ import Follow, { FollowType } from '../models/Follow';
 import User, { type IUser } from '../models/User';
 import { validate } from '../middleware/validate';
 import { usernameParams, profileSearchQuerySchema } from '../schemas/profiles.schemas';
-import { formatUserNameResponse, type NameParts } from '../utils/displayName';
+import { type NameParts } from '../utils/displayName';
+import { userIdentityFields, deriveIsFederated } from '../utils/userTransform';
 import { eligibleUserMatch, FEDERATED_RECOMMENDATION_MAX_AGE_MS } from '../utils/profileQuery';
 import { AppUserSignal } from '../models/AppUserSignal';
 import { AppAffinityEdge } from '../models/AppAffinityEdge';
@@ -214,23 +215,24 @@ const userProfileProjectionStage = {
   },
 };
 
-function formatProfileResult(u: RecommendationRow) {
+export function formatProfileResult(u: RecommendationRow) {
+  // Load-bearing identity fields (`id`, `name`, `username`, `avatar`) come from
+  // the SHARED `userIdentityFields` definer so this recommendation serializer can
+  // never diverge from the public/self serializers on them — `id` is the stable
+  // `_id` string, never the publicKey.
+  const identity = userIdentityFields(u);
   return {
-    id: u._id,
-    username: u.username,
-    name: formatUserNameResponse({
-      name: typeof u.name === 'object' ? u.name : undefined,
-      username: u.username,
-      publicKey: u.publicKey,
-    }),
-    avatar: u.avatar,
+    id: identity.id,
+    username: identity.username,
+    name: identity.name,
+    avatar: identity.avatar,
     description: u.description,
     verified: u.verified === true,
     trustTier: u.reputationTier,
     mutualCount: u.mutualCount || 0,
     ...(typeof u.score === 'number' ? { score: u.score } : {}),
     ...(u.matchedSignals ? { matchedSignals: u.matchedSignals } : {}),
-    isFederated: u.type === 'federated',
+    isFederated: deriveIsFederated(u.type),
     isAgent: u.type === 'agent',
     isAutomated: u.type === 'automated',
     instance: u.federation?.domain,

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -37,7 +37,7 @@ import {
   type PublicUserDocument,
 } from '../utils/publicUserProjection';
 import Subscription from '../models/Subscription';
-import { formatUserNameResponse, type NameParts } from '../utils/displayName';
+import { userIdentityFields, deriveIsFederated } from '../utils/userTransform';
 import { normalizeLocale } from '@oxyhq/core';
 
 // Constants
@@ -1596,33 +1596,28 @@ export class UserService {
     stats?: UserStatistics,
     options: { includePrivateFields?: boolean } = {}
   ): PublicUserProfile {
-    // Handle both IUser (Mongoose document) and UserData (plain object).
-    // The DTO `id` is ALWAYS the stable Mongo ObjectId, never the publicKey. The
-    // social graph the whole ecosystem keys on (`Post.oxyUserId`, follow edges,
-    // client follow-state maps) is anchored on `_id`, so a key-anchored account
-    // (one that has a `publicKey`) MUST keep its public `id === _id` — flipping
-    // it to the publicKey makes author-feed/follow lookups miss (the bug this
-    // serializer used to cause once a user linked a Commons identity). Key
-    // identity stays available via the separate `publicKey`/`did` fields. The
-    // `id` fallback covers objects that already went through the User schema's
-    // toObject/toJSON transform, which deletes `_id` and folds the identifier
-    // into `id` (e.g. a keyless managed/org account).
-    const userAsIUser = user as IUser & { id?: string };
-    const userId = userAsIUser._id?.toString() || userAsIUser.id;
-    if (!userId) {
+    // The load-bearing identity fields (`id`, `name`, `username`, `avatar`) come
+    // from the SHARED `userIdentityFields` definer, so this serializer can never
+    // diverge from the public/self/recommendation serializers on them. In
+    // particular the DTO `id` is ALWAYS the stable Mongo ObjectId, never the
+    // publicKey: the social graph the whole ecosystem keys on (`Post.oxyUserId`,
+    // follow edges, client follow-state maps) is anchored on `_id`, so a
+    // key-anchored account keeps `id === _id` (flipping it to the publicKey once
+    // a user links a Commons identity makes author-feed/follow lookups miss). Key
+    // identity stays available via the separate `publicKey`/`did` fields, and the
+    // helper's `id` fallback covers already-transformed keyless managed/org
+    // objects (schema toObject deletes `_id` and folds the identifier into `id`).
+    const identity = userIdentityFields(user);
+    if (!identity.id) {
       throw new Error('User must have an _id');
     }
     const userAny = user as unknown as Record<string, unknown>;
 
     const response: PublicUserProfile = {
-      id: userId,
-      username: user.username,
-      name: formatUserNameResponse({
-        name: user.name as NameParts | undefined,
-        username: user.username,
-        publicKey: userAsIUser.publicKey,
-      }),
-      avatar: user.avatar,
+      id: identity.id,
+      username: identity.username,
+      name: identity.name,
+      avatar: identity.avatar,
       verified: userAny.verified as boolean | undefined,
       bio: userAny.bio as string | undefined,
       description: userAny.description as string | undefined,
@@ -1645,7 +1640,7 @@ export class UserService {
     if (userAny.federation) {
       response.federation = userAny.federation;
     }
-    response.isFederated = userAny.type === 'federated';
+    response.isFederated = deriveIsFederated(userAny.type);
     // Public, derived: whether this account participates in fediverse sharing.
     // Intentionally public (like isFederated) — the state is observable anyway
     // (the AP actor 404s when off). The rest of privacySettings stays private.

--- a/packages/api/src/utils/__tests__/userIdentityBase.contract.test.ts
+++ b/packages/api/src/utils/__tests__/userIdentityBase.contract.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Cross-serializer identity drift-guard.
+ *
+ * Three serializers turn a `User` into a DTO and historically diverged on `id`
+ * (`services/user.service.ts` once used `id = publicKey || _id`, which made a
+ * user's posts vanish the moment they linked a Commons key — the whole social
+ * graph keys on `_id`). Option 1 of the hardening extracts ONE shared definer,
+ * `userIdentityFields`, that every serializer MUST call for the load-bearing
+ * `id` / `name` / `username` / `avatar` fields.
+ *
+ * This test asserts that all THREE serializers — the self/public
+ * `utils/userTransform.formatUserResponse`, the public + private
+ * `UserService.formatUserResponse` (including its `includePrivateFields`
+ * /users/me variant), and the recommendation `routes/profiles.formatProfileResult`
+ * — emit IDENTICAL `id`/`name`/`username`/`avatar` for the same input User, and
+ * that each equals the shared base. This makes the id-divergence bug structurally
+ * impossible: any serializer that stops delegating to `userIdentityFields` breaks
+ * this guard.
+ */
+
+// Use the REAL mongoose so the imported model files can define their schemas
+// (`.set`/`.virtual`/`.pre`) — the global jest.setup mock has no `.set`. No DB
+// connection is needed: these serializers are pure and touch no query.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import { Types } from 'mongoose';
+import { formatUserResponse, userIdentityFields, deriveIsFederated } from '../userTransform';
+import { userService } from '../../services/user.service';
+import { formatProfileResult } from '../../routes/profiles';
+
+describe('shared identity base — all three user-DTO serializers agree', () => {
+  const _id = new Types.ObjectId();
+  const input = {
+    _id,
+    // A key-anchored account: once linked, `id` MUST stay the ObjectId, not this.
+    publicKey: '048295c4a1b2c3d4e5f6a7b8c9d0e1f2',
+    username: 'nate',
+    name: { first: 'Nate', last: 'Rivera' },
+    avatar: 'file-abc123',
+  } as const;
+
+  // The single definer the three serializers delegate to.
+  const base = userIdentityFields(input);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cross-shape fixture; ts-jest does not type-check tests
+  const self = formatUserResponse(input);
+  const publicDto = userService.formatUserResponse(input as never);
+  const privateDto = userService.formatUserResponse(input as never, undefined, {
+    includePrivateFields: true,
+  });
+  const recommendation = formatProfileResult(input as never);
+
+  it('resolves id to the stable _id string, never the publicKey', () => {
+    expect(base.id).toBe(_id.toString());
+    expect(base.id).not.toBe(input.publicKey);
+  });
+
+  it('all three serializers produce an identical id', () => {
+    expect(self?.id).toBe(base.id);
+    expect(publicDto.id).toBe(base.id);
+    expect(privateDto.id).toBe(base.id);
+    expect(recommendation.id).toBe(base.id);
+  });
+
+  it('all three serializers produce an identical username', () => {
+    expect(self?.username).toBe(base.username);
+    expect(publicDto.username).toBe(base.username);
+    expect(privateDto.username).toBe(base.username);
+    expect(recommendation.username).toBe(base.username);
+    expect(base.username).toBe('nate');
+  });
+
+  it('all three serializers produce an identical avatar', () => {
+    expect(self?.avatar).toBe(base.avatar);
+    expect(publicDto.avatar).toBe(base.avatar);
+    expect(privateDto.avatar).toBe(base.avatar);
+    expect(recommendation.avatar).toBe(base.avatar);
+    expect(base.avatar).toBe('file-abc123');
+  });
+
+  it('all three serializers produce an identical (composed) name', () => {
+    expect(base.name).toEqual({ first: 'Nate', last: 'Rivera', full: 'Nate Rivera', displayName: 'Nate Rivera' });
+    expect(self?.name).toEqual(base.name);
+    expect(publicDto.name).toEqual(base.name);
+    expect(privateDto.name).toEqual(base.name);
+    expect(recommendation.name).toEqual(base.name);
+  });
+
+  it('the private /users/me variant only ADDS private fields — identity fields are unchanged', () => {
+    expect(privateDto.id).toBe(publicDto.id);
+    expect(privateDto.username).toBe(publicDto.username);
+    expect(privateDto.avatar).toBe(publicDto.avatar);
+    expect(privateDto.name).toEqual(publicDto.name);
+  });
+});
+
+describe('shared deriveIsFederated — the public and recommendation serializers agree', () => {
+  it('derives federated iff type === "federated"', () => {
+    expect(deriveIsFederated('federated')).toBe(true);
+    expect(deriveIsFederated('local')).toBe(false);
+    expect(deriveIsFederated(undefined)).toBe(false);
+  });
+
+  it('both serializers that emit isFederated derive it identically', () => {
+    const federated = { _id: new Types.ObjectId(), username: 'remote', type: 'federated' };
+    const local = { _id: new Types.ObjectId(), username: 'local', type: 'local' };
+
+    expect(userService.formatUserResponse(federated as never).isFederated).toBe(true);
+    expect(formatProfileResult(federated as never).isFederated).toBe(true);
+
+    expect(userService.formatUserResponse(local as never).isFederated).toBe(false);
+    expect(formatProfileResult(local as never).isFederated).toBe(false);
+  });
+});

--- a/packages/api/src/utils/userTransform.ts
+++ b/packages/api/src/utils/userTransform.ts
@@ -4,7 +4,7 @@
  */
 
 import { getUserLanguages } from '@oxyhq/core';
-import { formatUserNameResponse, type NameParts } from './displayName';
+import { formatUserNameResponse, type NameParts, type NameResponse } from './displayName';
 
 type StringableId = string | { toString(): string };
 
@@ -64,20 +64,87 @@ function booleanValue(value: unknown): boolean | undefined {
   return typeof value === 'boolean' ? value : undefined;
 }
 
-function toStringableId(value: unknown): StringableId | undefined {
-  if (typeof value === 'string') return value;
-  return isRecord(value) && typeof value.toString === 'function'
-    ? { toString: () => value.toString() }
-    : undefined;
+/**
+ * The minimal surface the shared identity base reads off a user document. Every
+ * field is `unknown` so ANY caller shape — a `Record<string, unknown>`, an
+ * `IUser` / `PublicUserDocument`, or a recommendation projection row — is
+ * structurally assignable with no cast.
+ */
+export interface UserIdentitySource {
+  _id?: unknown;
+  /**
+   * Present only on objects that already went through the User schema's
+   * toObject/toJSON transform, which deletes `_id` and folds the identifier into
+   * `id` (e.g. a keyless managed/org account).
+   */
+  id?: unknown;
+  name?: unknown;
+  username?: unknown;
+  avatar?: unknown;
+  publicKey?: unknown;
 }
 
-function toNameParts(value: unknown): NameParts | undefined {
-  if (!isRecord(value)) return undefined;
+/**
+ * The load-bearing identity fields every user-DTO serializer MUST agree on. `id`
+ * is `undefined` only when the source has no resolvable identifier — each caller
+ * decides whether that is a `null` return or a thrown error.
+ */
+export interface UserIdentityFields {
+  id: string | undefined;
+  name: NameResponse;
+  username: string | undefined;
+  avatar: string | undefined;
+}
+
+/**
+ * The SOLE definition of the DTO `id`: the stable Mongo ObjectId string, NEVER
+ * the `publicKey`. The whole social graph (`Post.oxyUserId`, follow edges,
+ * client follow-state maps) is keyed on `_id`, so flipping `id` to the publicKey
+ * once a user links a Commons identity makes author-feed/follow lookups miss —
+ * the bug this centralization prevents. Reads `_id` first, falling back to `id`
+ * for already-transformed (keyless) objects; returns `undefined` when neither
+ * yields a non-empty string.
+ */
+function resolveIdentityId(source: UserIdentitySource): string | undefined {
+  const rawId = source._id;
+  const fromObjectId = rawId == null ? '' : (rawId as { toString(): string }).toString();
+  const fallback = typeof source.id === 'string' ? source.id : '';
+  return fromObjectId || fallback || undefined;
+}
+
+/** Narrow a raw `name` value to the structured `NameParts` the composer reads. */
+function identityNameSource(name: unknown): NameParts | undefined {
+  return typeof name === 'object' && name !== null ? (name as NameParts) : undefined;
+}
+
+/**
+ * The SOLE definition of the derived public `isFederated` flag — an account is
+ * federated iff its `type` is `'federated'`. Shared by the public and
+ * recommendation serializers so the derivation cannot drift between them.
+ */
+export function deriveIsFederated(type: unknown): boolean {
+  return type === 'federated';
+}
+
+/**
+ * The single definer of the load-bearing identity fields (`id`, `name`,
+ * `username`, `avatar`) shared by every user-DTO serializer. Extracting this
+ * makes it structurally impossible for the three serializers
+ * (`formatUserResponse` here, `UserService.formatUserResponse`, and the
+ * recommendation `formatProfileResult`) to diverge on these fields again — the
+ * `id = publicKey || _id` class of bug. Each serializer keeps its own
+ * resource-specific tail; only these four fields come from here.
+ */
+export function userIdentityFields(source: UserIdentitySource): UserIdentityFields {
   return {
-    first: stringValue(value.first),
-    last: stringValue(value.last),
-    full: stringValue(value.full),
-    displayName: stringValue(value.displayName),
+    id: resolveIdentityId(source),
+    name: formatUserNameResponse({
+      name: identityNameSource(source.name),
+      username: stringValue(source.username),
+      publicKey: stringValue(source.publicKey),
+    }),
+    username: stringValue(source.username),
+    avatar: stringValue(source.avatar),
   };
 }
 
@@ -99,26 +166,19 @@ export function formatUserResponse(user: unknown) {
     return null;
   }
 
-  const rawId = toStringableId(user._id);
-  const userId = rawId?.toString();
-  if (!userId) {
+  const identity = userIdentityFields(user);
+  if (!identity.id) {
     return null;
   }
 
-  const name = formatUserNameResponse({
-    name: toNameParts(user.name),
-    username: stringValue(user.username),
-    publicKey: stringValue(user.publicKey),
-  });
-
   return {
-    id: userId,
+    id: identity.id,
     publicKey: stringValue(user.publicKey),
-    username: stringValue(user.username),
+    username: identity.username,
     email: stringValue(user.email),
-    avatar: stringValue(user.avatar),
+    avatar: identity.avatar,
     color: stringValue(user.color),
-    name,
+    name: identity.name,
     privacySettings: user.privacySettings,
     verified: booleanValue(user.verified),
     // Ordered account locales, PRIMARY first. `languages` is the ONLY language


### PR DESCRIPTION
## What

The three serializers that turn a `User` into a DTO each defined the load-bearing `id`/`name`/`username`/`avatar` fields independently:

1. `packages/api/src/utils/userTransform.ts` → `formatUserResponse` (self/public shape)
2. `packages/api/src/services/user.service.ts` → `UserService.formatUserResponse` (public shape + the `/users/me` private variant via `includePrivateFields`)
3. `packages/api/src/routes/profiles.ts` → `formatProfileResult` (recommendations shape)

That independent duplication is exactly what let #2 drift to `id = publicKey || _id`, which made a user's posts vanish the moment they linked a Commons key (the whole social graph keys on `_id`). The prior `id = _id` fix (`121faa09`) patched #2; this makes the divergence **structurally impossible**.

## How (Option 1 — shared identity BASE, keep the 3 serializers)

Extract ONE definer, `userIdentityFields(user)` in `userTransform.ts`, as the **sole** source of the four load-bearing fields:
- `id` = `_id.toString()`, falling back to a transformed keyless `id`, **never** the `publicKey`
- `name` via `formatUserNameResponse`
- `username` / `avatar` via `stringValue`

All three serializers delegate to it for those fields and keep their own resource-specific tails **unchanged**. The tiny duplicated `isFederated` derivation (in #2 and #3) is also folded into a shared `deriveIsFederated(type)`.

The 4 wire shapes are genuinely different resources, so they are NOT collapsed into one function — only the load-bearing fields are unified.

## Byte-stability

Pure internal refactor: **no field added, removed, or reshaped** on any of the four wire shapes; `id = _id` everywhere. Notes:
- `avatar` is `{ type: String }` with zero `null` writes in the codebase → `string | undefined` at runtime, so `stringValue` (drops `null`) equals the prior raw pass-through.
- `formatUserNameResponse` only reads `source.name` and re-guards every field with `typeof === 'string'`, so all three prior name-input styles produce identical output.
- profiles' `id: u._id` (ObjectId) already JSON-serialized to the same hex string as `_id.toString()`; no consumer calls ObjectId methods on the result `.id`.

## Tests

- New `packages/api/src/utils/__tests__/userIdentityBase.contract.test.ts` — regression guard asserting all three serializers (including the private `/users/me` variant) produce **identical** `id`/`name`/`username`/`avatar` for the same input User, plus the shared `deriveIsFederated`.
- api `tsc --noEmit`: clean.
- Full api suite: **169 suites, 1565 tests passing** (incl. `userTransform.contract`, `user.service.keylessProfile`, `formatUserResponse.fediverse`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)