### PR TITLE
feat(follow): efficient batched follow-status system (api/core/services)

### DIFF
--- a/packages/api/src/routes/__tests__/usersFollowStatusBulk.test.ts
+++ b/packages/api/src/routes/__tests__/usersFollowStatusBulk.test.ts
@@ -1,0 +1,201 @@
+/**
+ * POST /users/follow-status/bulk contract tests
+ *
+ * Verifies the batched follow-status endpoint:
+ *  - empty / missing / non-array `userIds` → 400 (validation), never queries
+ *  - more than the cap (MAX_BULK_FOLLOW = 200) → 400, never queries
+ *  - happy path returns `{ data: { statuses } }` from the REAL
+ *    `userService.getFollowingStatuses`
+ *  - registered BEFORE `/:userId`, so `follow-status` is never captured as a
+ *    userId param
+ *
+ * The router is mounted on a minimal Express app and exercised via `node:http`
+ * round-trips so we hit the real middleware + validation chain. Only the data
+ * source (`userService.getFollowingStatuses`) is stubbed. `authMiddleware` is
+ * mocked to inject a fixed viewer id.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const mockGetFollowingStatuses = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (req: { user?: { id: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 'viewer-1' };
+    next();
+  },
+  serviceAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/optionalAuth', () => ({
+  optionalUserOrServiceAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../services/email.service', () => ({
+  emailService: { deleteAllUserData: jest.fn() },
+}));
+jest.mock('../../services/federation.service', () => ({
+  federationService: { scheduleAvatarRefresh: jest.fn() },
+  isOwnFederationDomain: jest.fn(),
+}));
+jest.mock('../../services/assetServiceSingleton', () => ({
+  assetService: { ensureOwnedAssetPublic: jest.fn().mockResolvedValue(undefined) },
+  s3Service: {},
+}));
+jest.mock('../../services/user.service', () => ({
+  userService: {
+    getFollowingStatuses: mockGetFollowingStatuses,
+  },
+}));
+jest.mock('../../services/identityExport.service', () => ({
+  buildExportBundle: jest.fn(),
+}));
+jest.mock('../../services/signature.service', () => ({
+  __esModule: true,
+  default: {},
+}));
+jest.mock('../../controllers/users.controller', () => ({
+  UsersController: class {
+    searchUsers = jest.fn();
+  },
+}));
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: jest.fn() },
+}));
+jest.mock('../../utils/validation', () => ({
+  resolveUserIdToObjectId: jest.fn(),
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import usersRouter from '../users';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: { error?: string; message?: string; data?: unknown };
+}
+
+async function requestJson(
+  server: http.Server,
+  method: string,
+  path: string,
+  payload: unknown,
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload ?? {});
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            const parsed = raw.length > 0 ? JSON.parse(raw) : {};
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/users', usersRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetFollowingStatuses.mockReset();
+});
+
+describe('POST /users/follow-status/bulk', () => {
+  it('rejects an empty userIds array with 400 and never queries', async () => {
+    const res = await requestJson(server, 'POST', '/users/follow-status/bulk', { userIds: [] });
+
+    expect(res.status).toBe(400);
+    expect(mockGetFollowingStatuses).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing userIds field with 400', async () => {
+    const res = await requestJson(server, 'POST', '/users/follow-status/bulk', {});
+
+    expect(res.status).toBe(400);
+    expect(mockGetFollowingStatuses).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-array userIds with 400', async () => {
+    const res = await requestJson(server, 'POST', '/users/follow-status/bulk', { userIds: 'nope' });
+
+    expect(res.status).toBe(400);
+    expect(mockGetFollowingStatuses).not.toHaveBeenCalled();
+  });
+
+  it('rejects more than 200 ids with 400 and never queries', async () => {
+    const userIds = Array.from({ length: 201 }, (_, i) => `id-${i}`);
+
+    const res = await requestJson(server, 'POST', '/users/follow-status/bulk', { userIds });
+
+    expect(res.status).toBe(400);
+    expect(mockGetFollowingStatuses).not.toHaveBeenCalled();
+  });
+
+  it('returns { data: { statuses } } for valid ids, keyed off the auth viewer', async () => {
+    mockGetFollowingStatuses.mockResolvedValueOnce({ u1: true, u2: false });
+
+    const res = await requestJson(server, 'POST', '/users/follow-status/bulk', {
+      userIds: ['u1', 'u2'],
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockGetFollowingStatuses).toHaveBeenCalledTimes(1);
+    expect(mockGetFollowingStatuses).toHaveBeenCalledWith('viewer-1', ['u1', 'u2']);
+    expect(res.body.data).toEqual({ statuses: { u1: true, u2: false } });
+  });
+
+  it('is NOT captured by the /:userId param route (registered first)', async () => {
+    mockGetFollowingStatuses.mockResolvedValueOnce({ '000000000000000000000000': false });
+
+    const res = await requestJson(server, 'POST', '/users/follow-status/bulk', {
+      userIds: ['000000000000000000000000'],
+    });
+
+    // A 200 from the bulk handler (not a 404/405 from a param route) proves the
+    // `/follow-status/bulk` literal route won the match over `/:userId`.
+    expect(res.status).toBe(200);
+    expect(mockGetFollowingStatuses).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -513,6 +513,54 @@ router.post(
 );
 
 /**
+ * POST /users/follow-status/bulk
+ *
+ * Resolve the authenticated viewer's follow status for MANY target users in a
+ * single request. Built for list UIs (a page of N FollowButtons) that would
+ * otherwise fire N `GET /users/:id/follow-status` calls — this collapses them
+ * into one round-trip served by a single indexed query.
+ *
+ * Registered BEFORE the `/:userId` param routes so Express never treats
+ * `follow-status` as a `:userId` value.
+ *
+ * @body {string[]} userIds - Target user ids to check (max MAX_BULK_FOLLOW).
+ * @returns {{ statuses: Record<string, boolean> }} Every requested id mapped to
+ *   whether the viewer follows it; unknown/unfollowed ids are `false`.
+ */
+router.post(
+  '/follow-status/bulk',
+  authMiddleware,
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const currentUserId = req.user?.id;
+
+    if (!currentUserId) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const userIds = getUserIdsFromRequestBody(req.body);
+
+    if (!Array.isArray(userIds)) {
+      throw new BadRequestError('userIds must be an array');
+    }
+    if (userIds.length === 0) {
+      throw new BadRequestError('userIds must not be empty');
+    }
+    if (userIds.length > MAX_BULK_FOLLOW) {
+      throw new BadRequestError(`Cannot request more than ${MAX_BULK_FOLLOW} follow statuses at once`);
+    }
+
+    const statuses = await userService.getFollowingStatuses(currentUserId, userIds);
+
+    logger.debug('POST /users/follow-status/bulk', {
+      currentUserId,
+      requested: userIds.length,
+    });
+
+    sendSuccess(res, { statuses });
+  })
+);
+
+/**
  * POST /users/by-ids
  *
  * Batch-resolve PUBLIC user DTOs for up to 100 ids in a single round-trip.

--- a/packages/api/src/services/__tests__/user.service.getFollowingStatuses.test.ts
+++ b/packages/api/src/services/__tests__/user.service.getFollowingStatuses.test.ts
@@ -1,0 +1,159 @@
+// The global jest.setup.cjs mocks `mongoose` wholesale, which strips `Types`
+// (and therefore `Types.ObjectId`). This suite needs the real `Types` helper —
+// the models themselves are mocked below — so restore the actual mongoose.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import { Types } from 'mongoose';
+
+const mockFollowFindLean = jest.fn();
+const mockFollowFindSelect = jest.fn(() => ({ lean: mockFollowFindLean }));
+const mockFollowFind = jest.fn(() => ({ select: mockFollowFindSelect }));
+
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  default: {
+    find: mockFollowFind,
+  },
+  FollowType: {
+    USER: 'user',
+    HASHTAG: 'hashtag',
+    TOPIC: 'topic',
+  },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.mock('../securityActivityService', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+import { UserService } from '../user.service';
+
+describe('UserService.getFollowingStatuses', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFollowFindLean.mockResolvedValue([]);
+  });
+
+  it('maps every requested id to a boolean — followed ids true, the rest false', async () => {
+    const viewer = new Types.ObjectId().toHexString();
+    const followed = new Types.ObjectId();
+    const notFollowed = new Types.ObjectId();
+
+    mockFollowFindLean.mockResolvedValue([{ followedId: followed }]);
+
+    const result = await new UserService().getFollowingStatuses(viewer, [
+      followed.toHexString(),
+      notFollowed.toHexString(),
+    ]);
+
+    expect(mockFollowFind).toHaveBeenCalledTimes(1);
+    expect(mockFollowFind).toHaveBeenCalledWith({
+      followerUserId: viewer,
+      followType: 'user',
+      followedId: { $in: [followed.toHexString(), notFollowed.toHexString()] },
+    });
+    expect(result).toEqual({
+      [followed.toHexString()]: true,
+      [notFollowed.toHexString()]: false,
+    });
+  });
+
+  it('runs at most ONE query regardless of N', async () => {
+    const viewer = new Types.ObjectId().toHexString();
+    const ids = Array.from({ length: 50 }, () => new Types.ObjectId().toHexString());
+
+    mockFollowFindLean.mockResolvedValue([]);
+
+    const result = await new UserService().getFollowingStatuses(viewer, ids);
+
+    expect(mockFollowFind).toHaveBeenCalledTimes(1);
+    expect(Object.keys(result)).toHaveLength(50);
+    expect(Object.values(result).every((v) => v === false)).toBe(true);
+  });
+
+  it('defaults structurally-invalid ids to false and never puts them in the query', async () => {
+    const viewer = new Types.ObjectId().toHexString();
+    const valid = new Types.ObjectId();
+
+    mockFollowFindLean.mockResolvedValue([{ followedId: valid }]);
+
+    const result = await new UserService().getFollowingStatuses(viewer, [
+      valid.toHexString(),
+      'not-an-object-id',
+    ]);
+
+    expect(mockFollowFind).toHaveBeenCalledWith({
+      followerUserId: viewer,
+      followType: 'user',
+      followedId: { $in: [valid.toHexString()] },
+    });
+    expect(result).toEqual({
+      [valid.toHexString()]: true,
+      'not-an-object-id': false,
+    });
+  });
+
+  it('dedupes requested ids while still mapping each requested id', async () => {
+    const viewer = new Types.ObjectId().toHexString();
+    const id = new Types.ObjectId();
+
+    mockFollowFindLean.mockResolvedValue([{ followedId: id }]);
+
+    const result = await new UserService().getFollowingStatuses(viewer, [
+      id.toHexString(),
+      id.toHexString(),
+    ]);
+
+    expect(mockFollowFind).toHaveBeenCalledWith({
+      followerUserId: viewer,
+      followType: 'user',
+      followedId: { $in: [id.toHexString()] },
+    });
+    expect(result).toEqual({ [id.toHexString()]: true });
+  });
+
+  it('returns all-false with NO query for an anonymous viewer', async () => {
+    const target = new Types.ObjectId().toHexString();
+
+    const result = await new UserService().getFollowingStatuses('', [target]);
+
+    expect(mockFollowFind).not.toHaveBeenCalled();
+    expect(result).toEqual({ [target]: false });
+  });
+
+  it('returns {} with NO query for an empty id set', async () => {
+    const viewer = new Types.ObjectId().toHexString();
+
+    const result = await new UserService().getFollowingStatuses(viewer, []);
+
+    expect(mockFollowFind).not.toHaveBeenCalled();
+    expect(result).toEqual({});
+  });
+});

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -1482,6 +1482,81 @@ export class UserService {
   }
 
   /**
+   * Batch follow-status resolution for the authenticated viewer.
+   *
+   * Returns a boolean for EVERY requested target id: `true` when the viewer
+   * follows that user, `false` otherwise. Structurally-invalid ids and ids the
+   * viewer does not follow both map to `false`. An anonymous viewer or an
+   * empty/all-invalid id set resolves to all-`false` with no query.
+   *
+   * Efficiency contract: at most ONE indexed `Follow.find` regardless of N —
+   * keyed on `(followerUserId, followType, followedId $in validIds)`, the same
+   * axis `isFollowing` uses. Built to replace N per-button
+   * `GET /users/:id/follow-status` requests with a single round-trip.
+   *
+   * @param currentUserId The authenticated viewer (follower) id.
+   * @param targetIds Candidate user ids to check (may contain duplicates or
+   *   invalid ids).
+   * @returns A map of every requested id → whether the viewer follows it.
+   */
+  async getFollowingStatuses(
+    currentUserId: string,
+    targetIds: string[]
+  ): Promise<Record<string, boolean>> {
+    // Dedupe requested ids preserving first-seen order; every requested id must
+    // appear in the result (default false), including invalid ones.
+    const seen = new Set<string>();
+    const requestedIds: string[] = [];
+    for (const rawId of targetIds) {
+      if (typeof rawId !== 'string') continue;
+      const id = rawId.trim();
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      requestedIds.push(id);
+    }
+
+    const statuses: Record<string, boolean> = {};
+    for (const id of requestedIds) {
+      statuses[id] = false;
+    }
+
+    // Anonymous viewer or nothing to check → all false, no query.
+    if (!currentUserId || requestedIds.length === 0) {
+      return statuses;
+    }
+
+    // Only structurally-valid ids may enter the `$in` query.
+    const validIds = requestedIds.filter((id) => Types.ObjectId.isValid(id));
+    if (validIds.length === 0) {
+      return statuses;
+    }
+
+    // ONE indexed query for the viewer's follows within the requested set.
+    const follows = await Follow.find({
+      followerUserId: currentUserId,
+      followType: FollowType.USER,
+      followedId: { $in: validIds },
+    })
+      .select('followedId')
+      .lean();
+
+    const followedIds = new Set<string>(
+      follows
+        .map((follow) => follow.followedId)
+        .filter((id): id is Types.ObjectId | string => id != null)
+        .map((id) => id.toString())
+    );
+
+    for (const id of validIds) {
+      if (followedIds.has(id)) {
+        statuses[id] = true;
+      }
+    }
+
+    return statuses;
+  }
+
+  /**
    * Batch-resolve PUBLIC user DTOs for a set of ids.
    *
    * Returns the SAME shape as `GET /users/:id` (`formatUserResponse`), including

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "12.2.1",
+  "version": "12.3.0",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export type {
     BulkFollowResult,
     BulkUnfollowEntry,
     BulkUnfollowResult,
+    FollowMutationResult,
     ViewerGraph,
 } from './mixins/OxyServices.user';
 export { OxyAppDataIdentifierError } from './mixins/OxyServices.appData';

--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -31,6 +31,33 @@ import { extractErrorStatus } from '../utils/errorUtils';
  */
 const USERS_BY_IDS_CHUNK_SIZE = 100;
 
