### PR TITLE
chore(license): declare AGPL-3.0 for @oxyhq/ship

### DIFF
--- a/packages/ship/package.json
+++ b/packages/ship/package.json
@@ -2,6 +2,7 @@
   "name": "@oxyhq/ship",
   "version": "0.1.0",
   "description": "oxy-ship — publish Expo OTA updates to the Oxy Updates service",
+  "license": "AGPL-3.0-only",
   "type": "commonjs",
   "bin": {
     "oxy-ship": "dist/cli.js"


### PR DESCRIPTION
`packages/ship` is the only non-private package in OxyHQServices with no `license` field. It is `publishConfig.access: public` with `private` unset, so publishing it would ship it as **UNLICENSED**.

The AGPL relicense (#667) set the other publishable packages to `AGPL-3.0-only` but skipped ship because it had no `license` field to update. This closes that gap by matching the rest of the ecosystem.

- One line: `"license": "AGPL-3.0-only"`, placed after `description`.
- No code change, no version bump, no lockfile impact.
- ship is unpublished today, so no urgency — just closing the gap.

Note: ship is a publishing CLI, for which AGPL's network clause is an arguably-odd fit, but the owner's decision is ecosystem-wide AGPL and every other publishable package (`contracts`, `core`, `services`, `api`, `protocol`, `app-preset`, `create-oxy-app`, `expo-splash`) is `AGPL-3.0-only`, so consistency wins. Flag if a different license is preferred for dev tooling.