### PR TITLE
feat(identity): device-to-device identity transfer backend (b3 F2, "add a device")

### DIFF
--- a/packages/api/src/models/DevicePairingSession.ts
+++ b/packages/api/src/models/DevicePairingSession.ts
@@ -1,0 +1,107 @@
+import mongoose, { type Document, Schema } from "mongoose";
+
+/**
+ * DevicePairingSession Model (b3 Feature 2 — device-to-device identity transfer)
+ *
+ * Backs the short-lived, unauthenticated relay that clones an identity from an
+ * existing device to a fresh one. It is E2E-encrypted: the server stores only
+ * the two ephemeral secp256k1 public keys plus an opaque AEAD ciphertext/nonce
+ * and NEVER holds a key that can decrypt the transferred private key. A DB dump
+ * or on-path attacker sees only ciphertext.
+ *
+ * Lifecycle:
+ *   pending  -> new device created the pairing and is waiting (holds the
+ *               matching ephemeral private key in memory only)
+ *   approved -> old device sealed `{ privateKey, publicKey }` under the shared
+ *               transfer key and posted the ciphertext (atomic pending->approved)
+ *   denied   -> old device explicitly cancelled the transfer
+ *   expired  -> the 3-minute TTL elapsed before approval (also set lazily on read)
+ *
+ * Security invariants:
+ *   - Ephemeral keys are SINGLE-USE and never persisted beyond this row's TTL.
+ *   - The pending->approved transition is ATOMIC (findOneAndUpdate on
+ *     status:'pending') so a concurrent approve cannot double-complete.
+ *   - No IP / device fingerprint is persisted (privacy invariant).
+ */
+export type DevicePairingStatus = 'pending' | 'approved' | 'denied' | 'expired';
+
+export interface IDevicePairingSession extends Document {
+  /** 128-bit single-use handle carried in the QR (also the HKDF salt). */
+  pairingId: string;
+  /** The new device's ephemeral secp256k1 public key (hex). */
+  newDeviceEphemeralPublicKey: string;
+  /** Optional human-readable label for the new device. */
+  newDeviceLabel?: string | null;
+  /** The old device's ephemeral secp256k1 public key (hex) — set on approve. */
+  oldDeviceEphemeralPublicKey?: string | null;
+  /** AEAD ciphertext of `{ privateKey, publicKey }` (hex) — set on approve. */
+  ciphertext?: string | null;
+  /** AEAD nonce (hex, 24 bytes) — set on approve. */
+  nonce?: string | null;
+  status: DevicePairingStatus;
+  /** MongoDB id of the bearer-authenticated user who approved the transfer. */
+  approvedByUserId?: mongoose.Types.ObjectId | null;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const DevicePairingSessionSchema: Schema = new Schema(
+  {
+    pairingId: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    newDeviceEphemeralPublicKey: {
+      type: String,
+      required: true,
+    },
+    newDeviceLabel: {
+      type: String,
+      default: null,
+    },
+    oldDeviceEphemeralPublicKey: {
+      type: String,
+      default: null,
+    },
+    ciphertext: {
+      type: String,
+      default: null,
+    },
+    nonce: {
+      type: String,
+      default: null,
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'approved', 'denied', 'expired'],
+      default: 'pending',
+      index: true,
+    },
+    approvedByUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      default: null,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// TTL index — remove the row at `expiresAt` (Mongo's TTL monitor lags up to 60s,
+// which is fine; reads mark status:'expired' lazily before the sweep). The row
+// is single-use and ephemeral, so there is no reason to retain it past expiry.
+DevicePairingSessionSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export const DevicePairingSession = mongoose.model<IDevicePairingSession>(
+  "DevicePairingSession",
+  DevicePairingSessionSchema
+);
+export default DevicePairingSession;

--- a/packages/api/src/routes/__tests__/deviceTransferRateLimit.test.ts
+++ b/packages/api/src/routes/__tests__/deviceTransferRateLimit.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Every Redis-backed limiter in `routes/deviceTransfer.ts` MUST register a
+ * UNIQUE key prefix. Two limiters sharing a prefix increment the same counter
+ * when a request flows through both (express-rate-limit throws
+ * ERR_ERL_DOUBLE_COUNT and the effective per-key budget is silently halved).
+ * This suite captures each prefix at module-load time via a mocked RedisStore
+ * and asserts the four device-transfer limiters are present and distinct.
+ */
+
+const capturedPrefixes: string[] = [];
+
+jest.mock('rate-limit-redis', () => ({
+  RedisStore: jest.fn().mockImplementation((opts: { prefix?: string }) => {
+    if (typeof opts?.prefix === 'string') capturedPrefixes.push(opts.prefix);
+    return {
+      init: jest.fn(),
+      increment: jest.fn(async () => ({ totalHits: 1, resetTime: new Date() })),
+      decrement: jest.fn(),
+      resetKey: jest.fn(),
+      resetAll: jest.fn(),
+    };
+  }),
+}));
+
+// Force the Redis branch of `makeStore` so a RedisStore (with its prefix) is
+// actually constructed for each limiter at import time.
+jest.mock('../../config/redis', () => ({
+  getRedisClient: () => ({ call: jest.fn() }),
+}));
+
+// Stub the auth middleware, service, and socket util so importing the route only
+// constructs the limiters (avoids dragging the Session/User model graph through
+// the global mongoose mock, which lacks `Schema.methods`).
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../services/deviceTransfer.service', () => ({
+  initDeviceTransfer: jest.fn(),
+  getDeviceTransferInfo: jest.fn(),
+  approveDeviceTransfer: jest.fn(),
+  denyDeviceTransfer: jest.fn(),
+}));
+jest.mock('../../utils/devicePairSocket', () => ({
+  emitDevicePairUpdate: jest.fn(),
+}));
+
+// Importing the route builds every limiter at load time, populating
+// `capturedPrefixes` via the mocked RedisStore constructor.
+import '../deviceTransfer';
+
+describe('deviceTransfer.ts limiter prefixes are unique', () => {
+  const expected = [
+    'rl:identity:devicetransfer:init:',
+    'rl:identity:devicetransfer:info:',
+    'rl:identity:devicetransfer:approve:',
+    'rl:identity:devicetransfer:deny:',
+  ];
+
+  it('registers all four device-transfer limiters', () => {
+    for (const prefix of expected) {
+      expect(capturedPrefixes).toContain(prefix);
+    }
+  });
+
+  it('registers each prefix exactly once (no ERR_ERL_DOUBLE_COUNT)', () => {
+    for (const prefix of expected) {
+      expect(capturedPrefixes.filter((p) => p === prefix)).toHaveLength(1);
+    }
+    expect(new Set(expected).size).toBe(expected.length);
+  });
+});

