### PR TITLE
feat(api): exclude negative-reputation (restricted tier) users from people search

### DIFF
--- a/packages/api/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/users.controller.test.ts
@@ -82,6 +82,8 @@ describe('UsersController', () => {
         // Archived accounts (e.g. dead federated actors marked gone) are
         // excluded from search so they never surface as ghost hits.
         accountStatus: { $ne: 'archived' },
+        // Users in the punitive `restricted` reputation tier are excluded too.
+        reputationTier: { $ne: 'restricted' },
         $or: [
           { username: { $regex: 'test', $options: 'i' } },
           { 'name.first': { $regex: 'test', $options: 'i' } },
@@ -118,6 +120,81 @@ describe('UsersController', () => {
       // (the default) still match.
       const filter = mockFind.mock.calls[0]?.[0] as { accountStatus?: unknown };
       expect(filter.accountStatus).toEqual({ $ne: 'archived' });
+    });
+
+    it('excludes restricted-tier users from the search filter', async () => {
+      mockRequest.body = { query: 'test' };
+
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+      mockFind.mockReturnValue(mockQuery);
+
+      await usersController.searchUsers(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext
+      );
+
+      // Users in the punitive `restricted` reputation tier (lifetime total < 0
+      // OR abuseScore >= threshold) are hidden from people search alongside
+      // archived accounts. `{ $ne: 'restricted' }` still matches docs whose
+      // `reputationTier` is absent (untiered/new users), so no live user hides.
+      const filter = mockFind.mock.calls[0]?.[0] as { reputationTier?: unknown };
+      expect(filter.reputationTier).toEqual({ $ne: 'restricted' });
+    });
+
+    it('hides restricted OR archived users while an active untiered user shows', async () => {
+      mockRequest.body = { query: 'match' };
+
+      // A candidate pool exercising every axis: a restricted user, an archived
+      // user, a non-punitive `trusted` user, and an untiered active user.
+      const pool = [
+        { username: 'clean_match', accountStatus: 'active' as const },
+        { username: 'trusted_match', accountStatus: 'active' as const, reputationTier: 'trusted' as const },
+        { username: 'archived_match', accountStatus: 'archived' as const, reputationTier: 'trusted' as const },
+        { username: 'restricted_match', accountStatus: 'active' as const, reputationTier: 'restricted' as const },
+      ];
+
+      // Faithfully evaluate the controller's `{ $ne }` gates against the pool —
+      // a missing field is NOT equal to the excluded value (Mongo semantics), so
+      // the untiered user survives.
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockImplementation(() => {
+          const filter = mockFind.mock.calls[0]?.[0] as {
+            accountStatus?: { $ne?: string };
+            reputationTier?: { $ne?: string };
+          };
+          const acctNe = filter.accountStatus?.$ne;
+          const tierNe = filter.reputationTier?.$ne;
+          return Promise.resolve(
+            pool.filter(
+              (u) =>
+                u.accountStatus !== acctNe &&
+                (u as { reputationTier?: string }).reputationTier !== tierNe
+            )
+          );
+        }),
+      };
+      mockFind.mockReturnValue(mockQuery);
+
+      await usersController.searchUsers(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext
+      );
+
+      const responseJson = mockResponse.json as jest.Mock;
+      const returned = responseJson.mock.calls[0]?.[0]?.data as Array<{ username: string }>;
+      const usernames = returned.map((u) => u.username);
+      expect(usernames).toContain('clean_match');
+      expect(usernames).toContain('trusted_match');
+      expect(usernames).not.toContain('archived_match');
+      expect(usernames).not.toContain('restricted_match');
     });
 
     it('never projects the searched users\' email addresses', async () => {

--- a/packages/api/src/controllers/users.controller.ts
+++ b/packages/api/src/controllers/users.controller.ts
@@ -38,8 +38,14 @@ export class UsersController {
       // POST /federation/actor-gone, plus archived org/project accounts) so
       // they never surface as 0-post ghost search hits. Only `archived` is
       // filtered — active accounts (the default) all still match.
+      // Also exclude users in the punitive `restricted` reputation tier
+      // (lifetime total < 0 OR abuseScore >= threshold). `reputationTier` is
+      // absent until `recalculateBalance` first runs, and Mongo treats a missing
+      // field as NOT equal to 'restricted', so untiered/new users still match —
+      // only actively-restricted users are hidden.
       const users = await User.find({
         accountStatus: { $ne: 'archived' },
+        reputationTier: { $ne: 'restricted' },
         $or: [
           { username: { $regex: sanitizedQuery, $options: 'i' } },
           { 'name.first': { $regex: sanitizedQuery, $options: 'i' } },

--- a/packages/api/src/routes/__tests__/profilesSearch.test.ts
+++ b/packages/api/src/routes/__tests__/profilesSearch.test.ts
@@ -80,6 +80,7 @@ interface PoolUser {
   name?: { first?: string; last?: string };
   description?: string;
   accountStatus?: string;
+  reputationTier?: string;
   type?: string;
 }
 
@@ -117,13 +118,20 @@ function requestJson(server: http.Server, path: string): Promise<JsonResponse> {
 }
 
 /**
- * Faithfully evaluate the route's search `$match` (an `accountStatus` $ne gate
- * plus a `$or` of field regexes) against a candidate pool, mirroring MongoDB's
- * semantics for the exact operators the filter uses.
+ * Faithfully evaluate the route's search `$match` (an `accountStatus` $ne gate,
+ * a `reputationTier` $ne gate, plus a `$or` of field regexes) against a
+ * candidate pool, mirroring MongoDB's semantics for the exact operators the
+ * filter uses — crucially, `{ $ne: X }` MATCHES a document whose field is
+ * ABSENT (Mongo treats a missing field as not-equal), so an untiered user with
+ * no `reputationTier` still surfaces.
  */
 function matchesSearchFilter(user: PoolUser, filter: Record<string, unknown>): boolean {
   const acct = filter.accountStatus as { $ne?: string } | undefined;
   if (acct && typeof acct.$ne === 'string' && user.accountStatus === acct.$ne) {
+    return false;
+  }
+  const tier = filter.reputationTier as { $ne?: string } | undefined;
+  if (tier && typeof tier.$ne === 'string' && user.reputationTier === tier.$ne) {
     return false;
   }
   const or = filter.$or as Array<Record<string, RegExp>> | undefined;
@@ -153,6 +161,8 @@ function aggregateSearch(pool: PoolUser[]): (pipeline: unknown) => Promise<unkno
 
 const activeLocal = new Types.ObjectId();
 const archivedActor = new Types.ObjectId();
+const restrictedActor = new Types.ObjectId();
+const trustedActor = new Types.ObjectId();
 
 let server: http.Server;
 
@@ -186,6 +196,16 @@ describe('GET /profiles/search archived exclusion', () => {
     expect(pipeline[0].$match?.accountStatus).toEqual({ $ne: 'archived' });
   });
 
+  it('adds reputationTier: { $ne: "restricted" } to the aggregation $match', async () => {
+    mockUserAggregate.mockImplementation(aggregateSearch([]));
+
+    const res = await requestJson(server, '/profiles/search?query=test');
+    expect(res.status).toBe(200);
+
+    const pipeline = mockUserAggregate.mock.calls[0][0] as Array<{ $match?: Record<string, unknown> }>;
+    expect(pipeline[0].$match?.reputationTier).toEqual({ $ne: 'restricted' });
+  });
+
   it('filters archived accounts while surfacing active matches', async () => {
     const pool: PoolUser[] = [
       { _id: activeLocal, username: 'active_match', accountStatus: 'active' },
@@ -199,6 +219,63 @@ describe('GET /profiles/search archived exclusion', () => {
     const ids = (res.body.data ?? []).map((p) => String(p.id));
     expect(ids).toContain(activeLocal.toString());
     expect(ids).not.toContain(archivedActor.toString());
+  });
+
+  it('filters restricted-tier users while surfacing trusted and untiered matches', async () => {
+    const pool: PoolUser[] = [
+      // Active + no reputationTier (absent field) — must still surface.
+      { _id: activeLocal, username: 'untiered_match', accountStatus: 'active' },
+      // Active + explicit non-punitive tier — must still surface.
+      { _id: trustedActor, username: 'trusted_match', accountStatus: 'active', reputationTier: 'trusted' },
+      // Active but punitive `restricted` tier — must be hidden.
+      { _id: restrictedActor, username: 'restricted_match', accountStatus: 'active', reputationTier: 'restricted' },
+    ];
+    mockUserAggregate.mockImplementation(aggregateSearch(pool));
+
+    const res = await requestJson(server, '/profiles/search?query=match');
+    expect(res.status).toBe(200);
+
+    const ids = (res.body.data ?? []).map((p) => String(p.id));
+    expect(ids).toContain(activeLocal.toString());
+    expect(ids).toContain(trustedActor.toString());
+    expect(ids).not.toContain(restrictedActor.toString());
+  });
+
+  it('hides a restricted OR archived user while an active untiered user shows', async () => {
+    const pool: PoolUser[] = [
+      // Active, no tier — the only row that should survive both gates.
+      { _id: activeLocal, username: 'clean_match', accountStatus: 'active' },
+      // Archived (any tier) — hidden by the accountStatus gate.
+      { _id: archivedActor, username: 'archived_match', accountStatus: 'archived', reputationTier: 'trusted' },
+      // Restricted (active) — hidden by the reputationTier gate.
+      { _id: restrictedActor, username: 'restricted_match', accountStatus: 'active', reputationTier: 'restricted' },
+    ];
+    mockUserAggregate.mockImplementation(aggregateSearch(pool));
+
+    const res = await requestJson(server, '/profiles/search?query=match');
+    expect(res.status).toBe(200);
+
+    const ids = (res.body.data ?? []).map((p) => String(p.id));
+    expect(ids).toEqual([activeLocal.toString()]);
+  });
+
+  it('does NOT prepend a federated actor that resolves as restricted', async () => {
+    mockUserAggregate.mockImplementation(aggregateSearch([]));
+    mockIsFediverseHandle.mockReturnValue(true);
+    mockResolveAndUpsert.mockResolvedValue({
+      _id: restrictedActor,
+      username: 'abuser@remote.example',
+      type: 'federated',
+      accountStatus: 'active',
+      reputationTier: 'restricted',
+    });
+
+    const res = await requestJson(server, '/profiles/search?query=abuser@remote.example');
+    expect(res.status).toBe(200);
+
+    const ids = (res.body.data ?? []).map((p) => String(p.id));
+    expect(ids).not.toContain(restrictedActor.toString());
+    expect(res.body.data).toHaveLength(0);
   });
 
   it('does NOT prepend a federated actor that resolves as archived', async () => {

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -433,6 +433,13 @@ router.get(
       // is excluded — every legitimately-active account (accountStatus defaults
       // to 'active') still matches, so no live user is hidden.
       accountStatus: { $ne: 'archived' },
+      // Exclude users in the punitive `restricted` reputation tier (lifetime
+      // reputation total < 0 OR abuseScore >= threshold) — the negative tier is
+      // hidden from people search just like archived accounts. `reputationTier`
+      // is optional/absent until `recalculateBalance` first runs, and Mongo
+      // treats a missing field as NOT equal to 'restricted', so untiered/new
+      // users still surface — only actively-restricted users are hidden.
+      reputationTier: { $ne: 'restricted' },
       $or: [
         { username: searchRegex },
         { 'name.first': searchRegex },
@@ -467,10 +474,14 @@ router.get(
 
     // If federation resolved a user not already in DB results, prepend it.
     // `resolveAndUpsert` returns the cached row for a known federated actor,
-    // which can be an ARCHIVED (dead / 410-Gone) account — never let that
-    // prepend re-introduce an actor the `accountStatus` $match above just
-    // excluded.
-    if (federatedUser && federatedUser.accountStatus !== 'archived') {
+    // which can be an ARCHIVED (dead / 410-Gone) account or a `restricted`
+    // (negative-reputation) actor — never let that prepend re-introduce an actor
+    // the `accountStatus` / `reputationTier` $match above just excluded.
+    if (
+      federatedUser &&
+      federatedUser.accountStatus !== 'archived' &&
+      federatedUser.reputationTier !== 'restricted'
+    ) {
       const fedId = federatedUser._id?.toString();
       const alreadyIncluded = profiles.some((profile) => profile._id.toString() === fedId);
       if (!alreadyIncluded) {


### PR DESCRIPTION
Oxy has no bans — a `restricted` reputationTier (total<0 or abuseScore≥threshold) is the negative tier. Added `reputationTier:{$ne:'restricted'}` to `/profiles/search` + `/users/search` (+ the federated resolveAndUpsert prepend guard), alongside the archived exclusion. Absent-tier users still show (Mongo $ne matches missing field). The recommendation scorer already excludes restricted. tsc clean, 16/16 + 23/23 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)