### PR TITLE
chore(contracts): republish @oxyhq/contracts 0.16.0

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/contracts",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "OxyHQ API contracts — single source of truth for request/response Zod schemas and inferred types, shared by the backend and the client SDKs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Additive minor bump so the published contracts matches source. The b3 key-rotation (#645) and identity-backup (#647) PRs added keyRotation/keyRecovery symbols to contracts source but never republished, so @oxyhq/core already imports 5 symbols absent from published 0.15.0 — any core consumer's tsc breaks. This unblocks publishing @oxyhq/core@12.3.0 + @oxyhq/services@22.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)