--- a/packages/api/src/routes/deviceTransfer.ts
+++ b/packages/api/src/routes/deviceTransfer.ts
@@ -1,0 +1,199 @@
+/**
+ * Device-to-device identity transfer routes (b3 Feature 2 — "add a device").
+ *
+ * Mounted at `/identity/device-transfer` (no CSRF — public/unauthenticated init,
+ * info, deny; the approve write is bearer + signature-authenticated, so per the
+ * bearer-write CSRF rule it takes no ambient cookie CSRF token):
+ *  - `POST /identity/device-transfer/init`               (public) register a pairing
+ *  - `GET  /identity/device-transfer/:pairingId`         (public) resolve a pairing
+ *  - `POST /identity/device-transfer/:pairingId/approve` (bearer + signature) seal + relay
+ *  - `POST /identity/device-transfer/:pairingId/deny`    (public) cancel a pairing
+ *
+ * The relay is E2E-encrypted via an ephemeral secp256k1 ECDH handshake: the
+ * server stores only the two ephemeral public keys plus an opaque AEAD
+ * ciphertext/nonce and NEVER holds a decryption key. See
+ * `services/deviceTransfer.service.ts` for the full security model.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { authMiddleware, type AuthRequest } from '../middleware/auth';
+import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
+import { BadRequestError, ConflictError, NotFoundError, UnauthorizedError } from '../utils/error';
+import { validate } from '../middleware/validate';
+import { rateLimit } from '../middleware/rateLimiter';
+import { hashedIpKey } from '../utils/ipKey';
+import { logger } from '../utils/logger';
+import {
+  deviceTransferInitRequestSchema,
+  deviceTransferApproveRequestSchema,
+  type DeviceTransferInitRequest,
+  type DeviceTransferApproveRequest,
+} from '@oxyhq/contracts';
+import {
+  initDeviceTransfer,
+  getDeviceTransferInfo,
+  approveDeviceTransfer,
+  denyDeviceTransfer,
+} from '../services/deviceTransfer.service';
+import { emitDevicePairUpdate } from '../utils/devicePairSocket';
+
+const router = Router();
+
+/** `:pairingId` path param — the public 128-bit hex handle from the QR. */
+const pairingIdParams = z.object({
+  pairingId: z.string().trim().min(1).max(128),
+});
+
+/* -------------------------------------------------------------------------- */
+/*  Rate limiters — public endpoints keyed by hashed IP (privacy invariant),   */
+/*  the bearer approve keyed by user id.                                       */
+/* -------------------------------------------------------------------------- */
+
+const initLimiter = rateLimit({
+  prefix: 'rl:identity:devicetransfer:init:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 20,
+  message: 'Too many device-transfer requests. Please slow down.',
+  keyGenerator: (req: Request) => `devicetransfer:init:ip:${hashedIpKey(req)}`,
+});
+
+const infoLimiter = rateLimit({
+  prefix: 'rl:identity:devicetransfer:info:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 300 : 120,
+  message: 'Too many device-transfer lookups. Please slow down.',
+  keyGenerator: (req: Request) => `devicetransfer:info:ip:${hashedIpKey(req)}`,
+});
+
+const approveLimiter = rateLimit({
+  prefix: 'rl:identity:devicetransfer:approve:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 30,
+  message: 'Too many device-transfer approvals. Please slow down.',
+  keyGenerator: (req: Request) => {
+    const userId = (req as AuthRequest).user?.id;
+    return userId ? `devicetransfer:approve:${userId}` : `devicetransfer:approve:ip:${hashedIpKey(req)}`;
+  },
+});
+
+const denyLimiter = rateLimit({
+  prefix: 'rl:identity:devicetransfer:deny:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 30,
+  message: 'Too many device-transfer denials. Please slow down.',
+  keyGenerator: (req: Request) => `devicetransfer:deny:ip:${hashedIpKey(req)}`,
+});
+
+/* -------------------------------------------------------------------------- */
+/*  POST /identity/device-transfer/init                                        */
+/* -------------------------------------------------------------------------- */
+router.post(
+  '/init',
+  initLimiter,
+  validate({ body: deviceTransferInitRequestSchema }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { newEphPub, newDeviceLabel } = req.body as DeviceTransferInitRequest;
+
+    const outcome = await initDeviceTransfer({ newEphPub, newDeviceLabel });
+    if (!outcome.ok) {
+      throw new BadRequestError(outcome.message);
+    }
+
+    sendSuccess(
+      res,
+      { pairingId: outcome.pairingId, expiresAt: outcome.expiresAt.toISOString() },
+      201,
+    );
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  GET /identity/device-transfer/:pairingId                                   */
+/* -------------------------------------------------------------------------- */
+router.get(
+  '/:pairingId',
+  infoLimiter,
+  validate({ params: pairingIdParams }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { pairingId } = req.params;
+
+    const info = await getDeviceTransferInfo(pairingId);
+    if (!info) {
+      throw new NotFoundError('Pairing not found');
+    }
+
+    sendSuccess(res, info);
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  POST /identity/device-transfer/:pairingId/approve                          */
+/* -------------------------------------------------------------------------- */
+router.post(
+  '/:pairingId/approve',
+  authMiddleware,
+  approveLimiter,
+  validate({ params: pairingIdParams, body: deviceTransferApproveRequestSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const userId = req.user?._id?.toString();
+    if (!userId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const { pairingId } = req.params;
+    const { oldEphPub, ciphertext, nonce, signature, timestamp } =
+      req.body as DeviceTransferApproveRequest;
+
+    const outcome = await approveDeviceTransfer({
+      pairingId,
+      authenticatedUserId: userId,
+      oldEphPub,
+      ciphertext,
+      nonce,
+      signature,
+      timestamp,
+    });
+
+    if (!outcome.ok) {
+      if (outcome.status === 401) throw new UnauthorizedError(outcome.message);
+      if (outcome.status === 404) throw new NotFoundError(outcome.message);
+      if (outcome.status === 409) throw new ConflictError(outcome.message);
+      throw new BadRequestError(outcome.message);
+    }
+
+    // Notify the waiting new device to fetch the sealed material and import it.
+    emitDevicePairUpdate(pairingId, { status: 'approved' });
+
+    logger.info('Device transfer approved (relay sealed)', {
+      pairingId: pairingId.substring(0, 8) + '...',
+      userId,
+    });
+
+    sendSuccess(res, { success: true, pairingId, status: 'approved' as const });
+  }),
+);
+
+/* -------------------------------------------------------------------------- */
+/*  POST /identity/device-transfer/:pairingId/deny                             */
+/* -------------------------------------------------------------------------- */
+router.post(
+  '/:pairingId/deny',
+  denyLimiter,
+  validate({ params: pairingIdParams }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { pairingId } = req.params;
+
+    const outcome = await denyDeviceTransfer(pairingId);
+    if (!outcome.ok) {
+      if (outcome.status === 404) throw new NotFoundError(outcome.message);
+      throw new ConflictError(outcome.message);
+    }
+
+    emitDevicePairUpdate(pairingId, { status: 'denied' });
+
+    sendSuccess(res, { success: true, pairingId, status: outcome.status });
+  }),
+);
+
+export default router;

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -48,6 +48,7 @@ import userDataRouter from './routes/userData';
 import appSignalsRouter from './routes/appSignals';
 import identityRoutes from './routes/identity';
 import identityBackupRoutes from './routes/identityBackup';
+import deviceTransferRoutes from './routes/deviceTransfer';
 import civicRoutes from './routes/civic';
 import nodeRoutes from './routes/nodes';
 import { sweepValidations } from './services/civic/validator.service';
@@ -293,6 +294,7 @@ io.on('connection', (socket: AuthenticatedSocket) => {
 // Used for cross-app authentication via QR code
 // ============================================
 import { initAuthSessionNamespace } from './utils/authSessionSocket';
+import { initDevicePairNamespace } from './utils/devicePairSocket';
 
 const authSessionNamespace = io.of('/auth-session');
 authSessionNamespace.use(createSocketRateLimiter(20, 10_000)); // Stricter: 20 events per 10s
@@ -323,6 +325,41 @@ authSessionNamespace.on('connection', (socket) => {
   
   socket.on('disconnect', () => {
     logger.debug('Auth session socket disconnected', { socketId: socket.id });
+  });
+});
+
+// ============================================
+// Device-Pair Socket Namespace (Unauthenticated)
+// Used for device-to-device identity transfer ("add a device"). The waiting new
+// device joins room `devicepair:<pairingId>`; the server pushes a lightweight
+// status signal when the old device approves/denies. No key material flows over
+// this socket — the transferred bytes are E2E-encrypted regardless.
+// ============================================
+const devicePairNamespace = io.of('/device-pair');
+devicePairNamespace.use(createSocketRateLimiter(20, 10_000)); // Stricter: 20 events per 10s
+initDevicePairNamespace(devicePairNamespace);
+
+devicePairNamespace.on('connection', (socket) => {
+  logger.debug('Device-pair socket connected', { socketId: socket.id });
+
+  socket.on('join', (pairingId: string) => {
+    if (!pairingId || typeof pairingId !== 'string' || pairingId.length < 8) {
+      socket.emit('error', { message: 'Invalid pairing id' });
+      return;
+    }
+    const room = `devicepair:${pairingId}`;
+    socket.join(room);
+    logger.debug('Client joined device-pair room', { socketId: socket.id, room });
+    socket.emit('joined', { pairingId });
+  });
+
+  socket.on('leave', (pairingId: string) => {
+    if (!pairingId || typeof pairingId !== 'string') return;
+    socket.leave(`devicepair:${pairingId}`);
+  });
+
+  socket.on('disconnect', () => {
+    logger.debug('Device-pair socket disconnected', { socketId: socket.id });
   });
 });
 
@@ -571,6 +608,11 @@ app.use('/app-signals', appSignalsRouter);
 // auth, so no csrfProtection (bearer-write CSRF rule + public GET). Mounted
 // BEFORE `/identity` so the more specific `/identity/backup` prefix wins.
 app.use('/identity/backup', identityBackupRoutes);
+// Device-to-device identity transfer ("add a device"). Mounted BEFORE `/identity`
+// so its specific prefix wins over the identity router. Public init/info/deny +
+// bearer+signature approve; the relay is E2E-encrypted (no CSRF — no ambient
+// cookie credentials, per the bearer-write CSRF rule).
+app.use('/identity/device-transfer', deviceTransferRoutes);
 // Self-sovereign identity layer: signed records + verified-domain badges.
 // Mixed public/private routes (each gates its own auth); writes are
 // Bearer-authenticated, so no csrfProtection (bearer-write CSRF rule).

--- a/packages/api/src/services/__tests__/deviceTransfer.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceTransfer.service.test.ts
@@ -1,0 +1,294 @@
+/**
+ * deviceTransfer.service tests (b3 Feature 2 — device-to-device identity transfer).
+ *
+ * The relay is E2E-encrypted; the server-side logic under test is the
+ * SECURITY-CRITICAL half:
+ *   - init validates the ephemeral public key and stamps a short TTL.
+ *   - info marks a past-TTL pairing `expired` on read and only surfaces the
+ *     sealed material once approved.
+ *   - approve requires a FRESH signature over
+ *     `{ action:'approve_device_transfer', pairingId, timestamp }` made with the
+ *     caller's CURRENT identity key (a bearer alone must not exfiltrate the key),
+ *     and the pending->approved transition is ATOMIC (loser gets 409).
+ *
+ * Real `SignatureService` (secp256k1) is used so signature acceptance/rejection
+ * is genuine; the Mongoose models are mocked (api tests mock mongoose globally).
+ */
+
+import { ec as EC } from 'elliptic';
+
+const mockPairingFindOne = jest.fn();
+const mockPairingFindOneAndUpdate = jest.fn();
+const mockPairingCreate = jest.fn();
+const mockUserFindById = jest.fn();
+
+jest.mock('../../models/DevicePairingSession', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: unknown[]) => mockPairingFindOne(...args),
+    findOneAndUpdate: (...args: unknown[]) => mockPairingFindOneAndUpdate(...args),
+    create: (...args: unknown[]) => mockPairingCreate(...args),
+  },
+  DevicePairingSession: {
+    findOne: (...args: unknown[]) => mockPairingFindOne(...args),
+    findOneAndUpdate: (...args: unknown[]) => mockPairingFindOneAndUpdate(...args),
+    create: (...args: unknown[]) => mockPairingCreate(...args),
+  },
+}));
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: { findById: (...args: unknown[]) => mockUserFindById(...args) },
+  default: { findById: (...args: unknown[]) => mockUserFindById(...args) },
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import {
+  initDeviceTransfer,
+  getDeviceTransferInfo,
+  approveDeviceTransfer,
+  denyDeviceTransfer,
+  buildApprovalSigningMessage,
+} from '../deviceTransfer.service';
+import { SignatureService } from '../signature.service';
+
+const ec = new EC('secp256k1');
+const PAIRING_ID = 'a'.repeat(32);
+
+// A stable identity keypair for the caller (the CURRENT key it must sign with).
+const identityKey = ec.genKeyPair();
+const identityPriv = identityKey.getPrivate('hex');
+const identityPub = identityKey.getPublic('hex');
+// A valid single-use ephemeral public key the old device supplies.
+const oldEphPub = ec.genKeyPair().getPublic('hex');
+
+/** Chainable `User.findById(id).select('+publicKey')` mock. */
+function userWithPublicKey(publicKey: string | undefined) {
+  return { select: () => Promise.resolve(publicKey === undefined ? { _id: 'u1' } : { _id: 'u1', publicKey }) };
+}
+
+function pendingRow(over: Record<string, unknown> = {}) {
+  return {
+    pairingId: PAIRING_ID,
+    newDeviceEphemeralPublicKey: 'newpub',
+    newDeviceLabel: 'New iPhone',
+    status: 'pending' as string,
+    expiresAt: new Date(Date.now() + 60_000),
+    oldDeviceEphemeralPublicKey: null as string | null,
+    ciphertext: null as string | null,
+    nonce: null as string | null,
+    save: jest.fn().mockResolvedValue(undefined),
+    ...over,
+  };
+}
+
+function signApproval(privateKey: string, timestamp: number): string {
+  return SignatureService.signMessage(buildApprovalSigningMessage(PAIRING_ID, timestamp), privateKey);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('initDeviceTransfer', () => {
+  it('creates a pairing with a short TTL and a 128-bit id', async () => {
+    mockPairingCreate.mockResolvedValueOnce({});
+    const before = Date.now();
+
+    const outcome = await initDeviceTransfer({ newEphPub: oldEphPub, newDeviceLabel: 'iPad' });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.pairingId).toMatch(/^[0-9a-f]{32}$/);
+    // 3-minute TTL (allow a little slack for the clock).
+    const ttl = outcome.expiresAt.getTime() - before;
+    expect(ttl).toBeGreaterThan(150_000);
+    expect(ttl).toBeLessThanOrEqual(180_000 + 1000);
+    expect(mockPairingCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ newDeviceEphemeralPublicKey: oldEphPub, newDeviceLabel: 'iPad', status: 'pending' }),
+    );
+  });
+
+  it('rejects an invalid ephemeral public key WITHOUT writing', async () => {
+    const outcome = await initDeviceTransfer({ newEphPub: 'not-a-key' });
+    expect(outcome).toEqual({ ok: false, status: 400, message: 'Invalid ephemeral public key' });
+    expect(mockPairingCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('getDeviceTransferInfo', () => {
+  it('returns null for an unknown pairing', async () => {
+    mockPairingFindOne.mockResolvedValueOnce(null);
+    expect(await getDeviceTransferInfo(PAIRING_ID)).toBeNull();
+  });
+
+  it('marks a past-TTL pending pairing expired on read (lazy expiry)', async () => {
+    const row = pendingRow({ expiresAt: new Date(Date.now() - 1000) });
+    mockPairingFindOne.mockResolvedValueOnce(row);
+
+    const info = await getDeviceTransferInfo(PAIRING_ID);
+
+    expect(row.status).toBe('expired');
+    expect(row.save).toHaveBeenCalledTimes(1);
+    expect(info?.status).toBe('expired');
+    // Never leak material for a non-approved pairing.
+    expect(info?.ciphertext).toBeNull();
+    expect(info?.oldDeviceEphemeralPublicKey).toBeNull();
+  });
+
+  it('surfaces the sealed material ONLY once approved', async () => {
+    mockPairingFindOne.mockResolvedValueOnce(
+      pendingRow({ status: 'approved', oldDeviceEphemeralPublicKey: oldEphPub, ciphertext: 'ct', nonce: 'nn' }),
+    );
+
+    const info = await getDeviceTransferInfo(PAIRING_ID);
+
+    expect(info?.status).toBe('approved');
+    expect(info?.ciphertext).toBe('ct');
+    expect(info?.nonce).toBe('nn');
+    expect(info?.oldDeviceEphemeralPublicKey).toBe(oldEphPub);
+  });
+});
+
+describe('approveDeviceTransfer', () => {
+  function baseInput(over: Record<string, unknown> = {}) {
+    const timestamp = Date.now();
+    return {
+      pairingId: PAIRING_ID,
+      authenticatedUserId: 'u1',
+      oldEphPub,
+      ciphertext: 'ff'.repeat(20),
+      nonce: '00'.repeat(24),
+      signature: signApproval(identityPriv, timestamp),
+      timestamp,
+      ...over,
+    };
+  }
+
+  it('accepts a valid signature and ATOMICALLY seals the material', async () => {
+    mockUserFindById.mockReturnValueOnce(userWithPublicKey(identityPub));
+    mockPairingFindOne.mockResolvedValueOnce(pendingRow());
+    mockPairingFindOneAndUpdate.mockResolvedValueOnce(pendingRow({ status: 'approved' }));
+
+    const outcome = await approveDeviceTransfer(baseInput());
+
+    expect(outcome).toEqual({ ok: true, pairingId: PAIRING_ID });
+    expect(mockPairingFindOneAndUpdate).toHaveBeenCalledWith(
+      { pairingId: PAIRING_ID, status: 'pending', expiresAt: { $gt: expect.any(Date) } },
+      {
+        $set: expect.objectContaining({
+          status: 'approved',
+          oldDeviceEphemeralPublicKey: oldEphPub,
+          ciphertext: 'ff'.repeat(20),
+          nonce: '00'.repeat(24),
+        }),
+      },
+      { new: true },
+    );
+  });
+
+  it('rejects a signature NOT matching the caller current publicKey (401) before any pairing read', async () => {
+    // Sign with a DIFFERENT key than the account's registered publicKey.
+    const attackerPriv = ec.genKeyPair().getPrivate('hex');
+    const timestamp = Date.now();
+    mockUserFindById.mockReturnValueOnce(userWithPublicKey(identityPub));
+
+    const outcome = await approveDeviceTransfer(baseInput({ signature: signApproval(attackerPriv, timestamp), timestamp }));
+
+    expect(outcome).toEqual({ ok: false, status: 401, message: 'Invalid approval signature' });
+    // Never touched the pairing — signature is the gate.
+    expect(mockPairingFindOne).not.toHaveBeenCalled();
+    expect(mockPairingFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale signature (400) before any DB work', async () => {
+    const staleTs = Date.now() - 6 * 60 * 1000;
+    const outcome = await approveDeviceTransfer(baseInput({ signature: signApproval(identityPriv, staleTs), timestamp: staleTs }));
+
+    expect(outcome).toEqual({ ok: false, status: 400, message: 'Approval signature has expired' });
+    expect(mockUserFindById).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the account has no identity key (400)', async () => {
+    mockUserFindById.mockReturnValueOnce(userWithPublicKey(undefined));
+    const outcome = await approveDeviceTransfer(baseInput());
+    expect(outcome).toEqual({ ok: false, status: 400, message: 'Account has no identity key to transfer' });
+  });
+
+  it('rejects an already-approved pairing (409) WITHOUT the atomic update', async () => {
+    mockUserFindById.mockReturnValueOnce(userWithPublicKey(identityPub));
+    mockPairingFindOne.mockResolvedValueOnce(pendingRow({ status: 'approved' }));
+
+    const outcome = await approveDeviceTransfer(baseInput());
+
+    expect(outcome).toEqual({ ok: false, status: 409, message: 'Pairing already processed' });
+    expect(mockPairingFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('expires a past-TTL pairing on approve (400) WITHOUT the atomic update', async () => {
+    const row = pendingRow({ expiresAt: new Date(Date.now() - 1000) });
+    mockUserFindById.mockReturnValueOnce(userWithPublicKey(identityPub));
+    mockPairingFindOne.mockResolvedValueOnce(row);
+
+    const outcome = await approveDeviceTransfer(baseInput());
+
+    expect(outcome).toEqual({ ok: false, status: 400, message: 'Pairing has expired' });
+    expect(row.status).toBe('expired');
+    expect(row.save).toHaveBeenCalledTimes(1);
+    expect(mockPairingFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects the LOSER of a concurrent approve (409) when the atomic burn matches nothing', async () => {
+    mockUserFindById.mockReturnValueOnce(userWithPublicKey(identityPub));
+    mockPairingFindOne.mockResolvedValueOnce(pendingRow());
+    mockPairingFindOneAndUpdate.mockResolvedValueOnce(null); // a concurrent approve already won
+
+    const outcome = await approveDeviceTransfer(baseInput());
+
+    expect(outcome).toEqual({ ok: false, status: 409, message: 'Pairing not found or already processed' });
+  });
+
+  it('returns 404 for an unknown pairing (after a valid signature)', async () => {
+    mockUserFindById.mockReturnValueOnce(userWithPublicKey(identityPub));
+    mockPairingFindOne.mockResolvedValueOnce(null);
+
+    const outcome = await approveDeviceTransfer(baseInput());
+    expect(outcome).toEqual({ ok: false, status: 404, message: 'Pairing not found' });
+  });
+
+  it('rejects an invalid ephemeral public key (400)', async () => {
+    const outcome = await approveDeviceTransfer(baseInput({ oldEphPub: 'nope' }));
+    expect(outcome).toEqual({ ok: false, status: 400, message: 'Invalid ephemeral public key' });
+    expect(mockUserFindById).not.toHaveBeenCalled();
+  });
+});
+
+describe('denyDeviceTransfer', () => {
+  it('cancels a pending pairing', async () => {
+    mockPairingFindOne.mockResolvedValueOnce(pendingRow());
+    mockPairingFindOneAndUpdate.mockResolvedValueOnce(pendingRow({ status: 'denied' }));
+
+    const outcome = await denyDeviceTransfer(PAIRING_ID);
+    expect(outcome).toEqual({ ok: true, status: 'denied' });
+  });
+
+  it('is idempotent for an already-denied pairing', async () => {
+    mockPairingFindOne.mockResolvedValueOnce(pendingRow({ status: 'denied' }));
+    const outcome = await denyDeviceTransfer(PAIRING_ID);
+    expect(outcome).toEqual({ ok: true, status: 'denied' });
+    expect(mockPairingFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('refuses to deny an already-approved pairing (409)', async () => {
+    mockPairingFindOne.mockResolvedValueOnce(pendingRow({ status: 'approved' }));
+    const outcome = await denyDeviceTransfer(PAIRING_ID);
+    expect(outcome).toEqual({ ok: false, status: 409, message: 'Cannot deny a approved transfer' });
+  });
+
+  it('returns 404 for an unknown pairing', async () => {
+    mockPairingFindOne.mockResolvedValueOnce(null);
+    const outcome = await denyDeviceTransfer(PAIRING_ID);
+    expect(outcome).toEqual({ ok: false, status: 404, message: 'Pairing not found' });
+  });
+});

--- a/packages/api/src/services/deviceTransfer.service.ts
+++ b/packages/api/src/services/deviceTransfer.service.ts
@@ -1,0 +1,254 @@
+/**
+ * Device-to-device identity transfer service (b3 Feature 2 — "add a device").
+ *
+ * Backs the E2E-encrypted relay in `routes/deviceTransfer.ts`. All model access
+ * and the security-critical logic (signature verification, atomic status burn)
+ * live here so the route module stays a thin wrapper — and so the flow is unit
+ * testable under the api's mocked-mongoose regime (mirrors
+ * `authSession.service.ts`).
+ *
+ * The server NEVER decrypts: it only stores the ephemeral public keys and an
+ * opaque ciphertext/nonce and shuttles them between the two devices. The threat
+ * model is a PASSIVE / at-rest-compromised relay (DB dump, on-path capture) — a
+ * shared transfer key requires an ephemeral PRIVATE key held only by one device,
+ * so the stored material is undecryptable server-side. It is explicitly NOT
+ * hardened against an actively-malicious backend MITM'ing the ephemeral keys
+ * (same trust boundary as the existing QR sign-in; SAS compare deferred).
+ */
+
+import crypto from 'crypto';
+import { DevicePairingSession } from '../models/DevicePairingSession';
+import { User } from '../models/User';
+import { SignatureService } from './signature.service';
+import { logger } from '../utils/logger';
+import type { DeviceTransferInfoResponse, DevicePairingStatus } from '@oxyhq/contracts';
+
+/** Pairing lifetime — deliberately short (single interactive handoff). */
+export const DEVICE_TRANSFER_TTL_MS = 3 * 60 * 1000;
+
+/** Max age of the approval signature (freshness against replay). */
+const APPROVAL_SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
+
+/**
+ * The exact bytes the old device signs (and the server reconstructs) to prove
+ * possession of the CURRENT identity private key alongside its bearer token.
+ * JSON.stringify preserves this key order — it MUST match the client byte-for-byte.
+ */
+export function buildApprovalSigningMessage(pairingId: string, timestamp: number): string {
+  return JSON.stringify({ action: 'approve_device_transfer', pairingId, timestamp });
+}
+
+/* -------------------------------------------------------------------------- */
+/*  init                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export type InitDeviceTransferOutcome =
+  | { ok: true; pairingId: string; expiresAt: Date }
+  | { ok: false; status: 400; message: string };
+
+/**
+ * Register a new pairing from the fresh device's ephemeral public key. Public /
+ * unauthenticated — the new device has no identity yet.
+ */
+export async function initDeviceTransfer(input: {
+  newEphPub: string;
+  newDeviceLabel?: string;
+}): Promise<InitDeviceTransferOutcome> {
+  const { newEphPub, newDeviceLabel } = input;
+
+  if (!SignatureService.isValidPublicKey(newEphPub)) {
+    return { ok: false, status: 400, message: 'Invalid ephemeral public key' };
+  }
+
+  const pairingId = crypto.randomBytes(16).toString('hex'); // 128-bit
+  const expiresAt = new Date(Date.now() + DEVICE_TRANSFER_TTL_MS);
+
+  await DevicePairingSession.create({
+    pairingId,
+    newDeviceEphemeralPublicKey: newEphPub,
+    newDeviceLabel: newDeviceLabel ?? null,
+    status: 'pending',
+    expiresAt,
+  });
+
+  return { ok: true, pairingId, expiresAt };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  info                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Resolve a pairing for either device: the old device reads `newEphPub` + label
+ * before approving; the new device polls for the sealed material once approved.
+ * Public — the QR is not self-contained, so the server is the resolver.
+ *
+ * Returns `null` when the pairing does not exist (route → 404). Marks a
+ * past-TTL pending pairing as `expired` on read (lazy expiry before the TTL
+ * sweep). The encrypted material is surfaced ONLY once `status === 'approved'`.
+ */
+export async function getDeviceTransferInfo(
+  pairingId: string,
+): Promise<DeviceTransferInfoResponse | null> {
+  const session = await DevicePairingSession.findOne({ pairingId });
+  if (!session) {
+    return null;
+  }
+
+  if (session.status === 'pending' && session.expiresAt < new Date()) {
+    session.status = 'expired';
+    await session.save();
+  }
+
+  const approved = session.status === 'approved';
+  return {
+    pairingId: session.pairingId,
+    newDeviceEphemeralPublicKey: session.newDeviceEphemeralPublicKey,
+    newDeviceLabel: session.newDeviceLabel ?? null,
+    status: session.status as DevicePairingStatus,
+    expiresAt: session.expiresAt.toISOString(),
+    oldDeviceEphemeralPublicKey: approved ? session.oldDeviceEphemeralPublicKey ?? null : null,
+    ciphertext: approved ? session.ciphertext ?? null : null,
+    nonce: approved ? session.nonce ?? null : null,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  approve                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface ApproveDeviceTransferInput {
+  pairingId: string;
+  /** Bearer-resolved user id (never client-supplied). */
+  authenticatedUserId: string;
+  oldEphPub: string;
+  ciphertext: string;
+  nonce: string;
+  signature: string;
+  timestamp: number;
+}
+
+export type ApproveDeviceTransferOutcome =
+  | { ok: true; pairingId: string }
+  | { ok: false; status: 400 | 401 | 404 | 409; message: string };
+
+/**
+ * Approve a transfer: the bearer-authenticated old device proves possession of
+ * the CURRENT identity private key (fresh signature) AND supplies the E2E-sealed
+ * key material. The pending->approved transition is ATOMIC so a concurrent
+ * approve cannot double-complete; the loser gets 409.
+ *
+ * Dual-proof rationale: the bearer alone proves account control but NOT key
+ * possession — requiring a fresh signature over the current identity key means a
+ * stolen bearer token cannot exfiltrate the private key.
+ */
+export async function approveDeviceTransfer(
+  input: ApproveDeviceTransferInput,
+): Promise<ApproveDeviceTransferOutcome> {
+  const { pairingId, authenticatedUserId, oldEphPub, ciphertext, nonce, signature, timestamp } = input;
+
+  // Freshness FIRST — reject a stale/replayed signature before any DB work.
+  if (Date.now() - timestamp > APPROVAL_SIGNATURE_MAX_AGE_MS) {
+    return { ok: false, status: 400, message: 'Approval signature has expired' };
+  }
+
+  if (!SignatureService.isValidPublicKey(oldEphPub)) {
+    return { ok: false, status: 400, message: 'Invalid ephemeral public key' };
+  }
+
+  // Resolve the caller's CURRENT identity public key server-side. `publicKey` is
+  // `select:false`, so it must be explicitly selected (mirrors the delete flow).
+  const user = await User.findById(authenticatedUserId).select('+publicKey');
+  if (!user) {
+    return { ok: false, status: 404, message: 'User not found' };
+  }
+  if (!user.publicKey) {
+    return { ok: false, status: 400, message: 'Account has no identity key to transfer' };
+  }
+
+  // Verify the signature proves control of the CURRENT identity key. A bearer
+  // token alone must NOT be able to approve a key clone.
+  const message = buildApprovalSigningMessage(pairingId, timestamp);
+  if (!SignatureService.verifySignature(message, signature, user.publicKey)) {
+    return { ok: false, status: 401, message: 'Invalid approval signature' };
+  }
+
+  // Pre-flight read for precise error codes (unknown vs expired vs processed).
+  const session = await DevicePairingSession.findOne({ pairingId });
+  if (!session) {
+    return { ok: false, status: 404, message: 'Pairing not found' };
+  }
+  if (session.status === 'pending' && session.expiresAt < new Date()) {
+    session.status = 'expired';
+    await session.save();
+    return { ok: false, status: 400, message: 'Pairing has expired' };
+  }
+  if (session.status !== 'pending') {
+    return { ok: false, status: 409, message: 'Pairing already processed' };
+  }
+
+  // ATOMIC pending -> approved. Conditioned on status:'pending' + unexpired so
+  // two concurrent approves cannot both win; the loser matches nothing.
+  const claimed = await DevicePairingSession.findOneAndUpdate(
+    { pairingId, status: 'pending', expiresAt: { $gt: new Date() } },
+    {
+      $set: {
+        status: 'approved',
+        oldDeviceEphemeralPublicKey: oldEphPub,
+        ciphertext,
+        nonce,
+        approvedByUserId: user._id,
+      },
+    },
+    { new: true },
+  );
+
+  if (!claimed) {
+    return { ok: false, status: 409, message: 'Pairing not found or already processed' };
+  }
+
+  logger.info('Device transfer approved', {
+    pairingId: pairingId.substring(0, 8) + '...',
+    userId: authenticatedUserId,
+  });
+
+  return { ok: true, pairingId };
+}
+
+/* -------------------------------------------------------------------------- */
+/*  deny                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export type DenyDeviceTransferOutcome =
+  | { ok: true; status: DevicePairingStatus }
+  | { ok: false; status: 404 | 409; message: string };
+
+/**
+ * Deny (cancel) a pending transfer so the waiting new device stops. Public — the
+ * QR-scanning device cancels without a session. Idempotent for an already-denied
+ * pairing; refuses to undo an already-approved one.
+ */
+export async function denyDeviceTransfer(pairingId: string): Promise<DenyDeviceTransferOutcome> {
+  const session = await DevicePairingSession.findOne({ pairingId });
+  if (!session) {
+    return { ok: false, status: 404, message: 'Pairing not found' };
+  }
+  if (session.status === 'denied') {
+    return { ok: true, status: 'denied' };
+  }
+  if (session.status !== 'pending') {
+    return { ok: false, status: 409, message: `Cannot deny a ${session.status} transfer` };
+  }
+
+  const denied = await DevicePairingSession.findOneAndUpdate(
+    { pairingId, status: 'pending' },
+    { $set: { status: 'denied' } },
+    { new: true },
+  );
+  if (!denied) {
+    // Lost the race — someone approved/denied concurrently.
+    return { ok: false, status: 409, message: 'Pairing already processed' };
+  }
+
+  return { ok: true, status: 'denied' };
+}

--- a/packages/api/src/utils/devicePairSocket.ts
+++ b/packages/api/src/utils/devicePairSocket.ts
@@ -1,0 +1,43 @@
+/**
+ * Device-Pair Socket Utilities (b3 Feature 2 — device-to-device identity transfer)
+ *
+ * Real-time notification for the "add a device" flow. The new (waiting) device
+ * joins room `devicepair:<pairingId>` on the `/device-pair` namespace; when the
+ * old device approves or denies, the server pushes a lightweight status signal
+ * so the new device fetches the sealed material via
+ * `GET /identity/device-transfer/:pairingId`. Polling is the fallback.
+ *
+ * Mirrors `authSessionSocket.ts`. The push carries NO key material — only the
+ * pairing status — so the socket channel needs no confidentiality (the material
+ * itself is E2E-encrypted end to end regardless).
+ */
+
+import type { Namespace } from 'socket.io';
+import { logger } from './logger';
+
+let devicePairNamespace: Namespace | null = null;
+
+/**
+ * Initialize the device-pair namespace reference.
+ * Called from server.ts after Socket.IO is set up.
+ */
+export function initDevicePairNamespace(namespace: Namespace): void {
+  devicePairNamespace = namespace;
+}
+
+/**
+ * Emit a device-pair status update to the waiting new device.
+ * Used when the old device approves, denies, or the pairing expires.
+ */
+export function emitDevicePairUpdate(
+  pairingId: string,
+  payload: { status: 'approved' | 'denied' | 'expired' },
+): void {
+  if (!devicePairNamespace) {
+    logger.warn('Device-pair namespace not initialized');
+    return;
+  }
+
+  const room = `devicepair:${pairingId}`;
+  devicePairNamespace.to(room).emit('device_pair_update', payload);
+}

--- a/packages/contracts/src/devicePairing.ts
+++ b/packages/contracts/src/devicePairing.ts
@@ -1,0 +1,206 @@
+/**
+ * Device-to-device identity transfer contracts (b3 Feature 2 — "add a device").
+ *
+ * SINGLE SOURCE OF TRUTH for the wire shape of the short-lived, unauthenticated
+ * relay that carries E2E-encrypted key material from an existing (old) device to
+ * a fresh (new) device so both end up holding the SAME secp256k1 private key
+ * (key cloning). The relay is E2E-encrypted via an ephemeral secp256k1 ECDH
+ * handshake: the server stores only the two ephemeral public keys plus an opaque
+ * AEAD ciphertext + nonce and NEVER holds a decryption key.
+ *
+ * Flow:
+ *  1. New device (no identity) generates an ephemeral pair and calls
+ *     `POST /identity/device-transfer/init { newEphPub, newDeviceLabel? }` →
+ *     `{ pairingId, expiresAt }`. The QR carries ONLY `pairingId` (not
+ *     self-contained — mirrors the QR sign-in `approve-info` resolution).
+ *  2. Old device (has identity) scans, resolves the request via
+ *     `GET /identity/device-transfer/:pairingId` (returns `newEphPub` + label),
+ *     derives `transferKey = HKDF(ECDH(oldEphPriv, newEphPub), pairingId,
+ *     'oxy-device-transfer-v1')`, AEAD-encrypts `{ privateKey, publicKey }`, and
+ *     calls `POST /identity/device-transfer/:pairingId/approve` with the
+ *     ciphertext PLUS a fresh signature over
+ *     `{ action:'approve_device_transfer', pairingId, timestamp }` made with the
+ *     CURRENT identity key (dual-proof: a bearer alone cannot exfiltrate the key).
+ *  3. New device (socket push or poll fallback) re-derives the same
+ *     `transferKey` from `ECDH(newEphPriv, oldEphPub)`, decrypts, and imports the
+ *     private key, then completes a NORMAL challenge/verify sign-in.
+ *
+ * The load-bearing response shapes are declared as explicit `interface`s (same
+ * `moduleResolution: node` rationale as `UserNameResponse` / the identity/civic
+ * contracts: a nested `z.infer<>` can degrade to `{}` under a consumer's
+ * `moduleResolution: "node"`), with the runtime schemas annotated
+ * `z.ZodType<Interface>`.
+ *
+ * Platform-agnostic — zod only, no react/react-native/expo, ESM-safe.
+ */
+
+import { z } from 'zod';
+
+/* -------------------------------------------------------------------------- */
+/*  Shared field validators                                                   */
+/* -------------------------------------------------------------------------- */
+
+/** Lowercase/uppercase hex string (no `0x` prefix). */
+const hexString = z
+  .string()
+  .trim()
+  .regex(/^[0-9a-fA-F]+$/, 'must be a hex string');
+
+/**
+ * A secp256k1 public key, hex-encoded — compressed (`02`/`03` + 32 bytes = 66
+ * chars) or uncompressed (`04` + 64 bytes = 130 chars). The exact curve-point
+ * validity is re-checked server-side; this only bounds the shape/length.
+ */
+const publicKeyHex = hexString.min(66).max(130);
+
+/** DER-encoded ECDSA signature, hex (variable length, ~140–144 chars). */
+const signatureHex = hexString.min(2).max(256);
+
+/**
+ * The 24-byte XChaCha20-Poly1305 nonce, hex (exactly 48 chars). Matches
+ * `@oxyhq/core` `AEAD_NONCE_LENGTH` (24 bytes).
+ */
+const nonceHex = hexString.length(48);
+
+/**
+ * The AEAD ciphertext (Poly1305 tag appended), hex. The plaintext is the small
+ * JSON `{ privateKey, publicKey }` (~200 bytes), so the ciphertext stays well
+ * under the cap; the bound blunts relay-abuse via oversized blobs.
+ */
+const ciphertextHex = hexString.min(2).max(8192);
+
+/* -------------------------------------------------------------------------- */
+/*  Status                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Pairing lifecycle:
+ *  - `pending`  — created by the new device, awaiting the old device's approval.
+ *  - `approved` — the old device sealed and posted the encrypted key material.
+ *  - `denied`   — the old device explicitly cancelled the transfer.
+ *  - `expired`  — the 3-minute TTL elapsed before approval.
+ */
+export const devicePairingStatusSchema = z.enum([
+  'pending',
+  'approved',
+  'denied',
+  'expired',
+]);
+export type DevicePairingStatus = z.infer<typeof devicePairingStatusSchema>;
+
+/* -------------------------------------------------------------------------- */
+/*  POST /identity/device-transfer/init                                       */
+/* -------------------------------------------------------------------------- */
+
+/** Request body for `POST /identity/device-transfer/init` (public). */
+export const deviceTransferInitRequestSchema = z.object({
+  /** The new device's ephemeral secp256k1 public key (single-use). */
+  newEphPub: publicKeyHex,
+  /** Optional human-readable label for the new device (e.g. "iPhone 15"). */
+  newDeviceLabel: z.string().trim().min(1).max(120).optional(),
+});
+export type DeviceTransferInitRequest = z.infer<typeof deviceTransferInitRequestSchema>;
+
+export interface DeviceTransferInitResponse {
+  /** 128-bit single-use handle carried in the QR. Also the HKDF salt. */
+  pairingId: string;
+  /** ISO-8601 expiry (3 minutes from creation). */
+  expiresAt: string;
+}
+
+export const deviceTransferInitResponseSchema: z.ZodType<DeviceTransferInitResponse> =
+  z.object({
+    pairingId: z.string(),
+    expiresAt: z.string(),
+  });
+
+/* -------------------------------------------------------------------------- */
+/*  GET /identity/device-transfer/:pairingId                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface DeviceTransferInfoResponse {
+  pairingId: string;
+  /** The new device's ephemeral public key (so the old device can ECDH). */
+  newDeviceEphemeralPublicKey: string;
+  /** Optional new-device label supplied at init. */
+  newDeviceLabel: string | null;
+  status: DevicePairingStatus;
+  /** ISO-8601 expiry. */
+  expiresAt: string;
+  /**
+   * The old device's ephemeral public key — present ONLY once `status` is
+   * `approved` (so the new device can re-derive the shared secret).
+   */
+  oldDeviceEphemeralPublicKey: string | null;
+  /** AEAD ciphertext (hex) — present ONLY once `status` is `approved`. */
+  ciphertext: string | null;
+  /** AEAD nonce (hex) — present ONLY once `status` is `approved`. */
+  nonce: string | null;
+}
+
+export const deviceTransferInfoResponseSchema: z.ZodType<DeviceTransferInfoResponse> =
+  z.object({
+    pairingId: z.string(),
+    newDeviceEphemeralPublicKey: z.string(),
+    newDeviceLabel: z.string().nullable(),
+    status: devicePairingStatusSchema,
+    expiresAt: z.string(),
+    oldDeviceEphemeralPublicKey: z.string().nullable(),
+    ciphertext: z.string().nullable(),
+    nonce: z.string().nullable(),
+  });
+
+/* -------------------------------------------------------------------------- */
+/*  POST /identity/device-transfer/:pairingId/approve                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Request body for `POST /identity/device-transfer/:pairingId/approve`
+ * (bearer-authenticated AND signature-proven). The `signature` covers
+ * `JSON.stringify({ action:'approve_device_transfer', pairingId, timestamp })`
+ * made with the caller's CURRENT identity key — dual-proof so a bearer token
+ * alone can never exfiltrate the private key.
+ */
+export const deviceTransferApproveRequestSchema = z.object({
+  /** The old device's ephemeral secp256k1 public key (single-use). */
+  oldEphPub: publicKeyHex,
+  /** AEAD ciphertext of `{ privateKey, publicKey }`, hex. */
+  ciphertext: ciphertextHex,
+  /** AEAD nonce, hex (24 bytes). */
+  nonce: nonceHex,
+  /** ECDSA (DER, hex) signature proving control of the CURRENT identity key. */
+  signature: signatureHex,
+  /** Signing timestamp (ms since epoch) — freshness-checked server-side. */
+  timestamp: z.number().int().positive(),
+});
+export type DeviceTransferApproveRequest = z.infer<typeof deviceTransferApproveRequestSchema>;
+
+export interface DeviceTransferApproveResponse {
+  success: boolean;
+  pairingId: string;
+  status: DevicePairingStatus;
+}
+
+export const deviceTransferApproveResponseSchema: z.ZodType<DeviceTransferApproveResponse> =
+  z.object({
+    success: z.boolean(),
+    pairingId: z.string(),
+    status: devicePairingStatusSchema,
+  });
+
+/* -------------------------------------------------------------------------- */
+/*  POST /identity/device-transfer/:pairingId/deny                            */
+/* -------------------------------------------------------------------------- */
+
+export interface DeviceTransferDenyResponse {
+  success: boolean;
+  pairingId: string;
+  status: DevicePairingStatus;
+}
+
+export const deviceTransferDenyResponseSchema: z.ZodType<DeviceTransferDenyResponse> =
+  z.object({
+    success: z.boolean(),
+    pairingId: z.string(),
+    status: devicePairingStatusSchema,
+  });

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -353,3 +353,24 @@ export type {
     WebauthnRegisterVerifyRequest,
     WebauthnLoginVerifyRequest,
 } from './webauthn';
+
+export {
+    // Schemas
+    devicePairingStatusSchema,
+    deviceTransferInitRequestSchema,
+    deviceTransferInitResponseSchema,
+    deviceTransferInfoResponseSchema,
+    deviceTransferApproveRequestSchema,
+    deviceTransferApproveResponseSchema,
+    deviceTransferDenyResponseSchema,
+} from './devicePairing';
+
+export type {
+    DevicePairingStatus,
+    DeviceTransferInitRequest,
+    DeviceTransferInitResponse,
+    DeviceTransferInfoResponse,
+    DeviceTransferApproveRequest,
+    DeviceTransferApproveResponse,
+    DeviceTransferDenyResponse,
+} from './devicePairing';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,10 @@ export type {
     ContactDiscoveryResponse,
 } from './mixins/OxyServices.contacts';
 export type {
+    InitDeviceTransferResult,
+    DeviceTransferOutcome,
+} from './mixins/OxyServices.deviceTransfer';
+export type {
     BulkFollowEntry,
     BulkFollowResult,
     BulkUnfollowEntry,

--- a/packages/core/src/mixins/OxyServices.deviceTransfer.ts
+++ b/packages/core/src/mixins/OxyServices.deviceTransfer.ts
@@ -1,0 +1,397 @@
+/**
+ * Device-to-device Identity Transfer Mixin (b3 Feature 2 — "add a device")
+ *
+ * Clones an existing device's secp256k1 identity onto a fresh device over a
+ * short-lived, unauthenticated relay, WITHOUT the server ever holding a
+ * decryption key. Both devices end up holding the SAME private key.
+ *
+ * The two devices agree on a symmetric key via an ephemeral secp256k1 ECDH
+ * handshake (Phase-0 crypto): `deriveSharedSecret` → `hkdfSha256` → a per-pairing
+ * transfer key, used with `encryptAead`/`decryptAead` (XChaCha20-Poly1305) to
+ * seal `{ privateKey, publicKey }`. The relay carries only ephemeral public keys
+ * plus opaque ciphertext — a passive/at-rest-compromised backend cannot decrypt.
+ *
+ * Roles:
+ *  - NEW device (no identity): {@link initDeviceTransfer} (generate ephemeral
+ *    pair, register the pairing, render `pairingId` as a QR) then
+ *    {@link subscribeDeviceTransfer} (await approval over the `/device-pair`
+ *    socket with a poll fallback, decrypt, and import the key).
+ *  - OLD device (has identity): {@link getDeviceTransferInfo} (resolve the
+ *    scanned `pairingId` server-side — the QR is NOT self-contained) then
+ *    {@link approveDeviceTransfer} (biometric-gate in the UI, seal the key
+ *    material, and post it with a fresh signature over the CURRENT identity key).
+ *
+ * SECURITY: E2E against a passive relay only. Explicitly NOT hardened against an
+ * actively-malicious backend MITM'ing the ephemeral keys (same trust boundary as
+ * the existing QR sign-in; SAS compare deferred per owner decision). Approve
+ * requires BOTH a bearer token AND a fresh identity-key signature.
+ */
+
+import { ec as EC } from 'elliptic';
+import { bytesToHex, hexToBytes, utf8ToBytes, bytesToUtf8 } from '@noble/hashes/utils';
+import type { OxyServicesBase } from '../OxyServices.base';
+import type {
+  DeviceTransferInfoResponse,
+  DeviceTransferInitResponse,
+  DeviceTransferApproveResponse,
+  DeviceTransferDenyResponse,
+} from '@oxyhq/contracts';
+import { deriveSharedSecret } from '../crypto/ecdh';
+import { hkdfSha256 } from '../crypto/kdf';
+import { encryptAead, decryptAead } from '../crypto/aead';
+import { KeyManager } from '../crypto/keyManager';
+import { SignatureService } from '../crypto/signatureService';
+import { getSocketIO } from '../session/socketLoader';
+import type { MinimalSocket } from '../session/socketLoader';
+import { logger } from '../logger';
+
+const ecCurve = new EC('secp256k1');
+
+/**
+ * Ephemeral private keys for pairings an instance INITIATED, keyed by pairingId,
+ * held per OxyServices instance. In-memory ONLY (never persisted — single-use),
+ * cleared once the transfer settles. A module-level WeakMap (rather than a class
+ * field) keeps it off the mixin's emitted `.d.ts` (avoids TS4094 on the exported
+ * anonymous class) and lets the GC drop it with the instance.
+ */
+const ephemeralKeyStore = new WeakMap<object, Map<string, string>>();
+
+function getEphemeralKeys(instance: object): Map<string, string> {
+  let keys = ephemeralKeyStore.get(instance);
+  if (!keys) {
+    keys = new Map<string, string>();
+    ephemeralKeyStore.set(instance, keys);
+  }
+  return keys;
+}
+
+/** HKDF `info` binding — MUST match the server/other-device byte-for-byte. */
+const DEVICE_TRANSFER_HKDF_INFO = 'oxy-device-transfer-v1';
+/** Socket.IO namespace the API pushes device-pair approval events on. */
+const DEVICE_PAIR_NAMESPACE = '/device-pair';
+/** Fallback poll cadence — the socket delivers approval instantly; this covers
+ *  the case where the socket can't connect. */
+const DEVICE_TRANSFER_POLL_INTERVAL_MS = 2500;
+/** Action string signed on approve (mirrors `link_identity`'s scheme). */
+const DEVICE_TRANSFER_APPROVE_ACTION = 'approve_device_transfer';
+
+/** Result of {@link OxyServicesDeviceTransferMixin.initDeviceTransfer}. */
+export interface InitDeviceTransferResult {
+  /** 128-bit single-use handle to render in the QR (also the HKDF salt). */
+  pairingId: string;
+  /** ISO-8601 expiry (3 minutes). */
+  expiresAt: string;
+  /** The new device's ephemeral public key registered with the relay. */
+  newEphemeralPublicKey: string;
+}
+
+/** Terminal outcome delivered to {@link subscribeDeviceTransfer}'s callback. */
+export type DeviceTransferOutcome =
+  | { status: 'approved'; publicKey: string }
+  | { status: 'denied' }
+  | { status: 'expired' };
+
+/**
+ * Derive the per-pairing symmetric transfer key from an ECDH shared secret.
+ * Identical on both devices: `HKDF(ECDH, salt=pairingId, info=v1)`.
+ */
+function deriveTransferKey(sharedSecret: Uint8Array, pairingId: string): Uint8Array {
+  return hkdfSha256(
+    sharedSecret,
+    utf8ToBytes(pairingId),
+    utf8ToBytes(DEVICE_TRANSFER_HKDF_INFO),
+    32,
+  );
+}
+
+export function OxyServicesDeviceTransferMixin<T extends typeof OxyServicesBase>(Base: T) {
+  return class extends Base {
+    constructor(...args: any[]) {
+      super(...(args as [any]));
+    }
+
+    /**
+     * NEW device — begin an "add a device" transfer. Generates a single-use
+     * ephemeral secp256k1 pair, registers the pairing, and returns the
+     * `pairingId` to render as a QR. The ephemeral private key is held in memory
+     * (keyed by `pairingId`) for the subsequent {@link subscribeDeviceTransfer}.
+     *
+     * @param label - Optional human-readable label for this new device.
+     */
+    async initDeviceTransfer(label?: string): Promise<InitDeviceTransferResult> {
+      try {
+        const ephKeyPair = ecCurve.genKeyPair();
+        const ephPrivateKey = ephKeyPair.getPrivate('hex');
+        const ephPublicKey = ephKeyPair.getPublic('hex');
+
+        const res = await this.makeRequest<DeviceTransferInitResponse>(
+          'POST',
+          '/identity/device-transfer/init',
+          { newEphPub: ephPublicKey, ...(label ? { newDeviceLabel: label } : {}) },
+          { cache: false },
+        );
+
+        getEphemeralKeys(this).set(res.pairingId, ephPrivateKey);
+        return {
+          pairingId: res.pairingId,
+          expiresAt: res.expiresAt,
+          newEphemeralPublicKey: ephPublicKey,
+        };
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Resolve a pairing server-side (the QR carries only `pairingId`). The OLD
+     * device calls this after scanning to read the new device's ephemeral public
+     * key + label; the NEW device polls it to fetch the sealed material once
+     * approved. Public — no auth required.
+     */
+    async getDeviceTransferInfo(pairingId: string): Promise<DeviceTransferInfoResponse> {
+      try {
+        return await this.makeRequest<DeviceTransferInfoResponse>(
+          'GET',
+          `/identity/device-transfer/${encodeURIComponent(pairingId)}`,
+          undefined,
+          { cache: false, retry: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * OLD device — approve a scanned transfer. Reads the new device's ephemeral
+     * public key, derives the shared transfer key, AEAD-seals
+     * `{ privateKey, publicKey }`, and posts it PLUS a fresh signature over
+     * `{ action:'approve_device_transfer', pairingId, timestamp }` made with the
+     * CURRENT identity key (dual-proof alongside the bearer token).
+     *
+     * NATIVE-ONLY: requires a stored identity (throws otherwise). The UI must
+     * biometric-gate before calling this — a key clone leaves the device.
+     */
+    async approveDeviceTransfer(pairingId: string): Promise<DeviceTransferApproveResponse> {
+      try {
+        const info = await this.getDeviceTransferInfo(pairingId);
+        if (info.status !== 'pending') {
+          throw new Error(`This transfer can no longer be approved (status: ${info.status}).`);
+        }
+
+        const privateKey = await KeyManager.getPrivateKey();
+        const publicKey = await KeyManager.getPublicKey();
+        if (!privateKey || !publicKey) {
+          throw new Error('No identity found on this device. Create or import an identity first.');
+        }
+
+        // Ephemeral ECDH → per-pairing transfer key.
+        const oldEphKeyPair = ecCurve.genKeyPair();
+        const oldEphPrivateKey = oldEphKeyPair.getPrivate('hex');
+        const oldEphPublicKey = oldEphKeyPair.getPublic('hex');
+
+        const sharedSecret = deriveSharedSecret(oldEphPrivateKey, info.newDeviceEphemeralPublicKey);
+        const transferKey = deriveTransferKey(sharedSecret, pairingId);
+
+        // Seal the identity key material.
+        const plaintext = utf8ToBytes(JSON.stringify({ privateKey, publicKey }));
+        const { nonce, ciphertext } = encryptAead(transferKey, plaintext);
+
+        // Dual-proof: prove control of the CURRENT identity key (a bearer alone
+        // must not be able to exfiltrate the private key).
+        const timestamp = Date.now();
+        const message = JSON.stringify({
+          action: DEVICE_TRANSFER_APPROVE_ACTION,
+          pairingId,
+          timestamp,
+        });
+        const signature = await SignatureService.sign(message);
+
+        return await this.makeRequest<DeviceTransferApproveResponse>(
+          'POST',
+          `/identity/device-transfer/${encodeURIComponent(pairingId)}/approve`,
+          {
+            oldEphPub: oldEphPublicKey,
+            ciphertext: bytesToHex(ciphertext),
+            nonce: bytesToHex(nonce),
+            signature,
+            timestamp,
+          },
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * OLD device — deny (cancel) a scanned transfer so the waiting new device
+     * stops. Public — no auth required.
+     */
+    async denyDeviceTransfer(pairingId: string): Promise<DeviceTransferDenyResponse> {
+      try {
+        return await this.makeRequest<DeviceTransferDenyResponse>(
+          'POST',
+          `/identity/device-transfer/${encodeURIComponent(pairingId)}/deny`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * NEW device — await approval for a pairing started with
+     * {@link initDeviceTransfer}, then decrypt and import the transferred
+     * identity key. Primary path is an instant `device_pair_update` push over the
+     * `/device-pair` socket; a poll backstops a socket that can't connect.
+     *
+     * On `approved`: re-derives the shared transfer key from the old device's
+     * ephemeral public key, decrypts `{ privateKey, publicKey }`, imports it via
+     * `KeyManager.importKeyPair(privateKey, { overwrite: false })`, and invokes
+     * `onOutcome({ status:'approved', publicKey })`. The caller then runs the
+     * NORMAL challenge/verify sign-in — this method does not mint a session.
+     *
+     * @returns An unsubscribe function; call it to stop waiting (also called
+     *   automatically once the transfer settles).
+     */
+    subscribeDeviceTransfer(
+      pairingId: string,
+      onOutcome: (outcome: DeviceTransferOutcome) => void,
+    ): () => void {
+      const ephemeralKeys = getEphemeralKeys(this);
+      const ephPrivateKey = ephemeralKeys.get(pairingId);
+      if (!ephPrivateKey) {
+        throw new Error(
+          'No pending device transfer for this pairing id. Call initDeviceTransfer first.',
+        );
+      }
+
+      let settled = false;
+      let inFlight = false;
+      let socket: MinimalSocket | null = null;
+      let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+      const cleanup = (): void => {
+        if (pollTimer !== null) {
+          clearInterval(pollTimer);
+          pollTimer = null;
+        }
+        if (socket) {
+          try {
+            socket.off('device_pair_update');
+            socket.off('connect');
+            socket.disconnect();
+          } catch (error) {
+            logger.debug('[DeviceTransfer] socket close failed', { component: 'DeviceTransfer' }, error);
+          }
+          socket = null;
+        }
+        ephemeralKeys.delete(pairingId);
+      };
+
+      const finish = (outcome: DeviceTransferOutcome): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        onOutcome(outcome);
+      };
+
+      // Re-check authoritative status; on `approved`, decrypt + import.
+      const check = async (): Promise<void> => {
+        if (settled || inFlight) return;
+        inFlight = true;
+        try {
+          const info = await this.getDeviceTransferInfo(pairingId);
+          if (settled) return;
+
+          if (info.status === 'denied') {
+            finish({ status: 'denied' });
+            return;
+          }
+          if (info.status === 'expired') {
+            finish({ status: 'expired' });
+            return;
+          }
+          if (
+            info.status === 'approved' &&
+            info.oldDeviceEphemeralPublicKey &&
+            info.ciphertext &&
+            info.nonce
+          ) {
+            const sharedSecret = deriveSharedSecret(
+              ephPrivateKey,
+              info.oldDeviceEphemeralPublicKey,
+            );
+            const transferKey = deriveTransferKey(sharedSecret, pairingId);
+            const plaintext = decryptAead(
+              transferKey,
+              hexToBytes(info.nonce),
+              hexToBytes(info.ciphertext),
+            );
+            const parsed = JSON.parse(bytesToUtf8(plaintext)) as {
+              privateKey: string;
+              publicKey: string;
+            };
+            // Import WITHOUT overwrite: a fresh device has no identity, and we
+            // must never silently clobber an existing one.
+            const importedPublicKey = await KeyManager.importKeyPair(parsed.privateKey, {
+              overwrite: false,
+            });
+            finish({ status: 'approved', publicKey: importedPublicKey });
+          }
+        } catch (error) {
+          // Transient (a poll tick that raced the approve write, a decrypt on a
+          // half-written row) — keep waiting; the next tick/push retries.
+          logger.debug('[DeviceTransfer] status check failed', { component: 'DeviceTransfer' }, error);
+        } finally {
+          inFlight = false;
+        }
+      };
+
+      // Primary: instant socket wake. Fall back to polling if unavailable.
+      void (async () => {
+        const io = await getSocketIO();
+        if (settled || !io) return;
+        try {
+          const s = io(`${this.getBaseURL()}${DEVICE_PAIR_NAMESPACE}`, {
+            transports: ['websocket'],
+            autoConnect: true,
+            reconnection: true,
+            reconnectionAttempts: Number.POSITIVE_INFINITY,
+            reconnectionDelay: 1000,
+            reconnectionDelayMax: 10000,
+          });
+          const join = (): void => {
+            try {
+              s.emit('join', pairingId);
+            } catch (error) {
+              logger.debug('[DeviceTransfer] join failed', { component: 'DeviceTransfer' }, error);
+            }
+          };
+          s.on('connect', join);
+          if (s.connected) join();
+          s.on('device_pair_update', () => {
+            void check();
+          });
+          socket = s;
+        } catch (error) {
+          logger.debug('[DeviceTransfer] socket create failed (poll fallback)', { component: 'DeviceTransfer' }, error);
+        }
+      })();
+
+      // Fallback poll (also covers the already-approved-before-subscribe case via
+      // the immediate first tick below). unref so it never holds a Node event
+      // loop / test runner open.
+      pollTimer = setInterval(() => {
+        void check();
+      }, DEVICE_TRANSFER_POLL_INTERVAL_MS);
+      (pollTimer as { unref?: () => void }).unref?.();
+
+      // Immediate first check — the transfer may already be approved/denied.
+      void check();
+
+      return cleanup;
+    }
+  };
+}

--- a/packages/core/src/mixins/__tests__/OxyServices.deviceTransfer.test.ts
+++ b/packages/core/src/mixins/__tests__/OxyServices.deviceTransfer.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Device-to-device identity transfer mixin tests (b3 Feature 2 — "add a device").
+ *
+ * Exercises the E2E crypto path THROUGH the mixins with two independent
+ * OxyServices instances (old device + new device) wired to a shared in-memory
+ * "relay" that never sees a decryption key:
+ *   - ECDH symmetry: the old device seals with `ECDH(oldEphPriv, newEphPub)` and
+ *     the new device opens with `ECDH(newEphPriv, oldEphPub)` — same transfer key.
+ *   - full round-trip: the private key the old device holds is recovered and
+ *     imported byte-for-byte on the new device.
+ *   - tamper: a flipped ciphertext byte fails authentication (never imports).
+ *
+ * The socket is forced OFF (getSocketIO → null) so the deterministic poll path
+ * drives the flow; KeyManager + SignatureService.sign are stubbed (the identity
+ * key material and the approval signature are not the unit under test here — the
+ * server-side signature verification is covered in the api service tests).
+ */
+
+jest.mock('../../session/socketLoader', () => ({
+  getSocketIO: jest.fn(async () => null),
+}));
+
+import { ec as EC } from 'elliptic';
+import { OxyServices } from '../../OxyServices';
+import { KeyManager } from '../../crypto/keyManager';
+import { SignatureService } from '../../crypto/signatureService';
+import { deriveSharedSecret } from '../../crypto/ecdh';
+import { hkdfSha256 } from '../../crypto/kdf';
+import { encryptAead, decryptAead } from '../../crypto/aead';
+import { bytesToHex, hexToBytes, utf8ToBytes, bytesToUtf8 } from '@noble/hashes/utils';
+import type { DeviceTransferInfoResponse } from '@oxyhq/contracts';
+
+const ec = new EC('secp256k1');
+
+/** A shared in-memory relay: a single pairing row, mirroring the API's shape. */
+interface RelayState {
+  pairingId: string;
+  newDeviceEphemeralPublicKey: string;
+  newDeviceLabel: string | null;
+  status: 'pending' | 'approved' | 'denied' | 'expired';
+  expiresAt: string;
+  oldDeviceEphemeralPublicKey: string | null;
+  ciphertext: string | null;
+  nonce: string | null;
+}
+
+function makeRelay() {
+  const state: { row: RelayState | null } = { row: null };
+  const infoDto = (): DeviceTransferInfoResponse => {
+    const row = state.row!;
+    const approved = row.status === 'approved';
+    return {
+      pairingId: row.pairingId,
+      newDeviceEphemeralPublicKey: row.newDeviceEphemeralPublicKey,
+      newDeviceLabel: row.newDeviceLabel,
+      status: row.status,
+      expiresAt: row.expiresAt,
+      oldDeviceEphemeralPublicKey: approved ? row.oldDeviceEphemeralPublicKey : null,
+      ciphertext: approved ? row.ciphertext : null,
+      nonce: approved ? row.nonce : null,
+    };
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handle = (method: string, url: string, data?: any): Promise<unknown> => {
+    if (method === 'POST' && url === '/identity/device-transfer/init') {
+      state.row = {
+        pairingId: 'a'.repeat(32),
+        newDeviceEphemeralPublicKey: data.newEphPub,
+        newDeviceLabel: data.newDeviceLabel ?? null,
+        status: 'pending',
+        expiresAt: new Date(Date.now() + 180_000).toISOString(),
+        oldDeviceEphemeralPublicKey: null,
+        ciphertext: null,
+        nonce: null,
+      };
+      return Promise.resolve({ pairingId: state.row.pairingId, expiresAt: state.row.expiresAt });
+    }
+    if (method === 'GET' && url.startsWith('/identity/device-transfer/')) {
+      return Promise.resolve(infoDto());
+    }
+    if (method === 'POST' && url.endsWith('/approve')) {
+      state.row!.oldDeviceEphemeralPublicKey = data.oldEphPub;
+      state.row!.ciphertext = data.ciphertext;
+      state.row!.nonce = data.nonce;
+      state.row!.status = 'approved';
+      return Promise.resolve({ success: true, pairingId: state.row!.pairingId, status: 'approved' });
+    }
+    if (method === 'POST' && url.endsWith('/deny')) {
+      state.row!.status = 'denied';
+      return Promise.resolve({ success: true, pairingId: state.row!.pairingId, status: 'denied' });
+    }
+    return Promise.reject(new Error(`unexpected request ${method} ${url}`));
+  };
+  return { state, handle };
+}
+
+describe('OxyServices.deviceTransfer', () => {
+  let identityPriv: string;
+  let identityPub: string;
+  let importedPrivateKey: string | null;
+
+  beforeEach(() => {
+    const idKey = ec.genKeyPair();
+    identityPriv = idKey.getPrivate('hex');
+    identityPub = idKey.getPublic('hex');
+    importedPrivateKey = null;
+
+    // Old device HOLDS the identity; new device IMPORTS it. One KeyManager is
+    // shared, but the two roles call disjoint methods (get* vs import).
+    jest.spyOn(KeyManager, 'getPrivateKey').mockResolvedValue(identityPriv);
+    jest.spyOn(KeyManager, 'getPublicKey').mockResolvedValue(identityPub);
+    jest.spyOn(KeyManager, 'importKeyPair').mockImplementation(async (priv: string) => {
+      importedPrivateKey = priv;
+      return ec.keyFromPrivate(priv, 'hex').getPublic('hex');
+    });
+    // The server (api service test) verifies the signature; here it is opaque.
+    jest.spyOn(SignatureService, 'sign').mockResolvedValue('sig-hex');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('clones the identity end-to-end (ECDH symmetry + full round-trip via the mixins)', async () => {
+    const relay = makeRelay();
+    const newDevice = new OxyServices({ baseURL: 'http://relay.invalid' });
+    const oldDevice = new OxyServices({ baseURL: 'http://relay.invalid' });
+    jest.spyOn(newDevice, 'makeRequest').mockImplementation(relay.handle as never);
+    jest.spyOn(oldDevice, 'makeRequest').mockImplementation(relay.handle as never);
+
+    // 1. New device registers a pairing (generates + stores its ephemeral key).
+    const init = await newDevice.initDeviceTransfer('New iPhone');
+    expect(init.pairingId).toHaveLength(32);
+    expect(relay.state.row?.newDeviceEphemeralPublicKey).toBe(init.newEphemeralPublicKey);
+
+    // 2. Old device resolves the QR handle and approves (seals the identity key).
+    const approveResult = await oldDevice.approveDeviceTransfer(init.pairingId);
+    expect(approveResult).toEqual({ success: true, pairingId: init.pairingId, status: 'approved' });
+    // The relay stored ONLY ephemeral pubkeys + opaque ciphertext — never the key.
+    expect(relay.state.row?.ciphertext).toBeTruthy();
+    expect(relay.state.row?.ciphertext).not.toContain(identityPriv);
+
+    // 3. New device awaits approval, decrypts, and imports the SAME private key.
+    const outcome = await new Promise<{ status: string; publicKey?: string }>((resolve) => {
+      newDevice.subscribeDeviceTransfer(init.pairingId, resolve);
+    });
+
+    expect(outcome).toEqual({ status: 'approved', publicKey: identityPub });
+    // The recovered private key is byte-for-byte the old device's identity key.
+    expect(importedPrivateKey).toBe(identityPriv);
+    // Imported WITHOUT overwrite — a fresh device must never clobber an identity.
+    expect(KeyManager.importKeyPair).toHaveBeenCalledWith(identityPriv, { overwrite: false });
+  });
+
+  it('reports a denied transfer to the subscriber without importing', async () => {
+    const relay = makeRelay();
+    const newDevice = new OxyServices({ baseURL: 'http://relay.invalid' });
+    jest.spyOn(newDevice, 'makeRequest').mockImplementation(relay.handle as never);
+
+    await newDevice.initDeviceTransfer();
+    relay.state.row!.status = 'denied';
+
+    const outcome = await new Promise<{ status: string }>((resolve) => {
+      newDevice.subscribeDeviceTransfer(relay.state.row!.pairingId, resolve);
+    });
+
+    expect(outcome).toEqual({ status: 'denied' });
+    expect(KeyManager.importKeyPair).not.toHaveBeenCalled();
+  });
+
+  it('throws if subscribing to a pairing this instance never initiated', () => {
+    const newDevice = new OxyServices({ baseURL: 'http://relay.invalid' });
+    expect(() => newDevice.subscribeDeviceTransfer('unknown-pair', () => {})).toThrow(
+      /initDeviceTransfer first/i,
+    );
+  });
+
+  it('refuses to approve a non-pending pairing', async () => {
+    const relay = makeRelay();
+    const newDevice = new OxyServices({ baseURL: 'http://relay.invalid' });
+    const oldDevice = new OxyServices({ baseURL: 'http://relay.invalid' });
+    jest.spyOn(newDevice, 'makeRequest').mockImplementation(relay.handle as never);
+    jest.spyOn(oldDevice, 'makeRequest').mockImplementation(relay.handle as never);
+
+    const init = await newDevice.initDeviceTransfer();
+    relay.state.row!.status = 'denied';
+
+    await expect(oldDevice.approveDeviceTransfer(init.pairingId)).rejects.toThrow(
+      /can no longer be approved/i,
+    );
+  });
+});
+
+/**
+ * The exact crypto derivation the mixin uses, pinned independently: two ephemeral
+ * pairs agree on a symmetric key, seal/open a JSON key blob, and any tampering
+ * with the ciphertext fails authentication.
+ */
+describe('device-transfer crypto derivation', () => {
+  const HKDF_INFO = 'oxy-device-transfer-v1';
+  const deriveTransferKey = (shared: Uint8Array, pairingId: string): Uint8Array =>
+    hkdfSha256(shared, utf8ToBytes(pairingId), utf8ToBytes(HKDF_INFO), 32);
+
+  it('is symmetric and round-trips the sealed identity key', () => {
+    const pairingId = 'b'.repeat(32);
+    const oldEph = ec.genKeyPair();
+    const newEph = ec.genKeyPair();
+
+    const sharedOld = deriveSharedSecret(oldEph.getPrivate('hex'), newEph.getPublic('hex'));
+    const sharedNew = deriveSharedSecret(newEph.getPrivate('hex'), oldEph.getPublic('hex'));
+    expect(bytesToHex(sharedOld)).toBe(bytesToHex(sharedNew));
+
+    const keyOld = deriveTransferKey(sharedOld, pairingId);
+    const keyNew = deriveTransferKey(sharedNew, pairingId);
+    expect(bytesToHex(keyOld)).toBe(bytesToHex(keyNew));
+
+    const identity = { privateKey: 'ff'.repeat(32), publicKey: '04' + 'ab'.repeat(64) };
+    const { nonce, ciphertext } = encryptAead(keyOld, utf8ToBytes(JSON.stringify(identity)));
+
+    const opened = JSON.parse(bytesToUtf8(decryptAead(keyNew, nonce, ciphertext)));
+    expect(opened).toEqual(identity);
+  });
+
+  it('fails authentication when the ciphertext is tampered', () => {
+    const pairingId = 'c'.repeat(32);
+    const oldEph = ec.genKeyPair();
+    const newEph = ec.genKeyPair();
+    const key = deriveTransferKey(
+      deriveSharedSecret(oldEph.getPrivate('hex'), newEph.getPublic('hex')),
+      pairingId,
+    );
+    const { nonce, ciphertext } = encryptAead(key, utf8ToBytes('{"privateKey":"deadbeef"}'));
+
+    const tampered = Uint8Array.from(ciphertext);
+    tampered[0] ^= 0x01; // flip one bit
+    const keyNew = deriveTransferKey(
+      deriveSharedSecret(newEph.getPrivate('hex'), oldEph.getPublic('hex')),
+      pairingId,
+    );
+    expect(() => decryptAead(keyNew, nonce, tampered)).toThrow();
+    // And a wrong pairingId (wrong HKDF salt) also fails — binds to the pairing.
+    const wrongSaltKey = deriveTransferKey(
+      deriveSharedSecret(newEph.getPrivate('hex'), oldEph.getPublic('hex')),
+      'd'.repeat(32),
+    );
+    expect(() => decryptAead(wrongSaltKey, nonce, ciphertext)).toThrow();
+  });
+
+  it('re-derives from hex the way the wire transports the material', () => {
+    const pairingId = 'e'.repeat(32);
+    const oldEph = ec.genKeyPair();
+    const newEph = ec.genKeyPair();
+    const keyOld = deriveTransferKey(
+      deriveSharedSecret(oldEph.getPrivate('hex'), newEph.getPublic('hex')),
+      pairingId,
+    );
+    const { nonce, ciphertext } = encryptAead(keyOld, utf8ToBytes('{"k":1}'));
+
+    // Wire form: hex strings (exactly what the mixin sends/receives).
+    const nonceHex = bytesToHex(nonce);
+    const ciphertextHex = bytesToHex(ciphertext);
+
+    const keyNew = deriveTransferKey(
+      deriveSharedSecret(newEph.getPrivate('hex'), oldEph.getPublic('hex')),
+      pairingId,
+    );
+    const opened = bytesToUtf8(decryptAead(keyNew, hexToBytes(nonceHex), hexToBytes(ciphertextHex)));
+    expect(opened).toBe('{"k":1}');
+  });
+});

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -30,6 +30,7 @@ import { OxyServicesCivicMixin } from './OxyServices.civic';
 import { OxyServicesNodesMixin } from './OxyServices.nodes';
 import { OxyServicesLinksMixin } from './OxyServices.links';
 import { OxyServicesDeviceBootMixin } from './OxyServices.deviceBoot';
+import { OxyServicesDeviceTransferMixin } from './OxyServices.deviceTransfer';
 
 /**
  * Instance shape of every mixin in the pipeline, intersected. The runtime
@@ -64,6 +65,7 @@ type AllMixinInstances =
   & InstanceType<ReturnType<typeof OxyServicesNodesMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesLinksMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesDeviceBootMixin<typeof OxyServicesBase>>>
+  & InstanceType<ReturnType<typeof OxyServicesDeviceTransferMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesUtilityMixin<typeof OxyServicesBase>>>;
 
 /**
@@ -137,6 +139,10 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     // Device-first token mint: the client half of the zero-cookie transport
     // (`mintFromDeviceSecret` → `POST /session/device/token`).
     OxyServicesDeviceBootMixin,
+
+    // Device-to-device identity transfer ("add a device"): E2E-encrypted key
+    // clone over a short-lived relay (b3 Feature 2).
+    OxyServicesDeviceTransferMixin,
 
     // Utility (last, can use all above)
     OxyServicesUtilityMixin,


### PR DESCRIPTION
## What

Backend + core SDK slice of **b3 Feature 2 — device-to-device identity transfer ("add a device")**. A short-lived, unauthenticated relay clones an existing device's secp256k1 identity onto a fresh device **without the server ever holding a decryption key** — both devices end up holding the same private key. Built on the merged Phase-0 crypto (`deriveSharedSecret` ECDH, `hkdfSha256`, `encryptAead`/`decryptAead`).

## Design (as built)

- **New device** (no identity): generate ephemeral secp256k1 pair → `POST /identity/device-transfer/init { newEphPub, newDeviceLabel? }` → `{ pairingId, expiresAt }`; render a QR carrying **only** `pairingId`.
- **Old device** (has identity): scans → `GET /identity/device-transfer/:pairingId` (server resolves `newEphPub` + label — QR is not self-contained, mirrors `approve-info`) → biometric-gate → `shared = deriveSharedSecret(oldEphPriv, newEphPub)`; `transferKey = hkdfSha256(shared, pairingId, 'oxy-device-transfer-v1', 32)`; `encryptAead(transferKey, {privateKey, publicKey})` → `POST /:pairingId/approve { oldEphPub, ciphertext, nonce, signature, timestamp }` where `signature` is over `{ action:'approve_device_transfer', pairingId, timestamp }` signed with the **CURRENT identity key**.
- **New device** (socket push on `/device-pair`, poll fallback): `shared = deriveSharedSecret(newEphPriv, oldEphPub)` → same `transferKey` → decrypt → `KeyManager.importKeyPair(privateKey, { overwrite:false })` → then the NORMAL existing challenge/verify sign-in (no bespoke claim).

## Threat model

E2E against a **passive / at-rest-compromised relay** (DB dump, on-path capture) — the server only stores ephemeral public keys + opaque AEAD ciphertext, never a decryption key. **Explicitly NOT hardened** against an actively-malicious Oxy backend MITM'ing the ephemeral keys (same trust boundary as the existing QR sign-in; SAS compare deferred per owner decision).

## Security invariants

- Approve requires **BOTH** a bearer token **AND** a fresh identity-key signature (a stolen bearer alone cannot exfiltrate the private key).
- Signature verified server-side against the caller's **current** `publicKey`; freshness-checked (5 min).
- Ephemeral keys single-use, **never persisted** (new-device ephemeral private key held in-memory only, per-instance WeakMap, cleared on settle).
- 3-minute TTL; atomic `pending → approved` transition (`findOneAndUpdate` on `status:'pending'` + unexpired → loser gets 409).
- No IP persisted anywhere (privacy invariant); public limiters keyed by hashed IP.

## Files

- **contracts**: `packages/contracts/src/devicePairing.ts` (init/info/approve/deny request+response schemas) + index export.
- **api**: `models/DevicePairingSession.ts` (TTL), `services/deviceTransfer.service.ts` (init/info/approve/deny + atomic burn + signature verify), `routes/deviceTransfer.ts` (`/identity/device-transfer`; public init/info/deny + bearer+signature approve), `utils/devicePairSocket.ts`, plus `server.ts` (mount route before `/identity`; register `io.of('/device-pair')` after `/auth-session`).
- **core**: `mixins/OxyServices.deviceTransfer.ts` (`initDeviceTransfer`, `getDeviceTransferInfo`, `approveDeviceTransfer`, `denyDeviceTransfer`, `subscribeDeviceTransfer` decrypt-and-import + poll fallback) + pipeline/index registration.

## Tests

- **core** (+7): ECDH symmetry + full encrypt/decrypt round-trip **via the mixins** (E2E clone), tamper (flipped byte + wrong HKDF salt) fails auth, hex-wire re-derivation, denied path, subscribe-without-init guard, non-pending approve guard.
- **api** (+20): init validation + TTL; info lazy-expiry + material only-when-approved; approve accepts valid signature + atomic `$set`, rejects wrong signature (401, before any pairing read), stale signature (400), missing identity key, already-approved (409, no atomic update), expired-on-approve, concurrent loser (409), unknown pairing (404), invalid ephemeral key; deny lifecycle; rate-limit prefix uniqueness.
- Full suites green: **contracts 133, core 923, api 1605**; `api` + `core` tsc clean; core build clean.

## Follow-ups

- ⚠️ **security-reviewer needed before merge.**
- Commons add-device / approve UI is a **separate follow-up slice** (not in this PR).
- Contracts is `workspace:*` — **republish-first at merge** (publish `@oxyhq/contracts` before consumers if the new symbols are needed by an external install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)