### PR TITLE
feat(protocol): transparency tree + co-signable checkpoints

### DIFF
--- a/docs/superpowers/specs/2026-07-26-oxy-id-verifiability-faircoin-anchor-design.md
+++ b/docs/superpowers/specs/2026-07-26-oxy-id-verifiability-faircoin-anchor-design.md
@@ -1,0 +1,202 @@
+# Oxy ID Verifiability — Transparency Log + FairCoin Anchor
+
+**Date:** 2026-07-26
+**Status:** Approved (decision); implementation phased, not yet started
+**Owner question:** should Commons (identity + reputation) migrate to real blockchain technology — specifically, a Commons-owned chain connected to FairCoin so standing can earn rewards?
+**Decision:** No Commons-owned chain. Add a transparency log over the existing per-subject hash chains, anchor its root in **FairCoin** (`OP_RETURN`, 32-byte root, nothing else), and pay reputation rewards in FairCoin to a user-declared, identity-derived address. Reputation stays computed off-chain.
+
+## Why the question has this answer
+
+A blockchain buys exactly one thing the current design lacks: **you don't have to trust the operator**. That guarantee comes from validators that are *not* the operator — not from the data structure. Oxy already has the data structure:
+
+| Blockchain guarantee | What exists today | Evidence |
+|---|---|---|
+| Non-repudiable authorship | secp256k1-signed envelope v2, verified by the protocol engine | `packages/protocol/src/chain/verify.ts`, `engine.ts` |
+| Tamper-evident history | per-subject hash chain, `recordId = sha256(signingInput)`, `prev` → previous record | `packages/protocol/src/envelope/recordId.ts`, `chain/types.ts` |
+| No silent rewrite / no forks | continuity check `prev === head && seq === head.seq + 1`, plus a unique `(userId, seq)` index as the multi-writer backstop | `chain/continuity.ts`, `packages/api/src/models/SignedRecord.ts:116-119` |
+| O(1) head, one row per user | `RepoHead { userId, subjectDid, seq, headRecordId, recordCount }` | `packages/api/src/models/RepoHead.ts` |
+| Identity independent of any single key | `did:web` anchored on the account `_id`; keys are verification methods in `authMethods` | `packages/api/src/services/did.service.ts` |
+| Credible exit / portability | self-hostable node replicates the user's own chain and is the source of truth for it | `packages/node`, `packages/protocol/src/node/` |
+| Recovery from key loss | v2 slots + identity marker + backup/shared ladder + 12-word phrase | `packages/core/src/crypto/keyManager.ts` |
+
+What is missing is **an external witness**: nothing today stops Oxy from serving two different histories to two parties (equivocation), or from quietly suppressing a record, and nothing proves *when* a record existed. That gap is closed by a transparency log plus an anchor — not by owning a chain.
+
+### Why a Commons-owned chain is rejected
+
+1. **Validators.** A chain whose nodes are all operated by Oxy provides zero additional guarantee over the current MongoDB. It is a slower, permanently-public database. Making it real requires recruiting independent operators who cannot be switched off and who stay for years — an organizational problem no amount of code solves. Note that even the "own chain" projects are not standalone: Humanity Protocol and World Chain are rollups that publish to Ethereum and inherit its validator set.
+2. **Privacy — the disqualifying reason.** Commons' civic layer records who physically attested whom (`realLife.service.ts`) and who vouched for whose personhood (`personhood.service.ts`). On a public chain that is a permanent, correlatable graph of real-world human contact. This directly contradicts the standing owner mandate that no user IP or location may be persisted because the threat model is state-actor harassment of users (`docs/superpowers/specs/2026-07-14-no-ip-storage-design.md`). An IP is deletable; a chain entry is not.
+3. **Erasure.** Immutability and the right to erasure cannot both hold for personal data. Profile records, credential contents, and revocations must remain deletable.
+4. **Key loss.** On-chain, the key *is* the account. Oxy deliberately built the opposite: an account-anchored DID with rotatable verification methods and a recovery ladder, after the 2026-07-18 vault-wipe incident.
+5. **Cost and UX.** Gas, wallets, confirmations and block latency inside an onboarding flow that is currently "Hello Human" plus biometrics.
+
+### How web3 platforms actually do it (the pattern being adopted here)
+
+| Platform | On-chain | Off-chain (the bulk) |
+|---|---|---|
+| Farcaster | `IdRegistry`, `KeyRegistry`, `StorageRegistry` rent, recovery address (Optimism) | every message: signed CRDT sets in hubs/Snapchain, verified against the on-chain key registry. Reputation entirely off-chain (Neynar, OpenRank) |
+| Lens | profile/follow NFTs, publication pointers | content on IPFS/Arweave; had to migrate to its own L2 on cost |
+| ENS | name registry + resolvers | reads via CCIP-Read gateways and L2 |
+| EAS | schema + revocation registry, `timestamp`/`multiTimestamp` for batched roots | off-chain EIP-712 attestations stored anywhere |
+| Human Passport | only the published score, as an EAS attestation | stamps are off-chain VCs; score computed off-chain |
+| World ID / Humanity | Merkle root of the registered identity set; ZK membership + nullifier | biometric template never on-chain |
+| Ceramic | anchored stream-tip roots to Ethereum, then dropped it on cost/latency | signed event streams (same shape as our chains) |
+| Bluesky `did:plc` | nothing | a signed, publicly exportable operation log — "credible exit" instead of consensus |
+
+Nobody computes a reputation score on-chain; graph algorithms are not affordable in gas. The universal split is: **minimal registry on-chain, signed data off-chain, derived scores off-chain, ZK for privacy.** Oxy already has the middle two.
+
+Anti-patterns explicitly not copied: profile-as-NFT (Lens) makes identity **sellable**, fatal for civic identity; storage rent in ETH (Farcaster) puts a wallet in the onboarding path; and on-chain attestations of physical encounters publish the contact graph forever.
+
+## Invariant: what may ever touch a public chain
+
+Same standing as the no-IP rule. **This is not a default to be relaxed by a future change.**
+
+**Permitted on-chain, exhaustively:**
+- One 32-byte Merkle root per checkpoint period, plus a 4-byte magic and a 4-byte checkpoint index.
+- Reward payment transactions (amount + destination address).
+
+**Never on-chain, in any encoding, hashed or not:** DIDs, user ids, usernames/handles, record contents or types, the attestation/vouch/social graph, jury membership or votes, credential contents or identifiers, personhood evidence, biometric material, IP addresses or location, per-user counters, or the number of records any individual holds. A per-user datum in an `OP_RETURN` is a privacy regression even if it looks like a hash; treat any proposal to add "just one more field" as a design error.
+
+**Known, accepted leak:** a reward payment is public and links a FairCoin address to a payout. Mitigations in phase 3.
+
+## Phase 1 — Transparency log (no chain involved; prerequisite for everything else)
+
+### Model
+
+- **Leaf**, one per chained user, derived from the existing `RepoHead` row:
+  `leaf = sha256("oxy.leaf.v1" ‖ subjectDid ‖ ":" ‖ seq ‖ ":" ‖ headRecordId)`
+  Domain-separated (RFC 6962-style leaf/node prefixes) so a leaf hash can never be reinterpreted as an interior node.
+- **Tree**: leaves ordered by `subjectDid` lexicographically so any third party can recompute the root from a snapshot deterministically. Interior nodes `sha256("oxy.node.v1" ‖ left ‖ right)`.
+- **Checkpoint** (new Mongo collection, append-only, never mutated):
+  `{ index, periodEnd, treeSize, root, prevCheckpointHash, oxySignature, anchor?: { network, txid, confirmations, anchoredAt } }`
+  `prevCheckpointHash = sha256(canonicalize(previous checkpoint without its anchor))` — the checkpoint sequence is itself a hash chain, so checkpoint history cannot be rewritten after an anchor exists. Signed with the Oxy key (`OXY_PRIVATE_KEY`), the same provenance key used for custodial DID and export attestations.
+
+### Public endpoints (unauthenticated, cacheable, no CSRF)
+
+- `GET /transparency/checkpoints/latest` and `/transparency/checkpoints/:index` — the signed checkpoint.
+- `GET /transparency/proof?subject=<did>&index=<n>` — inclusion proof (audit path) for that subject's leaf in that checkpoint, plus the leaf preimage components (`seq`, `headRecordId`).
+- `GET /transparency/checkpoints?since=<index>` — the checkpoint chain, so a verifier can walk `prevCheckpointHash` links itself.
+
+A subject DID is a public identifier already served by `GET /u/:userId/did.json`, so serving a proof for it reveals nothing new. The endpoints must not accept a filter that would enumerate the full leaf set for an unauthenticated caller (rate-limit prefix `rl:transparency:read:`).
+
+### Where the code lives
+
+The tree, leaf/node hashing, proof generation, proof *verification*, and the checkpoint signing bytes live in **`packages/protocol`** (`src/transparency/`), app-agnostic like the chain engine, reusing `sha256` and `canonicalize` from `src/envelope/`. oxy-api only supplies the leaf source (a `RepoHead` cursor) and the HTTP surface; Commons and `@oxyhq/node` import the verifier. Response shapes go in `@oxyhq/contracts` and, per the standing rule, **contracts publishes before any consumer**.
+
+**Implemented** (`packages/protocol/src/transparency/`, 30 tests in `src/__tests__/transparency.test.ts`): `transparencyLeafHash`, `buildTransparencyTree`, `buildTransparencyTreeFromHeads`, `inclusionProof`, `verifyInclusionProof`, `EMPTY_TRANSPARENCY_ROOT`, `checkpointSigningInput`, `checkpointHash`, `signCheckpoint`, `verifyCheckpointSignature`. The tree follows RFC 6962 (Certificate Transparency) so it is independently reimplementable; leaf and interior hashes use distinct domain prefixes; `buildTransparencyTreeFromHeads` owns the canonical ordering (ascending `subjectDid`, UTF-16 code-unit order — never `localeCompare`, which is locale-dependent and would make two verifiers disagree on the root) and throws on a duplicate subject rather than committing to one of two heads.
+
+### What this proves, and what it does not
+
+Proves: at checkpoint *N*, Oxy committed to a specific head for a specific subject, and it published exactly one root for that period (verifiable once anchored). A client or node holding its own inclusion proofs across checkpoints detects any rollback, fork, or suppression of *its* chain, because a later checkpoint must show a head that extends the earlier one.
+
+Does not prove, by itself: that no record was removed for a user who never checks. This is a state-snapshot tree, not a per-entry append-only log — the accepted trade-off for a tree with one leaf per user instead of one per record. Commons and `@oxyhq/node` therefore **persist their own latest proof** and re-verify on each new checkpoint; that turns the guarantee from "auditable in principle" into "audited continuously by every device". Upgrade path if ever needed: add a second, CT-style append-only log of `recordId`s with real consistency proofs.
+
+### Witnesses (sub-phase, and the piece that makes equivocation undeniable)
+
+Independent parties co-sign each checkpoint root and serve what they signed. Detection then requires no cooperation from Oxy: two roots for one period, signed by disjoint witness sets, is proof of misbehaviour. Candidates and their operating requirements are an open question below; the checkpoint schema carries `witnessSignatures[]` from day one so adding them is not a migration.
+
+**Do not confuse this with the existing `NodeIngestWitness`** (`packages/api/src/models/NodeIngestWitness.ts`): that is *Oxy* counter-signing each record it ingests from a user's own node, so a later rewrite signed with a stolen user key cannot deny the original content. It is prior art for the same threat model from the opposite direction — it protects the user's history against the user's own key being stolen; the transparency log protects it against Oxy. The two are complementary and neither replaces the other. Name the new field/collection so the distinction is obvious in code (`checkpointWitnessSignatures`, not `witnesses`).
+
+### Scheduling and failure behaviour
+
+Reuse the existing fleet-safe job pattern rather than inventing one: BullMQ repeatable job with a stable scheduler id when `REDIS_URL` is set (exactly one schedule fleet-wide — the leader-gated effect), with an unref'd in-process interval fallback when it isn't. See `packages/api/src/queue/nodeIngest.queue.ts` (and its sibling `backgroundJobs.ts`) for the exact shape, including the `.unref?.()` requirement on any interval. There is no `LeaderElection` primitive in oxy-api; do not port one for this.
+
+The real mutex is the **unique index on `Checkpoint.index`**: if two tasks ever compute the same period concurrently they will produce slightly different roots, and only one insert survives. The loser must abandon its root entirely and re-read the persisted checkpoint — it must never retry with its own recomputed root, and the anchoring step must always anchor the *persisted* root, never a locally computed one. **Two signed roots for one period is precisely the equivocation this system exists to detect**, so this is a correctness constraint, not a race-condition nicety.
+
+If checkpoint computation fails, record writes are unaffected — the log falls behind and resumes; gaps in `index` are never allowed, so a missed period is computed late to keep the chain contiguous.
+
+## Phase 2 — FairCoin anchor
+
+FairCoin is used because it already exists, already has nodes outside Oxy, and accepts arbitrary data. Verified facts:
+
+| Fact | Evidence |
+|---|---|
+| Bitcoin/PIVX-derived; PoW→PoS boundary at block 10000; masternodes | `~/FairCoinWorkspace/FairCoin/src/chainparams.cpp:338`, `src/activemasternode.cpp` |
+| Mainnet port 46372, DNS seeds `seed1/seed2.fairco.in`, 2-minute target spacing | `chainparams.cpp:380`, `:389`, `:416` |
+| Testnet port 46374, seeds `testnet-seed1/2.fairco.in` | `chainparams.cpp:468`, `:490` |
+| `OP_RETURN` relayed and mined by default; carrier limit is **83 bytes of `scriptPubKey`** (so ≈80 bytes of payload after the `OP_RETURN` opcode and pushdata prefix), tunable via `-datacarriersize` | `src/script/standard.h:28` (`MAX_OP_RETURN_RELAY = 83`), `src/script/standard.cpp:198` (`scriptPubKey.size() > nMaxDatacarrierBytes`), `src/init.cpp:477-478`, `:880` |
+| Published JSON-RPC client | `@fairco.in/rpc-client@^0.1.1` (`~/FairCoinWorkspace/Explorer/package.json:21`) |
+| Raw-tx build/sign/broadcast without importing a wallet key into the node | `~/FairCoinWorkspace/Explorer/server/mcp/wallet-tools.ts` (`createrawtransaction` → `signrawtransaction` with a WIF → `sendrawtransaction`) |
+| UTXO read path requires `addressindex=1` on the node | `wallet-tools.ts:145-158` (`getaddressutxos`, with an explicit error when the index is off) |
+
+### Payload
+
+`OXY1` (4 bytes, ASCII) ‖ `uint32be(checkpoint.index)` ‖ `root` (32 bytes) = **40 bytes of payload**, i.e. 42–43 bytes of `scriptPubKey` including the opcode and pushdata — half the 83-byte policy ceiling, so no node needs a non-default `-datacarriersize`. No length-prefix games and no versioning inside the root: a new format gets a new magic (`OXY2`).
+
+### Operation
+
+- **Cadence:** proposal every 6 hours (4 transactions/day). Cost is negligible at FairCoin fee levels; the cadence bounds how long an equivocation can go unanchored, so it is a security parameter, not a cost parameter.
+- **Idempotence is a security property.** A checkpoint index maps to exactly one root and at most one anchoring attempt in flight. Retries must rebroadcast the *same* payload; the job must never compute a second root for an index that was already published. Store `txid` on the checkpoint on broadcast and reconcile confirmations on a later pass.
+- **Anchor wallet:** a dedicated key, held in SSM (`/oxy/oxy-api/FAIRCOIN_ANCHOR_WIF`), completely separate from the identity vault and from any user funds. It signs only anchor transactions. Needs monitoring for balance and a documented top-up procedure; a failed anchor degrades to "checkpoint published, not yet anchored" and never blocks record writes.
+- **Node access:** an Oxy-reachable `faircoind` with `-datacarrier=1` (default) and `addressindex=1` (required by the UTXO read path above), or a small hosted RPC endpoint. Confirm before committing to this phase.
+- **User-facing verification:** the checkpoint exposes its `txid`, and the FairCoin Explorer already renders transactions — "check it yourself on the blockchain" needs no new infrastructure. Optionally the Explorer grows an "Oxy checkpoint" view that decodes the `OXY1` payload.
+
+### Authorized FairCoin-side changes
+
+The owner has authorized improving FairCoin where needed. Minimum required:
+
+1. Extend the raw-tx path in `~/FairCoinWorkspace/Explorer/server/mcp/wallet-tools.ts` to build a `data` (`OP_RETURN`) output alongside the change output, and type it in `@fairco.in/rpc-client`. This is the only functional gap — the daemon already supports it.
+2. Verify `-datacarrier`/`-datacarriersize` on whichever node Oxy uses, and that a 40-byte `OP_RETURN` relays and confirms on mainnet (test on testnet first).
+
+Nothing in the FairCoin consensus code needs to change.
+
+### Bitcoin/OpenTimestamps as an additional anchor
+
+If the census of independent FairCoin nodes turns out to be thin, an additional OpenTimestamps anchor (free, batched, on Bitcoin) gives a much larger independent validator set for the timestamp claim. It is additive — same root, second witness — and is decided by the census, not by preference. The checkpoint's `anchor` field is therefore an array-capable shape from the start.
+
+## Phase 3 — Reputation rewards in FairCoin
+
+### What stays off-chain
+
+The reputation ledger and every derived score (`reputation.service.ts`, `ReputationTransaction`/`ReputationBalance`). No web3 platform computes this on-chain, and the trust-tier/influence math is a graph aggregate. What goes on-chain is **only the payment**.
+
+### Destination address
+
+`KeyManager.deriveScopedSeed('oxypay/faircoin/v1')` (`packages/core/src/crypto/keyManager.ts:2624`) already derives a domain-separated 32-byte seed from the on-device identity key via HKDF, without exposing the private key, and reproducible from the user's 12-word phrase. So a user's FairCoin wallet is already a function of their Oxy ID and survives device loss.
+
+The server **cannot** derive that address (the input key never leaves the device). Therefore the client publishes it: a signed record on the user's own chain, collection `app.oxy.payout`, `rkey` `faircoin`, containing the address (and the HD derivation index used). This is the right shape — no wallet-linking UI, no server-side key custody, the declaration is self-signed and auditable, and it goes through the existing `verifyAndStoreRecord` path with no new trust assumption. A payout with no such record is simply not paid.
+
+### Payment path
+
+Oxy publishes an Oxy-signed reward record (reusing the existing `emitAttestation` mechanism that already writes `reputation_attestation` records onto the earner's chain — `reputation.service.ts:274`, called from `realLife.service.ts:228`, `validator.service.ts:432`, `personhood.service.ts:354`), then pays the declared address. Because the reward record lands in a chain whose head gets anchored, the payout is auditable against the anchored checkpoint: the promise is timestamped, and the payment is on a public chain.
+
+### Hard rules
+
+- **Verification is never purchasable and never conditional on money.** Rewards recognise *service* — correct jury votes, valid real-life attestations — never status, and never "pay to be verified". A design where funds influence personhood is rejected outright.
+- Payouts are **opt-in**: no `app.oxy.payout` record, no payment, no on-chain footprint.
+- **Privacy disclosure, in the UI, before opt-in:** a payout is public and permanently links that FairCoin address to reward activity, and the address is declared in a public signed record — so opting in links an Oxy identity to on-chain economic activity. Mitigations: a fresh derived address per payout (index declared in the record), and one transaction per payout rather than batching many recipients into one transaction (a batched transaction publicly links every co-recipient). Batching is a privacy regression, not an optimisation.
+
+### Explicitly out of scope here
+
+Economic staking/slashing for validators (FairCoin at risk when a juror votes badly). It is coherent with the existing `vouch_slashed` mechanics, but it is a separate decision requiring: a custody model for stake, a dispute path that cannot be gamed by whoever holds more coin, and an answer to "does staking price ordinary users out of jury service". Revisit only after phase 1 is in production.
+
+## Phase 4 — web3 interoperability (optional, later)
+
+Designed but not committed: export records as EAS-compatible off-chain attestations (EIP-712); add `did:pkh` as an additional verification method on the existing `did:web` so an Ethereum address can be bound to the same account; selective disclosure (SD-JWT / BBS+) so a user can prove personhood or a standing threshold to an external verifier without revealing the underlying graph. All of it is additive to the off-chain core and none of it requires a chain of our own.
+
+## Rollout order
+
+1. ✅ **Done** — `@oxyhq/protocol` transparency tree, proof verifier, and co-signable checkpoint primitives, with tests (unpublished; `@oxyhq/protocol` still needs a version bump + publish before oxy-api can consume it from `dist/`). Next: `@oxyhq/contracts` checkpoint/proof schemas, published **first** per the standing rule.
+2. oxy-api: `Checkpoint` model, leader-elected checkpoint job, public read endpoints, rate-limit prefix. Done when a third party can recompute the root from a snapshot and verify an inclusion proof independently.
+3. FairCoin `data`-output support + testnet smoke test. Done when a 40-byte `OP_RETURN` is broadcast and read back by RPC on testnet, then mainnet.
+4. Anchoring job + `anchor` reconciliation + Commons/node continuous verification UI. Done when a user can see their own head anchored in a FairCoin transaction and the client detects a tampered proof.
+5. Witnesses.
+6. Payout records + payments (independent of 5).
+
+Phases 1–2 are additive and reversible: removing the checkpoint job and endpoints leaves the record chains untouched. Phase 3 is not reversible in the sense that published payments are permanent — which is why the disclosure and opt-in are part of the design, not follow-ups.
+
+## Open questions
+
+1. Checkpoint cadence (proposal: 6h) and whether the anchor cadence should differ from the checkpoint cadence.
+2. Who the witnesses are, and what they must run.
+3. **Census of FairCoin nodes/masternodes not operated by Oxy.** This determines how much the anchor is worth and whether OpenTimestamps is also required.
+4. Source and rate of reward emission (treasury? fee share?), and the cap that keeps it sustainable.
+5. Whether the FairCoin Explorer hosts an "Oxy checkpoint" decoder view.
+6. Whether the anchor uses an Oxy-operated `faircoind` (needs `addressindex=1`) or a hosted RPC.
+
+## Testing
+
+1. **Protocol unit tests** (`packages/protocol`): leaf/node domain separation, deterministic root over a fixed sorted leaf set, inclusion proof round-trip, and negative cases — a mutated `headRecordId`, a mutated `seq`, a leaf moved to a different index, and a proof from a different checkpoint must all fail verification.
+2. **Read-only production dry run:** count `RepoHead` rows and compute a root from a snapshot in a read-only script, to size the tree and the job's runtime. No writes.
+3. **Testnet anchor smoke test** before committing to phase 2: run `faircoind` on testnet (port 46374, seeds `testnet-seed1/2.fairco.in`), build a 40-byte `OP_RETURN` transaction through the raw-tx path, broadcast it, and read it back via RPC. If this fails, phase 2 changes shape and this document must be revised.
+4. **Red-team scenarios, each of which must be detected:** (a) Oxy alters a stored record — the client's next inclusion proof mismatches its retained head; (b) Oxy hides a record — the anchored head fails to extend the previously anchored head; (c) Oxy publishes two roots for one period — the unique index blocks it, and if it happened anyway only one is anchored, and the witnesses hold the other; (d) Oxy rewrites checkpoint history — `prevCheckpointHash` breaks against an already-anchored root. If any scenario is undetectable, the design is wrong.
+5. **Owner review** of the on-chain privacy invariant and of the "verification is never purchasable" rule.

--- a/packages/protocol/src/__tests__/transparency.test.ts
+++ b/packages/protocol/src/__tests__/transparency.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Transparency-log tests — leaf hashing, the Merkle tree, inclusion proofs, and
+ * the co-signable checkpoint.
+ *
+ * These lock the properties a third party depends on when auditing Oxy without
+ * trusting it: a root recomputable from a snapshot in any order, an inclusion
+ * proof verifiable from ONLY the verifier's own leaf (never the full leaf set),
+ * and a checkpoint whose signing bytes are identical for every independent
+ * co-signer (Oxy plus witness nodes).
+ */
+
+import { ec as EC } from 'elliptic';
+import {
+  sha256,
+  transparencyLeafHash,
+  buildTransparencyTree,
+  buildTransparencyTreeFromHeads,
+  inclusionProof,
+  verifyInclusionProof,
+  EMPTY_TRANSPARENCY_ROOT,
+  checkpointSigningInput,
+  checkpointHash,
+  signCheckpoint,
+  verifyCheckpointSignature,
+  type TransparencyHeadEntry,
+  type TransparencyCheckpointFields,
+} from '../index';
+
+const ec = new EC('secp256k1');
+
+const HEAD_A: TransparencyHeadEntry = {
+  subjectDid: 'did:web:oxy.so:u:aaa',
+  seq: 4,
+  headRecordId: 'a'.repeat(64),
+};
+const HEAD_B: TransparencyHeadEntry = {
+  subjectDid: 'did:web:oxy.so:u:bbb',
+  seq: 0,
+  headRecordId: 'b'.repeat(64),
+};
+const HEAD_C: TransparencyHeadEntry = {
+  subjectDid: 'did:web:oxy.so:u:ccc',
+  seq: 17,
+  headRecordId: 'c'.repeat(64),
+};
+
+/** `n` distinct head entries, deterministic. */
+function heads(n: number): TransparencyHeadEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    subjectDid: `did:web:oxy.so:u:${String(i).padStart(3, '0')}`,
+    seq: i,
+    headRecordId: String(i).padStart(64, '0'),
+  }));
+}
+
+describe('transparencyLeafHash', () => {
+  it('is deterministic for the same head', async () => {
+    expect(await transparencyLeafHash(HEAD_A)).toBe(await transparencyLeafHash(HEAD_A));
+  });
+
+  it('changes when seq advances', async () => {
+    const before = await transparencyLeafHash(HEAD_A);
+    const after = await transparencyLeafHash({ ...HEAD_A, seq: HEAD_A.seq + 1 });
+    expect(after).not.toBe(before);
+  });
+
+  it('changes when the head record id changes', async () => {
+    const tampered = await transparencyLeafHash({ ...HEAD_A, headRecordId: 'd'.repeat(64) });
+    expect(tampered).not.toBe(await transparencyLeafHash(HEAD_A));
+  });
+
+  it('changes when the subject changes', async () => {
+    const other = await transparencyLeafHash({ ...HEAD_A, subjectDid: HEAD_B.subjectDid });
+    expect(other).not.toBe(await transparencyLeafHash(HEAD_A));
+  });
+
+  it('is domain-separated, so it is never a bare hash of the concatenated fields', async () => {
+    const bare = await sha256(`${HEAD_A.subjectDid}${HEAD_A.seq}${HEAD_A.headRecordId}`);
+    expect(await transparencyLeafHash(HEAD_A)).not.toBe(bare);
+  });
+});
+
+describe('buildTransparencyTree', () => {
+  it('gives the empty tree a fixed, domain-separated root', async () => {
+    const tree = await buildTransparencyTree([]);
+    expect(tree.treeSize).toBe(0);
+    expect(tree.root).toBe(EMPTY_TRANSPARENCY_ROOT);
+  });
+
+  it('pins the empty root to the hash of its domain string', async () => {
+    // The constant is hard-coded (the hash is async), so this pins it against
+    // an accidental edit: a changed empty root changes every empty checkpoint.
+    expect(EMPTY_TRANSPARENCY_ROOT).toBe(await sha256('oxy.transparency.empty.v1'));
+  });
+
+  it('uses the leaf itself as the root of a single-leaf tree', async () => {
+    const leaf = await transparencyLeafHash(HEAD_A);
+    const tree = await buildTransparencyTree([leaf]);
+    expect(tree.root).toBe(leaf);
+    expect(tree.treeSize).toBe(1);
+  });
+
+  it('hashes a two-leaf tree as one interior node over the ordered pair', async () => {
+    const l0 = await transparencyLeafHash(HEAD_A);
+    const l1 = await transparencyLeafHash(HEAD_B);
+    const tree = await buildTransparencyTree([l0, l1]);
+    expect(tree.root).toBe(await sha256(`oxy.transparency.node.v1:${l0}${l1}`));
+  });
+
+  it('is order-sensitive at the leaf level (swapping two leaves changes the root)', async () => {
+    const l0 = await transparencyLeafHash(HEAD_A);
+    const l1 = await transparencyLeafHash(HEAD_B);
+    const forward = await buildTransparencyTree([l0, l1]);
+    const reversed = await buildTransparencyTree([l1, l0]);
+    expect(reversed.root).not.toBe(forward.root);
+  });
+
+  it('splits an odd tree so the left subtree is the largest power of two below the size', async () => {
+    const l = await Promise.all([HEAD_A, HEAD_B, HEAD_C].map(transparencyLeafHash));
+    const left = await sha256(`oxy.transparency.node.v1:${l[0]}${l[1]}`);
+    const tree = await buildTransparencyTree(l);
+    expect(tree.root).toBe(await sha256(`oxy.transparency.node.v1:${left}${l[2]}`));
+  });
+});
+
+describe('buildTransparencyTreeFromHeads', () => {
+  it('sorts by subject did, so the root does not depend on the input order', async () => {
+    const sorted = await buildTransparencyTreeFromHeads([HEAD_A, HEAD_B, HEAD_C]);
+    const shuffled = await buildTransparencyTreeFromHeads([HEAD_C, HEAD_A, HEAD_B]);
+    expect(shuffled.root).toBe(sorted.root);
+    expect(shuffled.treeSize).toBe(3);
+  });
+
+  it('reports the leaf index of each subject so a proof can be served', async () => {
+    const tree = await buildTransparencyTreeFromHeads([HEAD_C, HEAD_A, HEAD_B]);
+    expect(tree.indexBySubject[HEAD_A.subjectDid]).toBe(0);
+    expect(tree.indexBySubject[HEAD_B.subjectDid]).toBe(1);
+    expect(tree.indexBySubject[HEAD_C.subjectDid]).toBe(2);
+  });
+
+  it('rejects a duplicate subject rather than silently committing to one of them', async () => {
+    await expect(buildTransparencyTreeFromHeads([HEAD_A, HEAD_A])).rejects.toThrow(/duplicate/i);
+  });
+});
+
+describe('verifyInclusionProof', () => {
+  it('verifies every leaf of every tree size from 1 to 9', async () => {
+    for (let size = 1; size <= 9; size++) {
+      const entries = heads(size);
+      const tree = await buildTransparencyTreeFromHeads(entries);
+      for (let index = 0; index < size; index++) {
+        const leaf = await transparencyLeafHash(entries[index]);
+        const proof = await inclusionProof(tree.leaves, index);
+        await expect(
+          verifyInclusionProof({ leaf, index, treeSize: size, proof, root: tree.root }),
+        ).resolves.toBe(true);
+      }
+    }
+  });
+
+  it('verifies from the leaf alone, without the rest of the leaf set', async () => {
+    const entries = heads(7);
+    const tree = await buildTransparencyTreeFromHeads(entries);
+    const proof = await inclusionProof(tree.leaves, 5);
+    const leaf = await transparencyLeafHash(entries[5]);
+    // Only the verifier's own leaf, its index, the tree size, the path and the
+    // signed root — the full leaf set is never needed.
+    await expect(
+      verifyInclusionProof({ leaf, index: 5, treeSize: 7, proof, root: tree.root }),
+    ).resolves.toBe(true);
+  });
+
+  it('fails when the head record id was tampered with after the checkpoint', async () => {
+    const entries = heads(5);
+    const tree = await buildTransparencyTreeFromHeads(entries);
+    const proof = await inclusionProof(tree.leaves, 2);
+    const tamperedLeaf = await transparencyLeafHash({ ...entries[2], headRecordId: 'f'.repeat(64) });
+    await expect(
+      verifyInclusionProof({ leaf: tamperedLeaf, index: 2, treeSize: 5, proof, root: tree.root }),
+    ).resolves.toBe(false);
+  });
+
+  it('fails when a chain was rolled back to an earlier seq', async () => {
+    const entries = heads(5);
+    const tree = await buildTransparencyTreeFromHeads(entries);
+    const proof = await inclusionProof(tree.leaves, 3);
+    const rolledBack = await transparencyLeafHash({ ...entries[3], seq: entries[3].seq - 1 });
+    await expect(
+      verifyInclusionProof({ leaf: rolledBack, index: 3, treeSize: 5, proof, root: tree.root }),
+    ).resolves.toBe(false);
+  });
+
+  it('fails when the proof is replayed at a different index', async () => {
+    const entries = heads(6);
+    const tree = await buildTransparencyTreeFromHeads(entries);
+    const proof = await inclusionProof(tree.leaves, 1);
+    const leaf = await transparencyLeafHash(entries[1]);
+    await expect(
+      verifyInclusionProof({ leaf, index: 2, treeSize: 6, proof, root: tree.root }),
+    ).resolves.toBe(false);
+  });
+
+  it('fails against the root of a different checkpoint', async () => {
+    const entries = heads(4);
+    const tree = await buildTransparencyTreeFromHeads(entries);
+    const otherTree = await buildTransparencyTreeFromHeads(heads(5));
+    const proof = await inclusionProof(tree.leaves, 0);
+    const leaf = await transparencyLeafHash(entries[0]);
+    await expect(
+      verifyInclusionProof({ leaf, index: 0, treeSize: 4, proof, root: otherTree.root }),
+    ).resolves.toBe(false);
+  });
+
+  it('fails when the proof path is truncated', async () => {
+    const entries = heads(8);
+    const tree = await buildTransparencyTreeFromHeads(entries);
+    const proof = await inclusionProof(tree.leaves, 0);
+    await expect(
+      verifyInclusionProof({
+        leaf: await transparencyLeafHash(entries[0]),
+        index: 0,
+        treeSize: 8,
+        proof: proof.slice(0, -1),
+        root: tree.root,
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('rejects an index outside the tree instead of verifying', async () => {
+    const entries = heads(3);
+    const tree = await buildTransparencyTreeFromHeads(entries);
+    await expect(inclusionProof(tree.leaves, 3)).rejects.toThrow(/index/i);
+  });
+});
+
+describe('checkpoint signing', () => {
+  const fields: TransparencyCheckpointFields = {
+    index: 42,
+    periodEnd: 1_800_000_000_000,
+    treeSize: 3,
+    root: 'e'.repeat(64),
+    prevCheckpointHash: '9'.repeat(64),
+  };
+
+  it('produces stable, domain-separated signing bytes', async () => {
+    expect(checkpointSigningInput(fields)).toBe(checkpointSigningInput({ ...fields }));
+    expect(checkpointSigningInput(fields)).toContain('oxy.transparency.checkpoint.v1:');
+  });
+
+  it('does not depend on the key order of the fields object', () => {
+    const reordered: TransparencyCheckpointFields = {
+      prevCheckpointHash: fields.prevCheckpointHash,
+      root: fields.root,
+      treeSize: fields.treeSize,
+      periodEnd: fields.periodEnd,
+      index: fields.index,
+    };
+    expect(checkpointSigningInput(reordered)).toBe(checkpointSigningInput(fields));
+  });
+
+  it('changes the hash when the root changes', async () => {
+    const other = await checkpointHash({ ...fields, root: 'f'.repeat(64) });
+    expect(other).not.toBe(await checkpointHash(fields));
+  });
+
+  it('changes the hash when the previous checkpoint link changes', async () => {
+    const other = await checkpointHash({ ...fields, prevCheckpointHash: '8'.repeat(64) });
+    expect(other).not.toBe(await checkpointHash(fields));
+  });
+
+  it('verifies a signature made by the signer', async () => {
+    const key = ec.genKeyPair();
+    const signature = await signCheckpoint(fields, key.getPrivate('hex'));
+    expect(signature.alg).toBe('ES256K-DER-SHA256');
+    expect(signature.publicKey).toBe(key.getPublic('hex'));
+    await expect(verifyCheckpointSignature(fields, signature)).resolves.toBe(true);
+  });
+
+  it('rejects a signature once any signed field is altered', async () => {
+    const key = ec.genKeyPair();
+    const signature = await signCheckpoint(fields, key.getPrivate('hex'));
+    await expect(
+      verifyCheckpointSignature({ ...fields, treeSize: fields.treeSize + 1 }, signature),
+    ).resolves.toBe(false);
+  });
+
+  it('lets independent co-signers sign the identical bytes, so witnesses need no coordination', async () => {
+    const oxy = ec.genKeyPair();
+    const witnessOne = ec.genKeyPair();
+    const witnessTwo = ec.genKeyPair();
+    const signatures = await Promise.all(
+      [oxy, witnessOne, witnessTwo].map((k) => signCheckpoint(fields, k.getPrivate('hex'))),
+    );
+    for (const signature of signatures) {
+      await expect(verifyCheckpointSignature(fields, signature)).resolves.toBe(true);
+    }
+    // Distinct signers, distinct signatures, one set of signed bytes.
+    expect(new Set(signatures.map((s) => s.signature)).size).toBe(3);
+  });
+
+  it('does not accept a signature from one checkpoint on the next one', async () => {
+    const key = ec.genKeyPair();
+    const signature = await signCheckpoint(fields, key.getPrivate('hex'));
+    const next: TransparencyCheckpointFields = {
+      ...fields,
+      index: fields.index + 1,
+      prevCheckpointHash: await checkpointHash(fields),
+    };
+    await expect(verifyCheckpointSignature(next, signature)).resolves.toBe(false);
+  });
+});

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -41,6 +41,34 @@ export type { VerifyOptions } from './chain/verify';
 export { verifyAndAppend } from './chain/engine';
 
 // ---------------------------------------------------------------------------
+// Transparency — Merkle commitment over chain heads + co-signable checkpoints
+// ---------------------------------------------------------------------------
+export {
+  EMPTY_TRANSPARENCY_ROOT,
+  transparencyLeafHash,
+  buildTransparencyTree,
+  buildTransparencyTreeFromHeads,
+  inclusionProof,
+  verifyInclusionProof,
+} from './transparency/tree';
+export type {
+  TransparencyHeadEntry,
+  TransparencyTree,
+  TransparencyTreeFromHeads,
+  InclusionProofCheck,
+} from './transparency/tree';
+export {
+  checkpointSigningInput,
+  checkpointHash,
+  signCheckpoint,
+  verifyCheckpointSignature,
+} from './transparency/checkpoint';
+export type {
+  TransparencyCheckpointFields,
+  TransparencyCheckpointSignature,
+} from './transparency/checkpoint';
+
+// ---------------------------------------------------------------------------
 // Identity — injected verification-method resolution + authorization rule
 // ---------------------------------------------------------------------------
 export { isAuthorizedKey } from './identity/resolver';

--- a/packages/protocol/src/transparency/checkpoint.ts
+++ b/packages/protocol/src/transparency/checkpoint.ts
@@ -1,0 +1,109 @@
+/**
+ * Transparency checkpoint — the signed, hash-linked commitment to a tree root.
+ *
+ * A checkpoint is what the operator PUBLISHES: "at `periodEnd` I committed to
+ * `root` over `treeSize` subjects, and the previous checkpoint hashed to
+ * `prevCheckpointHash`". The `prevCheckpointHash` link makes the checkpoint
+ * sequence itself append-only: once any checkpoint is anchored publicly, none of
+ * its ancestors can be rewritten without breaking the chain of hashes.
+ *
+ * ## Why the signature covers ONLY the five fields
+ *
+ * The signing input is derived from exactly `{index, periodEnd, treeSize, root,
+ * prevCheckpointHash}` — never from the surrounding storage document, and never
+ * from other signatures. That is what makes a checkpoint CO-SIGNABLE: the
+ * operator and any number of independent witnesses (e.g. user-run
+ * `@oxyhq/node` deployments) each sign the identical bytes with their own key,
+ * with zero coordination and in any order. Two conflicting roots for one
+ * `index`, each carrying valid signatures, is then transferable proof of
+ * equivocation that needs no cooperation from the operator to demonstrate.
+ *
+ * Extra fields on the object passed in are ignored by design, so handing this a
+ * database document cannot change what was signed.
+ */
+
+import { canonicalize } from '../envelope/canonicalJson';
+import { sha256 } from '../envelope/recordId';
+import { signMessage, verifySignature } from '../envelope/sign';
+import { derivePublicKeyHex } from '../envelope/secp256k1';
+
+/** Domain prefix for checkpoint signing bytes. */
+const CHECKPOINT_PREFIX = 'oxy.transparency.checkpoint.v1:';
+
+/** The one signature algorithm the protocol emits. */
+const ALG = 'ES256K-DER-SHA256' as const;
+
+/** The signed body of a checkpoint. */
+export interface TransparencyCheckpointFields {
+  /** Monotonic checkpoint number; gapless. */
+  index: number;
+  /** End of the period this checkpoint commits to (ms epoch). */
+  periodEnd: number;
+  /** Number of leaves (subjects) committed. */
+  treeSize: number;
+  /** The Merkle root over the committed heads. */
+  root: string;
+  /** {@link checkpointHash} of the previous checkpoint; `null` at the first one. */
+  prevCheckpointHash: string | null;
+}
+
+/** One signer's endorsement of a checkpoint — the operator's or a witness's. */
+export interface TransparencyCheckpointSignature {
+  /** Uncompressed hex public key of the signer. */
+  publicKey: string;
+  alg: typeof ALG;
+  /** DER-encoded hex secp256k1 signature over {@link checkpointSigningInput}. */
+  signature: string;
+}
+
+/**
+ * The exact bytes every co-signer signs: the canonical JSON of the five signed
+ * fields under the checkpoint domain prefix. Key order in the input object is
+ * irrelevant; extra properties are dropped.
+ */
+export function checkpointSigningInput(fields: TransparencyCheckpointFields): string {
+  return `${CHECKPOINT_PREFIX}${canonicalize({
+    index: fields.index,
+    periodEnd: fields.periodEnd,
+    treeSize: fields.treeSize,
+    root: fields.root,
+    prevCheckpointHash: fields.prevCheckpointHash,
+  })}`;
+}
+
+/**
+ * The content address of a checkpoint — what the NEXT checkpoint's
+ * `prevCheckpointHash` references.
+ */
+export async function checkpointHash(fields: TransparencyCheckpointFields): Promise<string> {
+  return sha256(checkpointSigningInput(fields));
+}
+
+/**
+ * Sign a checkpoint with an explicit private key. Used by the operator and,
+ * identically, by every witness that co-signs the same checkpoint.
+ */
+export async function signCheckpoint(
+  fields: TransparencyCheckpointFields,
+  privateKeyHex: string,
+): Promise<TransparencyCheckpointSignature> {
+  return {
+    publicKey: derivePublicKeyHex(privateKeyHex),
+    alg: ALG,
+    signature: await signMessage(checkpointSigningInput(fields), privateKeyHex),
+  };
+}
+
+/**
+ * Verify one signature over a checkpoint's signed fields.
+ *
+ * Confirms the signature matches the embedded `publicKey` for exactly these
+ * fields. It does NOT establish that the key belongs to a trusted operator or an
+ * accepted witness — that policy lives with the verifier's key list.
+ */
+export async function verifyCheckpointSignature(
+  fields: TransparencyCheckpointFields,
+  signature: TransparencyCheckpointSignature,
+): Promise<boolean> {
+  return verifySignature(checkpointSigningInput(fields), signature.signature, signature.publicKey);
+}

--- a/packages/protocol/src/transparency/tree.ts
+++ b/packages/protocol/src/transparency/tree.ts
@@ -1,0 +1,240 @@
+/**
+ * Transparency Merkle tree — leaf hashing, root computation, and inclusion
+ * proofs over a snapshot of chain heads.
+ *
+ * ## What this is for
+ *
+ * A per-subject hash chain proves nobody edited a record. It does NOT prove the
+ * SERVER didn't serve two different histories to two parties (equivocation), or
+ * quietly drop a record. That gap is closed by committing to every subject's
+ * chain head at once, publishing the commitment, and letting anyone verify that
+ * their own head is inside it — which is exactly what this tree does. The
+ * commitment (the root) is what gets signed into a checkpoint (`./checkpoint`)
+ * and anchored on a public chain.
+ *
+ * ## Shape
+ *
+ * The tree follows RFC 6962 (Certificate Transparency) so the algorithms are
+ * standard and independently reimplementable: leaves and interior nodes are
+ * hashed under DISTINCT domain prefixes (a leaf hash can never be reinterpreted
+ * as an interior node), an odd level splits so the LEFT subtree is the largest
+ * power of two below the size, and a single-leaf tree's root is the leaf itself.
+ *
+ * Crucially, {@link verifyInclusionProof} needs only the verifier's OWN leaf,
+ * its index, the tree size, the audit path, and the signed root — never the
+ * other leaves. So a device or node can audit its own history against a
+ * published checkpoint without downloading anyone else's data.
+ *
+ * The leaf order is fixed by {@link buildTransparencyTreeFromHeads}: ascending
+ * by `subjectDid` in UTF-16 code-unit order. Order is part of the commitment, so
+ * every implementation MUST sort identically or the roots diverge.
+ */
+
+import { sha256 } from '../envelope/recordId';
+import { canonicalize } from '../envelope/canonicalJson';
+
+/** Domain prefix for a leaf hash. Distinct from {@link NODE_PREFIX}. */
+const LEAF_PREFIX = 'oxy.transparency.leaf.v1:';
+/** Domain prefix for an interior node hash. Distinct from {@link LEAF_PREFIX}. */
+const NODE_PREFIX = 'oxy.transparency.node.v1:';
+/** The pre-image of {@link EMPTY_TRANSPARENCY_ROOT}. */
+const EMPTY_PREIMAGE = 'oxy.transparency.empty.v1';
+
+/**
+ * The root of a tree with zero leaves: `sha256("oxy.transparency.empty.v1")`.
+ *
+ * Hard-coded because hashing is async and this is needed as a value; a Jest
+ * regression test pins it against the live hash of {@link EMPTY_PREIMAGE}.
+ */
+export const EMPTY_TRANSPARENCY_ROOT =
+  '315338df4bc34de7d057b583a082268016888323c79c0376586406a64f441b1e';
+
+/**
+ * One subject's committed chain position: the head of their signed-record chain
+ * at the moment the snapshot was taken. Mirrors the `RepoHead` row an app keeps.
+ */
+export interface TransparencyHeadEntry {
+  /** The chain's subject DID (`did:web:<domain>:u:<userId>`). */
+  subjectDid: string;
+  /** The `seq` of the head record. */
+  seq: number;
+  /** The `recordId` (content address) of the head record. */
+  headRecordId: string;
+}
+
+/** A built tree: its commitment plus the ordered leaf hashes proofs are cut from. */
+export interface TransparencyTree {
+  root: string;
+  treeSize: number;
+  /** Leaf hashes in committed order. */
+  leaves: string[];
+}
+
+/** A tree built from head entries, with the leaf index of every subject. */
+export interface TransparencyTreeFromHeads extends TransparencyTree {
+  /** `subjectDid` → leaf index, so a proof can be served by subject. */
+  indexBySubject: Record<string, number>;
+}
+
+/** Arguments for {@link verifyInclusionProof}. */
+export interface InclusionProofCheck {
+  /** The verifier's own leaf hash ({@link transparencyLeafHash}). */
+  leaf: string;
+  /** The leaf's index in the committed order. */
+  index: number;
+  /** The `treeSize` the checkpoint committed to. */
+  treeSize: number;
+  /** The audit path, leaf-adjacent sibling first. */
+  proof: string[];
+  /** The root the checkpoint committed to. */
+  root: string;
+}
+
+/**
+ * Hash one subject's head into a leaf.
+ *
+ * The pre-image is the canonical JSON of the three committed fields under the
+ * leaf domain prefix — so a DID containing a delimiter-like character cannot
+ * forge another subject's leaf (JSON escaping makes the encoding unambiguous),
+ * and a leaf can never collide with an interior node.
+ */
+export async function transparencyLeafHash(entry: TransparencyHeadEntry): Promise<string> {
+  const preimage = canonicalize({
+    subjectDid: entry.subjectDid,
+    seq: entry.seq,
+    headRecordId: entry.headRecordId,
+  });
+  return sha256(`${LEAF_PREFIX}${preimage}`);
+}
+
+/** Hash an interior node over its ordered children. */
+async function nodeHash(left: string, right: string): Promise<string> {
+  return sha256(`${NODE_PREFIX}${left}${right}`);
+}
+
+/** The largest power of two strictly below `n` (RFC 6962's split point; `n > 1`). */
+function splitPoint(n: number): number {
+  let k = 1;
+  while (k * 2 < n) {
+    k *= 2;
+  }
+  return k;
+}
+
+/** The Merkle tree hash of a leaf-hash slice (RFC 6962 MTH). */
+async function merkleTreeHash(leaves: string[]): Promise<string> {
+  if (leaves.length === 0) {
+    return EMPTY_TRANSPARENCY_ROOT;
+  }
+  if (leaves.length === 1) {
+    return leaves[0];
+  }
+  const k = splitPoint(leaves.length);
+  const [left, right] = await Promise.all([
+    merkleTreeHash(leaves.slice(0, k)),
+    merkleTreeHash(leaves.slice(k)),
+  ]);
+  return nodeHash(left, right);
+}
+
+/**
+ * Build a tree over already-hashed leaves, in the given order.
+ *
+ * The order IS part of the commitment — prefer
+ * {@link buildTransparencyTreeFromHeads}, which owns the canonical ordering.
+ */
+export async function buildTransparencyTree(leaves: string[]): Promise<TransparencyTree> {
+  return { root: await merkleTreeHash(leaves), treeSize: leaves.length, leaves: [...leaves] };
+}
+
+/**
+ * Build the canonical tree for a snapshot of chain heads.
+ *
+ * Sorts ascending by `subjectDid` in UTF-16 code-unit order — NEVER
+ * `localeCompare`, whose order is locale-dependent and would make two
+ * verifiers compute different roots from identical data.
+ *
+ * Throws on a duplicate `subjectDid`: a snapshot must commit to exactly one head
+ * per subject, and silently keeping one of two would hide the other's history.
+ */
+export async function buildTransparencyTreeFromHeads(
+  entries: TransparencyHeadEntry[],
+): Promise<TransparencyTreeFromHeads> {
+  const ordered = [...entries].sort((a, b) =>
+    a.subjectDid < b.subjectDid ? -1 : a.subjectDid > b.subjectDid ? 1 : 0,
+  );
+
+  const indexBySubject: Record<string, number> = {};
+  ordered.forEach((entry, index) => {
+    if (indexBySubject[entry.subjectDid] !== undefined) {
+      throw new Error(`Duplicate subject in transparency snapshot: ${entry.subjectDid}`);
+    }
+    indexBySubject[entry.subjectDid] = index;
+  });
+
+  const leaves = await Promise.all(ordered.map(transparencyLeafHash));
+  return { ...(await buildTransparencyTree(leaves)), indexBySubject };
+}
+
+/**
+ * The audit path proving `index` is committed in a tree over `leaves`
+ * (RFC 6962 PATH): each step is the sibling subtree hash, leaf-adjacent first.
+ */
+export async function inclusionProof(leaves: string[], index: number): Promise<string[]> {
+  if (!Number.isInteger(index) || index < 0 || index >= leaves.length) {
+    throw new Error(`Leaf index ${index} is outside a tree of ${leaves.length} leaves`);
+  }
+  if (leaves.length === 1) {
+    return [];
+  }
+  const k = splitPoint(leaves.length);
+  if (index < k) {
+    const path = await inclusionProof(leaves.slice(0, k), index);
+    return [...path, await merkleTreeHash(leaves.slice(k))];
+  }
+  const path = await inclusionProof(leaves.slice(k), index - k);
+  return [...path, await merkleTreeHash(leaves.slice(0, k))];
+}
+
+/**
+ * Verify an audit path against a committed root (RFC 6962 §2.1.1).
+ *
+ * Recomputes the root from the leaf upward using only the path, so the verifier
+ * never needs another subject's data. Returns `false` for every failure mode —
+ * tampered leaf, replayed index, truncated path, foreign root — rather than
+ * throwing, so callers treat auditing as a boolean.
+ */
+export async function verifyInclusionProof(check: InclusionProofCheck): Promise<boolean> {
+  const { leaf, index, treeSize, proof, root } = check;
+  if (!Number.isInteger(index) || !Number.isInteger(treeSize)) {
+    return false;
+  }
+  if (index < 0 || treeSize <= 0 || index >= treeSize) {
+    return false;
+  }
+
+  let fn = index;
+  let sn = treeSize - 1;
+  let computed = leaf;
+
+  for (const sibling of proof) {
+    if (sn === 0) {
+      // The path claims more levels than the tree has.
+      return false;
+    }
+    if (fn % 2 === 1 || fn === sn) {
+      computed = await nodeHash(sibling, computed);
+      while (fn % 2 === 0 && fn !== 0) {
+        fn = Math.floor(fn / 2);
+        sn = Math.floor(sn / 2);
+      }
+    } else {
+      computed = await nodeHash(computed, sibling);
+    }
+    fn = Math.floor(fn / 2);
+    sn = Math.floor(sn / 2);
+  }
+
+  // `sn > 0` means the path was truncated before reaching the root.
+  return sn === 0 && computed === root;
+}


### PR DESCRIPTION
Rescued from a stash — 660 lines of finished, tested code that was never committed.

Merkle commitment over per-subject chain heads plus signed checkpoints, so an
Oxy ID's signed-record chain can be proven included in a published root without
having to trust the server that served it.

- `transparency/tree.ts` — leaf hashing, tree build (from entries or from chain
  heads), inclusion proof + verification, `EMPTY_TRANSPARENCY_ROOT`
- `transparency/checkpoint.ts` — canonical signing input, hash, sign, verify
- both exported from the package barrel
- design spec for the FairCoin anchor under `docs/superpowers/specs/`

Additive only: no existing export changes, nothing else imports these yet.

## Verification
`packages/protocol`: 8 suites / 129 tests pass (`transparency.test.ts` included).
Dual CJS/ESM/types build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->