### PR TITLE
feat(auth): atomic key rotation + last-credential replacement (b3 F3, backend)

### DIFF
--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -283,11 +283,15 @@ export class SessionController {
         });
       }
 
-      // Find and validate the challenge (read-only query with .lean() for performance)
+      // Find and validate the challenge (read-only query with .lean() for
+      // performance). Scoped to signin-purpose challenges (default, or legacy
+      // docs predating the `purpose` field) so a `rotate_key` challenge cannot be
+      // spent to mint a session.
       const authChallenge = await AuthChallenge.findOne({
         publicKey,
         challenge,
         used: false,
+        purpose: { $in: ['signin', null] },
         expiresAt: { $gt: new Date() }
       }).lean();
 

--- a/packages/api/src/models/AuthChallenge.ts
+++ b/packages/api/src/models/AuthChallenge.ts
@@ -9,6 +9,13 @@ import mongoose, { type Document, Schema } from "mongoose";
 export interface IAuthChallenge extends Document {
   publicKey: string;
   challenge: string;
+  /**
+   * What the challenge may be spent on. Additive (default `'signin'`) so
+   * existing signin flows are unaffected. Purpose-scoped consumers (e.g. key
+   * rotation, which requires `'rotate_key'`) filter on this so a challenge
+   * minted for one flow can never be redeemed by another.
+   */
+  purpose: string;
   expiresAt: Date;
   used: boolean;
   createdAt: Date;
@@ -24,6 +31,10 @@ const AuthChallengeSchema: Schema = new Schema(
       type: String,
       required: true,
       unique: true,
+    },
+    purpose: {
+      type: String,
+      default: 'signin',
     },
     expiresAt: {
       type: Date,

--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -459,6 +459,11 @@ const UserSchema: Schema = new Schema(
       unique: true,
       sparse: true,
       trim: true,
+      // Canonical secp256k1 keys are stored uncompressed + lowercased (see
+      // SignatureService.canonicalizePublicKey). `lowercase` guards the case
+      // dimension of the unique index so a re-cased duplicate cannot slip past
+      // it. Existing keys are already lowercase-uncompressed, so this is safe.
+      lowercase: true,
       select: true,
     },
     refreshToken: {

--- a/packages/api/src/routes/__tests__/authLinking.reversibility.test.ts
+++ b/packages/api/src/routes/__tests__/authLinking.reversibility.test.ts
@@ -70,6 +70,20 @@ jest.mock('../../models/WebauthnCredential', () => ({
   },
 }));
 
+// authLinking imports the session service + Session model (for the key-rotation
+// `signOutEverywhere` path); stub them so the real modules — which crash at load
+// under the global mongoose mock (`SessionSchema.methods` is undefined) — are
+// never evaluated. These reversibility tests never exercise rotation.
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { deactivateAllUserSessions: jest.fn() },
+}));
+
+jest.mock('../../models/Session', () => ({
+  __esModule: true,
+  default: { find: jest.fn() },
+}));
+
 import authLinkingRouter from '../authLinking';
 import SignatureService from '../../services/signature.service';
 import { buildDidDocument, buildUserDid, OXY_DID } from '../../services/did.service';

