### PR TITLE
fix(api): exclude archived/gone federated users from search + add actor-gone service endpoint

### DIFF
--- a/packages/api/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/users.controller.test.ts
@@ -79,6 +79,9 @@ describe('UsersController', () => {
       );
 
       expect(mockFind).toHaveBeenCalledWith({
+        // Archived accounts (e.g. dead federated actors marked gone) are
+        // excluded from search so they never surface as ghost hits.
+        accountStatus: { $ne: 'archived' },
         $or: [
           { username: { $regex: 'test', $options: 'i' } },
           { 'name.first': { $regex: 'test', $options: 'i' } },
@@ -91,6 +94,30 @@ describe('UsersController', () => {
       expect(mockQuery.select).toHaveBeenCalledWith(PUBLIC_USER_PROFILE_SELECT);
       expect(mockQuery.limit).toHaveBeenCalledWith(5);
       expect(mockQuery.lean).toHaveBeenCalled();
+    });
+
+    it('excludes archived accounts from the search filter', async () => {
+      mockRequest.body = { query: 'test' };
+
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+      mockFind.mockReturnValue(mockQuery);
+
+      await usersController.searchUsers(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext
+      );
+
+      // Dead federated actors (marked gone via POST /federation/actor-gone) and
+      // archived org/project accounts are filtered so they never appear as
+      // 0-post ghost search hits. Only `archived` is excluded — active accounts
+      // (the default) still match.
+      const filter = mockFind.mock.calls[0]?.[0] as { accountStatus?: unknown };
+      expect(filter.accountStatus).toEqual({ $ne: 'archived' });
     });
 
     it('never projects the searched users\' email addresses', async () => {

--- a/packages/api/src/controllers/users.controller.ts
+++ b/packages/api/src/controllers/users.controller.ts
@@ -33,8 +33,13 @@ export class UsersController {
       // Sanitize search query (length limit + HTML escaping)
       const sanitizedQuery = sanitizeSearchQuery(query);
 
-      // Search for users where username or name matches the query
+      // Search for users where username or name matches the query.
+      // Exclude archived accounts (dead federated actors marked gone via
+      // POST /federation/actor-gone, plus archived org/project accounts) so
+      // they never surface as 0-post ghost search hits. Only `archived` is
+      // filtered — active accounts (the default) all still match.
       const users = await User.find({
+        accountStatus: { $ne: 'archived' },
         $or: [
           { username: { $regex: sanitizedQuery, $options: 'i' } },
           { 'name.first': { $regex: sanitizedQuery, $options: 'i' } },

--- a/packages/api/src/routes/__tests__/federationActorGone.test.ts
+++ b/packages/api/src/routes/__tests__/federationActorGone.test.ts
@@ -1,0 +1,306 @@
+/**
+ * POST /federation/actor-gone — service-credential "mark federated identity gone"
+ * bridge.
+ *
+ * Mention is the only component that talks to the remote fediverse; when it gets
+ * an HTTP 410 Gone for an actor it calls this route to archive the corresponding
+ * Oxy user so the dead identity leaves discovery/search surfaces. The suite walks
+ * the trust boundary and the idempotency guarantee:
+ *
+ *  - missing federation:write scope                         → 403
+ *  - body fails schema validation (non-ObjectId oxyUserId)  → 400
+ *  - unknown user                                           → 404
+ *  - target is NOT a federated user (local/agent/automated) → 409 (never written)
+ *  - a live federated actor is archived exactly once        → 200
+ *  - a repeated call on an already-archived actor is a no-op → idempotent 200
+ *
+ * The real router AND the real body schema run; only the Mongoose model + the
+ * user cache are replaced with in-memory doubles so the archival write and the
+ * cache invalidation can be asserted end-to-end.
+ */
+
+// The global jest.setup mocks `mongoose` wholesale (stripping `Types`). Restore
+// the real module so the router's imports behave.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+// ---------------------------------------------------------------------------
+// In-memory User store.
+// ---------------------------------------------------------------------------
+type UserType = 'local' | 'federated' | 'agent' | 'automated';
+interface StoreUser {
+  _id: string;
+  type: UserType;
+  accountStatus: string;
+}
+
+const users = new Map<string, StoreUser>();
+
+function seedUser(id: string, type: UserType, accountStatus = 'active'): StoreUser {
+  const user: StoreUser = { _id: id, type, accountStatus };
+  users.set(id, user);
+  return user;
+}
+
+const mockUserFindById = jest.fn((id: string) => {
+  const doc = users.get(id) ?? null;
+  return {
+    select(): { lean(): Promise<StoreUser | null> } {
+      return { lean: () => Promise.resolve(doc) };
+    },
+  };
+});
+
+const mockUserUpdateOne = jest.fn(
+  async (
+    filter: { _id: string; type?: string },
+    update: { $set?: Record<string, unknown> }
+  ): Promise<{ matchedCount: number; modifiedCount: number }> => {
+    const user = users.get(filter._id);
+    // Honour the route's `type: 'federated'` guard clause on the write filter.
+    if (user && (filter.type === undefined || user.type === filter.type)) {
+      if (update.$set) Object.assign(user, update.$set);
+      return { matchedCount: 1, modifiedCount: 1 };
+    }
+    return { matchedCount: 0, modifiedCount: 0 };
+  }
+);
+
+const mockUserCacheInvalidate = jest.fn();
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    findById: (...args: [string]) => mockUserFindById(...args),
+    updateOne: (...args: [{ _id: string; type?: string }, { $set?: Record<string, unknown> }]) =>
+      mockUserUpdateOne(...args),
+  },
+}));
+jest.mock('../../utils/userCache', () => ({
+  __esModule: true,
+  default: { invalidate: (...args: unknown[]) => mockUserCacheInvalidate(...args) },
+}));
+
+// Models / services the federation router (via user.service) pulls in but that
+// this suite does not exercise — stubbed so importing the router stays light.
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  default: {},
+  FollowType: { USER: 'user', HASHTAG: 'hashtag', TOPIC: 'topic' },
+}));
+jest.mock('../../models/Subscription', () => ({ __esModule: true, default: {} }));
+jest.mock('../../models/Application', () => ({ __esModule: true, default: {} }));
+jest.mock('../../utils/credentialDomainCache', () => ({
+  __esModule: true,
+  default: { getAllowedDomains: jest.fn() },
+}));
+jest.mock('../../services/securityActivityService', () => ({ __esModule: true, default: {} }));
+jest.mock('../../services/federation.service', () => ({
+  __esModule: true,
+  getUserPublicKey: jest.fn(),
+  signWithKeyId: jest.fn(),
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+const mockServiceAuthMiddleware = jest.fn();
+jest.mock('../../middleware/auth', () => ({
+  serviceAuthMiddleware: (...args: unknown[]) => mockServiceAuthMiddleware(...args),
+}));
+
+import federationRouter from '../federation';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: {
+    error?: string;
+    message?: string;
+    data?: { oxyUserId?: string; accountStatus?: string; alreadyArchived?: boolean };
+  };
+}
+
+function requestJson(
+  server: http.Server,
+  method: string,
+  path: string,
+  payload: unknown
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload ?? {});
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          try {
+            const parsed = raw.length > 0 ? JSON.parse(raw) : {};
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+// Deterministic 24-hex ObjectId strings that satisfy the route schema.
+const FEDERATED_ID = 'a'.repeat(24);
+const LOCAL_ID = 'b'.repeat(24);
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/federation', federationRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  users.clear();
+  // Default: the service credential carries the federation:write scope.
+  mockServiceAuthMiddleware.mockImplementation(
+    (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
+      req.serviceApp = {
+        type: 'service',
+        appId: 'app-1',
+        appName: 'mention',
+        credentialId: 'cred-1',
+        scopes: ['federation:write'],
+      };
+      next();
+    }
+  );
+});
+
+describe('POST /federation/actor-gone', () => {
+  it('rejects when the service token lacks federation:write scope', async () => {
+    mockServiceAuthMiddleware.mockImplementationOnce(
+      (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
+        req.serviceApp = {
+          type: 'service',
+          appId: 'app-1',
+          appName: 'limited',
+          credentialId: 'cred-1',
+          scopes: [],
+        };
+        next();
+      }
+    );
+    seedUser(FEDERATED_ID, 'federated');
+
+    const res = await requestJson(server, 'POST', '/federation/actor-gone', {
+      oxyUserId: FEDERATED_ID,
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/federation:write/i);
+    expect(mockUserUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects a body that fails schema validation (non-ObjectId id)', async () => {
+    const res = await requestJson(server, 'POST', '/federation/actor-gone', {
+      oxyUserId: 'not-an-object-id',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockUserFindById).not.toHaveBeenCalled();
+    expect(mockUserUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the user does not exist', async () => {
+    const res = await requestJson(server, 'POST', '/federation/actor-gone', {
+      oxyUserId: FEDERATED_ID,
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toMatch(/user not found/i);
+    expect(mockUserUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('refuses (409) to archive a non-federated (local) user and never writes', async () => {
+    const local = seedUser(LOCAL_ID, 'local');
+
+    const res = await requestJson(server, 'POST', '/federation/actor-gone', {
+      oxyUserId: LOCAL_ID,
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.message).toMatch(/not a federated actor/i);
+    // The real account was never touched.
+    expect(mockUserUpdateOne).not.toHaveBeenCalled();
+    expect(mockUserCacheInvalidate).not.toHaveBeenCalled();
+    expect(local.accountStatus).toBe('active');
+  });
+
+  it('archives a live federated actor exactly once and invalidates its cache', async () => {
+    const actor = seedUser(FEDERATED_ID, 'federated', 'active');
+
+    const res = await requestJson(server, 'POST', '/federation/actor-gone', {
+      oxyUserId: FEDERATED_ID,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      oxyUserId: FEDERATED_ID,
+      accountStatus: 'archived',
+      alreadyArchived: false,
+    });
+    expect(actor.accountStatus).toBe('archived');
+    // The write whitelists only accountStatus and re-asserts the federated guard.
+    expect(mockUserUpdateOne).toHaveBeenCalledTimes(1);
+    expect(mockUserUpdateOne).toHaveBeenCalledWith(
+      { _id: FEDERATED_ID, type: 'federated' },
+      { $set: { accountStatus: 'archived' } }
+    );
+    expect(mockUserCacheInvalidate).toHaveBeenCalledWith(FEDERATED_ID);
+  });
+
+  it('is idempotent: an already-archived actor is a 200 no-op (no write, no invalidate)', async () => {
+    seedUser(FEDERATED_ID, 'federated', 'archived');
+
+    const res = await requestJson(server, 'POST', '/federation/actor-gone', {
+      oxyUserId: FEDERATED_ID,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      oxyUserId: FEDERATED_ID,
+      accountStatus: 'archived',
+      alreadyArchived: true,
+    });
+    expect(mockUserUpdateOne).not.toHaveBeenCalled();
+    expect(mockUserCacheInvalidate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/__tests__/profilesSearch.test.ts
+++ b/packages/api/src/routes/__tests__/profilesSearch.test.ts
@@ -1,0 +1,238 @@
+/**
+ * GET /profiles/search archived-exclusion coverage.
+ *
+ * Proves the people-search surface never returns archived accounts (dead
+ * federated actors marked gone via POST /federation/actor-gone, or archived
+ * org/project accounts):
+ *
+ *   1. the DB aggregation's `$match` carries `accountStatus: { $ne: 'archived' }`
+ *      and an archived pool row is filtered while an active one surfaces, and
+ *   2. the federated-resolution prepend never re-introduces an archived actor,
+ *      while a live federated actor is still prepended.
+ *
+ * The router is mounted on a minimal Express app and exercised via `node:http`
+ * round-trips (mirrors profilesSimilar.test.ts). The mocked `User.aggregate`
+ * faithfully evaluates the route's `$match` against an in-memory pool so the
+ * assertions verify the route's own filter rather than a stub's behaviour.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+// The global mongoose mock (jest.setup.cjs) does not expose `Types`, which the
+// profiles route relies on. Restore the REAL mongoose.
+jest.mock('mongoose', () => jest.requireActual('mongoose'));
+import { Types } from 'mongoose';
+
+const mockUserAggregate = jest.fn();
+const mockFollowAggregate = jest.fn();
+const mockResolveAndUpsert = jest.fn();
+const mockIsFediverseHandle = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../middleware/optionalAuth', () => ({
+  optionalUserOrServiceAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  resolveViewerId: (): string | undefined => undefined,
+}));
+jest.mock('../../middleware/validate', () => ({
+  validate: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../services/user.service', () => ({
+  userService: {
+    getUserStats: jest.fn(),
+    // Minimal serializer: the route only asserts identity passes through.
+    formatUserResponse: (profile: { _id: Types.ObjectId; username?: string }) => ({
+      id: profile._id.toString(),
+      username: profile.username,
+    }),
+  },
+}));
+jest.mock('../../services/federation.service', () => ({
+  federationService: { resolveAndUpsert: (...args: unknown[]) => mockResolveAndUpsert(...args) },
+  isFediverseHandle: (...args: unknown[]) => mockIsFediverseHandle(...args),
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  FollowType: { USER: 'user', HASHTAG: 'hashtag', TOPIC: 'topic' },
+  default: {
+    aggregate: (...args: unknown[]) => mockFollowAggregate(...args),
+  },
+}));
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    aggregate: (...args: unknown[]) => mockUserAggregate(...args),
+  },
+}));
+
+import profilesRouter from '../profiles';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface PoolUser {
+  _id: Types.ObjectId;
+  username?: string;
+  name?: { first?: string; last?: string };
+  description?: string;
+  accountStatus?: string;
+  type?: string;
+}
+
+interface ProfileResult {
+  id: unknown;
+  username?: string;
+}
+
+interface JsonResponse {
+  status: number;
+  body: { error?: string; message?: string; data?: ProfileResult[] };
+}
+
+function requestJson(server: http.Server, path: string): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method: 'GET', host: '127.0.0.1', port: address.port, path },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            const parsed = raw.length > 0 ? JSON.parse(raw) : {};
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/**
+ * Faithfully evaluate the route's search `$match` (an `accountStatus` $ne gate
+ * plus a `$or` of field regexes) against a candidate pool, mirroring MongoDB's
+ * semantics for the exact operators the filter uses.
+ */
+function matchesSearchFilter(user: PoolUser, filter: Record<string, unknown>): boolean {
+  const acct = filter.accountStatus as { $ne?: string } | undefined;
+  if (acct && typeof acct.$ne === 'string' && user.accountStatus === acct.$ne) {
+    return false;
+  }
+  const or = filter.$or as Array<Record<string, RegExp>> | undefined;
+  if (!Array.isArray(or)) return true;
+  return or.some((clause) => {
+    const [field, regex] = Object.entries(clause)[0];
+    const value =
+      field === 'name.first' ? user.name?.first
+        : field === 'name.last' ? user.name?.last
+          : field === 'description' ? user.description
+            : user.username;
+    return typeof value === 'string' && regex instanceof RegExp && regex.test(value);
+  });
+}
+
+/** Drive the mocked `User.aggregate`: evaluate the `$match` against the pool. */
+function aggregateSearch(pool: PoolUser[]): (pipeline: unknown) => Promise<unknown[]> {
+  return (pipeline: unknown) => {
+    const stages = pipeline as Array<{ $match?: Record<string, unknown> }>;
+    const matchStage = stages[0]?.$match ?? {};
+    const matched = pool.filter((u) => matchesSearchFilter(u, matchStage));
+    return Promise.resolve([
+      { profiles: matched, totalCount: [{ count: matched.length }] },
+    ]);
+  };
+}
+
+const activeLocal = new Types.ObjectId();
+const archivedActor = new Types.ObjectId();
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/profiles', profilesRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Follower/following count aggregations return empty for every test.
+  mockFollowAggregate.mockResolvedValue([]);
+  mockIsFediverseHandle.mockReturnValue(false);
+});
+
+describe('GET /profiles/search archived exclusion', () => {
+  it('adds accountStatus: { $ne: "archived" } to the aggregation $match', async () => {
+    mockUserAggregate.mockImplementation(aggregateSearch([]));
+
+    const res = await requestJson(server, '/profiles/search?query=test');
+    expect(res.status).toBe(200);
+
+    const pipeline = mockUserAggregate.mock.calls[0][0] as Array<{ $match?: Record<string, unknown> }>;
+    expect(pipeline[0].$match?.accountStatus).toEqual({ $ne: 'archived' });
+  });
+
+  it('filters archived accounts while surfacing active matches', async () => {
+    const pool: PoolUser[] = [
+      { _id: activeLocal, username: 'active_match', accountStatus: 'active' },
+      { _id: archivedActor, username: 'archived_match', accountStatus: 'archived' },
+    ];
+    mockUserAggregate.mockImplementation(aggregateSearch(pool));
+
+    const res = await requestJson(server, '/profiles/search?query=match');
+    expect(res.status).toBe(200);
+
+    const ids = (res.body.data ?? []).map((p) => String(p.id));
+    expect(ids).toContain(activeLocal.toString());
+    expect(ids).not.toContain(archivedActor.toString());
+  });
+
+  it('does NOT prepend a federated actor that resolves as archived', async () => {
+    mockUserAggregate.mockImplementation(aggregateSearch([]));
+    mockIsFediverseHandle.mockReturnValue(true);
+    mockResolveAndUpsert.mockResolvedValue({
+      _id: archivedActor,
+      username: 'gone@remote.example',
+      type: 'federated',
+      accountStatus: 'archived',
+    });
+
+    const res = await requestJson(server, '/profiles/search?query=gone@remote.example');
+    expect(res.status).toBe(200);
+
+    const ids = (res.body.data ?? []).map((p) => String(p.id));
+    expect(ids).not.toContain(archivedActor.toString());
+    expect(res.body.data).toHaveLength(0);
+  });
+
+  it('prepends a live federated actor resolved via federation', async () => {
+    mockUserAggregate.mockImplementation(aggregateSearch([]));
+    mockIsFediverseHandle.mockReturnValue(true);
+    mockResolveAndUpsert.mockResolvedValue({
+      _id: activeLocal,
+      username: 'alive@remote.example',
+      type: 'federated',
+      accountStatus: 'active',
+    });
+
+    const res = await requestJson(server, '/profiles/search?query=alive@remote.example');
+    expect(res.status).toBe(200);
+
+    const ids = (res.body.data ?? []).map((p) => String(p.id));
+    expect(ids).toContain(activeLocal.toString());
+  });
+});

--- a/packages/api/src/routes/federation.ts
+++ b/packages/api/src/routes/federation.ts
@@ -2,10 +2,11 @@ import { Router, type Response } from 'express';
 import { serviceAuthMiddleware, type ServiceAuthRequest } from '../middleware/auth';
 import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
 import { validate } from '../middleware/validate';
-import { ForbiddenError, NotFoundError } from '../utils/error';
+import { ForbiddenError, NotFoundError, ConflictError } from '../utils/error';
 import { logger } from '../utils/logger';
 import Application from '../models/Application';
 import User from '../models/User';
+import userCache from '../utils/userCache';
 import credentialDomainCache from '../utils/credentialDomainCache';
 import {
   getUserPublicKey,
@@ -17,10 +18,12 @@ import {
   publicKeyQuerySchema,
   signRequestSchema,
   federationFollowSchema,
+  federationActorGoneSchema,
   type PublicKeyParams,
   type PublicKeyQuery,
   type SignRequestBody,
   type FederationFollowBody,
+  type FederationActorGoneBody,
 } from '../schemas/federation.schemas';
 
 const router = Router();
@@ -225,6 +228,72 @@ router.post(
 
     const { removed, counts } = await userService.unfollowUser(followerUserId, targetUserId);
     return sendSuccess(res, { removed, counts });
+  }),
+);
+
+/**
+ * POST /federation/actor-gone
+ *
+ * Marks a dead remote fediverse identity gone. Mention is the only component
+ * that talks to the remote fediverse; when it receives an HTTP 410 Gone for an
+ * actor (the remote Mastodon/Bluesky account was deleted) it calls this to
+ * archive the corresponding Oxy user, so the dead identity leaves Oxy's
+ * discovery/search surfaces instead of lingering as a 0-post ghost profile.
+ *
+ * SAFETY: the user document is NEVER hard-deleted — archival mirrors
+ * `accountService.archiveAccount` (set `accountStatus: 'archived'`, invalidate
+ * the user cache), so Oxy keeps the archived identity and Mention keeps its
+ * FederatedActor tombstone; the follow-graph edges survive intact.
+ *
+ * ANTI-FOOTGUN: only a `type:'federated'` user may be archived here. Archiving a
+ * local/agent/automated account would silently disable a real account, so a
+ * non-federated target is rejected with 409 and never written.
+ *
+ * Idempotent: an already-archived actor returns 200 with `alreadyArchived:true`
+ * and performs no write.
+ */
+router.post(
+  '/actor-gone',
+  serviceAuthMiddleware,
+  validate({ body: federationActorGoneSchema }),
+  asyncHandler(async (req: ServiceAuthRequest, res: Response) => {
+    assertFederationScope(req);
+
+    const { oxyUserId } = req.body as FederationActorGoneBody;
+
+    const user = await User.findById(oxyUserId).select('type accountStatus').lean();
+    if (!user) {
+      throw new NotFoundError('user not found');
+    }
+    // HARD GUARD: never archive a local/agent/automated account through this
+    // service bridge — only a dead remote fediverse actor.
+    if (user.type !== 'federated') {
+      throw new ConflictError('user is not a federated actor and cannot be archived');
+    }
+
+    // Idempotent: an already-archived actor is a no-op 200.
+    const alreadyArchived = user.accountStatus === 'archived';
+    if (!alreadyArchived) {
+      // Whitelist the single field; the `type:'federated'` filter re-asserts the
+      // guard atomically so a concurrent type change can never let the write
+      // touch a non-federated account.
+      await User.updateOne(
+        { _id: oxyUserId, type: 'federated' },
+        { $set: { accountStatus: 'archived' } },
+      );
+      userCache.invalidate(oxyUserId);
+      logger.info('federation/actor-gone: archived dead federated actor', {
+        oxyUserId,
+        appId: req.serviceApp?.appId,
+        credentialId: req.serviceApp?.credentialId,
+      });
+    }
+
+    return sendSuccess(res, {
+      oxyUserId,
+      accountStatus: 'archived',
+      alreadyArchived,
+    });
   }),
 );
 

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -427,6 +427,12 @@ router.get(
     const searchRegex = new RegExp(sanitizedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
 
     const searchFilter = {
+      // Exclude archived accounts (e.g. dead federated actors marked gone via
+      // POST /federation/actor-gone, or archived org/project accounts) so
+      // 0-post ghost profiles never surface in people search. Only `archived`
+      // is excluded — every legitimately-active account (accountStatus defaults
+      // to 'active') still matches, so no live user is hidden.
+      accountStatus: { $ne: 'archived' },
       $or: [
         { username: searchRegex },
         { 'name.first': searchRegex },
@@ -459,8 +465,12 @@ router.get(
     const profiles = dbResult.profiles ?? [];
     const total = dbResult.totalCount?.[0]?.count ?? 0;
 
-    // If federation resolved a user not already in DB results, prepend it
-    if (federatedUser) {
+    // If federation resolved a user not already in DB results, prepend it.
+    // `resolveAndUpsert` returns the cached row for a known federated actor,
+    // which can be an ARCHIVED (dead / 410-Gone) account — never let that
+    // prepend re-introduce an actor the `accountStatus` $match above just
+    // excluded.
+    if (federatedUser && federatedUser.accountStatus !== 'archived') {
       const fedId = federatedUser._id?.toString();
       const alreadyIncluded = profiles.some((profile) => profile._id.toString() === fedId);
       if (!alreadyIncluded) {

--- a/packages/api/src/schemas/federation.schemas.ts
+++ b/packages/api/src/schemas/federation.schemas.ts
@@ -86,7 +86,22 @@ export const federationFollowSchema = z.object({
   action: z.enum(['follow', 'unfollow']),
 });
 
+/**
+ * POST /federation/actor-gone
+ *
+ * Marks a dead remote fediverse identity gone. Mention is the only component
+ * that talks to the remote fediverse; when it gets an HTTP 410 Gone for an
+ * actor it calls this to archive the corresponding Oxy user so the identity
+ * leaves discovery/search surfaces. `oxyUserId` is the (federated) actor's Oxy
+ * user id; the route enforces that it resolves to a `type:'federated'` user
+ * before archiving (a local/agent/automated account is never archivable here).
+ */
+export const federationActorGoneSchema = z.object({
+  oxyUserId: objectIdSchema,
+});
+
 export type PublicKeyParams = z.infer<typeof publicKeyParamsSchema>;
 export type PublicKeyQuery = z.infer<typeof publicKeyQuerySchema>;
 export type SignRequestBody = z.infer<typeof signRequestSchema>;
 export type FederationFollowBody = z.infer<typeof federationFollowSchema>;
+export type FederationActorGoneBody = z.infer<typeof federationActorGoneSchema>;


### PR DESCRIPTION
Dead federated users (remote Mastodon/Bluesky account deleted → 410 Gone) surface as 0-post ghost profiles in people search. Identity lives in Oxy, so the exclusion + the mark-gone write belong here.

- **Search exclusion:** `accountStatus: { $ne: 'archived' }` on `GET /profiles/search` + `POST /users/search`. Only `archived` excluded — active/unset accounts still match. The `resolveAndUpsert` federated prepend is guarded so a cached archived actor can't slip back in.
- **`POST /federation/actor-gone`** (service auth, scope `federation:write`, alongside `/federation/follow`): body `{ oxyUserId }` → sets `accountStatus='archived'` (mirrors `accountService.archiveAccount`: cache invalidation, no doc/edge deletion). Guards `type:'federated'` (409 otherwise), idempotent (`alreadyArchived`), whitelisted `$set`. Mention calls this on 410 Gone.

Tests: 26/26 new + regression suites green. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)