### PR TITLE
feat(auth): popup OAuth transport with a shared completion path (#691 phase 2)

### DIFF
--- a/packages/auth/components/login-form.tsx
+++ b/packages/auth/components/login-form.tsx
@@ -26,6 +26,12 @@ type LoginFormProps = React.ComponentProps<"div"> & {
     codeChallengeMethod?: string
     scope?: string
     /**
+     * `response_mode=web_message` (popup sign-in), carried through to
+     * `/authorize` so the result is posted to the opener rather than navigating
+     * this popup to the relying party.
+     */
+    responseMode?: string
+    /**
      * Username to pre-fill and re-authenticate. Set via `?login_hint=` when a
      * caller (e.g. the OAuth consent page's re-auth fallback) routes a specific
      * account here for explicit sign-in — pre-fills the handle so the user can
@@ -55,6 +61,7 @@ export function LoginForm({
     codeChallenge,
     codeChallengeMethod,
     scope,
+    responseMode,
     loginHint,
     ...props
 }: LoginFormProps) {
@@ -68,6 +75,7 @@ export function LoginForm({
         if (codeChallenge) params.set("code_challenge", codeChallenge)
         if (codeChallengeMethod) params.set("code_challenge_method", codeChallengeMethod)
         if (scope) params.set("scope", scope)
+        if (responseMode) params.set("response_mode", responseMode)
         const qs = params.toString()
         return qs ? `/signup?${qs}` : "/signup"
     })()
@@ -187,6 +195,7 @@ export function LoginForm({
             codeChallenge,
             codeChallengeMethod,
             scope,
+            responseMode,
         }))
     }
 

--- a/packages/auth/components/sign-up-form.tsx
+++ b/packages/auth/components/sign-up-form.tsx
@@ -21,6 +21,12 @@ type SignUpFormProps = React.ComponentProps<"div"> & {
     codeChallenge?: string
     codeChallengeMethod?: string
     scope?: string
+    /**
+     * `response_mode=web_message` (popup sign-in), carried through to
+     * `/authorize` so the result is posted to the opener rather than navigating
+     * this popup to the relying party.
+     */
+    responseMode?: string
 }
 
 type AvailabilityStatus = "idle" | "checking" | "available" | "taken"
@@ -81,6 +87,7 @@ export function SignUpForm({
     codeChallenge,
     codeChallengeMethod,
     scope,
+    responseMode,
     ...props
 }: SignUpFormProps) {
     const navigate = useNavigate()
@@ -132,6 +139,7 @@ export function SignUpForm({
                 codeChallenge,
                 codeChallengeMethod,
                 scope,
+                responseMode,
             }))
         } catch (err) {
             const message = describePasskeyError(err)

--- a/packages/auth/lib/__tests__/oauth-web-message.test.ts
+++ b/packages/auth/lib/__tests__/oauth-web-message.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, test } from "bun:test";
+import {
+  OAUTH_CODE_MESSAGE_TYPE,
+  OAUTH_ERROR_MESSAGE_TYPE,
+  WEB_MESSAGE_RESPONSE_MODE,
+  buildOAuthRedirectUrl,
+  buildRelayMessage,
+  deliverOAuthResult,
+  resolveWebMessageTarget,
+  webMessageTargetOrigin,
+  type OAuthRelayMessage,
+  type OAuthResult,
+} from "@/lib/oauth-web-message";
+
+const REDIRECT_URI = "https://inbox.oxy.so/oauth/callback";
+const REDIRECT_ORIGIN = "https://inbox.oxy.so";
+const CODE = "authorization-code-abc123";
+const STATE = "opaque-state-xyz";
+
+type PostedMessage = { message: OAuthRelayMessage; targetOrigin: string };
+
+/**
+ * A fake `window` implementing only the surface `deliverOAuthResult` touches,
+ * recording the call order so "closed AFTER posting" is assertable.
+ */
+class FakeWindow {
+  opener: unknown = null;
+  location = { href: "" };
+  closed = false;
+  closeCalls = 0;
+  posted: PostedMessage[] = [];
+  calls: string[] = [];
+
+  /** An opener whose `postMessage` records into this window's log. */
+  openerWindow(): { postMessage: (m: OAuthRelayMessage, o: string) => void } {
+    return {
+      postMessage: (message: OAuthRelayMessage, targetOrigin: string) => {
+        this.posted.push({ message, targetOrigin });
+        this.calls.push("postMessage");
+      },
+    };
+  }
+
+  close(): void {
+    this.closed = true;
+    this.closeCalls += 1;
+    this.calls.push("close");
+  }
+}
+
+function windowWithOpener(): FakeWindow {
+  const win = new FakeWindow();
+  win.opener = win.openerWindow();
+  return win;
+}
+
+const codeResult: OAuthResult = { kind: "code", code: CODE, state: STATE };
+const denyResult: OAuthResult = {
+  kind: "error",
+  error: "access_denied",
+  state: STATE,
+};
+
+/** Every key appearing anywhere in a (possibly nested) posted payload. */
+function collectKeys(value: unknown, into: Set<string> = new Set()): Set<string> {
+  if (Array.isArray(value)) {
+    for (const item of value) collectKeys(item, into);
+    return into;
+  }
+  if (typeof value === "object" && value !== null) {
+    for (const [key, nested] of Object.entries(value)) {
+      into.add(key);
+      collectKeys(nested, into);
+    }
+  }
+  return into;
+}
+
+describe("webMessageTargetOrigin", () => {
+  test("is the exact origin of the validated redirect URI", () => {
+    expect(webMessageTargetOrigin(REDIRECT_URI)).toBe(REDIRECT_ORIGIN);
+    expect(webMessageTargetOrigin("https://inbox.oxy.so/deep/path?x=1#y")).toBe(
+      REDIRECT_ORIGIN
+    );
+  });
+
+  test("keeps the port as part of the origin", () => {
+    expect(webMessageTargetOrigin("http://localhost:8081/callback")).toBe(
+      "http://localhost:8081"
+    );
+    expect(webMessageTargetOrigin("https://inbox.oxy.so:8443/cb")).toBe(
+      "https://inbox.oxy.so:8443"
+    );
+  });
+
+  test("never widens to a wildcard or a parent domain", () => {
+    const origin = webMessageTargetOrigin("https://a.b.inbox.oxy.so/cb");
+    expect(origin).toBe("https://a.b.inbox.oxy.so");
+    expect(origin).not.toBe("*");
+    expect(origin).not.toBe(REDIRECT_ORIGIN);
+  });
+
+  test("rejects redirect targets with no web origin", () => {
+    // Native schemes serialize to the opaque `null` origin — they can never be
+    // a postMessage target, so those requests must fall back to the redirect.
+    expect(webMessageTargetOrigin("astro://oauth/callback")).toBeNull();
+    expect(webMessageTargetOrigin("not a url")).toBeNull();
+  });
+});
+
+describe("resolveWebMessageTarget", () => {
+  test("requires BOTH response_mode=web_message and a real opener", () => {
+    const win = windowWithOpener();
+    expect(
+      resolveWebMessageTarget({
+        responseMode: WEB_MESSAGE_RESPONSE_MODE,
+        safeRedirectUri: REDIRECT_URI,
+        window: win,
+      })
+    ).not.toBeNull();
+
+    // response_mode missing / not web_message
+    for (const responseMode of [null, "", "query", "fragment", "form_post"]) {
+      expect(
+        resolveWebMessageTarget({
+          responseMode,
+          safeRedirectUri: REDIRECT_URI,
+          window: windowWithOpener(),
+        })
+      ).toBeNull();
+    }
+
+    // no opener
+    expect(
+      resolveWebMessageTarget({
+        responseMode: WEB_MESSAGE_RESPONSE_MODE,
+        safeRedirectUri: REDIRECT_URI,
+        window: new FakeWindow(),
+      })
+    ).toBeNull();
+  });
+
+  test("rejects an opener that is this window itself", () => {
+    const win = new FakeWindow();
+    win.opener = win;
+    expect(
+      resolveWebMessageTarget({
+        responseMode: WEB_MESSAGE_RESPONSE_MODE,
+        safeRedirectUri: REDIRECT_URI,
+        window: win,
+      })
+    ).toBeNull();
+  });
+
+  test("rejects an opener that cannot receive messages", () => {
+    const win = new FakeWindow();
+    win.opener = { name: "not-a-window" };
+    expect(
+      resolveWebMessageTarget({
+        responseMode: WEB_MESSAGE_RESPONSE_MODE,
+        safeRedirectUri: REDIRECT_URI,
+        window: win,
+      })
+    ).toBeNull();
+  });
+
+  test("resolves the target origin from the redirect URI, not the opener", () => {
+    const win = windowWithOpener();
+    const resolved = resolveWebMessageTarget({
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      safeRedirectUri: REDIRECT_URI,
+      window: win,
+    });
+    expect(resolved?.targetOrigin).toBe(REDIRECT_ORIGIN);
+  });
+});
+
+describe("buildRelayMessage", () => {
+  test("code messages carry only type + code + state", () => {
+    const message = buildRelayMessage(codeResult);
+    expect(message).toEqual({
+      type: OAUTH_CODE_MESSAGE_TYPE,
+      code: CODE,
+      state: STATE,
+    });
+    expect(Object.keys(message).sort()).toEqual(["code", "state", "type"]);
+  });
+
+  test("a missing state still produces the contract's string field", () => {
+    const message = buildRelayMessage({ kind: "code", code: CODE, state: null });
+    expect(message).toEqual({
+      type: OAUTH_CODE_MESSAGE_TYPE,
+      code: CODE,
+      state: "",
+    });
+  });
+
+  test("error messages carry only type + error (+ optional state/description)", () => {
+    expect(buildRelayMessage(denyResult)).toEqual({
+      type: OAUTH_ERROR_MESSAGE_TYPE,
+      error: "access_denied",
+      state: STATE,
+    });
+    expect(
+      buildRelayMessage({ kind: "error", error: "server_error", state: null })
+    ).toEqual({ type: OAUTH_ERROR_MESSAGE_TYPE, error: "server_error" });
+    expect(
+      buildRelayMessage({
+        kind: "error",
+        error: "invalid_request",
+        errorDescription: "redirect_uri mismatch",
+        state: STATE,
+      })
+    ).toEqual({
+      type: OAUTH_ERROR_MESSAGE_TYPE,
+      error: "invalid_request",
+      errorDescription: "redirect_uri mismatch",
+      state: STATE,
+    });
+  });
+});
+
+describe("deliverOAuthResult — web message transport", () => {
+  test("posts the code to the opener at the redirect URI's exact origin", () => {
+    const win = windowWithOpener();
+    const delivery = deliverOAuthResult({
+      result: codeResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      window: win,
+    });
+
+    expect(delivery.mode).toBe("web_message");
+    expect(win.posted).toHaveLength(1);
+    expect(win.posted[0].targetOrigin).toBe(REDIRECT_ORIGIN);
+    expect(win.posted[0].targetOrigin).not.toBe("*");
+    expect(win.posted[0].message).toEqual({
+      type: OAUTH_CODE_MESSAGE_TYPE,
+      code: CODE,
+      state: STATE,
+    });
+    // The window is NOT navigated in popup mode.
+    expect(win.location.href).toBe("");
+  });
+
+  test("closes the window AFTER posting", () => {
+    const win = windowWithOpener();
+    deliverOAuthResult({
+      result: codeResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      window: win,
+    });
+
+    expect(win.calls).toEqual(["postMessage", "close"]);
+    expect(win.closed).toBe(true);
+    expect(win.closeCalls).toBe(1);
+  });
+
+  test("a refused close still reports a completed delivery", () => {
+    const win = windowWithOpener();
+    win.close = () => {
+      throw new Error("Scripts may close only the windows that were opened by them");
+    };
+
+    const delivery = deliverOAuthResult({
+      result: codeResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      window: win,
+    });
+
+    expect(delivery.mode).toBe("web_message");
+    expect(win.posted).toHaveLength(1);
+  });
+
+  test("the payload leaks nothing but the code, the state and the type", () => {
+    const win = windowWithOpener();
+    deliverOAuthResult({
+      result: codeResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      window: win,
+    });
+
+    const message = win.posted[0].message;
+    expect([...collectKeys(message)].sort()).toEqual(["code", "state", "type"]);
+
+    // No token / session / device / user material may ever cross the window
+    // boundary, in any casing or nesting.
+    const serialized = JSON.stringify(message).toLowerCase();
+    for (const forbidden of [
+      "token",
+      "accesstoken",
+      "refresh",
+      "session",
+      "device",
+      "secret",
+      "user",
+      "email",
+      "password",
+      "bearer",
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+    // Every value is a plain string — no objects smuggled through.
+    for (const value of Object.values(message)) {
+      expect(typeof value).toBe("string");
+    }
+  });
+
+  test("deny relays access_denied instead of redirecting", () => {
+    const win = windowWithOpener();
+    const delivery = deliverOAuthResult({
+      result: denyResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      window: win,
+    });
+
+    expect(delivery.mode).toBe("web_message");
+    expect(win.posted[0].targetOrigin).toBe(REDIRECT_ORIGIN);
+    expect(win.posted[0].message).toEqual({
+      type: OAUTH_ERROR_MESSAGE_TYPE,
+      error: "access_denied",
+      state: STATE,
+    });
+    expect(win.location.href).toBe("");
+    expect(win.closed).toBe(true);
+  });
+});
+
+describe("deliverOAuthResult — redirect fallback", () => {
+  test("no opener falls back to the redirect", () => {
+    const win = new FakeWindow();
+    const delivery = deliverOAuthResult({
+      result: codeResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      window: win,
+    });
+
+    expect(delivery.mode).toBe("redirect");
+    expect(win.posted).toHaveLength(0);
+    expect(win.closed).toBe(false);
+    expect(win.location.href).toBe(
+      `${REDIRECT_URI}?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  test("no response_mode falls back to the redirect even with an opener", () => {
+    const win = windowWithOpener();
+    const delivery = deliverOAuthResult({
+      result: codeResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: null,
+      window: win,
+    });
+
+    expect(delivery.mode).toBe("redirect");
+    expect(win.posted).toHaveLength(0);
+    expect(win.closed).toBe(false);
+    expect(win.location.href).toBe(
+      `${REDIRECT_URI}?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  test("a redirect target with no web origin falls back to the redirect", () => {
+    const win = windowWithOpener();
+    const delivery = deliverOAuthResult({
+      result: codeResult,
+      safeRedirectUri: "astro://oauth/callback",
+      responseMode: WEB_MESSAGE_RESPONSE_MODE,
+      window: win,
+    });
+
+    expect(delivery.mode).toBe("redirect");
+    expect(win.posted).toHaveLength(0);
+    expect(win.location.href).toBe(
+      `astro://oauth/callback?code=${CODE}&state=${STATE}`
+    );
+  });
+
+  test("deny falls back to ?error=access_denied", () => {
+    const win = new FakeWindow();
+    deliverOAuthResult({
+      result: denyResult,
+      safeRedirectUri: REDIRECT_URI,
+      responseMode: null,
+      window: win,
+    });
+
+    expect(win.location.href).toBe(
+      `${REDIRECT_URI}?error=access_denied&state=${STATE}`
+    );
+  });
+
+  test("preserves query params already on the redirect URI", () => {
+    expect(
+      buildOAuthRedirectUrl(codeResult, "https://inbox.oxy.so/cb?from=app")
+    ).toBe(`https://inbox.oxy.so/cb?from=app&code=${CODE}&state=${STATE}`);
+  });
+
+  test("omits state when the request carried none", () => {
+    expect(
+      buildOAuthRedirectUrl({ kind: "code", code: CODE, state: null }, REDIRECT_URI)
+    ).toBe(`${REDIRECT_URI}?code=${CODE}`);
+  });
+});

--- a/packages/auth/lib/auth-utils.ts
+++ b/packages/auth/lib/auth-utils.ts
@@ -6,6 +6,12 @@ type PostLoginRedirectParams = {
     codeChallenge?: string
     codeChallengeMethod?: string
     scope?: string
+    /**
+     * `response_mode=web_message` (popup sign-in). Carried across the sign-in
+     * hop so a popup that had to authenticate still delivers its result to the
+     * opener instead of navigating itself to the relying party.
+     */
+    responseMode?: string
 }
 
 /**
@@ -28,6 +34,7 @@ export function buildPostLoginRedirect({
     codeChallenge,
     codeChallengeMethod,
     scope,
+    responseMode,
 }: PostLoginRedirectParams): string {
     const nextUrl = new URL("/authorize", window.location.origin)
     if (sessionToken) nextUrl.searchParams.set("token", sessionToken)
@@ -37,6 +44,7 @@ export function buildPostLoginRedirect({
     if (codeChallenge) nextUrl.searchParams.set("code_challenge", codeChallenge)
     if (codeChallengeMethod) nextUrl.searchParams.set("code_challenge_method", codeChallengeMethod)
     if (scope) nextUrl.searchParams.set("scope", scope)
+    if (responseMode) nextUrl.searchParams.set("response_mode", responseMode)
     if (!sessionToken && !redirectUri && !clientId) {
         nextUrl.searchParams.set(
             "error",

--- a/packages/auth/lib/oauth-web-message.ts
+++ b/packages/auth/lib/oauth-web-message.ts
@@ -1,0 +1,238 @@
+/**
+ * Delivery of an OAuth authorization response back to the relying party.
+ *
+ * Two transports, chosen per request:
+ *
+ *  - **redirect** (the default): a top-level navigation to the validated
+ *    `redirect_uri` carrying `?code=…&state=…` or `?error=…`.
+ *  - **web message** (popup sign-in): the relying party asks for it with
+ *    `response_mode=web_message` on the authorize URL. The result is
+ *    `postMessage`d to `window.opener` and this window closes, so the relying
+ *    party's own tab is never navigated.
+ *
+ * The web-message transport is a REQUEST, not a guarantee: without a usable
+ * opener (or with a redirect target that has no web origin) delivery falls back
+ * to the redirect. Relying parties must handle both outcomes.
+ *
+ * SECURITY INVARIANTS — the reason this logic lives in one small, tested module:
+ *
+ *  1. The target origin is ALWAYS the exact origin of the redirect URI the API
+ *     accepted for this request; it is NEVER `'*'` and never a wildcard
+ *     fallback. `POST /auth/oauth/authorize` validates that URI by exact
+ *     constant-time match against the application's registered `redirectUris`,
+ *     so its origin is a registered origin — that server-side validation is what
+ *     makes this target trustworthy. A redirect URI with no web origin (a native
+ *     scheme, whose `URL.origin` is the opaque `"null"`) can never be a target.
+ *  2. The ONLY values that cross the window boundary are the single-use
+ *     authorization code, the `state` echo, and a standard OAuth error code
+ *     (with an optional description). Never a token, session id, device secret,
+ *     or user object — the message shapes below are exhaustive.
+ */
+
+/** `response_mode` value with which a relying party requests popup delivery. */
+export const WEB_MESSAGE_RESPONSE_MODE = "web_message";
+
+/** Message type carrying a successful authorization. */
+export const OAUTH_CODE_MESSAGE_TYPE = "oxy:oauth:code";
+
+/** Message type carrying a failed or denied authorization. */
+export const OAUTH_ERROR_MESSAGE_TYPE = "oxy:oauth:error";
+
+/** Successful authorization delivered to the opener. */
+export interface OAuthCodeMessage {
+  type: typeof OAUTH_CODE_MESSAGE_TYPE;
+  code: string;
+  state: string;
+}
+
+/** Failed or denied authorization delivered to the opener. */
+export interface OAuthErrorMessage {
+  type: typeof OAUTH_ERROR_MESSAGE_TYPE;
+  error: string;
+  errorDescription?: string;
+  state?: string;
+}
+
+/** Every message shape that may cross the window boundary. */
+export type OAuthRelayMessage = OAuthCodeMessage | OAuthErrorMessage;
+
+/**
+ * The authorization outcome to deliver. Discriminated and closed over primitive
+ * fields only, so no caller can widen what reaches the relying party.
+ */
+export type OAuthResult =
+  | { kind: "code"; code: string; state: string | null }
+  | {
+      kind: "error";
+      error: string;
+      errorDescription?: string;
+      state: string | null;
+    };
+
+/** How a result was delivered. */
+export type OAuthDelivery =
+  | { mode: "web_message"; message: OAuthRelayMessage; targetOrigin: string }
+  | { mode: "redirect"; url: string };
+
+/** The opener surface used for web-message delivery. */
+export interface WebMessageTarget {
+  postMessage(message: OAuthRelayMessage, targetOrigin: string): void;
+}
+
+/**
+ * The minimal `window` surface delivery needs. Injected rather than reached for
+ * globally so the transport decision is testable without a browser.
+ */
+export interface DeliveryWindow {
+  readonly opener: unknown;
+  readonly location: { href: string };
+  close(): void;
+}
+
+/** A resolved web-message destination. */
+export interface ResolvedWebMessageTarget {
+  target: WebMessageTarget;
+  targetOrigin: string;
+}
+
+function isWebMessageTarget(value: unknown): value is WebMessageTarget {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { postMessage?: unknown }).postMessage === "function"
+  );
+}
+
+/**
+ * The exact `postMessage` target origin for a validated redirect URI, or null
+ * when the URI has no web origin (native schemes serialize to the opaque
+ * `"null"` origin and can never receive a web message).
+ */
+export function webMessageTargetOrigin(
+  safeRedirectUri: string
+): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(safeRedirectUri);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return null;
+  }
+  const origin = parsed.origin;
+  if (!origin || origin === "null") return null;
+  return origin;
+}
+
+/**
+ * Resolve the web-message destination for this request, or null when the result
+ * must be delivered by redirect instead. Requires ALL of: the relying party
+ * asked for `response_mode=web_message`, a real opener window that is not this
+ * window, and a redirect URI with a usable web origin.
+ */
+export function resolveWebMessageTarget(input: {
+  responseMode: string | null;
+  safeRedirectUri: string;
+  window: DeliveryWindow;
+}): ResolvedWebMessageTarget | null {
+  if (input.responseMode !== WEB_MESSAGE_RESPONSE_MODE) return null;
+
+  const opener = input.window.opener;
+  if (!opener || opener === input.window) return null;
+  if (!isWebMessageTarget(opener)) return null;
+
+  const targetOrigin = webMessageTargetOrigin(input.safeRedirectUri);
+  if (!targetOrigin) return null;
+
+  return { target: opener, targetOrigin };
+}
+
+/**
+ * Build the message for a result. Constructed field by field so the payload can
+ * only ever contain the contract's fields — nothing from the surrounding
+ * session can be spread in.
+ */
+export function buildRelayMessage(result: OAuthResult): OAuthRelayMessage {
+  if (result.kind === "code") {
+    return {
+      type: OAUTH_CODE_MESSAGE_TYPE,
+      code: result.code,
+      state: result.state ?? "",
+    };
+  }
+
+  const message: OAuthErrorMessage = {
+    type: OAUTH_ERROR_MESSAGE_TYPE,
+    error: result.error,
+  };
+  if (result.errorDescription) {
+    message.errorDescription = result.errorDescription;
+  }
+  if (result.state) {
+    message.state = result.state;
+  }
+  return message;
+}
+
+/** Build the top-level redirect URL for a result. */
+export function buildOAuthRedirectUrl(
+  result: OAuthResult,
+  safeRedirectUri: string
+): string {
+  const url = new URL(safeRedirectUri);
+  if (result.kind === "code") {
+    url.searchParams.set("code", result.code);
+  } else {
+    url.searchParams.set("error", result.error);
+    if (result.errorDescription) {
+      url.searchParams.set("error_description", result.errorDescription);
+    }
+  }
+  if (result.state) {
+    url.searchParams.set("state", result.state);
+  }
+  return url.toString();
+}
+
+/**
+ * Deliver an authorization result to the relying party and report which
+ * transport was used.
+ *
+ * Web message: posts to the opener at the redirect URI's exact origin, then
+ * closes this window. A browser that refuses the close leaves the caller to
+ * render a terminal "you can close this window" state — the result is already
+ * delivered either way.
+ *
+ * Redirect: navigates this window to the redirect URI with the result in the
+ * query string.
+ */
+export function deliverOAuthResult(input: {
+  result: OAuthResult;
+  safeRedirectUri: string;
+  responseMode: string | null;
+  window: DeliveryWindow;
+}): OAuthDelivery {
+  const relay = resolveWebMessageTarget({
+    responseMode: input.responseMode,
+    safeRedirectUri: input.safeRedirectUri,
+    window: input.window,
+  });
+
+  if (relay) {
+    const message = buildRelayMessage(input.result);
+    relay.target.postMessage(message, relay.targetOrigin);
+    try {
+      input.window.close();
+    } catch {
+      // A window the browser refuses to close is not a delivery failure: the
+      // message is already posted. The caller's terminal state stays on screen
+      // so the user is told they can close it themselves.
+    }
+    return { mode: "web_message", message, targetOrigin: relay.targetOrigin };
+  }
+
+  const url = buildOAuthRedirectUrl(input.result, input.safeRedirectUri);
+  input.window.location.href = url;
+  return { mode: "redirect", url };
+}

--- a/packages/auth/src/pages/authorize.tsx
+++ b/packages/auth/src/pages/authorize.tsx
@@ -25,6 +25,7 @@ import {
   getAvatarUrl,
 } from "@/lib/oxy-api-client";
 import { safeRedirectUrl } from "@/lib/oauth-redirect";
+import { deliverOAuthResult, type OAuthResult } from "@/lib/oauth-web-message";
 
 /**
  * The requesting-application + auth-request resolution state. The signed-in
@@ -39,8 +40,20 @@ type AuthorizeData = {
   error: string | null;
 };
 
+/**
+ * Terminal state of a popup ("web message") delivery: the result has already
+ * been posted to the opener and this window asked to close.
+ */
+type RelayOutcome = "approved" | "denied" | "failed";
+
 /** Error shown when the requesting application cannot be resolved. */
 const UNRESOLVED_APP_ERROR = "Unable to identify the requesting application.";
+
+/** Which terminal message a delivered popup result should leave on screen. */
+function relayOutcomeFor(result: OAuthResult): RelayOutcome {
+  if (result.kind === "code") return "approved";
+  return result.error === "access_denied" ? "denied" : "failed";
+}
 
 /**
  * Resolve a `client_id` to its public application identity via the unauthenticated
@@ -98,6 +111,11 @@ export function AuthorizePage() {
   const prompt = searchParams.get("prompt");
   const statusParam = searchParams.get("status");
   const urlError = searchParams.get("error");
+  // Popup sign-in: `response_mode=web_message` asks us to post the result to
+  // `window.opener` instead of navigating this window to `redirect_uri`. It is a
+  // request, not a guarantee — with no opener we still redirect (see
+  // `lib/oauth-web-message.ts`).
+  const responseMode = searchParams.get("response_mode");
 
   // Device-first SDK: the signed-in user + active bearer + device account set.
   // The bearer for the OAuth authorize call is ALWAYS the SDK's active-account
@@ -145,22 +163,48 @@ export function AuthorizePage() {
   >(null);
   // The auto-approve probe runs at most once per mount for the active account.
   const autoApproveAttemptedRef = useRef(false);
+  // Set once a result has been posted to the opener in popup mode. The window is
+  // asked to close immediately after the post, so this only ever becomes visible
+  // when the browser refuses that close — it keeps the user from staring at a
+  // dead consent screen.
+  const [relayOutcome, setRelayOutcome] = useState<RelayOutcome | null>(null);
 
   const isSilentPrompt = prompt === "none";
 
+  /**
+   * Hand an authorization result (code or OAuth error) to the relying party.
+   * Popup mode (`response_mode=web_message` + a real opener) posts it to the
+   * opener at the redirect URI's exact origin and closes this window; every
+   * other request redirects to `redirect_uri` as before. The caller must not
+   * navigate afterwards — delivery is complete either way.
+   */
+  function deliverToRelyingParty(
+    result: OAuthResult,
+    safeRedirect: string
+  ): void {
+    const delivery = deliverOAuthResult({
+      result,
+      safeRedirectUri: safeRedirect,
+      responseMode,
+      window,
+    });
+    if (delivery.mode === "web_message") {
+      setRelayOutcome(relayOutcomeFor(result));
+    }
+  }
+
   // OAuth `prompt=none`: silent cross-origin restore — never show login UI.
-  // Fail with standard OAuth errors back to the RP redirect_uri.
-  function redirectOAuthError(errorCode: string): void {
+  // Fail with standard OAuth errors back to the RP (posted to the opener in
+  // popup mode, otherwise redirected to `redirect_uri`). With no usable redirect
+  // target the error is surfaced on this page instead.
+  function deliverOAuthError(errorCode: string): void {
     setAutoApproving(false);
     const safeRedirect = safeRedirectUrl(redirectUri);
     if (!safeRedirect) {
       setData((prev) => ({ ...prev, error: errorCode }));
       return;
     }
-    const url = new URL(safeRedirect);
-    url.searchParams.set("error", errorCode);
-    if (state) url.searchParams.set("state", state);
-    window.location.href = url.toString();
+    deliverToRelyingParty({ kind: "error", error: errorCode, state }, safeRedirect);
   }
 
   // Silent restore: when prompt=none and the IdP has no session, bounce
@@ -169,7 +213,7 @@ export function AuthorizePage() {
   useEffect(() => {
     if (!isSilentPrompt || !isAuthResolved || deviceAccountsLoading) return;
     if (isAuthenticated || currentSessionId || deviceAccounts.length > 0) return;
-    redirectOAuthError("login_required");
+    deliverOAuthError("login_required");
   }, [
     isSilentPrompt,
     isAuthResolved,
@@ -186,11 +230,11 @@ export function AuthorizePage() {
     if (!isSilentPrompt || !isAuthResolved || deviceAccountsLoading) return;
     if (!isAuthenticated && !currentSessionId && deviceAccounts.length === 0) return;
     if (!clientId) {
-      redirectOAuthError("invalid_request");
+      deliverOAuthError("invalid_request");
       return;
     }
     if (!safeRedirectUrl(redirectUri)) {
-      redirectOAuthError("invalid_request");
+      deliverOAuthError("invalid_request");
     }
   }, [
     isSilentPrompt,
@@ -221,12 +265,12 @@ export function AuthorizePage() {
     void (async () => {
       const token = oxyServices.getAccessToken();
       if (!token) {
-        redirectOAuthError("login_required");
+        deliverOAuthError("login_required");
         return;
       }
       const safeRedirect = safeRedirectUrl(redirectUri);
       if (!safeRedirect) {
-        redirectOAuthError("invalid_request");
+        deliverOAuthError("invalid_request");
         return;
       }
 
@@ -247,22 +291,22 @@ export function AuthorizePage() {
         if (!response.ok) {
           setAutoApproving(false);
           if (response.status === 403 || response.status === 400) {
-            redirectOAuthError("invalid_request");
+            deliverOAuthError("invalid_request");
           } else {
-            redirectOAuthError("server_error");
+            deliverOAuthError("server_error");
           }
           return;
         }
         body = await response.json().catch(() => null);
       } catch {
         setAutoApproving(false);
-        redirectOAuthError("server_error");
+        deliverOAuthError("server_error");
         return;
       }
 
       if (consentRequiredFromBody(body)) {
         setAutoApproving(false);
-        redirectOAuthError("consent_required");
+        deliverOAuthError("consent_required");
         return;
       }
 
@@ -423,6 +467,7 @@ export function AuthorizePage() {
         code_challenge: codeChallenge || undefined,
         code_challenge_method: codeChallengeMethod || undefined,
         scope: scope || undefined,
+        response_mode: responseMode || undefined,
         login_hint: hint || undefined,
       })
     );
@@ -504,7 +549,7 @@ export function AuthorizePage() {
 
     if (codeResponse.status === 401) {
       if (isSilentPrompt) {
-        redirectOAuthError("login_required");
+        deliverOAuthError("login_required");
         return;
       }
       navigate(
@@ -516,6 +561,7 @@ export function AuthorizePage() {
           code_challenge: codeChallenge || undefined,
           code_challenge_method: codeChallengeMethod || undefined,
           scope: scope || undefined,
+          response_mode: responseMode || undefined,
           error: "Session expired. Please sign in again.",
         })
       );
@@ -528,7 +574,7 @@ export function AuthorizePage() {
           codeResponse.status === 403 || codeResponse.status === 400
             ? "invalid_request"
             : "server_error";
-        redirectOAuthError(oauthError);
+        deliverOAuthError(oauthError);
         return;
       }
       const errPayload = await codeResponse.json().catch(() => ({}));
@@ -545,11 +591,24 @@ export function AuthorizePage() {
     }
 
     const codeResult = await codeResponse.json();
-    const codeData = codeResult.data || codeResult;
-    const url = new URL(safeRedirect);
-    url.searchParams.set("code", codeData.code);
-    if (state) url.searchParams.set("state", state);
-    window.location.href = url.toString();
+    const codeData = codeResult?.data ?? codeResult;
+    const code: unknown = codeData?.code;
+    if (typeof code !== "string" || code.length === 0) {
+      // A 2xx without a code violates the authorize contract — fail closed
+      // rather than handing the relying party an empty credential.
+      if (isSilentPrompt) {
+        deliverOAuthError("server_error");
+        return;
+      }
+      setAutoApproving(false);
+      setSubmitting(false);
+      setData((prev) => ({ ...prev, error: "Authorization failed" }));
+      return;
+    }
+
+    // Popup mode posts `{code, state}` to the opener and closes this window;
+    // every other request redirects to `redirect_uri?code=&state=` as before.
+    deliverToRelyingParty({ kind: "code", code, state }, safeRedirect);
   }
 
   // Ask the server whether the OAuth consent screen must be shown for this
@@ -633,10 +692,13 @@ export function AuthorizePage() {
         }
       }
       if (safeRedirect) {
-        const url = new URL(safeRedirect);
-        url.searchParams.set("error", "access_denied");
-        if (state) url.searchParams.set("state", state);
-        window.location.href = url.toString();
+        // Same delivery contract as the approve path: popup mode posts
+        // `access_denied` to the opener and closes; otherwise we redirect to
+        // `redirect_uri?error=access_denied`.
+        deliverToRelyingParty(
+          { kind: "error", error: "access_denied", state },
+          safeRedirect
+        );
       } else {
         navigate(
           buildRelativeUrl("/authorize", {
@@ -708,6 +770,7 @@ export function AuthorizePage() {
             code_challenge: codeChallenge || undefined,
             code_challenge_method: codeChallengeMethod || undefined,
             scope: scope || undefined,
+            response_mode: responseMode || undefined,
             error: "Session expired. Please sign in again.",
           })
         );
@@ -740,6 +803,27 @@ export function AuthorizePage() {
       setData((prev) => ({ ...prev, error: msg }));
       setSubmitting(false);
     }
+  }
+
+  // Popup delivery is terminal: the result is already posted to the opener and
+  // this window asked to close. Rendering this state at all means the browser
+  // refused the close, so tell the user they can close it themselves rather than
+  // leaving a dead consent screen (or a spinner) on screen.
+  if (relayOutcome) {
+    return (
+      <AuthFormLayout>
+        <AuthFormHeader
+          title={
+            relayOutcome === "approved"
+              ? t("authorize.completeTitle")
+              : relayOutcome === "denied"
+                ? t("authorize.deniedTitle")
+                : t("authorize.silentFailedTitle")
+          }
+          description={t("authorize.completeDesc")}
+        />
+      </AuthFormLayout>
+    );
   }
 
   if (loading || deviceAccountsLoading) {
@@ -819,6 +903,7 @@ export function AuthorizePage() {
           code_challenge: codeChallenge || undefined,
           code_challenge_method: codeChallengeMethod || undefined,
           scope: scope || undefined,
+          response_mode: responseMode || undefined,
         })}
         replace
       />

--- a/packages/auth/src/pages/login.tsx
+++ b/packages/auth/src/pages/login.tsx
@@ -18,6 +18,7 @@ export function LoginPage() {
       codeChallenge={searchParams.get("code_challenge") ?? undefined}
       codeChallengeMethod={searchParams.get("code_challenge_method") ?? undefined}
       scope={searchParams.get("scope") ?? undefined}
+      responseMode={searchParams.get("response_mode") ?? undefined}
       loginHint={searchParams.get("login_hint") ?? undefined}
     />
   );

--- a/packages/auth/src/pages/signup.tsx
+++ b/packages/auth/src/pages/signup.tsx
@@ -14,6 +14,7 @@ export function SignUpPage() {
       codeChallenge={searchParams.get("code_challenge") ?? undefined}
       codeChallengeMethod={searchParams.get("code_challenge_method") ?? undefined}
       scope={searchParams.get("scope") ?? undefined}
+      responseMode={searchParams.get("response_mode") ?? undefined}
     />
   );
 }

--- a/packages/core/src/utils/oauthPkce.ts
+++ b/packages/core/src/utils/oauthPkce.ts
@@ -66,6 +66,18 @@ export interface BuildOAuthAuthorizeUrlParams {
    * (no UI when the IdP hub already has a session + grant).
    */
   prompt?: 'none' | 'login' | 'consent';
+  /**
+   * How the IdP should deliver the authorization response. Omitted (the
+   * default) means the ordinary top-level redirect back to `redirectUri`.
+   *
+   * `web_message` asks the IdP to `postMessage` the result to its opener
+   * instead, so a popup sign-in never navigates the relying party's tab. It is
+   * a REQUEST, not a guarantee: an IdP with no opener still redirects, which is
+   * why the popup transport must handle both outcomes. Only the authorization
+   * code, the `state`, and a typed OAuth error ever cross that channel — never
+   * a token, device secret, or the PKCE verifier, which the opener keeps.
+   */
+  responseMode?: 'web_message';
 }
 
 /**
@@ -191,6 +203,9 @@ export function buildOAuthAuthorizeUrl(params: BuildOAuthAuthorizeUrlParams): st
   url.searchParams.set('code_challenge_method', 'S256');
   if (params.prompt) {
     url.searchParams.set('prompt', params.prompt);
+  }
+  if (params.responseMode) {
+    url.searchParams.set('response_mode', params.responseMode);
   }
 
   return url.toString();

--- a/packages/services/__tests__/components/OxySignInButton.test.tsx
+++ b/packages/services/__tests__/components/OxySignInButton.test.tsx
@@ -1,12 +1,18 @@
 /**
  * `OxySignInButton` — the public "Sign in with Oxy" button.
  *
- * These tests cover the Fase 4 fork: on press the button resolves the requesting
- * Application (via `oxyServices.getPublicApplication(clientId)`) and routes by
- * type — an official / first-party app opens the in-app account dialog, a
- * `third_party` app starts an OAuth 2.0 + PKCE redirect to `auth.oxy.so`. The
- * cross-platform PKCE/URL helpers are the REAL `@oxyhq/core` implementations so
- * the asserted authorize URL is the one an RP actually receives.
+ * These tests cover the routing fork: on press the button resolves the
+ * requesting Application (via `oxyServices.getPublicApplication(clientId)`) and
+ * routes by type — an official / first-party app opens the in-app account
+ * dialog, a `third_party` app starts OAuth 2.0 + PKCE against `auth.oxy.so`.
+ *
+ * On WEB the OAuth half is delegated to the shared transport
+ * (`useOxy().startWebOAuthSignIn`), which owns popup-vs-redirect selection, the
+ * authorize URL, and the handshake — those are asserted in
+ * `src/ui/oauth/__tests__/browserAuthTransport.test.ts`. What is asserted here
+ * is that the button routes to it and never navigates on its own. Native still
+ * builds the handshake itself with the REAL `@oxyhq/core` PKCE helpers and hands
+ * it to the RP.
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -14,11 +20,10 @@ import { Platform } from 'react-native';
 import { logger } from '@oxyhq/core';
 import type { PublicApplication } from '@oxyhq/core';
 import { redirectToAuthorize, openAuthorizeUrlNative } from '../../src/ui/components/oauthNavigation';
-import {
-  OXY_OAUTH_STATE_STORAGE_KEY,
-  OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
-} from '@oxyhq/core';
+import { OXY_OAUTH_STATE_STORAGE_KEY } from '@oxyhq/core';
 import OxySignInButton from '../../src/ui/components/OxySignInButton';
+import type { StartWebOAuthSignInOptions } from '../../src/ui/oauth/browserAuthTransport';
+import type { WebAuthMode, WebOAuthSignInResult } from '../../src/ui/oauth/types';
 
 const makeApp = (over: Partial<PublicApplication>): PublicApplication => ({
   id: 'app-1',
@@ -32,11 +37,19 @@ const makeApp = (over: Partial<PublicApplication>): PublicApplication => ({
 
 const openAccountDialog = jest.fn();
 const getPublicApplication = jest.fn<Promise<PublicApplication>, [string]>();
+const startWebOAuthSignIn = jest.fn<Promise<WebOAuthSignInResult>, [StartWebOAuthSignInOptions]>();
 let clientId: string | null = 'oxy_dk_test';
+let webAuthMode: WebAuthMode = 'redirect';
 
 jest.mock('../../src/ui/context/OxyContext', () => ({
   __esModule: true,
-  useOxy: () => ({ openAccountDialog, oxyServices: { getPublicApplication }, clientId }),
+  useOxy: () => ({
+    openAccountDialog,
+    oxyServices: { getPublicApplication },
+    clientId,
+    webAuthMode,
+    startWebOAuthSignIn,
+  }),
 }));
 
 jest.mock('../../src/ui/stores/authStore', () => ({
@@ -71,8 +84,10 @@ const openAuthorizeUrlNativeMock = openAuthorizeUrlNative as jest.MockedFunction
 beforeEach(() => {
   jest.clearAllMocks();
   clientId = 'oxy_dk_test';
+  webAuthMode = 'redirect';
   Platform.OS = 'web';
   openAuthorizeUrlNativeMock.mockResolvedValue({ redirectUrl: null });
+  startWebOAuthSignIn.mockResolvedValue({ status: 'redirecting', via: 'redirect-mode' });
   window.sessionStorage.clear();
 });
 
@@ -93,7 +108,7 @@ describe('OxySignInButton', () => {
     expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
   });
 
-  it('starts an OAuth + PKCE redirect for a third_party application (web)', async () => {
+  it('delegates a third_party web sign-in to the shared transport', async () => {
     getPublicApplication.mockResolvedValue(
       makeApp({ type: 'third_party', isOfficial: false, name: 'Third Party' }),
     );
@@ -101,27 +116,18 @@ describe('OxySignInButton', () => {
     render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
     fireEvent.click(screen.getByRole('button'));
 
-    await waitFor(() => expect(redirectToAuthorizeMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(startWebOAuthSignIn).toHaveBeenCalledTimes(1));
+    expect(startWebOAuthSignIn).toHaveBeenCalledWith({
+      redirectUri: 'https://rp.example/callback',
+    });
     expect(openAccountDialog).not.toHaveBeenCalled();
-
-    const url = new URL(redirectToAuthorizeMock.mock.calls[0][0]);
-    expect(`${url.origin}${url.pathname}`).toBe('https://auth.oxy.so/authorize');
-    expect(url.searchParams.get('client_id')).toBe('oxy_dk_test');
-    expect(url.searchParams.get('redirect_uri')).toBe('https://rp.example/callback');
-    expect(url.searchParams.get('response_type')).toBe('code');
-    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
-    const state = url.searchParams.get('state');
-    const codeChallenge = url.searchParams.get('code_challenge');
-    expect(state).toBeTruthy();
-    expect(codeChallenge).toBeTruthy();
-
-    // The CSRF state + PKCE verifier are persisted for the RP's redirect-URI
-    // callback: state matches the redirect, and a verifier is stored.
-    expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBe(state);
-    expect(window.sessionStorage.getItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY)).toBeTruthy();
+    // The button itself never navigates or writes the handshake — the transport
+    // owns both, so exactly one implementation of either exists.
+    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
   });
 
-  it('aborts (no redirect) for a third_party application with no oauthRedirectUri', async () => {
+  it('aborts (no sign-in attempt) for a third_party application with no oauthRedirectUri', async () => {
     const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
     getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
 
@@ -129,6 +135,7 @@ describe('OxySignInButton', () => {
     fireEvent.click(screen.getByRole('button'));
 
     await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    expect(startWebOAuthSignIn).not.toHaveBeenCalled();
     expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
     expect(openAccountDialog).not.toHaveBeenCalled();
     expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
@@ -224,21 +231,115 @@ describe('OxySignInButton', () => {
     expect(getPublicApplication).toHaveBeenCalledTimes(2);
   });
 
-  it('aborts the third_party web redirect when the handshake cannot be persisted', async () => {
+  it('surfaces a failure reported by the shared transport instead of silently ending', async () => {
     const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
-    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-      throw new Error('QuotaExceededError');
-    });
+    startWebOAuthSignIn.mockResolvedValue({ status: 'failed', reason: 'handshake-storage' });
     getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
 
     render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
     fireEvent.click(screen.getByRole('button'));
 
     await waitFor(() => expect(warnSpy).toHaveBeenCalled());
-    expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(warnSpy.mock.calls[0][0]).toContain('handshake-storage');
     expect(openAccountDialog).not.toHaveBeenCalled();
 
-    setItemSpy.mockRestore();
     warnSpy.mockRestore();
+  });
+
+  // ── Popup mode ────────────────────────────────────────────────────────────
+  // `window.open` only survives while the click is still being handled, and the
+  // button awaits a network resolve before it even knows the application is
+  // third-party — so the window MUST be claimed in the press handler and carried
+  // into the transport, and released again on every path that does not use it.
+  describe('popup mode', () => {
+    let popup: { closed: boolean; close: jest.Mock; location: { href: string } };
+    let openSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      webAuthMode = 'popup';
+      popup = { closed: false, close: jest.fn(), location: { href: '' } };
+      openSpy = jest.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+    });
+
+    afterEach(() => {
+      openSpy.mockRestore();
+    });
+
+    it('claims the popup during the press and carries it into the shared transport', async () => {
+      // Resolve the application only once the press has been observed.
+      let releaseApplication: (app: PublicApplication) => void = () => undefined;
+      getPublicApplication.mockReturnValue(
+        new Promise<PublicApplication>((resolve) => {
+          releaseApplication = resolve;
+        }),
+      );
+
+      render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+      fireEvent.click(screen.getByRole('button'));
+
+      // Synchronously after the click, with the application still unresolved.
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      expect(startWebOAuthSignIn).not.toHaveBeenCalled();
+
+      releaseApplication(makeApp({ type: 'third_party', isOfficial: false }));
+
+      await waitFor(() => expect(startWebOAuthSignIn).toHaveBeenCalledTimes(1));
+      expect(startWebOAuthSignIn).toHaveBeenCalledWith({
+        redirectUri: 'https://rp.example/callback',
+        popup,
+      });
+      expect(openSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('hands the transport a null popup when the browser blocked it', async () => {
+      openSpy.mockReturnValue(null);
+      getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+
+      render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+      fireEvent.click(screen.getByRole('button'));
+
+      await waitFor(() => expect(startWebOAuthSignIn).toHaveBeenCalledTimes(1));
+      expect(startWebOAuthSignIn).toHaveBeenCalledWith({
+        redirectUri: 'https://rp.example/callback',
+        popup: null,
+      });
+    });
+
+    it('closes the pre-opened popup when the application turns out to be official', async () => {
+      getPublicApplication.mockResolvedValue(makeApp({ type: 'first_party', isOfficial: true }));
+
+      render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+      fireEvent.click(screen.getByRole('button'));
+
+      await waitFor(() => expect(openAccountDialog).toHaveBeenCalledWith('signin'));
+      expect(popup.close).toHaveBeenCalledTimes(1);
+      expect(startWebOAuthSignIn).not.toHaveBeenCalled();
+    });
+
+    it('opens no window for an application that has no registered redirect URI', async () => {
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+      getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+
+      render(<OxySignInButton />);
+      fireEvent.click(screen.getByRole('button'));
+
+      await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+      expect(openSpy).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+  });
+
+  it('opens no window in redirect mode, even for a third_party application', async () => {
+    const openSpy = jest.spyOn(window, 'open');
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+
+    render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(startWebOAuthSignIn).toHaveBeenCalledTimes(1));
+    expect(openSpy).not.toHaveBeenCalled();
+
+    openSpy.mockRestore();
   });
 });

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -214,6 +214,21 @@ export {
 } from '@oxyhq/core';
 export { default as OxySignInButton } from './ui/components/OxySignInButton';
 export type { OxySignInButtonProps, OxyOAuthResult } from './ui/components/OxySignInButton';
+
+// Web OAuth transport (popup / redirect). RPs that ship their own sign-in
+// button call `useOxy().startWebOAuthSignIn(...)`; only the popup opener is
+// exported, because it MUST run synchronously inside the press handler to keep
+// the browser's user-gesture attribution.
+export { openOAuthPopup } from './ui/oauth/oauthPopup';
+export type { StartWebOAuthSignInOptions } from './ui/oauth/browserAuthTransport';
+export type {
+  WebAuthMode,
+  WebOAuthSignInResult,
+  WebOAuthRedirectReason,
+  WebOAuthFailureReason,
+  WebOAuthUnsupportedReason,
+  OAuthPopupHandle,
+} from './ui/oauth/types';
 export { OxyAuthPrompt } from './ui/components/OxyAuthPrompt';
 export type { OxyAuthPromptProps } from './ui/components/OxyAuthPrompt';
 export { OxyOAuthCallback } from './ui/components/OxyOAuthCallback';

--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -96,6 +96,7 @@ const OxyProvider: FC<OxyProviderProps> = ({
     authRedirectUri,
     authorizeBaseUrl,
     sessionMode = 'account',
+    webAuthMode = 'redirect',
     queryClient: providedQueryClient,
     requireAuth = 'off',
     hubSync = true,
@@ -295,6 +296,7 @@ const OxyProvider: FC<OxyProviderProps> = ({
                     storageKeyPrefix={storageKeyPrefix}
                     clientId={clientId}
                     sessionMode={sessionMode}
+                    webAuthMode={webAuthMode}
                     hubSync={hubSync}
                     onAuthStateChange={onAuthStateChange as OxyContextProviderProps['onAuthStateChange']}
                 >

--- a/packages/services/src/ui/components/OxySignInButton.tsx
+++ b/packages/services/src/ui/components/OxySignInButton.tsx
@@ -6,9 +6,6 @@ import {
     generatePkcePair,
     generateOAuthState,
     buildOAuthAuthorizeUrl,
-    OXY_OAUTH_STATE_STORAGE_KEY,
-    OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
-    persistOAuthHandshake,
     type PublicApplication,
 } from '@oxyhq/core';
 import { useAuthStore } from '../stores/authStore';
@@ -18,13 +15,15 @@ import { Button, type ButtonVariant } from '@oxyhq/bloom/button';
 import { useOxy } from '../context/OxyContext';
 import { LogoIcon } from './logo/LogoIcon';
 import { subscribeToAccountDialog } from '../navigation/accountDialogManager';
-import { redirectToAuthorize, openAuthorizeUrlNative } from './oauthNavigation';
+import { openAuthorizeUrlNative } from './oauthNavigation';
+import { closeOAuthPopup, openOAuthPopup } from '../oauth/oauthPopup';
+import type { OAuthPopupHandle } from '../oauth/types';
 
 /**
  * The OAuth handshake surfaced to a NATIVE third-party RP via
  * {@link OxySignInButtonProps.onOAuthResult} so it can finish the code exchange
- * (`POST /auth/oauth/token`). Web RPs read the same `state` / `code_verifier`
- * back from `sessionStorage` across the redirect and do not need this callback.
+ * (`POST /auth/oauth/token`). Web sign-in is handled entirely by the SDK's web
+ * transport (`useOxy().startWebOAuthSignIn`) and never uses this callback.
  */
 export interface OxyOAuthResult {
     /** Deep-link URL the native auth session returned to (`?code=…&state=…`), or `null` if unobserved. */
@@ -33,17 +32,6 @@ export interface OxyOAuthResult {
     state: string;
     /** The PKCE `code_verifier` to replay on the token exchange. */
     codeVerifier: string;
-}
-
-/**
- * Persist the OAuth CSRF `state` + PKCE `code_verifier` for the RP callback.
- * Returns `false` when the handshake could not be stored — no `sessionStorage`
- * (SSR / non-browser host) or a write that threw (`SecurityError` /
- * `QuotaExceededError`, e.g. Safari private mode) — so the caller aborts the
- * flow cleanly rather than redirect to a callback that cannot validate `state`.
- */
-function persistOAuthHandshakeForButton(state: string, codeVerifier: string): boolean {
-    return persistOAuthHandshake(state, codeVerifier);
 }
 
 export interface OxySignInButtonProps {
@@ -90,19 +78,20 @@ export interface OxySignInButtonProps {
     /**
      * Exact registered redirect URI the OAuth authorization code is returned to.
      * REQUIRED only for third-party (`type: 'third_party'`) applications, which
-     * sign in via an OAuth + PKCE redirect to `auth.oxy.so`. First-party /
-     * official apps open the in-app dialog and ignore this prop. If a third-party
-     * app resolves without it, the button logs an error and does nothing (it will
-     * not invent a redirect URI).
+     * sign in via OAuth + PKCE against `auth.oxy.so`. First-party / official apps
+     * open the in-app dialog and ignore this prop. If a third-party app resolves
+     * without it, the button logs an error and does nothing (it will not invent a
+     * redirect URI).
      */
     oauthRedirectUri?: string;
 
     /**
      * Native only: receives the OAuth handshake after a third-party auth session
-     * so the RP can finish the token exchange. On web the handshake is read back
-     * from `sessionStorage` across the full-page redirect, so this is not used
-     * there. A native third-party sign-in with NO `onOAuthResult` handler cannot
-     * complete (the `state` + `code_verifier` are lost) and logs a warning.
+     * so the RP can finish the token exchange. On web the SDK completes the flow
+     * itself — the popup transport keeps the handshake in memory, and the
+     * redirect transport reads it back from `sessionStorage` — so this is never
+     * called there. A native third-party sign-in with NO `onOAuthResult` handler
+     * cannot complete (the `state` + `code_verifier` are lost) and logs a warning.
      *
      * @example
      * ```tsx
@@ -155,7 +144,7 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
     onOAuthResult,
 }) => {
     const theme = useTheme();
-    const { openAccountDialog, oxyServices, clientId } = useOxy();
+    const { openAccountDialog, oxyServices, clientId, webAuthMode, startWebOAuthSignIn } = useOxy();
     const { isAuthenticated, isLoading } = useAuthStore(
         useShallow((state) => ({ isAuthenticated: state.isAuthenticated, isLoading: state.isLoading }))
     );
@@ -180,6 +169,12 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
     // redirects, so block a second concurrent press from racing the sessionStorage
     // handshake against a different PKCE pair.
     const routingRef = useRef(false);
+    // Popup mode only opens a window for applications that could actually need
+    // one: `oauthRedirectUri` is required for (and only for) third-party OAuth,
+    // so an official app never flashes a popup open and closed while its
+    // in-app dialog loads.
+    const shouldPreOpenPopup =
+        Platform.OS === 'web' && webAuthMode === 'popup' && Boolean(oauthRedirectUri);
 
     const resolvePublicApplication = useCallback((): Promise<PublicApplication> | null => {
         if (!clientId) return null;
@@ -204,23 +199,51 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
         openAccountDialog('signin');
     }, [openAccountDialog]);
 
-    // Third-party surface: an OAuth 2.0 authorization-code + PKCE redirect to
+    // Third-party surface: an OAuth 2.0 authorization-code + PKCE flow against
     // auth.oxy.so. No FedCM, no SSO bounce, no Oxy session cookies.
+    //
+    // Web delegates to the ONE shared transport (`startWebOAuthSignIn`), which
+    // owns popup-vs-redirect selection, the popup lifecycle, the code exchange,
+    // and the session commit. Native keeps its in-app auth session and hands the
+    // handshake to the RP, which owns that exchange.
     const startThirdPartyOAuth = useCallback(
-        async (app: PublicApplication): Promise<void> => {
+        async (app: PublicApplication, popup: OAuthPopupHandle | null): Promise<void> => {
             if (!clientId) {
+                closeOAuthPopup(popup);
                 startOfficialSignIn();
                 return;
             }
             if (!oauthRedirectUri) {
+                closeOAuthPopup(popup);
                 logger.error(
-                    'OxySignInButton: a third_party application requires the `oauthRedirectUri` prop to start the OAuth redirect; sign-in aborted',
+                    'OxySignInButton: a third_party application requires the `oauthRedirectUri` prop to start the OAuth flow; sign-in aborted',
                     undefined,
                     { component: 'OxySignInButton', clientId, application: app.name },
                 );
                 return;
             }
 
+            if (Platform.OS === 'web') {
+                const result = await startWebOAuthSignIn({
+                    redirectUri: oauthRedirectUri,
+                    // In popup mode the window was claimed during the press (see
+                    // `handlePress`); `null` means the browser blocked it and the
+                    // transport falls back to a redirect. `undefined` (redirect
+                    // mode) lets the transport decide for itself.
+                    ...(shouldPreOpenPopup ? { popup } : {}),
+                });
+                if (result.status === 'failed') {
+                    logger.warn(
+                        `OxySignInButton: web sign-in failed (${result.reason})`,
+                        { component: 'OxySignInButton', application: app.name },
+                        result.description,
+                    );
+                }
+                return;
+            }
+
+            // Native: open the in-app auth session, then hand the handshake to the
+            // RP so it can complete the token exchange from its deep-link callback.
             const [pkce, state] = await Promise.all([generatePkcePair(), generateOAuthState()]);
             const authorizeUrl = buildOAuthAuthorizeUrl({
                 clientId,
@@ -228,20 +251,6 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                 state,
                 codeChallenge: pkce.codeChallenge,
             });
-
-            if (Platform.OS === 'web') {
-                // Persist the handshake for the RP callback, then hand the
-                // top-level document to the IdP. Without storage the callback
-                // cannot validate `state`, so abort cleanly rather than redirect.
-                if (!persistOAuthHandshakeForButton(state, pkce.codeVerifier)) {
-                    return;
-                }
-                redirectToAuthorize(authorizeUrl);
-                return;
-            }
-
-            // Native: open the in-app auth session, then hand the handshake to the
-            // RP so it can complete the token exchange from its deep-link callback.
             const { redirectUrl } = await openAuthorizeUrlNative(authorizeUrl, oauthRedirectUri);
             if (onOAuthResult) {
                 onOAuthResult({ redirectUrl, state, codeVerifier: pkce.codeVerifier });
@@ -252,51 +261,73 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                 { component: 'OxySignInButton', application: app.name },
             );
         },
-        [clientId, oauthRedirectUri, onOAuthResult, startOfficialSignIn],
+        [
+            clientId,
+            oauthRedirectUri,
+            onOAuthResult,
+            startOfficialSignIn,
+            startWebOAuthSignIn,
+            shouldPreOpenPopup,
+        ],
     );
 
-    // Resolve the Application once, then route: third-party → OAuth redirect;
-    // first-party / official / unresolved → the in-app dialog. Resolution failure
-    // NEVER breaks an official app's sign-in — it falls back to the dialog.
-    const routeSignIn = useCallback(async (): Promise<void> => {
-        if (routingRef.current) return;
-        routingRef.current = true;
-        try {
-            const resolving = resolvePublicApplication();
-            if (!resolving) {
-                startOfficialSignIn();
+    // Resolve the Application once, then route: third-party → OAuth; first-party
+    // / official / unresolved → the in-app dialog. Resolution failure NEVER
+    // breaks an official app's sign-in — it falls back to the dialog. Every path
+    // that does NOT reach the OAuth lane closes the pre-opened popup, so a
+    // mis-routed press can never leave an empty window on screen.
+    const routeSignIn = useCallback(
+        async (popup: OAuthPopupHandle | null): Promise<void> => {
+            if (routingRef.current) {
+                closeOAuthPopup(popup);
                 return;
             }
-            let app: PublicApplication;
+            routingRef.current = true;
             try {
-                app = await resolving;
-            } catch (error) {
-                logger.warn(
-                    'OxySignInButton: could not resolve the application; opening the sign-in dialog',
-                    { component: 'OxySignInButton', clientId },
-                    error,
-                );
+                const resolving = resolvePublicApplication();
+                if (!resolving) {
+                    closeOAuthPopup(popup);
+                    startOfficialSignIn();
+                    return;
+                }
+                let app: PublicApplication;
+                try {
+                    app = await resolving;
+                } catch (error) {
+                    closeOAuthPopup(popup);
+                    logger.warn(
+                        'OxySignInButton: could not resolve the application; opening the sign-in dialog',
+                        { component: 'OxySignInButton', clientId },
+                        error,
+                    );
+                    startOfficialSignIn();
+                    return;
+                }
+                if (app.type === 'third_party' && !app.isOfficial) {
+                    await startThirdPartyOAuth(app, popup);
+                    return;
+                }
+                closeOAuthPopup(popup);
                 startOfficialSignIn();
-                return;
+            } finally {
+                routingRef.current = false;
             }
-            if (app.type === 'third_party' && !app.isOfficial) {
-                await startThirdPartyOAuth(app);
-                return;
-            }
-            startOfficialSignIn();
-        } finally {
-            routingRef.current = false;
-        }
-    }, [resolvePublicApplication, startOfficialSignIn, startThirdPartyOAuth, clientId]);
+        },
+        [resolvePublicApplication, startOfficialSignIn, startThirdPartyOAuth, clientId],
+    );
 
     // Defer to a caller-supplied handler, otherwise route by application type.
+    //
+    // The popup is opened HERE, synchronously, before the async application
+    // resolve: `window.open` only survives while the click is still being
+    // handled, so a window opened after that first `await` is silently blocked.
     const handlePress = useCallback(() => {
         if (onPress) {
             onPress();
             return;
         }
-        void routeSignIn();
-    }, [onPress, routeSignIn]);
+        void routeSignIn(shouldPreOpenPopup ? openOAuthPopup() : null);
+    }, [onPress, routeSignIn, shouldPreOpenPopup]);
 
     // Don't show the button if already authenticated (unless explicitly overridden)
     if (isAuthenticated && !showWhenAuthenticated) return null;

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -34,6 +34,11 @@ import {
 } from '../navigation/accountDialogManager';
 import { redirectToAuthorize } from '../components/oauthNavigation';
 import { openPasskeyHubPopup } from '../components/passkeyHubPopup';
+import {
+  startWebOAuthSignIn,
+  type StartWebOAuthSignInOptions,
+} from '../oauth/browserAuthTransport';
+import type { WebOAuthSignInResult } from '../oauth/types';
 import { isWebBrowser } from '../utils/isWebBrowser';
 import { runProviderColdBoot } from '../boot/runProviderColdBoot';
 import { loadPersistedDeviceCredential } from '../utils/deviceCredential';
@@ -97,6 +102,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
   storageKeyPrefix = 'oxy_session',
   clientId: clientIdProp,
   sessionMode = 'account',
+  webAuthMode = 'redirect',
   hubSync = true,
   onAuthStateChange,
   onError,
@@ -742,6 +748,33 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     [commitSession],
   );
 
+  // ── Web third-party OAuth sign-in ──────────────────────────────────────────
+  // The shared operation `OxySignInButton` (and any RP-owned button) delegates
+  // to, so no consumer ever writes popup listeners or a token exchange. The
+  // transport picks popup vs redirect from `webAuthMode`; both lanes land on the
+  // SAME completion path (`completeOAuthCode`) and the same commit funnel here.
+  //
+  // `hubSync: false` is deliberate: hub sync is a full-page redirect to
+  // auth.oxy.so, which would undo the one thing popup mode exists to guarantee —
+  // that the relying party never leaves its route. It matches how the redirect
+  // lane's return leg commits (see `runProviderColdBoot`).
+  const startWebOAuthSignInForContext = useCallback(
+    (options: StartWebOAuthSignInOptions): Promise<WebOAuthSignInResult> =>
+      startWebOAuthSignIn(
+        {
+          mode: webAuthMode,
+          oxyServices,
+          clientId,
+          authorizeBaseUrl,
+          identityBound: isIdentityBound,
+          commitSession: (input) =>
+            commitSessionRef.current(input, { activate: true, hubSync: false }),
+        },
+        options,
+      ),
+    [webAuthMode, oxyServices, clientId, authorizeBaseUrl, isIdentityBound],
+  );
+
   // ── Unified account dialog ─────────────────────────────────────────────────
   // The single account-chooser + sign-in surface. Built ONCE per provider mount
   // and bound to the live `oxyServices` + `sessionClient` + this provider's
@@ -1191,6 +1224,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       isAuthResolved: authResolved,
       isStorageReady: storage !== null,
       sessionMode: isIdentityBound ? 'identity' : 'account',
+      webAuthMode,
       error,
       currentLanguage,
       currentLanguages,
@@ -1206,6 +1240,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       removePasskey,
       revokeSuspiciousSignIn,
       handleWebSession,
+      startWebOAuthSignIn: startWebOAuthSignInForContext,
       logout,
       logoutAll,
       switchSession: switchSessionForContext,
@@ -1246,6 +1281,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       authResolved,
       storage,
       isIdentityBound,
+      webAuthMode,
       error,
       currentLanguage,
       currentLanguages,
@@ -1261,6 +1297,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       removePasskey,
       revokeSuspiciousSignIn,
       handleWebSession,
+      startWebOAuthSignInForContext,
       logout,
       logoutAll,
       switchSessionForContext,
@@ -1319,6 +1356,7 @@ const LOADING_STATE: OxyContextState = {
   isAuthResolved: false,
   isStorageReady: false,
   sessionMode: 'account',
+  webAuthMode: 'redirect',
   error: null,
   currentLanguage: 'en-US',
   currentLanguages: [],
@@ -1334,6 +1372,7 @@ const LOADING_STATE: OxyContextState = {
   removePasskey: () => rejectMissingProvider<void>(),
   revokeSuspiciousSignIn: () => rejectMissingProvider<void>(),
   handleWebSession: () => rejectMissingProvider<void>(),
+  startWebOAuthSignIn: () => rejectMissingProvider<WebOAuthSignInResult>(),
   logout: () => rejectMissingProvider<void>(),
   logoutAll: () => rejectMissingProvider<void>(),
   switchSession: () => rejectMissingProvider<User>(),

--- a/packages/services/src/ui/context/oxyContextTypes.ts
+++ b/packages/services/src/ui/context/oxyContextTypes.ts
@@ -3,6 +3,8 @@ import type { OxyServices, User, SessionLoginResponse, AccountNode, CreateAccoun
 import type { UseFollowHook } from '../hooks/useFollow.types';
 import type { useLanguageManagement } from '../hooks/useLanguageManagement';
 import type { RouteName } from '../navigation/routes';
+import type { StartWebOAuthSignInOptions } from '../oauth/browserAuthTransport';
+import type { WebAuthMode, WebOAuthSignInResult } from '../oauth/types';
 
 export interface OxyContextState {
   user: User | null;
@@ -37,6 +39,8 @@ export interface OxyContextState {
    * while `accounts` stays empty and the account dialog never opens.
    */
   sessionMode: SessionMode;
+  /** How web third-party sign-in reaches the IdP (see `OxyProviderProps.webAuthMode`). */
+  webAuthMode: WebAuthMode;
   error: string | null;
   /** Active UI locale (`language-REGION`): the account's primary locale when signed in, else the guest/device locale. */
   currentLanguage: string;
@@ -89,6 +93,24 @@ export interface OxyContextState {
 
   revokeSuspiciousSignIn: () => Promise<void>;
   handleWebSession: (session: SessionLoginResponse) => Promise<void>;
+
+  /**
+   * Run a WEB third-party OAuth sign-in (authorization code + PKCE) end to end
+   * using this provider's `webAuthMode`, and commit the resulting session.
+   *
+   * This is the shared operation `OxySignInButton` delegates to; RPs that ship
+   * their own button call it directly and never implement popup listeners, a
+   * token exchange, or `state` validation themselves. Returns a typed result —
+   * closing the popup and running out of time are values, not exceptions.
+   *
+   * In popup mode the window MUST be opened during the user's click: either
+   * call this synchronously from the press handler (it opens one itself), or
+   * call `openOAuthPopup()` there and pass the handle as `popup`.
+   *
+   * No-op outside a browser and in `sessionMode: 'identity'`, both of which
+   * resolve to `{ status: 'unsupported' }`.
+   */
+  startWebOAuthSignIn: (options: StartWebOAuthSignInOptions) => Promise<WebOAuthSignInResult>;
 
   logout: (targetSessionId?: string) => Promise<void>;
   logoutAll: () => Promise<void>;
@@ -150,6 +172,11 @@ export interface OxyContextProviderProps {
    * @default 'account'
    */
   sessionMode?: SessionMode;
+  /**
+   * Transport for WEB third-party sign-in. See `OxyProviderProps.webAuthMode`.
+   * @default 'redirect'
+   */
+  webAuthMode?: WebAuthMode;
   /** Sync device credentials to auth.oxy.so after interactive sign-in. @default true */
   hubSync?: boolean;
   onAuthStateChange?: (user: User | null) => void;

--- a/packages/services/src/ui/oauth/__tests__/browserAuthTransport.test.ts
+++ b/packages/services/src/ui/oauth/__tests__/browserAuthTransport.test.ts
@@ -1,0 +1,335 @@
+// The platform redirect is spied on so no real navigation happens and the
+// authorize URL each lane hands to the browser can be asserted.
+jest.mock('../../components/oauthNavigation', () => ({
+  redirectToAuthorize: jest.fn(),
+}));
+
+import type { OxyServices } from '@oxyhq/core';
+import {
+  computeCodeChallenge,
+  OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
+  OXY_OAUTH_STATE_STORAGE_KEY,
+} from '@oxyhq/core';
+import { redirectToAuthorize } from '../../components/oauthNavigation';
+import {
+  startWebOAuthSignIn,
+  type WebOAuthTransportContext,
+} from '../browserAuthTransport';
+import { OXY_OAUTH_CODE_MESSAGE_TYPE, OXY_OAUTH_ERROR_MESSAGE_TYPE } from '../oauthPopupMessages';
+import type { OAuthPopupHandle } from '../types';
+
+const mockRedirect = redirectToAuthorize as jest.Mock;
+
+const CLIENT_ID = 'oxy_dk_test';
+const REDIRECT_URI = 'https://mention.earth';
+const AUTHORIZE_BASE_URL = 'https://auth.oxy.so/authorize';
+const IDP_ORIGIN = 'https://auth.oxy.so';
+
+const SESSION = {
+  sessionId: 'sess-1',
+  deviceId: 'dev-1',
+  deviceSecret: 'secret-1',
+  accessToken: 'token-1',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  user: { id: 'user-1', username: 'nate' },
+};
+
+interface ControllablePopup extends OAuthPopupHandle {
+  close: jest.Mock;
+}
+
+function fakePopup(): ControllablePopup {
+  let closed = false;
+  return {
+    get closed() {
+      return closed;
+    },
+    close: jest.fn(() => {
+      closed = true;
+    }),
+    location: { href: '' },
+  };
+}
+
+function makeContext(
+  overrides: Partial<WebOAuthTransportContext> = {},
+): WebOAuthTransportContext & { exchangeOAuthCode: jest.Mock; commitSession: jest.Mock } {
+  const exchangeOAuthCode = jest.fn().mockResolvedValue(SESSION);
+  const commitSession = jest.fn().mockResolvedValue(undefined);
+  const base: WebOAuthTransportContext = {
+    mode: 'popup',
+    oxyServices: { exchangeOAuthCode } as unknown as OxyServices,
+    clientId: CLIENT_ID,
+    authorizeBaseUrl: AUTHORIZE_BASE_URL,
+    identityBound: false,
+    commitSession,
+  };
+  return { ...base, ...overrides, exchangeOAuthCode, commitSession };
+}
+
+/** Wait for the transport to finish preparing PKCE and navigate the popup. */
+async function waitForAuthorizeUrl(popup: OAuthPopupHandle): Promise<URL> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (popup.location.href) return new URL(popup.location.href);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5);
+    });
+  }
+  throw new Error('the popup was never navigated to the authorize URL');
+}
+
+function dispatchFromPopup(data: unknown, source: unknown, origin = IDP_ORIGIN): void {
+  const event = new Event('message');
+  Object.assign(event, { data, origin, source });
+  window.dispatchEvent(event);
+}
+
+describe('startWebOAuthSignIn', () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+    globalThis.sessionStorage?.clear();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('popup mode', () => {
+    it('signs in without navigating the relying party', async () => {
+      const context = makeContext();
+      const popup = fakePopup();
+
+      const pending = startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI, popup });
+      const authorizeUrl = await waitForAuthorizeUrl(popup);
+
+      // The IdP is asked for the popup channel, with the standard PKCE binding.
+      expect(authorizeUrl.origin).toBe(IDP_ORIGIN);
+      expect(authorizeUrl.searchParams.get('response_mode')).toBe('web_message');
+      expect(authorizeUrl.searchParams.get('client_id')).toBe(CLIENT_ID);
+      expect(authorizeUrl.searchParams.get('redirect_uri')).toBe(REDIRECT_URI);
+      expect(authorizeUrl.searchParams.get('code_challenge_method')).toBe('S256');
+
+      const state = authorizeUrl.searchParams.get('state');
+      dispatchFromPopup(
+        { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'code-1', state },
+        popup,
+      );
+
+      await expect(pending).resolves.toEqual({ status: 'signed-in' });
+      expect(mockRedirect).not.toHaveBeenCalled();
+
+      // The verifier the main window replays is the one behind the challenge it
+      // sent — the popup never saw either.
+      const exchangeArgs = context.exchangeOAuthCode.mock.calls[0][0];
+      expect(exchangeArgs.code).toBe('code-1');
+      expect(exchangeArgs.redirectUri).toBe(REDIRECT_URI);
+      await expect(computeCodeChallenge(exchangeArgs.codeVerifier)).resolves.toBe(
+        authorizeUrl.searchParams.get('code_challenge'),
+      );
+
+      expect(context.commitSession).toHaveBeenCalledTimes(1);
+      // Nothing about the popup handshake is left in storage.
+      expect(sessionStorage.getItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY)).toBeNull();
+      expect(sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
+    });
+
+    it('opens the window itself when the caller did not pre-open one', async () => {
+      const context = makeContext();
+      const popup = fakePopup();
+      const openSpy = jest.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+      const pending = startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI });
+      const authorizeUrl = await waitForAuthorizeUrl(popup);
+      dispatchFromPopup(
+        {
+          type: OXY_OAUTH_CODE_MESSAGE_TYPE,
+          code: 'code-1',
+          state: authorizeUrl.searchParams.get('state'),
+        },
+        popup,
+      );
+
+      await expect(pending).resolves.toEqual({ status: 'signed-in' });
+      expect(openSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to a full-page redirect when the popup was blocked', async () => {
+      const context = makeContext();
+
+      const result = await startWebOAuthSignIn(context, {
+        redirectUri: REDIRECT_URI,
+        popup: null,
+      });
+
+      expect(result).toEqual({ status: 'redirecting', via: 'popup-blocked' });
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      // The fallback is a plain redirect request — no popup channel.
+      const url = new URL(mockRedirect.mock.calls[0][0]);
+      expect(url.searchParams.get('response_mode')).toBeNull();
+      // …and its handshake survives the navigation.
+      expect(sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBe(
+        url.searchParams.get('state'),
+      );
+      expect(sessionStorage.getItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY)).toBeTruthy();
+      expect(context.exchangeOAuthCode).not.toHaveBeenCalled();
+    });
+
+    it('falls back to a full-page redirect when the popup cannot be navigated', async () => {
+      const context = makeContext();
+      const deadPopup: OAuthPopupHandle = {
+        closed: false,
+        close: jest.fn(),
+        get location(): { href: string } {
+          throw new Error('window closed');
+        },
+      };
+
+      const result = await startWebOAuthSignIn(context, {
+        redirectUri: REDIRECT_URI,
+        popup: deadPopup,
+      });
+
+      expect(result).toEqual({ status: 'redirecting', via: 'popup-navigation-failed' });
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces a typed IdP error and closes the window', async () => {
+      const context = makeContext();
+      const popup = fakePopup();
+
+      const pending = startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI, popup });
+      const authorizeUrl = await waitForAuthorizeUrl(popup);
+      dispatchFromPopup(
+        {
+          type: OXY_OAUTH_ERROR_MESSAGE_TYPE,
+          error: 'access_denied',
+          errorDescription: 'user declined',
+          state: authorizeUrl.searchParams.get('state'),
+        },
+        popup,
+      );
+
+      await expect(pending).resolves.toEqual({
+        status: 'failed',
+        reason: 'idp-error',
+        description: 'user declined',
+      });
+      expect(context.exchangeOAuthCode).not.toHaveBeenCalled();
+      expect(popup.close).toHaveBeenCalled();
+    });
+
+    it('refuses a result carrying the wrong state', async () => {
+      const context = makeContext();
+      const popup = fakePopup();
+
+      const pending = startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI, popup });
+      await waitForAuthorizeUrl(popup);
+      dispatchFromPopup(
+        { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'code-1', state: 'forged-state' },
+        popup,
+      );
+
+      await expect(pending).resolves.toEqual({ status: 'failed', reason: 'state-mismatch' });
+      expect(context.exchangeOAuthCode).not.toHaveBeenCalled();
+      expect(context.commitSession).not.toHaveBeenCalled();
+    });
+
+    it('reports a timeout when the popup never answers', async () => {
+      const context = makeContext();
+      const popup = fakePopup();
+
+      const result = await startWebOAuthSignIn(context, {
+        redirectUri: REDIRECT_URI,
+        popup,
+        timeoutMs: 20,
+      });
+
+      expect(result).toEqual({ status: 'timed-out' });
+      expect(popup.close).toHaveBeenCalled();
+      expect(context.exchangeOAuthCode).not.toHaveBeenCalled();
+    });
+
+    it('reports a failed exchange', async () => {
+      const context = makeContext();
+      context.exchangeOAuthCode.mockRejectedValue(new Error('invalid_grant'));
+      const popup = fakePopup();
+
+      const pending = startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI, popup });
+      const authorizeUrl = await waitForAuthorizeUrl(popup);
+      dispatchFromPopup(
+        {
+          type: OXY_OAUTH_CODE_MESSAGE_TYPE,
+          code: 'code-1',
+          state: authorizeUrl.searchParams.get('state'),
+        },
+        popup,
+      );
+
+      await expect(pending).resolves.toEqual({ status: 'failed', reason: 'exchange-failed' });
+      expect(context.commitSession).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('redirect mode', () => {
+    it('hands the top-level document to the IdP and persists the handshake', async () => {
+      const context = makeContext({ mode: 'redirect' });
+
+      const result = await startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI });
+
+      expect(result).toEqual({ status: 'redirecting', via: 'redirect-mode' });
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      const url = new URL(mockRedirect.mock.calls[0][0]);
+      expect(url.searchParams.get('response_mode')).toBeNull();
+      expect(url.searchParams.get('client_id')).toBe(CLIENT_ID);
+      expect(sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBe(
+        url.searchParams.get('state'),
+      );
+    });
+
+    it('never opens a window, even if one was handed to it', async () => {
+      const context = makeContext({ mode: 'redirect' });
+      const popup = fakePopup();
+      const openSpy = jest.spyOn(window, 'open');
+
+      await startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI, popup });
+
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(popup.close).toHaveBeenCalledTimes(1);
+      expect(popup.location.href).toBe('');
+    });
+
+    it('aborts instead of redirecting when the handshake cannot be persisted', async () => {
+      const context = makeContext({ mode: 'redirect' });
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('storage is disabled');
+      });
+
+      const result = await startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI });
+
+      expect(result).toEqual({ status: 'failed', reason: 'handshake-storage' });
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('inapplicable configurations', () => {
+    it('refuses an identity-bound provider and closes any popup it was given', async () => {
+      const context = makeContext({ identityBound: true });
+      const popup = fakePopup();
+
+      const result = await startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI, popup });
+
+      expect(result).toEqual({ status: 'unsupported', reason: 'identity-bound' });
+      expect(popup.close).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it('refuses a provider with no clientId', async () => {
+      const context = makeContext({ clientId: null });
+
+      const result = await startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI });
+
+      expect(result).toEqual({ status: 'unsupported', reason: 'missing-client-id' });
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/services/src/ui/oauth/__tests__/completeOAuthCode.test.ts
+++ b/packages/services/src/ui/oauth/__tests__/completeOAuthCode.test.ts
@@ -1,0 +1,142 @@
+import type { OxyServices } from '@oxyhq/core';
+import { completeOAuthCode } from '../completeOAuthCode';
+import type { OAuthSessionCommitInput } from '../types';
+
+const HANDSHAKE = { state: 'state-abc', codeVerifier: 'verifier-xyz' };
+const REDIRECT_URI = 'https://mention.earth';
+
+const SESSION = {
+  sessionId: 'sess-1',
+  deviceId: 'dev-1',
+  deviceSecret: 'secret-1',
+  accessToken: 'token-1',
+  expiresAt: '2099-01-01T00:00:00.000Z',
+  user: { id: 'user-1', username: 'nate', avatar: 'a1' },
+};
+
+function makeOxyServices(exchange: jest.Mock): OxyServices {
+  return { exchangeOAuthCode: exchange } as unknown as OxyServices;
+}
+
+describe('completeOAuthCode', () => {
+  it('exchanges the code and commits the session it returns', async () => {
+    const exchange = jest.fn().mockResolvedValue(SESSION);
+    const committed: OAuthSessionCommitInput[] = [];
+
+    const result = await completeOAuthCode({
+      oxyServices: makeOxyServices(exchange),
+      clientId: 'oxy_dk_test',
+      code: 'code-1',
+      returnedState: HANDSHAKE.state,
+      handshake: HANDSHAKE,
+      redirectUri: REDIRECT_URI,
+      commitSession: async (input) => {
+        committed.push(input);
+      },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(exchange).toHaveBeenCalledWith({
+      code: 'code-1',
+      clientId: 'oxy_dk_test',
+      redirectUri: REDIRECT_URI,
+      codeVerifier: HANDSHAKE.codeVerifier,
+    });
+    expect(committed).toEqual([
+      {
+        sessionId: 'sess-1',
+        accessToken: 'token-1',
+        deviceId: 'dev-1',
+        deviceSecret: 'secret-1',
+        userId: 'user-1',
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        user: SESSION.user,
+      },
+    ]);
+  });
+
+  it('cleans up BEFORE committing, so a stale code cannot re-enter the exchange', async () => {
+    const order: string[] = [];
+    const result = await completeOAuthCode({
+      oxyServices: makeOxyServices(jest.fn().mockResolvedValue(SESSION)),
+      clientId: 'oxy_dk_test',
+      code: 'code-1',
+      returnedState: HANDSHAKE.state,
+      handshake: HANDSHAKE,
+      redirectUri: REDIRECT_URI,
+      commitSession: async () => {
+        order.push('commit');
+      },
+      cleanup: () => {
+        order.push('cleanup');
+      },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(order).toEqual(['cleanup', 'commit']);
+  });
+
+  it.each([
+    ['a mismatched state', 'someone-elses-state', HANDSHAKE],
+    ['no returned state', null, HANDSHAKE],
+    ['no stored handshake', HANDSHAKE.state, null],
+  ])('refuses to exchange the code with %s', async (_label, returnedState, handshake) => {
+    const exchange = jest.fn();
+    const commitSession = jest.fn();
+    const cleanup = jest.fn();
+
+    const result = await completeOAuthCode({
+      oxyServices: makeOxyServices(exchange),
+      clientId: 'oxy_dk_test',
+      code: 'code-1',
+      returnedState,
+      handshake,
+      redirectUri: REDIRECT_URI,
+      commitSession,
+      cleanup,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'state-mismatch' });
+    expect(exchange).not.toHaveBeenCalled();
+    expect(commitSession).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a failed exchange without throwing, and still cleans up', async () => {
+    const cleanup = jest.fn();
+    const commitSession = jest.fn();
+
+    const result = await completeOAuthCode({
+      oxyServices: makeOxyServices(jest.fn().mockRejectedValue(new Error('invalid_grant'))),
+      clientId: 'oxy_dk_test',
+      code: 'code-1',
+      returnedState: HANDSHAKE.state,
+      handshake: HANDSHAKE,
+      redirectUri: REDIRECT_URI,
+      commitSession,
+      cleanup,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'exchange-failed' });
+    expect(commitSession).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a failed commit without throwing, and cleans up exactly once', async () => {
+    const cleanup = jest.fn();
+
+    const result = await completeOAuthCode({
+      oxyServices: makeOxyServices(jest.fn().mockResolvedValue(SESSION)),
+      clientId: 'oxy_dk_test',
+      code: 'code-1',
+      returnedState: HANDSHAKE.state,
+      handshake: HANDSHAKE,
+      redirectUri: REDIRECT_URI,
+      commitSession: jest.fn().mockRejectedValue(new Error('commit blew up')),
+      cleanup,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'exchange-failed' });
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/services/src/ui/oauth/__tests__/oauthPopup.test.ts
+++ b/packages/services/src/ui/oauth/__tests__/oauthPopup.test.ts
@@ -1,0 +1,326 @@
+import {
+  awaitOAuthPopupResult,
+  closeOAuthPopup,
+  navigateOAuthPopup,
+  openOAuthPopup,
+  OXY_OAUTH_POPUP_WINDOW_NAME,
+} from '../oauthPopup';
+import { OXY_OAUTH_CODE_MESSAGE_TYPE, OXY_OAUTH_ERROR_MESSAGE_TYPE } from '../oauthPopupMessages';
+import type { OAuthPopupHandle, OAuthPopupOutcome } from '../types';
+
+const IDP_ORIGIN = 'https://auth.oxy.so';
+const STATE = 'state-abc';
+
+interface ControllablePopup extends OAuthPopupHandle {
+  close: jest.Mock;
+  setClosed: () => void;
+}
+
+function fakePopup(): ControllablePopup {
+  let closed = false;
+  return {
+    get closed() {
+      return closed;
+    },
+    close: jest.fn(() => {
+      closed = true;
+    }),
+    location: { href: '' },
+    setClosed: () => {
+      closed = true;
+    },
+  };
+}
+
+function dispatchMessage(init: { data: unknown; origin: string; source: unknown }): void {
+  const event = new Event('message');
+  Object.assign(event, init);
+  window.dispatchEvent(event);
+}
+
+function codeMessage(source: unknown, state = STATE, origin = IDP_ORIGIN) {
+  return {
+    data: { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'code-1', state },
+    origin,
+    source,
+  };
+}
+
+/** Resolve the outcome, or `'pending'` when the promise has not settled yet. */
+async function outcomeOrPending(
+  promise: Promise<OAuthPopupOutcome>,
+): Promise<OAuthPopupOutcome | 'pending'> {
+  return Promise.race([
+    promise,
+    Promise.resolve().then(() => 'pending' as const),
+  ]);
+}
+
+describe('openOAuthPopup', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('opens an empty, named window so a second press reuses it', () => {
+    const handle = fakePopup();
+    const openSpy = jest
+      .spyOn(window, 'open')
+      .mockReturnValue(handle as unknown as Window);
+
+    expect(openOAuthPopup()).toBe(handle);
+    expect(openSpy).toHaveBeenCalledWith('', OXY_OAUTH_POPUP_WINDOW_NAME, expect.any(String));
+    // The window is navigated later, once the authorize URL exists.
+    expect(openSpy.mock.calls[0][0]).toBe('');
+  });
+
+  it('returns null when the browser blocks the popup', () => {
+    jest.spyOn(window, 'open').mockReturnValue(null);
+    expect(openOAuthPopup()).toBeNull();
+  });
+
+  it('returns null instead of throwing when window.open throws', () => {
+    jest.spyOn(window, 'open').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(openOAuthPopup()).toBeNull();
+  });
+});
+
+describe('navigateOAuthPopup', () => {
+  it('points the popup at the authorize URL', () => {
+    const popup = fakePopup();
+    expect(navigateOAuthPopup(popup, `${IDP_ORIGIN}/authorize?x=1`)).toBe(true);
+    expect(popup.location.href).toBe(`${IDP_ORIGIN}/authorize?x=1`);
+  });
+
+  it('reports failure instead of throwing when the window is gone', () => {
+    const popup: OAuthPopupHandle = {
+      closed: true,
+      close: () => undefined,
+      get location(): { href: string } {
+        throw new Error('window closed');
+      },
+    };
+    expect(navigateOAuthPopup(popup, `${IDP_ORIGIN}/authorize`)).toBe(false);
+  });
+});
+
+describe('closeOAuthPopup', () => {
+  it('is a no-op for null and for an already-closed window', () => {
+    expect(() => closeOAuthPopup(null)).not.toThrow();
+    const popup = fakePopup();
+    popup.setClosed();
+    closeOAuthPopup(popup);
+    expect(popup.close).not.toHaveBeenCalled();
+  });
+
+  it('closes an open window and swallows a close that throws', () => {
+    const popup = fakePopup();
+    closeOAuthPopup(popup);
+    expect(popup.close).toHaveBeenCalledTimes(1);
+
+    const hostile: OAuthPopupHandle = {
+      closed: false,
+      close: () => {
+        throw new Error('denied');
+      },
+      location: { href: '' },
+    };
+    expect(() => closeOAuthPopup(hostile)).not.toThrow();
+  });
+});
+
+describe('awaitOAuthPopupResult', () => {
+  let addSpy: jest.SpyInstance;
+  let removeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    addSpy = jest.spyOn(window, 'addEventListener');
+    removeSpy = jest.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  /** Every exit path must leave zero listeners and zero timers behind. */
+  function expectFullCleanup(): void {
+    const registered = addSpy.mock.calls.filter(([type]) => type === 'message');
+    const removed = removeSpy.mock.calls.filter(([type]) => type === 'message');
+    expect(registered).toHaveLength(1);
+    expect(removed).toHaveLength(1);
+    expect(removed[0][1]).toBe(registered[0][1]);
+    expect(jest.getTimerCount()).toBe(0);
+  }
+
+  it('resolves with the authorization code on a valid message', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+    });
+
+    dispatchMessage(codeMessage(popup));
+
+    await expect(promise).resolves.toEqual({ kind: 'code', code: 'code-1', state: STATE });
+    expectFullCleanup();
+  });
+
+  it('resolves with a typed IdP error', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+    });
+
+    dispatchMessage({
+      data: {
+        type: OXY_OAUTH_ERROR_MESSAGE_TYPE,
+        error: 'access_denied',
+        errorDescription: 'user declined',
+        state: STATE,
+      },
+      origin: IDP_ORIGIN,
+      source: popup,
+    });
+
+    await expect(promise).resolves.toEqual({
+      kind: 'oauth-error',
+      error: 'access_denied',
+      errorDescription: 'user declined',
+    });
+    expectFullCleanup();
+  });
+
+  it('resolves with a state mismatch when our popup answers another request', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+    });
+
+    dispatchMessage(codeMessage(popup, 'a-different-state'));
+
+    await expect(promise).resolves.toEqual({ kind: 'state-mismatch' });
+    expectFullCleanup();
+  });
+
+  it.each([
+    ['a foreign origin', () => codeMessage(fakePopup(), STATE, 'https://evil.example')],
+    ['a foreign window', () => codeMessage(fakePopup())],
+  ])('keeps waiting after a message from %s', async (_label, build) => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+      timeoutMs: 60_000,
+    });
+
+    dispatchMessage(build());
+    expect(await outcomeOrPending(promise)).toBe('pending');
+
+    // The real popup can still complete the flow afterwards.
+    dispatchMessage(codeMessage(popup));
+    await expect(promise).resolves.toEqual({ kind: 'code', code: 'code-1', state: STATE });
+    expectFullCleanup();
+  });
+
+  it('keeps waiting after a malformed payload from the real popup', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+      timeoutMs: 60_000,
+    });
+
+    dispatchMessage({ data: { type: 'oxy:oauth:code' }, origin: IDP_ORIGIN, source: popup });
+    expect(await outcomeOrPending(promise)).toBe('pending');
+
+    dispatchMessage(codeMessage(popup));
+    await expect(promise).resolves.toEqual({ kind: 'code', code: 'code-1', state: STATE });
+    expectFullCleanup();
+  });
+
+  it('ignores a duplicate result: the first message wins and the listener is gone', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+    });
+
+    dispatchMessage(codeMessage(popup));
+    await expect(promise).resolves.toEqual({ kind: 'code', code: 'code-1', state: STATE });
+
+    // A late redelivery (or a second, contradicting message) reaches nothing.
+    expect(() =>
+      dispatchMessage({
+        data: { type: OXY_OAUTH_ERROR_MESSAGE_TYPE, error: 'access_denied', state: STATE },
+        origin: IDP_ORIGIN,
+        source: popup,
+      }),
+    ).not.toThrow();
+    await expect(promise).resolves.toEqual({ kind: 'code', code: 'code-1', state: STATE });
+    expectFullCleanup();
+  });
+
+  it('reports cancellation once the user closes the window', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+    });
+
+    popup.setClosed();
+    jest.advanceTimersByTime(1000);
+    // The close is not reported instantly: an already-queued message may still win.
+    expect(await outcomeOrPending(promise)).toBe('pending');
+
+    jest.advanceTimersByTime(400);
+    await expect(promise).resolves.toEqual({ kind: 'closed' });
+    expectFullCleanup();
+  });
+
+  it('lets a result that arrived just before the close win the race', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+    });
+
+    // The IdP posts its result and immediately closes itself.
+    popup.setClosed();
+    jest.advanceTimersByTime(1000);
+    dispatchMessage(codeMessage(popup));
+    jest.advanceTimersByTime(1000);
+
+    await expect(promise).resolves.toEqual({ kind: 'code', code: 'code-1', state: STATE });
+    expectFullCleanup();
+  });
+
+  it('times out when nothing ever answers', async () => {
+    const popup = fakePopup();
+    const promise = awaitOAuthPopupResult({
+      popup,
+      expectedOrigin: IDP_ORIGIN,
+      expectedState: STATE,
+      timeoutMs: 30_000,
+    });
+
+    jest.advanceTimersByTime(29_999);
+    expect(await outcomeOrPending(promise)).toBe('pending');
+
+    jest.advanceTimersByTime(1);
+    await expect(promise).resolves.toEqual({ kind: 'timed-out' });
+    expectFullCleanup();
+  });
+});

