### PR TITLE
feat(identity): encrypted off-device identity backup (b3 Feature 1, backend)

### DIFF
--- a/packages/api/src/models/IdentityBackup.ts
+++ b/packages/api/src/models/IdentityBackup.ts
@@ -1,0 +1,74 @@
+import mongoose, { type Document, Schema } from 'mongoose';
+
+/**
+ * Encrypted off-device identity backup (b3 Feature 1).
+ *
+ * Zero-knowledge at rest: the server stores ONLY opaque ciphertext plus
+ * `lookupIdHash` = `sha256(lookupId)` — it never sees the recovery phrase, the
+ * derived encryption key, the plaintext private key, or the raw `lookupId`
+ * (mirrors the `DeviceSession.secretHash` pattern, where the raw secret is never
+ * persisted). A DB dump therefore yields un-decryptable ciphertext keyed by an
+ * un-invertible hash: the server can neither locate a backup (it lacks the seed
+ * to compute a `lookupId`) nor decrypt one (it lacks the seed to compute the
+ * backup key).
+ *
+ * One backup per user (`userId` unique) — a re-upload upserts/replaces. The
+ * envelope fields are stored verbatim so the public restore endpoint can return
+ * the exact `EncryptedBackupEnvelope` the client uploaded. `createdAt` is the
+ * CLIENT's ISO timestamp (not a DB row timestamp), refreshed on each replace, so
+ * it reflects when the backup snapshot was created; `updatedAt` tracks the row.
+ */
+export interface IIdentityBackup extends Document {
+  /** The owning account. One backup per user. */
+  userId: mongoose.Types.ObjectId;
+  /**
+   * `sha256(lookupId)` hex. Unique — the public restore endpoint hashes the
+   * client-supplied raw `lookupId` and matches on this. The raw `lookupId` is
+   * NEVER stored, so possession of the 256-bit locator (which requires the full
+   * seed to compute) is the only way to fetch a backup.
+   */
+  lookupIdHash: string;
+  /** Short, non-sensitive public-key prefix so the owner can recognise the identity. */
+  publicKeyHint: string;
+  /** XChaCha20-Poly1305 ciphertext (with appended Poly1305 tag), hex. */
+  ciphertext: string;
+  /** The 24-byte AEAD nonce, hex. */
+  nonce: string;
+  /** The AEAD used to seal the ciphertext (e.g. `xchacha20poly1305`). */
+  algorithm: string;
+  /** The HKDF `info` label used to derive the encryption key (domain-separation tag). */
+  kdfInfo: string;
+  /** Envelope/KDF version, so a future scheme migration is distinguishable at rest. */
+  version: number;
+  /** The client's ISO-8601 backup-creation timestamp (stored verbatim). */
+  createdAt: string;
+  /** Row bookkeeping — last write time (mongoose-managed). */
+  updatedAt: Date;
+}
+
+const IdentityBackupSchema = new Schema<IIdentityBackup>(
+  {
+    // Uniqueness for both is declared once, below, via `schema.index()` (never
+    // also field-level `unique`, which would register a duplicate index).
+    userId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+    lookupIdHash: { type: String, required: true },
+    publicKeyHint: { type: String, required: true },
+    ciphertext: { type: String, required: true },
+    nonce: { type: String, required: true },
+    algorithm: { type: String, required: true },
+    kdfInfo: { type: String, required: true },
+    version: { type: Number, required: true },
+    // The client's snapshot timestamp, stored verbatim (see interface note).
+    createdAt: { type: String, required: true },
+  },
+  // Only `updatedAt` is mongoose-managed; `createdAt` is the client's value.
+  { timestamps: { createdAt: false, updatedAt: true } },
+);
+
+// One backup per user; the locator hash is globally unique (used by the public
+// restore lookup). Both are declared unique above; the explicit indexes keep the
+// intent legible alongside the other identity models.
+IdentityBackupSchema.index({ userId: 1 }, { unique: true });
+IdentityBackupSchema.index({ lookupIdHash: 1 }, { unique: true });
+
+export default mongoose.model<IIdentityBackup>('IdentityBackup', IdentityBackupSchema);

--- a/packages/api/src/models/__tests__/identityBackup.model.test.ts
+++ b/packages/api/src/models/__tests__/identityBackup.model.test.ts
@@ -1,0 +1,68 @@
+// Opt OUT of the global mongoose mock so the REAL schema (indexes, required
+// fields, types) is exercised without a live connection.
+jest.mock('mongoose', () => jest.requireActual('mongoose'));
+import mongoose from 'mongoose';
+import IdentityBackup from '../IdentityBackup';
+
+const validDoc = {
+  userId: new mongoose.Types.ObjectId(),
+  lookupIdHash: 'a'.repeat(64),
+  publicKeyHint: '04abcdef01234567',
+  ciphertext: 'deadbeef',
+  nonce: '00'.repeat(24),
+  algorithm: 'xchacha20poly1305',
+  kdfInfo: 'oxy-backup-encryption-key',
+  version: 1,
+  createdAt: '2026-07-16T00:00:00.000Z',
+};
+
+describe('IdentityBackup model', () => {
+  it('registers on the "identitybackups" collection', () => {
+    expect(IdentityBackup.collection.name).toBe('identitybackups');
+  });
+
+  it('validates a complete document', () => {
+    const doc = new IdentityBackup(validDoc);
+    expect(doc.validateSync()).toBeUndefined();
+    // createdAt is the client's verbatim ISO STRING (not a Date).
+    expect(typeof doc.createdAt).toBe('string');
+    expect(doc.createdAt).toBe('2026-07-16T00:00:00.000Z');
+  });
+
+  it.each([
+    'userId',
+    'lookupIdHash',
+    'publicKeyHint',
+    'ciphertext',
+    'nonce',
+    'algorithm',
+    'kdfInfo',
+    'version',
+    'createdAt',
+  ])('requires %s', (field) => {
+    const partial: Record<string, unknown> = { ...validDoc };
+    delete partial[field];
+    const doc = new IdentityBackup(partial);
+    const err = doc.validateSync();
+    expect(err?.errors?.[field]).toBeDefined();
+  });
+
+  it('declares a unique index on userId (one backup per user)', () => {
+    const indexes = IdentityBackup.schema.indexes();
+    const userIndex = indexes.find(([keys]) => keys.userId === 1);
+    expect(userIndex).toBeDefined();
+    expect(userIndex?.[1]).toMatchObject({ unique: true });
+  });
+
+  it('declares a unique index on lookupIdHash (global locator)', () => {
+    const indexes = IdentityBackup.schema.indexes();
+    const lookupIndex = indexes.find(([keys]) => keys.lookupIdHash === 1);
+    expect(lookupIndex).toBeDefined();
+    expect(lookupIndex?.[1]).toMatchObject({ unique: true });
+  });
+
+  it('does NOT define a raw lookupId field (only the hash is ever stored)', () => {
+    expect(IdentityBackup.schema.path('lookupId')).toBeUndefined();
+    expect(IdentityBackup.schema.path('lookupIdHash')).toBeDefined();
+  });
+});

