### PR TITLE
fix(services): useUserByUsername refetches stale cache seed under refetchOnMount:false

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -670,7 +670,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "22.7.0",
+      "version": "22.8.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "^12.9.0",

--- a/packages/services/__tests__/hooks/useAccountQueries.staleSeedRefetch.test.tsx
+++ b/packages/services/__tests__/hooks/useAccountQueries.staleSeedRefetch.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * `useUserByUsername` must honor the `upsertCachedUser` stale-seed contract
+ * even under a consuming app's global `refetchOnMount: false`.
+ *
+ * `upsertCachedUser` seeds a COLD by-username slot from a sparse feed/post
+ * author (no `createdAt`/`relationship`/`_count`) and marks it STALE
+ * (`updatedAt: 0`) so the reading hook refetches the full authoritative
+ * profile on mount. A consumer whose QueryClient sets
+ * `defaultOptions.queries.refetchOnMount: false` (a common perf setting —
+ * Mention does exactly this) would defeat that contract: the stale sparse seed
+ * is served forever and the authoritative fetch (which carries `createdAt`)
+ * never runs — the "Joined <date> missing depending on where you came from"
+ * bug. `useUserByUsername` pins `refetchOnMount: true` locally so the seed is
+ * always refetched; the 5m `staleTime` keeps a genuinely fresh entry from
+ * refetching redundantly.
+ */
+
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { User } from '@oxyhq/core';
+import { queryKeys } from '../../src/ui/hooks/queries/queryKeys';
+import { useUserByUsername } from '../../src/ui/hooks/queries/useAccountQueries';
+
+interface MockOxyServices {
+  getUserById: jest.Mock;
+  getProfileByUsername: jest.Mock;
+}
+
+interface MockOxyState {
+  oxyServices: MockOxyServices;
+  user: { id: string } | null;
+}
+
+/** What a feed/post hydration precache lands in the cache: NO `createdAt`. */
+const SPARSE_SEED: User = {
+  id: 'target-1',
+  username: 'alice',
+  name: { displayName: 'Alice' },
+} as User;
+
+/** What the authoritative single-profile fetch returns: carries `createdAt`. */
+const FULL_PROFILE: User = {
+  ...SPARSE_SEED,
+  createdAt: '2021-05-01T00:00:00.000Z',
+  relationship: { isFollowing: false, followsYou: true },
+} as User;
+
+let mockState: MockOxyState;
+
+jest.mock('../../src/ui/context/OxyContext', () => ({
+  __esModule: true,
+  useOxy: () => mockState,
+}));
+
+const makeWrapper = (queryClient: QueryClient) =>
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+
+describe('useUserByUsername stale-seed refetch under refetchOnMount:false', () => {
+  it('refetches the sparse {updatedAt:0} seed on mount and fills createdAt', async () => {
+    const getProfileByUsername = jest.fn(async () => FULL_PROFILE);
+    mockState = {
+      oxyServices: {
+        getUserById: jest.fn(async () => SPARSE_SEED),
+        getProfileByUsername,
+      },
+      // Anonymous viewer — the by-username key's viewer scope is '' here, which
+      // is exactly where a pre-session precache seeds.
+      user: null,
+    };
+
+    // A consumer QueryClient that NEVER refetches stale cache on mount by
+    // default (Mention's real setting) with the SDK's own 5m staleTime.
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          staleTime: 5 * 60 * 1000,
+          refetchOnMount: false,
+        },
+      },
+    });
+
+    // Precache the sparse author into the EXACT key the hook reads, marked STALE
+    // — mirrors upsertCachedUser seeding a cold slot from a feed author.
+    queryClient.setQueryData(queryKeys.users.byUsername('alice', ''), SPARSE_SEED, {
+      updatedAt: 0,
+    });
+
+    const { result } = renderHook(() => useUserByUsername('alice'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    // Despite the client-level refetchOnMount:false, the hook's local
+    // refetchOnMount:true refetches the stale seed and fills createdAt.
+    await waitFor(() =>
+      expect((result.current.data as User | undefined)?.createdAt).toBe(FULL_PROFILE.createdAt),
+    );
+    expect(getProfileByUsername).toHaveBeenCalledTimes(1);
+    expect(getProfileByUsername).toHaveBeenCalledWith('alice');
+    expect(queryClient.getQueryData(queryKeys.users.byUsername('alice', ''))).toEqual(FULL_PROFILE);
+  });
+
+  it('control: a fresh (recently-fetched) seed is NOT refetched — staleTime protects it', async () => {
+    const getProfileByUsername = jest.fn(async () => FULL_PROFILE);
+    mockState = {
+      oxyServices: {
+        getUserById: jest.fn(async () => SPARSE_SEED),
+        getProfileByUsername,
+      },
+      user: null,
+    };
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          staleTime: 5 * 60 * 1000,
+          refetchOnMount: false,
+        },
+      },
+    });
+
+    // Seed the SAME sparse object but mark it FRESH (fetched just now). Because
+    // it is inside the 5m staleTime window, refetchOnMount:true is a no-op —
+    // proving the override only refetches STALE seeds, never fresh entries (so
+    // no redundant refetch for a profile that just came from the real fetch).
+    queryClient.setQueryData(queryKeys.users.byUsername('alice', ''), SPARSE_SEED, {
+      updatedAt: Date.now(),
+    });
+
+    renderHook(() => useUserByUsername('alice'), {
+      wrapper: makeWrapper(queryClient),
+    });
+
+    // Give any pending microtask/refetch a chance to fire, then assert none did.
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getProfileByUsername).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(queryKeys.users.byUsername('alice', ''))).toEqual(SPARSE_SEED);
+  });
+});

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "22.7.0",
+  "version": "22.8.0",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/hooks/queries/useAccountQueries.ts
+++ b/packages/services/src/ui/hooks/queries/useAccountQueries.ts
@@ -214,6 +214,22 @@ export const useUserByUsername = (username: string | null, options?: { enabled?:
     enabled: (options?.enabled !== false) && !!username,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    // Enforce the `upsertCachedUser` stale-seed contract from THIS hook rather
+    // than relying on the consuming app's global `refetchOnMount` default.
+    // When a feed/post author is precached into the by-username key it is seeded
+    // SPARSE (no `createdAt`/`relationship`/`_count`) and marked STALE
+    // (`updatedAt: 0`) precisely so this hook refetches the full authoritative
+    // profile on mount. A consumer whose QueryClient sets
+    // `defaultOptions.queries.refetchOnMount: false` (a common perf setting —
+    // Mention does this) would otherwise serve the stale sparse seed forever and
+    // the authoritative fetch (which carries `createdAt`) would never run — the
+    // "Joined <date> missing depending on where you came from" bug. `true` (NOT
+    // `'always'`) with the 5m `staleTime` keeps it efficient: a genuinely fresh
+    // real fetch is NOT refetched, only a stale seed / >5m-old entry is.
+    // `useUserByUsername` is consumed ONLY for single-profile views (never an
+    // N-instance list), so this is exactly one fetch. `useUserById` — the card
+    // workhorse in N-instance lists — deliberately does NOT do this.
+    refetchOnMount: true,
   });
 };
 


### PR DESCRIPTION
## Summary
- `useUserByUsername` now pins `refetchOnMount: true` so a stale seeded cache entry (e.g. from a prior route's prefetch) is always revalidated on mount, instead of silently serving stale data when the app's global `refetchOnMount:false` default applies.
- Adds a regression test covering the stale-seed-under-refetchOnMount:false scenario.
- Bumps `@oxyhq/services` 22.7.0 → 22.8.0.

## Test plan
- [x] `cd packages/services && bun run test` — 41 suites / 307 tests pass
- [x] `bun run typescript` (tsc, deps built via turbo) — clean
- [x] `bun run build` (react-native-builder-bob) — succeeds
- [x] `bun pm pack` — tarball is 22.8.0; `@oxyhq/core` / `@oxyhq/contracts` deps resolve against currently published versions
- [x] Diff against `origin/main` is scoped to exactly 4 files: the hook fix, the new test, `package.json`, `bun.lock`

Not publishing to npm from this PR — the services engineer will publish after this lands on `main`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>