--- a/packages/api/src/routes/__tests__/keyRotation.test.ts
+++ b/packages/api/src/routes/__tests__/keyRotation.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Key-rotation route tests (b3 Feature 3 — atomic key rotation + last-credential
+ * replacement).
+ *
+ * Proves the security invariants of `POST /auth/rotate/challenge` +
+ * `POST /auth/rotate/complete`:
+ *  - `oldPublicKey` is ALWAYS derived from the user doc, never the request (a
+ *    client-supplied `oldPublicKey` is ignored; a signature from the wrong key
+ *    is rejected);
+ *  - the `rotate_key` challenge is purpose-scoped (a signin challenge can NEVER
+ *    complete a rotation) and single-use (burn is atomic);
+ *  - rotation is an atomic REPLACE — the `authMethods` array length is unchanged
+ *    (never a `countAuthMethods() === 0` window);
+ *  - `newPublicKey` already registered elsewhere is rejected (409);
+ *  - `userCache.invalidate` fires and the derived DID reflects the new key
+ *    immediately;
+ *  - `signOutEverywhere` revokes other sessions.
+ *
+ * The real `SignatureService` and `did.service` run; only the models + cache +
+ * session service are mocked (the global mongoose mock cannot load the real
+ * schema).
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { ec as EC } from 'elliptic';
+
+const USER_ID = '507f1f77bcf86cd799439011';
+
+interface MockUserDoc {
+  _id: string;
+  email?: string;
+  publicKey?: string;
+  createdAt: Date;
+  authMethods: Array<{ type: string; linkedAt: Date; metadata?: Record<string, unknown> }>;
+  save: jest.Mock;
+}
+
+interface ChallengeEntry {
+  publicKey: string;
+  purpose: string;
+  used: boolean;
+  expiresAt: Date;
+}
+
+let mockUserDoc: MockUserDoc;
+let mockConflictUser: { _id: string } | null;
+let mockOtherSessions: Array<{ sessionId: string }>;
+const mockInvalidate = jest.fn();
+const mockDeactivateAll = jest.fn();
+const mockEmitSessionUpdate = jest.fn();
+const mockChallengeStore = new Map<string, ChallengeEntry>();
+
+function selectable(doc: unknown) {
+  return {
+    select: () => selectable(doc),
+    lean: () => Promise.resolve(doc),
+    then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(doc).then(resolve, reject),
+  };
+}
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+    req.user = mockUserDoc;
+    next();
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: {
+    findById: () => selectable(mockUserDoc),
+    findOne: () => ({ select: () => ({ lean: () => Promise.resolve(mockConflictUser) }) }),
+  },
+  buildAuthMethod: (type: string, metadata?: Record<string, unknown>) => ({ type, linkedAt: new Date(), metadata }),
+}));
+
+jest.mock('../../models/AuthChallenge', () => ({
+  __esModule: true,
+  default: {
+    create: async (doc: { publicKey: string; challenge: string; purpose?: string; expiresAt: Date; used?: boolean }) => {
+      mockChallengeStore.set(doc.challenge, {
+        publicKey: doc.publicKey,
+        purpose: doc.purpose ?? 'signin',
+        used: doc.used ?? false,
+        expiresAt: doc.expiresAt,
+      });
+      return doc;
+    },
+    // Atomic single-use burn: matches the same {challenge, publicKey, used:false,
+    // purpose, expiresAt:$gt} filter the route uses, marks it used, returns the
+    // prior (truthy) doc or null.
+    findOneAndUpdate: async (filter: {
+      challenge: string;
+      publicKey?: string;
+      used?: boolean;
+      purpose?: string;
+      expiresAt?: { $gt: Date };
+    }) => {
+      const entry = mockChallengeStore.get(filter.challenge);
+      if (!entry || entry.used) return null;
+      if (filter.publicKey !== undefined && entry.publicKey !== filter.publicKey) return null;
+      if (filter.purpose !== undefined && entry.purpose !== filter.purpose) return null;
+      if (filter.expiresAt?.$gt && !(entry.expiresAt > filter.expiresAt.$gt)) return null;
+      entry.used = true;
+      return { _id: 'challenge-id', challenge: filter.challenge };
+    },
+  },
+}));
+
+jest.mock('../../models/Session', () => ({
+  __esModule: true,
+  default: {
+    find: () => ({ select: () => ({ lean: () => Promise.resolve(mockOtherSessions) }) }),
+  },
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { deactivateAllUserSessions: (...args: unknown[]) => mockDeactivateAll(...args) },
+}));
+
+jest.mock('../../server', () => ({
+  __esModule: true,
+  emitSessionUpdate: (...args: unknown[]) => mockEmitSessionUpdate(...args),
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: (...args: unknown[]) => mockInvalidate(...args) },
+}));
+
+import authLinkingRouter from '../authLinking';
+import SignatureService from '../../services/signature.service';
+import { buildDidDocument } from '../../services/did.service';
+
+const ec = new EC('secp256k1');
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function request(server: http.Server, method: string, path: string, payload?: unknown): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? undefined : JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: body !== undefined
+          ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) }
+          : {},
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }));
+      },
+    );
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+let oldKeyPair: EC.KeyPair;
+let oldPublicKey: string;
+let oldPrivateKey: string;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/auth', authLinkingRouter);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockChallengeStore.clear();
+  mockConflictUser = null;
+  mockOtherSessions = [];
+
+  oldKeyPair = ec.genKeyPair();
+  oldPublicKey = oldKeyPair.getPublic('hex');
+  oldPrivateKey = oldKeyPair.getPrivate('hex');
+
+  mockUserDoc = {
+    _id: USER_ID,
+    email: 'nate@oxy.so',
+    publicKey: oldPublicKey,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    authMethods: [
+      { type: 'identity', linkedAt: new Date('2026-01-01T00:00:00.000Z'), metadata: { publicKey: oldPublicKey } },
+    ],
+    save: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+/** Mint a rotate_key challenge for the current user via the real endpoint. */
+async function mintRotateChallenge(): Promise<string> {
+  const res = await request(server, 'POST', '/auth/rotate/challenge');
+  expect(res.status).toBe(200);
+  return res.body.challenge as string;
+}
+
+/** Sign the canonical rotation payload with the given private key. */
+function signRotation(params: {
+  privateKey: string;
+  oldPublicKey: string;
+  newPublicKey: string;
+  challenge: string;
+  timestamp: number;
+}): string {
+  const message = JSON.stringify({
+    action: 'rotate_key',
+    userId: USER_ID,
+    oldPublicKey: params.oldPublicKey,
+    newPublicKey: params.newPublicKey,
+    challenge: params.challenge,
+    timestamp: params.timestamp,
+  });
+  return SignatureService.signMessage(message, params.privateKey);
+}
+
+describe('POST /auth/rotate/complete — happy path', () => {
+  it('atomically replaces the identity key, keeping authMethods length constant', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    const lengthBefore = mockUserDoc.authMethods.length;
+
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+
+    expect(res.status).toBe(200);
+    expect(res.body.publicKey).toBe(newPublicKey);
+    // Swapped in place.
+    expect(mockUserDoc.publicKey).toBe(newPublicKey);
+    // Atomic replace: array length is NEVER changed (no countAuthMethods()===0 window).
+    expect(mockUserDoc.authMethods).toHaveLength(lengthBefore);
+    expect(mockUserDoc.authMethods).toHaveLength(1);
+    const identity = mockUserDoc.authMethods.find((m) => m.type === 'identity');
+    expect(identity?.metadata?.publicKey).toBe(newPublicKey);
+    expect(mockUserDoc.save).toHaveBeenCalledTimes(1);
+    // Cache invalidated.
+    expect(mockInvalidate).toHaveBeenCalledWith(USER_ID);
+    // The derived DID reflects the new key IMMEDIATELY.
+    const vms = buildDidDocument(mockUserDoc).verificationMethod as Array<{ publicKeyHex?: string }>;
+    expect(vms.some((vm) => vm.publicKeyHex === newPublicKey)).toBe(true);
+    expect(vms.some((vm) => vm.publicKeyHex === oldPublicKey)).toBe(false);
+  });
+});
+
+describe('security invariant — oldPublicKey is server-derived', () => {
+  it('ignores a client-supplied oldPublicKey and validates against the user doc key', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    const attacker = ec.genKeyPair();
+
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    // Sign correctly with the REAL old key; also smuggle a bogus oldPublicKey field.
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', {
+      newPublicKey,
+      challenge,
+      signature,
+      timestamp,
+      oldPublicKey: attacker.getPublic('hex'), // ignored by the server
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUserDoc.publicKey).toBe(newPublicKey);
+  });
+
+  it('rejects a signature made with a key other than the account key (proving control of X but rotating Y)', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    const attacker = ec.genKeyPair();
+
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    // Attacker signs with THEIR key; the server reconstructs with the doc's oldPublicKey.
+    const signature = signRotation({ privateKey: attacker.getPrivate('hex'), oldPublicKey, newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+    expect(mockInvalidate).not.toHaveBeenCalled();
+    expect(mockUserDoc.publicKey).toBe(oldPublicKey);
+  });
+});
+
+describe('security invariant — purpose scoping', () => {
+  it('a signin challenge (default purpose) can NOT complete a rotation', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    // Seed a SIGNIN-purpose challenge directly (as the signin flow would).
+    const challenge = 'signin-challenge-value';
+    mockChallengeStore.set(challenge, {
+      publicKey: oldPublicKey,
+      purpose: 'signin',
+      used: false,
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+
+    expect(res.status).toBe(401);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+    // The signin challenge must remain UNUSED (rotation never touched it).
+    expect(mockChallengeStore.get(challenge)?.used).toBe(false);
+  });
+});
+
+describe('security invariant — single-use challenge', () => {
+  it('rejects a second rotation with an already-burned challenge', async () => {
+    const first = ec.genKeyPair().getPublic('hex');
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const sig1 = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey: first, challenge, timestamp });
+
+    const res1 = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: first, challenge, signature: sig1, timestamp });
+    expect(res1.status).toBe(200);
+
+    // Replay with the same (now burned) challenge — the account key is now `first`.
+    const second = ec.genKeyPair().getPublic('hex');
+    const sig2 = signRotation({ privateKey: oldPrivateKey, oldPublicKey: first, newPublicKey: second, challenge, timestamp });
+    const res2 = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: second, challenge, signature: sig2, timestamp });
+    expect(res2.status).toBe(401);
+  });
+});
+
+describe('conflict + validation guards', () => {
+  it('rejects a newPublicKey already registered to another account (409)', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    mockConflictUser = { _id: 'a-different-user' };
+
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+
+    expect(res.status).toBe(409);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+    expect(mockUserDoc.publicKey).toBe(oldPublicKey);
+  });
+
+  it('rejects rotating to the SAME key (400)', async () => {
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey: oldPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: oldPublicKey, challenge, signature, timestamp });
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid newPublicKey (400)', async () => {
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey: 'not-a-key', challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: 'not-a-key', challenge, signature, timestamp });
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+  });
+
+  it('the challenge endpoint rejects an account with no identity key (400)', async () => {
+    mockUserDoc.publicKey = undefined;
+    const res = await request(server, 'POST', '/auth/rotate/challenge');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('signOutEverywhere', () => {
+  it('revokes other sessions and pushes a sessions_removed event on success', async () => {
+    mockOtherSessions = [{ sessionId: 's2' }, { sessionId: 's3' }];
+    mockDeactivateAll.mockResolvedValue(2);
+
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', {
+      newPublicKey,
+      challenge,
+      signature,
+      timestamp,
+      signOutEverywhere: true,
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockDeactivateAll).toHaveBeenCalledWith(USER_ID, undefined);
+    expect(mockEmitSessionUpdate).toHaveBeenCalledWith(USER_ID, { type: 'sessions_removed', sessionIds: ['s2', 's3'] });
+  });
+
+  it('does NOT revoke other sessions when the flag is absent', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+
+    expect(res.status).toBe(200);
+    expect(mockDeactivateAll).not.toHaveBeenCalled();
+    expect(mockEmitSessionUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/__tests__/keyRotation.test.ts
+++ b/packages/api/src/routes/__tests__/keyRotation.test.ts
@@ -46,10 +46,14 @@ interface ChallengeEntry {
 
 let mockUserDoc: MockUserDoc;
 let mockConflictUser: { _id: string } | null;
+// When set, the conflict is only returned for this EXACT queried publicKey — used
+// to prove the conflict query runs against the CANONICAL key.
+let mockConflictKey: string | null;
 let mockOtherSessions: Array<{ sessionId: string }>;
 const mockInvalidate = jest.fn();
 const mockDeactivateAll = jest.fn();
 const mockEmitSessionUpdate = jest.fn();
+const mockUserFindOne = jest.fn();
 const mockChallengeStore = new Map<string, ChallengeEntry>();
 
 function selectable(doc: unknown) {
@@ -72,7 +76,14 @@ jest.mock('../../models/User', () => ({
   __esModule: true,
   User: {
     findById: () => selectable(mockUserDoc),
-    findOne: () => ({ select: () => ({ lean: () => Promise.resolve(mockConflictUser) }) }),
+    findOne: (filter: { publicKey?: string }) => {
+      mockUserFindOne(filter);
+      const conflict =
+        mockConflictUser && (mockConflictKey === null || filter?.publicKey === mockConflictKey)
+          ? mockConflictUser
+          : null;
+      return { select: () => ({ lean: () => Promise.resolve(conflict) }) };
+    },
   },
   buildAuthMethod: (type: string, metadata?: Record<string, unknown>) => ({ type, linkedAt: new Date(), metadata }),
 }));
@@ -135,6 +146,7 @@ jest.mock('../../utils/userCache', () => ({
 import authLinkingRouter from '../authLinking';
 import SignatureService from '../../services/signature.service';
 import { buildDidDocument } from '../../services/did.service';
+import { errorHandler } from '../../middleware/errorHandler';
 
 const ec = new EC('secp256k1');
 
@@ -178,6 +190,9 @@ beforeAll((done) => {
   const app = express();
   app.use(express.json());
   app.use('/auth', authLinkingRouter);
+  // Mirror production: convert thrown ApiErrors (e.g. Zod validation via the
+  // `validate` middleware) into JSON responses instead of Express's default HTML.
+  app.use(errorHandler);
   server = app.listen(0, '127.0.0.1', done);
 });
 
@@ -189,6 +204,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockChallengeStore.clear();
   mockConflictUser = null;
+  mockConflictKey = null;
   mockOtherSessions = [];
 
   oldKeyPair = ec.genKeyPair();
@@ -214,7 +230,7 @@ async function mintRotateChallenge(): Promise<string> {
   return res.body.challenge as string;
 }
 
-/** Sign the canonical rotation payload with the given private key. */
+/** Sign the OLD-key rotation proof with the given private key. */
 function signRotation(params: {
   privateKey: string;
   oldPublicKey: string;
@@ -233,6 +249,51 @@ function signRotation(params: {
   return SignatureService.signMessage(message, params.privateKey);
 }
 
+/** Sign the NEW-key proof-of-possession with the NEW private key. */
+function signNewKeyProof(params: {
+  newPrivateKey: string;
+  newPublicKey: string;
+  challenge: string;
+  timestamp: number;
+}): string {
+  const message = JSON.stringify({
+    action: 'rotate_key_new',
+    userId: USER_ID,
+    newPublicKey: params.newPublicKey,
+    challenge: params.challenge,
+    timestamp: params.timestamp,
+  });
+  return SignatureService.signMessage(message, params.newPrivateKey);
+}
+
+/** Build a complete-rotation request body with both proofs signed. */
+function buildCompleteBody(params: {
+  oldPrivateKey: string;
+  newKeyPair: EC.KeyPair;
+  oldPublicKey: string;
+  newPublicKey?: string; // encoding to send (defaults to uncompressed of newKeyPair)
+  challenge: string;
+  timestamp: number;
+  signOutEverywhere?: boolean;
+}): Record<string, unknown> {
+  const newPublicKey = params.newPublicKey ?? params.newKeyPair.getPublic('hex');
+  const newPrivateKey = params.newKeyPair.getPrivate('hex');
+  return {
+    newPublicKey,
+    challenge: params.challenge,
+    signature: signRotation({
+      privateKey: params.oldPrivateKey,
+      oldPublicKey: params.oldPublicKey,
+      newPublicKey,
+      challenge: params.challenge,
+      timestamp: params.timestamp,
+    }),
+    newKeyProof: signNewKeyProof({ newPrivateKey, newPublicKey, challenge: params.challenge, timestamp: params.timestamp }),
+    timestamp: params.timestamp,
+    ...(params.signOutEverywhere ? { signOutEverywhere: true } : {}),
+  };
+}
+
 describe('POST /auth/rotate/complete — happy path', () => {
   it('atomically replaces the identity key, keeping authMethods length constant', async () => {
     const newKeyPair = ec.genKeyPair();
@@ -241,9 +302,9 @@ describe('POST /auth/rotate/complete — happy path', () => {
 
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
-    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, challenge, timestamp });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
 
     expect(res.status).toBe(200);
     expect(res.body.publicKey).toBe(newPublicKey);
@@ -264,6 +325,86 @@ describe('POST /auth/rotate/complete — happy path', () => {
   });
 });
 
+describe('security invariant — proof-of-possession of the new key', () => {
+  it('rejects a request missing newKeyProof (schema validation, 400)', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+
+    // No newKeyProof field.
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+  });
+
+  it('rejects a newKeyProof NOT signed by the new key (400)', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const newPublicKey = newKeyPair.getPublic('hex');
+    const impostor = ec.genKeyPair();
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+
+    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+    // Proof signed by a DIFFERENT key than newPublicKey.
+    const newKeyProof = signNewKeyProof({ newPrivateKey: impostor.getPrivate('hex'), newPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, newKeyProof, timestamp });
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+    expect(mockUserDoc.publicKey).toBe(oldPublicKey);
+  });
+});
+
+describe('security invariant — key re-encoding is canonicalized', () => {
+  it('stores the canonical (uncompressed, lowercased) key even when a compressed/uppercased form is sent', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const compressed = newKeyPair.getPublic(true, 'hex').toUpperCase(); // compressed + uppercased
+    const canonical = newKeyPair.getPublic(false, 'hex').toLowerCase(); // uncompressed + lowercased
+
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, newPublicKey: compressed, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
+
+    expect(res.status).toBe(200);
+    // Stored + returned in canonical form, NOT the re-encoding that was sent.
+    expect(res.body.publicKey).toBe(canonical);
+    expect(mockUserDoc.publicKey).toBe(canonical);
+    const identity = mockUserDoc.authMethods.find((m) => m.type === 'identity');
+    expect(identity?.metadata?.publicKey).toBe(canonical);
+    // The uniqueness query ran against the CANONICAL key.
+    expect(mockUserFindOne).toHaveBeenCalledWith({ publicKey: canonical });
+  });
+
+  it('rejects rotating to a re-encoding (compressed) of a key already registered to another account (409)', async () => {
+    // A key some OTHER account already holds (canonical form).
+    const victimKeyPair = ec.genKeyPair();
+    const victimCanonical = victimKeyPair.getPublic(false, 'hex').toLowerCase();
+    const victimCompressed = victimKeyPair.getPublic(true, 'hex');
+    // The conflict only fires for the CANONICAL victim key — proving the server
+    // canonicalizes the compressed re-encoding BEFORE the uniqueness query.
+    mockConflictUser = { _id: 'victim-account' };
+    mockConflictKey = victimCanonical;
+
+    const challenge = await mintRotateChallenge();
+    const timestamp = Date.now();
+    // The caller controls the victim key (has its private key) so proof-of-possession passes.
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair: victimKeyPair, oldPublicKey, newPublicKey: victimCompressed, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
+
+    expect(res.status).toBe(409);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+    expect(mockUserDoc.publicKey).toBe(oldPublicKey);
+    expect(mockUserFindOne).toHaveBeenCalledWith({ publicKey: victimCanonical });
+  });
+});
+
 describe('security invariant — oldPublicKey is server-derived', () => {
   it('ignores a client-supplied oldPublicKey and validates against the user doc key', async () => {
     const newKeyPair = ec.genKeyPair();
@@ -272,14 +413,10 @@ describe('security invariant — oldPublicKey is server-derived', () => {
 
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
-    // Sign correctly with the REAL old key; also smuggle a bogus oldPublicKey field.
-    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, challenge, timestamp });
 
     const res = await request(server, 'POST', '/auth/rotate/complete', {
-      newPublicKey,
-      challenge,
-      signature,
-      timestamp,
+      ...body,
       oldPublicKey: attacker.getPublic('hex'), // ignored by the server
     });
 
@@ -294,10 +431,11 @@ describe('security invariant — oldPublicKey is server-derived', () => {
 
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
-    // Attacker signs with THEIR key; the server reconstructs with the doc's oldPublicKey.
+    // Old-key signature by the WRONG key; new-key proof is valid.
     const signature = signRotation({ privateKey: attacker.getPrivate('hex'), oldPublicKey, newPublicKey, challenge, timestamp });
+    const newKeyProof = signNewKeyProof({ newPrivateKey: newKeyPair.getPrivate('hex'), newPublicKey, challenge, timestamp });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, newKeyProof, timestamp });
 
     expect(res.status).toBe(400);
     expect(mockUserDoc.save).not.toHaveBeenCalled();
@@ -320,9 +458,9 @@ describe('security invariant — purpose scoping', () => {
     });
 
     const timestamp = Date.now();
-    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, newPublicKey, challenge, timestamp });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
 
     expect(res.status).toBe(401);
     expect(mockUserDoc.save).not.toHaveBeenCalled();
@@ -333,33 +471,58 @@ describe('security invariant — purpose scoping', () => {
 
 describe('security invariant — single-use challenge', () => {
   it('rejects a second rotation with an already-burned challenge', async () => {
-    const first = ec.genKeyPair().getPublic('hex');
+    const firstKeyPair = ec.genKeyPair();
+    const first = firstKeyPair.getPublic('hex');
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
-    const sig1 = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey: first, challenge, timestamp });
 
-    const res1 = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: first, challenge, signature: sig1, timestamp });
+    const res1 = await request(
+      server,
+      'POST',
+      '/auth/rotate/complete',
+      buildCompleteBody({ oldPrivateKey, newKeyPair: firstKeyPair, oldPublicKey, challenge, timestamp }),
+    );
     expect(res1.status).toBe(200);
 
     // Replay with the same (now burned) challenge — the account key is now `first`.
-    const second = ec.genKeyPair().getPublic('hex');
-    const sig2 = signRotation({ privateKey: oldPrivateKey, oldPublicKey: first, newPublicKey: second, challenge, timestamp });
-    const res2 = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: second, challenge, signature: sig2, timestamp });
+    const secondKeyPair = ec.genKeyPair();
+    const res2 = await request(
+      server,
+      'POST',
+      '/auth/rotate/complete',
+      buildCompleteBody({ oldPrivateKey: firstKeyPair.getPrivate('hex'), newKeyPair: secondKeyPair, oldPublicKey: first, challenge, timestamp }),
+    );
     expect(res2.status).toBe(401);
+  });
+});
+
+describe('security invariant — stale request does not self-burn its challenge', () => {
+  it('rejects a stale timestamp BEFORE burning the challenge', async () => {
+    const newKeyPair = ec.genKeyPair();
+    const challenge = await mintRotateChallenge();
+    // 10 minutes old — beyond the 5-minute freshness window.
+    const timestamp = Date.now() - 10 * 60 * 1000;
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, challenge, timestamp });
+
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
+
+    expect(res.status).toBe(400);
+    expect(mockUserDoc.save).not.toHaveBeenCalled();
+    // The challenge was NOT consumed — a fresh retry can still use it.
+    expect(mockChallengeStore.get(challenge)?.used).toBe(false);
   });
 });
 
 describe('conflict + validation guards', () => {
   it('rejects a newPublicKey already registered to another account (409)', async () => {
     const newKeyPair = ec.genKeyPair();
-    const newPublicKey = newKeyPair.getPublic('hex');
     mockConflictUser = { _id: 'a-different-user' };
 
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
-    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, challenge, timestamp });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
 
     expect(res.status).toBe(409);
     expect(mockUserDoc.save).not.toHaveBeenCalled();
@@ -370,8 +533,9 @@ describe('conflict + validation guards', () => {
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
     const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey: oldPublicKey, challenge, timestamp });
+    const newKeyProof = signNewKeyProof({ newPrivateKey: oldPrivateKey, newPublicKey: oldPublicKey, challenge, timestamp });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: oldPublicKey, challenge, signature, timestamp });
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: oldPublicKey, challenge, signature, newKeyProof, timestamp });
 
     expect(res.status).toBe(400);
     expect(mockUserDoc.save).not.toHaveBeenCalled();
@@ -382,7 +546,7 @@ describe('conflict + validation guards', () => {
     const timestamp = Date.now();
     const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey: 'not-a-key', challenge, timestamp });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: 'not-a-key', challenge, signature, timestamp });
+    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey: 'not-a-key', challenge, signature, newKeyProof: 'deadbeef', timestamp });
 
     expect(res.status).toBe(400);
     expect(mockUserDoc.save).not.toHaveBeenCalled();
@@ -401,18 +565,11 @@ describe('signOutEverywhere', () => {
     mockDeactivateAll.mockResolvedValue(2);
 
     const newKeyPair = ec.genKeyPair();
-    const newPublicKey = newKeyPair.getPublic('hex');
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
-    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, challenge, timestamp, signOutEverywhere: true });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', {
-      newPublicKey,
-      challenge,
-      signature,
-      timestamp,
-      signOutEverywhere: true,
-    });
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
 
     expect(res.status).toBe(200);
     expect(mockDeactivateAll).toHaveBeenCalledWith(USER_ID, undefined);