+/**
+ * Maximum number of ids sent per `POST /users/follow-status/bulk` request.
+ * Matches the server-side `MAX_BULK_FOLLOW` cap; larger inputs are split into
+ * multiple chunked calls whose result maps are merged.
+ */
+const FOLLOW_STATUS_CHUNK_SIZE = 200;
+
+/**
+ * Response of the single follow/unfollow toggle route
+ * (`POST /users/:id/follow` and `DELETE /users/:id/follow`). The route reports a
+ * status message, which side of the toggle was applied, and the post-write
+ * follower/following counts for the affected users.
+ */
+export interface FollowMutationResult {
+  /** Human-readable status message. */
+  message: string;
+  /** Which side of the toggle was applied, when reported by the route. */
+  action?: 'follow' | 'unfollow';
+  /** Post-write counts, when reported by the route. */
+  counts?: {
+    /** The target user's follower count after the write. */
+    followers: number;
+    /** The viewer's following count after the write. */
+    following: number;
+  };
+}
+
 /** Per-user outcome returned by `POST /users/follow/bulk`. */
 export interface BulkFollowEntry {
   /** The user ID that was processed. */
@@ -679,9 +706,9 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
      * UI (the "follow resets after navigating away and back" bug).
      * `clearCacheEntry` deletes every identity-scoped variant of the key.
      */
-    async followUser(userId: string): Promise<{ success: boolean; message: string }> {
+    async followUser(userId: string): Promise<FollowMutationResult> {
       try {
-        const result = await this.makeRequest<{ success: boolean; message: string }>('POST', `/users/${userId}/follow`, undefined, { cache: false });
+        const result = await this.makeRequest<FollowMutationResult>('POST', `/users/${userId}/follow`, undefined, { cache: false });
         this.clearCacheEntry(`GET:/users/${userId}/follow-status`);
         // The follow changed the viewer's graph — bust the cached consolidated
         // `GET /users/me/graph` so the next read reflects the new following/
@@ -748,9 +775,9 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
     /**
      * Unfollow a user
      */
-    async unfollowUser(userId: string): Promise<{ success: boolean; message: string }> {
+    async unfollowUser(userId: string): Promise<FollowMutationResult> {
       try {
-        const result = await this.makeRequest<{ success: boolean; message: string }>('DELETE', `/users/${userId}/follow`, undefined, { cache: false });
+        const result = await this.makeRequest<FollowMutationResult>('DELETE', `/users/${userId}/follow`, undefined, { cache: false });
         // Bust the cached follow-status so a remount reads fresh truth (see `followUser`).
         this.clearCacheEntry(`GET:/users/${userId}/follow-status`);
         // The unfollow changed the viewer's graph — bust the consolidated cache.
@@ -770,6 +797,57 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
           cache: true,
           cacheTTL: 1 * 60 * 1000, // 1 minute cache
         });
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Resolve the viewer's follow status for MANY users in one round-trip per
+     * chunk. Built for list UIs (a page of `FollowButton`s) that would otherwise
+     * fire one `getFollowStatus` per button (the classic N+1).
+     *
+     * Ids are deduplicated and validated (empty/blank ids dropped), split into
+     * chunks of {@link FOLLOW_STATUS_CHUNK_SIZE} (the server's bulk cap), and
+     * POSTed to `/users/follow-status/bulk` as `{ userIds }`. The per-chunk
+     * `{ statuses }` maps are merged into one `Record<string, boolean>` covering
+     * every requested id — ids the viewer does not follow come back `false`.
+     *
+     * Uncached (`{ cache: false }`): the UI store owns follow-status freshness
+     * and writes optimistically on every mutation, so an SDK cache here would
+     * serve a stale status right after a follow/unfollow. An empty/whitespace-
+     * only input resolves immediately with `{}` and performs no network call.
+     */
+    async getFollowStatuses(userIds: string[]): Promise<Record<string, boolean>> {
+      const uniqueIds = Array.from(
+        new Set(userIds.filter((id): id is string => typeof id === 'string' && id.trim().length > 0)),
+      );
+      if (uniqueIds.length === 0) {
+        return {};
+      }
+
+      const chunks: string[][] = [];
+      for (let i = 0; i < uniqueIds.length; i += FOLLOW_STATUS_CHUNK_SIZE) {
+        chunks.push(uniqueIds.slice(i, i + FOLLOW_STATUS_CHUNK_SIZE));
+      }
+
+      try {
+        const responses = await Promise.all(
+          chunks.map((chunk) =>
+            this.makeRequest<{ statuses: Record<string, boolean> }>(
+              'POST',
+              '/users/follow-status/bulk',
+              { userIds: chunk },
+              { cache: false },
+            ),
+          ),
+        );
+
+        const merged: Record<string, boolean> = {};
+        for (const response of responses) {
+          Object.assign(merged, response?.statuses ?? {});
+        }
+        return merged;
       } catch (error) {
         throw this.handleError(error);
       }

--- a/packages/core/src/mixins/__tests__/getFollowStatuses.test.ts
+++ b/packages/core/src/mixins/__tests__/getFollowStatuses.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `getFollowStatuses` — batched follow-status resolution tests.
+ *
+ * The SDK method collapses N per-button `getFollowStatus` calls into one bulk
+ * `POST /users/follow-status/bulk` per chunk. It must:
+ *  - dedup + drop blank ids, and resolve to `{}` with NO network call on empty
+ *    input;
+ *  - POST `{ userIds }` uncached (`{ cache: false }`) so the UI store owns
+ *    follow-status freshness;
+ *  - chunk at the server cap (200) and MERGE the per-chunk `{ statuses }` maps
+ *    into one record covering every requested id.
+ *
+ * `makeRequest` is stubbed so the tests run with no network.
+ */
+
+import { OxyServices } from '../../OxyServices';
+
+describe('OxyServices.getFollowStatuses — batched follow status', () => {
+  let oxy: OxyServices;
+  let makeRequestSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    makeRequestSpy = jest.spyOn(oxy, 'makeRequest');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns {} and performs no network call for empty / whitespace input', async () => {
+    await expect(oxy.getFollowStatuses([])).resolves.toEqual({});
+    await expect(oxy.getFollowStatuses(['', '   '])).resolves.toEqual({});
+    expect(makeRequestSpy).not.toHaveBeenCalled();
+  });
+
+  it('POSTs { userIds } uncached and returns the statuses map', async () => {
+    makeRequestSpy.mockResolvedValueOnce({ statuses: { a: true, b: false } });
+
+    const result = await oxy.getFollowStatuses(['a', 'b']);
+
+    expect(makeRequestSpy).toHaveBeenCalledTimes(1);
+    expect(makeRequestSpy).toHaveBeenCalledWith(
+      'POST',
+      '/users/follow-status/bulk',
+      { userIds: ['a', 'b'] },
+      { cache: false },
+    );
+    expect(result).toEqual({ a: true, b: false });
+  });
+
+  it('de-duplicates ids and drops blanks before the request', async () => {
+    makeRequestSpy.mockResolvedValueOnce({ statuses: { a: true } });
+
+    await oxy.getFollowStatuses(['a', 'a', '   ', 'a']);
+
+    expect(makeRequestSpy).toHaveBeenCalledTimes(1);
+    expect(makeRequestSpy).toHaveBeenCalledWith(
+      'POST',
+      '/users/follow-status/bulk',
+      { userIds: ['a'] },
+      { cache: false },
+    );
+  });
+
+  it('chunks at 200 ids per request and merges the per-chunk maps', async () => {
+    const ids = Array.from({ length: 450 }, (_, i) => `id-${i}`);
+    makeRequestSpy.mockImplementation(
+      async (
+        _method: string,
+        _url: string,
+        data?: { userIds: string[] },
+      ): Promise<{ statuses: Record<string, boolean> }> => {
+        const statuses: Record<string, boolean> = {};
+        for (const id of data?.userIds ?? []) {
+          statuses[id] = id.endsWith('0'); // deterministic mix of true/false
+        }
+        return { statuses };
+      },
+    );
+
+    const result = await oxy.getFollowStatuses(ids);
+
+    // 450 unique ids => 200 + 200 + 50 across three POSTs.
+    expect(makeRequestSpy).toHaveBeenCalledTimes(3);
+    const chunkSizes = makeRequestSpy.mock.calls.map(
+      (call) => (call[2] as { userIds: string[] }).userIds.length,
+    );
+    expect(chunkSizes).toEqual([200, 200, 50]);
+    // Every requested id is present in the merged result.
+    expect(Object.keys(result)).toHaveLength(450);
+    expect(result['id-10']).toBe(true);
+    expect(result['id-11']).toBe(false);
+  });
+});

--- a/packages/services/__tests__/components/FollowButton.multiUser.test.tsx
+++ b/packages/services/__tests__/components/FollowButton.multiUser.test.tsx
@@ -4,7 +4,11 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 
 const oxyServicesStub = {
-  getFollowStatus: jest.fn(async () => ({ isFollowing: false })),
+  // Multi-user status resolution now goes through the batched bulk endpoint
+  // (one call for all members) rather than N single `getFollowStatus` calls.
+  getFollowStatuses: jest.fn(async (ids: string[]) =>
+    Object.fromEntries(ids.map((id) => [id, false])),
+  ),
   followUsers: jest.fn(),
   unfollowUsers: jest.fn(),
   getCurrentUserId: jest.fn(() => 'me'),

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "22.2.0",
+  "version": "22.3.0",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -65,7 +65,7 @@ export {
 // ---------------------------------------------------------------------------
 export { useAssets, setOxyAssetInstance } from './ui/hooks/useAssets';
 export { useFileDownloadUrl } from './ui/hooks/useFileDownloadUrl';
-export { useFollow, useFollowerCounts } from './ui/hooks/useFollow';
+export { useFollow, useFollowerCounts, useSeedFollowStatuses } from './ui/hooks/useFollow';
 export { useStorage } from './ui/hooks/useStorage';
 export type { UseStorageOptions, UseStorageResult } from './ui/hooks/useStorage';
 

--- a/packages/services/src/ui/components/FollowButton.tsx
+++ b/packages/services/src/ui/components/FollowButton.tsx
@@ -60,7 +60,7 @@ const isMultiMode = (props: FollowButtonProps): props is MultiFollowButtonProps 
 const FollowButtonInner = memo(function FollowButtonInner({
   userId,
   oxyServices,
-  initiallyFollowing = false,
+  initiallyFollowing,
   size = 'medium',
   onFollowChange,
   style,
@@ -73,18 +73,19 @@ const FollowButtonInner = memo(function FollowButtonInner({
 
   const {
     isFollowing,
+    isKnown,
     isLoading,
     toggleFollow,
-    setFollowStatus,
-    fetchStatus,
-  } = useFollowForButton(userId, oxyServices);
+    resolveStatus,
+  } = useFollowForButton(userId, oxyServices, initiallyFollowing);
 
   const handlePress = useCallback(async (event?: { preventDefault?: () => void; stopPropagation?: () => void }) => {
     if (preventParentActions && event?.preventDefault) {
       event.preventDefault();
       event.stopPropagation?.();
     }
-    if (disabled || isLoading) return;
+    // Ignore presses while a mutation is in flight or the status is still unknown.
+    if (disabled || isLoading || !isKnown) return;
 
     try {
       await toggleFollow();
@@ -93,38 +94,39 @@ const FollowButtonInner = memo(function FollowButtonInner({
       const error = err instanceof Error ? err : new Error(String(err));
       toast.error(error.message || 'Failed to update follow status');
     }
-  }, [disabled, isLoading, toggleFollow, onFollowChange, isFollowing, preventParentActions]);
+  }, [disabled, isLoading, isKnown, toggleFollow, onFollowChange, isFollowing, preventParentActions]);
 
+  // Enqueue a batched status fetch ONLY when the status is genuinely unknown
+  // (not seeded from `initiallyFollowing`, not already resolved). All buttons
+  // that enqueue in the same commit coalesce into a single bulk request; known/
+  // seeded ids never fetch. Once resolved, `isKnown` flips true and this no-ops.
   useEffect(() => {
-    if (userId && !isFollowing && initiallyFollowing) {
-      setFollowStatus(initiallyFollowing);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userId, initiallyFollowing]);
+    if (!isKnown) resolveStatus();
+  }, [isKnown, resolveStatus]);
 
-  useEffect(() => {
-    if (userId) fetchStatus();
-  }, [userId, fetchStatus]);
-
-  const showSpinner = showLoadingState && isLoading;
+  // While the status is genuinely unknown (being resolved), present a NEUTRAL,
+  // non-interactive state rather than a definitive "Follow".
+  const isBusy = isLoading || !isKnown;
+  const showFollowing = isKnown && isFollowing;
+  const showSpinner = showLoadingState && isBusy;
 
   return (
     <Button
-      variant={isFollowing ? 'secondary' : 'primary'}
+      variant={showFollowing ? 'secondary' : 'primary'}
       size={size}
       onPress={() => { void handlePress(); }}
-      disabled={disabled || isLoading}
+      disabled={disabled || isBusy}
       style={style}
       textStyle={textStyle}
       icon={showSpinner ? (
         <Loading
           variant="inline"
           size="small"
-          color={isFollowing ? colors.text : colors.primaryForeground}
+          color={showFollowing ? colors.text : colors.primaryForeground}
         />
       ) : undefined}
     >
-      {showSpinner ? undefined : (isFollowing ? 'Following' : 'Follow')}
+      {showSpinner ? undefined : (isKnown ? (isFollowing ? 'Following' : 'Follow') : undefined)}
     </Button>
   );
 });

--- a/packages/services/src/ui/hooks/useFollow.ts
+++ b/packages/services/src/ui/hooks/useFollow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useFollowStore } from '../stores/followStore';
 import { useOxy } from '../context/OxyContext';
@@ -110,7 +110,7 @@ export const useFollow = (userId?: string | string[]) => {
   const fetchStatus = useCallback(async () => {
     if (!isSingleUser || !userId) throw new Error('fetchStatus is only available for single user mode');
     if (!canUsePrivateApi) return;
-    await useFollowStore.getState().fetchFollowStatus(userId, oxyServices);
+    useFollowStore.getState().resolveFollowStatuses([userId], oxyServices);
   }, [isSingleUser, userId, canUsePrivateApi, oxyServices]);
 
   const clearError = useCallback(() => {
@@ -170,13 +170,14 @@ export const useFollow = (userId?: string | string[]) => {
 
   const fetchStatusForUser = useCallback(async (targetUserId: string) => {
     if (!canUsePrivateApi) return;
-    await useFollowStore.getState().fetchFollowStatus(targetUserId, oxyServices);
+    useFollowStore.getState().resolveFollowStatuses([targetUserId], oxyServices);
   }, [canUsePrivateApi, oxyServices]);
 
+  // Resolve EVERY member's status in ONE micro-batched bulk call (never N
+  // single requests). Ids already known/seeded are skipped by the resolver.
   const fetchAllStatuses = useCallback(async () => {
     if (!canUsePrivateApi) return;
-    const store = useFollowStore.getState();
-    await Promise.all(userIds.map(uid => store.fetchFollowStatus(uid, oxyServices)));
+    useFollowStore.getState().resolveFollowStatuses(userIds, oxyServices);
   }, [canUsePrivateApi, userIds, oxyServices]);
 
   // Bulk follow — follows ALL users in ONE network call (never unfollows).
@@ -242,9 +243,31 @@ export const useFollow = (userId?: string | string[]) => {
  * - Only subscribes to the specific user's follow and loading state
  * - Returns only what FollowButton needs (no counts, no multi-user)
  */
-export const useFollowForButton = (userId: string, oxyServices: OxyServices) => {
+export const useFollowForButton = (userId: string, oxyServices: OxyServices, initiallyFollowing?: boolean) => {
+  // Seed the store synchronously on the FIRST render (before paint) when the
+  // caller provided a definite `initiallyFollowing` and the store has no entry
+  // yet. This makes the first paint show the correct label (no post-mount
+  // "Follow → Following" correction) and marks the id KNOWN so the batched
+  // resolver skips it. An OMITTED `initiallyFollowing` leaves the id UNKNOWN,
+  // so the batched resolver fetches its real status. The useState lazy
+  // initializer runs exactly once per mount; `setFollowStatuses` is
+  // seed-only-if-absent, so it never clobbers a live value.
+  useState(() => {
+    if (initiallyFollowing === undefined) return null;
+    const store = useFollowStore.getState();
+    if (!Object.prototype.hasOwnProperty.call(store.followingUsers, userId)) {
+      store.setFollowStatuses({ [userId]: initiallyFollowing });
+    }
+    return null;
+  });
+
   const isFollowing = useFollowStore(
     useCallback((s) => s.followingUsers[userId] ?? false, [userId])
+  );
+  // Tri-state: a present key (seeded or fetched) is a DEFINITE status; a missing
+  // key is UNKNOWN. The button renders a neutral/disabled state while unknown.
+  const isKnown = useFollowStore(
+    useCallback((s) => Object.prototype.hasOwnProperty.call(s.followingUsers, userId), [userId])
   );
   const isLoading = useFollowStore(
     useCallback((s) => s.loadingUsers[userId] ?? false, [userId])
@@ -258,8 +281,12 @@ export const useFollowForButton = (userId: string, oxyServices: OxyServices) => 
     await useFollowStore.getState().toggleFollowUser(userId, oxyServices, currentlyFollowing);
   }, [userId, oxyServices]);
 
-  const fetchStatus = useCallback(async () => {
-    await useFollowStore.getState().fetchFollowStatus(userId, oxyServices);
+  // Enqueue this id into the micro-batched resolver — every button that enqueues
+  // in the same tick coalesces into ONE bulk `getFollowStatuses` call. Known /
+  // seeded / in-flight ids are skipped by the resolver, so this is a no-op for
+  // them.
+  const resolveStatus = useCallback(() => {
+    useFollowStore.getState().resolveFollowStatuses([userId], oxyServices);
   }, [userId, oxyServices]);
 
   const setFollowStatus = useCallback((following: boolean) => {
@@ -272,14 +299,29 @@ export const useFollowForButton = (userId: string, oxyServices: OxyServices) => 
 
   return {
     isFollowing,
+    isKnown,
     isLoading,
     error,
     toggleFollow,
-    fetchStatus,
+    resolveStatus,
     setFollowStatus,
     clearError,
   };
 };
+
+/**
+ * useSeedFollowStatuses — returns a stable callback that bulk-seeds follow
+ * statuses into the store (seed-only-if-absent; never clobbers a live value).
+ *
+ * Wire this at the app root to seed from `oxyServices.getViewerGraph()
+ * .followingIds` (map each followed id → `true`) so a page of `FollowButton`s
+ * paints the correct label on first render with ZERO follow-status network
+ * calls — the batched resolver then skips every seeded id.
+ */
+export const useSeedFollowStatuses = () =>
+  useCallback((statuses: Record<string, boolean>) => {
+    useFollowStore.getState().setFollowStatuses(statuses);
+  }, []);
 
 // Convenience hook for just follower counts
 export const useFollowerCounts = (userId: string) => {

--- a/packages/services/src/ui/index.ts
+++ b/packages/services/src/ui/index.ts
@@ -32,7 +32,7 @@ export { default as ProfileButton } from './components/ProfileButton';
 // Context + hooks
 export { useOxy } from './context/OxyContext';
 export { useAuth } from './hooks/useAuth';
-export { useFollow } from './hooks/useFollow';
+export { useFollow, useSeedFollowStatuses } from './hooks/useFollow';
 export { useStorage } from './hooks/useStorage';
 export type { UseStorageOptions, UseStorageResult } from './hooks/useStorage';
 

--- a/packages/services/src/ui/stores/__tests__/followStore.test.ts
+++ b/packages/services/src/ui/stores/__tests__/followStore.test.ts
@@ -1,0 +1,153 @@
+/**
+ * followStore — tri-state seed, micro-batched resolution, and optimistic
+ * mutation tests.
+ *
+ * Covers the follow-system efficiency overhaul:
+ *  - `setFollowStatuses` seeds only-if-absent (never clobbers a definite value)
+ *  - `resolveFollowStatuses` coalesces every UNKNOWN id requested in one tick
+ *    into a SINGLE `getFollowStatuses` call, and skips known/seeded ids
+ *  - `toggleFollowUser` writes optimistically BEFORE the await and rolls back on
+ *    error
+ */
+
+import type { OxyServices, FollowMutationResult } from '@oxyhq/core';
+import { useFollowStore } from '../followStore';
+
+// A microtask + macrotask flush: `resolveFollowStatuses` schedules its bulk call
+// via `queueMicrotask`, and the mocked `getFollowStatuses` resolves on the
+// microtask queue, so a single macrotask turn drains both.
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+interface FollowServicesMock {
+  getFollowStatuses: jest.Mock<Promise<Record<string, boolean>>, [string[]]>;
+  followUser: jest.Mock<Promise<FollowMutationResult>, [string]>;
+  unfollowUser: jest.Mock<Promise<FollowMutationResult>, [string]>;
+  getCurrentUserId: jest.Mock<string | null, []>;
+}
+
+const makeServices = (): { mock: FollowServicesMock; services: OxyServices } => {
+  const mock: FollowServicesMock = {
+    getFollowStatuses: jest.fn(async (ids: string[]) =>
+      Object.fromEntries(ids.map((id) => [id, false])),
+    ),
+    followUser: jest.fn(async () => ({ message: 'ok' })),
+    unfollowUser: jest.fn(async () => ({ message: 'ok' })),
+    getCurrentUserId: jest.fn(() => 'viewer-1'),
+  };
+  return { mock, services: mock as unknown as OxyServices };
+};
+
+beforeEach(() => {
+  useFollowStore.getState().resetFollowState();
+});
+
+afterEach(async () => {
+  // Drain any pending micro-batch so module-level state never leaks between tests.
+  await flush();
+});
+
+describe('setFollowStatuses (seed-only-if-absent)', () => {
+  it('seeds absent ids and never clobbers an existing definite value', () => {
+    const store = useFollowStore.getState();
+    store.setFollowStatuses({ u1: true });
+    store.setFollowStatuses({ u1: false, u2: true });
+
+    expect(useFollowStore.getState().followingUsers).toEqual({ u1: true, u2: true });
+  });
+});
+
+describe('resolveFollowStatuses (micro-batched)', () => {
+  it('coalesces every id requested in one tick into a SINGLE call', async () => {
+    const { mock, services } = makeServices();
+    mock.getFollowStatuses.mockImplementation(async (ids) =>
+      Object.fromEntries(ids.map((id) => [id, id === 'u1'])),
+    );
+
+    const store = useFollowStore.getState();
+    store.resolveFollowStatuses(['u1', 'u2'], services);
+    store.resolveFollowStatuses(['u3'], services);
+
+    await flush();
+
+    expect(mock.getFollowStatuses).toHaveBeenCalledTimes(1);
+    expect(mock.getFollowStatuses).toHaveBeenCalledWith(['u1', 'u2', 'u3']);
+    expect(useFollowStore.getState().followingUsers).toEqual({ u1: true, u2: false, u3: false });
+  });
+
+  it('skips ids whose status is already known/seeded', async () => {
+    const { mock, services } = makeServices();
+    const store = useFollowStore.getState();
+    store.setFollowStatuses({ u1: false }); // seeded → must NOT re-fetch
+
+    store.resolveFollowStatuses(['u1', 'u2'], services);
+    await flush();
+
+    expect(mock.getFollowStatuses).toHaveBeenCalledTimes(1);
+    expect(mock.getFollowStatuses).toHaveBeenCalledWith(['u2']);
+    // The seeded false is preserved; u2 resolved.
+    expect(useFollowStore.getState().followingUsers).toEqual({ u1: false, u2: false });
+  });
+
+  it('performs NO call when every requested id is already known', async () => {
+    const { mock, services } = makeServices();
+    const store = useFollowStore.getState();
+    store.setFollowStatuses({ u1: true, u2: false });
+
+    store.resolveFollowStatuses(['u1', 'u2'], services);
+    await flush();
+
+    expect(mock.getFollowStatuses).not.toHaveBeenCalled();
+  });
+});
+
+describe('toggleFollowUser (optimistic)', () => {
+  it('writes the new value BEFORE the await and reconciles on success', async () => {
+    const { mock, services } = makeServices();
+    let resolveFollow: (value: FollowMutationResult) => void = () => {};
+    mock.followUser.mockReturnValueOnce(
+      new Promise<FollowMutationResult>((resolve) => { resolveFollow = resolve; }),
+    );
+
+    const store = useFollowStore.getState();
+    const pending = store.toggleFollowUser('u1', services, false);
+
+    // Optimistic write happened synchronously, before the network resolved.
+    expect(useFollowStore.getState().followingUsers.u1).toBe(true);
+    expect(useFollowStore.getState().loadingUsers.u1).toBe(true);
+
+    resolveFollow({ message: 'ok', counts: { followers: 10, following: 3 } });
+    await pending;
+
+    expect(useFollowStore.getState().followingUsers.u1).toBe(true);
+    expect(useFollowStore.getState().loadingUsers.u1).toBe(false);
+    // Counts from the response were applied.
+    expect(useFollowStore.getState().followerCounts.u1).toBe(10);
+    expect(useFollowStore.getState().followingCounts['viewer-1']).toBe(3);
+  });
+
+  it('rolls back to the prior definite value on error', async () => {
+    const { mock, services } = makeServices();
+    mock.followUser.mockRejectedValueOnce(new Error('boom'));
+
+    const store = useFollowStore.getState();
+    store.setFollowStatuses({ u1: false });
+
+    await store.toggleFollowUser('u1', services, false);
+
+    // Optimistic true was rolled back to the seeded false.
+    expect(useFollowStore.getState().followingUsers.u1).toBe(false);
+    expect(useFollowStore.getState().loadingUsers.u1).toBe(false);
+    expect(useFollowStore.getState().errors.u1).toBe('boom');
+  });
+
+  it('rolls back to UNKNOWN when there was no prior value', async () => {
+    const { mock, services } = makeServices();
+    mock.followUser.mockRejectedValueOnce(new Error('nope'));
+
+    const store = useFollowStore.getState();
+    await store.toggleFollowUser('u1', services, false);
+
+    // The key is removed → back to UNKNOWN (tri-state), not a definite false.
+    expect(Object.prototype.hasOwnProperty.call(useFollowStore.getState().followingUsers, 'u1')).toBe(false);
+  });
+});

--- a/packages/services/src/ui/stores/followStore.ts
+++ b/packages/services/src/ui/stores/followStore.ts
@@ -1,7 +1,11 @@
 import { create } from 'zustand';
-import type { OxyServices, BulkFollowResult, BulkUnfollowResult } from '@oxyhq/core';
+import type { OxyServices, BulkFollowResult, BulkUnfollowResult, FollowMutationResult } from '@oxyhq/core';
 
 interface FollowState {
+  // Tri-state follow map: a MISSING key means UNKNOWN (status not yet resolved),
+  // a present `true`/`false` is a DEFINITE value. Read sites must NOT collapse a
+  // missing key to `false` when they need to distinguish "unknown" from "not
+  // following" (see `useFollowForButton`'s `isKnown`).
   followingUsers: Record<string, boolean>;
   loadingUsers: Record<string, boolean>;
   fetchingUsers: Record<string, boolean>;
@@ -12,9 +16,17 @@ interface FollowState {
   // Loading states for counts
   loadingCounts: Record<string, boolean>;
   setFollowingStatus: (userId: string, isFollowing: boolean) => void;
+  // Bulk-seed follow statuses (seed-only-if-absent — never clobbers a definite
+  // value the store already holds). Consumers call this to seed from
+  // `getViewerGraph().followingIds` so a page of FollowButtons paints correctly
+  // with ZERO network calls.
+  setFollowStatuses: (map: Record<string, boolean>) => void;
   clearFollowError: (userId: string) => void;
   resetFollowState: () => void;
-  fetchFollowStatus: (userId: string, oxyServices: OxyServices) => Promise<void>;
+  // Micro-batched status resolver: enqueue UNKNOWN ids, coalesce every id
+  // requested within the same tick into ONE `getFollowStatuses` call. Ids that
+  // are already known/seeded or already in flight are skipped.
+  resolveFollowStatuses: (userIds: string[], oxyServices: OxyServices) => void;
   toggleFollowUser: (userId: string, oxyServices: OxyServices, isCurrentlyFollowing: boolean) => Promise<void>;
   // Bulk follow — follows MANY users in one network call; never unfollows.
   followManyUsers: (userIds: string[], oxyServices: OxyServices) => Promise<BulkFollowResult>;
@@ -27,7 +39,34 @@ interface FollowState {
   fetchUserCounts: (userId: string, oxyServices: OxyServices) => Promise<void>;
 }
 
-export const useFollowStore = create<FollowState>((set: any, get: any) => ({
+const hasKey = (map: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(map, key);
+
+const scheduleMicrotask = (cb: () => void): void => {
+  if (typeof queueMicrotask === 'function') {
+    queueMicrotask(cb);
+  } else {
+    setTimeout(cb, 0);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Module-level micro-batch coordination for `resolveFollowStatuses`.
+//
+// Every UNKNOWN id requested within a single synchronous tick (e.g. a whole
+// page of FollowButtons mounting in one commit) is collected in `pendingIds`
+// and flushed by a SINGLE coalesced `getFollowStatuses` call on the next
+// microtask. `inFlightIds` prevents an id already being fetched from being
+// re-enqueued before its result lands. These are imperative coordination
+// primitives read/written ONLY inside store actions — never in a render/memo
+// position — so they are safe under the React Compiler.
+// ---------------------------------------------------------------------------
+let pendingIds = new Set<string>();
+let pendingServices: OxyServices | null = null;
+let flushScheduled = false;
+const inFlightIds = new Set<string>();
+
+export const useFollowStore = create<FollowState>((set, get) => ({
   followingUsers: {},
   loadingUsers: {},
   fetchingUsers: {},
@@ -35,11 +74,25 @@ export const useFollowStore = create<FollowState>((set: any, get: any) => ({
   followerCounts: {},
   followingCounts: {},
   loadingCounts: {},
-  setFollowingStatus: (userId: string, isFollowing: boolean) => set((state: FollowState) => ({
+  setFollowingStatus: (userId: string, isFollowing: boolean) => set((state) => ({
     followingUsers: { ...state.followingUsers, [userId]: isFollowing },
     errors: { ...state.errors, [userId]: null },
   })),
-  clearFollowError: (userId: string) => set((state: FollowState) => ({
+  setFollowStatuses: (map: Record<string, boolean>) => set((state) => {
+    const followingUsers = { ...state.followingUsers };
+    let changed = false;
+    for (const [userId, isFollowing] of Object.entries(map)) {
+      // Seed only if absent — never overwrite a definite value the store already
+      // holds (e.g. one written optimistically). Idempotent and safe to call on
+      // every graph refresh.
+      if (!hasKey(followingUsers, userId)) {
+        followingUsers[userId] = isFollowing;
+        changed = true;
+      }
+    }
+    return changed ? { followingUsers } : {};
+  }),
+  clearFollowError: (userId: string) => set((state) => ({
     errors: { ...state.errors, [userId]: null },
   })),
   resetFollowState: () => set({
@@ -51,98 +104,164 @@ export const useFollowStore = create<FollowState>((set: any, get: any) => ({
     followingCounts: {},
     loadingCounts: {},
   }),
-  fetchFollowStatus: async (userId: string, oxyServices: OxyServices) => {
-    set((state: FollowState) => ({
-      fetchingUsers: { ...state.fetchingUsers, [userId]: true },
-      errors: { ...state.errors, [userId]: null },
-    }));
-    try {
-      const response = await oxyServices.getFollowStatus(userId);
-      set((state: FollowState) => ({
-        followingUsers: { ...state.followingUsers, [userId]: response.isFollowing },
-        fetchingUsers: { ...state.fetchingUsers, [userId]: false },
-        errors: { ...state.errors, [userId]: null },
-      }));
-    } catch (error: unknown) {
-      set((state: FollowState) => ({
-        fetchingUsers: { ...state.fetchingUsers, [userId]: false },
-        errors: { ...state.errors, [userId]: (error instanceof Error ? error.message : null) || 'Failed to fetch follow status' },
-      }));
+  resolveFollowStatuses: (userIds: string[], oxyServices: OxyServices) => {
+    const { followingUsers } = get();
+    let enqueuedAny = false;
+    for (const rawId of userIds) {
+      if (typeof rawId !== 'string') continue;
+      const id = rawId.trim();
+      if (!id) continue;
+      // Skip ids with a known (seeded or fetched) status, already-in-flight ids,
+      // and ids already queued for this flush.
+      if (hasKey(followingUsers, id) || inFlightIds.has(id) || pendingIds.has(id)) continue;
+      pendingIds.add(id);
+      enqueuedAny = true;
     }
+
+    if (!enqueuedAny) return;
+
+    // The most recent instance wins the flush — they are the same client per app.
+    pendingServices = oxyServices;
+
+    if (flushScheduled) return;
+    flushScheduled = true;
+
+    scheduleMicrotask(() => {
+      flushScheduled = false;
+      const ids = Array.from(pendingIds);
+      pendingIds = new Set<string>();
+      const services = pendingServices;
+      pendingServices = null;
+      if (ids.length === 0 || !services) return;
+
+      for (const id of ids) inFlightIds.add(id);
+      set((state) => {
+        const fetchingUsers = { ...state.fetchingUsers };
+        for (const id of ids) fetchingUsers[id] = true;
+        return { fetchingUsers };
+      });
+
+      void services
+        .getFollowStatuses(ids)
+        .then((statuses) => {
+          set((state) => {
+            const followingUsersNext = { ...state.followingUsers };
+            const fetchingUsers = { ...state.fetchingUsers };
+            for (const id of ids) {
+              // Do not clobber a definite value written by a mutation that raced
+              // ahead of this batch — seed only if still unknown.
+              if (!hasKey(followingUsersNext, id)) {
+                followingUsersNext[id] = statuses[id] ?? false;
+              }
+              fetchingUsers[id] = false;
+            }
+            return { followingUsers: followingUsersNext, fetchingUsers };
+          });
+        })
+        .catch((error: unknown) => {
+          const message = (error instanceof Error ? error.message : null) || 'Failed to fetch follow status';
+          set((state) => {
+            const fetchingUsers = { ...state.fetchingUsers };
+            const errors = { ...state.errors };
+            for (const id of ids) {
+              fetchingUsers[id] = false;
+              errors[id] = message;
+            }
+            return { fetchingUsers, errors };
+          });
+        })
+        .finally(() => {
+          for (const id of ids) inFlightIds.delete(id);
+        });
+    });
   },
   toggleFollowUser: async (userId: string, oxyServices: OxyServices, isCurrentlyFollowing: boolean) => {
-    set((state: FollowState) => ({
+    // Snapshot the prior value for rollback. `undefined` = was UNKNOWN.
+    const priorState = get().followingUsers;
+    const hadPrevious = hasKey(priorState, userId);
+    const previousValue = priorState[userId];
+    const optimisticValue = !isCurrentlyFollowing;
+
+    // Write the new value IMMEDIATELY (before the await) so the button flips
+    // instantly; mark loading; clear any prior error.
+    set((state) => ({
+      followingUsers: { ...state.followingUsers, [userId]: optimisticValue },
       loadingUsers: { ...state.loadingUsers, [userId]: true },
       errors: { ...state.errors, [userId]: null },
     }));
+
     try {
-      let response: any;
-      let newFollowState;
-      if (isCurrentlyFollowing) {
-        response = await oxyServices.unfollowUser(userId);
-        newFollowState = false;
-      } else {
-        response = await oxyServices.followUser(userId);
-        newFollowState = true;
-      }
-      
-      // Update follow status
-      set((state: FollowState) => ({
-        followingUsers: { ...state.followingUsers, [userId]: newFollowState },
+      const response: FollowMutationResult = isCurrentlyFollowing
+        ? await oxyServices.unfollowUser(userId)
+        : await oxyServices.followUser(userId);
+
+      // Reconcile: confirm the optimistic value is authoritative, clear loading.
+      set((state) => ({
+        followingUsers: { ...state.followingUsers, [userId]: optimisticValue },
         loadingUsers: { ...state.loadingUsers, [userId]: false },
         errors: { ...state.errors, [userId]: null },
       }));
 
-      // Update counts if the response includes them
+      // Update counts if the response includes them.
       // The API returns counts for both users:
       // - followers: target user's follower count (the user being followed)
       // - following: current user's following count (the user doing the following)
-      if (response?.counts) {
+      if (response.counts) {
         const { counts } = response;
-        
-        // Get current user ID from oxyServices
         const currentUserId = oxyServices.getCurrentUserId();
-        
-        set((state: FollowState) => {
-          const updates: any = {};
-          
-          // Update target user's follower count (the user being followed)
-          updates.followerCounts = { 
-            ...state.followerCounts, 
-            [userId]: counts.followers 
-          };
-          
-          // Update current user's following count (the user doing the following)
+
+        set((state) => {
+          const followerCounts = { ...state.followerCounts, [userId]: counts.followers };
           if (currentUserId) {
-            updates.followingCounts = { 
-              ...state.followingCounts, 
-              [currentUserId]: counts.following 
+            return {
+              followerCounts,
+              followingCounts: { ...state.followingCounts, [currentUserId]: counts.following },
             };
           }
-          
-          return updates;
+          return { followerCounts };
         });
       }
     } catch (error: unknown) {
-      set((state: FollowState) => ({
-        loadingUsers: { ...state.loadingUsers, [userId]: false },
-        errors: { ...state.errors, [userId]: (error instanceof Error ? error.message : null) || 'Failed to update follow status' },
-      }));
+      // Roll back to the prior value (or back to UNKNOWN if there was none).
+      set((state) => {
+        const followingUsers = { ...state.followingUsers };
+        if (hadPrevious) {
+          followingUsers[userId] = previousValue;
+        } else {
+          delete followingUsers[userId];
+        }
+        return {
+          followingUsers,
+          loadingUsers: { ...state.loadingUsers, [userId]: false },
+          errors: { ...state.errors, [userId]: (error instanceof Error ? error.message : null) || 'Failed to update follow status' },
+        };
+      });
     }
   },
   followManyUsers: async (userIds: string[], oxyServices: OxyServices): Promise<BulkFollowResult> => {
-    set((state: FollowState) => {
+    // Snapshot prior values for rollback (tri-state: undefined = unknown).
+    const prior = get().followingUsers;
+    const previous = new Map<string, boolean | undefined>();
+    for (const uid of userIds) {
+      previous.set(uid, hasKey(prior, uid) ? prior[uid] : undefined);
+    }
+
+    // Optimistically mark every target followed BEFORE the await.
+    set((state) => {
+      const followingUsers = { ...state.followingUsers };
       const loadingUsers = { ...state.loadingUsers };
       const errors = { ...state.errors };
       for (const uid of userIds) {
+        followingUsers[uid] = true;
         loadingUsers[uid] = true;
         errors[uid] = null;
       }
-      return { loadingUsers, errors };
+      return { followingUsers, loadingUsers, errors };
     });
+
     try {
       const result = await oxyServices.followUsers(userIds);
-      set((state: FollowState) => {
+      set((state) => {
         const followingUsers = { ...state.followingUsers };
         const loadingUsers = { ...state.loadingUsers };
         const errors = { ...state.errors };
@@ -154,6 +273,13 @@ export const useFollowStore = create<FollowState>((set: any, get: any) => ({
             followingUsers[entry.userId] = true;
             errors[entry.userId] = null;
           } else {
+            // This target failed — roll IT back to its prior value.
+            const prev = previous.get(entry.userId);
+            if (prev === undefined) {
+              delete followingUsers[entry.userId];
+            } else {
+              followingUsers[entry.userId] = prev;
+            }
             errors[entry.userId] = 'Failed to update follow status';
           }
         }
@@ -162,31 +288,50 @@ export const useFollowStore = create<FollowState>((set: any, get: any) => ({
       return result;
     } catch (error: unknown) {
       const message = (error instanceof Error ? error.message : null) || 'Failed to update follow status';
-      set((state: FollowState) => {
+      // Whole batch failed — roll ALL targets back to their prior values.
+      set((state) => {
+        const followingUsers = { ...state.followingUsers };
         const loadingUsers = { ...state.loadingUsers };
         const errors = { ...state.errors };
         for (const uid of userIds) {
+          const prev = previous.get(uid);
+          if (prev === undefined) {
+            delete followingUsers[uid];
+          } else {
+            followingUsers[uid] = prev;
+          }
           loadingUsers[uid] = false;
           errors[uid] = message;
         }
-        return { loadingUsers, errors };
+        return { followingUsers, loadingUsers, errors };
       });
       throw error;
     }
   },
   unfollowManyUsers: async (userIds: string[], oxyServices: OxyServices): Promise<BulkUnfollowResult> => {
-    set((state: FollowState) => {
+    // Snapshot prior values for rollback (tri-state: undefined = unknown).
+    const prior = get().followingUsers;
+    const previous = new Map<string, boolean | undefined>();
+    for (const uid of userIds) {
+      previous.set(uid, hasKey(prior, uid) ? prior[uid] : undefined);
+    }
+
+    // Optimistically mark every target NOT followed BEFORE the await.
+    set((state) => {
+      const followingUsers = { ...state.followingUsers };
       const loadingUsers = { ...state.loadingUsers };
       const errors = { ...state.errors };
       for (const uid of userIds) {
+        followingUsers[uid] = false;
         loadingUsers[uid] = true;
         errors[uid] = null;
       }
-      return { loadingUsers, errors };
+      return { followingUsers, loadingUsers, errors };
     });
+
     try {
       const result = await oxyServices.unfollowUsers(userIds);
-      set((state: FollowState) => {
+      set((state) => {
         const followingUsers = { ...state.followingUsers };
         const loadingUsers = { ...state.loadingUsers };
         const errors = { ...state.errors };
@@ -198,6 +343,13 @@ export const useFollowStore = create<FollowState>((set: any, get: any) => ({
             followingUsers[entry.userId] = false;
             errors[entry.userId] = null;
           } else {
+            // This target failed — roll IT back to its prior value.
+            const prev = previous.get(entry.userId);
+            if (prev === undefined) {
+              delete followingUsers[entry.userId];
+            } else {
+              followingUsers[entry.userId] = prev;
+            }
             errors[entry.userId] = 'Failed to update follow status';
           }
         }
@@ -206,68 +358,71 @@ export const useFollowStore = create<FollowState>((set: any, get: any) => ({
       return result;
     } catch (error: unknown) {
       const message = (error instanceof Error ? error.message : null) || 'Failed to update follow status';
-      set((state: FollowState) => {
+      // Whole batch failed — roll ALL targets back to their prior values.
+      set((state) => {
+        const followingUsers = { ...state.followingUsers };
         const loadingUsers = { ...state.loadingUsers };
         const errors = { ...state.errors };
         for (const uid of userIds) {
+          const prev = previous.get(uid);
+          if (prev === undefined) {
+            delete followingUsers[uid];
+          } else {
+            followingUsers[uid] = prev;
+          }
           loadingUsers[uid] = false;
           errors[uid] = message;
         }
-        return { loadingUsers, errors };
+        return { followingUsers, loadingUsers, errors };
       });
       throw error;
     }
   },
-  setFollowerCount: (userId: string, count: number) => set((state: FollowState) => ({
+  setFollowerCount: (userId: string, count: number) => set((state) => ({
     followerCounts: { ...state.followerCounts, [userId]: count },
   })),
-  setFollowingCount: (userId: string, count: number) => set((state: FollowState) => ({
+  setFollowingCount: (userId: string, count: number) => set((state) => ({
     followingCounts: { ...state.followingCounts, [userId]: count },
   })),
   updateCountsFromFollowAction: (targetUserId: string, action: 'follow' | 'unfollow', counts: { followers: number; following: number }, currentUserId?: string) => {
-    set((state: FollowState) => {
-      const updates: any = {};
-      
-      // Update target user's follower count (the user being followed)
-      updates.followerCounts = { 
-        ...state.followerCounts, 
-        [targetUserId]: counts.followers 
-      };
-      
-      // Update current user's following count (the user doing the following)
+    set((state) => {
+      const followerCounts = { ...state.followerCounts, [targetUserId]: counts.followers };
       if (currentUserId) {
-        updates.followingCounts = { 
-          ...state.followingCounts, 
-          [currentUserId]: counts.following 
+        return {
+          followerCounts,
+          followingCounts: { ...state.followingCounts, [currentUserId]: counts.following },
         };
       }
-      
-      return updates;
+      return { followerCounts };
     });
   },
   fetchUserCounts: async (userId: string, oxyServices: OxyServices) => {
-    set((state: FollowState) => ({
+    set((state) => ({
       loadingCounts: { ...state.loadingCounts, [userId]: true },
     }));
     try {
       const user = await oxyServices.getUserById(userId);
       if (user?._count) {
-        set((state: FollowState) => ({
-          followerCounts: { 
-            ...state.followerCounts, 
-            [userId]: user._count?.followers || 0 
+        set((state) => ({
+          followerCounts: {
+            ...state.followerCounts,
+            [userId]: user._count?.followers || 0,
           },
-          followingCounts: { 
-            ...state.followingCounts, 
-            [userId]: user._count?.following || 0 
+          followingCounts: {
+            ...state.followingCounts,
+            [userId]: user._count?.following || 0,
           },
+          loadingCounts: { ...state.loadingCounts, [userId]: false },
+        }));
+      } else {
+        set((state) => ({
           loadingCounts: { ...state.loadingCounts, [userId]: false },
         }));
       }
     } catch (error: unknown) {
-      set((state: FollowState) => ({
+      set((state) => ({
         loadingCounts: { ...state.loadingCounts, [userId]: false },
       }));
     }
   },
-})); 
+}));


### PR DESCRIPTION
Fixes the follow-button Follow->Following flash and the N+1 per-button status fetch.

- **oxy-api**: `POST /users/follow-status/bulk` — one indexed query returns `{ statuses }` for up to 200 ids.
- **@oxyhq/core 12.3.0**: `getFollowStatuses(userIds)` (chunked, no-cache).
- **@oxyhq/services 22.3.0**: tri-state follow store (missing = unknown) + `setFollowStatuses` seed + `resolveFollowStatuses` micro-batch (one coalesced request per commit, skips seeded/known/in-flight); optimistic mutations with rollback; FollowButton seeds label on first paint, only fetches unknown ids; new `useSeedFollowStatuses()`.

Net: one batched status request per list (zero when seeded), correct label on first paint, instant optimistic toggle. Additive/back-compat. Tests: api 1569, core 882, services 241 — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)