--- a/packages/services/src/ui/oauth/__tests__/oauthPopupMessages.test.ts
+++ b/packages/services/src/ui/oauth/__tests__/oauthPopupMessages.test.ts
@@ -1,0 +1,189 @@
+import {
+  OXY_OAUTH_CODE_MESSAGE_TYPE,
+  OXY_OAUTH_ERROR_MESSAGE_TYPE,
+  parseOAuthPopupMessage,
+  readOAuthPopupMessage,
+} from '../oauthPopupMessages';
+import type { OAuthPopupHandle } from '../types';
+
+const IDP_ORIGIN = 'https://auth.oxy.so';
+const STATE = 'state-abc';
+
+/** A stand-in for the popup `Window`; identity is all the validator compares. */
+function fakePopup(): OAuthPopupHandle {
+  return { closed: false, close: () => undefined, location: { href: '' } };
+}
+
+/**
+ * Build a `message` event with attacker-controllable fields. jsdom's
+ * `MessageEvent` constructor refuses a non-`Window` `source`, so the event is
+ * assembled the way the browser hands it to the listener instead.
+ */
+function makeMessageEvent(init: {
+  data: unknown;
+  origin: string;
+  source: unknown;
+}): MessageEvent {
+  const event = new Event('message');
+  Object.assign(event, init);
+  return event as MessageEvent;
+}
+
+describe('parseOAuthPopupMessage', () => {
+  it('accepts a well-formed code message', () => {
+    expect(
+      parseOAuthPopupMessage({ type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c1', state: STATE }),
+    ).toEqual({ type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c1', state: STATE });
+  });
+
+  it('accepts a well-formed error message and its optional fields', () => {
+    expect(
+      parseOAuthPopupMessage({
+        type: OXY_OAUTH_ERROR_MESSAGE_TYPE,
+        error: 'access_denied',
+        errorDescription: 'user said no',
+        state: STATE,
+      }),
+    ).toEqual({
+      type: OXY_OAUTH_ERROR_MESSAGE_TYPE,
+      error: 'access_denied',
+      errorDescription: 'user said no',
+      state: STATE,
+    });
+  });
+
+  it('drops optional error fields that are not non-empty strings', () => {
+    expect(
+      parseOAuthPopupMessage({
+        type: OXY_OAUTH_ERROR_MESSAGE_TYPE,
+        error: 'server_error',
+        errorDescription: 42,
+        state: '',
+      }),
+    ).toEqual({ type: OXY_OAUTH_ERROR_MESSAGE_TYPE, error: 'server_error' });
+  });
+
+  it('never surfaces extra properties a sender smuggled in', () => {
+    const parsed = parseOAuthPopupMessage({
+      type: OXY_OAUTH_CODE_MESSAGE_TYPE,
+      code: 'c1',
+      state: STATE,
+      accessToken: 'leaked',
+      deviceSecret: 'leaked',
+    });
+    expect(parsed).toEqual({ type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c1', state: STATE });
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'oxy:oauth:code'],
+    ['a number', 7],
+    ['an array', [{ type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c', state: STATE }]],
+    ['an unknown type', { type: 'oxy:oauth:token', code: 'c', state: STATE }],
+    ['a code message with no code', { type: OXY_OAUTH_CODE_MESSAGE_TYPE, state: STATE }],
+    ['a code message with an empty code', { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: '', state: STATE }],
+    ['a code message with no state', { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c' }],
+    ['a code message with a non-string code', { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 1, state: STATE }],
+    ['an error message with no error', { type: OXY_OAUTH_ERROR_MESSAGE_TYPE, state: STATE }],
+  ])('rejects %s', (_label, data) => {
+    expect(parseOAuthPopupMessage(data)).toBeNull();
+  });
+});
+
+describe('readOAuthPopupMessage', () => {
+  const popup = fakePopup();
+  const context = { expectedOrigin: IDP_ORIGIN, expectedState: STATE, popup };
+
+  it('returns the code when origin, source, shape and state all match', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({
+        data: { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c1', state: STATE },
+        origin: IDP_ORIGIN,
+        source: popup,
+      }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'code', code: 'c1', state: STATE });
+  });
+
+  it('ignores a message from another origin, even with a valid payload', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({
+        data: { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'evil', state: STATE },
+        origin: 'https://evil.example',
+        source: popup,
+      }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'ignore' });
+  });
+
+  it('ignores a message from a window that is not the popup we opened', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({
+        data: { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'evil', state: STATE },
+        origin: IDP_ORIGIN,
+        source: fakePopup(),
+      }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'ignore' });
+  });
+
+  it('ignores a message with no source at all', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({
+        data: { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c1', state: STATE },
+        origin: IDP_ORIGIN,
+        source: null,
+      }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'ignore' });
+  });
+
+  it('ignores a malformed payload from the real popup', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({ data: { hello: 'world' }, origin: IDP_ORIGIN, source: popup }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'ignore' });
+  });
+
+  it('reports a state mismatch on a code message bound to another request', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({
+        data: { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'c1', state: 'other-state' },
+        origin: IDP_ORIGIN,
+        source: popup,
+      }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'state-mismatch' });
+  });
+
+  it('accepts an error message that carries no state', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({
+        data: { type: OXY_OAUTH_ERROR_MESSAGE_TYPE, error: 'access_denied' },
+        origin: IDP_ORIGIN,
+        source: popup,
+      }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'oauth-error', error: 'access_denied' });
+  });
+
+  it('reports a state mismatch on an error message bound to another request', () => {
+    const verdict = readOAuthPopupMessage(
+      makeMessageEvent({
+        data: { type: OXY_OAUTH_ERROR_MESSAGE_TYPE, error: 'access_denied', state: 'other' },
+        origin: IDP_ORIGIN,
+        source: popup,
+      }),
+      context,
+    );
+    expect(verdict).toEqual({ kind: 'state-mismatch' });
+  });
+});

