### PR TITLE
fix(i18n): define accountSwitcher.switchWhileSignedInAs in all 11 locales

### DIFF
--- a/packages/core/src/i18n/locales/ar-SA.json
+++ b/packages/core/src/i18n/locales/ar-SA.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "جارٍ تسجيل الدخول…",
     "getCommons": "احصل على Commons",
     "commonsNotInstalled": "لا تملك Commons؟ احصل على التطبيق لتسجيل الدخول بمعرّف Oxy الخاص بك.",
-    "showQrAnyway": "لدي Commons على جهاز آخر"
+    "showQrAnyway": "لدي Commons على جهاز آخر",
+    "switchWhileSignedInAs": "تبديل الحساب، مسجّل الدخول باسم {{name}}"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/ca-ES.json
+++ b/packages/core/src/i18n/locales/ca-ES.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "Iniciant sessió…",
     "getCommons": "Descarrega Commons",
     "commonsNotInstalled": "No tens Commons? Descarrega l'app per iniciar sessió amb el teu Oxy ID.",
-    "showQrAnyway": "Tinc Commons en un altre dispositiu"
+    "showQrAnyway": "Tinc Commons en un altre dispositiu",
+    "switchWhileSignedInAs": "Canvia de compte, amb la sessió iniciada com a {{name}}"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/de-DE.json
+++ b/packages/core/src/i18n/locales/de-DE.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "Anmeldung läuft…",
     "getCommons": "Commons herunterladen",
     "commonsNotInstalled": "Kein Commons? Holen Sie sich die App, um sich mit Ihrer Oxy-ID anzumelden.",
-    "showQrAnyway": "Ich habe Commons auf einem anderen Gerät"
+    "showQrAnyway": "Ich habe Commons auf einem anderen Gerät",
+    "switchWhileSignedInAs": "Konto wechseln, angemeldet als {{name}}"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/en-US.json
+++ b/packages/core/src/i18n/locales/en-US.json
@@ -420,7 +420,8 @@
     "passkeySigningIn": "Signing in…",
     "getCommons": "Get Commons",
     "commonsNotInstalled": "Don't have Commons? Get the app to sign in with your Oxy ID.",
