### PR TITLE
fix(api,core): compute viewer relationship on /profiles/resolve (federated "Follows you")

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -411,7 +411,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "12.5.1",
+      "version": "12.5.2",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -669,7 +669,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "22.4.1",
+      "version": "22.4.2",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "^12.5.0",

--- a/packages/api/src/routes/__tests__/profilesResolve.test.ts
+++ b/packages/api/src/routes/__tests__/profilesResolve.test.ts
@@ -1,0 +1,209 @@
+/**
+ * GET /profiles/resolve viewer-relationship coverage.
+ *
+ * Proves the resolve handler computes the same viewer-relative `relationship`
+ * field as its two sibling single-profile routes (/profiles/username/:username
+ * and /users/:userId): present only when the request is authenticated AND the
+ * viewer is not the target, omitted otherwise. This is what makes "Follows you"
+ * render on a federated profile fetched through resolve.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+jest.mock('mongoose', () => jest.requireActual('mongoose'));
+import { Types } from 'mongoose';
+
+const mockUserFindOne = jest.fn();
+const mockUserFindById = jest.fn();
+const mockResolveAndUpsert = jest.fn();
+const mockIsFediverseHandle = jest.fn();
+const mockGetUserStats = jest.fn();
+const mockGetViewerRelationship = jest.fn();
+
+let currentViewerId: string | undefined;
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../middleware/optionalAuth', () => ({
+  optionalUserOrServiceAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  resolveViewerId: (): string | undefined => currentViewerId,
+}));
+jest.mock('../../middleware/validate', () => ({
+  validate: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../services/user.service', () => ({
+  userService: {
+    getUserStats: (...args: unknown[]) => mockGetUserStats(...args),
+    formatUserResponse: (profile: { _id: Types.ObjectId; username?: string }) => ({
+      id: profile._id.toString(),
+      username: profile.username,
+    }),
+    getViewerRelationship: (...args: unknown[]) => mockGetViewerRelationship(...args),
+  },
+}));
+jest.mock('../../services/federation.service', () => ({
+  federationService: { resolveAndUpsert: (...args: unknown[]) => mockResolveAndUpsert(...args) },
+  isFediverseHandle: (...args: unknown[]) => mockIsFediverseHandle(...args),
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('../../models/Follow', () => ({
+  __esModule: true,
+  FollowType: { USER: 'user', HASHTAG: 'hashtag', TOPIC: 'topic' },
+  default: { aggregate: jest.fn() },
+}));
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  default: {
+    aggregate: jest.fn(),
+    findOne: (...args: unknown[]) => mockUserFindOne(...args),
+    findById: (...args: unknown[]) => mockUserFindById(...args),
+  },
+}));
+
+import profilesRouter from '../profiles';
+import { errorHandler } from '../../middleware/errorHandler';
+
+const targetUserId = new Types.ObjectId();
+
+function findOneQuery(result: Record<string, unknown> | null) {
+  return {
+    select: () => ({
+      lean: async () => result,
+    }),
+  };
+}
+
+interface JsonResponse {
+  status: number;
+  body: { message?: string; data?: Record<string, unknown> | null };
+}
+
+function requestJson(server: http.Server, handle: string): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: 'GET',
+        host: '127.0.0.1',
+        port: address.port,
+        path: `/profiles/resolve?handle=${encodeURIComponent(handle)}`,
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: raw.length > 0 ? JSON.parse(raw) : {} });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('GET /profiles/resolve relationship', () => {
+  let server: http.Server;
+
+  beforeAll((done) => {
+    const app = express();
+    app.use('/profiles', profilesRouter);
+    app.use(errorHandler);
+    server = app.listen(0, done);
+  });
+
+  afterAll((done) => {
+    server.close(done);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentViewerId = undefined;
+    mockIsFediverseHandle.mockReturnValue(false);
+    mockGetUserStats.mockResolvedValue({});
+  });
+
+  it('includes relationship (followsYou true) when an authed viewer resolves a local target that follows them', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+    currentViewerId = viewerId;
+    mockUserFindOne.mockReturnValue(
+      findOneQuery({
+        _id: targetUserId,
+        username: 'remote@mastodon.social',
+        accountStatus: 'active',
+        reputationTier: 'trusted',
+      }),
+    );
+    mockGetViewerRelationship.mockResolvedValue({ isFollowing: false, followsYou: true });
+
+    const res = await requestJson(server, '@remote@mastodon.social');
+    expect(res.status).toBe(200);
+    expect(res.body.data?.relationship).toEqual({ isFollowing: false, followsYou: true });
+    expect(mockGetViewerRelationship).toHaveBeenCalledWith(viewerId, targetUserId.toString());
+    // Local-first hit never touches remote discovery.
+    expect(mockResolveAndUpsert).not.toHaveBeenCalled();
+  });
+
+  it('omits relationship for anonymous viewers', async () => {
+    mockUserFindOne.mockReturnValue(
+      findOneQuery({
+        _id: targetUserId,
+        username: 'remote@mastodon.social',
+        accountStatus: 'active',
+        reputationTier: 'trusted',
+      }),
+    );
+
+    const res = await requestJson(server, '@remote@mastodon.social');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ id: targetUserId.toString(), username: 'remote@mastodon.social' });
+    expect(res.body.data?.relationship).toBeUndefined();
+    expect(mockGetViewerRelationship).not.toHaveBeenCalled();
+  });
+
+  it('omits relationship on a self-view', async () => {
+    currentViewerId = targetUserId.toHexString();
+    mockUserFindOne.mockReturnValue(
+      findOneQuery({
+        _id: targetUserId,
+        username: 'me@mastodon.social',
+        accountStatus: 'active',
+        reputationTier: 'trusted',
+      }),
+    );
+
+    const res = await requestJson(server, '@me@mastodon.social');
+    expect(res.status).toBe(200);
+    expect(res.body.data?.relationship).toBeUndefined();
+    expect(mockGetViewerRelationship).not.toHaveBeenCalled();
+  });
+
+  it('computes relationship on the discovery branch for a freshly-upserted actor', async () => {
+    const viewerId = new Types.ObjectId().toHexString();
+    currentViewerId = viewerId;
+    // No local row → discovery path. The handle must pass the fediverse-format gate.
+    mockUserFindOne.mockReturnValue(findOneQuery(null));
+    mockIsFediverseHandle.mockReturnValue(true);
+    mockResolveAndUpsert.mockResolvedValue({
+      _id: targetUserId,
+      username: 'fresh@mastodon.social',
+      accountStatus: 'active',
+      reputationTier: 'trusted',
+    });
+    mockGetViewerRelationship.mockResolvedValue({ isFollowing: false, followsYou: false });
+
+    const res = await requestJson(server, '@fresh@mastodon.social');
+    expect(res.status).toBe(200);
+    expect(res.body.data?.relationship).toEqual({ isFollowing: false, followsYou: false });
+    expect(mockGetViewerRelationship).toHaveBeenCalledWith(viewerId, targetUserId.toString());
+    expect(mockResolveAndUpsert).toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/profiles.ts
+++ b/packages/api/src/routes/profiles.ts
@@ -568,7 +568,8 @@ router.get(
  */
 router.get(
   '/resolve',
-  asyncHandler(async (req: Request, res: Response) => {
+  optionalUserOrServiceAuth,
+  asyncHandler(async (req: OptionalUserOrServiceRequest, res: Response) => {
     // Normalize handle input: trim, strip optional `acct:` prefix, and remove a
     // single leading `@` so `@user@host` matches the stored `user@host` username.
     const rawHandle = (req.query.handle as string || '')
@@ -599,6 +600,21 @@ router.get(
       }
       const stats = await userService.getUserStats(localUser._id.toString());
       const response = userService.formatUserResponse(localUser, stats);
+
+      // Viewer-relative relationship: same in-handler computation as the two
+      // sibling single-profile routes (/profiles/username/:username and
+      // /users/:userId). A federated actor that bridged into the Oxy graph via an
+      // inbound follow IS a known Oxy row here, so `getViewerRelationship`
+      // returns real follow edges — this is what lets "Follows you" render on a
+      // federated profile fetched through resolve. OMITTED for anonymous requests
+      // and for a self-view, so consumers can distinguish "unknown" from "known,
+      // not following".
+      const viewerId = resolveViewerId(req);
+      const targetId = localUser._id.toString();
+      if (viewerId && viewerId !== targetId) {
+        response.relationship = await userService.getViewerRelationship(viewerId, targetId);
+      }
+
       logger.debug('GET /profiles/resolve (local)', { handle });
       return sendSuccess(res, response);
     }
@@ -616,6 +632,17 @@ router.get(
 
     const stats = await userService.getUserStats(user._id.toString());
     const response = userService.formatUserResponse(user, stats);
+
+    // Same viewer-relative relationship as the local branch above. A
+    // freshly-discovered actor is now a known Oxy row (`resolveAndUpsert`
+    // persisted it), so its id is canonical; a brand-new actor simply has no
+    // follow edges yet (`isFollowing`/`followsYou` both false). OMITTED for
+    // anonymous requests and for a self-view.
+    const viewerId = resolveViewerId(req);
+    const targetId = user._id.toString();
+    if (viewerId && viewerId !== targetId) {
+      response.relationship = await userService.getViewerRelationship(viewerId, targetId);
+    }
 
     logger.debug('GET /profiles/resolve', { handle });
     sendSuccess(res, response);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "12.5.1",
+  "version": "12.5.2",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -244,7 +244,15 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
           handle,
         }, {
           cache: true,
-          cacheTTL: 24 * 60 * 60 * 1000, // 24h cache — matches server-side staleness window
+          // 5 min — matches the sibling profile fetches (getUserById /
+          // getProfileByUsername). /profiles/resolve now carries the viewer-relative
+          // `relationship` (isFollowing / followsYou); `followsYou` is target→viewer,
+          // so the viewer can't self-refresh it via a follow action. The GET cache is
+          // identity-scoped (keyed by the caller's access-token identity tag → no
+          // cross-viewer poison), so a short TTL keeps "Follows you" reasonably fresh
+          // without a per-call bypass. The identity fields alone tolerate a longer
+          // window, but a 24h stale relationship is not acceptable.
+          cacheTTL: 5 * 60 * 1000,
         });
         return normalizeUserIdentityOrNull(result);
       } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- `GET /profiles/resolve` never computed the viewer-relative `relationship` field, unlike its two sibling single-profile routes (`/profiles/username/:username` and `/users/:userId`). Mention's federated profile branch resolves through this endpoint, so `followsYou` was always undefined and the "Follows you" tag never rendered for federated profiles.
- api: add `optionalUserOrServiceAuth` to `/profiles/resolve` and compute `response.relationship = getViewerRelationship(viewerId, targetId)` on both the local-first and the discovery (`resolveAndUpsert`) branches, when authenticated and non-self. Federated actors bridged into the Oxy graph are known rows, so this returns real follow edges. Mirrors the exact shape + guards of the sibling routes (present only when authed+non-self).
- core: drop the `resolveProfile` GET-cache TTL from 24h to 5 min to match the sibling profile fetches. The response now carries the viewer-relative relationship; `followsYou` is target->viewer so the viewer can't self-refresh it. The cache is identity-scoped (no cross-viewer poison), so a short TTL keeps it fresh without a per-call bypass. Bumps `@oxyhq/core` 12.5.1 -> 12.5.2.
- test: route coverage for `/profiles/resolve` mirroring `usersUserId.test.ts` (authed+followed -> followsYou:true; anon omitted; self omitted; plus the discovery branch).

## Test plan
- [x] Unit tests (route coverage mirroring `usersUserId.test.ts`)
- [x] Typecheck
- [x] Full monorepo build
- [x] `bun install --frozen-lockfile`

Already validated locally by the calling agent prior to this PR being opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>