### PR TITLE
fix(api): strip leading @ in people search + resolve known federated profiles local-first

### DIFF
--- a/packages/api/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/users.controller.test.ts
@@ -220,6 +220,71 @@ describe('UsersController', () => {
       expect(projection.split(' ')).not.toContain('email');
     });
 
+    it('strips a single leading @ so a Bluesky handle matches the stored username', async () => {
+      // The stored atproto username has no leading @; the client query does.
+      mockRequest.body = { query: '@adamrbjack.bsky.social@bsky.social' };
+
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+      mockFind.mockReturnValue(mockQuery);
+
+      await usersController.searchUsers(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext
+      );
+
+      // `sanitizeSearchQuery` is mocked as identity, so the `$regex` value is the
+      // stripped query — the leading @ is gone, matching the stored username.
+      const filter = mockFind.mock.calls[0]?.[0] as { $or?: Array<{ username?: { $regex?: string } }> };
+      expect(filter.$or?.[0]?.username?.$regex).toBe('adamrbjack.bsky.social@bsky.social');
+    });
+
+    it('strips only the leading @ — a Mastodon @user@host matches user@host', async () => {
+      mockRequest.body = { query: '@user@mastodon.social' };
+
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+      mockFind.mockReturnValue(mockQuery);
+
+      await usersController.searchUsers(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext
+      );
+
+      // One leading @ removed; the mid-string @ (the user@host separator) stays.
+      const filter = mockFind.mock.calls[0]?.[0] as { $or?: Array<{ username?: { $regex?: string } }> };
+      expect(filter.$or?.[0]?.username?.$regex).toBe('user@mastodon.social');
+    });
+
+    it('does NOT strip a mid-string @ when there is no leading @', async () => {
+      mockRequest.body = { query: 'user@mastodon.social' };
+
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockResolvedValue([]),
+      };
+      mockFind.mockReturnValue(mockQuery);
+
+      await usersController.searchUsers(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext
+      );
+
+      // A query with no leading @ is unchanged — the internal @ is preserved.
+      const filter = mockFind.mock.calls[0]?.[0] as { $or?: Array<{ username?: { $regex?: string } }> };
+      expect(filter.$or?.[0]?.username?.$regex).toBe('user@mastodon.social');
+    });
+
     it('should throw InternalServerError on database errors', async () => {
       mockRequest.body = { query: 'test' };
 

--- a/packages/api/src/controllers/users.controller.ts
+++ b/packages/api/src/controllers/users.controller.ts
@@ -30,8 +30,15 @@ export class UsersController {
         throw new BadRequestError('Search query is required and must be a non-empty string');
       }
 
+      // Strip a single leading `@` (and trim) BEFORE sanitizing so a handle-style
+      // query matches the STORED username: an atproto handle
+      // `@adamrbjack.bsky.social` finds `adamrbjack.bsky.social@bsky.social`, and
+      // a Mastodon `@user@host` matches `user@host`. Only ONE leading `@` is
+      // removed — a mid-string `@` (the `user@host` separator) is preserved.
+      const strippedQuery = query.trim().replace(/^@/, '');
+
       // Sanitize search query (length limit + HTML escaping)
-      const sanitizedQuery = sanitizeSearchQuery(query);
+      const sanitizedQuery = sanitizeSearchQuery(strippedQuery);
 
       // Search for users where username or name matches the query.
       // Exclude archived accounts (dead federated actors marked gone via

--- a/packages/api/src/routes/__tests__/profilesSearch.test.ts
+++ b/packages/api/src/routes/__tests__/profilesSearch.test.ts
@@ -26,9 +26,11 @@ jest.mock('mongoose', () => jest.requireActual('mongoose'));
 import { Types } from 'mongoose';
 
 const mockUserAggregate = jest.fn();
+const mockUserFindOne = jest.fn();
 const mockFollowAggregate = jest.fn();
 const mockResolveAndUpsert = jest.fn();
 const mockIsFediverseHandle = jest.fn();
+const mockGetUserStats = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -42,7 +44,7 @@ jest.mock('../../middleware/validate', () => ({
 }));
 jest.mock('../../services/user.service', () => ({
   userService: {
-    getUserStats: jest.fn(),
+    getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
     // Minimal serializer: the route only asserts identity passes through.
     formatUserResponse: (profile: { _id: Types.ObjectId; username?: string }) => ({
       id: profile._id.toString(),
@@ -68,6 +70,7 @@ jest.mock('../../models/User', () => ({
   __esModule: true,
   default: {
     aggregate: (...args: unknown[]) => mockUserAggregate(...args),
+    findOne: (...args: unknown[]) => mockUserFindOne(...args),
   },
 }));
 
@@ -89,12 +92,12 @@ interface ProfileResult {
   username?: string;
 }
 
-interface JsonResponse {
+interface JsonResponse<T = ProfileResult[]> {
   status: number;
-  body: { error?: string; message?: string; data?: ProfileResult[] };
+  body: { error?: string; message?: string; data?: T };
 }
 
-function requestJson(server: http.Server, path: string): Promise<JsonResponse> {
+function requestJson<T = ProfileResult[]>(server: http.Server, path: string): Promise<JsonResponse<T>> {
   const address = server.address() as AddressInfo;
   return new Promise((resolve, reject) => {
     const req = http.request(
@@ -183,7 +186,26 @@ beforeEach(() => {
   // Follower/following count aggregations return empty for every test.
   mockFollowAggregate.mockResolvedValue([]);
   mockIsFediverseHandle.mockReturnValue(false);
+  mockGetUserStats.mockResolvedValue({ followers: 0, following: 0 });
+  // Default: no local user (the resolve tests override per-case).
+  mockUserFindOne.mockReturnValue(findOneQuery(null));
 });
+
+/**
+ * A chainable stub matching `User.findOne(...).select(...).lean({ virtuals })`
+ * as the `/profiles/resolve` local-first lookup calls it.
+ */
+function findOneQuery(user: PoolUser | null): {
+  select: jest.Mock;
+  lean: jest.Mock;
+} {
+  const query = {
+    select: jest.fn(),
+    lean: jest.fn().mockResolvedValue(user),
+  };
+  query.select.mockReturnValue(query);
+  return query;
+}
 
 describe('GET /profiles/search archived exclusion', () => {
   it('adds accountStatus: { $ne: "archived" } to the aggregation $match', async () => {
@@ -311,5 +333,137 @@ describe('GET /profiles/search archived exclusion', () => {
 
     const ids = (res.body.data ?? []).map((p) => String(p.id));
     expect(ids).toContain(activeLocal.toString());
+  });
+});
+
+/**
+ * BUG A — a leading `@` on a people-search query must be stripped BEFORE the
+ * regex is built, otherwise the literal `@` never matches the STORED username.
+ * The mocked `User.aggregate` evaluates the route's ACTUAL compiled regex against
+ * the pool, so these assertions exercise the real strip + escape, not a stub.
+ */
+describe('GET /profiles/search leading-@ handling', () => {
+  it('strips a single leading @ so a Bluesky handle matches the stored username', async () => {
+    // Stored atproto username has NO leading @; the query the client sends does.
+    const pool: PoolUser[] = [
+      { _id: activeLocal, username: 'adamrbjack.bsky.social@bsky.social', accountStatus: 'active' },
+    ];
+    mockUserAggregate.mockImplementation(aggregateSearch(pool));
+
+    const res = await requestJson(
+      server,
+      `/profiles/search?query=${encodeURIComponent('@adamrbjack.bsky.social@bsky.social')}`
+    );
+    expect(res.status).toBe(200);
+
+    const usernames = (res.body.data ?? []).map((p) => p.username);
+    expect(usernames).toContain('adamrbjack.bsky.social@bsky.social');
+  });
+
+  it('strips only the leading @ — a mid-string @ (user@host) is preserved', async () => {
+    const userAtHost = new Types.ObjectId();
+    const userNoAt = new Types.ObjectId();
+    const pool: PoolUser[] = [
+      // Should match: `@user@host.example` → stripped to `user@host.example`.
+      { _id: userAtHost, username: 'user@host.example', accountStatus: 'active' },
+      // Must NOT match: only surfaces if the mid-string @ were also stripped.
+      { _id: userNoAt, username: 'userhost.example', accountStatus: 'active' },
+    ];
+    mockUserAggregate.mockImplementation(aggregateSearch(pool));
+
+    const res = await requestJson(
+      server,
+      `/profiles/search?query=${encodeURIComponent('@user@host.example')}`
+    );
+    expect(res.status).toBe(200);
+
+    const usernames = (res.body.data ?? []).map((p) => p.username);
+    expect(usernames).toContain('user@host.example');
+    expect(usernames).not.toContain('userhost.example');
+  });
+});
+
+/**
+ * BUG B — `/profiles/resolve` must be LOCAL-FIRST: a handle that already maps to
+ * a known Oxy user resolves straight from the DB (crucial for atproto/Bluesky
+ * actors whose `user@bsky.social` username oxy-api's WebFinger can never
+ * resolve). Only an UNKNOWN handle falls through to `resolveAndUpsert`.
+ */
+describe('GET /profiles/resolve local-first', () => {
+  it('resolves an existing federated user by exact username WITHOUT WebFinger', async () => {
+    const known: PoolUser = {
+      _id: activeLocal,
+      username: 'adamrbjack.bsky.social@bsky.social',
+      accountStatus: 'active',
+      type: 'federated',
+    };
+    mockUserFindOne.mockReturnValue(findOneQuery(known));
+    // Prove the local lookup runs regardless of the strict handle-format check.
+    mockIsFediverseHandle.mockReturnValue(false);
+
+    const res = await requestJson<ProfileResult | null>(
+      server,
+      `/profiles/resolve?handle=${encodeURIComponent('adamrbjack.bsky.social@bsky.social')}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data?.id).toBe(activeLocal.toString());
+    expect(res.body.data?.username).toBe('adamrbjack.bsky.social@bsky.social');
+
+    // The exact handle is used as the username lookup key…
+    expect(mockUserFindOne).toHaveBeenCalledWith({ username: 'adamrbjack.bsky.social@bsky.social' });
+    // …and remote discovery is never invoked for a known user.
+    expect(mockResolveAndUpsert).not.toHaveBeenCalled();
+  });
+
+  it('returns null for an archived local match without WebFinger', async () => {
+    mockUserFindOne.mockReturnValue(
+      findOneQuery({ _id: archivedActor, username: 'gone@remote.example', accountStatus: 'archived' })
+    );
+
+    const res = await requestJson<ProfileResult | null>(
+      server,
+      `/profiles/resolve?handle=${encodeURIComponent('gone@remote.example')}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+    expect(mockResolveAndUpsert).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a restricted-tier local match without WebFinger', async () => {
+    mockUserFindOne.mockReturnValue(
+      findOneQuery({
+        _id: restrictedActor,
+        username: 'abuser@remote.example',
+        accountStatus: 'active',
+        reputationTier: 'restricted',
+      })
+    );
+
+    const res = await requestJson<ProfileResult | null>(
+      server,
+      `/profiles/resolve?handle=${encodeURIComponent('abuser@remote.example')}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeNull();
+    expect(mockResolveAndUpsert).not.toHaveBeenCalled();
+  });
+
+  it('falls through to resolveAndUpsert for an unknown handle', async () => {
+    // No local user (default findOne → null); it is a valid fediverse handle.
+    mockIsFediverseHandle.mockReturnValue(true);
+    mockResolveAndUpsert.mockResolvedValue({
+      _id: activeLocal,
+      username: 'newuser@remote.example',
+      type: 'federated',
+      accountStatus: 'active',
+    });
+
+    const res = await requestJson<ProfileResult | null>(
+      server,
+      `/profiles/resolve?handle=${encodeURIComponent('newuser@remote.example')}`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data?.id).toBe(activeLocal.toString());
+    expect(mockResolveAndUpsert).toHaveBeenCalledWith('newuser@remote.example');
   });
 });

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -422,8 +422,13 @@ router.get(
       : PAGINATION.DEFAULT_LIMIT;
     const parsedOffset = offset ? Number.parseInt(offset, 10) : 0;
 
-    // Sanitize search query to prevent regex injection
-    const sanitizedQuery = query.trim().substring(0, 100);
+    // Sanitize search query to prevent regex injection. A single leading `@` is
+    // stripped first so a handle-style query matches the STORED username: an
+    // atproto handle `@adamrbjack.bsky.social` finds the stored
+    // `adamrbjack.bsky.social@bsky.social`, and a Mastodon `@user@host` matches
+    // the stored `user@host`. Only ONE leading `@` is removed — a mid-string `@`
+    // (the `user@host` separator) is preserved, so the regex still requires it.
+    const sanitizedQuery = query.trim().replace(/^@/, '').substring(0, 100);
     const searchRegex = new RegExp(sanitizedQuery.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i');
 
     const searchFilter = {
@@ -528,11 +533,21 @@ router.get(
 /**
  * GET /profiles/resolve
  *
- * Resolve a fediverse handle (e.g. @user@mastodon.social) to an Oxy user profile.
- * Performs WebFinger discovery, fetches the ActivityPub actor, and upserts as a
- * federated user. Returns cached results if resolved within the last 24 hours.
+ * Resolve a handle (e.g. @user@mastodon.social) to an Oxy user profile.
  *
- * @query {string} handle - Fediverse handle (e.g. "@user@domain" or "user@domain")
+ * LOCAL-FIRST: a handle that already maps to a known Oxy user is resolved
+ * directly from the DB — no network round-trip. This is essential for atproto
+ * (Bluesky) actors whose `user@bsky.social` username oxy-api's WebFinger can
+ * never resolve: the user already exists, so remote discovery must NOT run (it
+ * would fail and yield a false "Profile not found"). The local lookup runs
+ * regardless of `isFediverseHandle` because a stored `user@domain` username is a
+ * valid lookup key even when the strict handle-format check would reject it.
+ *
+ * Only when NO local user exists do we fall through to WebFinger/ActivityPub
+ * discovery (`resolveAndUpsert`) — genuine discovery of an unknown handle, which
+ * is where the `isFediverseHandle` format validation still applies.
+ *
+ * @query {string} handle - Handle (e.g. "@user@domain" or "user@domain")
  * @returns {User | null} Resolved user profile or null
  */
 router.get(
@@ -540,7 +555,32 @@ router.get(
   asyncHandler(async (req: Request, res: Response) => {
     const handle = (req.query.handle as string || '').trim();
 
-    if (!handle || !isFediverseHandle(handle)) {
+    if (!handle) {
+      throw new BadRequestError('Invalid fediverse handle. Expected format: @user@domain or user@domain');
+    }
+
+    // Local-first: resolve an already-known user by exact username.
+    const localUser = await User.findOne({ username: handle })
+      .select('-password -refreshToken')
+      .lean({ virtuals: true });
+
+    if (localUser) {
+      // A known user is never handed to remote discovery. Archived (dead /
+      // 410-Gone) and `restricted`-tier accounts resolve to null — the same gate
+      // people search applies, and consistent with the archived→null behavior of
+      // the discovery path below.
+      if (localUser.accountStatus === 'archived' || localUser.reputationTier === 'restricted') {
+        return sendSuccess(res, null);
+      }
+      const stats = await userService.getUserStats(localUser._id.toString());
+      const response = userService.formatUserResponse(localUser, stats);
+      logger.debug('GET /profiles/resolve (local)', { handle });
+      return sendSuccess(res, response);
+    }
+
+    // No local user → genuine discovery of an unknown handle. Enforce the strict
+    // fediverse-handle format only now, then WebFinger/ActivityPub resolve+upsert.
+    if (!isFediverseHandle(handle)) {
       throw new BadRequestError('Invalid fediverse handle. Expected format: @user@domain or user@domain');
     }
 


### PR DESCRIPTION
Two Bluesky-handle bugs (evidence: @adamrbjack.bsky.social):
- **Search with leading @** returned nothing — the raw `@` was a literal regex char that never matched the stored `user@bsky.social`. Both search endpoints now `.replace(/^@/,'')` (single leading @ only; mid-string @ preserved → Mastodon `@user@host` still matches `user@host`).
- **'Profile not found'** on a known Bluesky user — `/profiles/resolve` did WebFinger-only, which can't resolve atproto. Now local-first: `User.findOne({username})` before `resolveAndUpsert`, so any already-known federated user opens; archived/restricted → null; unknown handles still discover via WebFinger.

tsc clean; 25 + 58 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)