-    "showQrAnyway": "I have Commons on another device"
+    "showQrAnyway": "I have Commons on another device",
+    "switchWhileSignedInAs": "Switch account, signed in as {{name}}"
   },
   "reputation": {
     "faq": {

--- a/packages/core/src/i18n/locales/es-ES.json
+++ b/packages/core/src/i18n/locales/es-ES.json
@@ -618,7 +618,8 @@
     "passkeySigningIn": "Iniciando sesión…",
     "getCommons": "Descargar Commons",
     "commonsNotInstalled": "¿No tienes Commons? Descarga la app para iniciar sesión con tu Oxy ID.",
-    "showQrAnyway": "Tengo Commons en otro dispositivo"
+    "showQrAnyway": "Tengo Commons en otro dispositivo",
+    "switchWhileSignedInAs": "Cambiar de cuenta, con la sesión iniciada como {{name}}"
   },
   "feedback": {
     "type": {

--- a/packages/core/src/i18n/locales/fr-FR.json
+++ b/packages/core/src/i18n/locales/fr-FR.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "Connexion…",
     "getCommons": "Obtenir Commons",
     "commonsNotInstalled": "Pas de Commons ? Téléchargez l'app pour vous connecter avec votre Oxy ID.",
-    "showQrAnyway": "J'ai Commons sur un autre appareil"
+    "showQrAnyway": "J'ai Commons sur un autre appareil",
+    "switchWhileSignedInAs": "Changer de compte, connecté en tant que {{name}}"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/it-IT.json
+++ b/packages/core/src/i18n/locales/it-IT.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "Accesso in corso…",
     "getCommons": "Ottieni Commons",
     "commonsNotInstalled": "Non hai Commons? Scarica l'app per accedere con il tuo Oxy ID.",
-    "showQrAnyway": "Ho Commons su un altro dispositivo"
+    "showQrAnyway": "Ho Commons su un altro dispositivo",
+    "switchWhileSignedInAs": "Cambia account, connesso come {{name}}"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/ja-JP.json
+++ b/packages/core/src/i18n/locales/ja-JP.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "サインインしています…",
     "getCommons": "Commonsを入手",
     "commonsNotInstalled": "Commonsがありませんか？アプリを入手してOxy IDでサインインしましょう。",
-    "showQrAnyway": "別のデバイスにCommonsがあります"
+    "showQrAnyway": "別のデバイスにCommonsがあります",
+    "switchWhileSignedInAs": "アカウントを切り替え（{{name}} としてログイン中）"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/ko-KR.json
+++ b/packages/core/src/i18n/locales/ko-KR.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "로그인 중…",
     "getCommons": "Commons 다운로드",
     "commonsNotInstalled": "Commons가 없으신가요? 앱을 다운로드하여 Oxy ID로 로그인하세요.",
-    "showQrAnyway": "다른 기기에 Commons가 있습니다"
+    "showQrAnyway": "다른 기기에 Commons가 있습니다",
+    "switchWhileSignedInAs": "계정 전환, {{name}}(으)로 로그인됨"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/pt-PT.json
+++ b/packages/core/src/i18n/locales/pt-PT.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "A iniciar sessão…",
     "getCommons": "Obter o Commons",
     "commonsNotInstalled": "Não tem o Commons? Obtenha a app para iniciar sessão com o seu Oxy ID.",
-    "showQrAnyway": "Tenho o Commons noutro dispositivo"
+    "showQrAnyway": "Tenho o Commons noutro dispositivo",
+    "switchWhileSignedInAs": "Mudar de conta, com sessão iniciada como {{name}}"
   },
   "common": {
     "actions": {

--- a/packages/core/src/i18n/locales/zh-CN.json
+++ b/packages/core/src/i18n/locales/zh-CN.json
@@ -118,7 +118,8 @@
     "passkeySigningIn": "正在登录…",
     "getCommons": "获取 Commons",
     "commonsNotInstalled": "没有 Commons？获取应用以使用您的 Oxy ID 登录。",
-    "showQrAnyway": "我在另一台设备上有 Commons"
+    "showQrAnyway": "我在另一台设备上有 Commons",
+    "switchWhileSignedInAs": "切换账号，当前登录为 {{name}}"
   },
   "common": {
     "actions": {

--- a/packages/services/src/ui/components/ProfileButton.tsx
+++ b/packages/services/src/ui/components/ProfileButton.tsx
@@ -211,8 +211,7 @@ const ProfileButton: React.FC<ProfileButtonProps> = ({
     // `state.hovered || state.focused`. Only web ever sets these, so on native
     // the row renders statically.
     const active = hovered || focused;
-    const accountLabel = t('accountSwitcher.switchWhileSignedInAs', { name: displayName })
-        || `Switch account, signed in as ${displayName}`;
+    const accountLabel = t('accountSwitcher.switchWhileSignedInAs', { name: displayName });
 
     // Web-only pointer/focus handlers. RN-Web forwards `onHoverIn`/`onHoverOut`
     // to the underlying element; native Pressable ignores them harmlessly, but


### PR DESCRIPTION
## Summary
- `ProfileButton` requests `accountSwitcher.switchWhileSignedInAs` to build the account row's accessibility label, but the key was defined in zero locale files. `translate()` echoes the key back verbatim when a key is missing in every locale, so screen readers announced the literal string `accountSwitcher.switchWhileSignedInAs` instead of a real sentence.
- Adds the key into the EXISTING top-level `accountSwitcher` block in all 11 `packages/core/src/i18n/locales/*.json` files (2-line diff per file). Translations were lifted verbatim from the abandoned `chore/services-remove-legacy-account-ui` branch rather than re-invented.
- That branch was deliberately NOT cherry-picked: it appended a SECOND top-level `accountSwitcher` block in nine locales, which would collide with the block `main` already has.
- Also removes the dead `|| \`Switch account, signed in as \${displayName}\`` fallback in `packages/services/src/ui/components/ProfileButton.tsx` — it was unreachable because `translate()` returns the key itself on a miss, and a non-empty key string is always truthy.

## Verification
- All 11 locale files parse as valid JSON with exactly one top-level `accountSwitcher` block and no duplicate keys.
- `translate()` resolves `accountSwitcher.switchWhileSignedInAs` with `{{name}}` interpolation in all 11 locales through the built dist.
- `packages/core`: `bun run test` -> 76 suites / 952 tests passed.
- `packages/services`: `bun run test` -> 33 suites / 250 tests passed.
- Build order `contracts -> core -> services` all green.
- `bun install --frozen-lockfile` passes (no dependency changes in this commit).

## Test plan
- [x] packages/core test suite green
- [x] packages/services test suite green
- [x] contracts/core/services build green
- [x] lockfile frozen-install check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)