### PR TITLE
fix(services): viewer-scope useUserByUsername query key so "Follows you" survives cold boot

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -669,7 +669,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "22.4.0",
+      "version": "22.4.1",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "^12.5.0",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "22.4.0",
+  "version": "22.4.1",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/hooks/queries/useAccountQueries.ts
+++ b/packages/services/src/ui/hooks/queries/useAccountQueries.ts
@@ -168,10 +168,21 @@ export const useUserById = (userId: string | null, options?: { enabled?: boolean
  * Get user profile by username
  */
 export const useUserByUsername = (username: string | null, options?: { enabled?: boolean }) => {
-  const { oxyServices } = useOxy();
+  const { oxyServices, user } = useOxy();
+  // Viewer-scope the cache. Authenticated single-profile fetches embed a
+  // viewer-relative `relationship` ({ isFollowing, followsYou }); anonymous
+  // fetches omit it and different viewers get different values. Without the
+  // active viewer in the key, react-query freezes the first (often anonymous
+  // cold-boot) copy and never refetches when the session lands ~5-25s later,
+  // so the "Follows you" tag flashes then vanishes forever. Adding the viewer
+  // makes anon vs authed distinct entries AND forces a refetch when the
+  // session resolves or the account switches. (The SDK's GET response cache is
+  // already identity-scoped by the access-token user id via `computeIdentityTag`,
+  // so it never cross-poisons `relationship` — the only gap was this key.)
+  const viewerId = user?.id ?? '';
 
   return useQuery({
-    queryKey: [...queryKeys.users.details(), 'username', username || ''],
+    queryKey: [...queryKeys.users.details(), 'username', username || '', 'viewer', viewerId],
     queryFn: async () => {
       if (!username) {
         throw new Error('Username is required');


### PR DESCRIPTION
## Summary
- Authenticated single-profile fetches embed a viewer-relative `relationship` (`{isFollowing, followsYou}`), but the react-query key for `useUserByUsername` was viewer-agnostic — it froze the first anonymous cold-boot copy and never refetched when the Oxy session landed 5-25s later, so Mention's "Follows you" tag flashed then vanished forever.
- Adds the active viewer's user id to the query key so anon vs authed are distinct cache entries and a refetch fires when the session resolves or the account switches.
- Bumps `@oxyhq/services` 22.4.0 -> 22.4.1.

## Test plan
- [x] `turbo build --filter @oxyhq/services` — 4/4 packages ok
- [x] `bun run --filter @oxyhq/services typescript` — exit 0
- [x] Test suite — 32 suites / 246 tests pass
- [x] `bun install --frozen-lockfile` — no changes (lockfile gate green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>