@@ -421,12 +578,11 @@ describe('signOutEverywhere', () => {
 
   it('does NOT revoke other sessions when the flag is absent', async () => {
     const newKeyPair = ec.genKeyPair();
-    const newPublicKey = newKeyPair.getPublic('hex');
     const challenge = await mintRotateChallenge();
     const timestamp = Date.now();
-    const signature = signRotation({ privateKey: oldPrivateKey, oldPublicKey, newPublicKey, challenge, timestamp });
+    const body = buildCompleteBody({ oldPrivateKey, newKeyPair, oldPublicKey, challenge, timestamp });
 
-    const res = await request(server, 'POST', '/auth/rotate/complete', { newPublicKey, challenge, signature, timestamp });
+    const res = await request(server, 'POST', '/auth/rotate/complete', body);
 
     expect(res.status).toBe(200);
     expect(mockDeactivateAll).not.toHaveBeenCalled();

--- a/packages/api/src/routes/authLinking.ts
+++ b/packages/api/src/routes/authLinking.ts
@@ -214,6 +214,14 @@ router.post('/rotate/complete', rotateCompleteLimiter, validate({ body: rotateKe
   const { newPublicKey, challenge, signature, newKeyProof, timestamp, signOutEverywhere } = req.body as RotateKeyCompleteRequest;
   const safeNewPublicKey = newPublicKey.trim();
 
+  // Defense-in-depth: bind the Mongo-query-bound `challenge` to a primitive
+  // string so a crafted object value can never inject query operators (e.g.
+  // `{$ne: null}`), independent of the upstream Zod validation. Mirrors the
+  // explicit string guards in POST /auth/link.
+  if (typeof challenge !== 'string') {
+    throw new BadRequestError('challenge must be a string');
+  }
+
   // Load the authoritative user document (for the write AND the server-derived
   // old key).
   const user = await User.findById(userIdObj);

--- a/packages/api/src/routes/authLinking.ts
+++ b/packages/api/src/routes/authLinking.ts
@@ -8,19 +8,31 @@
  * - Unlink an identity or an individual passkey (webauthn)
  */
 
-import { Router, type Response } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { User, buildAuthMethod } from '../models/User.js';
 import { authMiddleware, type AuthRequest } from '../middleware/auth.js';
 import SignatureService from '../services/signature.service.js';
 import { asyncHandler } from '../utils/asyncHandler.js';
-import { BadRequestError, ConflictError } from '../utils/error.js';
+import { BadRequestError, ConflictError, UnauthorizedError } from '../utils/error.js';
 import { validate } from '../middleware/validate.js';
 import { linkAuthMethodSchema, unlinkTypeParams, unlinkWebauthnParams } from '../schemas/authLinking.schemas.js';
 import WebauthnCredential from '../models/WebauthnCredential.js';
+import AuthChallenge from '../models/AuthChallenge.js';
+import Session from '../models/Session.js';
+import sessionService from '../services/session.service.js';
+import { rateLimit } from '../middleware/rateLimiter.js';
+import { hashedIpKey } from '../utils/ipKey.js';
+import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils.js';
 import userCache from '../utils/userCache.js';
 import { buildUserDid } from '../services/did.service.js';
 import { buildAuthMethodEntries } from '../utils/authMethodEntries.js';
-import { authMethodsResponseSchema } from '@oxyhq/contracts';
+import {
+  authMethodsResponseSchema,
+  rotateKeyChallengeResponseSchema,
+  rotateKeyCompleteRequestSchema,
+  rotateKeyCompleteResponseSchema,
+  type RotateKeyCompleteRequest,
+} from '@oxyhq/contracts';
 
 const router = Router();
 
@@ -38,6 +50,62 @@ function countAuthMethods(user: {
   const methods = user.authMethods ?? [];
   count += methods.filter((m) => m.type === 'webauthn').length;
   return count;
+}
+
+/** Rotation-challenge time-to-live (5 minutes), matching the signin challenge. */
+const ROTATE_CHALLENGE_TTL_MS = 5 * 60 * 1000;
+
+/** Max age accepted for the client rotation signature (5 minutes). */
+const ROTATE_SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
+
+/** Per-authenticated-user rate-limit key (falls back to a hashed IP pre-auth). */
+function rotateKey(scope: string) {
+  return (req: Request): string => {
+    const userId = (req as AuthRequest).user?._id?.toString();
+    return userId ? `${scope}:${userId}` : `${scope}:ip:${hashedIpKey(req)}`;
+  };
+}
+
+const rotateChallengeLimiter = rateLimit({
+  prefix: 'rl:identity:rotate:challenge:',
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  message: 'Too many key-rotation requests. Please try again later.',
+  keyGenerator: rotateKey('identity:rotate:challenge'),
+});
+
+const rotateCompleteLimiter = rateLimit({
+  prefix: 'rl:identity:rotate:complete:',
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  message: 'Too many key-rotation attempts. Please try again later.',
+  keyGenerator: rotateKey('identity:rotate:complete'),
+});
+
+/**
+ * Revoke every OTHER active session for the account, keeping the session that
+ * made this request signed in (mirrors the "logout all sessions" controller).
+ * Pushes a `sessions_removed` event so connected clients drop immediately.
+ *
+ * `emitSessionUpdate` is loaded DYNAMICALLY to avoid a load-time import cycle
+ * with `server.ts` (which imports this router).
+ */
+async function revokeOtherSessions(req: Request, userId: string): Promise<void> {
+  const token = extractTokenFromRequest(req);
+  const currentSessionId = token ? decodeToken(token)?.sessionId : undefined;
+
+  const filter: Record<string, unknown> = { userId, isActive: true, expiresAt: { $gt: new Date() } };
+  if (currentSessionId) filter.sessionId = { $ne: currentSessionId };
+
+  const others = await Session.find(filter).select('sessionId').lean();
+  const sessionIds = others.map((s) => s.sessionId);
+
+  await sessionService.deactivateAllUserSessions(userId, currentSessionId);
+
+  if (sessionIds.length > 0) {
+    const { emitSessionUpdate } = await import('../server.js');
+    emitSessionUpdate(userId, { type: 'sessions_removed', sessionIds });
+  }
 }
 
 // All routes require authentication
@@ -71,6 +139,165 @@ router.get('/methods', asyncHandler(async (req: AuthRequest, res: Response) => {
     methods,
   });
 
+  res.json(response);
+}));
+
+/**
+ * POST /api/auth/rotate/challenge
+ * Mint a single-use `rotate_key` challenge for the current account. The client
+ * signs it with its CURRENT key to prove control before the swap.
+ *
+ * The challenge is bound to the account's current `publicKey` and carries
+ * `purpose: 'rotate_key'`, so a signin challenge (default purpose) can never be
+ * spent here and vice-versa.
+ */
+router.post('/rotate/challenge', rotateChallengeLimiter, asyncHandler(async (req: AuthRequest, res: Response) => {
+  const userId = req.user?._id;
+  if (!userId) {
+    throw new BadRequestError('User not authenticated');
+  }
+
+  const oldPublicKey = req.user?.publicKey;
+  if (!oldPublicKey) {
+    throw new BadRequestError('No identity key is linked to this account — nothing to rotate.');
+  }
+
+  const challenge = SignatureService.generateChallenge();
+  const expiresAt = new Date(Date.now() + ROTATE_CHALLENGE_TTL_MS);
+
+  await AuthChallenge.create({
+    publicKey: oldPublicKey,
+    challenge,
+    purpose: 'rotate_key',
+    expiresAt,
+    used: false,
+  });
+
+  const response = rotateKeyChallengeResponseSchema.parse({
+    challenge,
+    expiresAt: expiresAt.toISOString(),
+  });
+  res.json(response);
+}));
+
+/**
+ * POST /api/auth/rotate/complete
+ * Atomically REPLACE the account's identity key with `newPublicKey`.
+ *
+ * Rotation is a single atomic swap — never a remove-then-add — so it never
+ * passes through a zero-auth-method state and is independent of the unlink
+ * guards. Because control of the CURRENT key is proven (from SecureStore OR a
+ * recovery-phrase re-derivation), even the LAST remaining credential can be
+ * replaced.
+ *
+ * Security invariants:
+ *  - `oldPublicKey` is ALWAYS derived from the authenticated user doc, NEVER
+ *    from the request (prevents proving control of key X but rotating key Y).
+ *  - the `rotate_key` challenge is burned ATOMICALLY (single-use) before the
+ *    signature is trusted.
+ *  - the signature is verified against the CURRENT key with the same primitive
+ *    `POST /auth/link` uses.
+ *  - the array length of `authMethods` is never changed (the single identity
+ *    entry is replaced in place), so `countAuthMethods()` is never 0.
+ */
+router.post('/rotate/complete', rotateCompleteLimiter, validate({ body: rotateKeyCompleteRequestSchema }), asyncHandler(async (req: AuthRequest, res: Response) => {
+  const userIdObj = req.user?._id;
+  if (!userIdObj) {
+    throw new BadRequestError('User not authenticated');
+  }
+  const userId = userIdObj.toString();
+
+  const { newPublicKey, challenge, signature, timestamp, signOutEverywhere } = req.body as RotateKeyCompleteRequest;
+  const safeNewPublicKey = newPublicKey.trim();
+
+  // Load the authoritative user document (for the write AND the server-derived
+  // old key).
+  const user = await User.findById(userIdObj);
+  if (!user) {
+    throw new BadRequestError('User not found');
+  }
+
+  // 1. oldPublicKey is derived from the USER DOC — never client-supplied.
+  const oldPublicKey = user.publicKey;
+  if (!oldPublicKey) {
+    throw new BadRequestError('No identity key is linked to this account — nothing to rotate.');
+  }
+
+  // Structural guards on the incoming new key.
+  if (!SignatureService.isValidPublicKey(safeNewPublicKey)) {
+    throw new BadRequestError('newPublicKey is not a valid public key');
+  }
+  if (safeNewPublicKey.toLowerCase() === oldPublicKey.toLowerCase()) {
+    throw new BadRequestError('newPublicKey must differ from the current identity key');
+  }
+
+  // 2. Atomically burn the rotate_key challenge (single-use, purpose-scoped,
+  //    bound to the account's CURRENT key). If nothing matches, the challenge
+  //    was never minted for rotation, was for a different key, is expired, or
+  //    was already consumed — reject in every case.
+  const burned = await AuthChallenge.findOneAndUpdate(
+    { challenge, publicKey: oldPublicKey, used: false, purpose: 'rotate_key', expiresAt: { $gt: new Date() } },
+    { $set: { used: true } },
+    { new: false },
+  );
+  if (!burned) {
+    throw new UnauthorizedError('Invalid or expired rotation challenge');
+  }
+
+  // 3. Verify the client signature proves control of the CURRENT key. The signed
+  //    bytes MUST match this reconstruction exactly (same key order).
+  const message = JSON.stringify({
+    action: 'rotate_key',
+    userId,
+    oldPublicKey,
+    newPublicKey: safeNewPublicKey,
+    challenge,
+    timestamp,
+  });
+  if (!SignatureService.verifySignature(message, signature, oldPublicKey)) {
+    throw new BadRequestError('Invalid signature — cannot verify control of the current key');
+  }
+
+  // Timestamp freshness (recent, not in the future).
+  const age = Date.now() - timestamp;
+  if (age > ROTATE_SIGNATURE_MAX_AGE_MS || age < 0) {
+    throw new BadRequestError('Signature expired or invalid timestamp — please try again');
+  }
+
+  // 4. Reject if the new key already belongs to another account.
+  const conflict = await User.findOne({ publicKey: safeNewPublicKey }).select('_id').lean();
+  if (conflict && conflict._id.toString() !== userId) {
+    throw new ConflictError('This identity is already linked to another account');
+  }
+
+  // 5. ATOMIC REPLACE: swap `publicKey` AND replace the single identity
+  //    `authMethods` entry in place. The array length is never changed, so the
+  //    account never passes through `countAuthMethods() === 0`. `user.save()`
+  //    persists both fields in one document update.
+  const methods = user.authMethods ?? [];
+  const hasIdentity = methods.some((m) => m.type === 'identity');
+  user.authMethods = hasIdentity
+    ? methods.map((m) =>
+        m.type === 'identity'
+          ? buildAuthMethod('identity', { ...m.metadata, publicKey: safeNewPublicKey })
+          : m,
+      )
+    : [...methods, buildAuthMethod('identity', { publicKey: safeNewPublicKey })];
+  user.publicKey = safeNewPublicKey;
+  await user.save();
+  userCache.invalidate(userId);
+
+  // 6. Optional: revoke every OTHER session (the rotating device stays signed
+  //    in) when the caller suspects the old key is compromised.
+  if (signOutEverywhere) {
+    await revokeOtherSessions(req, userId);
+  }
+
+  const response = rotateKeyCompleteResponseSchema.parse({
+    success: true,
+    publicKey: safeNewPublicKey,
+    message: 'Identity key rotated successfully',
+  });
   res.json(response);
 }));
 

--- a/packages/api/src/routes/authLinking.ts
+++ b/packages/api/src/routes/authLinking.ts
@@ -193,10 +193,14 @@ router.post('/rotate/challenge', rotateChallengeLimiter, asyncHandler(async (req
  * Security invariants:
  *  - `oldPublicKey` is ALWAYS derived from the authenticated user doc, NEVER
  *    from the request (prevents proving control of key X but rotating key Y).
- *  - the `rotate_key` challenge is burned ATOMICALLY (single-use) before the
- *    signature is trusted.
- *  - the signature is verified against the CURRENT key with the same primitive
- *    `POST /auth/link` uses.
+ *  - control of the CURRENT key is proven (`signature`) AND possession of the
+ *    NEW key is proven (`newKeyProof`) — the latter stops an attacker rotating
+ *    their account to a re-encoding of a key they do not control.
+ *  - the incoming key is canonicalized (uncompressed, lowercased) before the
+ *    uniqueness check and the write, so two encodings of the same point cannot
+ *    coexist across accounts.
+ *  - the `rotate_key` challenge is burned ATOMICALLY (single-use); the timestamp
+ *    is checked BEFORE the burn so a stale request cannot self-burn a challenge.
  *  - the array length of `authMethods` is never changed (the single identity
  *    entry is replaced in place), so `countAuthMethods()` is never 0.
  */
@@ -207,7 +211,7 @@ router.post('/rotate/complete', rotateCompleteLimiter, validate({ body: rotateKe
   }
   const userId = userIdObj.toString();
 
-  const { newPublicKey, challenge, signature, timestamp, signOutEverywhere } = req.body as RotateKeyCompleteRequest;
+  const { newPublicKey, challenge, signature, newKeyProof, timestamp, signOutEverywhere } = req.body as RotateKeyCompleteRequest;
   const safeNewPublicKey = newPublicKey.trim();
 
   // Load the authoritative user document (for the write AND the server-derived
@@ -227,11 +231,24 @@ router.post('/rotate/complete', rotateCompleteLimiter, validate({ body: rotateKe
   if (!SignatureService.isValidPublicKey(safeNewPublicKey)) {
     throw new BadRequestError('newPublicKey is not a valid public key');
   }
-  if (safeNewPublicKey.toLowerCase() === oldPublicKey.toLowerCase()) {
+
+  // Canonicalize BOTH keys (uncompressed, lowercased). The differ-check, the
+  // uniqueness query, and the write all operate on the canonical form so a
+  // re-encoded (compressed / re-cased) duplicate can never slip past them.
+  const canonicalNewPublicKey = SignatureService.canonicalizePublicKey(safeNewPublicKey);
+  const canonicalOldPublicKey = SignatureService.canonicalizePublicKey(oldPublicKey);
+  if (canonicalNewPublicKey === canonicalOldPublicKey) {
     throw new BadRequestError('newPublicKey must differ from the current identity key');
   }
 
-  // 2. Atomically burn the rotate_key challenge (single-use, purpose-scoped,
+  // 2. Timestamp freshness (recent, not in the future) — BEFORE the burn, so a
+  //    stale-but-otherwise-valid request cannot consume its own challenge.
+  const age = Date.now() - timestamp;
+  if (age > ROTATE_SIGNATURE_MAX_AGE_MS || age < 0) {
+    throw new BadRequestError('Signature expired or invalid timestamp — please try again');
+  }
+
+  // 3. Atomically burn the rotate_key challenge (single-use, purpose-scoped,
   //    bound to the account's CURRENT key). If nothing matches, the challenge
   //    was never minted for rotation, was for a different key, is expired, or
   //    was already consumed — reject in every case.
@@ -244,7 +261,7 @@ router.post('/rotate/complete', rotateCompleteLimiter, validate({ body: rotateKe
     throw new UnauthorizedError('Invalid or expired rotation challenge');
   }
 
-  // 3. Verify the client signature proves control of the CURRENT key. The signed
+  // 4. Verify the client signature proves control of the CURRENT key. The signed
   //    bytes MUST match this reconstruction exactly (same key order).
   const message = JSON.stringify({
     action: 'rotate_key',
@@ -258,36 +275,46 @@ router.post('/rotate/complete', rotateCompleteLimiter, validate({ body: rotateKe
     throw new BadRequestError('Invalid signature — cannot verify control of the current key');
   }
 
-  // Timestamp freshness (recent, not in the future).
-  const age = Date.now() - timestamp;
-  if (age > ROTATE_SIGNATURE_MAX_AGE_MS || age < 0) {
-    throw new BadRequestError('Signature expired or invalid timestamp — please try again');
+  // 5. Verify proof-of-possession of the NEW key. Without this, an attacker
+  //    could rotate their OWN account to a re-encoding of a victim's key (read
+  //    from the public DID) — passing the uniqueness check but never controlling
+  //    the private key. Requiring the new key to sign closes that.
+  const newKeyMessage = JSON.stringify({
+    action: 'rotate_key_new',
+    userId,
+    newPublicKey: safeNewPublicKey,
+    challenge,
+    timestamp,
+  });
+  if (!SignatureService.verifySignature(newKeyMessage, newKeyProof, safeNewPublicKey)) {
+    throw new BadRequestError('Invalid new-key proof — cannot verify possession of the new key');
   }
 
-  // 4. Reject if the new key already belongs to another account.
-  const conflict = await User.findOne({ publicKey: safeNewPublicKey }).select('_id').lean();
+  // 6. Reject if the (canonical) new key already belongs to another account.
+  const conflict = await User.findOne({ publicKey: canonicalNewPublicKey }).select('_id').lean();
   if (conflict && conflict._id.toString() !== userId) {
     throw new ConflictError('This identity is already linked to another account');
   }
 
-  // 5. ATOMIC REPLACE: swap `publicKey` AND replace the single identity
-  //    `authMethods` entry in place. The array length is never changed, so the
-  //    account never passes through `countAuthMethods() === 0`. `user.save()`
-  //    persists both fields in one document update.
+  // 7. ATOMIC REPLACE: swap `publicKey` AND replace the single identity
+  //    `authMethods` entry in place, storing the CANONICAL key. The array length
+  //    is never changed, so the account never passes through
+  //    `countAuthMethods() === 0`. `user.save()` persists both fields in one
+  //    document update.
   const methods = user.authMethods ?? [];
   const hasIdentity = methods.some((m) => m.type === 'identity');
   user.authMethods = hasIdentity
     ? methods.map((m) =>
         m.type === 'identity'
-          ? buildAuthMethod('identity', { ...m.metadata, publicKey: safeNewPublicKey })
+          ? buildAuthMethod('identity', { ...m.metadata, publicKey: canonicalNewPublicKey })
           : m,
       )
-    : [...methods, buildAuthMethod('identity', { publicKey: safeNewPublicKey })];
-  user.publicKey = safeNewPublicKey;
+    : [...methods, buildAuthMethod('identity', { publicKey: canonicalNewPublicKey })];
+  user.publicKey = canonicalNewPublicKey;
   await user.save();
   userCache.invalidate(userId);
 
-  // 6. Optional: revoke every OTHER session (the rotating device stays signed
+  // 8. Optional: revoke every OTHER session (the rotating device stays signed
   //    in) when the caller suspects the old key is compromised.
   if (signOutEverywhere) {
     await revokeOtherSessions(req, userId);
@@ -295,7 +322,7 @@ router.post('/rotate/complete', rotateCompleteLimiter, validate({ body: rotateKe
 
   const response = rotateKeyCompleteResponseSchema.parse({
     success: true,
-    publicKey: safeNewPublicKey,
+    publicKey: canonicalNewPublicKey,
     message: 'Identity key rotated successfully',
   });
   res.json(response);

--- a/packages/api/src/services/__tests__/authSessionPurposeScope.test.ts
+++ b/packages/api/src/services/__tests__/authSessionPurposeScope.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Purpose-scoping of the signin/handoff challenge burn (b3 F3 security review).
+ *
+ * The symmetric invariant to the rotate flow's purpose scoping: a `rotate_key`
+ * challenge must NOT be spendable by the "Sign in with Oxy" key-signed handoff
+ * (`authorizeSessionWithSignedChallenge`). The signin challenge lookup is scoped
+ * to `purpose ∈ {signin, null}`, so a `rotate_key` challenge is never found and
+ * the flow returns 401 BEFORE it ever verifies a signature — distinct from the
+ * "found but bad signature" path, which lets us prove the gate is the purpose
+ * filter (not just a missing challenge).
+ */
+
+interface ChallengeEntry {
+  publicKey: string;
+  purpose: string | null;
+  used: boolean;
+  expiresAt: Date;
+}
+
+const mockChallengeStore = new Map<string, ChallengeEntry>();
+
+jest.mock('../../models/AuthChallenge', () => ({
+  __esModule: true,
+  default: {
+    findOne: (filter: {
+      publicKey?: string;
+      challenge: string;
+      used?: boolean;
+      purpose?: { $in: Array<string | null> };
+      expiresAt?: { $gt: Date };
+    }) => ({
+      lean: () => {
+        const entry = mockChallengeStore.get(filter.challenge);
+        if (!entry) return Promise.resolve(null);
+        if (filter.publicKey !== undefined && entry.publicKey !== filter.publicKey) return Promise.resolve(null);
+        if (filter.used !== undefined && entry.used !== filter.used) return Promise.resolve(null);
+        if (filter.purpose?.$in && !filter.purpose.$in.includes(entry.purpose)) return Promise.resolve(null);
+        if (filter.expiresAt?.$gt && !(entry.expiresAt > filter.expiresAt.$gt)) return Promise.resolve(null);
+        return Promise.resolve({ _id: 'challenge-id', ...entry });
+      },
+    }),
+    findOneAndUpdate: () => Promise.resolve(null),
+  },
+}));
+
+// Minimal stubs for the model/service imports that would otherwise crash under
+// the global mongoose mock. None are reached in these tests — the flow returns
+// at (or before) the signature check.
+jest.mock('../../models/AuthSession', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn() },
+  AuthSession: { findOne: jest.fn() },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: { findOne: jest.fn() },
+}));
+
+jest.mock('../../models/Application', () => ({
+  __esModule: true,
+  Application: { findById: jest.fn() },
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: jest.fn() },
+}));
+
+import type { Request } from 'express';
+import { authorizeSessionWithSignedChallenge } from '../authSession.service';
+
+const PUBLIC_KEY = 'test-public-key';
+
+beforeEach(() => {
+  mockChallengeStore.clear();
+});
+
+describe('authorizeSessionWithSignedChallenge — challenge purpose scoping', () => {
+  it('rejects a rotate_key challenge at the challenge gate (never reaches signature verification)', async () => {
+    mockChallengeStore.set('chal-rotate', {
+      publicKey: PUBLIC_KEY,
+      purpose: 'rotate_key',
+      used: false,
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    const outcome = await authorizeSessionWithSignedChallenge({
+      authorizeCode: 'code-1',
+      publicKey: PUBLIC_KEY,
+      challenge: 'chal-rotate',
+      signature: 'anything',
+      timestamp: Date.now(),
+      req: {} as Request,
+    });
+
+    // 401 with the "not found" message — the purpose filter excluded it BEFORE
+    // any signature check (a bad-signature rejection would say 'Invalid signature').
+    expect(outcome).toEqual({ ok: false, status: 401, message: 'Invalid or expired challenge' });
+  });
+
+  it('finds a signin-purpose challenge (fails later at signature verification)', async () => {
+    mockChallengeStore.set('chal-signin', {
+      publicKey: PUBLIC_KEY,
+      purpose: 'signin',
+      used: false,
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    const outcome = await authorizeSessionWithSignedChallenge({
+      authorizeCode: 'code-1',
+      publicKey: PUBLIC_KEY,
+      challenge: 'chal-signin',
+      signature: 'a-bogus-signature',
+      timestamp: Date.now(),
+      req: {} as Request,
+    });
+
+    // The challenge WAS found (purpose gate passed) — it only failed at the
+    // signature check, proving the gate accepts signin challenges.
+    expect(outcome).toEqual({ ok: false, status: 401, message: 'Invalid signature' });
+  });
+
+  it('finds a legacy challenge with no purpose field (treated as signin)', async () => {
+    mockChallengeStore.set('chal-legacy', {
+      publicKey: PUBLIC_KEY,
+      purpose: null, // predates the `purpose` field
+      used: false,
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+    });
+
+    const outcome = await authorizeSessionWithSignedChallenge({
+      authorizeCode: 'code-1',
+      publicKey: PUBLIC_KEY,
+      challenge: 'chal-legacy',
+      signature: 'a-bogus-signature',
+      timestamp: Date.now(),
+      req: {} as Request,
+    });
+
+    expect(outcome).toEqual({ ok: false, status: 401, message: 'Invalid signature' });
+  });
+});

--- a/packages/api/src/services/authSession.service.ts
+++ b/packages/api/src/services/authSession.service.ts
@@ -133,10 +133,14 @@ export async function authorizeSessionWithSignedChallenge(
   const { authorizeCode, publicKey, challenge, signature, timestamp, deviceName, deviceFingerprint, req } = options;
 
   // 1. Validate + cryptographically verify + atomically burn the challenge.
+  //    Scope to signin-purpose challenges (default, or legacy docs predating the
+  //    `purpose` field) so a `rotate_key` challenge can NOT be spent to mint a
+  //    session — the symmetric invariant to the rotate flow's purpose scoping.
   const authChallenge = await AuthChallenge.findOne({
     publicKey,
     challenge,
     used: false,
+    purpose: { $in: ['signin', null] },
     expiresAt: { $gt: new Date() },
   }).lean();
   if (!authChallenge) {

--- a/packages/api/src/services/signature.service.ts
+++ b/packages/api/src/services/signature.service.ts
@@ -151,6 +151,22 @@ export class SignatureService {
   }
 
   /**
+   * Canonicalize a secp256k1 public key to ONE form: uncompressed, lowercased
+   * hex. `isValidPublicKey` accepts the same point in compressed (`02/03…`),
+   * uncompressed (`04…`), or any-case encodings, but the `User.publicKey` unique
+   * index and the conflict/lookup queries are raw-string/case-sensitive. Storing
+   * and comparing the canonical form makes those checks encoding-independent, so
+   * two encodings of the same point can never coexist across accounts.
+   *
+   * @param publicKey - The public key in any valid hex encoding.
+   * @returns The uncompressed, lowercased hex encoding of the same point.
+   * @throws if `publicKey` is not a valid secp256k1 public key.
+   */
+  static canonicalizePublicKey(publicKey: string): string {
+    return ec.keyFromPublic(publicKey, 'hex').getPublic(false, 'hex').toLowerCase();
+  }
+
+  /**
    * Get a shortened display version of a public key
    */
   static shortenPublicKey(publicKey: string): string {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -250,6 +250,19 @@ export type {
 } from './deviceBoot';
 
 export {
+    // Schemas
+    rotateKeyChallengeResponseSchema,
+    rotateKeyCompleteRequestSchema,
+    rotateKeyCompleteResponseSchema,
+} from './keyRotation';
+
+export type {
+    RotateKeyChallengeResponse,
+    RotateKeyCompleteRequest,
+    RotateKeyCompleteResponse,
+} from './keyRotation';
+
+export {
     // Shared primitives
     updatePlatformSchema,
     updateStatusSchema,

--- a/packages/contracts/src/keyRotation.ts
+++ b/packages/contracts/src/keyRotation.ts
@@ -1,0 +1,73 @@
+/**
+ * Key-rotation contract (b3 Feature 3 — key rotation + last-credential replacement).
+ *
+ * SINGLE SOURCE OF TRUTH for the atomic key-rotation flow:
+ *  - `POST /auth/rotate/challenge` — mint a single-use `rotate_key` challenge.
+ *  - `POST /auth/rotate/complete`  — prove control of the CURRENT (old) key and
+ *    atomically swap in the new one.
+ *
+ * Rotation is an atomic REPLACE of the single identity key, never a
+ * remove-then-add, so it never passes through a zero-auth-method state and is
+ * independent of the unlink guards. Because the client proves possession of the
+ * current key (from SecureStore OR a recovery-phrase re-derivation), the LAST
+ * remaining credential can be replaced — the server only cares that the
+ * signature validates against the current `publicKey`.
+ *
+ * The API validates its output against these schemas; `@oxyhq/core`'s identity
+ * mixin validates its input against the same definitions, so producer and
+ * consumer cannot drift.
+ *
+ * All shapes here are FLAT (no nested objects), so `z.infer<>` is safe under a
+ * consumer's node10 `moduleResolution` — no interface-pinning needed.
+ *
+ * Platform-agnostic — zod only, ESM-safe (no `require()`).
+ */
+import { z } from 'zod';
+
+/**
+ * Response of `POST /auth/rotate/challenge`: the single-use `rotate_key`
+ * challenge the client must sign with its CURRENT key, plus its expiry.
+ */
+export const rotateKeyChallengeResponseSchema = z.object({
+    challenge: z.string(),
+    /** ISO-8601 expiry timestamp. */
+    expiresAt: z.string(),
+});
+
+export type RotateKeyChallengeResponse = z.infer<typeof rotateKeyChallengeResponseSchema>;
+
+/**
+ * Request body of `POST /auth/rotate/complete`.
+ *
+ * The client signs the canonical bytes
+ * `JSON.stringify({ action: 'rotate_key', userId, oldPublicKey, newPublicKey,
+ * challenge, timestamp })` with the CURRENT (old) key.
+ *
+ * The request carries ONLY `newPublicKey` — `oldPublicKey` and `userId` are
+ * derived server-side from the authenticated user document (never
+ * client-supplied), so a caller cannot prove control of key X while rotating
+ * key Y.
+ */
+export const rotateKeyCompleteRequestSchema = z.object({
+    newPublicKey: z.string().trim().min(1),
+    challenge: z.string().trim().min(1),
+    signature: z.string().trim().min(1),
+    timestamp: z.number(),
+    /**
+     * When true, all OTHER active sessions for the account are revoked after a
+     * successful rotation (the rotating device stays signed in). Use it when the
+     * old key is presumed compromised.
+     */
+    signOutEverywhere: z.boolean().optional(),
+});
+
+export type RotateKeyCompleteRequest = z.infer<typeof rotateKeyCompleteRequestSchema>;
+
+/** Response of `POST /auth/rotate/complete`: the account's new (rotated) public key. */
+export const rotateKeyCompleteResponseSchema = z.object({
+    success: z.boolean(),
+    publicKey: z.string(),
+    message: z.string(),
+});
+
+export type RotateKeyCompleteResponse = z.infer<typeof rotateKeyCompleteResponseSchema>;

--- a/packages/contracts/src/keyRotation.ts
+++ b/packages/contracts/src/keyRotation.ts
@@ -39,9 +39,15 @@ export type RotateKeyChallengeResponse = z.infer<typeof rotateKeyChallengeRespon
 /**
  * Request body of `POST /auth/rotate/complete`.
  *
- * The client signs the canonical bytes
- * `JSON.stringify({ action: 'rotate_key', userId, oldPublicKey, newPublicKey,
- * challenge, timestamp })` with the CURRENT (old) key.
+ * Two proofs are required:
+ *  - `signature` — the CURRENT (old) key signs
+ *    `JSON.stringify({ action: 'rotate_key', userId, oldPublicKey, newPublicKey,
+ *    challenge, timestamp })` (proves control of the key being replaced).
+ *  - `newKeyProof` — the NEW key signs
+ *    `JSON.stringify({ action: 'rotate_key_new', userId, newPublicKey, challenge,
+ *    timestamp })` (proof-of-possession of the key being rotated IN; prevents an
+ *    attacker rotating their account to a re-encoding of someone else's key they
+ *    do not control).
  *
  * The request carries ONLY `newPublicKey` — `oldPublicKey` and `userId` are
  * derived server-side from the authenticated user document (never
@@ -52,6 +58,8 @@ export const rotateKeyCompleteRequestSchema = z.object({
     newPublicKey: z.string().trim().min(1),
     challenge: z.string().trim().min(1),
     signature: z.string().trim().min(1),
+    /** Proof-of-possession: the NEW key signs the rotate_key_new payload. */
+    newKeyProof: z.string().trim().min(1),
     timestamp: z.number(),
     /**
      * When true, all OTHER active sessions for the account are revoked after a

--- a/packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts
+++ b/packages/core/src/crypto/__tests__/keyManager.atomicity.test.ts
@@ -237,6 +237,39 @@ describe('KeyManager atomicity & recoverability under flaky storage', () => {
     expect(KeyManager.derivePublicKey(m.get('oxy_identity_private_key') as string)).toBe(a);
   });
 
+  it('a failed primary write during the post-rotation importKeyPair leaves the OLD key recoverable from backup', async () => {
+    // b3 key rotation: the server has already swapped to the NEW key; the device
+    // now commits it via importKeyPair({overwrite:true}). If that write fails
+    // mid-overwrite, the OLD key MUST remain intact and recoverable — never a
+    // half-written new identity that can't be decrypted or backed up.
+    const oldPublic = await KeyManager.createIdentity();
+    const ss = (await import('expo-secure-store' as string)) as unknown as SecureStoreTestHandle;
+    const oldPriv = ss.__getStore__().get('oxy_identity_private_key');
+    resetCaches();
+
+    // The NEW rotated key material (generateKeyPair does NOT persist).
+    const rotated = await KeyManager.generateKeyPair();
+
+    // The new primary private write fails mid-commit.
+    ss.__failPlan__.failOp = 'set';
+    ss.__failPlan__.failKey = 'oxy_identity_private_key';
+    await expect(KeyManager.importKeyPair(rotated.privateKey, { overwrite: true })).rejects.toBeDefined();
+
+    // Recover from the simulated fault.
+    ss.__failPlan__.failKey = undefined;
+    ss.__failPlan__.failOp = undefined;
+    resetCaches();
+
+    // Primary is STILL the old identity (rolled back — never the new one).
+    expect(await KeyManager.hasIdentity()).toBe(true);
+    expect(await KeyManager.getPublicKey()).toBe(oldPublic);
+    const m = ss.__getStore__();
+    expect(m.get('oxy_identity_private_key')).toBe(oldPriv);
+    // And the backup still holds the OLD identity, so the user can recover it.
+    expect(m.get('oxy_identity_backup_private_key')).toBe(oldPriv);
+    expect(m.get('oxy_identity_backup_public_key')).toBe(oldPublic);
+  });
+
   it('restores a provably-absent primary from a valid backup', async () => {
     const original = await KeyManager.createIdentity();
     const ss = (await import('expo-secure-store' as string)) as unknown as SecureStoreTestHandle;

--- a/packages/core/src/crypto/__tests__/recoveryPhrase.test.ts
+++ b/packages/core/src/crypto/__tests__/recoveryPhrase.test.ts
@@ -1,0 +1,61 @@
+/**
+ * RecoveryPhraseService — pure, non-persisting derivation helpers (b3 rotation).
+ *
+ * `derivePendingIdentity()` and `derivePrivateKeyFromPhrase()` must produce
+ * valid, self-consistent key material WITHOUT touching secure storage — the
+ * whole point of a "pending" identity is that nothing is committed until an
+ * external step (a server-confirmed key rotation) succeeds.
+ */
+
+import { RecoveryPhraseService } from '../recoveryPhrase';
+import { KeyManager } from '../keyManager';
+
+describe('RecoveryPhraseService.derivePendingIdentity (non-persisting)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('produces a valid 12-word phrase whose privateKey derives the returned publicKey', async () => {
+    const pending = await RecoveryPhraseService.derivePendingIdentity();
+
+    expect(RecoveryPhraseService.validatePhrase(pending.phrase)).toBe(true);
+    expect(pending.words).toHaveLength(12);
+    expect(pending.words.join(' ')).toBe(pending.phrase);
+
+    // The private key is a canonical 64-hex-char secp256k1 scalar…
+    expect(pending.privateKey).toMatch(/^[0-9a-f]{64}$/);
+    // …and it deterministically derives the returned public key.
+    expect(KeyManager.derivePublicKey(pending.privateKey)).toBe(pending.publicKey);
+  });
+
+  it('does NOT persist anything to secure storage (never imports a key pair)', async () => {
+    const importSpy = jest.spyOn(KeyManager, 'importKeyPair');
+    const createSpy = jest.spyOn(KeyManager, 'createIdentity');
+
+    await RecoveryPhraseService.derivePendingIdentity();
+
+    expect(importSpy).not.toHaveBeenCalled();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('yields a distinct identity on each call', async () => {
+    const a = await RecoveryPhraseService.derivePendingIdentity();
+    const b = await RecoveryPhraseService.derivePendingIdentity();
+    expect(a.phrase).not.toBe(b.phrase);
+    expect(a.publicKey).not.toBe(b.publicKey);
+  });
+
+  it('derivePrivateKeyFromPhrase round-trips: same phrase → same private/public key', async () => {
+    const pending = await RecoveryPhraseService.derivePendingIdentity();
+
+    const rederivedPrivate = await RecoveryPhraseService.derivePrivateKeyFromPhrase(pending.phrase);
+    expect(rederivedPrivate).toBe(pending.privateKey);
+    expect(KeyManager.derivePublicKey(rederivedPrivate)).toBe(pending.publicKey);
+  });
+
+  it('derivePrivateKeyFromPhrase rejects an invalid mnemonic', async () => {
+    await expect(
+      RecoveryPhraseService.derivePrivateKeyFromPhrase('not a real recovery phrase at all'),
+    ).rejects.toThrow(/Invalid recovery phrase/);
+  });
+});

--- a/packages/core/src/crypto/recoveryPhrase.ts
+++ b/packages/core/src/crypto/recoveryPhrase.ts
@@ -28,6 +28,21 @@ export interface RecoveryPhraseResult {
   publicKey: string;
 }
 
+/**
+ * A freshly-derived identity that has NOT been persisted to secure storage.
+ *
+ * Unlike {@link RecoveryPhraseResult} this also exposes the `privateKey`, because
+ * the caller must be able to sign with (or later persist) the material itself —
+ * the whole point of a "pending" identity is that nothing is committed until an
+ * external step (e.g. a server-confirmed key rotation) succeeds.
+ */
+export interface PendingIdentityResult {
+  phrase: string;
+  words: string[];
+  privateKey: string;
+  publicKey: string;
+}
+
 export interface GenerateIdentityOptions {
   /**
    * Pass `true` to allow overwriting an existing on-device identity.
@@ -101,6 +116,54 @@ export class RecoveryPhraseService {
       words: mnemonic.split(' '),
       publicKey,
     };
+  }
+
+  /**
+   * Derive a brand-new identity + recovery phrase WITHOUT persisting anything.
+   *
+   * Pure: same derivation as {@link generateIdentityWithRecovery} (128-bit
+   * mnemonic → seed → first 32 bytes as the secp256k1 private key) but it stops
+   * BEFORE `KeyManager.importKeyPair`, so no on-device identity is touched. The
+   * caller decides if/when to commit the material (e.g. only after a server
+   * confirms a key rotation). Works on web too — it never reads or writes secure
+   * storage.
+   *
+   * The 12-word `phrase` MUST be shown to the user before the identity is
+   * committed anywhere — if it is lost the account becomes unrecoverable.
+   */
+  static async derivePendingIdentity(): Promise<PendingIdentityResult> {
+    const mnemonic = bip39.generateMnemonic(128);
+    const seed = await bip39.mnemonicToSeed(mnemonic);
+    const seedSlice = seed.subarray ? seed.subarray(0, 32) : seed.slice(0, 32);
+    const privateKey = toHex(seedSlice);
+    const publicKey = KeyManager.derivePublicKey(privateKey);
+
+    return {
+      phrase: mnemonic,
+      words: mnemonic.split(' '),
+      privateKey,
+      publicKey,
+    };
+  }
+
+  /**
+   * Derive the private key from a recovery phrase WITHOUT storing it.
+   *
+   * The private-key counterpart of {@link derivePublicKeyFromPhrase}. Used to
+   * re-derive a key in memory (e.g. to sign a rotation proof with the current
+   * key when the device has no SecureStore copy). Never persists — the returned
+   * material lives only in the caller's memory.
+   */
+  static async derivePrivateKeyFromPhrase(phrase: string): Promise<string> {
+    const normalizedPhrase = phrase.trim().toLowerCase();
+
+    if (!bip39.validateMnemonic(normalizedPhrase)) {
+      throw new Error('Invalid recovery phrase');
+    }
+
+    const seed = await bip39.mnemonicToSeed(normalizedPhrase);
+    const seedSlice = seed.subarray ? seed.subarray(0, 32) : seed.slice(0, 32);
+    return toHex(seedSlice);
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -173,6 +173,9 @@ export type {
     VerifyRecordResult,
     VerifyDomainResult,
     RemoveDomainResult,
+    RotateKeyProof,
+    RotateKeyOptions,
+    RotateKeyResult,
 } from './mixins/OxyServices.identity';
 
 // ---------------------------------------------------------------------------
@@ -242,7 +245,7 @@ export type { KeyPair } from './crypto/keyManager';
 export { SignatureService } from './crypto/signatureService';
 export type { SignedMessage, AuthChallenge } from './crypto/signatureService';
 export { RecoveryPhraseService } from './crypto/recoveryPhrase';
-export type { RecoveryPhraseResult } from './crypto/recoveryPhrase';
+export type { RecoveryPhraseResult, PendingIdentityResult } from './crypto/recoveryPhrase';
 
 // ---------------------------------------------------------------------------
 // Devices

--- a/packages/core/src/mixins/OxyServices.identity.ts
+++ b/packages/core/src/mixins/OxyServices.identity.ts
@@ -29,12 +29,17 @@ import type {
   DomainVerificationInstructions,
   ExportBundle,
   OxySignedRecordType,
+  RotateKeyChallengeResponse,
+  RotateKeyCompleteResponse,
   SignedRecordEnvelope,
   VerifiedDomain,
 } from '@oxyhq/contracts';
+import { signMessage } from '@oxyhq/protocol';
 import type { OxyServicesBase } from '../OxyServices.base';
 import { KeyManager } from '../crypto/keyManager';
 import { SignatureService } from '../crypto/signatureService';
+import { RecoveryPhraseService, type PendingIdentityResult } from '../crypto/recoveryPhrase';
+import { isWeb } from '../utils/platform';
 import { CACHE_TIMES } from './mixinHelpers';
 
 /**
@@ -91,6 +96,50 @@ export interface VerifyDomainResult {
 /** Result of removing a verified domain (`DELETE /identity/domains/:domain`). */
 export interface RemoveDomainResult {
   success: boolean;
+}
+
+/** How the caller proves control of the CURRENT key during a key rotation. */
+export type RotateKeyProof = 'device' | 'phrase';
+
+/** Options for {@link OxyServicesIdentityMixin.rotateKey}. */
+export interface RotateKeyOptions {
+  /**
+   * How to prove control of the CURRENT key:
+   *  - `'device'`: sign with the on-device SecureStore key (native-only).
+   *  - `'phrase'`: re-derive the current key from the entered recovery `phrase`
+   *    and sign with it. This works even when the device holds NO SecureStore
+   *    copy of the key — it is how the LAST remaining credential is replaced.
+   */
+  proof: RotateKeyProof;
+  /** The CURRENT identity's recovery phrase. Required when `proof: 'phrase'`. */
+  phrase?: string;
+  /**
+   * When true, all OTHER active sessions are revoked after a successful
+   * rotation (the rotating device stays signed in). Use it when the old key is
+   * presumed compromised.
+   */
+  signOutEverywhere?: boolean;
+  /**
+   * A pre-derived NEW identity to rotate to (from
+   * {@link RecoveryPhraseService.derivePendingIdentity}). Pass it when the UI
+   * derived + SHOWED the new phrase to the user BEFORE committing, so the SAME
+   * identity is the one rotated in. When omitted, a fresh identity is derived
+   * internally and its phrase is returned in the result.
+   */
+  pendingIdentity?: PendingIdentityResult;
+}
+
+/** Result of a successful key rotation. */
+export interface RotateKeyResult {
+  /** The account's new (rotated) public key. */
+  newPublicKey: string;
+  /**
+   * The NEW identity's recovery phrase. It MUST be surfaced to the user so they
+   * can back up the rotated key — if lost, the new identity is unrecoverable.
+   */
+  newPhrase: string;
+  /** The recovery phrase split into its individual words. */
+  words: string[];
 }
 
 /**
@@ -252,6 +301,167 @@ export function OxyServicesIdentityMixin<T extends typeof OxyServicesBase>(Base:
       } catch (error) {
         throw this.handleError(error);
       }
+    }
+
+    /**
+     * Rotate the account's identity key: derive a brand-new keypair, prove
+     * control of the CURRENT key, and have the server ATOMICALLY replace the old
+     * key with the new one.
+     *
+     * The rotation is an atomic REPLACE on the server (never remove-then-add), so
+     * it never passes through a zero-auth-method state and is independent of the
+     * unlink guards. Because control of the current key is PROVEN (from
+     * SecureStore in `'device'` mode, or a recovery-phrase re-derivation in
+     * `'phrase'` mode), even the LAST remaining credential can be replaced.
+     *
+     * Ordering (safety-critical): the new key is persisted on-device ONLY AFTER
+     * the server confirms the swap. Persisting earlier would clobber the local
+     * key while the server still trusts the old one, locking the device out.
+     *
+     * Ambiguous-network-failure guard: if the `complete` response is lost
+     * (request sent, no reply), the swap may already have applied server-side.
+     * Before surfacing the error we reconcile against the derived DID document —
+     * if it already advertises the new key, the rotation is treated as done.
+     *
+     * NOTE: the UI is responsible for showing `newPhrase` to the user. For a
+     * "show-phrase-first" flow, derive the identity up front via
+     * {@link RecoveryPhraseService.derivePendingIdentity}, display it, then pass
+     * it back as `options.pendingIdentity` so the SAME identity is committed.
+     *
+     * @throws when no user is authenticated, when `proof: 'phrase'` is given
+     *   without a `phrase`, when `proof: 'device'` runs with no on-device key,
+     *   or when the rotation does not complete.
+     */
+    async rotateKey(options: RotateKeyOptions): Promise<RotateKeyResult> {
+      try {
+        const userId = this.getCurrentUserId();
+        if (!userId) {
+          throw new Error('No authenticated user — sign in before rotating your key.');
+        }
+
+        // 1. The NEW identity (in memory only). The UI may pre-derive + pre-show
+        //    it and pass it back here so the phrase shown === the phrase committed.
+        const pending = options.pendingIdentity ?? (await RecoveryPhraseService.derivePendingIdentity());
+        const newPublicKey = pending.publicKey;
+
+        // 2. Resolve the OLD signing capability from the chosen proof mode.
+        let oldPublicKey: string;
+        let signWithOldKey: (message: string) => Promise<string>;
+        if (options.proof === 'phrase') {
+          const phrase = options.phrase?.trim();
+          if (!phrase) {
+            throw new Error('A recovery phrase is required for phrase-proof rotation.');
+          }
+          const oldPrivateKey = await RecoveryPhraseService.derivePrivateKeyFromPhrase(phrase);
+          oldPublicKey = KeyManager.derivePublicKey(oldPrivateKey);
+          signWithOldKey = (message) => signMessage(message, oldPrivateKey);
+        } else {
+          const currentPublicKey = await KeyManager.getPublicKey();
+          if (!currentPublicKey) {
+            throw new Error('No on-device identity found. Use the recovery-phrase option to rotate your key.');
+          }
+          oldPublicKey = currentPublicKey;
+          signWithOldKey = (message) => SignatureService.sign(message);
+        }
+
+        // 3. Request a single-use rotate_key challenge (bearer).
+        const { challenge } = await this.makeRequest<RotateKeyChallengeResponse>(
+          'POST',
+          '/auth/rotate/challenge',
+          undefined,
+          { cache: false },
+        );
+
+        // 4. Sign the rotation proof with the OLD key. The signed bytes MUST match
+        //    the server's reconstruction exactly (this key order).
+        const timestamp = Date.now();
+        const message = JSON.stringify({
+          action: 'rotate_key',
+          userId,
+          oldPublicKey,
+          newPublicKey,
+          challenge,
+          timestamp,
+        });
+        const signature = await signWithOldKey(message);
+
+        // 5. Complete the rotation. On an AMBIGUOUS failure, reconcile against the
+        //    DID before deciding the rotation failed.
+        let applied = false;
+        try {
+          const result = await this.makeRequest<RotateKeyCompleteResponse>(
+            'POST',
+            '/auth/rotate/complete',
+            {
+              newPublicKey,
+              challenge,
+              signature,
+              timestamp,
+              ...(options.signOutEverywhere ? { signOutEverywhere: true } : {}),
+            },
+            { cache: false },
+          );
+          applied = result.success && result.publicKey.toLowerCase() === newPublicKey.toLowerCase();
+        } catch (error) {
+          const reconciled = await this._rotationAlreadyApplied(userId, newPublicKey);
+          if (!reconciled) {
+            throw error;
+          }
+          applied = true;
+        }
+
+        if (!applied) {
+          throw new Error('Key rotation did not complete — your previous key is unchanged.');
+        }
+
+        // 6. ONLY after the server confirms the swap, persist the new key locally,
+        //    overwriting the old one. `importKeyPair({ overwrite: true })` uses the
+        //    atomic persist path (backs the previous key up first). Native-only —
+        //    on web the key never lived in SecureStore, so there is nothing to
+        //    persist locally.
+        if (!isWeb()) {
+          await KeyManager.importKeyPair(pending.privateKey, { overwrite: true });
+        }
+
+        this._invalidateIdentityCaches(userId);
+
+        return { newPublicKey, newPhrase: pending.phrase, words: pending.words };
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Reconciliation probe for the rotation ambiguous-failure guard: fetch the
+     * account's derived DID document (uncached) and report whether it already
+     * advertises `newPublicKey` as a verification method — i.e. whether the swap
+     * already landed server-side. A failed probe returns `false` (unconfirmed),
+     * so the caller surfaces the original network error.
+     *
+     * Uses the DID document rather than `GET /auth/methods` because the latter
+     * intentionally does NOT expose raw public keys, whereas the DID's
+     * `verificationMethod[].publicKeyHex` is derived live from the account's
+     * current key — so it reflects a completed rotation immediately.
+     *
+     * Internal helper (leading underscore); public rather than `private` for the
+     * same TS4094 reason as {@link _invalidateIdentityCaches}.
+     */
+    async _rotationAlreadyApplied(userId: string, newPublicKey: string): Promise<boolean> {
+      return this.makeRequest<DidDocument>(
+        'GET',
+        `/u/${encodeURIComponent(userId)}/did.json`,
+        undefined,
+        { cache: false },
+      )
+        .then((doc) =>
+          doc.verificationMethod.some(
+            (vm) =>
+              'publicKeyHex' in vm &&
+              typeof vm.publicKeyHex === 'string' &&
+              vm.publicKeyHex.toLowerCase() === newPublicKey.toLowerCase(),
+          ),
+        )
+        .catch(() => false);
     }
 
     /**

--- a/packages/core/src/mixins/OxyServices.identity.ts
+++ b/packages/core/src/mixins/OxyServices.identity.ts
@@ -40,6 +40,7 @@ import { KeyManager } from '../crypto/keyManager';
 import { SignatureService } from '../crypto/signatureService';
 import { RecoveryPhraseService, type PendingIdentityResult } from '../crypto/recoveryPhrase';
 import { isWeb } from '../utils/platform';
+import { logger } from '../logger';
 import { CACHE_TIMES } from './mixinHelpers';
 
 /**
@@ -140,6 +141,13 @@ export interface RotateKeyResult {
   newPhrase: string;
   /** The recovery phrase split into its individual words. */
   words: string[];
+  /**
+   * Present (and `true`) only when the server rotated successfully but the new
+   * key could NOT be persisted on-device. The account key IS the new one
+   * server-side, so the user must re-import it from `newPhrase`; the caller
+   * should surface a recovery prompt. Omitted on full success.
+   */
+  localPersistFailed?: true;
 }
 
 /**
@@ -372,8 +380,11 @@ export function OxyServicesIdentityMixin<T extends typeof OxyServicesBase>(Base:
           { cache: false },
         );
 
-        // 4. Sign the rotation proof with the OLD key. The signed bytes MUST match
-        //    the server's reconstruction exactly (this key order).
+        // 4. Sign the rotation proofs. The OLD key proves control of the key being
+        //    replaced; the NEW key proves possession of the key being rotated in
+        //    (so the server never accepts a re-encoding of a key the caller does
+        //    not control). Both signed byte strings MUST match the server's
+        //    reconstruction exactly (this key order).
         const timestamp = Date.now();
         const message = JSON.stringify({
           action: 'rotate_key',
@@ -384,6 +395,14 @@ export function OxyServicesIdentityMixin<T extends typeof OxyServicesBase>(Base:
           timestamp,
         });
         const signature = await signWithOldKey(message);
+        const newKeyMessage = JSON.stringify({
+          action: 'rotate_key_new',
+          userId,
+          newPublicKey,
+          challenge,
+          timestamp,
+        });
+        const newKeyProof = await signMessage(newKeyMessage, pending.privateKey);
 
         // 5. Complete the rotation. On an AMBIGUOUS failure, reconcile against the
         //    DID before deciding the rotation failed.
@@ -396,6 +415,7 @@ export function OxyServicesIdentityMixin<T extends typeof OxyServicesBase>(Base:
               newPublicKey,
               challenge,
               signature,
+              newKeyProof,
               timestamp,
               ...(options.signOutEverywhere ? { signOutEverywhere: true } : {}),
             },
@@ -419,13 +439,31 @@ export function OxyServicesIdentityMixin<T extends typeof OxyServicesBase>(Base:
         //    atomic persist path (backs the previous key up first). Native-only —
         //    on web the key never lived in SecureStore, so there is nothing to
         //    persist locally.
+        //
+        //    If this local write fails the server key is ALREADY the new one, so
+        //    we must NOT throw and swallow the phrase — the caller needs it to
+        //    re-import the now-live key. Surface the result with
+        //    `localPersistFailed: true` (mirrors the pendingIdentity
+        //    show-phrase-first path, where the caller already holds the phrase).
+        let localPersistFailed = false;
         if (!isWeb()) {
-          await KeyManager.importKeyPair(pending.privateKey, { overwrite: true });
+          try {
+            await KeyManager.importKeyPair(pending.privateKey, { overwrite: true });
+          } catch (persistError) {
+            localPersistFailed = true;
+            logger.warn(
+              'Key rotated on the server but persisting the new key on-device failed; returning the new phrase so it can be re-imported.',
+              { component: 'OxyServices.identity', method: 'rotateKey' },
+              persistError,
+            );
+          }
         }
 
         this._invalidateIdentityCaches(userId);
 
-        return { newPublicKey, newPhrase: pending.phrase, words: pending.words };
+        return localPersistFailed
+          ? { newPublicKey, newPhrase: pending.phrase, words: pending.words, localPersistFailed: true }
+          : { newPublicKey, newPhrase: pending.phrase, words: pending.words };
       } catch (error) {
         throw this.handleError(error);
       }

--- a/packages/core/src/mixins/__tests__/OxyServices.rotateKey.test.ts
+++ b/packages/core/src/mixins/__tests__/OxyServices.rotateKey.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Key-rotation mixin tests (b3 Feature 3).
+ *
+ * Cover the client orchestration of `oxy.identity.rotateKey(...)`:
+ *  - the EXACT signed rotation payload (must match the server's reconstruction
+ *    byte-for-byte);
+ *  - device-proof signs with the on-device key; phrase-proof re-derives and
+ *    signs with the OLD key (proving the last credential can be replaced);
+ *  - the safety ordering (local key persisted ONLY after server confirmation);
+ *  - the ambiguous-network-failure reconciliation against the DID document.
+ *
+ * `makeRequest` is stubbed so the tests run with no network. The real
+ * secp256k1 signing runs in the phrase-proof test so we can cryptographically
+ * assert which key produced the signature.
+ */
+
+import type { DidDocument } from '@oxyhq/contracts';
+import { verifySignature } from '@oxyhq/protocol';
+import { OxyServices } from '../../OxyServices';
+import { KeyManager } from '../../crypto/keyManager';
+import { SignatureService } from '../../crypto/signatureService';
+import { RecoveryPhraseService } from '../../crypto/recoveryPhrase';
+import { setPlatformOS } from '../../utils/platform';
+
+const OLD_PUBLIC = 'oldpub-hex';
+const NEW_PUBLIC = 'newpub-hex';
+
+const pendingFixture = {
+  phrase: 'alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima',
+  words: ['alpha', 'bravo', 'charlie', 'delta', 'echo', 'foxtrot', 'golf', 'hotel', 'india', 'juliet', 'kilo', 'lima'],
+  privateKey: 'newpriv-hex',
+  publicKey: NEW_PUBLIC,
+};
+
+function didDocWithKey(publicKeyHex: string): DidDocument {
+  return {
+    '@context': ['https://www.w3.org/ns/did/v1'],
+    id: 'did:web:oxy.so:u:user-123',
+    controller: ['did:web:oxy.so:u:user-123', 'did:web:oxy.so'],
+    verificationMethod: [
+      {
+        id: 'did:web:oxy.so:u:user-123#key-1',
+        type: 'EcdsaSecp256k1VerificationKey2019',
+        controller: 'did:web:oxy.so:u:user-123',
+        publicKeyHex,
+      },
+    ],
+    authentication: ['did:web:oxy.so:u:user-123#key-1'],
+    assertionMethod: ['did:web:oxy.so:u:user-123#key-1'],
+    alsoKnownAs: [],
+    service: [],
+  };
+}
+
+describe('OxyServices.rotateKey', () => {
+  let oxy: OxyServices;
+  let makeRequestSpy: jest.SpyInstance;
+  let clearEntrySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    setPlatformOS('ios'); // native → the new key is persisted locally after success
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequestSpy = jest.spyOn(oxy, 'makeRequest');
+    jest.spyOn(oxy, 'clearCacheByPrefix').mockReturnValue(0);
+    clearEntrySpy = jest.spyOn(oxy, 'clearCacheEntry').mockReturnValue(undefined);
+    jest.spyOn(oxy, 'getCurrentUserId').mockReturnValue('user-123');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('device proof', () => {
+    it('signs the exact rotation payload, POSTs challenge→complete, then persists the new key locally', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
+      jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
+      const signSpy = jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+      const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
+      makeRequestSpy
+        .mockResolvedValueOnce({ challenge: 'chal-1', expiresAt: '2999-01-01T00:00:00.000Z' })
+        .mockResolvedValueOnce({ success: true, publicKey: NEW_PUBLIC, message: 'ok' });
+
+      const result = await oxy.rotateKey({ proof: 'device' });
+
+      expect(result).toEqual({ newPublicKey: NEW_PUBLIC, newPhrase: pendingFixture.phrase, words: pendingFixture.words });
+
+      // The signed message MUST match the server's reconstruction byte-for-byte.
+      const expectedMessage = JSON.stringify({
+        action: 'rotate_key',
+        userId: 'user-123',
+        oldPublicKey: OLD_PUBLIC,
+        newPublicKey: NEW_PUBLIC,
+        challenge: 'chal-1',
+        timestamp: 1700000000000,
+      });
+      expect(signSpy).toHaveBeenCalledWith(expectedMessage);
+
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(1, 'POST', '/auth/rotate/challenge', undefined, expect.objectContaining({ cache: false }));
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        2,
+        'POST',
+        '/auth/rotate/complete',
+        { newPublicKey: NEW_PUBLIC, challenge: 'chal-1', signature: 'sig-hex', timestamp: 1700000000000 },
+        expect.objectContaining({ cache: false }),
+      );
+
+      // Persisted ONLY after the server confirmed the swap.
+      expect(importSpy).toHaveBeenCalledWith('newpriv-hex', { overwrite: true });
+      // DID + auth-method caches are swept.
+      expect(clearEntrySpy).toHaveBeenCalledWith('GET:/u/user-123/did.json');
+      expect(clearEntrySpy).toHaveBeenCalledWith('GET:/auth/methods');
+    });
+
+    it('forwards signOutEverywhere in the complete body', async () => {
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
+      jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
+      jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+      jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
+      makeRequestSpy
+        .mockResolvedValueOnce({ challenge: 'chal-1', expiresAt: '2999-01-01T00:00:00.000Z' })
+        .mockResolvedValueOnce({ success: true, publicKey: NEW_PUBLIC, message: 'ok' });
+
+      await oxy.rotateKey({ proof: 'device', signOutEverywhere: true });
+
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(
+        2,
+        'POST',
+        '/auth/rotate/complete',
+        expect.objectContaining({ signOutEverywhere: true }),
+        expect.anything(),
+      );
+    });
+
+    it('throws (no network) when the device holds no identity', async () => {
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
+      jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(null);
+
+      await expect(oxy.rotateKey({ proof: 'device' })).rejects.toThrow(/No on-device identity/);
+      expect(makeRequestSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('phrase proof (replace the LAST credential)', () => {
+    it('re-derives the CURRENT key from the entered phrase and signs the proof with it', async () => {
+      // A real "current" identity whose phrase the user re-enters, and a real new one.
+      const current = await RecoveryPhraseService.derivePendingIdentity();
+      const next = await RecoveryPhraseService.derivePendingIdentity();
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(next);
+      jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(next.publicKey);
+
+      let completeBody: Record<string, unknown> | undefined;
+      makeRequestSpy.mockImplementation((_m: string, path: string, body?: unknown) => {
+        if (path === '/auth/rotate/challenge') return Promise.resolve({ challenge: 'chal-x', expiresAt: '2999-01-01T00:00:00.000Z' });
+        if (path === '/auth/rotate/complete') {
+          completeBody = body as Record<string, unknown>;
+          return Promise.resolve({ success: true, publicKey: next.publicKey, message: 'ok' });
+        }
+        return Promise.reject(new Error(`unexpected ${path}`));
+      });
+
+      const result = await oxy.rotateKey({ proof: 'phrase', phrase: current.phrase });
+      expect(result.newPublicKey).toBe(next.publicKey);
+
+      // The signature MUST verify against the OLD key over the exact reconstructed message.
+      const message = JSON.stringify({
+        action: 'rotate_key',
+        userId: 'user-123',
+        oldPublicKey: current.publicKey,
+        newPublicKey: next.publicKey,
+        challenge: 'chal-x',
+        timestamp: completeBody?.timestamp,
+      });
+      expect(await verifySignature(message, completeBody?.signature as string, current.publicKey)).toBe(true);
+      // …and must NOT verify against the new key (proves it was signed by the current key).
+      expect(await verifySignature(message, completeBody?.signature as string, next.publicKey)).toBe(false);
+    });
+
+    it('throws when proof is phrase but no phrase is supplied', async () => {
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
+      await expect(oxy.rotateKey({ proof: 'phrase' })).rejects.toThrow(/recovery phrase is required/);
+      expect(makeRequestSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ambiguous network failure', () => {
+    it('reconciles a lost complete-response against the DID and treats a landed swap as done', async () => {
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
+      jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
+      jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+      const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
+      makeRequestSpy
+        .mockResolvedValueOnce({ challenge: 'chal-1', expiresAt: '2999-01-01T00:00:00.000Z' })
+        .mockRejectedValueOnce(new Error('network lost'))
+        .mockResolvedValueOnce(didDocWithKey(NEW_PUBLIC)); // DID already advertises the new key
+
+      const result = await oxy.rotateKey({ proof: 'device' });
+
+      expect(result.newPublicKey).toBe(NEW_PUBLIC);
+      expect(makeRequestSpy).toHaveBeenNthCalledWith(3, 'GET', '/u/user-123/did.json', undefined, expect.objectContaining({ cache: false }));
+      // The swap landed server-side, so the new key is persisted locally.
+      expect(importSpy).toHaveBeenCalledWith('newpriv-hex', { overwrite: true });
+    });
+
+    it('surfaces the error and does NOT persist locally when the DID shows the swap did not land', async () => {
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
+      jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
+      jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+      const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
+      makeRequestSpy
+        .mockResolvedValueOnce({ challenge: 'chal-1', expiresAt: '2999-01-01T00:00:00.000Z' })
+        .mockRejectedValueOnce(new Error('network lost'))
+        .mockResolvedValueOnce(didDocWithKey(OLD_PUBLIC)); // DID still shows the OLD key
+
+      await expect(oxy.rotateKey({ proof: 'device' })).rejects.toBeDefined();
+      expect(importSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/mixins/__tests__/OxyServices.rotateKey.test.ts
+++ b/packages/core/src/mixins/__tests__/OxyServices.rotateKey.test.ts
@@ -6,16 +6,19 @@
  *    byte-for-byte);
  *  - device-proof signs with the on-device key; phrase-proof re-derives and
  *    signs with the OLD key (proving the last credential can be replaced);
+ *  - BOTH proofs are sent: the OLD key signs `rotate_key`, the NEW key signs the
+ *    `rotate_key_new` proof-of-possession;
  *  - the safety ordering (local key persisted ONLY after server confirmation);
+ *  - the local-persist failure path still surfaces the new phrase;
  *  - the ambiguous-network-failure reconciliation against the DID document.
  *
  * `makeRequest` is stubbed so the tests run with no network. The real
  * secp256k1 signing runs in the phrase-proof test so we can cryptographically
- * assert which key produced the signature.
+ * assert which key produced each signature.
  */
 
 import type { DidDocument } from '@oxyhq/contracts';
-import { verifySignature } from '@oxyhq/protocol';
+import * as protocol from '@oxyhq/protocol';
 import { OxyServices } from '../../OxyServices';
 import { KeyManager } from '../../crypto/keyManager';
 import { SignatureService } from '../../crypto/signatureService';
@@ -76,6 +79,8 @@ describe('OxyServices.rotateKey', () => {
       jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
       jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
       const signSpy = jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+      // The new-key proof is signed with the pending private key via protocol.signMessage.
+      const newKeySignSpy = jest.spyOn(protocol, 'signMessage').mockResolvedValue('newkeyproof-hex');
       const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
       makeRequestSpy
         .mockResolvedValueOnce({ challenge: 'chal-1', expiresAt: '2999-01-01T00:00:00.000Z' })
@@ -85,7 +90,7 @@ describe('OxyServices.rotateKey', () => {
 
       expect(result).toEqual({ newPublicKey: NEW_PUBLIC, newPhrase: pendingFixture.phrase, words: pendingFixture.words });
 
-      // The signed message MUST match the server's reconstruction byte-for-byte.
+      // The OLD-key signed message MUST match the server's reconstruction byte-for-byte.
       const expectedMessage = JSON.stringify({
         action: 'rotate_key',
         userId: 'user-123',
@@ -95,13 +100,22 @@ describe('OxyServices.rotateKey', () => {
         timestamp: 1700000000000,
       });
       expect(signSpy).toHaveBeenCalledWith(expectedMessage);
+      // The NEW-key proof is signed with the pending private key over rotate_key_new.
+      const expectedNewKeyMessage = JSON.stringify({
+        action: 'rotate_key_new',
+        userId: 'user-123',
+        newPublicKey: NEW_PUBLIC,
+        challenge: 'chal-1',
+        timestamp: 1700000000000,
+      });
+      expect(newKeySignSpy).toHaveBeenCalledWith(expectedNewKeyMessage, 'newpriv-hex');
 
       expect(makeRequestSpy).toHaveBeenNthCalledWith(1, 'POST', '/auth/rotate/challenge', undefined, expect.objectContaining({ cache: false }));
       expect(makeRequestSpy).toHaveBeenNthCalledWith(
         2,
         'POST',
         '/auth/rotate/complete',
-        { newPublicKey: NEW_PUBLIC, challenge: 'chal-1', signature: 'sig-hex', timestamp: 1700000000000 },
+        { newPublicKey: NEW_PUBLIC, challenge: 'chal-1', signature: 'sig-hex', newKeyProof: 'newkeyproof-hex', timestamp: 1700000000000 },
         expect.objectContaining({ cache: false }),
       );
 
@@ -116,6 +130,7 @@ describe('OxyServices.rotateKey', () => {
       jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
       jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
       jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+      jest.spyOn(protocol, 'signMessage').mockResolvedValue('newkeyproof-hex');
       jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
       makeRequestSpy
         .mockResolvedValueOnce({ challenge: 'chal-1', expiresAt: '2999-01-01T00:00:00.000Z' })
@@ -127,9 +142,33 @@ describe('OxyServices.rotateKey', () => {
         2,
         'POST',
         '/auth/rotate/complete',
-        expect.objectContaining({ signOutEverywhere: true }),
+        expect.objectContaining({ signOutEverywhere: true, newKeyProof: 'newkeyproof-hex' }),
         expect.anything(),
       );
+    });
+
+    it('does NOT throw and surfaces the new phrase when the local key persist fails after a server rotation', async () => {
+      jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
+      jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
+      jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+      jest.spyOn(protocol, 'signMessage').mockResolvedValue('newkeyproof-hex');
+      // The server rotated successfully, but the on-device persist fails.
+      jest.spyOn(KeyManager, 'importKeyPair').mockRejectedValue(new Error('secure store write failed'));
+      makeRequestSpy
+        .mockResolvedValueOnce({ challenge: 'chal-1', expiresAt: '2999-01-01T00:00:00.000Z' })
+        .mockResolvedValueOnce({ success: true, publicKey: NEW_PUBLIC, message: 'ok' });
+
+      const result = await oxy.rotateKey({ proof: 'device' });
+
+      // The phrase for the now-live key is surfaced, with a failure flag — never lost.
+      expect(result).toEqual({
+        newPublicKey: NEW_PUBLIC,
+        newPhrase: pendingFixture.phrase,
+        words: pendingFixture.words,
+        localPersistFailed: true,
+      });
+      // Caches are still swept (the server key is the new one).
+      expect(clearEntrySpy).toHaveBeenCalledWith('GET:/u/user-123/did.json');
     });
 
     it('throws (no network) when the device holds no identity', async () => {
@@ -162,7 +201,7 @@ describe('OxyServices.rotateKey', () => {
       const result = await oxy.rotateKey({ proof: 'phrase', phrase: current.phrase });
       expect(result.newPublicKey).toBe(next.publicKey);
 
-      // The signature MUST verify against the OLD key over the exact reconstructed message.
+      // The OLD-key signature MUST verify against the current key over the exact message.
       const message = JSON.stringify({
         action: 'rotate_key',
         userId: 'user-123',
@@ -171,9 +210,21 @@ describe('OxyServices.rotateKey', () => {
         challenge: 'chal-x',
         timestamp: completeBody?.timestamp,
       });
-      expect(await verifySignature(message, completeBody?.signature as string, current.publicKey)).toBe(true);
+      expect(await protocol.verifySignature(message, completeBody?.signature as string, current.publicKey)).toBe(true);
       // …and must NOT verify against the new key (proves it was signed by the current key).
-      expect(await verifySignature(message, completeBody?.signature as string, next.publicKey)).toBe(false);
+      expect(await protocol.verifySignature(message, completeBody?.signature as string, next.publicKey)).toBe(false);
+
+      // The NEW-key proof-of-possession MUST verify against the NEW key.
+      const newKeyMessage = JSON.stringify({
+        action: 'rotate_key_new',
+        userId: 'user-123',
+        newPublicKey: next.publicKey,
+        challenge: 'chal-x',
+        timestamp: completeBody?.timestamp,
+      });
+      expect(await protocol.verifySignature(newKeyMessage, completeBody?.newKeyProof as string, next.publicKey)).toBe(true);
+      // …and must NOT verify against the old key (proves possession of the new key).
+      expect(await protocol.verifySignature(newKeyMessage, completeBody?.newKeyProof as string, current.publicKey)).toBe(false);
     });
 
     it('throws when proof is phrase but no phrase is supplied', async () => {
@@ -187,6 +238,7 @@ describe('OxyServices.rotateKey', () => {
     it('reconciles a lost complete-response against the DID and treats a landed swap as done', async () => {
       jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
       jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
+      jest.spyOn(protocol, 'signMessage').mockResolvedValue('newkeyproof-hex');
       jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
       const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
       makeRequestSpy
@@ -205,6 +257,7 @@ describe('OxyServices.rotateKey', () => {
     it('surfaces the error and does NOT persist locally when the DID shows the swap did not land', async () => {
       jest.spyOn(RecoveryPhraseService, 'derivePendingIdentity').mockResolvedValue(pendingFixture);
       jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(OLD_PUBLIC);
+      jest.spyOn(protocol, 'signMessage').mockResolvedValue('newkeyproof-hex');
       jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
       const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue(NEW_PUBLIC);
       makeRequestSpy


### PR DESCRIPTION
## b3 Feature 3 — key rotation + last-credential replacement (BACKEND slice)

The security-critical, verifiable-here part (contracts + core + api). The Commons native UI (rotate-key screens) is a **separate follow-up slice** and is NOT in this PR.

Rotation is an **atomic REPLACE** of the single identity key — never remove-then-add — so it never passes through `countAuthMethods() === 0` and is independent of the unlink guards in `authLinking.ts`. Because control of the current key is *proven* (SecureStore in `device` mode, or a recovery-phrase re-derivation in `phrase` mode), even the **last remaining credential** can be replaced.

### contracts (`packages/contracts`)
- `src/keyRotation.ts`: `rotateKeyChallengeResponseSchema`, `rotateKeyCompleteRequestSchema`, `rotateKeyCompleteResponseSchema` + inferred types; exported from `index.ts`. Internal `workspace:*` — **no npm publish in this PR**.

### api (`packages/api`)
- `models/AuthChallenge.ts`: additive `purpose: String` (default `'signin'`) — non-breaking.
- `routes/authLinking.ts`:
  - `POST /auth/rotate/challenge` (bearer, `rl:identity:rotate:challenge:`) — mints a `purpose:'rotate_key'` `AuthChallenge` bound to the account's current key.
  - `POST /auth/rotate/complete` (bearer, `rl:identity:rotate:complete:`) — (1) derives `oldPublicKey` **from the user doc, never the request**; (2) **atomically burns** the purpose-scoped, key-bound challenge; (3) verifies the signature over `JSON.stringify({action:'rotate_key', userId, oldPublicKey, newPublicKey, challenge, timestamp})` against the CURRENT key (same primitive `/auth/link` uses); (4) rejects a `newPublicKey` already registered elsewhere; (5) swaps `user.publicKey` **and** replaces the single `authMethods` identity entry in place (array length unchanged). Invalidates `userCache`. Optional `signOutEverywhere` revokes other sessions. DID needs **zero migration** (derived live).

### core (`packages/core`)
- `crypto/recoveryPhrase.ts`: `derivePendingIdentity()` + `derivePrivateKeyFromPhrase()` — pure, **non-persisting** derivation.
- `mixins/OxyServices.identity.ts`: `rotateKey({ proof, phrase?, signOutEverywhere?, pendingIdentity? })` — derive new identity → sign with old key → challenge/complete → `KeyManager.importKeyPair(overwrite)` **only after server confirmation**. Ambiguous-network-failure guard reconciles against the derived DID (which carries `publicKeyHex`) before surfacing the error.

## Security invariants (proven by tests)
- `oldPublicKey` is always server-derived from the user doc; a client-supplied `oldPublicKey` is ignored and a signature from a different key is rejected (400).
- The `rotate_key` challenge is **purpose-scoped** (a signin challenge can never complete a rotation → 401) and **single-use** (atomic burn).
- Rotation is atomic: `authMethods` length is unchanged (never a `countAuthMethods()===0` window).
- `newPublicKey` already registered → 409; rotating to the same key → 400.
- `userCache.invalidate` fires; the derived DID reflects the new key immediately.
- KeyManager fault injection: fail the primary write *after* the server swap → the old key is still recoverable from backup.

## Verification
- api `tsc --noEmit` clean; full `bun run test` green (**1568** pass, 169 suites).
- core build + tsc + tests green (**891** pass); contracts build + tests green (**133** pass).

## Reviewer notes / follow-ups
- **(a) A `security-reviewer` pass is needed before merge** — atomic swap + last-credential replacement + challenge-burn ordering.
- **(b) The Commons rotate-key UI is the follow-up slice** (not in this PR).
- **(c) `@oxyhq/contracts` needs republish-first at merge time** (before the core/api consumers) so the new schemas are available to any external consumer.
- Deviation from the blueprint's literal wording: the ambiguous-retry reconciliation checks the **derived DID document** rather than `GET /auth/methods`, because the auth-methods contract intentionally does NOT expose raw public keys, whereas the DID's `verificationMethod[].publicKeyHex` is derived live and reflects a completed rotation immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)