--- a/packages/api/src/routes/__tests__/identityBackup.test.ts
+++ b/packages/api/src/routes/__tests__/identityBackup.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Encrypted off-device identity backup route tests (b3 Feature 1).
+ *
+ * Proves the server-side security + storage invariants of `/identity/backup`:
+ *  - the server hashes the client's raw `lookupId` and stores ONLY the hash
+ *    (never the raw locator, mirroring `DeviceSession.secretHash`);
+ *  - POST is an UPSERT by userId — a re-upload REPLACES the prior backup rather
+ *    than accumulating duplicates;
+ *  - `GET /status` reports existence without leaking ciphertext or locator;
+ *  - the PUBLIC `GET /:lookupId` restore endpoint hashes-and-looks-up in BOTH
+ *    the found and not-found paths (no existence-timing short-circuit) and
+ *    returns a constant-shape 404 for an unknown locator.
+ *
+ * The IdentityBackup model + auth middleware are mocked (the global mongoose
+ * mock cannot load the real schema); the real router + errorHandler run.
+ */
+import express from 'express';
+import http from 'http';
+import crypto from 'crypto';
+import type { AddressInfo } from 'net';
+
+const USER_ID = '507f1f77bcf86cd799439011';
+
+interface StoredDoc {
+  userId: string;
+  lookupIdHash: string;
+  publicKeyHint: string;
+  ciphertext: string;
+  nonce: string;
+  algorithm: string;
+  kdfInfo: string;
+  version: number;
+  createdAt: string;
+}
+
+const mockByUser = new Map<string, StoredDoc>();
+const mockFindOneAndUpdate = jest.fn();
+const mockFindOne = jest.fn();
+const mockDeleteOne = jest.fn();
+
+const mockIdentityBackup = {
+  findOneAndUpdate: async (
+    filter: { userId: string },
+    update: { $set: Omit<StoredDoc, 'userId'> },
+    _opts: unknown,
+  ): Promise<StoredDoc> => {
+    mockFindOneAndUpdate(filter, update, _opts);
+    const set = update.$set;
+    // Enforce the global lookupIdHash uniqueness (E11000 on a cross-user collision).
+    for (const [uid, d] of mockByUser) {
+      if (uid !== filter.userId && d.lookupIdHash === set.lookupIdHash) {
+        const err = new Error('E11000 duplicate key error') as Error & { code?: number };
+        err.code = 11000;
+        throw err;
+      }
+    }
+    const doc: StoredDoc = { userId: filter.userId, ...set };
+    mockByUser.set(filter.userId, doc);
+    return doc;
+  },
+  findOne: (filter: { userId?: string; lookupIdHash?: string }) => {
+    mockFindOne(filter);
+    return {
+      lean: async (): Promise<StoredDoc | null> => {
+        if (filter.userId) return mockByUser.get(filter.userId) ?? null;
+        if (filter.lookupIdHash) {
+          for (const d of mockByUser.values()) {
+            if (d.lookupIdHash === filter.lookupIdHash) return d;
+          }
+          return null;
+        }
+        return null;
+      },
+    };
+  },
+  deleteOne: async (filter: { userId: string }): Promise<{ deletedCount: number }> => {
+    mockDeleteOne(filter);
+    const existed = mockByUser.delete(filter.userId);
+    return { deletedCount: existed ? 1 : 0 };
+  },
+};
+
+jest.mock('../../models/IdentityBackup', () => ({ __esModule: true, default: mockIdentityBackup }));
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+    req.user = { _id: USER_ID };
+    next();
+  },
+}));
+
+import identityBackupRouter from '../identityBackup';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function request(method: string, path: string, payload?: unknown): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? undefined : JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers:
+          body !== undefined
+            ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) }
+            : {},
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }));
+      },
+    );
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+const sha256Hex = (v: string): string => crypto.createHash('sha256').update(v).digest('hex');
+
+function uploadBody(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    version: 1,
+    algorithm: 'xchacha20poly1305',
+    kdfInfo: 'oxy-backup-encryption-key',
+    nonce: '00'.repeat(24),
+    ciphertext: 'deadbeefcafe',
+    publicKeyHint: '04abcdef01234567',
+    createdAt: '2026-07-16T00:00:00.000Z',
+    lookupId: 'a'.repeat(64),
+    ...overrides,
+  };
+}
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/identity/backup', identityBackupRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockByUser.clear();
+});
+
+describe('POST /identity/backup', () => {
+  it('stores sha256(lookupId) and NEVER the raw lookupId', async () => {
+    const rawLookupId = 'a'.repeat(64);
+    const res = await request('POST', '/identity/backup', uploadBody({ lookupId: rawLookupId }));
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ exists: true, publicKeyHint: '04abcdef01234567' });
+
+    // The $set carries the HASH, not the raw locator.
+    const [, update] = mockFindOneAndUpdate.mock.calls[0];
+    const set = (update as { $set: Record<string, unknown> }).$set;
+    expect(set.lookupIdHash).toBe(sha256Hex(rawLookupId));
+    expect(set.lookupIdHash).not.toBe(rawLookupId);
+    expect('lookupId' in set).toBe(false);
+
+    // Persisted doc holds only the hash.
+    const stored = mockByUser.get(USER_ID);
+    expect(stored?.lookupIdHash).toBe(sha256Hex(rawLookupId));
+  });
+
+  it('upserts by userId — a re-upload REPLACES, never duplicates', async () => {
+    await request('POST', '/identity/backup', uploadBody({ lookupId: 'a'.repeat(64) }));
+    await request('POST', '/identity/backup', uploadBody({ lookupId: 'b'.repeat(64), ciphertext: 'feed' }));
+
+    // Exactly one logical backup for the user, holding the SECOND upload.
+    expect(mockByUser.size).toBe(1);
+    const stored = mockByUser.get(USER_ID);
+    expect(stored?.lookupIdHash).toBe(sha256Hex('b'.repeat(64)));
+    expect(stored?.ciphertext).toBe('feed');
+
+    // Both writes targeted the SAME userId with upsert:true.
+    for (const [filter, , opts] of mockFindOneAndUpdate.mock.calls) {
+      expect(filter).toEqual({ userId: USER_ID });
+      expect(opts).toMatchObject({ upsert: true });
+    }
+  });
+
+  it('rejects a malformed body (Zod validation → 400)', async () => {
+    const res = await request('POST', '/identity/backup', uploadBody({ algorithm: 'aes-gcm' }));
+    expect(res.status).toBe(400);
+    expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 when the lookup hash collides with a different user', async () => {
+    // Seed a DIFFERENT user's backup with the same locator hash.
+    mockByUser.set('other-user', {
+      userId: 'other-user',
+      lookupIdHash: sha256Hex('a'.repeat(64)),
+      publicKeyHint: 'x',
+      ciphertext: 'x',
+      nonce: 'x',
+      algorithm: 'xchacha20poly1305',
+      kdfInfo: 'x',
+      version: 1,
+      createdAt: 'x',
+    });
+    const res = await request('POST', '/identity/backup', uploadBody({ lookupId: 'a'.repeat(64) }));
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('GET /identity/backup/status', () => {
+  it('reports absence with a constant shape', async () => {
+    const res = await request('GET', '/identity/backup/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ exists: false });
+  });
+
+  it('reports presence with the hint + timestamp, no ciphertext/locator', async () => {
+    await request('POST', '/identity/backup', uploadBody());
+    const res = await request('GET', '/identity/backup/status');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      exists: true,
+      publicKeyHint: '04abcdef01234567',
+      createdAt: '2026-07-16T00:00:00.000Z',
+    });
+    expect(res.body.ciphertext).toBeUndefined();
+    expect(res.body.lookupIdHash).toBeUndefined();
+  });
+});
+
+describe('DELETE /identity/backup', () => {
+  it('is idempotent (succeeds even with no backup)', async () => {
+    const res = await request('DELETE', '/identity/backup');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(mockDeleteOne).toHaveBeenCalledWith({ userId: USER_ID });
+  });
+
+  it('removes an existing backup', async () => {
+    await request('POST', '/identity/backup', uploadBody());
+    expect(mockByUser.size).toBe(1);
+    const res = await request('DELETE', '/identity/backup');
+    expect(res.status).toBe(200);
+    expect(mockByUser.size).toBe(0);
+  });
+});
+
+describe('GET /identity/backup/:lookupId (public restore)', () => {
+  it('returns the envelope for a known locator — hashing the supplied value', async () => {
+    const rawLookupId = 'c'.repeat(64);
+    await request('POST', '/identity/backup', uploadBody({ lookupId: rawLookupId }));
+
+    const res = await request('GET', `/identity/backup/${rawLookupId}`);
+    expect(res.status).toBe(200);
+    // Full envelope, no locator/hash leaked.
+    expect(res.body).toEqual({
+      version: 1,
+      algorithm: 'xchacha20poly1305',
+      kdfInfo: 'oxy-backup-encryption-key',
+      nonce: '00'.repeat(24),
+      ciphertext: 'deadbeefcafe',
+      publicKeyHint: '04abcdef01234567',
+      createdAt: '2026-07-16T00:00:00.000Z',
+    });
+    expect(res.body.lookupIdHash).toBeUndefined();
+
+    // The lookup was BY the hash of the supplied raw locator.
+    const lastFindOne = mockFindOne.mock.calls.at(-1)?.[0] as { lookupIdHash?: string };
+    expect(lastFindOne.lookupIdHash).toBe(sha256Hex(rawLookupId));
+  });
+
+  it('returns a constant-shape 404 for an unknown locator (no existence short-circuit)', async () => {
+    const res = await request('GET', `/identity/backup/${'d'.repeat(64)}`);
+    expect(res.status).toBe(404);
+    // The not-found path STILL performed the hash-and-lookup — proof there is no
+    // pre-query short-circuit that could leak existence via timing.
+    const lastFindOne = mockFindOne.mock.calls.at(-1)?.[0] as { lookupIdHash?: string };
+    expect(lastFindOne.lookupIdHash).toBe(sha256Hex('d'.repeat(64)));
+  });
+
+  it('does not leak whether a DIFFERENT user has a backup (only the exact locator matches)', async () => {
+    // A backup exists (some user), but a lookup with the WRONG locator 404s.
+    await request('POST', '/identity/backup', uploadBody({ lookupId: 'e'.repeat(64) }));
+    const res = await request('GET', `/identity/backup/${'f'.repeat(64)}`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/api/src/routes/identityBackup.ts
+++ b/packages/api/src/routes/identityBackup.ts
@@ -1,0 +1,197 @@
+/**
+ * Encrypted off-device identity backup routes (b3 Feature 1).
+ *
+ * Mounted at `/identity/backup`:
+ *  - `POST   /identity/backup`            (bearer) upsert the encrypted backup
+ *  - `GET    /identity/backup/status`     (bearer) does the caller have a backup?
+ *  - `DELETE /identity/backup`            (bearer) delete the caller's backup
+ *  - `GET    /identity/backup/:lookupId`  (PUBLIC) fetch the envelope by locator
+ *
+ * Zero-knowledge: the server persists ONLY ciphertext + `sha256(lookupId)`. It
+ * never sees the recovery phrase, the derived backup key, the plaintext private
+ * key, or the raw `lookupId`.
+ *
+ * The `:lookupId` restore endpoint is PUBLIC because possession of the 256-bit
+ * locator (which itself requires the full BIP-39 seed to compute) IS the
+ * authorization — a signed-out device recovering from the phrase alone has no
+ * bearer token. Its real protection is that entropy; the hash-and-lookup +
+ * constant-shape 404 are defense-in-depth against enumeration. No bearer writes
+ * carry ambient cookies, so this router is mounted without CSRF.
+ */
+import { Router, type Request, type Response } from 'express';
+import crypto from 'crypto';
+import { authMiddleware, type AuthRequest } from '../middleware/auth';
+import { asyncHandler } from '../utils/asyncHandler';
+import { ConflictError, NotFoundError, UnauthorizedError } from '../utils/error';
+import { validate } from '../middleware/validate';
+import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
+import {
+  backupUploadRequestSchema,
+  type BackupUploadRequest,
+  type BackupStatusResponse,
+  type EncryptedBackupEnvelope,
+} from '@oxyhq/contracts';
+import IdentityBackup, { type IIdentityBackup } from '../models/IdentityBackup';
+
+const router = Router();
+
+/**
+ * `sha256(lookupId)` — the ONLY form of the locator that is ever stored or
+ * compared. The raw `lookupId` (256-bit, derived from the full seed) is
+ * discarded after hashing, so a DB dump cannot recompute a locator.
+ */
+function lookupIdHashOf(rawLookupId: string): string {
+  return crypto.createHash('sha256').update(rawLookupId).digest('hex');
+}
+
+/** Whether a thrown error is a Mongo duplicate-key (E11000) error. */
+function isDuplicateKeyError(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: number }).code === 11000;
+}
+
+/** The stored fields the public envelope is projected from (lean-query friendly). */
+type StoredEnvelopeFields = Pick<
+  IIdentityBackup,
+  'version' | 'kdfInfo' | 'nonce' | 'ciphertext' | 'publicKeyHint' | 'createdAt'
+>;
+
+/** Project a stored backup row into the public `EncryptedBackupEnvelope`. */
+function toEnvelope(doc: StoredEnvelopeFields): EncryptedBackupEnvelope {
+  return {
+    version: doc.version,
+    algorithm: 'xchacha20poly1305',
+    kdfInfo: doc.kdfInfo,
+    nonce: doc.nonce,
+    ciphertext: doc.ciphertext,
+    publicKeyHint: doc.publicKeyHint,
+    createdAt: doc.createdAt,
+  };
+}
+
+/**
+ * Public restore-lookup limiter (IP-keyed — the endpoint is unauthenticated).
+ * Bounds brute-force scanning of the locator space (already 256-bit, so this is
+ * defense-in-depth, not the primary control).
+ */
+const publicRestoreLimiter = rateLimit({
+  prefix: 'rl:identity:backup:',
+  windowMs: 60 * 1000,
+  max: 30,
+  message: 'Too many backup lookups. Please try again shortly.',
+  keyGenerator: (req: Request): string => `identity:backup:ip:${hashedIpKey(req)}`,
+});
+
+/**
+ * POST /identity/backup — create or REPLACE the caller's encrypted backup.
+ * Upsert by `userId`, so a re-upload never accumulates duplicates. The raw
+ * `lookupId` from the body is hashed before storage; only the hash is persisted.
+ */
+router.post(
+  '/',
+  authMiddleware,
+  validate({ body: backupUploadRequestSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const userId = req.user?._id?.toString();
+    if (!userId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const body = req.body as BackupUploadRequest;
+    const lookupIdHash = lookupIdHashOf(body.lookupId);
+
+    try {
+      const doc = await IdentityBackup.findOneAndUpdate(
+        { userId },
+        {
+          $set: {
+            lookupIdHash,
+            publicKeyHint: body.publicKeyHint,
+            ciphertext: body.ciphertext,
+            nonce: body.nonce,
+            algorithm: body.algorithm,
+            kdfInfo: body.kdfInfo,
+            version: body.version,
+            createdAt: body.createdAt,
+          },
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true },
+      );
+
+      const payload: BackupStatusResponse = {
+        exists: true,
+        publicKeyHint: doc.publicKeyHint,
+        createdAt: doc.createdAt,
+      };
+      res.status(200).json(payload);
+    } catch (err) {
+      // A `lookupIdHash` collision with a DIFFERENT user's backup is
+      // astronomically unlikely at 256-bit entropy; never silently overwrite
+      // another user's record — surface a clean conflict.
+      if (isDuplicateKeyError(err)) {
+        throw new ConflictError('Backup locator already in use.');
+      }
+      throw err;
+    }
+  }),
+);
+
+/**
+ * GET /identity/backup/status — whether the caller has a backup, plus the
+ * non-sensitive hint + timestamp when one exists. No ciphertext, no locator.
+ */
+router.get(
+  '/status',
+  authMiddleware,
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const userId = req.user?._id?.toString();
+    if (!userId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const doc = await IdentityBackup.findOne({ userId }).lean();
+    const payload: BackupStatusResponse = doc
+      ? { exists: true, publicKeyHint: doc.publicKeyHint, createdAt: doc.createdAt }
+      : { exists: false };
+    res.status(200).json(payload);
+  }),
+);
+
+/**
+ * DELETE /identity/backup — remove the caller's backup. Idempotent (deleting a
+ * non-existent backup still returns success).
+ */
+router.delete(
+  '/',
+  authMiddleware,
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const userId = req.user?._id?.toString();
+    if (!userId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    await IdentityBackup.deleteOne({ userId });
+    res.status(200).json({ success: true });
+  }),
+);
+
+/**
+ * GET /identity/backup/:lookupId — PUBLIC restore fetch. Hash the supplied raw
+ * locator and return the matching envelope, or a constant-shape 404. No user
+ * enumeration is possible: the response reveals only found/not-found, gated by
+ * the locator's 256-bit entropy.
+ */
+router.get(
+  '/:lookupId',
+  publicRestoreLimiter,
+  asyncHandler(async (req: Request, res: Response) => {
+    const rawLookupId = req.params.lookupId;
+    const doc = await IdentityBackup.findOne({ lookupIdHash: lookupIdHashOf(rawLookupId) }).lean();
+    if (!doc) {
+      throw new NotFoundError('Backup not found');
+    }
+    res.status(200).json(toEnvelope(doc));
+  }),
+);
+
+export default router;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -47,6 +47,7 @@ import contactsRouter from './routes/contacts';
 import userDataRouter from './routes/userData';
 import appSignalsRouter from './routes/appSignals';
 import identityRoutes from './routes/identity';
+import identityBackupRoutes from './routes/identityBackup';
 import civicRoutes from './routes/civic';
 import nodeRoutes from './routes/nodes';
 import { sweepValidations } from './services/civic/validator.service';
@@ -563,6 +564,11 @@ app.use('/contacts', userRateLimiter, csrfProtection, contactsRouter);
 // csrfProtection — Bearer-authenticated service writes are exempt (no ambient
 // cookie credentials), per the bearer-write CSRF rule.
 app.use('/app-signals', appSignalsRouter);
+// Encrypted off-device identity backup (b3 Feature 1). Mixed private (bearer
+// upsert/status/delete) + public (restore-by-locator) routes; each gates its own
+// auth, so no csrfProtection (bearer-write CSRF rule + public GET). Mounted
+// BEFORE `/identity` so the more specific `/identity/backup` prefix wins.
+app.use('/identity/backup', identityBackupRoutes);
 // Self-sovereign identity layer: signed records + verified-domain badges.
 // Mixed public/private routes (each gates its own auth); writes are
 // Bearer-authenticated, so no csrfProtection (bearer-write CSRF rule).

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -263,6 +263,19 @@ export type {
 } from './keyRotation';
 
 export {
+    // Schemas — encrypted off-device identity backup (b3 Feature 1)
+    encryptedBackupEnvelopeSchema,
+    backupUploadRequestSchema,
+    backupStatusResponseSchema,
+} from './keyRecovery';
+
+export type {
+    EncryptedBackupEnvelope,
+    BackupUploadRequest,
+    BackupStatusResponse,
+} from './keyRecovery';
+
+export {
     // Shared primitives
     updatePlatformSchema,
     updateStatusSchema,

--- a/packages/contracts/src/keyRecovery.ts
+++ b/packages/contracts/src/keyRecovery.ts
@@ -1,0 +1,92 @@
+/**
+ * Encrypted off-device identity backup contract (b3 Feature 1).
+ *
+ * SINGLE SOURCE OF TRUTH for the "encrypted identity backup" flow, where a
+ * client stores an encrypted copy of its self-custody identity key off-device so
+ * a lost/wiped device can be recovered from the recovery phrase ALONE — without
+ * the platform ever seeing the phrase, the derived encryption key, or the
+ * plaintext private key.
+ *
+ * Zero-knowledge design (mirrors the zero-cookie `DeviceSession.secretHash`
+ * pattern): the client derives, from the FULL 64-byte BIP-39 seed, both an
+ * encryption key (`backupKey`) and a locator (`lookupId`) via HKDF with
+ * domain-separated `info` labels. It uploads ONLY the XChaCha20-Poly1305
+ * ciphertext plus the raw `lookupId`; the server stores the ciphertext and
+ * `sha256(lookupId)` (never the raw `lookupId`). Restoration re-derives both
+ * from the phrase, fetches the envelope by `lookupId`, and decrypts locally.
+ *
+ * The server can neither locate a backup (it lacks the seed to compute the
+ * lookup id) nor decrypt one (it lacks the seed to compute the backup key) — a
+ * DB dump yields only opaque ciphertext keyed by an un-invertible hash.
+ *
+ * The producer (`@oxyhq/api`) validates its request/response against these
+ * schemas; the consumer (`@oxyhq/core` identity-backup mixin) validates its
+ * input against the same definitions, so the wire shape cannot drift.
+ *
+ * All shapes here are FLAT (no nested objects), so `z.infer<>` is safe under a
+ * consumer's node10 `moduleResolution`. Platform-agnostic — zod only, ESM-safe
+ * (no `require()`).
+ */
+import { z } from 'zod';
+
+/**
+ * The stored, self-describing encrypted backup as it lives at rest and travels
+ * on the public restore endpoint. Contains NO secret and NO locator: the
+ * `lookupId` is uploaded separately (see {@link backupUploadRequestSchema}) and
+ * only its hash is ever persisted.
+ *
+ * - `version`       — envelope/KDF version, so a future scheme migration is
+ *   distinguishable at rest.
+ * - `algorithm`     — the AEAD used. Pinned literal so a mismatched decryptor
+ *   fails loudly rather than silently.
+ * - `kdfInfo`       — the HKDF `info` label used to derive the encryption key
+ *   (domain-separation tag; documents exactly which context produced the key).
+ * - `nonce`         — the 24-byte XChaCha20-Poly1305 nonce, hex.
+ * - `ciphertext`    — the encrypted `{privateKey, publicKey, createdAt}` payload
+ *   with the appended Poly1305 tag, hex.
+ * - `publicKeyHint` — a short, non-sensitive prefix of the backed-up identity's
+ *   public key, so the owner can recognise WHICH identity a backup belongs to
+ *   without exposing the full key. Bound into the AEAD associated data.
+ * - `createdAt`     — ISO-8601 creation timestamp.
+ */
+export const encryptedBackupEnvelopeSchema = z.object({
+    version: z.number().int().positive(),
+    algorithm: z.literal('xchacha20poly1305'),
+    kdfInfo: z.string().min(1),
+    nonce: z.string().trim().min(1),
+    ciphertext: z.string().trim().min(1),
+    publicKeyHint: z.string().trim().min(1),
+    createdAt: z.string().trim().min(1),
+});
+
+export type EncryptedBackupEnvelope = z.infer<typeof encryptedBackupEnvelopeSchema>;
+
+/**
+ * Request body of `POST /identity/backup` — the envelope PLUS the raw
+ * `lookupId`. The server sha256-hashes `lookupId` before storing it (it never
+ * persists the raw value), and upserts by the authenticated user id so a
+ * re-upload REPLACES the prior backup rather than accumulating duplicates.
+ */
+export const backupUploadRequestSchema = encryptedBackupEnvelopeSchema.extend({
+    /**
+     * The raw 256-bit backup locator (hex), derived client-side from the seed
+     * with a domain-separated HKDF `info`. The server stores ONLY its sha256; a
+     * DB dump therefore cannot recompute a locator to enumerate backups.
+     */
+    lookupId: z.string().trim().min(1),
+});
+
+export type BackupUploadRequest = z.infer<typeof backupUploadRequestSchema>;
+
+/**
+ * Response of `GET /identity/backup/status` (and the write/delete acks): whether
+ * the authenticated user has a stored backup, plus the non-sensitive hint +
+ * timestamp when one exists. Carries no ciphertext and no locator.
+ */
+export const backupStatusResponseSchema = z.object({
+    exists: z.boolean(),
+    publicKeyHint: z.string().optional(),
+    createdAt: z.string().optional(),
+});
+
+export type BackupStatusResponse = z.infer<typeof backupStatusResponseSchema>;

--- a/packages/core/src/crypto/__tests__/backupMaterial.test.ts
+++ b/packages/core/src/crypto/__tests__/backupMaterial.test.ts
@@ -1,0 +1,86 @@
+/**
+ * RecoveryPhraseService.deriveBackupMaterial — encrypted off-device backup key
+ * schedule (b3 Feature 1).
+ *
+ * The two outputs are derived from the FULL 64-byte BIP-39 seed via HKDF-SHA256
+ * with domain-separated `info` labels. These tests PIN the derivation against a
+ * fixed phrase so an accidental algorithm/library/label swap is caught as a
+ * regression, and assert the domain separation is real (backup key ≠ lookup id ≠
+ * the raw private key, all from the same seed).
+ *
+ * The fixed phrase is the canonical BIP-39 all-zero-entropy vector
+ * ("abandon…about"), whose seed is the published `5eb00bbd…ce9e38e4` — so the
+ * pinned outputs below are reproducible from any independent HKDF-SHA256
+ * implementation over that seed.
+ */
+import { RecoveryPhraseService } from '../recoveryPhrase';
+import { KeyManager } from '../keyManager';
+
+const FIXED_PHRASE =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+// Pinned outputs (independently reproducible — see file header).
+const EXPECTED_BACKUP_KEY_HEX = 'c6bb29585610550e2667a9d05f35d081f67dd8ccee20a04488c39b25f47a9e74';
+const EXPECTED_LOOKUP_ID = '8cad137ca961bfc62a2ef329869e8369777737c7c5353a8d94bb70d888c0ad0d';
+// The raw private key = seed[0:32] (the FROZEN phrase→privateKey derivation).
+const EXPECTED_PRIVATE_KEY = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1';
+
+const toHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString('hex');
+
+describe('RecoveryPhraseService.deriveBackupMaterial (KDF vectors)', () => {
+  it('derives the pinned backupKey + lookupId for the fixed phrase', async () => {
+    const { backupKey, lookupId } = await RecoveryPhraseService.deriveBackupMaterial(FIXED_PHRASE);
+
+    expect(backupKey).toBeInstanceOf(Uint8Array);
+    expect(backupKey).toHaveLength(32);
+    expect(toHex(backupKey)).toBe(EXPECTED_BACKUP_KEY_HEX);
+
+    expect(lookupId).toBe(EXPECTED_LOOKUP_ID);
+    expect(lookupId).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic (same phrase → identical material)', async () => {
+    const a = await RecoveryPhraseService.deriveBackupMaterial(FIXED_PHRASE);
+    const b = await RecoveryPhraseService.deriveBackupMaterial(FIXED_PHRASE);
+    expect(toHex(a.backupKey)).toBe(toHex(b.backupKey));
+    expect(a.lookupId).toBe(b.lookupId);
+  });
+
+  it('normalizes case/whitespace like the other phrase helpers', async () => {
+    const messy = `  ${FIXED_PHRASE.toUpperCase()}  `;
+    const { backupKey, lookupId } = await RecoveryPhraseService.deriveBackupMaterial(messy);
+    expect(toHex(backupKey)).toBe(EXPECTED_BACKUP_KEY_HEX);
+    expect(lookupId).toBe(EXPECTED_LOOKUP_ID);
+  });
+
+  it('enforces real domain separation (backupKey ≠ lookupId ≠ raw private key)', async () => {
+    const { backupKey, lookupId } = await RecoveryPhraseService.deriveBackupMaterial(FIXED_PHRASE);
+    const privateKey = await RecoveryPhraseService.derivePrivateKeyFromPhrase(FIXED_PHRASE);
+
+    // Sanity: the frozen phrase→privateKey path is unchanged.
+    expect(privateKey).toBe(EXPECTED_PRIVATE_KEY);
+
+    // The three derivations from the SAME seed are mutually distinct — a device
+    // compromise leaking only the 32-byte private key reveals nothing about the
+    // backup key or lookup id (both need the full 64-byte seed).
+    expect(toHex(backupKey)).not.toBe(lookupId);
+    expect(toHex(backupKey)).not.toBe(privateKey);
+    expect(lookupId).not.toBe(privateKey);
+  });
+
+  it('produces a valid signing key material that is NOT the backup key', async () => {
+    // Extra guard: the backupKey must never coincide with a usable identity key
+    // for this phrase.
+    const { backupKey } = await RecoveryPhraseService.deriveBackupMaterial(FIXED_PHRASE);
+    const privateKey = await RecoveryPhraseService.derivePrivateKeyFromPhrase(FIXED_PHRASE);
+    const publicKey = KeyManager.derivePublicKey(privateKey);
+    expect(publicKey).toMatch(/^04[0-9a-f]+$/);
+    expect(toHex(backupKey)).not.toBe(privateKey);
+  });
+
+  it('rejects an invalid recovery phrase', async () => {
+    await expect(RecoveryPhraseService.deriveBackupMaterial('not a real phrase')).rejects.toThrow(
+      /Invalid recovery phrase/,
+    );
+  });
+});

--- a/packages/core/src/crypto/recoveryPhrase.ts
+++ b/packages/core/src/crypto/recoveryPhrase.ts
@@ -9,6 +9,7 @@
 
 import * as bip39 from 'bip39';
 import { KeyManager } from './keyManager';
+import { hkdfSha256 } from './kdf';
 
 /**
  * Convert Uint8Array or array-like to hexadecimal string
@@ -20,6 +21,43 @@ function toHex(data: Uint8Array | ArrayLike<number>): string {
   return Array.from(bytes)
     .map(b => b.toString(16).padStart(2, '0'))
     .join('');
+}
+
+/** UTF-8 encode an ASCII label to bytes (for HKDF salt/info). */
+function utf8(label: string): Uint8Array {
+  return new TextEncoder().encode(label);
+}
+
+/**
+ * HKDF context tag for the encrypted-backup key schedule (b3 Feature 1). Used as
+ * the HKDF `salt`; distinct from any other Oxy key-derivation salt so the backup
+ * key schedule is independent. Versioned so a future scheme change is a new tag.
+ */
+export const BACKUP_KDF_SALT = 'oxy-identity-backup-v1';
+/** HKDF `info` label that derives the symmetric AEAD key from the seed. */
+export const BACKUP_KDF_ENCRYPTION_INFO = 'oxy-backup-encryption-key';
+/** HKDF `info` label that derives the (server-hashed) backup locator from the seed. */
+export const BACKUP_KDF_LOOKUP_INFO = 'oxy-backup-lookup-id';
+/** Byte length of both the derived backup key and the derived lookup id (256-bit). */
+export const BACKUP_MATERIAL_LENGTH = 32;
+
+/**
+ * The two pieces of key material derived from a recovery phrase for the
+ * encrypted off-device backup, kept strictly separate by HKDF domain separation.
+ */
+export interface BackupMaterial {
+  /**
+   * The 32-byte symmetric key handed to `encryptAead`/`decryptAead`. NEVER
+   * leaves the device — the server sees only ciphertext produced with it.
+   */
+  backupKey: Uint8Array;
+  /**
+   * The 256-bit backup locator, hex. Sent to the server, which stores ONLY
+   * `sha256(lookupId)` — so possession of this value (which itself requires the
+   * full seed to compute) is what locates a backup, and the server can never
+   * recompute it from what it stores.
+   */
+  lookupId: string;
 }
 
 export interface RecoveryPhraseResult {
@@ -164,6 +202,38 @@ export class RecoveryPhraseService {
     const seed = await bip39.mnemonicToSeed(normalizedPhrase);
     const seedSlice = seed.subarray ? seed.subarray(0, 32) : seed.slice(0, 32);
     return toHex(seedSlice);
+  }
+
+  /**
+   * Derive the encrypted-backup key material from a recovery phrase (b3 Feature
+   * 1). PURE and additive — it does NOT touch the frozen phrase→privateKey
+   * derivation ({@link derivePrivateKeyFromPhrase} slices the first 32 seed
+   * bytes) and never reads or writes secure storage.
+   *
+   * Both outputs are derived from the FULL 64-byte BIP-39 seed via HKDF-SHA256
+   * with domain-separated `info` labels, so the domain separation is real: a
+   * device compromise that leaks only the raw 32-byte private key can compute
+   * NEITHER the backup key nor the lookup id (both need the whole seed). Locating
+   * AND decrypting a backup therefore requires the recovery phrase.
+   *
+   * @param phrase - The BIP-39 recovery phrase (validated + normalized here).
+   * @returns `{ backupKey, lookupId }` — the AEAD key (kept local) and the hex
+   *   locator (uploaded; server stores only its hash).
+   * @throws if the phrase is not a valid BIP-39 mnemonic.
+   */
+  static async deriveBackupMaterial(phrase: string): Promise<BackupMaterial> {
+    const normalizedPhrase = phrase.trim().toLowerCase();
+
+    if (!bip39.validateMnemonic(normalizedPhrase)) {
+      throw new Error('Invalid recovery phrase. Please check the words and try again.');
+    }
+
+    const seed = await bip39.mnemonicToSeed(normalizedPhrase);
+    const salt = utf8(BACKUP_KDF_SALT);
+    const backupKey = hkdfSha256(seed, salt, utf8(BACKUP_KDF_ENCRYPTION_INFO), BACKUP_MATERIAL_LENGTH);
+    const lookupId = toHex(hkdfSha256(seed, salt, utf8(BACKUP_KDF_LOOKUP_INFO), BACKUP_MATERIAL_LENGTH));
+
+    return { backupKey, lookupId };
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -245,7 +245,7 @@ export type { KeyPair } from './crypto/keyManager';
 export { SignatureService } from './crypto/signatureService';
 export type { SignedMessage, AuthChallenge } from './crypto/signatureService';
 export { RecoveryPhraseService } from './crypto/recoveryPhrase';
-export type { RecoveryPhraseResult, PendingIdentityResult } from './crypto/recoveryPhrase';
+export type { RecoveryPhraseResult, PendingIdentityResult, BackupMaterial } from './crypto/recoveryPhrase';
 
 // Low-level crypto primitives (b3 Phase 0 — encrypted backup + device transfer)
 export { hkdfSha256 } from './crypto/kdf';

--- a/packages/core/src/mixins/OxyServices.identityBackup.ts
+++ b/packages/core/src/mixins/OxyServices.identityBackup.ts
@@ -1,0 +1,237 @@
+/**
+ * Encrypted off-device identity backup mixin (b3 Feature 1).
+ *
+ * Lets a self-custody identity store an ENCRYPTED copy of its key off-device so
+ * a lost/wiped device can be recovered from the recovery phrase alone — while the
+ * platform never sees the phrase, the derived key, or the plaintext private key.
+ *
+ * Key schedule (from the recovery phrase; see
+ * {@link RecoveryPhraseService.deriveBackupMaterial}):
+ *   seed      = bip39.mnemonicToSeed(phrase)                    // 64 bytes, UNCHANGED
+ *   backupKey = HKDF(seed, 'oxy-identity-backup-v1', 'oxy-backup-encryption-key')
+ *   lookupId  = HKDF(seed, 'oxy-identity-backup-v1', 'oxy-backup-lookup-id')   // hex
+ *
+ * The two derivations require the FULL seed, so a device compromise that leaks
+ * only the raw 32-byte private key can neither locate nor decrypt the backup.
+ *
+ * Wire shapes come from `@oxyhq/contracts` (`EncryptedBackupEnvelope`,
+ * `BackupUploadRequest`, `BackupStatusResponse`) — the API validates its
+ * request/response against the same schemas, so producer and consumer cannot
+ * drift.
+ *
+ * Encryption/derivation are cross-platform (pure `@noble/*`), but persisting a
+ * restored key is NATIVE-ONLY: `restoreFromEncryptedBackup` ends in
+ * `KeyManager.importKeyPair`, which throws on web (SecureStore does not exist
+ * there) — decryption still succeeds, only the local write is native-only.
+ */
+import type {
+  BackupStatusResponse,
+  BackupUploadRequest,
+  EncryptedBackupEnvelope,
+} from '@oxyhq/contracts';
+import type { OxyServicesBase } from '../OxyServices.base';
+import { KeyManager, IdentityAlreadyExistsError } from '../crypto/keyManager';
+import { RecoveryPhraseService, BACKUP_KDF_ENCRYPTION_INFO } from '../crypto/recoveryPhrase';
+import { encryptAead, decryptAead } from '../crypto/aead';
+
+/** Envelope/KDF version — bump only on a breaking scheme change. */
+const BACKUP_ENVELOPE_VERSION = 1;
+/** The AEAD the backup is sealed with. Pinned so a mismatched decryptor fails loudly. */
+const BACKUP_ALGORITHM = 'xchacha20poly1305' as const;
+/**
+ * Length (hex chars) of the public-key HINT stored/echoed with a backup — enough
+ * to let the owner recognise WHICH identity a backup belongs to, but only a
+ * prefix (the full key is public anyway; a prefix keeps the record minimal).
+ */
+const PUBLIC_KEY_HINT_LENGTH = 16;
+
+/** The decrypted backup payload. */
+interface BackupPayload {
+  privateKey: string;
+  publicKey: string;
+  createdAt: string;
+}
+
+/** Encode bytes as lowercase hex (cross-platform, no Buffer dependency). */
+function toHex(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += bytes[i].toString(16).padStart(2, '0');
+  }
+  return out;
+}
+
+/** Decode a lowercase/uppercase hex string to bytes. Throws on malformed input. */
+function fromHex(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0 || /[^0-9a-fA-F]/.test(hex)) {
+    throw new Error('Malformed hex in encrypted backup envelope.');
+  }
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/**
+ * The AEAD associated data binds the ciphertext to its `{version, publicKeyHint}`
+ * context: the exact bytes must be reproduced at decrypt time, so a mismatched
+ * version or hint (e.g. an envelope re-stamped by a tamperer) fails the
+ * Poly1305 check. Deterministic: both sides build the SAME object literal, so
+ * `JSON.stringify` yields identical bytes.
+ */
+function buildBackupAad(version: number, publicKeyHint: string): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify({ version, publicKeyHint }));
+}
+
+export function OxyServicesIdentityBackupMixin<T extends typeof OxyServicesBase>(Base: T) {
+  return class extends Base {
+    constructor(...args: any[]) {
+      super(...(args as [any]));
+    }
+
+    /**
+     * Derive the backup key material from the recovery phrase, encrypt the
+     * identity's `{privateKey, publicKey, createdAt}` with it, and upload the
+     * ciphertext + raw `lookupId` (`POST /identity/backup`, bearer). The server
+     * stores only `sha256(lookupId)` + the ciphertext. Idempotent per user: a
+     * re-upload REPLACES the prior backup (upsert by user id).
+     *
+     * The identity is derived from the PHRASE (not read from SecureStore), so
+     * this works cross-platform and does not require an on-device key.
+     *
+     * @param phrase - The identity's BIP-39 recovery phrase.
+     * @returns The post-write backup status (`{ exists: true, publicKeyHint, createdAt }`).
+     */
+    async createEncryptedBackup(phrase: string): Promise<BackupStatusResponse> {
+      try {
+        const { backupKey, lookupId } = await RecoveryPhraseService.deriveBackupMaterial(phrase);
+        const privateKey = await RecoveryPhraseService.derivePrivateKeyFromPhrase(phrase);
+        const publicKey = KeyManager.derivePublicKey(privateKey);
+        const createdAt = new Date().toISOString();
+        const publicKeyHint = publicKey.slice(0, PUBLIC_KEY_HINT_LENGTH);
+
+        const payload: BackupPayload = { privateKey, publicKey, createdAt };
+        const plaintext = new TextEncoder().encode(JSON.stringify(payload));
+        const aad = buildBackupAad(BACKUP_ENVELOPE_VERSION, publicKeyHint);
+        const { nonce, ciphertext } = encryptAead(backupKey, plaintext, aad);
+
+        const body: BackupUploadRequest = {
+          version: BACKUP_ENVELOPE_VERSION,
+          algorithm: BACKUP_ALGORITHM,
+          kdfInfo: BACKUP_KDF_ENCRYPTION_INFO,
+          nonce: toHex(nonce),
+          ciphertext: toHex(ciphertext),
+          publicKeyHint,
+          createdAt,
+          lookupId,
+        };
+
+        return await this.makeRequest<BackupStatusResponse>(
+          'POST',
+          '/identity/backup',
+          body,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Whether the authenticated user has a stored encrypted backup, plus the
+     * non-sensitive hint + timestamp when one exists (`GET /identity/backup/status`,
+     * bearer). Returns no ciphertext and no locator.
+     */
+    async getBackupStatus(): Promise<BackupStatusResponse> {
+      try {
+        return await this.makeRequest<BackupStatusResponse>(
+          'GET',
+          '/identity/backup/status',
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Delete the authenticated user's stored backup (`DELETE /identity/backup`,
+     * bearer). Idempotent — deleting a non-existent backup still succeeds.
+     */
+    async deleteBackup(): Promise<{ success: boolean }> {
+      try {
+        return await this.makeRequest<{ success: boolean }>(
+          'DELETE',
+          '/identity/backup',
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Restore an identity from its encrypted off-device backup using ONLY the
+     * recovery phrase: re-derive `{backupKey, lookupId}`, fetch the envelope by
+     * `lookupId` (`GET /identity/backup/:lookupId`, PUBLIC — the 256-bit locator
+     * is the protection), decrypt + authenticate locally, then persist the key.
+     *
+     * NATIVE-ONLY persistence: `KeyManager.importKeyPair` throws on web. It also
+     * refuses to clobber a DIFFERENT existing on-device identity unless
+     * `overwrite: true` — the {@link import('../crypto/keyManager').IdentityAlreadyExistsError}
+     * propagates to the caller (never swallowed) so the UI can confirm before
+     * overwriting.
+     *
+     * @param phrase - The identity's BIP-39 recovery phrase.
+     * @param options.overwrite - Replace a different existing on-device identity.
+     * @returns The restored identity's public key.
+     * @throws if the phrase is invalid, no backup exists (404), the ciphertext
+     *   fails authentication (tamper), or an existing identity blocks the import.
+     */
+    async restoreFromEncryptedBackup(
+      phrase: string,
+      options?: { overwrite?: boolean },
+    ): Promise<string> {
+      try {
+        const { backupKey, lookupId } = await RecoveryPhraseService.deriveBackupMaterial(phrase);
+
+        const envelope = await this.makeRequest<EncryptedBackupEnvelope>(
+          'GET',
+          `/identity/backup/${encodeURIComponent(lookupId)}`,
+          undefined,
+          { cache: false },
+        );
+
+        if (envelope.algorithm !== BACKUP_ALGORITHM) {
+          throw new Error(`Unsupported backup algorithm: ${envelope.algorithm}`);
+        }
+
+        const aad = buildBackupAad(envelope.version, envelope.publicKeyHint);
+        const plaintext = decryptAead(
+          backupKey,
+          fromHex(envelope.nonce),
+          fromHex(envelope.ciphertext),
+          aad,
+        );
+        const payload = JSON.parse(new TextDecoder().decode(plaintext)) as BackupPayload;
+
+        // Persist the recovered key. Native-only; refuses to clobber a different
+        // identity unless overwrite — the IdentityAlreadyExistsError propagates.
+        return await KeyManager.importKeyPair(payload.privateKey, {
+          overwrite: options?.overwrite === true,
+        });
+      } catch (error) {
+        // Preserve the typed "an identity already exists" signal so the caller
+        // can prompt for overwrite. `handleError` would flatten it to a generic
+        // Error and lose that discrimination.
+        if (error instanceof IdentityAlreadyExistsError) {
+          throw error;
+        }
+        throw this.handleError(error);
+      }
+    }
+  };
+}

--- a/packages/core/src/mixins/__tests__/identityBackup.test.ts
+++ b/packages/core/src/mixins/__tests__/identityBackup.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Encrypted off-device identity backup mixin (b3 Feature 1).
+ *
+ * Exercises the full client contract with a REAL crypto round-trip (only
+ * `KeyManager.importKeyPair` — the native SecureStore write — is mocked):
+ *  - `createEncryptedBackup` derives the material, encrypts the identity, and
+ *    POSTs the envelope + raw `lookupId` (the server never sees the phrase/key).
+ *  - the uploaded envelope decrypts back to the SAME private key via
+ *    `restoreFromEncryptedBackup` (round-trip).
+ *  - any tamper (ciphertext / nonce / AAD-bound publicKeyHint) fails the
+ *    Poly1305 check → restore rejects.
+ *  - an existing on-device identity surfaces `IdentityAlreadyExistsError`
+ *    UNCHANGED (not flattened by `handleError`), and `overwrite` forwards.
+ */
+import { OxyServices } from '../../OxyServices';
+import { KeyManager, IdentityAlreadyExistsError } from '../../crypto/keyManager';
+import { RecoveryPhraseService } from '../../crypto/recoveryPhrase';
+import type { EncryptedBackupEnvelope, BackupUploadRequest } from '@oxyhq/contracts';
+
+const FIXED_PHRASE =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const EXPECTED_LOOKUP_ID = '8cad137ca961bfc62a2ef329869e8369777737c7c5353a8d94bb70d888c0ad0d';
+const EXPECTED_PRIVATE_KEY = '5eb00bbddcf069084889a8ab9155568165f5c453ccb85e70811aaed6f6da5fc1';
+
+/** Build a non-verified JWT whose payload decodes to the given claims. */
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (obj: Record<string, unknown>): string =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const fullPayload = { exp: Math.floor(Date.now() / 1000) + 3600, ...payload };
+  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url(fullPayload)}.sig`;
+}
+
+/** A JSON `Response` returning the body verbatim (no `{ data }` wrapper). */
+function plainResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('encrypted identity backup mixin', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+  let oxy: OxyServices;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    oxy.httpService.setTokens(makeJwt({ userId: 'me' }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  /** Read + parse the body of the Nth fetch call as the upload request. */
+  function uploadBodyFromCall(index: number): BackupUploadRequest {
+    const init = fetchMock.mock.calls[index][1];
+    return JSON.parse(String(init?.body)) as BackupUploadRequest;
+  }
+
+  it('createEncryptedBackup uploads an envelope + raw lookupId derived from the phrase', async () => {
+    fetchMock.mockResolvedValueOnce(
+      plainResponse({ exists: true, publicKeyHint: '04abc', createdAt: 'x' }),
+    );
+
+    await oxy.createEncryptedBackup(FIXED_PHRASE);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('http://test.invalid/identity/backup');
+    expect(init?.method).toBe('POST');
+
+    const body = uploadBodyFromCall(0);
+    // Envelope metadata.
+    expect(body.version).toBe(1);
+    expect(body.algorithm).toBe('xchacha20poly1305');
+    expect(body.kdfInfo).toBe('oxy-backup-encryption-key');
+    // The raw lookup id is the phrase-derived value (server will hash it).
+    expect(body.lookupId).toBe(EXPECTED_LOOKUP_ID);
+    // Hex ciphertext + 24-byte (48 hex) nonce.
+    expect(body.nonce).toMatch(/^[0-9a-f]{48}$/);
+    expect(body.ciphertext).toMatch(/^[0-9a-f]+$/);
+    // The hint is a 16-char prefix of the identity's real public key.
+    const publicKey = KeyManager.derivePublicKey(EXPECTED_PRIVATE_KEY);
+    expect(body.publicKeyHint).toBe(publicKey.slice(0, 16));
+    expect(body.publicKeyHint).toHaveLength(16);
+    // The plaintext private key NEVER appears on the wire.
+    expect(String(init?.body)).not.toContain(EXPECTED_PRIVATE_KEY);
+  });
+
+  it('round-trips: the uploaded envelope decrypts back to the SAME private key', async () => {
+    // 1) Encrypt + capture the real envelope.
+    fetchMock.mockResolvedValueOnce(
+      plainResponse({ exists: true, publicKeyHint: '04', createdAt: 'x' }),
+    );
+    await oxy.createEncryptedBackup(FIXED_PHRASE);
+    const uploaded = uploadBodyFromCall(0);
+    const envelope: EncryptedBackupEnvelope = {
+      version: uploaded.version,
+      algorithm: uploaded.algorithm,
+      kdfInfo: uploaded.kdfInfo,
+      nonce: uploaded.nonce,
+      ciphertext: uploaded.ciphertext,
+      publicKeyHint: uploaded.publicKeyHint,
+      createdAt: uploaded.createdAt,
+    };
+
+    // 2) Restore: intercept the native SecureStore write.
+    const importSpy = jest
+      .spyOn(KeyManager, 'importKeyPair')
+      .mockResolvedValue('restored-public-key');
+    fetchMock.mockResolvedValueOnce(plainResponse(envelope));
+
+    const publicKey = await oxy.restoreFromEncryptedBackup(FIXED_PHRASE);
+
+    // The GET targets the locator; import receives the decrypted private key.
+    const [url, init] = fetchMock.mock.calls[1];
+    expect(String(url)).toBe(`http://test.invalid/identity/backup/${EXPECTED_LOOKUP_ID}`);
+    expect(init?.method).toBe('GET');
+    expect(importSpy).toHaveBeenCalledWith(EXPECTED_PRIVATE_KEY, { overwrite: false });
+    expect(publicKey).toBe('restored-public-key');
+  });
+
+  it('rejects a tampered ciphertext (Poly1305 authentication fails)', async () => {
+    fetchMock.mockResolvedValueOnce(plainResponse({ exists: true }));
+    await oxy.createEncryptedBackup(FIXED_PHRASE);
+    const uploaded = uploadBodyFromCall(0);
+
+    // Flip the first ciphertext byte.
+    const firstByte = uploaded.ciphertext.slice(0, 2);
+    const flipped = (Number.parseInt(firstByte, 16) ^ 0xff).toString(16).padStart(2, '0');
+    const tampered: EncryptedBackupEnvelope = {
+      version: uploaded.version,
+      algorithm: uploaded.algorithm,
+      kdfInfo: uploaded.kdfInfo,
+      nonce: uploaded.nonce,
+      ciphertext: flipped + uploaded.ciphertext.slice(2),
+      publicKeyHint: uploaded.publicKeyHint,
+      createdAt: uploaded.createdAt,
+    };
+
+    const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue('x');
+    fetchMock.mockResolvedValueOnce(plainResponse(tampered));
+
+    await expect(oxy.restoreFromEncryptedBackup(FIXED_PHRASE)).rejects.toThrow();
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the AAD-bound publicKeyHint is altered', async () => {
+    fetchMock.mockResolvedValueOnce(plainResponse({ exists: true }));
+    await oxy.createEncryptedBackup(FIXED_PHRASE);
+    const uploaded = uploadBodyFromCall(0);
+
+    const tampered: EncryptedBackupEnvelope = {
+      version: uploaded.version,
+      algorithm: uploaded.algorithm,
+      kdfInfo: uploaded.kdfInfo,
+      nonce: uploaded.nonce,
+      ciphertext: uploaded.ciphertext,
+      publicKeyHint: 'deadbeefdeadbeef', // wrong hint → AAD mismatch
+      createdAt: uploaded.createdAt,
+    };
+
+    const importSpy = jest.spyOn(KeyManager, 'importKeyPair').mockResolvedValue('x');
+    fetchMock.mockResolvedValueOnce(plainResponse(tampered));
+
+    await expect(oxy.restoreFromEncryptedBackup(FIXED_PHRASE)).rejects.toThrow();
+    expect(importSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a mismatched nonce', async () => {
+    fetchMock.mockResolvedValueOnce(plainResponse({ exists: true }));
+    await oxy.createEncryptedBackup(FIXED_PHRASE);
+    const uploaded = uploadBodyFromCall(0);
+
+    const tampered: EncryptedBackupEnvelope = {
+      version: uploaded.version,
+      algorithm: uploaded.algorithm,
+      kdfInfo: uploaded.kdfInfo,
+      nonce: '00'.repeat(24), // wrong nonce
+      ciphertext: uploaded.ciphertext,
+      publicKeyHint: uploaded.publicKeyHint,
+      createdAt: uploaded.createdAt,
+    };
+
+    fetchMock.mockResolvedValueOnce(plainResponse(tampered));
+    await expect(oxy.restoreFromEncryptedBackup(FIXED_PHRASE)).rejects.toThrow();
+  });
+
+  it('propagates IdentityAlreadyExistsError UNCHANGED (so the caller can offer overwrite)', async () => {
+    fetchMock.mockResolvedValueOnce(plainResponse({ exists: true }));
+    await oxy.createEncryptedBackup(FIXED_PHRASE);
+    const uploaded = uploadBodyFromCall(0);
+    const envelope: EncryptedBackupEnvelope = {
+      version: uploaded.version,
+      algorithm: uploaded.algorithm,
+      kdfInfo: uploaded.kdfInfo,
+      nonce: uploaded.nonce,
+      ciphertext: uploaded.ciphertext,
+      publicKeyHint: uploaded.publicKeyHint,
+      createdAt: uploaded.createdAt,
+    };
+
+    jest
+      .spyOn(KeyManager, 'importKeyPair')
+      .mockRejectedValue(new IdentityAlreadyExistsError('04existingkey'));
+    fetchMock.mockResolvedValueOnce(plainResponse(envelope));
+
+    await expect(oxy.restoreFromEncryptedBackup(FIXED_PHRASE)).rejects.toBeInstanceOf(
+      IdentityAlreadyExistsError,
+    );
+  });
+
+  it('forwards overwrite:true to importKeyPair', async () => {
+    fetchMock.mockResolvedValueOnce(plainResponse({ exists: true }));
+    await oxy.createEncryptedBackup(FIXED_PHRASE);
+    const uploaded = uploadBodyFromCall(0);
+    const envelope: EncryptedBackupEnvelope = {
+      version: uploaded.version,
+      algorithm: uploaded.algorithm,
+      kdfInfo: uploaded.kdfInfo,
+      nonce: uploaded.nonce,
+      ciphertext: uploaded.ciphertext,
+      publicKeyHint: uploaded.publicKeyHint,
+      createdAt: uploaded.createdAt,
+    };
+
+    const importSpy = jest
+      .spyOn(KeyManager, 'importKeyPair')
+      .mockResolvedValue('restored-public-key');
+    fetchMock.mockResolvedValueOnce(plainResponse(envelope));
+
+    await oxy.restoreFromEncryptedBackup(FIXED_PHRASE, { overwrite: true });
+    expect(importSpy).toHaveBeenCalledWith(EXPECTED_PRIVATE_KEY, { overwrite: true });
+  });
+
+  it('getBackupStatus + deleteBackup hit the right endpoints', async () => {
+    fetchMock.mockResolvedValueOnce(
+      plainResponse({ exists: true, publicKeyHint: '04abc', createdAt: 'iso' }),
+    );
+    const status = await oxy.getBackupStatus();
+    expect(status).toEqual({ exists: true, publicKeyHint: '04abc', createdAt: 'iso' });
+    let [url, init] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe('http://test.invalid/identity/backup/status');
+    expect(init?.method).toBe('GET');
+
+    fetchMock.mockResolvedValueOnce(plainResponse({ success: true }));
+    await expect(oxy.deleteBackup()).resolves.toEqual({ success: true });
+    [url, init] = fetchMock.mock.calls[1];
+    expect(String(url)).toBe('http://test.invalid/identity/backup');
+    expect(init?.method).toBe('DELETE');
+  });
+});

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -9,6 +9,7 @@ import { OxyServicesBase } from '../OxyServices.base';
 import { OxyServicesAuthMixin } from './OxyServices.auth';
 import { OxyServicesUserMixin } from './OxyServices.user';
 import { OxyServicesIdentityMixin } from './OxyServices.identity';
+import { OxyServicesIdentityBackupMixin } from './OxyServices.identityBackup';
 import { OxyServicesPrivacyMixin } from './OxyServices.privacy';
 import { OxyServicesLanguageMixin } from './OxyServices.language';
 import { OxyServicesPaymentMixin } from './OxyServices.payment';
@@ -43,6 +44,7 @@ type AllMixinInstances =
   & InstanceType<ReturnType<typeof OxyServicesAuthMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesUserMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesIdentityMixin<typeof OxyServicesBase>>>
+  & InstanceType<ReturnType<typeof OxyServicesIdentityBackupMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesPrivacyMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesLanguageMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesPaymentMixin<typeof OxyServicesBase>>>
@@ -98,6 +100,9 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     OxyServicesUserMixin,
     // Self-sovereign identity (DID, signed records, auth-method ↔ VM mapping)
     OxyServicesIdentityMixin,
+    // Encrypted off-device identity backup (b3 Feature 1): store/restore an
+    // encrypted copy of the self-custody key, keyed off the recovery phrase.
+    OxyServicesIdentityBackupMixin,
     OxyServicesPrivacyMixin,
 
     // Feature mixins


### PR DESCRIPTION
## b3 Feature 1 — encrypted off-device identity backup (BACKEND slice)

Zero-knowledge, phrase-derived backup of a self-custody identity key so a lost/wiped device can be recovered from the recovery phrase **alone**. Builds on the merged Phase 0 crypto primitives (`hkdfSha256`, `encryptAead`/`decryptAead`). The Commons UI is a separate follow-up slice.

### Design as-built
The server stores **only** ciphertext + `sha256(lookupId)` — never the phrase, the derived key, the plaintext private key, or the raw `lookupId` (mirrors `DeviceSession.secretHash`).

Key schedule (does **not** touch the frozen phrase→privateKey derivation):
```
seed      = bip39.mnemonicToSeed(phrase)                       // UNCHANGED (seed[0:32] stays the identity key)
backupKey = hkdfSha256(seed, 'oxy-identity-backup-v1', 'oxy-backup-encryption-key', 32)
lookupId  = hkdfSha256(seed, 'oxy-identity-backup-v1', 'oxy-backup-lookup-id', 32)  // hex
```
Domain separation is real: both require the **full 64-byte seed**, so a device compromise (raw 32-byte private key only) can compute neither `backupKey` nor `lookupId`. Restore needs the phrase.

### Changes
**contracts** (`@oxyhq/contracts`, internal `workspace:*`): `keyRecovery.ts` — `encryptedBackupEnvelopeSchema`, `backupUploadRequestSchema`, `backupStatusResponseSchema` + inferred types, exported from index.

**core** (`@oxyhq/core`):
- `RecoveryPhraseService.deriveBackupMaterial(phrase)` → `{ backupKey, lookupId }` (pure, additive; Phase 0 `hkdfSha256`).
- `OxyServices.identityBackup` mixin: `createEncryptedBackup` / `getBackupStatus` / `deleteBackup` / `restoreFromEncryptedBackup`. AAD binds `{version, publicKeyHint}`; restore ends in `KeyManager.importKeyPair` and propagates `IdentityAlreadyExistsError` **unchanged** so the UI can prompt for overwrite. Registered in `MIXIN_PIPELINE` + `AllMixinInstances`.

**api** (`@oxyhq/api`):
- `models/IdentityBackup.ts` (collection `identitybackups`): `userId` unique, `lookupIdHash` unique (= `sha256` of the client-sent `lookupId`; raw never stored).
- `routes/identityBackup.ts` at `/identity/backup`: `POST /` (bearer, upsert by userId), `GET /status` (bearer), `DELETE /` (bearer), `GET /:lookupId` (**public**, `rl:identity:backup:`, hash-and-lookup + constant-shape 404). Mounted before `/identity`, no CSRF (bearer writes + public read).

### Security invariants
- Server never sees phrase / backupKey / plaintext key — only `lookupIdHash` + ciphertext.
- AEAD binds `{version, publicKeyHint}`; any tamper fails Poly1305.
- Public restore endpoint is defense-in-depth; real protection is the locator's 256-bit entropy.
- No IP persisted; public limiter keys on `hashedIpKey`.

### Tests
KDF vectors pinned to the canonical BIP-39 `abandon…about` seed; AEAD round-trip + tamper (ciphertext / nonce / AAD) via the mixin; `IdentityAlreadyExistsError` propagation + overwrite forwarding; POST upsert-not-duplicate; `sha256(lookupId)` stored (not raw); model unique-index declarations; public restore 404 with no existence short-circuit.

**Verification (in-worktree):** api tsc ✓ · core build + tsc ✓ · api **1610** · core **930** · contracts **133** — all green.

### Flags
- 🔒 **security-reviewer needed before merge.**
- Commons create-backup / restore UI = **follow-up** slice.
- `@oxyhq/contracts` is **republish-first at merge** (new `keyRecovery` symbols) before core consumes them from a published build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)