### PR TITLE
chore(deps): bloom 0.43.0 — secondary/tertiary tonal surfaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@oxyhq/sdk",
       "dependencies": {
         "@expo/metro-runtime": "~57.0.5",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "expo-contacts": "~57.0.1",
         "expo-splash-screen": "~57.0.4",
         "is-arrayish": "^0.3.4",
@@ -27,7 +27,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/core": "*",
         "@oxyhq/expo-splash": "workspace:*",
         "@oxyhq/services": "*",
@@ -210,7 +210,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@hugeicons/core-free-icons": "^3.3.0",
         "@hugeicons/react": "^1.1.9",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "workspace:*",
         "@oxyhq/services": "workspace:*",
@@ -265,7 +265,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@lottiefiles/dotlottie-react": "^0.19.9",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/core": "*",
         "@oxyhq/expo-splash": "workspace:*",
         "@oxyhq/services": "*",
@@ -341,7 +341,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@hugeicons/core-free-icons": "^3.3.0",
         "@hugeicons/react": "^1.1.9",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/contracts": "*",
         "@oxyhq/core": "*",
         "@oxyhq/services": "*",
@@ -524,7 +524,7 @@
         "@hugeicons/react": "^1.1.9",
         "@lottiefiles/dotlottie-react": "^0.19.9",
         "@lottiefiles/dotlottie-react-native": "^0.11.0",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/core": "*",
         "@oxyhq/services": "*",
         "@radix-ui/react-dropdown-menu": "^2.1.20",
@@ -790,7 +790,7 @@
         "@gorhom/bottom-sheet": "^5.2.14",
         "@lottiefiles/dotlottie-react": "^0.19.9",
         "@oxyhq/app-preset": "workspace:*",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/services": "*",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native/virtualized-lists": "0.86.0",
@@ -853,7 +853,7 @@
         "@fontsource-variable/inter": "^5.2.8",
         "@hugeicons/core-free-icons": "^3.3.0",
         "@hugeicons/react": "^1.1.4",
-        "@oxyhq/bloom": "^0.41.0",
+        "@oxyhq/bloom": "^0.43.0",
         "@oxyhq/core": "*",
         "@oxyhq/services": "*",
         "@tailwindcss/vite": "^4.1.17",
@@ -900,7 +900,7 @@
     "react-native-hce@0.3.0": "patches/react-native-hce@0.3.0.patch",
   },
   "overrides": {
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@radix-ui/react-slot": "1.2.3",
     "ioredis": "5.11.1",
     "lightningcss": "1.30.1",
@@ -1750,7 +1750,7 @@
 
     "@oxyhq/app-preset": ["@oxyhq/app-preset@workspace:packages/app-preset"],
 
-    "@oxyhq/bloom": ["@oxyhq/bloom@0.41.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-jyufBluqZxF/6sDTrljs6gJ6PWD8G6uCCoLo3WglJjV++lJVmzyD2tuQsQ0pndYDG7Vr8cm5p4LJeN59iCPf2Q=="],
+    "@oxyhq/bloom": ["@oxyhq/bloom@0.43.0", "", { "dependencies": { "@tanstack/react-virtual": "^3.14.3", "nanoid": "^5.1.5", "react-native-css": "3.0.7", "react-remove-scroll-bar": "^2.3.8" }, "peerDependencies": { "expo": "*", "expo-blur": "*", "expo-font": "*", "expo-haptics": "*", "expo-image": "*", "expo-router": ">=3.0.0", "nativewind": ">=5.0.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "react-native": ">=0.73.0", "react-native-gesture-handler": ">=2.0.0", "react-native-reanimated": ">=3.0.0", "react-native-safe-area-context": ">=5.0.0", "react-native-svg": ">=13.0.0", "sonner": ">=2.0.0", "sonner-native": ">=0.17.0" }, "optionalPeers": ["expo", "expo-font", "expo-haptics", "expo-router", "nativewind", "react-dom", "react-native-svg", "sonner", "sonner-native"] }, "sha512-GOZUizlYWy+50Cy+zbn2KBcqT5HWSVDd8mGPdgIIeekcmLMCh0iu4TgckukS50RkguQEmoJ4WQz0qiBWptCbAg=="],
 
     "@oxyhq/contracts": ["@oxyhq/contracts@workspace:packages/contracts"],
 

--- a/package.json
+++ b/package.json
@@ -87,13 +87,13 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "@radix-ui/react-slot": "1.2.3",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "markdown-it": "12.3.2",
     "lightningcss": "1.30.1"
   },
   "dependencies": {
     "@expo/metro-runtime": "~57.0.5",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "expo-contacts": "~57.0.1",
     "expo-splash-screen": "~57.0.4",
     "is-arrayish": "^0.3.4",

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/core": "*",
     "@oxyhq/expo-splash": "workspace:*",
     "@oxyhq/services": "*",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -16,7 +16,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@hugeicons/core-free-icons": "^3.3.0",
     "@hugeicons/react": "^1.1.9",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/contracts": "workspace:*",
     "@oxyhq/core": "workspace:*",
     "@oxyhq/services": "workspace:*",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.1.1",
     "@lottiefiles/dotlottie-react": "^0.19.9",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/core": "*",
     "@oxyhq/expo-splash": "workspace:*",
     "@oxyhq/services": "*",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -16,7 +16,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@hugeicons/core-free-icons": "^3.3.0",
     "@hugeicons/react": "^1.1.9",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/contracts": "*",
     "@oxyhq/core": "*",
     "@oxyhq/services": "*",

--- a/packages/inbox/package.json
+++ b/packages/inbox/package.json
@@ -18,7 +18,7 @@
     "@hugeicons/react": "^1.1.9",
     "@lottiefiles/dotlottie-react": "^0.19.9",
     "@lottiefiles/dotlottie-react-native": "^0.11.0",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/core": "*",
     "@oxyhq/services": "*",
     "@radix-ui/react-dropdown-menu": "^2.1.20",

--- a/packages/test-app-expo/package.json
+++ b/packages/test-app-expo/package.json
@@ -18,7 +18,7 @@
     "@gorhom/bottom-sheet": "^5.2.14",
     "@lottiefiles/dotlottie-react": "^0.19.9",
     "@oxyhq/app-preset": "workspace:*",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/services": "*",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native/virtualized-lists": "0.86.0",

--- a/packages/test-app-vite/package.json
+++ b/packages/test-app-vite/package.json
@@ -16,7 +16,7 @@
     "@fontsource-variable/inter": "^5.2.8",
     "@hugeicons/core-free-icons": "^3.3.0",
     "@hugeicons/react": "^1.1.4",
-    "@oxyhq/bloom": "^0.41.0",
+    "@oxyhq/bloom": "^0.43.0",
     "@oxyhq/core": "*",
     "@oxyhq/services": "*",
     "@tailwindcss/vite": "^4.1.17",


### PR DESCRIPTION
Bumps @oxyhq/bloom to ^0.43.0: `--secondary`/`--tertiary` map to the soft M3 container roles (shadcn-secondary = tonal surface), so `bg-secondary`/`bg-tertiary` fills read as soft brand-tinted surfaces again instead of dark/vivid slabs. Ecosystem-wide fix, no consumer changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)