### PR TITLE
fix(session): don't wipe the device credential on an ambiguous 401 (stops deploy-time logout ecosystem-wide)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "12.4.0",
+  "version": "12.4.1",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/session/__tests__/refresh.test.ts
+++ b/packages/core/src/session/__tests__/refresh.test.ts
@@ -159,6 +159,26 @@ describe('refreshPersistedSession — arm 1 (device-secret mint)', () => {
     expect(await store.load()).toEqual(STORED);
     expect(signInWithSharedIdentity).not.toHaveBeenCalled();
   });
+
+  it('KEEPS the store on an UNRECOGNIZED 401 (proxy / middleware / deploy-window) — never wipes the credential on an ambiguous 401', async () => {
+    const store = createMemoryAuthStateStore();
+    await store.save(STORED);
+    const signInWithSharedIdentity = jest.fn(async () => null);
+    const { oxy } = makeOxy({
+      mintFromDeviceSecret: async () => {
+        // A 401 whose body is NEITHER `invalid_device_secret` NOR `no_active_session`
+        // — an auth-layer / proxy / starting-instance 401 common during a deploy
+        // window. It is NOT proof the secret diverged, so the durable device
+        // credential must survive (treated as transient) and a later attempt self-heals.
+        throw Object.assign(new Error('Unauthorized'), { status: 401 });
+      },
+      signInWithSharedIdentity,
+    });
+
+    expect(await refreshPersistedSession({ oxy, store, allowSharedKeyFallback: true })).toBeNull();
+    expect(await store.load()).toEqual(STORED);
+    expect(signInWithSharedIdentity).not.toHaveBeenCalled();
+  });
 });
 
 describe('refreshPersistedSession — arm 2 (native shared-key fallback)', () => {

--- a/packages/core/src/session/refresh.ts
+++ b/packages/core/src/session/refresh.ts
@@ -136,9 +136,18 @@ export async function refreshDeviceSecretArm(deps: {
         // Structural read (not `instanceof Error`): the thrown value can be a
         // plain ApiError-shaped object or come from another realm.
         const message = (error as { message?: unknown })?.message;
-        return typeof message === 'string' && message.includes('no_active_session')
-          ? { status: 'no-session' }
-          : { status: 'invalid-secret' };
+        const body = typeof message === 'string' ? message : '';
+        // ONLY the server's explicit `invalid_device_secret` proves the presented
+        // secret is bad and may clear the durable device credential. `no_active_session`
+        // is an authoritative signed-out. ANY OTHER 401 — a middleware/CSRF/proxy 401,
+        // an ALB/starting-instance 401, a CORS error page, etc., all common during a
+        // deploy/restart window — is NOT proof the secret diverged: treat it as
+        // transient and KEEP the credential so a later attempt self-heals. Wiping the
+        // credential on an ambiguous 401 is what logged users out on every deploy,
+        // ecosystem-wide.
+        if (body.includes('invalid_device_secret')) return { status: 'invalid-secret' };
+        if (body.includes('no_active_session')) return { status: 'no-session' };
+        return { status: 'transient' };
       }
       return { status: 'transient' };
     }


### PR DESCRIPTION
**Root cause of 'every oxy-api deploy logs users out across all apps':** the device-secret mint classifier mapped ANY 401 that isn't `no_active_session` → `invalid-secret`, which drops the durable device credential. During a deploy/restart window, a generic middleware/proxy/starting-instance 401 (or a CORS-adjacent failure surfacing as 401) was misread as 'your secret is invalid' → credential wiped → logged out everywhere, unable to re-mint.

Fix: only the server's explicit `invalid_device_secret` clears the credential; `no_active_session` stays signed-out; **every other 401 is `transient`** → credential survives, later mint self-heals. One shared classifier (`refreshDeviceSecretArm`) covers cold-boot AND in-session refresh. +1 test. core 12.4.0 → 12.4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)