--- a/packages/services/src/ui/oauth/__tests__/sharedCompletionPath.test.ts
+++ b/packages/services/src/ui/oauth/__tests__/sharedCompletionPath.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Both web transports MUST finish through the same completion function.
+ *
+ * A duplicated exchange/commit implementation is how the popup and redirect
+ * lanes would silently drift apart on `state` validation, PKCE replay, or the
+ * session commit — so this suite mocks `completeOAuthCode` and proves each lane
+ * routes through it and performs no exchange of its own.
+ */
+
+jest.mock('../completeOAuthCode', () => ({
+  completeOAuthCode: jest.fn(),
+}));
+jest.mock('../../components/oauthNavigation', () => ({
+  redirectToAuthorize: jest.fn(),
+}));
+
+import type { OxyServices } from '@oxyhq/core';
+import {
+  OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY,
+  OXY_OAUTH_STATE_STORAGE_KEY,
+} from '@oxyhq/core';
+import { tryCompleteOAuthReturn } from '../../utils/oauthReturn';
+import { startWebOAuthSignIn, type WebOAuthTransportContext } from '../browserAuthTransport';
+import { completeOAuthCode } from '../completeOAuthCode';
+import { OXY_OAUTH_CODE_MESSAGE_TYPE } from '../oauthPopupMessages';
+import type { CompleteOAuthCodeInput } from '../completeOAuthCode';
+import type { OAuthPopupHandle } from '../types';
+
+const mockCompleteOAuthCode = completeOAuthCode as jest.Mock;
+
+const CLIENT_ID = 'oxy_dk_test';
+const REDIRECT_URI = 'https://mention.earth';
+const IDP_ORIGIN = 'https://auth.oxy.so';
+
+function fakePopup(): OAuthPopupHandle {
+  return { closed: false, close: jest.fn(), location: { href: '' } };
+}
+
+function makeContext(mode: 'popup' | 'redirect'): WebOAuthTransportContext & {
+  exchangeOAuthCode: jest.Mock;
+} {
+  const exchangeOAuthCode = jest.fn();
+  return {
+    mode,
+    oxyServices: { exchangeOAuthCode } as unknown as OxyServices,
+    clientId: CLIENT_ID,
+    authorizeBaseUrl: `${IDP_ORIGIN}/authorize`,
+    identityBound: false,
+    commitSession: jest.fn().mockResolvedValue(undefined),
+    exchangeOAuthCode,
+  };
+}
+
+async function waitForAuthorizeUrl(popup: OAuthPopupHandle): Promise<URL> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (popup.location.href) return new URL(popup.location.href);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5);
+    });
+  }
+  throw new Error('the popup was never navigated to the authorize URL');
+}
+
+describe('shared OAuth completion path', () => {
+  beforeEach(() => {
+    mockCompleteOAuthCode.mockReset();
+    mockCompleteOAuthCode.mockResolvedValue({ ok: true });
+    globalThis.sessionStorage?.clear();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('the popup transport completes through completeOAuthCode with its in-memory handshake', async () => {
+    const context = makeContext('popup');
+    const popup = fakePopup();
+
+    const pending = startWebOAuthSignIn(context, { redirectUri: REDIRECT_URI, popup });
+    const authorizeUrl = await waitForAuthorizeUrl(popup);
+    const state = authorizeUrl.searchParams.get('state');
+    const event = new Event('message');
+    Object.assign(event, {
+      data: { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: 'code-1', state },
+      origin: IDP_ORIGIN,
+      source: popup,
+    });
+    window.dispatchEvent(event);
+
+    await expect(pending).resolves.toEqual({ status: 'signed-in' });
+
+    expect(mockCompleteOAuthCode).toHaveBeenCalledTimes(1);
+    const input = mockCompleteOAuthCode.mock.calls[0][0] as CompleteOAuthCodeInput;
+    expect(input.code).toBe('code-1');
+    expect(input.clientId).toBe(CLIENT_ID);
+    expect(input.redirectUri).toBe(REDIRECT_URI);
+    expect(input.returnedState).toBe(state);
+    expect(input.handshake?.state).toBe(state);
+    expect(input.handshake?.codeVerifier).toEqual(expect.any(String));
+    // Nothing was persisted, so there is nothing for this lane to clean up.
+    expect(input.cleanup).toBeUndefined();
+    // The transport never exchanges the code itself.
+    expect(context.exchangeOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it('the redirect return leg completes through completeOAuthCode with the persisted handshake', async () => {
+    const exchangeOAuthCode = jest.fn();
+    const oxyServices = { exchangeOAuthCode } as unknown as OxyServices;
+    sessionStorage.setItem(OXY_OAUTH_STATE_STORAGE_KEY, 'state-from-storage');
+    sessionStorage.setItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY, 'verifier-from-storage');
+    window.history.replaceState({}, '', '/feed?code=code-2&state=state-from-storage');
+
+    await expect(
+      tryCompleteOAuthReturn({
+        oxyServices,
+        clientId: CLIENT_ID,
+        authRedirectUri: REDIRECT_URI,
+        commitSession: jest.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBe(true);
+
+    expect(mockCompleteOAuthCode).toHaveBeenCalledTimes(1);
+    const input = mockCompleteOAuthCode.mock.calls[0][0] as CompleteOAuthCodeInput;
+    expect(input.code).toBe('code-2');
+    expect(input.returnedState).toBe('state-from-storage');
+    expect(input.handshake).toEqual({
+      state: 'state-from-storage',
+      codeVerifier: 'verifier-from-storage',
+    });
+    expect(input.redirectUri).toBe(REDIRECT_URI);
+    // This lane DOES have persisted state + a dirty URL to clear.
+    expect(typeof input.cleanup).toBe('function');
+    // The return leg never exchanges the code itself.
+    expect(exchangeOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it('reports the shared path failing rather than committing a session', async () => {
+    mockCompleteOAuthCode.mockResolvedValue({ ok: false, reason: 'state-mismatch' });
+    sessionStorage.setItem(OXY_OAUTH_STATE_STORAGE_KEY, 'state-from-storage');
+    sessionStorage.setItem(OXY_OAUTH_CODE_VERIFIER_STORAGE_KEY, 'verifier-from-storage');
+    window.history.replaceState({}, '', '/?code=code-3&state=state-from-storage');
+
+    await expect(
+      tryCompleteOAuthReturn({
+        oxyServices: { exchangeOAuthCode: jest.fn() } as unknown as OxyServices,
+        clientId: CLIENT_ID,
+        commitSession: jest.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('never reaches the shared path without a clientId', async () => {
+    window.history.replaceState({}, '', '/?code=code-4&state=state-from-storage');
+
+    await expect(
+      tryCompleteOAuthReturn({
+        oxyServices: { exchangeOAuthCode: jest.fn() } as unknown as OxyServices,
+        clientId: null,
+        commitSession: jest.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBe(false);
+    expect(mockCompleteOAuthCode).not.toHaveBeenCalled();
+  });
+
+  it('never reaches the shared path when the IdP returned an error instead of a code', async () => {
+    window.history.replaceState({}, '', '/?error=access_denied&state=state-from-storage');
+
+    await expect(
+      tryCompleteOAuthReturn({
+        oxyServices: { exchangeOAuthCode: jest.fn() } as unknown as OxyServices,
+        clientId: CLIENT_ID,
+        commitSession: jest.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toBe(false);
+    expect(mockCompleteOAuthCode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/src/ui/oauth/browserAuthTransport.ts
+++ b/packages/services/src/ui/oauth/browserAuthTransport.ts
@@ -1,0 +1,187 @@
+/**
+ * The single web entry point for third-party "Sign in with Oxy".
+ *
+ * Picks the transport (`popup` or `redirect`), drives it, and returns ONE typed
+ * result — so callers (`OxySignInButton`, and any RP with its own button) never
+ * touch `window.open`, `postMessage`, or the token exchange themselves.
+ *
+ * Popup mode keeps the relying party mounted: its route, scroll position, and
+ * unsaved state survive because the tab never navigates. Redirect mode is the
+ * compatibility fallback, and is also where popup mode lands when the browser
+ * blocks the window — a blocked popup must still sign the user in, not dead-end.
+ *
+ * Native is NOT handled here: `openAuthorizeUrlNative` (an in-app auth session)
+ * remains the native lane and is untouched by this module.
+ */
+
+import { logger, persistOAuthHandshake } from '@oxyhq/core';
+import type { OxyServices } from '@oxyhq/core';
+import { redirectToAuthorize } from '../components/oauthNavigation';
+import { isWebBrowser } from '../utils/isWebBrowser';
+import { completeOAuthCode } from './completeOAuthCode';
+import { prepareAuthorizeRequest } from './oauthHandshake';
+import { awaitOAuthPopupResult, closeOAuthPopup, navigateOAuthPopup, openOAuthPopup } from './oauthPopup';
+import type {
+  OAuthPopupHandle,
+  OAuthSessionCommitInput,
+  WebAuthMode,
+  WebOAuthRedirectReason,
+  WebOAuthSignInResult,
+} from './types';
+
+/** Provider-owned wiring for a web sign-in — everything that is not per-press. */
+export interface WebOAuthTransportContext {
+  /** The provider's `webAuthMode`. */
+  mode: WebAuthMode;
+  oxyServices: OxyServices;
+  /** The app's registered client id; `null` disables third-party sign-in. */
+  clientId: string | null;
+  /** Authorize endpoint override (local/staging deployments). */
+  authorizeBaseUrl?: string;
+  /** `sessionMode: 'identity'` — no third-party OAuth lane exists by design. */
+  identityBound: boolean;
+  /** The provider's session commit funnel. */
+  commitSession: (input: OAuthSessionCommitInput) => Promise<void>;
+}
+
+/** Per-press inputs for {@link startWebOAuthSignIn}. */
+export interface StartWebOAuthSignInOptions {
+  /** EXACT registered redirect URI for this application. */
+  redirectUri: string;
+  /**
+   * The popup to drive, when the caller already opened one.
+   *
+   * - omitted — this call opens the window itself, which is only valid when it
+   *   was invoked SYNCHRONOUSLY from the user's click (gesture attribution);
+   * - `null` — the caller tried and the browser blocked it: fall back to a
+   *   full-page redirect;
+   * - a handle — use exactly this window.
+   *
+   * Callers that must `await` before signing in (resolving the application, for
+   * instance) have to open the window in their press handler and pass it here;
+   * a window opened after an `await` is silently blocked by every browser.
+   */
+  popup?: OAuthPopupHandle | null;
+  /** Requested scope; defaults to the SDK's standard sign-in scope. */
+  scope?: string;
+  /** Popup timeout override (ms). */
+  timeoutMs?: number;
+}
+
+export async function startWebOAuthSignIn(
+  context: WebOAuthTransportContext,
+  options: StartWebOAuthSignInOptions,
+): Promise<WebOAuthSignInResult> {
+  if (!isWebBrowser()) {
+    closeOAuthPopup(options.popup ?? null);
+    return { status: 'unsupported', reason: 'no-browser' };
+  }
+  if (context.identityBound) {
+    closeOAuthPopup(options.popup ?? null);
+    return { status: 'unsupported', reason: 'identity-bound' };
+  }
+  if (!context.clientId) {
+    closeOAuthPopup(options.popup ?? null);
+    return { status: 'unsupported', reason: 'missing-client-id' };
+  }
+
+  // Claim the window BEFORE the first `await` below, so a caller that invoked us
+  // straight from the click still has gesture attribution. An explicit `null`
+  // means the caller already tried and was blocked.
+  const popup =
+    context.mode === 'popup' && options.popup === undefined ? openOAuthPopup() : options.popup ?? null;
+
+  if (context.mode === 'redirect') {
+    closeOAuthPopup(popup);
+    return startRedirectSignIn(context, options, 'redirect-mode');
+  }
+  if (!popup) {
+    logger.warn('OAuth sign-in popup was blocked; falling back to a full-page redirect', {
+      component: 'browserAuthTransport',
+    });
+    return startRedirectSignIn(context, options, 'popup-blocked');
+  }
+
+  const prepared = await prepareAuthorizeRequest({
+    clientId: context.clientId,
+    redirectUri: options.redirectUri,
+    authorizeBaseUrl: context.authorizeBaseUrl,
+    scope: options.scope,
+    responseMode: 'web_message',
+  });
+
+  if (!navigateOAuthPopup(popup, prepared.authorizeUrl)) {
+    closeOAuthPopup(popup);
+    return startRedirectSignIn(context, options, 'popup-navigation-failed');
+  }
+
+  const outcome = await awaitOAuthPopupResult({
+    popup,
+    expectedOrigin: prepared.authorizeOrigin,
+    expectedState: prepared.handshake.state,
+    ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+  });
+  // The IdP closes itself after delivering; this covers every other outcome
+  // (timeout, mismatch, an error the IdP reported before closing).
+  closeOAuthPopup(popup);
+
+  switch (outcome.kind) {
+    case 'code': {
+      const completion = await completeOAuthCode({
+        oxyServices: context.oxyServices,
+        clientId: context.clientId,
+        code: outcome.code,
+        returnedState: outcome.state,
+        handshake: prepared.handshake,
+        redirectUri: options.redirectUri,
+        commitSession: context.commitSession,
+      });
+      return completion.ok
+        ? { status: 'signed-in' }
+        : { status: 'failed', reason: completion.reason };
+    }
+    case 'oauth-error':
+      return {
+        status: 'failed',
+        reason: 'idp-error',
+        description: outcome.errorDescription ?? outcome.error,
+      };
+    case 'state-mismatch':
+      return { status: 'failed', reason: 'state-mismatch' };
+    case 'closed':
+      return { status: 'cancelled' };
+    case 'timed-out':
+      return { status: 'timed-out' };
+    case 'unsupported':
+      return { status: 'unsupported', reason: 'no-browser' };
+  }
+}
+
+/**
+ * Full-page hand-off to the IdP. The document is destroyed by the navigation, so
+ * the handshake MUST reach `sessionStorage` first — without it the return trip
+ * cannot validate `state`, and starting the redirect anyway would strand the
+ * user at a callback that can only refuse them.
+ */
+async function startRedirectSignIn(
+  context: WebOAuthTransportContext,
+  options: StartWebOAuthSignInOptions,
+  via: WebOAuthRedirectReason,
+): Promise<WebOAuthSignInResult> {
+  // Narrowed by the caller; repeated here so this helper is safe on its own.
+  if (!context.clientId) return { status: 'unsupported', reason: 'missing-client-id' };
+
+  const prepared = await prepareAuthorizeRequest({
+    clientId: context.clientId,
+    redirectUri: options.redirectUri,
+    authorizeBaseUrl: context.authorizeBaseUrl,
+    scope: options.scope,
+  });
+
+  if (!persistOAuthHandshake(prepared.handshake.state, prepared.handshake.codeVerifier)) {
+    return { status: 'failed', reason: 'handshake-storage' };
+  }
+
+  redirectToAuthorize(prepared.authorizeUrl);
+  return { status: 'redirecting', via };
+}

--- a/packages/services/src/ui/oauth/completeOAuthCode.ts
+++ b/packages/services/src/ui/oauth/completeOAuthCode.ts
@@ -1,0 +1,93 @@
+/**
+ * The ONE path from an OAuth authorization code to a committed session.
+ *
+ * Both web transports end here — the popup with an in-memory handshake, the
+ * redirect lane with one read back from `sessionStorage` — so state validation,
+ * the PKCE exchange, the session commit, and handshake cleanup exist exactly
+ * once. Duplicating any of those per transport is how the two lanes would drift
+ * apart on the security-critical steps.
+ *
+ * Ordering is deliberate and load-bearing:
+ *   1. validate `state` BEFORE anything is sent to the token endpoint,
+ *   2. exchange the code for a session,
+ *   3. run `cleanup` (drop the persisted handshake / strip `?code=` from the
+ *      URL) BEFORE the commit, so a stale code can never re-enter the exchange,
+ *   4. commit the session.
+ *
+ * `cleanup` runs exactly once on EVERY exit path, including a state mismatch
+ * and a failed exchange.
+ */
+
+import type { OxyServices } from '@oxyhq/core';
+import { logger } from '@oxyhq/core';
+import type { OAuthCompletionResult, OAuthHandshake, OAuthSessionCommitInput } from './types';
+
+/** Inputs for {@link completeOAuthCode}. */
+export interface CompleteOAuthCodeInput {
+  oxyServices: OxyServices;
+  /** The registered `ApplicationCredential` public key (`oxy_dk_…`). */
+  clientId: string;
+  /** The single-use authorization code the IdP issued. */
+  code: string;
+  /** The `state` the IdP returned, or `null` when it sent none. */
+  returnedState: string | null;
+  /**
+   * The handshake this RP started the authorize request with, or `null` when it
+   * is gone (never stored, expired, or a different tab's). A missing handshake
+   * is treated exactly like a mismatched `state`: no exchange is attempted.
+   */
+  handshake: OAuthHandshake | null;
+  /** EXACT redirect URI sent on the authorize request — OAuth requires a match. */
+  redirectUri: string;
+  /** The provider's session commit funnel. */
+  commitSession: (input: OAuthSessionCommitInput) => Promise<void>;
+  /**
+   * Transport-specific teardown, invoked once after the exchange settles and
+   * before the commit. The redirect lane strips `?code=` and clears the
+   * persisted handshake; the popup lane has nothing persisted and omits it.
+   */
+  cleanup?: () => void;
+}
+
+export async function completeOAuthCode(
+  input: CompleteOAuthCodeInput,
+): Promise<OAuthCompletionResult> {
+  let cleaned = false;
+  const runCleanup = (): void => {
+    if (cleaned) return;
+    cleaned = true;
+    input.cleanup?.();
+  };
+
+  if (!input.handshake || !input.returnedState || input.handshake.state !== input.returnedState) {
+    logger.warn('OAuth completion rejected: missing or mismatched state', {
+      component: 'completeOAuthCode',
+    });
+    runCleanup();
+    return { ok: false, reason: 'state-mismatch' };
+  }
+
+  try {
+    const result = await input.oxyServices.exchangeOAuthCode({
+      code: input.code,
+      clientId: input.clientId,
+      redirectUri: input.redirectUri,
+      codeVerifier: input.handshake.codeVerifier,
+    });
+    runCleanup();
+    await input.commitSession({
+      sessionId: result.sessionId,
+      accessToken: result.accessToken,
+      deviceId: result.deviceId,
+      deviceSecret: result.deviceSecret,
+      userId: result.user.id,
+      expiresAt: result.expiresAt,
+      user: result.user,
+    });
+    return { ok: true };
+  } catch (error) {
+    logger.warn('OAuth code exchange failed', { component: 'completeOAuthCode' }, error);
+    runCleanup();
+    return { ok: false, reason: 'exchange-failed' };
+  }
+}

--- a/packages/services/src/ui/oauth/oauthHandshake.ts
+++ b/packages/services/src/ui/oauth/oauthHandshake.ts
@@ -1,0 +1,74 @@
+/**
+ * The RP half of an OAuth authorize request: a fresh CSRF `state` + PKCE pair,
+ * and the authorize URL built from them.
+ *
+ * Both web transports start here, and the ONLY difference between them is one
+ * parameter: `popup` asks the IdP for `response_mode=web_message` so the result
+ * comes back to `window.opener` instead of navigating the RP's tab. Everything
+ * else — `S256` PKCE, exact registered `redirect_uri`, random `state` — is
+ * identical, which is what lets both lanes converge on one completion path.
+ */
+
+import { buildOAuthAuthorizeUrl, generateOAuthState, generatePkcePair } from '@oxyhq/core';
+import type { OAuthHandshake } from './types';
+
+/** Inputs for {@link prepareAuthorizeRequest}. */
+export interface PrepareAuthorizeRequestParams {
+  /** The registered `ApplicationCredential` public key (`oxy_dk_…`). */
+  clientId: string;
+  /** EXACT registered redirect URI. The token exchange must replay this value. */
+  redirectUri: string;
+  /** Authorize endpoint override; defaults to the production Oxy IdP. */
+  authorizeBaseUrl?: string;
+  /** Requested scope; defaults to the SDK's standard sign-in scope. */
+  scope?: string;
+  /**
+   * Ask the IdP to deliver the result to `window.opener` via `postMessage`
+   * instead of redirecting. Set ONLY by the popup transport. It is a request,
+   * not a guarantee — an IdP with no opener still redirects.
+   */
+  responseMode?: 'web_message';
+}
+
+/** A ready-to-use authorize request plus the secrets that finish it. */
+export interface PreparedAuthorizeRequest {
+  /** Fully-built `auth.oxy.so/authorize` URL. */
+  authorizeUrl: string;
+  /**
+   * Exact origin of {@link authorizeUrl}. The popup transport accepts
+   * `postMessage` from this origin and no other.
+   */
+  authorizeOrigin: string;
+  /** The `state` + PKCE verifier this request is bound to. */
+  handshake: OAuthHandshake;
+}
+
+/**
+ * Generate a fresh handshake and build the authorize URL around it.
+ *
+ * The verifier is returned to the caller and never stored here: the popup
+ * transport keeps it in memory for the lifetime of the attempt, and the
+ * redirect transport persists it through `persistOAuthHandshake` because a
+ * full-page navigation destroys the running document.
+ */
+export async function prepareAuthorizeRequest(
+  params: PrepareAuthorizeRequestParams,
+): Promise<PreparedAuthorizeRequest> {
+  const [pkce, state] = await Promise.all([generatePkcePair(), generateOAuthState()]);
+
+  const authorizeUrl = buildOAuthAuthorizeUrl({
+    authorizeBaseUrl: params.authorizeBaseUrl,
+    clientId: params.clientId,
+    redirectUri: params.redirectUri,
+    scope: params.scope,
+    state,
+    codeChallenge: pkce.codeChallenge,
+    ...(params.responseMode ? { responseMode: params.responseMode } : {}),
+  });
+
+  return {
+    authorizeUrl,
+    authorizeOrigin: new URL(authorizeUrl).origin,
+    handshake: { state, codeVerifier: pkce.codeVerifier },
+  };
+}

--- a/packages/services/src/ui/oauth/oauthPopup.ts
+++ b/packages/services/src/ui/oauth/oauthPopup.ts
@@ -1,0 +1,219 @@
+/**
+ * Popup lifecycle for the web OAuth transport.
+ *
+ * Owns the window itself — opening it, navigating it, watching it, and tearing
+ * every listener and timer down — and nothing else: message validation lives in
+ * `oauthPopupMessages.ts`, and the code exchange in `completeOAuthCode.ts`.
+ *
+ * Three browser realities shape this module:
+ *
+ * - **Gesture attribution.** `window.open` only succeeds while the user's click
+ *   is still being handled. Anything awaited first (resolving the application,
+ *   generating PKCE) loses it and the popup is silently blocked. So the window
+ *   is opened EMPTY up front and navigated once the authorize URL exists —
+ *   the same shape as `passkeyHubPopup.ts`.
+ * - **No close event.** A cross-origin popup fires nothing when the user
+ *   dismisses it; polling `closed` is the only mechanism (as in core's
+ *   `AccountDialogController.watchPopup`).
+ * - **No cross-origin reads.** The popup's URL, title, and document are all
+ *   opaque. The authorization result arrives ONLY as a `postMessage`.
+ */
+
+import { logger } from '@oxyhq/core';
+import { readOAuthPopupMessage } from './oauthPopupMessages';
+import type { OAuthPopupHandle, OAuthPopupOutcome } from './types';
+
+/**
+ * Window name for the sign-in popup. Naming the target means a second press
+ * REUSES the same window instead of stacking a new one behind the first.
+ */
+export const OXY_OAUTH_POPUP_WINDOW_NAME = 'oxy-oauth';
+
+/** Chrome-free window roughly sized for the IdP's sign-in / QR surface. */
+const POPUP_FEATURES = 'popup=yes,width=460,height=700,menubar=no,toolbar=no,location=no,status=no';
+
+/**
+ * How long a popup sign-in may stay unanswered (ms).
+ *
+ * Generous on purpose: the IdP surface can involve scanning a QR and approving
+ * on a phone, so this tracks the authorize handle's own ~5-minute lifetime
+ * rather than a UI-scale timeout. It is a backstop against a wedged popup, not
+ * a pace-setter — a user who gives up closes the window and gets the faster
+ * `closed` outcome.
+ */
+export const DEFAULT_OAUTH_POPUP_TIMEOUT_MS = 300_000;
+
+/** How often the popup's `closed` flag is sampled (ms). */
+const CLOSE_POLL_INTERVAL_MS = 1000;
+
+/**
+ * Grace period (ms) after `closed` flips before reporting cancellation.
+ *
+ * The IdP posts its result and THEN closes itself. Both land as separate tasks,
+ * so a poll tick that happens to fall between them would otherwise turn a
+ * successful sign-in into a "user cancelled". One short grace window lets the
+ * already-queued message win.
+ */
+const CLOSE_GRACE_MS = 400;
+
+/** The `message` half of the DOM host, absent on native and during SSR. */
+interface MessageEventHost {
+  addEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+  removeEventListener(type: 'message', listener: (event: MessageEvent) => void): void;
+}
+
+/** The `open` half of the DOM host, absent on native and during SSR. */
+interface PopupOpenerHost {
+  open?: (url: string, target: string, features: string) => OAuthPopupHandle | null;
+}
+
+function messageEventHost(): MessageEventHost | null {
+  const win = (globalThis as { window?: Partial<MessageEventHost> }).window;
+  if (!win || typeof win.addEventListener !== 'function' || typeof win.removeEventListener !== 'function') {
+    return null;
+  }
+  return win as MessageEventHost;
+}
+
+/**
+ * Open a new, EMPTY sign-in popup.
+ *
+ * MUST be called SYNCHRONOUSLY from a user-gesture handler, before any `await`.
+ * Returns `null` when the browser blocked it, when `window.open` threw, and on
+ * hosts with no DOM (native / SSR) — never throws, because "no popup" is an
+ * ordinary outcome the caller answers by falling back to a redirect.
+ */
+export function openOAuthPopup(): OAuthPopupHandle | null {
+  const win = (globalThis as { window?: PopupOpenerHost }).window;
+  if (!win || typeof win.open !== 'function') return null;
+  try {
+    return win.open('', OXY_OAUTH_POPUP_WINDOW_NAME, POPUP_FEATURES) ?? null;
+  } catch (error) {
+    logger.warn('Could not open the OAuth sign-in popup', { component: 'oauthPopup' }, error);
+    return null;
+  }
+}
+
+/**
+ * Point an already-open popup at the authorize URL. Returns `false` when the
+ * assignment threw (a window closed between opening and navigating), so the
+ * caller can fall back to a redirect instead of waiting on a dead window.
+ */
+export function navigateOAuthPopup(popup: OAuthPopupHandle, url: string): boolean {
+  try {
+    popup.location.href = url;
+    return true;
+  } catch (error) {
+    logger.warn('Could not navigate the OAuth sign-in popup', { component: 'oauthPopup' }, error);
+    return false;
+  }
+}
+
+/** Close the popup if it is still open. Idempotent, null-safe, never throws. */
+export function closeOAuthPopup(popup: OAuthPopupHandle | null): void {
+  if (!popup || popup.closed) return;
+  try {
+    popup.close();
+  } catch (error) {
+    logger.debug('OAuth popup close failed', { component: 'oauthPopup' }, error);
+  }
+}
+
+/** Inputs for {@link awaitOAuthPopupResult}. */
+export interface AwaitOAuthPopupOptions {
+  /** The exact window reference returned by {@link openOAuthPopup}. */
+  popup: OAuthPopupHandle;
+  /** Exact origin the IdP will post from (`new URL(authorizeUrl).origin`). */
+  expectedOrigin: string;
+  /** The CSRF `state` sent on the authorize request. */
+  expectedState: string;
+  /** @default DEFAULT_OAUTH_POPUP_TIMEOUT_MS */
+  timeoutMs?: number;
+}
+
+/**
+ * Wait for the popup to deliver an authorization result.
+ *
+ * Settles EXACTLY once, with a typed outcome for every path — code, IdP error,
+ * state mismatch, user-closed, timeout — and removes its listener, its close
+ * poll, and both timers before resolving, whatever the outcome. Messages that
+ * arrive after settling reach nothing, so a duplicate delivery is inert.
+ *
+ * Never rejects: closing the window and running out of time are expected
+ * outcomes, not exceptions.
+ */
+export function awaitOAuthPopupResult(
+  options: AwaitOAuthPopupOptions,
+): Promise<OAuthPopupOutcome> {
+  const { popup, expectedOrigin, expectedState, timeoutMs = DEFAULT_OAUTH_POPUP_TIMEOUT_MS } =
+    options;
+
+  const host = messageEventHost();
+  if (!host) return Promise.resolve({ kind: 'unsupported' });
+
+  return new Promise<OAuthPopupOutcome>((resolve) => {
+    let settled = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    let closeGraceTimer: ReturnType<typeof setTimeout> | null = null;
+    let closePoll: ReturnType<typeof setInterval> | null = null;
+
+    const onMessage = (event: MessageEvent): void => {
+      const verdict = readOAuthPopupMessage(event, { expectedOrigin, expectedState, popup });
+      switch (verdict.kind) {
+        case 'ignore':
+          return;
+        case 'code':
+          settle({ kind: 'code', code: verdict.code, state: verdict.state });
+          return;
+        case 'oauth-error':
+          settle({
+            kind: 'oauth-error',
+            error: verdict.error,
+            ...(verdict.errorDescription ? { errorDescription: verdict.errorDescription } : {}),
+          });
+          return;
+        case 'state-mismatch':
+          settle({ kind: 'state-mismatch' });
+          return;
+      }
+    };
+
+    const cleanup = (): void => {
+      host.removeEventListener('message', onMessage);
+      if (timeoutTimer !== null) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = null;
+      }
+      if (closeGraceTimer !== null) {
+        clearTimeout(closeGraceTimer);
+        closeGraceTimer = null;
+      }
+      if (closePoll !== null) {
+        clearInterval(closePoll);
+        closePoll = null;
+      }
+    };
+
+    function settle(outcome: OAuthPopupOutcome): void {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(outcome);
+    }
+
+    host.addEventListener('message', onMessage);
+
+    timeoutTimer = setTimeout(() => settle({ kind: 'timed-out' }), timeoutMs);
+
+    closePoll = setInterval(() => {
+      if (!popup.closed) return;
+      // Stop sampling immediately: the window is gone and only the in-flight
+      // message (if any) can still change the outcome.
+      if (closePoll !== null) {
+        clearInterval(closePoll);
+        closePoll = null;
+      }
+      closeGraceTimer = setTimeout(() => settle({ kind: 'closed' }), CLOSE_GRACE_MS);
+    }, CLOSE_POLL_INTERVAL_MS);
+  });
+}

--- a/packages/services/src/ui/oauth/oauthPopupMessages.ts
+++ b/packages/services/src/ui/oauth/oauthPopupMessages.ts
@@ -1,0 +1,136 @@
+/**
+ * Runtime validation for the popup OAuth `postMessage` channel.
+ *
+ * Everything arriving on `window`'s `message` event is untrusted: any frame on
+ * the page, any other popup, and any browser extension can post to us. This
+ * module is the ONLY place that decides whether an incoming event is a genuine
+ * authorization response, and it answers with a value — never a thrown error.
+ *
+ * A message is accepted only when ALL of these hold:
+ *   1. `event.origin` is EXACTLY the authorize endpoint's origin,
+ *   2. `event.source` is the exact `Window` reference we opened,
+ *   3. `event.data` matches one of the two frozen message shapes,
+ *   4. the `state` it carries matches the one this RP sent.
+ *
+ * Failing (1)–(3) is indistinguishable from unrelated page traffic, so the
+ * message is IGNORED and the flow keeps waiting. Failing (4) means our own
+ * popup answered a different request than the one in flight, which is terminal:
+ * it is reported as a mismatch rather than left to hang until the timeout.
+ */
+
+import { logger } from '@oxyhq/core';
+import type { OAuthPopupHandle, OxyOAuthMessage } from './types';
+
+/** `postMessage` discriminator for a successful authorization. */
+export const OXY_OAUTH_CODE_MESSAGE_TYPE = 'oxy:oauth:code';
+
+/** `postMessage` discriminator for a typed OAuth failure. */
+export const OXY_OAUTH_ERROR_MESSAGE_TYPE = 'oxy:oauth:error';
+
+/** Verdict for one incoming `message` event. */
+export type OAuthPopupMessageVerdict =
+  /** Not ours (wrong origin/source) or not a valid message — keep waiting. */
+  | { kind: 'ignore' }
+  | { kind: 'code'; code: string; state: string }
+  | { kind: 'oauth-error'; error: string; errorDescription?: string }
+  /** Well-formed, from our popup, but bound to a different authorize request. */
+  | { kind: 'state-mismatch' };
+
+/** What {@link readOAuthPopupMessage} validates an event against. */
+export interface OAuthPopupMessageContext {
+  /** Exact origin of the authorize endpoint (`new URL(authorizeUrl).origin`). */
+  expectedOrigin: string;
+  /** The CSRF `state` this RP sent on the authorize request. */
+  expectedState: string;
+  /** The exact popup reference `window.open()` returned. */
+  popup: OAuthPopupHandle;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+/**
+ * Reference equality across two `unknown` values.
+ *
+ * `event.source` is a `WindowProxy` and {@link OAuthPopupHandle} is a narrow
+ * structural type, so comparing them directly is a type error. Widening both to
+ * `unknown` keeps the check a plain identity comparison — which is exactly the
+ * security property we want — without a cast.
+ */
+function isSameWindowReference(a: unknown, b: unknown): boolean {
+  return a === b;
+}
+
+/**
+ * Parse untrusted `event.data` into one of the two frozen message shapes, or
+ * `null` when it is anything else (including `null`, primitives, arrays, and
+ * objects with missing/wrong-typed fields).
+ *
+ * Unknown extra properties are tolerated but never read: only the fields below
+ * are ever surfaced, so a hostile sender cannot smuggle values past this point.
+ */
+export function parseOAuthPopupMessage(data: unknown): OxyOAuthMessage | null {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) return null;
+  const record = data as Record<string, unknown>;
+
+  if (record.type === OXY_OAUTH_CODE_MESSAGE_TYPE) {
+    if (!isNonEmptyString(record.code) || !isNonEmptyString(record.state)) return null;
+    return { type: OXY_OAUTH_CODE_MESSAGE_TYPE, code: record.code, state: record.state };
+  }
+
+  if (record.type === OXY_OAUTH_ERROR_MESSAGE_TYPE) {
+    if (!isNonEmptyString(record.error)) return null;
+    return {
+      type: OXY_OAUTH_ERROR_MESSAGE_TYPE,
+      error: record.error,
+      ...(isNonEmptyString(record.errorDescription)
+        ? { errorDescription: record.errorDescription }
+        : {}),
+      ...(isNonEmptyString(record.state) ? { state: record.state } : {}),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Classify one `message` event against the in-flight authorize request.
+ *
+ * Never throws. See the module header for the acceptance rules.
+ */
+export function readOAuthPopupMessage(
+  event: MessageEvent,
+  context: OAuthPopupMessageContext,
+): OAuthPopupMessageVerdict {
+  if (event.origin !== context.expectedOrigin) return { kind: 'ignore' };
+  if (!isSameWindowReference(event.source, context.popup)) return { kind: 'ignore' };
+
+  const message = parseOAuthPopupMessage(event.data);
+  if (!message) {
+    // Origin and source matched, so this came from the IdP window we opened —
+    // a shape we cannot read is worth a breadcrumb, unlike ordinary page noise.
+    logger.debug(
+      'Ignored an unrecognised message from the OAuth popup',
+      { component: 'oauthPopupMessages' },
+    );
+    return { kind: 'ignore' };
+  }
+
+  if (message.type === OXY_OAUTH_CODE_MESSAGE_TYPE) {
+    if (message.state !== context.expectedState) return { kind: 'state-mismatch' };
+    return { kind: 'code', code: message.code, state: message.state };
+  }
+
+  // An error MAY carry `state` (the IdP omits it when the request never got far
+  // enough to bind one). When present it must match: a foreign error must not be
+  // able to end an unrelated in-flight sign-in.
+  if (message.state !== undefined && message.state !== context.expectedState) {
+    return { kind: 'state-mismatch' };
+  }
+  return {
+    kind: 'oauth-error',
+    error: message.error,
+    ...(message.errorDescription ? { errorDescription: message.errorDescription } : {}),
+  };
+}

--- a/packages/services/src/ui/oauth/types.ts
+++ b/packages/services/src/ui/oauth/types.ts
@@ -1,0 +1,150 @@
+/**
+ * Typed contracts shared by the browser "Sign in with Oxy" OAuth transports.
+ *
+ * Two transports deliver the same authorization code to the same completion
+ * path (see `completeOAuthCode.ts`):
+ *
+ * - `redirect` — the historical full-page hand-off to `auth.oxy.so/authorize`.
+ *   The RP tab navigates away and comes back to its registered `redirect_uri`
+ *   with `?code=…&state=…`; cold boot finishes the exchange.
+ * - `popup` — a small `auth.oxy.so` window opened from the user's click. The RP
+ *   stays mounted with its route and unsaved state intact; the IdP delivers the
+ *   result to `window.opener` via `postMessage` and closes itself.
+ *
+ * Only the authorization code, the CSRF `state`, and a typed OAuth error ever
+ * cross the `postMessage` channel. Access tokens, device secrets, and the PKCE
+ * `code_verifier` NEVER do — the opener keeps the verifier and performs the code
+ * exchange itself.
+ */
+
+/** How a web relying party hands the user to the IdP for third-party sign-in. */
+export type WebAuthMode = 'popup' | 'redirect';
+
+/**
+ * Minimal structural handle over a popup `Window` — exactly what the popup
+ * transport needs: navigate it once the authorize URL is built, detect the user
+ * closing it (`closed`, polled — there is no cross-origin close event), and
+ * close it programmatically on completion. Satisfied directly by the value
+ * `window.open()` returns.
+ *
+ * Deliberately NOT `Window`: the transport must never read cross-origin
+ * properties off the popup, and a narrow handle makes that impossible to do by
+ * accident (and trivial to fake in tests).
+ */
+export interface OAuthPopupHandle {
+  readonly closed: boolean;
+  close(): void;
+  location: { href: string };
+}
+
+/**
+ * The RP-side OAuth handshake for one authorize request: the CSRF `state` sent
+ * to the IdP and the PKCE `code_verifier` replayed on the token exchange.
+ *
+ * In `redirect` mode it is persisted to `sessionStorage` across the full-page
+ * navigation; in `popup` mode it never leaves memory.
+ */
+export interface OAuthHandshake {
+  /** Opaque CSRF token echoed back by the IdP and validated before any exchange. */
+  state: string;
+  /** The PKCE secret. Never crosses `postMessage`, a URL, or storage in popup mode. */
+  codeVerifier: string;
+}
+
+/** Successful authorization delivered by the IdP over `postMessage`. */
+export interface OxyOAuthCodeMessage {
+  type: 'oxy:oauth:code';
+  code: string;
+  state: string;
+}
+
+/** Typed OAuth failure delivered by the IdP over `postMessage`. */
+export interface OxyOAuthErrorMessage {
+  type: 'oxy:oauth:error';
+  error: string;
+  errorDescription?: string;
+  state?: string;
+}
+
+/** The ONLY two message shapes that may cross the popup channel. */
+export type OxyOAuthMessage = OxyOAuthCodeMessage | OxyOAuthErrorMessage;
+
+/** Session material handed to the provider's commit funnel after an exchange. */
+export interface OAuthSessionCommitInput {
+  sessionId: string;
+  accessToken?: string;
+  deviceId?: string;
+  deviceSecret?: string;
+  userId: string;
+  expiresAt?: string;
+  user?: { id: string; username?: string; avatar?: string };
+}
+
+/**
+ * Terminal outcome of one popup sign-in attempt. Every expected path — the user
+ * closing the window, a timeout, an IdP error — is a value, never a thrown
+ * exception.
+ */
+export type OAuthPopupOutcome =
+  /** The IdP delivered an authorization code whose `state` matched. */
+  | { kind: 'code'; code: string; state: string }
+  /** The IdP delivered a typed OAuth error (`access_denied`, `login_required`, …). */
+  | { kind: 'oauth-error'; error: string; errorDescription?: string }
+  /** A well-formed message from our popup carried the wrong `state`. */
+  | { kind: 'state-mismatch' }
+  /** The user dismissed the popup without completing sign-in. */
+  | { kind: 'closed' }
+  /** No result arrived within the allotted window. */
+  | { kind: 'timed-out' }
+  /** No DOM message host (SSR / native) — the popup transport does not apply. */
+  | { kind: 'unsupported' };
+
+/** Why the shared completion path could not produce a session. */
+export type OAuthCompletionFailure = 'state-mismatch' | 'exchange-failed';
+
+/** Result of the ONE completion path both transports run. */
+export type OAuthCompletionResult =
+  | { ok: true }
+  | { ok: false; reason: OAuthCompletionFailure };
+
+/** Why the transport fell back to a full-page redirect. */
+export type WebOAuthRedirectReason =
+  /** `webAuthMode: 'redirect'` — the configured transport. */
+  | 'redirect-mode'
+  /** The browser refused `window.open` (blocker, or no gesture attribution). */
+  | 'popup-blocked'
+  /** The popup opened but could not be navigated to the authorize URL. */
+  | 'popup-navigation-failed';
+
+/** Why a web sign-in attempt failed outright. */
+export type WebOAuthFailureReason =
+  /** The handshake could not be persisted for the redirect return (no/blocked storage). */
+  | 'handshake-storage'
+  /** The `state` returned by the IdP did not match the one we sent. */
+  | 'state-mismatch'
+  /** `POST /auth/oauth/token` or the session commit failed. */
+  | 'exchange-failed'
+  /** The IdP reported a typed OAuth error. */
+  | 'idp-error';
+
+/** Why a web sign-in attempt was not applicable at all. */
+export type WebOAuthUnsupportedReason =
+  /** Not a browser (native / SSR) — native uses `openAuthorizeUrlNative`. */
+  | 'no-browser'
+  /** `sessionMode: 'identity'` has no third-party OAuth lane by construction. */
+  | 'identity-bound'
+  /** No `clientId` is configured on the provider. */
+  | 'missing-client-id';
+
+/** Terminal, typed outcome of a web third-party sign-in attempt. */
+export type WebOAuthSignInResult =
+  /** A session was committed; the RP is authenticated without a reload. */
+  | { status: 'signed-in' }
+  /** The tab is navigating to the IdP; nothing else will resolve in this document. */
+  | { status: 'redirecting'; via: WebOAuthRedirectReason }
+  /** The user dismissed the popup. */
+  | { status: 'cancelled' }
+  /** No result arrived within the allotted window. */
+  | { status: 'timed-out' }
+  | { status: 'failed'; reason: WebOAuthFailureReason; description?: string }
+  | { status: 'unsupported'; reason: WebOAuthUnsupportedReason };

--- a/packages/services/src/ui/types/navigation.ts
+++ b/packages/services/src/ui/types/navigation.ts
@@ -3,6 +3,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import type { RouteName } from '../navigation/routes';
 import type { User } from '@oxyhq/core';
 import type { ClientSession, SessionMode } from '@oxyhq/core';
+import type { WebAuthMode } from '../oauth/types';
 
 export interface StepController {
     canGoBack: () => boolean;
@@ -106,6 +107,22 @@ export interface OxyProviderProps {
      * @default 'account'
      */
     sessionMode?: SessionMode;
+    /**
+     * How a WEB third-party "Sign in with Oxy" hands the user to the IdP.
+     *
+     * - `'redirect'` (default) — a full-page navigation to `auth.oxy.so`, which
+     *   returns to the registered `redirect_uri` with `?code=`. The tab unmounts
+     *   and remounts, so route and unsaved state are lost.
+     * - `'popup'` — a small `auth.oxy.so` window opened from the user's click.
+     *   The app stays MOUNTED and becomes authenticated without a reload; the
+     *   IdP delivers only the authorization code + `state` back to the opener
+     *   via `postMessage` (never a token, device secret, or PKCE verifier). A
+     *   blocked popup falls back to the redirect automatically.
+     *
+     * Native is unaffected — it always uses an in-app auth session.
+     * @default 'redirect'
+     */
+    webAuthMode?: WebAuthMode;
     queryClient?: QueryClient;
     /** Sync device credentials to auth.oxy.so after interactive sign-in. @default true */
     hubSync?: boolean;

--- a/packages/services/src/ui/utils/oauthReturn.ts
+++ b/packages/services/src/ui/utils/oauthReturn.ts
@@ -6,27 +6,26 @@ import {
   normalizeOAuthRedirectUri,
   readOAuthHandshake,
 } from '@oxyhq/core';
+import { completeOAuthCode } from '../oauth/completeOAuthCode';
+import type { OAuthSessionCommitInput } from '../oauth/types';
 import { isWebBrowser } from './isWebBrowser';
 
-export interface OAuthReturnCommitInput {
-  sessionId: string;
-  accessToken?: string;
-  deviceId?: string;
-  deviceSecret?: string;
-  userId: string;
-  expiresAt?: string;
-  user?: { id: string; username?: string; avatar?: string };
-}
-
 /**
- * When the RP lands with `?code=` after password sign-in at auth.oxy.so, exchange
- * the code for a device-first session before cold boot runs.
+ * When the RP lands with `?code=` after signing in at auth.oxy.so, exchange the
+ * code for a device-first session before cold boot runs.
+ *
+ * This is the REDIRECT transport's return leg. It owns only what is specific to
+ * a full-page round trip — reading the code off the URL, recovering the
+ * handshake `sessionStorage` carried across the navigation, and cleaning both up
+ * afterwards — and delegates state validation, the PKCE exchange, and the
+ * session commit to `completeOAuthCode`, the same function the popup transport
+ * runs.
  */
 export async function tryCompleteOAuthReturn(opts: {
   oxyServices: OxyServices;
   clientId?: string | null;
   authRedirectUri?: string;
-  commitSession: (input: OAuthReturnCommitInput) => Promise<void>;
+  commitSession: (input: OAuthSessionCommitInput) => Promise<void>;
 }): Promise<boolean> {
   if (!isWebBrowser()) return false;
   const location = (globalThis as { location?: Location }).location;
@@ -50,50 +49,23 @@ export async function tryCompleteOAuthReturn(opts: {
     return false;
   }
 
-  const returnedState = params.get('state');
-  const handshake = readOAuthHandshake();
-  if (!handshake || !returnedState || handshake.state !== returnedState) {
-    logger.warn('OAuth return ignored: missing or mismatched handshake', {
-      component: 'oauthReturn',
-    });
-    // Consume the return path before clearing the handshake — clearOAuthHandshake
-    // drops the persisted path along with the PKCE keys.
-    stripOAuthParamsFromUrl();
-    clearOAuthHandshake();
-    return false;
-  }
-
-  const redirectUri = normalizeOAuthRedirectUri(
-    opts.authRedirectUri ?? location.origin,
-  );
-
-  try {
-    const result = await opts.oxyServices.exchangeOAuthCode({
-      code,
-      clientId,
-      redirectUri,
-      codeVerifier: handshake.codeVerifier,
-    });
-    // Strip OAuth params before commit so a stale `?code=` cannot re-enter the exchange loop.
-    // Read the return path first — clearOAuthHandshake drops it with the PKCE keys.
-    stripOAuthParamsFromUrl();
-    clearOAuthHandshake();
-    await opts.commitSession({
-      sessionId: result.sessionId,
-      accessToken: result.accessToken,
-      deviceId: result.deviceId,
-      deviceSecret: result.deviceSecret,
-      userId: result.user.id,
-      expiresAt: result.expiresAt,
-      user: result.user,
-    });
-    return true;
-  } catch (error) {
-    logger.warn('OAuth return exchange failed', { component: 'oauthReturn' }, error);
-    stripOAuthParamsFromUrl();
-    clearOAuthHandshake();
-    return false;
-  }
+  const result = await completeOAuthCode({
+    oxyServices: opts.oxyServices,
+    clientId,
+    code,
+    returnedState: params.get('state'),
+    handshake: readOAuthHandshake(),
+    redirectUri: normalizeOAuthRedirectUri(opts.authRedirectUri ?? location.origin),
+    commitSession: opts.commitSession,
+    // Strip the params before the commit so a stale `?code=` cannot re-enter the
+    // exchange loop, and read the return path FIRST — clearOAuthHandshake drops
+    // it along with the PKCE keys.
+    cleanup: () => {
+      stripOAuthParamsFromUrl();
+      clearOAuthHandshake();
+    },
+  });
+  return result.ok;
 }
 
 /**


### PR DESCRIPTION
Phase 2 of #691, on top of #695.

## Why

Third-party "Sign in with Oxy" on the web navigates the relying party's tab away and back, so the RP unmounts — its route, scroll position and unsaved state are gone by the time it is authenticated. This adds a popup transport so the main window never leaves its current route and becomes authenticated without a reload.

## How it degrades

The transport is a **request, not an assumption**. The RP asks with `response_mode=web_message` on the authorize URL; the IdP relays to its opener only when it actually has one, and otherwise performs today's top-level redirect. Both outcomes are handled on the SDK side, so an old IdP with a new SDK (or the reverse) still completes the flow.

## Security properties

- Only the authorization code, the `state`, and a typed OAuth error ever cross `postMessage`. The main window keeps the PKCE verifier and performs the exchange itself, so a compromised popup cannot obtain a token.
- Target origin is the exact origin of the redirect URI the API already validated by constant-time exact match against the application's registered `redirectUris`. Never `*`. A native-scheme redirect (`astro://…`, opaque `URL.origin`) falls back to the redirect rather than widening the target; a non-`postMessage` opener is ignored.
- The opener validates `event.origin`, `event.source` against the retained window reference, the message shape at runtime, and `state`. Wrong origin/source/shape are ignored; a state mismatch is a terminal rejection; duplicates are dropped.
- The IdP payload is literal-built from the contract fields; a test asserts the recursive key set is exactly `{type, code, state}` and scans for `token`/`session`/`device`/`secret`/`user`/`bearer` substrings.

## Lifecycle details that matter

- The popup is opened **synchronously from the click, before any `await`** — otherwise the browser attributes no user gesture and blocks it — then navigated once the PKCE pair and resolved application are ready.
- Closure is polled (`closed`; there is no cross-origin close event) with a short grace, so a poll tick landing between the IdP's post and its self-close cannot turn a success into a cancellation.
- Every listener and timer is removed on every exit path; tests assert `getTimerCount() === 0` and `removeEventListener` with the identical listener reference.
- If the browser refuses the IdP's self-close, the popup renders a terminal "You can close this window" state rather than hanging.

## One completion path

Popup and redirect now share one implementation — state validation → PKCE exchange → session commit → handshake cleanup. `tryCompleteOAuthReturn` delegates to it; a test proves neither lane calls `exchangeOAuthCode` itself.

## New surface

```ts
webAuthMode?: 'popup' | 'redirect'   // OxyProvider, default 'redirect'
useOxy().startWebOAuthSignIn(options): Promise<WebOAuthSignInResult>
```
`OxySignInButton` delegates to it instead of navigating itself. Native (`openAuthorizeUrlNative`) is untouched. The popup lane commits with `hubSync: false` — hub sync is a full-page redirect and would undo the point of popup mode.

`response_mode` is preserved across the IdP's own `/login` and `/signup` hop; without it the primary case (a user not yet signed in at the IdP) would always degrade to the redirect after authenticating.

## Tests

- services: 54 suites / 462 pass (+80 across 6 new suites) — success, popup blocked, popup closed, timeout, invalid origin, invalid source, malformed payload, state mismatch, duplicate ignored, cleanup on every path, redirect fallback, shared completion path.
- auth IdP: 81 pass / 0 fail (59 baseline + 22 new) — relay requires both signals, exact target origin (asserted `!== '*'` and not a parent domain), payload leak scan, deny relays `access_denied`, fallbacks, close-after-post ordering, refused close.

`webAuthMode` defaults to `redirect`; the flip is Phase 7, after the Mention pilot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->