### PR TITLE
feat(services): surface OxyAuthChooser errors as Bloom toasts, not inline banners

### DIFF
--- a/packages/core/src/i18n/locales/en-US.json
+++ b/packages/core/src/i18n/locales/en-US.json
@@ -72,6 +72,9 @@
     "backToSignInLink": "Already have an account? Sign in",
     "hubExplainer": "Create your Oxy ID in a secure window, then come right back.",
     "continueInWindow": "Continue in a new window",
+    "toasts": {
+      "passkeyCreateFailed": "We couldn't create your account. Please try again."
+    },
     "welcome": {
       "title": "Welcome to Oxy!",
       "subtitle": "Let's create your account in just a few steps",
@@ -374,6 +377,7 @@
     "toasts": {
       "switchSuccess": "Account switched successfully!",
       "switchFailed": "There was a problem switching accounts. Please try again.",
+      "passkeySignInFailed": "Passkey sign-in failed. Please try again.",
       "removeSuccess": "Account removed successfully!",
       "removeFailed": "There was a problem removing the account. Please try again.",
       "signOutAllSuccess": "All accounts signed out successfully!",

--- a/packages/core/src/i18n/locales/es-ES.json
+++ b/packages/core/src/i18n/locales/es-ES.json
@@ -72,6 +72,9 @@
     "backToSignInLink": "¿Ya tienes cuenta? Inicia sesión",
     "hubExplainer": "Crea tu Oxy ID en una ventana segura y vuelve enseguida.",
     "continueInWindow": "Continuar en una ventana nueva",
+    "toasts": {
+      "passkeyCreateFailed": "No pudimos crear tu cuenta. Inténtalo de nuevo."
+    },
     "welcome": {
       "title": "¡Te damos la bienvenida a Oxy!",
       "subtitle": "Crea tu cuenta en pocos pasos",
@@ -572,6 +575,7 @@
     "toasts": {
       "switchSuccess": "¡Cuenta cambiada correctamente!",
       "switchFailed": "Hubo un problema al cambiar de cuenta. Inténtalo de nuevo.",
+      "passkeySignInFailed": "No se pudo iniciar sesión con la llave de acceso. Inténtalo de nuevo.",
       "removeSuccess": "¡Cuenta eliminada correctamente!",
       "removeFailed": "Hubo un problema al eliminar la cuenta. Inténtalo de nuevo.",
       "signOutAllSuccess": "¡Todas las cuentas cerradas correctamente!",

--- a/packages/services/__tests__/components/OxyAuthChooser.test.tsx
+++ b/packages/services/__tests__/components/OxyAuthChooser.test.tsx
@@ -10,9 +10,17 @@
  * (`signInWithPasskey`/`registerWithPasskey`), routed through the auth.oxy.so
  * hub popup elsewhere (`controller.startPasskeyHubSignIn`, b2). The
  * controller's own state machine + projection are unit-tested in `@oxyhq/core`.
+ *
+ * Error-surfacing contract (owner mandate: NO error renders inline inside the
+ * dialog): every failure — account-switch, passkey sign-in ceremony, passkey
+ * account creation, username-availability check — fires a Bloom `toast.error(...)`
+ * at the point of failure and paints NO inline banner/text. The `toast` here is
+ * the shared `@oxyhq/bloom` jest.fn mock; the removed inline `ErrorBanner` is
+ * asserted absent.
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { toast } from '@oxyhq/bloom';
 import type { AccountDialogSnapshot, SwitchableAccount, User } from '@oxyhq/core';
 
 const makeUser = (id: string): User => ({ id, username: id, name: { displayName: id } } as unknown as User);
@@ -134,21 +142,45 @@ describe('OxyAuthChooser', () => {
     expect(screen.getByText('Add another account')).toBeTruthy();
   });
 
-  it('renders a blocked/failed switch error in the accounts view (carried in from fix/account-switch)', () => {
-    snapshot = makeSnapshot({ error: 'Could not switch accounts. Please try again.' });
+  it('toasts a failed account switch instead of rendering an inline banner', async () => {
+    snapshot = makeSnapshot({
+      activeAccountId: 'a',
+      accounts: [
+        makeAccount({ accountId: 'a', displayName: 'Alice', isCurrent: true, sessionId: 's-a' }),
+        makeAccount({ accountId: 'b', displayName: 'Bob', sessionId: 's-b' }),
+      ],
+    });
+    // `switchTo` never throws — it records the failure on the controller's
+    // snapshot, which the chooser reads back at the point the switch settles.
+    controller.switchTo.mockImplementationOnce(async () => {
+      snapshot = makeSnapshot({ ...snapshot, error: 'Account switch did not return a valid session' });
+    });
 
     render(<OxyAuthChooser />);
+    fireEvent.click(screen.getByRole('button', { name: 'Bob' }));
 
-    expect(screen.getByText('Could not switch accounts. Please try again.')).toBeTruthy();
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        'There was a problem switching accounts. Please try again.',
+      ),
+    );
+    // The failure is a toast — never inline text (neither the friendly copy nor
+    // the raw controller error string is painted in the dialog body), and the
+    // success side effects never run.
+    expect(screen.queryByText('There was a problem switching accounts. Please try again.')).toBeNull();
+    expect(screen.queryByText('Account switch did not return a valid session')).toBeNull();
+    expect(invalidateQueries).not.toHaveBeenCalled();
   });
 
-  it('renders the account-list error in the sign-in view too', () => {
+  it('does not render an inline error banner in the accounts or sign-in views (errors go to toasts)', () => {
     isWebBrowserMock.mockReturnValue(false); // stay on signin, no auto-start to qr
     snapshot = makeSnapshot({ view: 'signin', error: 'Something went wrong.' });
 
     render(<OxyAuthChooser />);
 
-    expect(screen.getByText('Something went wrong.')).toBeTruthy();
+    // A `snapshot.error` no longer paints an inline banner anywhere — the
+    // account-switch failure it represents is surfaced as a toast at the call site.
+    expect(screen.queryByText('Something went wrong.')).toBeNull();
   });
 
   it('switches through controller.switchTo when a non-active row is tapped', async () => {
@@ -165,6 +197,8 @@ describe('OxyAuthChooser', () => {
 
     await waitFor(() => expect(controller.switchTo).toHaveBeenCalledWith('b'));
     expect(invalidateQueries).toHaveBeenCalled();
+    // A successful switch fires no error toast.
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it('auto-starts the device flow on web the instant the sign-in entry is reached — no click needed', () => {
@@ -245,6 +279,20 @@ describe('OxyAuthChooser', () => {
       await waitFor(() => expect(closeAccountDialog).not.toHaveBeenCalled()); // onComplete is not wired without a host
     });
 
+    it('toasts the ceremony error (never inline) when the direct passkey sign-in fails', async () => {
+      signInWithPasskey.mockRejectedValueOnce(new Error('The passkey request was cancelled.'));
+      snapshot = qrSnapshot();
+      render(<OxyAuthChooser />);
+
+      fireEvent.click(screen.getByTestId('passkey-signin-link'));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith('The passkey request was cancelled.'),
+      );
+      // The QR view keeps its own state; the failure never renders inline.
+      expect(screen.queryByText('The passkey request was cancelled.')).toBeNull();
+    });
+
     it('still offers the link on a non-Oxy origin, alongside the QR (b2 hub popup)', () => {
       isOxyRpOriginMock.mockReturnValue(false);
       snapshot = qrSnapshot();
@@ -281,6 +329,38 @@ describe('OxyAuthChooser', () => {
 
       fireEvent.click(screen.getByTestId('signup-create-button'));
       await waitFor(() => expect(registerWithPasskey).toHaveBeenCalledWith({ username: 'newuser' }));
+    });
+
+    it('toasts (never inline) when the username-availability check fails', async () => {
+      checkUsernameAvailability.mockRejectedValueOnce(new Error('network'));
+      snapshot = makeSnapshot({ view: 'signup' });
+      render(<OxyAuthChooser />);
+
+      fireEvent.change(screen.getByTestId('signup-username-input'), { target: { value: 'newuser' } });
+
+      await waitFor(
+        () => expect(toast.error).toHaveBeenCalledWith('Could not check availability'),
+        { timeout: 1000 },
+      );
+      // The availability indicator (checking/available/taken) stays inline; only
+      // the network ERROR moves to a toast — no inline error text is painted.
+      expect(screen.queryByText('Could not check availability')).toBeNull();
+    });
+
+    it('toasts when passkey account creation fails (after the username resolves available)', async () => {
+      registerWithPasskey.mockRejectedValueOnce(new Error('Passkey attestation rejected.'));
+      snapshot = makeSnapshot({ view: 'signup' });
+      render(<OxyAuthChooser />);
+
+      fireEvent.change(screen.getByTestId('signup-username-input'), { target: { value: 'newuser' } });
+      await waitFor(
+        () => expect((screen.getByTestId('signup-create-button') as HTMLButtonElement).disabled).toBe(false),
+        { timeout: 1000 },
+      );
+
+      fireEvent.click(screen.getByTestId('signup-create-button'));
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Passkey attestation rejected.'));
     });
 
     it('offers the auth.oxy.so hub popup (b2) on a non-Oxy web origin, instead of the direct passkey form', () => {

--- a/packages/services/src/ui/components/OxyAuthChooser.tsx
+++ b/packages/services/src/ui/components/OxyAuthChooser.tsx
@@ -61,6 +61,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import QRCode from 'react-native-qrcode-svg';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import { Button } from '@oxyhq/bloom/button';
+import { toast } from '@oxyhq/bloom';
 import { Text } from '@oxyhq/bloom/typography';
 import {
   useTheme,
@@ -154,44 +155,45 @@ const OxyAuthChooser: React.FC<OxyAuthChooserProps> = ({ onComplete }) => {
   const passkeyAvailable = passkeyMode !== 'none';
 
   const [signInPasskeyPending, setSignInPasskeyPending] = useState(false);
-  const [signInPasskeyError, setSignInPasskeyError] = useState<string | null>(null);
   const handleSignInWithPasskey = useCallback(async () => {
     if (signInPasskeyPending) return;
     setSignInPasskeyPending(true);
-    setSignInPasskeyError(null);
     try {
       await signInWithPasskey();
       onComplete?.();
     } catch (error) {
       // A cancelled/failed ceremony keeps the view open so the user can retry
-      // or fall back to the QR — surface a concise message, never swallow.
-      setSignInPasskeyError(
-        error instanceof Error && error.message ? error.message : 'Passkey sign-in failed.',
+      // or fall back to the QR — surface the reason as a toast (owner mandate:
+      // errors never render inline inside the dialog), never swallow.
+      toast.error(
+        error instanceof Error && error.message
+          ? error.message
+          : t('accountSwitcher.toasts.passkeySignInFailed') || 'Passkey sign-in failed.',
       );
     } finally {
       setSignInPasskeyPending(false);
     }
-  }, [signInPasskeyPending, signInWithPasskey, onComplete]);
+  }, [signInPasskeyPending, signInWithPasskey, onComplete, t]);
 
   const [createPasskeyPending, setCreatePasskeyPending] = useState(false);
-  const [createPasskeyError, setCreatePasskeyError] = useState<string | null>(null);
   const handleCreateWithPasskey = useCallback(
     async (username: string) => {
       if (createPasskeyPending) return;
       setCreatePasskeyPending(true);
-      setCreatePasskeyError(null);
       try {
         await registerWithPasskey({ username });
         onComplete?.();
       } catch (error) {
-        setCreatePasskeyError(
-          error instanceof Error && error.message ? error.message : 'Account creation failed.',
+        toast.error(
+          error instanceof Error && error.message
+            ? error.message
+            : t('signup.toasts.passkeyCreateFailed') || 'Account creation failed.',
         );
       } finally {
         setCreatePasskeyPending(false);
       }
     },
-    [createPasskeyPending, registerWithPasskey, onComplete],
+    [createPasskeyPending, registerWithPasskey, onComplete, t],
   );
 
   // Bind the headless controller. `getSnapshot` returns a stable reference
@@ -234,20 +236,28 @@ const OxyAuthChooser: React.FC<OxyAuthChooserProps> = ({ onComplete }) => {
       setSwitching(true);
       try {
         await controller.switchTo(accountId);
-        // A switch succeeds unless the controller recorded an error. On success
-        // reload the app's account graph and drop cached account-scoped data so
-        // the new active identity re-fetches — the same side effects the
-        // context's own `switchToAccount` performs.
-        if (!controller.getSnapshot().error) {
-          void refreshAccounts();
-          queryClient.invalidateQueries();
-          onComplete?.();
+        // `switchTo` never throws — it records a failure on the controller's
+        // snapshot. Read it back at the point the switch settles and surface it
+        // as a toast (event-driven, at the failure site — NOT an inline banner
+        // and NOT a snapshot-reaction). On success reload the app's account
+        // graph and drop cached account-scoped data so the new active identity
+        // re-fetches — the same side effects the context's own
+        // `switchToAccount` performs.
+        if (controller.getSnapshot().error) {
+          toast.error(
+            t('accountSwitcher.toasts.switchFailed') ||
+              'There was a problem switching accounts. Please try again.',
+          );
+          return;
         }
+        void refreshAccounts();
+        queryClient.invalidateQueries();
+        onComplete?.();
       } finally {
         setSwitching(false);
       }
     },
-    [controller, switching, snapshot.activeAccountId, onComplete, refreshAccounts, queryClient],
+    [controller, switching, snapshot.activeAccountId, onComplete, refreshAccounts, queryClient, t],
   );
 
   const handleManage = useCallback(() => {
@@ -287,11 +297,11 @@ const OxyAuthChooser: React.FC<OxyAuthChooserProps> = ({ onComplete }) => {
             ? () => void handleSignInWithPasskey()
             : () => void controller.startPasskeyHubSignIn()
         }
-        // The hub-popup flow's pending/error state is `snapshot.signIn`
-        // (already rendered elsewhere in this view) — only the DIRECT ceremony
-        // uses this component-local pair.
+        // The hub-popup flow's pending state is `snapshot.signIn` (already
+        // rendered elsewhere in this view) — only the DIRECT ceremony uses this
+        // component-local pending flag. A ceremony FAILURE is surfaced as a
+        // toast by `handleSignInWithPasskey`, never inline.
         passkeyPending={passkeyMode === 'direct' ? signInPasskeyPending : false}
-        passkeyError={passkeyMode === 'direct' ? signInPasskeyError : null}
         onCreateAccount={() => controller.startSignup()}
       />
     );
@@ -307,7 +317,6 @@ const OxyAuthChooser: React.FC<OxyAuthChooserProps> = ({ onComplete }) => {
         passkeyMode={passkeyMode}
         onCreateWithPasskey={handleCreateWithPasskey}
         createPending={createPasskeyPending}
-        createError={createPasskeyError}
         onOpenHub={() => void controller.startPasskeyHubSignIn()}
         onBackToSignIn={() => controller.setView('signin')}
       />
@@ -331,22 +340,6 @@ const OxyAuthChooser: React.FC<OxyAuthChooserProps> = ({ onComplete }) => {
 // Accounts view
 // ---------------------------------------------------------------------------
 
-/**
- * Inline error banner for `snapshot.error` (the account-list / switch-failure
- * error — distinct from `snapshot.signIn.error`, which `QrView` already
- * renders). `AccountsView` and `SignInView` previously swallowed it: a
- * blocked/failed switch left the user with no feedback outside the QR view.
- */
-const ErrorBanner: React.FC<{ error: string | null; theme: Theme }> = ({ error, theme }) => {
-  if (!error) return null;
-  return (
-    <View style={[styles.errorBanner, { backgroundColor: theme.colors.negativeSubtle }]}>
-      <MaterialCommunityIcons name="alert-circle-outline" size={18} color={theme.colors.error} />
-      <Text style={[styles.errorBannerText, { color: theme.colors.error }]}>{error}</Text>
-    </View>
-  );
-};
-
 interface AccountsViewProps {
   snapshot: AccountDialogSnapshot;
   theme: Theme;
@@ -368,7 +361,6 @@ const AccountsView: React.FC<AccountsViewProps> = ({ snapshot, theme, t, handler
 
   return (
     <View style={styles.rows}>
-      <ErrorBanner error={snapshot.error} theme={theme} />
       {snapshot.accounts.map((account) => (
         <AccountRow
           key={account.accountId}
@@ -490,7 +482,6 @@ const SignInView: React.FC<SignInViewProps> = ({
   onCreateAccount,
 }) => (
   <View style={styles.signInBlock}>
-    <ErrorBanner error={snapshot.error} theme={theme} />
     {snapshot.accounts.length > 0 ? (
       <View style={styles.rows}>
         {snapshot.accounts.map((account) => (
@@ -571,7 +562,6 @@ interface QrViewProps {
   passkeyAvailable: boolean;
   onSignInWithPasskey: () => void;
   passkeyPending: boolean;
-  passkeyError: string | null;
   onCreateAccount: () => void;
 }
 
@@ -583,32 +573,28 @@ const QrView: React.FC<QrViewProps> = ({
   passkeyAvailable,
   onSignInWithPasskey,
   passkeyPending,
-  passkeyError,
   onCreateAccount,
 }) => {
   const { signIn, commonsAvailability } = snapshot;
   const [showQrAnyway, setShowQrAnyway] = useState(false);
 
+  // A ceremony FAILURE is surfaced as a toast by `handleSignInWithPasskey` — the
+  // link itself never renders an inline error (owner mandate).
   const passkeyLink =
     passkeyAvailable && signIn.phase !== 'authorized' ? (
-      <>
-        <Pressable
-          onPress={onSignInWithPasskey}
-          disabled={passkeyPending}
-          accessibilityRole="button"
-          style={styles.footerLink}
-          testID="passkey-signin-link"
-        >
-          <Text style={[styles.linkText, { color: theme.colors.textSecondary }]}>
-            {passkeyPending
-              ? t('accountSwitcher.passkeySigningIn') || 'Signing in…'
-              : t('accountSwitcher.useIdentityOnDevice') || 'No Commons? Use a passkey on this device instead'}
-          </Text>
-        </Pressable>
-        {passkeyError ? (
-          <Text style={[styles.errorText, { color: theme.colors.error }]}>{passkeyError}</Text>
-        ) : null}
-      </>
+      <Pressable
+        onPress={onSignInWithPasskey}
+        disabled={passkeyPending}
+        accessibilityRole="button"
+        style={styles.footerLink}
+        testID="passkey-signin-link"
+      >
+        <Text style={[styles.linkText, { color: theme.colors.textSecondary }]}>
+          {passkeyPending
+            ? t('accountSwitcher.passkeySigningIn') || 'Signing in…'
+            : t('accountSwitcher.useIdentityOnDevice') || 'No Commons? Use a passkey on this device instead'}
+        </Text>
+      </Pressable>
     ) : null;
 
   // Native, Commons confirmed NOT installed: a same-device QR is a dead
@@ -690,7 +676,10 @@ const QrView: React.FC<QrViewProps> = ({
 type UsernameStatus = 'idle' | 'checking' | 'available' | 'taken';
 
 /** Debounced username-availability check over the existing SDK method. */
-function useUsernameAvailability(oxyServices: OxyServices): {
+function useUsernameAvailability(
+  oxyServices: OxyServices,
+  t: Translate,
+): {
   status: UsernameStatus;
   check: (value: string) => void;
 } {
@@ -716,11 +705,16 @@ function useUsernameAvailability(oxyServices: OxyServices): {
           })
           .catch(() => {
             if (seq !== requestSeqRef.current) return;
-            setStatus('idle'); // network/error — don't block on a stale verdict
+            // Reset the (now stale) verdict rather than block on it, and surface
+            // the failure as a toast — never an inline error inside the dialog.
+            setStatus('idle');
+            toast.error(
+              t('accounts.create.username.checkFailed') || 'Could not check availability',
+            );
           });
       }, 400);
     },
-    [oxyServices],
+    [oxyServices, t],
   );
 
   return { status, check };
@@ -761,7 +755,6 @@ interface SignUpViewProps {
   passkeyMode: 'direct' | 'hub' | 'none';
   onCreateWithPasskey: (username: string) => Promise<void>;
   createPending: boolean;
-  createError: string | null;
   /** Open the auth.oxy.so hub popup (b2) — the 'hub' mode's only path. */
   onOpenHub: () => void;
   onBackToSignIn: () => void;
@@ -775,12 +768,11 @@ const SignUpView: React.FC<SignUpViewProps> = ({
   passkeyMode,
   onCreateWithPasskey,
   createPending,
-  createError,
   onOpenHub,
   onBackToSignIn,
 }) => {
   const [username, setUsername] = useState('');
-  const { status: usernameStatus, check: checkUsername } = useUsernameAvailability(oxyServices);
+  const { status: usernameStatus, check: checkUsername } = useUsernameAvailability(oxyServices, t);
   const canSubmit = username.trim().length >= 3 && usernameStatus === 'available' && !createPending;
 
   // Native — Commons owns identity creation. Mirrors the QR view's own
@@ -851,9 +843,6 @@ const SignUpView: React.FC<SignUpViewProps> = ({
           testID="signup-username-input"
         />
         <UsernameStatusText status={usernameStatus} theme={theme} t={t} />
-        {createError ? (
-          <Text style={[styles.errorText, { color: theme.colors.error }]}>{createError}</Text>
-        ) : null}
         <Button
           variant="secondary"
           onPress={() => void onCreateWithPasskey(username.trim())}

--- a/packages/services/src/ui/components/oxyAuthChooserStyles.ts
+++ b/packages/services/src/ui/components/oxyAuthChooserStyles.ts
@@ -129,21 +129,6 @@ export const authChooserStyles = StyleSheet.create({
     fontSize: 14,
     textAlign: 'center',
   },
-  errorBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    width: '100%',
-    borderRadius: 12,
-    paddingVertical: 10,
-    paddingHorizontal: 12,
-    marginBottom: 12,
-  },
-  errorBannerText: {
-    flex: 1,
-    fontSize: 13.5,
-    lineHeight: 18,
-  },
   qrPlate: {
     padding: 16,
     borderRadius: 16,


### PR DESCRIPTION
## Summary
- `OxyAuthChooser` (account switcher / sign-in dialog) now fires Bloom `toast.error(...)` for failures — account switch, passkey sign-in ceremony, passkey account creation, username-availability check — instead of rendering an inline error banner in the dialog body.
- Removed the two now-orphaned inline-banner styles from `oxyAuthChooserStyles.ts`.
- Added two additive i18n keys consumed by the new toast copy: `accountSwitcher.toasts.passkeySignInFailed` and `signup.toasts.passkeyCreateFailed` (en-US + es-ES).
- Updated the `OxyAuthChooser` test suite to assert `toast.error` is called (and that no inline banner renders) for each failure path.

## Test plan
- [x] `bun run --filter @oxyhq/contracts build` — exit 0
- [x] `bun run --filter @oxyhq/protocol build` — exit 0
- [x] `bun run --filter @oxyhq/core build` — exit 0; verified the new i18n keys are present in `dist/cjs/i18n/locales/{en-US,es-ES}.json`
- [x] `bun run --filter @oxyhq/services build` — exit 0
- [x] `packages/services` typecheck (`tsc --skipLibCheck --noEmit`) — clean
- [x] `packages/services` jest — 237/237 passed across 31 suites (OxyAuthChooser suite: 18/18)
- [x] `packages/core` jest — 902/902 passed across 70 suites
- [x] `bun install --frozen-lockfile` — passes, no lockfile drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)