### PR TITLE
feat(auth): OAuth-bound AuthSession with atomic finalization (#691 phase 3)

### DIFF
--- a/packages/api/src/models/AuthCode.ts
+++ b/packages/api/src/models/AuthCode.ts
@@ -25,8 +25,20 @@ import mongoose, { type Document, Schema } from "mongoose";
 export interface IAuthCode extends Document {
   /** SHA-256 hex digest of the raw authorization code. */
   codeHash: string;
-  /** ObjectId of the user that approved this grant. */
+  /**
+   * SUBJECT of the grant — the account the code authorizes access to. For a
+   * delegated authorization this is the ORGANIZATION/PROJECT account, not the
+   * human that approved it (see `operatedByUserId`).
+   */
   userId: mongoose.Types.ObjectId;
+  /**
+   * OPERATOR identity for a DELEGATED grant: the human identity that approved
+   * the app to act as `userId`. Absent for ordinary self-grants. Modelled
+   * separately so identity and account are never conflated; the session minted
+   * at exchange time carries it as `operatedByUserId`, which binds that
+   * session's validity to the operator's live `account:act_as` membership.
+   */
+  operatedByUserId?: mongoose.Types.ObjectId;
   /** Application ObjectId (string) the code was issued for. */
   appId: string;
   /** Exact redirect URI used at issue time — must match exchange request. */
@@ -62,6 +74,11 @@ const AuthCodeSchema: Schema = new Schema(
       ref: 'User',
       required: true,
       index: true,
+    },
+    operatedByUserId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      default: null,
     },
     appId: {
       type: String,

--- a/packages/api/src/models/AuthSession.ts
+++ b/packages/api/src/models/AuthSession.ts
@@ -24,8 +24,47 @@ import mongoose, { type Document, Schema } from "mongoose";
  *                   `applicationId` at create time) — there is no free-form app
  *                   label. It links the session to authoritative, sanitized app
  *                   metadata (name/icon/badge/scopes) for the consent UI.
+ *
+ * Purpose:
+ *   A session is EITHER a device sign-in (the historical QR/app-to-app handoff,
+ *   claimed for an access token via `POST /auth/session/claim`) OR an OAuth
+ *   authorization request (finalized into a single-use `AuthCode` via
+ *   `POST /auth/session/finalize/:sessionToken`). One request model, one state
+ *   machine, every delivery surface (popup / push / QR / deep link) converging
+ *   on it — never two competing authorization models.
  */
 export type AuthSessionStatus = 'pending' | 'authorized' | 'consumed' | 'expired' | 'cancelled';
+
+/**
+ * What this authorization request is FOR. Delivery progress (push sent, opened
+ * in Commons, …) is never a purpose and never a status — the authoritative
+ * state machine stays `pending -> authorized -> consumed` / `cancelled` /
+ * `expired`.
+ */
+export type AuthSessionPurpose = 'device_sign_in' | 'oauth_authorization';
+
+/**
+ * The MINIMUM OAuth request binding needed to safely finalize an approval into
+ * an authorization code. Deliberately does NOT duplicate anything owned by
+ * `Application` (client identity, registered redirect URIs, app scopes),
+ * `AuthCode` (the code itself, its hash, single-use state) or `DeviceSession`.
+ * The RP-owned `state` stays in the relying party and is validated there.
+ */
+export interface IAuthSessionOAuthContext {
+  /** Exact redirect URI, validated against the Application allowlist at bind time. */
+  redirectUri: string;
+  /** PKCE challenge (S256 only — `plain` is rejected at bind time). */
+  codeChallenge: string;
+  codeChallengeMethod: 'S256';
+  /** Requested scopes, normalized exactly like `POST /auth/oauth/authorize`. */
+  scopes: string[];
+  /**
+   * OPTIONAL delegated subject: the account the app will act AS. The approving
+   * identity must hold `account:act_as` over it — re-verified at approval AND
+   * at finalization, never trusted from the request.
+   */
+  subjectAccountId?: mongoose.Types.ObjectId;
+}
 
 export interface IAuthSession extends Document {
   sessionToken: string;      // Unique token for this auth session (128-bit secret held only by the originating client)
@@ -63,14 +102,42 @@ export interface IAuthSession extends Document {
    */
   deviceId?: string;
   status: AuthSessionStatus;
+  /** What the request authorizes. Legacy rows (no field) read as `device_sign_in`. */
+  purpose: AuthSessionPurpose;
+  /** Present only for `purpose: 'oauth_authorization'`. */
+  oauth?: IAuthSessionOAuthContext;
+  /**
+   * The `_id` RESERVED for this request's one and only `AuthCode`, written by the
+   * same atomic update that spends the session. Its presence is the proof that
+   * finalization already happened: the claim is conditioned on it being null, so
+   * a request can never mint a second authorization code — not on retry, not
+   * under concurrent finalize calls.
+   */
+  finalizedAuthCodeId?: mongoose.Types.ObjectId;
   authorizedBy?: string;     // Public key of the user who authorized
-  authorizedUserId?: mongoose.Types.ObjectId; // MongoDB user ID of the authorizing user
-  authorizedSessionId?: string; // The actual session ID after authorization
+  authorizedUserId?: mongoose.Types.ObjectId; // MongoDB user ID of the authorizing IDENTITY
+  authorizedSessionId?: string; // The actual session ID after authorization (device sign-in only)
   consumedAt?: Date;         // Timestamp when the sessionToken was exchanged for a token
   expiresAt: Date;
   createdAt: Date;
   updatedAt: Date;
 }
+
+/**
+ * Single-nested OAuth binding. Declared as its own schema (rather than inline
+ * nested paths) so the whole `oauth` path stays UNDEFINED on device-sign-in
+ * rows instead of materialising an empty object that reads as truthy.
+ */
+const AuthSessionOAuthSchema: Schema = new Schema(
+  {
+    redirectUri: { type: String, required: true },
+    codeChallenge: { type: String, required: true },
+    codeChallengeMethod: { type: String, enum: ['S256'], required: true },
+    scopes: { type: [String], default: [] },
+    subjectAccountId: { type: Schema.Types.ObjectId, ref: 'User', default: null },
+  },
+  { _id: false }
+);
 
 const AuthSessionSchema: Schema = new Schema(
   {
@@ -111,6 +178,22 @@ const AuthSessionSchema: Schema = new Schema(
       type: String,
       enum: ['pending', 'authorized', 'consumed', 'expired', 'cancelled'],
       default: 'pending',
+    },
+    purpose: {
+      type: String,
+      enum: ['device_sign_in', 'oauth_authorization'],
+      default: 'device_sign_in',
+    },
+    oauth: {
+      type: AuthSessionOAuthSchema,
+    },
+    // Never `required`/defaulted to anything but null — the atomic finalization
+    // claim matches on `finalizedAuthCodeId: null` (which also matches a missing
+    // field, so legacy rows behave as un-finalized).
+    finalizedAuthCodeId: {
+      type: Schema.Types.ObjectId,
+      ref: 'AuthCode',
+      default: null,
     },
     authorizedBy: {
       type: String, // Public key

--- a/packages/api/src/routes/__tests__/authSessionOAuthRequest.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionOAuthRequest.test.ts
@@ -1,0 +1,609 @@
+/**
+ * OAuth-bound authorization requests on the ONE `AuthSession` model (issue #691,
+ * phase 3).
+ *
+ * `POST /auth/session/create` optionally carries an `oauth` binding that turns
+ * the request into an OAuth authorization request; every delivery surface
+ * (popup, push, QR, verified app link) then approves that SAME request and it
+ * finalizes into one standard OAuth authorization code. These tests pin the
+ * wire contract and the security gates at the route boundary:
+ *
+ *  - the redirect URI is matched with the SAME exact allowlist check
+ *    `POST /auth/oauth/authorize` uses; a miss is an error, NEVER a redirect
+ *  - only S256 PKCE is accepted
+ *  - the approval screen sees `purpose` + a sanitized delegated subject, and
+ *    still no secret whatsoever
+ *  - a delegated subject is refused unless the approving identity holds
+ *    `account:act_as` over it, and approving an OAuth request mints no session
+ *  - device sign-in requests behave exactly as before
+ *
+ * Real request validation (`validate`) and the real `authSession.service` logic
+ * run; only models / infrastructure are mocked.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const mockAuthMiddleware = jest.fn();
+const mockAuthSessionFindOne = jest.fn();
+const mockAuthSessionCreate = jest.fn();
+const mockApplicationFindOne = jest.fn();
+const mockApplicationFindById = jest.fn();
+const mockApplicationCredentialFindOne = jest.fn();
+const mockUserFindById = jest.fn();
+const mockCreateSession = jest.fn();
+const mockVerifyActingAs = jest.fn();
+const mockFinalizeOAuthAuthorization = jest.fn();
+const mockEmitAuthSessionUpdate = jest.fn();
+const mockBroadcastSessionAccountsChanged = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
+  serviceAuthMiddleware: jest.fn(),
+  rejectQueryToken: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+// REAL request validation — the OAuth binding schema must actually be exercised.
+jest.unmock('../../middleware/validate');
+
+jest.mock('../../models/AuthSession', () => ({
+  __esModule: true,
+  default: { findOne: mockAuthSessionFindOne, create: mockAuthSessionCreate, findOneAndUpdate: jest.fn() },
+  AuthSession: { findOne: mockAuthSessionFindOne, create: mockAuthSessionCreate, findOneAndUpdate: jest.fn() },
+}));
+
+jest.mock('../../models/Session', () => ({ __esModule: true, default: { findOne: jest.fn() } }));
+
+jest.mock('../../models/AuthChallenge', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn(), findOneAndUpdate: jest.fn() },
+}));
+
+jest.mock('../../models/AuthCode', () => ({
+  __esModule: true,
+  AuthCode: { create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() },
+  default: { create: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn() },
+}));
+
+jest.mock('../../models/Application', () => ({
+  __esModule: true,
+  Application: { findOne: mockApplicationFindOne, findById: mockApplicationFindById },
+  default: { findOne: mockApplicationFindOne, findById: mockApplicationFindById },
+}));
+
+jest.mock('../../models/ApplicationCredential', () => ({
+  __esModule: true,
+  ApplicationCredential: { findOne: mockApplicationCredentialFindOne },
+  default: { findOne: mockApplicationCredentialFindOne },
+}));
+
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: { findOne: jest.fn(), findById: (...args: unknown[]) => mockUserFindById(...args) },
+  default: { findOne: jest.fn(), findById: (...args: unknown[]) => mockUserFindById(...args) },
+}));
+
+jest.mock('../../models/AppGrant', () => ({
+  __esModule: true,
+  AppGrant: { findOne: jest.fn(), find: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn() },
+  default: { findOne: jest.fn(), find: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn() },
+}));
+
+// Real service logic (redirect matching, purpose branching, delegation gate);
+// only the terminal finalization is stubbed so the ROUTE mapping is what is
+// asserted here — its internals are covered in
+// `services/__tests__/authSessionOAuthFinalize.test.ts`.
+jest.mock('../../services/authSession.service', () => ({
+  ...jest.requireActual('../../services/authSession.service'),
+  finalizeOAuthAuthorization: (...args: unknown[]) => mockFinalizeOAuthAuthorization(...args),
+}));
+
+jest.mock('../../services/account.service', () => ({
+  __esModule: true,
+  accountService: { verifyActingAs: (...args: unknown[]) => mockVerifyActingAs(...args) },
+}));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: (...args: unknown[]) => mockCreateSession(...args), getAccessToken: jest.fn() },
+}));
+
+jest.mock('../../services/signature.service', () => ({
+  __esModule: true,
+  default: {
+    isValidPublicKey: jest.fn(),
+    verifyChallengeResponse: jest.fn(),
+    verifyRegistrationSignature: jest.fn(),
+    verifySignature: jest.fn(),
+    generateChallenge: jest.fn(),
+    shortenPublicKey: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/userTransform', () => ({ formatUserResponse: jest.fn() }));
+jest.mock('../../utils/authSessionSocket', () => ({
+  emitAuthSessionUpdate: (...args: unknown[]) => mockEmitAuthSessionUpdate(...args),
+}));
+jest.mock('../../utils/socket', () => ({
+  broadcastSessionAccountsChanged: (...args: unknown[]) => mockBroadcastSessionAccountsChanged(...args),
+}));
+
+jest.mock('../../controllers/session.controller', () => ({
+  SessionController: {
+    register: jest.fn(), signUp: jest.fn(), signIn: jest.fn(), requestChallenge: jest.fn(),
+    verifyChallenge: jest.fn(), requestPasswordReset: jest.fn(), verifyRecoveryCode: jest.fn(),
+    resetPassword: jest.fn(), getUserByPublicKey: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import authRouter from '../auth';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  raw: string;
+  body: { error?: string; message?: string; data?: Record<string, unknown> };
+}
+
+async function requestJson(
+  method: string,
+  path: string,
+  payload: unknown,
+  headers: Record<string, string> = {}
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload ?? {});
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+          ...headers,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            resolve({
+              status: res.statusCode ?? 0,
+              headers: res.headers,
+              raw,
+              body: raw.length > 0 ? JSON.parse(raw) : {},
+            });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+const APP_ID = '64f7c2a1b8e9d3f4a1c2b301';
+const ORG_ID = '64f7c2a1b8e9d3f4a1c2b402';
+const IDENTITY_ID = '64f7c2a1b8e9d3f4a1c2b401';
+const REDIRECT_URI = 'https://mention.earth/oauth/callback';
+const CODE_CHALLENGE = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+function thirdPartyApp(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: { toString: () => APP_ID },
+    name: 'Mention',
+    description: 'A third-party integration',
+    type: 'third_party',
+    status: 'active',
+    isOfficial: false,
+    isInternal: false,
+    scopes: ['user:read', 'files:read'],
+    redirectUris: [REDIRECT_URI],
+    createdByUserId: { toString: () => 'owner-1' },
+    ...overrides,
+  };
+}
+
+function usableCredential() {
+  return {
+    _id: { toString: () => 'cred-1' },
+    publicKey: 'oxy_dk_client',
+    applicationId: { toString: () => APP_ID },
+    status: 'active',
+  };
+}
+
+function oauthBinding(overrides: Record<string, unknown> = {}) {
+  return {
+    redirectUri: REDIRECT_URI,
+    codeChallenge: CODE_CHALLENGE,
+    codeChallengeMethod: 'S256',
+    scope: 'user:read',
+    ...overrides,
+  };
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/auth', authRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => { server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthSessionFindOne.mockResolvedValue(null);
+  mockAuthSessionCreate.mockImplementation(async (doc: Record<string, unknown>) => ({
+    ...doc,
+    expiresAt: doc.expiresAt instanceof Date ? doc.expiresAt : new Date(Date.now() + 60_000),
+    status: doc.status ?? 'pending',
+  }));
+  mockAuthMiddleware.mockImplementation((req: { user?: unknown }, _res: unknown, next: () => void) => {
+    req.user = {
+      _id: { toString: () => IDENTITY_ID },
+      publicKey: 'pk-identity',
+      username: 'nate',
+    };
+    next();
+  });
+});
+
+describe('POST /auth/session/create — OAuth binding', () => {
+  it('binds the OAuth request context and marks the purpose', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential());
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-oauth-1',
+      clientId: 'oxy_dk_client',
+      oauth: oauthBinding({ subjectAccountId: ORG_ID }),
+    });
+
+    expect(res.status).toBe(200);
+    const created = mockAuthSessionCreate.mock.calls[0][0] as {
+      purpose: string;
+      oauth: {
+        redirectUri: string;
+        codeChallenge: string;
+        codeChallengeMethod: string;
+        scopes: string[];
+        subjectAccountId?: string;
+      };
+    };
+    expect(created.purpose).toBe('oauth_authorization');
+    expect(created.oauth).toEqual({
+      redirectUri: REDIRECT_URI,
+      codeChallenge: CODE_CHALLENGE,
+      codeChallengeMethod: 'S256',
+      // Normalized exactly like POST /auth/oauth/authorize.
+      scopes: ['user:read'],
+      subjectAccountId: ORG_ID,
+    });
+  });
+
+  it('rejects an unregistered redirect URI with 403 and NO redirect (RFC 6749 §3.1.2.4)', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential());
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-oauth-bad-redirect',
+      clientId: 'oxy_dk_client',
+      oauth: oauthBinding({ redirectUri: 'https://evil.example/callback' }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.headers.location).toBeUndefined();
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a prefix/suffix variation of a registered redirect URI (exact match only)', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential());
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-oauth-prefix',
+      clientId: 'oxy_dk_client',
+      oauth: oauthBinding({ redirectUri: `${REDIRECT_URI}/../evil` }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-S256 code challenge method', async () => {
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-oauth-plain',
+      clientId: 'oxy_dk_client',
+      oauth: oauthBinding({ codeChallengeMethod: 'plain' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an OAuth binding with no PKCE challenge', async () => {
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-oauth-nopkce',
+      clientId: 'oxy_dk_client',
+      oauth: { redirectUri: REDIRECT_URI, codeChallengeMethod: 'S256' },
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an OAuth binding identified only by applicationId (no client_id)', async () => {
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-oauth-noclient',
+      applicationId: APP_ID,
+      oauth: oauthBinding(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed subjectAccountId', async () => {
+    mockApplicationCredentialFindOne.mockResolvedValueOnce(usableCredential());
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-oauth-badsubject',
+      clientId: 'oxy_dk_client',
+      oauth: oauthBinding({ subjectAccountId: 'not-an-objectid' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockAuthSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('leaves a plain device sign-in request untouched (no oauth block)', async () => {
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+
+    const res = await requestJson('POST', '/auth/session/create', {
+      sessionToken: 'tok-device',
+      applicationId: APP_ID,
+    });
+
+    expect(res.status).toBe(200);
+    const created = mockAuthSessionCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(created.purpose).toBe('device_sign_in');
+    expect(created).not.toHaveProperty('oauth');
+  });
+});
+
+describe('GET /auth/session/approve-info/:authorizeCode — purpose + delegated subject', () => {
+  function oauthRow(overrides: Record<string, unknown> = {}) {
+    return {
+      sessionToken: 'SECRET-do-not-leak',
+      authorizeCode: 'code-oauth',
+      applicationId: { toString: () => APP_ID },
+      boundOrigin: 'https://mention.earth',
+      originVerified: false,
+      status: 'pending',
+      purpose: 'oauth_authorization',
+      oauth: {
+        redirectUri: REDIRECT_URI,
+        codeChallenge: CODE_CHALLENGE,
+        codeChallengeMethod: 'S256',
+        scopes: ['user:read'],
+        subjectAccountId: { toString: () => ORG_ID },
+      },
+      expiresAt: new Date(Date.now() + 60_000),
+      save: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  it('exposes the purpose and a sanitized delegated subject, and leaks nothing else', async () => {
+    mockAuthSessionFindOne.mockResolvedValueOnce(oauthRow());
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+    // Developer-name lookup, then the delegated subject lookup.
+    mockUserFindById
+      .mockReturnValueOnce({ select: () => ({ lean: () => Promise.resolve({ username: 'ada' }) }) })
+      .mockReturnValueOnce({
+        select: () => ({
+          lean: () => Promise.resolve({
+            _id: { toString: () => ORG_ID },
+            username: 'oxy',
+            name: { displayName: 'The Oxy Collective' },
+          }),
+        }),
+      });
+
+    const res = await requestJson('GET', '/auth/session/approve-info/code-oauth', null);
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as {
+      purpose: string;
+      subjectAccount: { id: string; username: string; displayName: string };
+      scopes: string[];
+    };
+    expect(data.purpose).toBe('oauth_authorization');
+    expect(data.subjectAccount).toEqual({
+      id: ORG_ID,
+      username: 'oxy',
+      displayName: 'The Oxy Collective',
+    });
+    // What the app will ACTUALLY receive — the requested scopes, not the app's
+    // full registered set.
+    expect(data.scopes).toEqual(['user:read']);
+    // No secret, no PKCE binding, no redirect target on this PUBLIC endpoint.
+    expect(res.raw).not.toContain('SECRET-do-not-leak');
+    expect(res.raw).not.toContain(CODE_CHALLENGE);
+    expect(res.raw).not.toContain(REDIRECT_URI);
+  });
+
+  it('reports a device sign-in request as such with no subject account', async () => {
+    mockAuthSessionFindOne.mockResolvedValueOnce(
+      oauthRow({ purpose: 'device_sign_in', oauth: undefined })
+    );
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+    mockUserFindById.mockReturnValueOnce({ select: () => ({ lean: () => Promise.resolve(null) }) });
+
+    const res = await requestJson('GET', '/auth/session/approve-info/code-oauth', null);
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as { purpose: string; subjectAccount: null; scopes: string[] };
+    expect(data.purpose).toBe('device_sign_in');
+    expect(data.subjectAccount).toBeNull();
+    // Unchanged behaviour: the app's registered scopes.
+    expect(data.scopes).toEqual(['user:read', 'files:read']);
+  });
+});
+
+describe('POST /auth/session/authorize/:sessionToken — delegated subject + no session mint', () => {
+  function pendingOAuthRow(overrides: Record<string, unknown> = {}) {
+    return {
+      sessionToken: 'tok-oauth-approve',
+      applicationId: { toString: () => APP_ID },
+      status: 'pending',
+      purpose: 'oauth_authorization',
+      oauth: {
+        redirectUri: REDIRECT_URI,
+        codeChallenge: CODE_CHALLENGE,
+        codeChallengeMethod: 'S256',
+        scopes: ['user:read'],
+        subjectAccountId: { toString: () => ORG_ID },
+      },
+      expiresAt: new Date(Date.now() + 60_000),
+      save: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  it('refuses an approval whose identity cannot act as the delegated subject', async () => {
+    const row = pendingOAuthRow();
+    mockAuthSessionFindOne.mockResolvedValueOnce(row);
+    mockUserFindById.mockReturnValueOnce({
+      select: () => ({ lean: () => Promise.resolve({ kind: 'organization', accountStatus: 'active' }) }),
+    });
+    mockVerifyActingAs.mockResolvedValueOnce(null);
+
+    const res = await requestJson('POST', '/auth/session/authorize/tok-oauth-approve', {}, {
+      Authorization: 'Bearer valid',
+    });
+
+    expect(res.status).toBe(403);
+    expect(mockVerifyActingAs).toHaveBeenCalledWith(IDENTITY_ID, ORG_ID);
+    expect(row.save).not.toHaveBeenCalled();
+    expect(mockCreateSession).not.toHaveBeenCalled();
+  });
+
+  it('authorizes a permitted delegated subject WITHOUT minting a session', async () => {
+    const row = pendingOAuthRow();
+    mockAuthSessionFindOne.mockResolvedValueOnce(row);
+    mockUserFindById.mockReturnValueOnce({
+      select: () => ({ lean: () => Promise.resolve({ kind: 'organization', accountStatus: 'active' }) }),
+    });
+    mockVerifyActingAs.mockResolvedValueOnce('admin');
+
+    const res = await requestJson('POST', '/auth/session/authorize/tok-oauth-approve', {}, {
+      Authorization: 'Bearer valid',
+    });
+
+    expect(res.status).toBe(200);
+    // An OAuth request's result is an authorization code — never a session here.
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(row.status).toBe('authorized');
+    expect(row.save).toHaveBeenCalled();
+    expect(res.body.data).not.toHaveProperty('sessionId');
+    // Nothing was minted, so no account-graph refetch is broadcast.
+    expect(mockBroadcastSessionAccountsChanged).not.toHaveBeenCalled();
+  });
+
+  it('still mints a session for a device sign-in approval (unchanged)', async () => {
+    const row = pendingOAuthRow({ purpose: 'device_sign_in', oauth: undefined });
+    mockAuthSessionFindOne.mockResolvedValueOnce(row);
+    mockApplicationFindById.mockResolvedValueOnce(thirdPartyApp());
+    mockCreateSession.mockResolvedValueOnce({ sessionId: 'sess-1', deviceId: 'dev-1' });
+
+    const res = await requestJson('POST', '/auth/session/authorize/tok-oauth-approve', {}, {
+      Authorization: 'Bearer valid',
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    expect(mockVerifyActingAs).not.toHaveBeenCalled();
+    expect((res.body.data as { sessionId: string }).sessionId).toBe('sess-1');
+    expect(mockBroadcastSessionAccountsChanged).toHaveBeenCalled();
+  });
+});
+
+describe('POST /auth/session/finalize/:sessionToken', () => {
+  it('returns the authorization code, its redirect target, and the TTL', async () => {
+    mockFinalizeOAuthAuthorization.mockResolvedValueOnce({
+      ok: true,
+      code: 'raw-authorization-code',
+      redirectUri: REDIRECT_URI,
+      expiresIn: 60,
+    });
+
+    const res = await requestJson('POST', '/auth/session/finalize/tok-oauth-approve', {});
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      code: 'raw-authorization-code',
+      redirectUri: REDIRECT_URI,
+      expiresIn: 60,
+    });
+    expect(mockFinalizeOAuthAuthorization).toHaveBeenCalledWith({
+      sessionToken: 'tok-oauth-approve',
+    });
+  });
+
+  it('needs no bearer token — the secret sessionToken IS the credential', async () => {
+    mockFinalizeOAuthAuthorization.mockResolvedValueOnce({
+      ok: true,
+      code: 'raw-authorization-code',
+      redirectUri: REDIRECT_URI,
+      expiresIn: 60,
+    });
+
+    const res = await requestJson('POST', '/auth/session/finalize/tok-oauth-approve', {});
+
+    expect(res.status).toBe(200);
+    expect(mockAuthMiddleware).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['not_found'],
+    ['wrong_purpose'],
+    ['not_authorized'],
+    ['expired'],
+    ['already_finalized'],
+    ['delegation_denied'],
+    ['redirect_uri_unregistered'],
+  ])('collapses the "%s" rejection into one generic invalid_grant', async (reason) => {
+    mockFinalizeOAuthAuthorization.mockResolvedValueOnce({ ok: false, reason });
+
+    const res = await requestJson('POST', '/auth/session/finalize/tok-oauth-approve', {});
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('invalid_grant');
+    // The precise reason never reaches the client.
+    expect(res.raw).not.toContain(reason);
+  });
+});

--- a/packages/api/src/routes/__tests__/sessionApproveInfo.test.ts
+++ b/packages/api/src/routes/__tests__/sessionApproveInfo.test.ts
@@ -32,7 +32,11 @@ jest.mock('../../models/AuthSession', () => ({
   AuthSession: { findOne: mockAuthSessionFindOne },
 }));
 jest.mock('../../models/Session', () => ({ __esModule: true, default: { findOne: jest.fn() } }));
+// Partial mock: the approval-flow entry points are stubbed, but the module's
+// PURE helpers (`resolveOAuthContext`, …) stay real so the route's OAuth-purpose
+// branching is exercised rather than silently short-circuited by an undefined.
 jest.mock('../../services/authSession.service', () => ({
+  ...jest.requireActual('../../services/authSession.service'),
   claimAuthSession: jest.fn(),
   authorizeSessionWithSignedChallenge: jest.fn(),
 }));

--- a/packages/api/src/routes/__tests__/sessionAuthorize.test.ts
+++ b/packages/api/src/routes/__tests__/sessionAuthorize.test.ts
@@ -57,7 +57,11 @@ jest.mock('../../models/Session', () => ({
 
 // authSession.service is consumed by `/auth/session/claim` only; we
 // mock it to avoid the model import chain.
+// Partial mock: `claimAuthSession` is stubbed, but the module's PURE helpers
+// (`resolveOAuthContext`, …) stay real so the authorize route's OAuth-purpose
+// branching is exercised rather than silently short-circuited by an undefined.
 jest.mock('../../services/authSession.service', () => ({
+  ...jest.requireActual('../../services/authSession.service'),
   claimAuthSession: jest.fn(),
 }));
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -32,8 +32,16 @@ import { validate } from '../middleware/validate';
 import sessionService from '../services/session.service';
 import { finalizeDeviceLogin } from '../services/deviceLogin.service';
 import { formatUserResponse } from '../utils/userTransform';
-import { issueAuthCode, exchangeAuthCode, AUTH_CODE_TTL_MS, canonicalizeOAuthRedirectUri } from '../services/oauthCode.service';
-import { claimAuthSession, authorizeSessionWithSignedChallenge, authorizeSessionWithBearer } from '../services/authSession.service';
+import { issueAuthCode, exchangeAuthCode, AUTH_CODE_TTL_MS } from '../services/oauthCode.service';
+import {
+  claimAuthSession,
+  authorizeSessionWithSignedChallenge,
+  authorizeSessionWithBearer,
+  finalizeOAuthAuthorization,
+  resolveOAuthContext,
+  verifyDelegatedSubject,
+} from '../services/authSession.service';
+import { isAllowedRedirectUri } from '../utils/oauthRedirect';
 import Session from '../models/Session';
 import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils';
 import {
@@ -567,12 +575,19 @@ import AuthSession from '../models/AuthSession';
  *         description: Application is not available (suspended/deleted/pending review).
  */
 router.post('/session/create', validate({ body: authSessionCreateSchema }), asyncHandler(async (req, res) => {
-  const { sessionToken, expiresAt, clientId, applicationId, deviceId } = req.body as {
+  const { sessionToken, expiresAt, clientId, applicationId, deviceId, oauth } = req.body as {
     sessionToken: string;
     clientId?: string;
     applicationId?: string;
     expiresAt?: string | number;
     deviceId?: string;
+    oauth?: {
+      redirectUri: string;
+      codeChallenge: string;
+      codeChallengeMethod: string;
+      scope?: string;
+      subjectAccountId?: string;
+    };
   };
 
   if (!sessionToken) {
@@ -580,6 +595,15 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
   }
   if (!clientId && !applicationId) {
     throw new BadRequestError('Either clientId or applicationId is required');
+  }
+  // An OAuth-bound request is matched against the OAuth CLIENT's registered
+  // redirect allowlist, so it must be identified by its client_id.
+  if (oauth && !clientId) {
+    throw new BadRequestError('clientId is required for an OAuth-bound session');
+  }
+  // Only S256 — `plain` is rejected outright, matching POST /auth/oauth/authorize.
+  if (oauth && oauth.codeChallengeMethod !== 'S256') {
+    throw new BadRequestError('Only S256 code_challenge_method is supported');
   }
 
   const now = Date.now();
@@ -648,6 +672,40 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
     !!boundOrigin &&
     applicationAllowsOrigin(resolvedApp, boundOrigin);
 
+  // OAuth binding (optional). When present this request stops being a device
+  // sign-in and becomes an OAuth authorization request that finalizes into a
+  // single-use AuthCode. The redirect URI is validated against the SAME exact,
+  // constant-time allowlist check `POST /auth/oauth/authorize` uses — and a
+  // failure is surfaced as an error, NEVER a redirect (RFC 6749 §3.1.2.4).
+  let oauthContext:
+    | {
+        redirectUri: string;
+        codeChallenge: string;
+        codeChallengeMethod: 'S256';
+        scopes: string[];
+        subjectAccountId?: string;
+      }
+    | undefined;
+  if (oauth) {
+    if (!isAllowedRedirectUri(resolvedApp, oauth.redirectUri)) {
+      logger.warn('[OAuth] Rejected unregistered redirect_uri on session/create', {
+        applicationId: resolvedApp._id.toString(),
+      });
+      throw new ForbiddenError('redirect_uri is not registered for this client');
+    }
+    if (oauth.subjectAccountId && !isValidObjectId(oauth.subjectAccountId)) {
+      throw new BadRequestError('Invalid subjectAccountId');
+    }
+    oauthContext = {
+      redirectUri: oauth.redirectUri,
+      codeChallenge: oauth.codeChallenge,
+      codeChallengeMethod: 'S256',
+      // Normalized exactly like POST /auth/oauth/authorize.
+      scopes: oauth.scope ? oauth.scope.split(/\s+/).filter(Boolean) : [],
+      ...(oauth.subjectAccountId ? { subjectAccountId: oauth.subjectAccountId } : {}),
+    };
+  }
+
   // Check if session token already exists (generic error to prevent enumeration)
   const existing = await AuthSession.findOne({ sessionToken });
   if (existing) {
@@ -662,7 +720,8 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
   const authorizeCode = crypto.randomBytes(16).toString('hex');
   const qrNonce = crypto.randomBytes(8).toString('hex');
 
-  // Create new auth session
+  // Create new auth session. Every field is written from a SERVER-resolved value
+  // or an explicitly whitelisted one — `req.body` is never spread in.
   const authSession = await AuthSession.create({
     sessionToken,
     applicationId: resolvedApp._id,
@@ -672,6 +731,8 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
     challengeNonce: qrNonce,
     expiresAt: expiresAtDate,
     status: 'pending',
+    purpose: oauthContext ? 'oauth_authorization' : 'device_sign_in',
+    ...(oauthContext ? { oauth: oauthContext } : {}),
     ...(typeof deviceId === 'string' && deviceId.trim() ? { deviceId: deviceId.trim() } : {}),
   });
 
@@ -929,33 +990,60 @@ router.post('/session/authorize/:sessionToken', authMiddleware, validate({ param
 
   const authenticatedUserId = authenticatedUser._id.toString();
 
-  // Resolve the bound Application for the device-name label. The session can't
-  // exist without a valid applicationId; fall back to a generic label only if
-  // the app was hard-deleted between create and authorize.
-  const app = await Application.findById(authSession.applicationId);
-  const appLabel = app ? app.name : 'App';
-
-  // Create a new session for the third-party app, owned by the
-  // authenticated user identified via the bearer token. When the flow was
-  // started with a device binding (`deviceId` persisted at create time), pass it
-  // as the explicit deviceId so the session lands on the originating device.
-  const newSession = await sessionService.createSession(
-    authenticatedUserId,
-    req,
-    {
-      deviceName: deviceName || `${appLabel} App`,
-      deviceFingerprint,
-      ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
+  // Delegated subject gate: approving an app acting AS another account requires
+  // the authenticated identity to hold `account:act_as` over it (the same
+  // predicate `POST /accounts/:id/switch` uses). The identity never becomes the
+  // account — it authorises the app to act as it.
+  const oauthContext = resolveOAuthContext(authSession);
+  const subjectAccountId = oauthContext?.subjectAccountId?.toString();
+  if (subjectAccountId) {
+    const delegation = await verifyDelegatedSubject(authenticatedUserId, subjectAccountId);
+    if (!delegation.ok) {
+      logger.warn('Delegated subject refused on session authorize', {
+        sessionToken: sessionToken.substring(0, 8) + '...',
+        userId: authenticatedUserId,
+        reason: delegation.reason,
+      });
+      throw new ForbiddenError('Not authorized to act as the requested account');
     }
-  );
+  }
 
-  // Update auth session
+  // An OAuth authorization request mints NO session on approval — its result is
+  // the single-use authorization code produced by
+  // `POST /auth/session/finalize/:sessionToken`.
+  let newSessionId: string | undefined;
+  if (!oauthContext) {
+    // Resolve the bound Application for the device-name label. The session can't
+    // exist without a valid applicationId; fall back to a generic label only if
+    // the app was hard-deleted between create and authorize.
+    const app = await Application.findById(authSession.applicationId);
+    const appLabel = app ? app.name : 'App';
+
+    // Create a new session for the third-party app, owned by the
+    // authenticated user identified via the bearer token. When the flow was
+    // started with a device binding (`deviceId` persisted at create time), pass it
+    // as the explicit deviceId so the session lands on the originating device.
+    const newSession = await sessionService.createSession(
+      authenticatedUserId,
+      req,
+      {
+        deviceName: deviceName || `${appLabel} App`,
+        deviceFingerprint,
+        ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
+      }
+    );
+    newSessionId = newSession.sessionId;
+  }
+
+  // Update auth session — including WHICH identity approved.
   authSession.status = 'authorized';
   if (authenticatedUser.publicKey) {
     authSession.authorizedBy = authenticatedUser.publicKey;
   }
   authSession.authorizedUserId = authenticatedUser._id;
-  authSession.authorizedSessionId = newSession.sessionId;
+  if (newSessionId) {
+    authSession.authorizedSessionId = newSessionId;
+  }
   await authSession.save();
 
   logger.info('Auth session authorized', {
@@ -967,7 +1055,7 @@ router.post('/session/authorize/:sessionToken', authMiddleware, validate({ param
   // Emit socket event to notify the waiting client
   emitAuthSessionUpdate(sessionToken, {
     status: 'authorized',
-    sessionId: newSession.sessionId,
+    sessionId: newSessionId,
     publicKey: authenticatedUser.publicKey,
     userId: authenticatedUserId,
     username: authenticatedUser.username,
@@ -975,12 +1063,15 @@ router.post('/session/authorize/:sessionToken', authMiddleware, validate({ param
 
   // A1: a brand-new session was minted for this user — signal all of their other
   // connected sockets (across devices/origins) to refetch. No device mutation
-  // happens here, so the revision hint is 0.
-  broadcastSessionAccountsChanged(authenticatedUserId, 0, 'login');
+  // happens here, so the revision hint is 0. Nothing was minted for an OAuth
+  // authorization request, so there is nothing to refetch.
+  if (newSessionId) {
+    broadcastSessionAccountsChanged(authenticatedUserId, 0, 'login');
+  }
 
   sendSuccess(res, {
     success: true,
-    sessionId: newSession.sessionId,
+    sessionId: newSessionId,
     user: {
       id: authenticatedUserId,
       username: authenticatedUser.username,
@@ -1221,11 +1312,24 @@ const authSessionAuthorizeSignedLimiter = rateLimit({
 });
 
 /**
+ * Sanitized identity of a DELEGATED subject account for the approval screen —
+ * id + handle + display name and NOTHING else. Enough for Commons to render
+ * "Mention will act as: The Oxy Collective"; never a channel for account
+ * internals (kind, membership, owner, status) on a public endpoint.
+ */
+interface SanitizedSubjectAccount {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+}
+
+/**
  * GET /auth/session/approve-info/:authorizeCode
  *
  * PUBLIC. Returns the server-resolved, sanitized Application identity (never the
- * QR's self-asserted strings) plus the bound origin and status, so the Commons
- * approval screen renders the TRUE app. Never leaks the secret `sessionToken`.
+ * QR's self-asserted strings) plus the bound origin, purpose, delegated subject
+ * and status, so the Commons approval screen renders the TRUE request. Never
+ * leaks the secret `sessionToken`, tokens, or the PKCE binding.
  */
 router.get(
   '/session/approve-info/:authorizeCode',
@@ -1244,13 +1348,45 @@ router.get(
       await authSession.save();
     }
 
+    const oauthContext = resolveOAuthContext(authSession);
+
     let application = null;
     let scopes: string[] = [];
     const app = await Application.findById(authSession.applicationId);
     if (app && app.status === 'active') {
       const developerName = await resolveDeveloperName(app);
       application = serializePublicApplication(app, developerName);
-      scopes = Array.isArray(app.scopes) ? [...app.scopes] : [];
+      const appScopes = Array.isArray(app.scopes) ? [...app.scopes] : [];
+      // What the app will ACTUALLY receive if this is approved. For an OAuth
+      // request that is the requested set narrowed to the app's registered
+      // scopes (an app can never receive more than it is registered for); a
+      // device sign-in has no per-request scope set, so it is the app's own.
+      scopes =
+        oauthContext && oauthContext.scopes.length > 0
+          ? intersectScopes(oauthContext.scopes, appScopes)
+          : appScopes;
+    }
+
+    // Delegated subject: "who will the app act as". Resolved SERVER-side from
+    // the bound id — the QR/deep link never carries display data.
+    let subjectAccount: SanitizedSubjectAccount | null = null;
+    const subjectAccountId = oauthContext?.subjectAccountId?.toString();
+    if (subjectAccountId) {
+      const subject = await User.findById(subjectAccountId)
+        .select('username name')
+        .lean<{
+          _id: mongoose.Types.ObjectId;
+          username?: string;
+          name?: { first?: string; last?: string; full?: string; displayName?: string };
+        } | null>();
+      if (subject) {
+        const name = formatUserNameResponse({ name: subject.name, username: subject.username });
+        subjectAccount = {
+          id: subject._id.toString(),
+          username: typeof subject.username === 'string' ? subject.username : null,
+          displayName: name.displayName ?? null,
+        };
+      }
     }
 
     sendSuccess(res, {
@@ -1261,6 +1397,9 @@ router.get(
       // session NOT proven to originate from a trusted app's own registered
       // origin), Commons warns the approver that the source is unverifiable.
       originVerified: authSession.originVerified ?? false,
+      // What approving this request does. Legacy rows read as a device sign-in.
+      purpose: authSession.purpose ?? 'device_sign_in',
+      subjectAccount,
       expiresAt: authSession.expiresAt.toISOString(),
       status: authSession.status,
     });
@@ -1307,6 +1446,7 @@ router.post(
 
     if (!outcome.ok) {
       if (outcome.status === 401) throw new UnauthorizedError(outcome.message);
+      if (outcome.status === 403) throw new ForbiddenError(outcome.message);
       if (outcome.status === 404) throw new NotFoundError(outcome.message);
       throw new BadRequestError(outcome.message);
     }
@@ -1327,8 +1467,11 @@ router.post(
 
     // A1: a brand-new session was minted for the signer via the QR handoff —
     // signal all of their other connected sockets to refetch. No device mutation
-    // happens here, so the revision hint is 0.
-    broadcastSessionAccountsChanged(outcome.userId, 0, 'login');
+    // happens here, so the revision hint is 0. An OAuth authorization request
+    // mints no session, so there is nothing to refetch.
+    if (outcome.sessionId) {
+      broadcastSessionAccountsChanged(outcome.userId, 0, 'login');
+    }
 
     sendSuccess(res, {
       success: true,
@@ -1392,6 +1535,7 @@ router.post(
     });
 
     if (!outcome.ok) {
+      if (outcome.status === 403) throw new ForbiddenError(outcome.message);
       if (outcome.status === 404) throw new NotFoundError(outcome.message);
       throw new BadRequestError(outcome.message);
     }
@@ -1413,8 +1557,11 @@ router.post(
 
     // A1: a brand-new session was minted for this user — signal all of their
     // other connected sockets (across devices/origins) to refetch. No device
-    // mutation happens here, so the revision hint is 0.
-    broadcastSessionAccountsChanged(authenticatedUserId, 0, 'login');
+    // mutation happens here, so the revision hint is 0. An OAuth authorization
+    // request mints no session, so there is nothing to refetch.
+    if (outcome.sessionId) {
+      broadcastSessionAccountsChanged(authenticatedUserId, 0, 'login');
+    }
 
     sendSuccess(res, {
       success: true,
@@ -1457,6 +1604,95 @@ router.post(
   }),
 );
 
+// Finalization of an OAuth-bound request. Tight, like the claim limiter — a
+// legitimate flow hits this exactly once (the request is single-use), so the cap
+// only blunts brute force against the 128-bit sessionToken.
+const authSessionFinalizeLimiter = rateLimit({
+  prefix: 'rl:auth:session-finalize:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 30,
+});
+
+/**
+ * @openapi
+ * /auth/session/finalize/{sessionToken}:
+ *   post:
+ *     tags:
+ *       - Authentication
+ *     security: []
+ *     summary: Finalize an approved OAuth-bound auth session into an authorization code
+ *     description: >
+ *       Terminal step of an OAuth authorization request created with
+ *       `POST /auth/session/create` + an `oauth` binding and approved through any
+ *       delivery surface (popup, push, QR, verified app link). Mints the ONE
+ *       single-use `AuthCode` the relying party redeems at
+ *       `POST /auth/oauth/token` with its PKCE verifier.
+ *
+ *       No `Authorization` header: the 128-bit `sessionToken` — held only by the
+ *       originating client, never echoed to observers — IS the credential,
+ *       exactly as on `POST /auth/session/claim`. No access token is ever handed
+ *       out here.
+ *
+ *       Atomic and single-use: the authorization code's identity is reserved by
+ *       the same update that spends the request, so a request can never mint a
+ *       second code, even under concurrent calls. Every failure mode collapses to
+ *       one generic `invalid_grant` (RFC 6749 §5.2) — nothing enumerates which
+ *       precondition failed.
+ *     parameters:
+ *       - name: sessionToken
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Authorization code issued.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 code:
+ *                   type: string
+ *                 redirectUri:
+ *                   type: string
+ *                   format: uri
+ *                 expiresIn:
+ *                   type: integer
+ *                   example: 60
+ *       401:
+ *         description: >
+ *           Unknown, not an OAuth request, not approved, expired, already
+ *           finalized, no longer permitted, or its application/redirect binding
+ *           is no longer valid.
+ */
+router.post(
+  '/session/finalize/:sessionToken',
+  authSessionFinalizeLimiter,
+  validate({ params: authSessionTokenParams }),
+  asyncHandler(async (req, res) => {
+    const { sessionToken } = req.params;
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken });
+
+    if (!outcome.ok) {
+      // One generic error for every rejection — the precise reason stays in the
+      // server log so a caller cannot probe the request's state.
+      logger.warn('[AuthSession] Finalize rejected', {
+        reason: outcome.reason,
+        sessionToken: sessionToken.substring(0, 8) + '...',
+      });
+      throw new UnauthorizedError('invalid_grant');
+    }
+
+    sendSuccess(res, {
+      code: outcome.code,
+      redirectUri: outcome.redirectUri,
+      expiresIn: outcome.expiresIn,
+    });
+  }),
+);
+
 // ============================================
 // OAuth2 Authorization Code Flow (with PKCE)
 // ============================================
@@ -1474,29 +1710,6 @@ router.post(
 //      for `{ access_token, deviceId, deviceSecret, session_id, user }`.
 //
 // Access tokens never appear in the URL bar.
-
-/**
- * Validate a redirect URI against the Application allowlist using an exact
- * match (per OAuth2 RFC 6749 §3.1.2). Partial / prefix matching is the
- * source of countless open-redirect vulnerabilities — we never normalise
- * away path or query for the comparison. Constant-time equality keeps the
- * comparison from leaking the allowlist contents via timing.
- *
- * Origin-only https URLs are canonicalized so `https://app.example` and
- * `https://app.example/` match the same registered apex origin.
- */
-function isAllowedRedirectUri(app: { redirectUris?: string[] }, redirectUri: string): boolean {
-  const allowlist = app.redirectUris ?? [];
-  if (allowlist.length === 0) return false;
-  const provided = Buffer.from(canonicalizeOAuthRedirectUri(redirectUri));
-  for (const allowed of allowlist) {
-    const allowedBuf = Buffer.from(canonicalizeOAuthRedirectUri(allowed));
-    if (allowedBuf.length === provided.length && crypto.timingSafeEqual(allowedBuf, provided)) {
-      return true;
-    }
-  }
-  return false;
-}
 
 /**
  * Resolve an OAuth `clientId` (= ApplicationCredential.publicKey) to its
@@ -2143,12 +2356,22 @@ router.post(
         ? exchange.code.deviceId.trim()
         : undefined;
 
+    // A DELEGATED code authorises the app to act as `userId` on behalf of the
+    // approving identity. Carry that operator onto the session so its validity
+    // stays bound to their live `account:act_as` membership — revoking the
+    // membership kills the session (re-checked on validate + refresh), exactly
+    // like a managed-account switch.
+    const operatedByUserId = exchange.code.operatedByUserId
+      ? exchange.code.operatedByUserId.toString()
+      : undefined;
+
     const session = await sessionService.createSession(
       userId,
       req,
       {
         deviceName: `${app.name} OAuth`,
         ...(sharedDeviceId ? { deviceId: sharedDeviceId } : {}),
+        ...(operatedByUserId ? { operatedByUserId } : {}),
       },
     );
 

--- a/packages/api/src/schemas/auth.schemas.ts
+++ b/packages/api/src/schemas/auth.schemas.ts
@@ -68,6 +68,24 @@ export const getUserByPublicKeyParams = z.object({
 //   - `clientId`      an ApplicationCredential.publicKey / OAuth client_id, or
 //   - `applicationId` an Application _id.
 // There is no free-form app label.
+//
+// An OPTIONAL `oauth` block turns the session into an OAuth authorization
+// request (`purpose: 'oauth_authorization'`) that finalizes into a single-use
+// `AuthCode` instead of a device sign-in claim. It carries only the MINIMUM
+// request binding — nothing already owned by `Application`, `AuthCode` or
+// `DeviceSession`. The RP-owned `state` never reaches the server.
+export const authSessionOAuthContextSchema = z.object({
+  redirectUri: z.string().trim().url(),
+  /** PKCE is MANDATORY for an OAuth-bound session (no confidential-client path here). */
+  codeChallenge: z.string().trim().min(43).max(128),
+  /** S256 only — `plain` is rejected outright, per current OAuth BCP. */
+  codeChallengeMethod: z.literal('S256'),
+  /** Space-separated, normalized exactly like `POST /auth/oauth/authorize`. */
+  scope: z.string().trim().max(512).optional(),
+  /** Delegated account the app will act AS; permission is verified server-side. */
+  subjectAccountId: z.string().trim().min(1).max(64).optional(),
+});
+
 export const authSessionCreateSchema = z.object({
   sessionToken: z.string().trim().min(1),
   clientId: z.string().trim().min(1).optional(),
@@ -75,12 +93,21 @@ export const authSessionCreateSchema = z.object({
   expiresAt: z.union([z.string(), z.number()]).optional(),
   /** Originating RP device id — converges QR sign-in onto the same DeviceSession. */
   deviceId: deviceIdField,
+  oauth: authSessionOAuthContextSchema.optional(),
 }).refine(
   (data) => Boolean(data.clientId) || Boolean(data.applicationId),
   { message: 'Either clientId or applicationId is required' }
+).refine(
+  // The redirect URI is matched against the OAuth client's registered
+  // allowlist, so an OAuth-bound session must be identified by its client_id —
+  // an `applicationId`-only reference has no credential to bind to.
+  (data) => !data.oauth || Boolean(data.clientId),
+  { message: 'clientId is required for an OAuth-bound session' }
 );
 
-// GET /auth/session/status/:sessionToken
+// :sessionToken path param — the SECRET credential held only by the originating
+// client. Shared by GET /auth/session/status, POST /auth/session/authorize,
+// POST /auth/session/cancel and POST /auth/session/finalize.
 export const authSessionTokenParams = z.object({
   sessionToken: z.string().trim().min(1),
 });

--- a/packages/api/src/services/__tests__/authSessionOAuthFinalize.test.ts
+++ b/packages/api/src/services/__tests__/authSessionOAuthFinalize.test.ts
@@ -1,0 +1,528 @@
+/**
+ * OAuth-bound AuthSession finalization (issue #691, phase 3).
+ *
+ * One authorization request, one authorization code — forever. These tests pin
+ * the security properties at the MODEL boundary (what actually reaches
+ * `AuthSession.findOneAndUpdate` / `AuthCode.create`), because that is where the
+ * single-use guarantee lives:
+ *
+ *  - exactly ONE `AuthCode` per request, even under concurrent finalizations
+ *  - a finalized request can never mint a second code
+ *  - the issued code is still single-use + PKCE-bound through `exchangeAuthCode`
+ *  - a delegated subject is refused unless the approving identity holds
+ *    `account:act_as` over it (the EXISTING act-as mechanism, mocked here)
+ *  - device-sign-in requests are untouched: they still claim, and they can never
+ *    be finalized into a code
+ *
+ * Models are mocked with faithful in-memory stores; all service logic is real.
+ */
+
+import * as crypto from 'crypto';
+
+interface StoredAuthSession {
+  _id: string;
+  sessionToken: string;
+  authorizeCode: string;
+  applicationId: { toString: () => string };
+  status: string;
+  purpose?: string;
+  oauth?: {
+    redirectUri: string;
+    codeChallenge: string;
+    codeChallengeMethod: string;
+    scopes: string[];
+    subjectAccountId?: { toString: () => string };
+  };
+  finalizedAuthCodeId: unknown;
+  authorizedUserId?: { toString: () => string };
+  deviceId?: string;
+  consumedAt?: Date;
+  expiresAt: Date;
+}
+
+const authSessions = new Map<string, StoredAuthSession>();
+
+/** Mongo semantics: `{ field: null }` matches null AND missing. */
+function matchesNullish(value: unknown): boolean {
+  return value === null || value === undefined;
+}
+
+const mockAuthSessionFindOneAndUpdate = jest.fn(
+  async (
+    filter: Record<string, unknown>,
+    update: { $set: Record<string, unknown> }
+  ): Promise<StoredAuthSession | null> => {
+    for (const doc of authSessions.values()) {
+      if (filter._id !== undefined && doc._id !== filter._id) continue;
+      if (filter.purpose !== undefined && doc.purpose !== filter.purpose) continue;
+      if (filter.status !== undefined && doc.status !== filter.status) continue;
+      if (filter.finalizedAuthCodeId === null && !matchesNullish(doc.finalizedAuthCodeId)) continue;
+      Object.assign(doc, update.$set);
+      return { ...doc };
+    }
+    return null;
+  }
+);
+
+jest.mock('../../models/AuthSession', () => ({
+  __esModule: true,
+  default: {
+    // Return a SNAPSHOT (as a real driver would) so pre-claim reads can never
+    // observe a concurrent claim — only the atomic update decides the winner.
+    findOne: jest.fn(async (query: { sessionToken?: string }) => {
+      for (const doc of authSessions.values()) {
+        if (query.sessionToken && doc.sessionToken === query.sessionToken) return { ...doc };
+      }
+      return null;
+    }),
+    findOneAndUpdate: (...args: [Record<string, unknown>, { $set: Record<string, unknown> }]) =>
+      mockAuthSessionFindOneAndUpdate(...args),
+  },
+}));
+
+interface StoredCode {
+  _id: string;
+  codeHash: string;
+  userId: string;
+  operatedByUserId: string | null;
+  appId: string;
+  redirectUri: string;
+  codeChallenge: string | null;
+  codeChallengeMethod: string | null;
+  scopes: string[];
+  deviceId: string | null;
+  usedAt: Date | null;
+  expiresAt: Date;
+}
+
+const codes = new Map<string, StoredCode>();
+const mockAuthCodeCreate = jest.fn(async (data: Record<string, unknown>) => {
+  const record: StoredCode = {
+    _id: String(data._id ?? `code-${codes.size + 1}`),
+    codeHash: String(data.codeHash ?? ''),
+    userId: String(data.userId ?? ''),
+    operatedByUserId: data.operatedByUserId ? String(data.operatedByUserId) : null,
+    appId: String(data.appId ?? ''),
+    redirectUri: String(data.redirectUri ?? ''),
+    codeChallenge: data.codeChallenge ? String(data.codeChallenge) : null,
+    codeChallengeMethod: data.codeChallengeMethod ? String(data.codeChallengeMethod) : null,
+    scopes: Array.isArray(data.scopes) ? (data.scopes as string[]) : [],
+    deviceId: data.deviceId ? String(data.deviceId) : null,
+    usedAt: null,
+    expiresAt: data.expiresAt instanceof Date ? data.expiresAt : new Date(Date.now() + 60_000),
+  };
+  codes.set(record.codeHash, record);
+  return record;
+});
+
+jest.mock('../../models/AuthCode', () => ({
+  __esModule: true,
+  default: {
+    create: (...args: [Record<string, unknown>]) => mockAuthCodeCreate(...args),
+    findOne: jest.fn(async (query: { codeHash: string }) => codes.get(query.codeHash) ?? null),
+    findOneAndUpdate: jest.fn(
+      async (filter: { _id: string; usedAt: null }, update: { $set: { usedAt: Date } }) => {
+        for (const record of codes.values()) {
+          if (record._id !== filter._id) continue;
+          if (record.usedAt !== null) return null;
+          record.usedAt = update.$set.usedAt;
+          return record;
+        }
+        return null;
+      }
+    ),
+  },
+  AuthCode: {},
+}));
+
+const mockApplicationFindOne = jest.fn();
+jest.mock('../../models/Application', () => ({
+  __esModule: true,
+  Application: {
+    findOne: (...args: unknown[]) => mockApplicationFindOne(...args),
+    findById: jest.fn(),
+  },
+  default: {
+    findOne: (...args: unknown[]) => mockApplicationFindOne(...args),
+    findById: jest.fn(),
+  },
+}));
+
+const mockUserFindById = jest.fn();
+jest.mock('../../models/User', () => ({
+  __esModule: true,
+  User: { findOne: jest.fn(), findById: (...args: unknown[]) => mockUserFindById(...args) },
+  default: { findOne: jest.fn(), findById: (...args: unknown[]) => mockUserFindById(...args) },
+}));
+
+const mockAppGrantFindOneAndUpdate = jest.fn(async () => ({}));
+jest.mock('../../models/AppGrant', () => ({
+  __esModule: true,
+  AppGrant: { findOneAndUpdate: (...args: unknown[]) => mockAppGrantFindOneAndUpdate(...args) },
+  default: { findOneAndUpdate: (...args: unknown[]) => mockAppGrantFindOneAndUpdate(...args) },
+}));
+
+jest.mock('../../models/AuthChallenge', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn(), findOneAndUpdate: jest.fn() },
+}));
+
+const mockCreateSession = jest.fn();
+jest.mock('../session.service', () => ({
+  __esModule: true,
+  default: { createSession: (...args: unknown[]) => mockCreateSession(...args) },
+}));
+
+jest.mock('../signature.service', () => ({
+  __esModule: true,
+  default: { verifyChallengeResponse: jest.fn(), isValidPublicKey: jest.fn() },
+}));
+
+const mockVerifyActingAs = jest.fn();
+jest.mock('../account.service', () => ({
+  __esModule: true,
+  accountService: { verifyActingAs: (...args: unknown[]) => mockVerifyActingAs(...args) },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import { claimAuthSession, finalizeOAuthAuthorization } from '../authSession.service';
+import { exchangeAuthCode } from '../oauthCode.service';
+
+const APP_ID = '64f7c2a1b8e9d3f4a1c2b301';
+const IDENTITY_ID = '64f7c2a1b8e9d3f4a1c2b401';
+const ORG_ID = '64f7c2a1b8e9d3f4a1c2b402';
+const REDIRECT_URI = 'https://mention.earth/oauth/callback';
+const CODE_VERIFIER = 'a'.repeat(64);
+const CODE_CHALLENGE = crypto
+  .createHash('sha256')
+  .update(CODE_VERIFIER)
+  .digest('base64')
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_')
+  .replace(/=+$/, '');
+
+function activeApp(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: { toString: () => APP_ID },
+    name: 'Mention',
+    status: 'active',
+    type: 'third_party',
+    isOfficial: false,
+    isInternal: false,
+    scopes: ['user:read'],
+    redirectUris: [REDIRECT_URI],
+    ...overrides,
+  };
+}
+
+function seedOAuthSession(overrides: Partial<StoredAuthSession> = {}): StoredAuthSession {
+  const doc: StoredAuthSession = {
+    _id: 'as-1',
+    sessionToken: 'secret-session-token',
+    authorizeCode: 'public-code',
+    applicationId: { toString: () => APP_ID },
+    status: 'authorized',
+    purpose: 'oauth_authorization',
+    oauth: {
+      redirectUri: REDIRECT_URI,
+      codeChallenge: CODE_CHALLENGE,
+      codeChallengeMethod: 'S256',
+      scopes: ['user:read'],
+    },
+    finalizedAuthCodeId: null,
+    authorizedUserId: { toString: () => IDENTITY_ID },
+    expiresAt: new Date(Date.now() + 60_000),
+    ...overrides,
+  };
+  authSessions.set(doc._id, doc);
+  return doc;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  authSessions.clear();
+  codes.clear();
+  mockApplicationFindOne.mockResolvedValue(activeApp());
+  mockAppGrantFindOneAndUpdate.mockResolvedValue({});
+});
+
+describe('finalizeOAuthAuthorization — preconditions', () => {
+  it('refuses a request that was never approved', async () => {
+    seedOAuthSession({ status: 'pending' });
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'not_authorized' });
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses a device sign-in request (wrong purpose) even when authorized', async () => {
+    seedOAuthSession({ purpose: 'device_sign_in', oauth: undefined });
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'wrong_purpose' });
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown sessionToken', async () => {
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'nope' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'not_found' });
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses an expired request', async () => {
+    seedOAuthSession({ expiresAt: new Date(Date.now() - 1_000) });
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'expired' });
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the application is no longer active', async () => {
+    seedOAuthSession();
+    mockApplicationFindOne.mockResolvedValue(null);
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'application_unavailable' });
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the bound redirect URI is no longer registered', async () => {
+    seedOAuthSession();
+    mockApplicationFindOne.mockResolvedValue(
+      activeApp({ redirectUris: ['https://mention.earth/other/callback'] })
+    );
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'redirect_uri_unregistered' });
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('finalizeOAuthAuthorization — atomic, single-use minting', () => {
+  it('mints exactly one AuthCode and spends the request', async () => {
+    seedOAuthSession({ deviceId: 'device-rp-1' });
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({
+      ok: true,
+      code: expect.any(String),
+      redirectUri: REDIRECT_URI,
+      expiresIn: 60,
+    });
+    expect(mockAuthCodeCreate).toHaveBeenCalledTimes(1);
+
+    const created = mockAuthCodeCreate.mock.calls[0][0];
+    // Bound to the approving identity, the app, the exact redirect, PKCE and scopes.
+    expect(created.userId).toBe(IDENTITY_ID);
+    expect(created.operatedByUserId).toBeNull();
+    expect(created.appId).toBe(APP_ID);
+    expect(created.redirectUri).toBe(REDIRECT_URI);
+    expect(created.codeChallenge).toBe(CODE_CHALLENGE);
+    expect(created.codeChallengeMethod).toBe('S256');
+    expect(created.scopes).toEqual(['user:read']);
+    // Threads the originating RP device instead of sprawling a new one.
+    expect(created.deviceId).toBe('device-rp-1');
+    // The raw code is NEVER stored — only its hash.
+    expect(JSON.stringify(created)).not.toContain((outcome as { code: string }).code);
+
+    // The request is spent: consumed + the code id reserved on the row.
+    const stored = authSessions.get('as-1');
+    expect(stored?.status).toBe('consumed');
+    expect(stored?.finalizedAuthCodeId).toBe(created._id);
+    expect(stored?.consumedAt).toBeInstanceOf(Date);
+  });
+
+  it('two concurrent finalizations yield exactly ONE AuthCode', async () => {
+    seedOAuthSession();
+
+    const [first, second] = await Promise.all([
+      finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' }),
+      finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' }),
+    ]);
+
+    // Both raced past the read-only preconditions; only one won the atomic claim.
+    expect(mockAuthSessionFindOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(mockAuthCodeCreate).toHaveBeenCalledTimes(1);
+
+    const outcomes = [first, second];
+    expect(outcomes.filter((o) => o.ok)).toHaveLength(1);
+    expect(outcomes.filter((o) => !o.ok)).toEqual([{ ok: false, reason: 'already_finalized' }]);
+  });
+
+  it('a finalized request can never mint a second code', async () => {
+    seedOAuthSession();
+
+    const first = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+    expect(first.ok).toBe(true);
+
+    const replay = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(replay).toEqual({ ok: false, reason: 'already_finalized' });
+    expect(mockAuthCodeCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the third-party grant so the app stays revocable in Connected apps', async () => {
+    seedOAuthSession();
+
+    await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(mockAppGrantFindOneAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('never records a grant for a trusted first-party app (auto-approved)', async () => {
+    seedOAuthSession();
+    mockApplicationFindOne.mockResolvedValue(activeApp({ type: 'first_party', isOfficial: true }));
+
+    await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(mockAuthCodeCreate).toHaveBeenCalledTimes(1);
+    expect(mockAppGrantFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('finalizeOAuthAuthorization — issued code stays single-use + PKCE bound', () => {
+  it('exchanges once with the correct verifier and never again', async () => {
+    seedOAuthSession();
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+    if (!outcome.ok) throw new Error('expected finalization to succeed');
+
+    const wrongVerifier = await exchangeAuthCode({
+      rawCode: outcome.code,
+      appId: APP_ID,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: 'b'.repeat(64),
+    });
+    expect(wrongVerifier).toEqual({ ok: false, reason: 'invalid_grant' });
+
+    const first = await exchangeAuthCode({
+      rawCode: outcome.code,
+      appId: APP_ID,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+    });
+    expect(first.ok).toBe(true);
+
+    const replay = await exchangeAuthCode({
+      rawCode: outcome.code,
+      appId: APP_ID,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+    });
+    expect(replay).toEqual({ ok: false, reason: 'invalid_grant' });
+  });
+
+  it('refuses the exchange when the redirect URI does not match the binding', async () => {
+    seedOAuthSession();
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+    if (!outcome.ok) throw new Error('expected finalization to succeed');
+
+    const mismatched = await exchangeAuthCode({
+      rawCode: outcome.code,
+      appId: APP_ID,
+      redirectUri: 'https://evil.example/callback',
+      codeVerifier: CODE_VERIFIER,
+    });
+
+    expect(mismatched).toEqual({ ok: false, reason: 'invalid_grant' });
+  });
+});
+
+describe('finalizeOAuthAuthorization — delegated subject', () => {
+  function seedDelegated() {
+    return seedOAuthSession({
+      oauth: {
+        redirectUri: REDIRECT_URI,
+        codeChallenge: CODE_CHALLENGE,
+        codeChallengeMethod: 'S256',
+        scopes: ['user:read'],
+        subjectAccountId: { toString: () => ORG_ID },
+      },
+    });
+  }
+
+  function mockSubjectAccount(account: { kind?: string; accountStatus?: string } | null) {
+    mockUserFindById.mockReturnValue({ select: () => ({ lean: () => Promise.resolve(account) }) });
+  }
+
+  it('refuses when the approving identity does not hold act_as over the subject', async () => {
+    seedDelegated();
+    mockSubjectAccount({ kind: 'organization', accountStatus: 'active' });
+    mockVerifyActingAs.mockResolvedValue(null);
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'delegation_denied' });
+    expect(mockVerifyActingAs).toHaveBeenCalledWith(IDENTITY_ID, ORG_ID);
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+    // Nothing was spent — a refused delegation must not consume the request.
+    expect(authSessions.get('as-1')?.status).toBe('authorized');
+  });
+
+  it('refuses a PERSONAL account as a delegated subject (that would be impersonation)', async () => {
+    seedDelegated();
+    mockSubjectAccount({ kind: 'personal', accountStatus: 'active' });
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'delegation_denied' });
+    expect(mockVerifyActingAs).not.toHaveBeenCalled();
+    expect(mockAuthCodeCreate).not.toHaveBeenCalled();
+  });
+
+  it('issues the code FOR the subject account with the approving identity recorded', async () => {
+    seedDelegated();
+    mockSubjectAccount({ kind: 'organization', accountStatus: 'active' });
+    mockVerifyActingAs.mockResolvedValue('admin');
+
+    const outcome = await finalizeOAuthAuthorization({ sessionToken: 'secret-session-token' });
+
+    expect(outcome.ok).toBe(true);
+    expect(mockAuthCodeCreate).toHaveBeenCalledTimes(1);
+    const created = mockAuthCodeCreate.mock.calls[0][0];
+    // The two ids are modelled explicitly — never conflated.
+    expect(created.userId).toBe(ORG_ID);
+    expect(created.operatedByUserId).toBe(IDENTITY_ID);
+  });
+});
+
+describe('device sign-in requests are unaffected', () => {
+  it('still claims a device sign-in request', async () => {
+    seedOAuthSession({ purpose: 'device_sign_in', oauth: undefined });
+
+    const outcome = await claimAuthSession({ sessionToken: 'secret-session-token' });
+
+    expect(outcome.ok).toBe(true);
+    expect(mockAuthSessionFindOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'authorized' }),
+      expect.objectContaining({ $set: expect.objectContaining({ status: 'consumed' }) }),
+      expect.anything()
+    );
+  });
+
+  it('still claims a legacy row that predates the purpose field', async () => {
+    seedOAuthSession({ purpose: undefined, oauth: undefined });
+
+    const outcome = await claimAuthSession({ sessionToken: 'secret-session-token' });
+
+    expect(outcome.ok).toBe(true);
+  });
+
+  it('refuses to claim an OAuth authorization request (no access token for a code flow)', async () => {
+    seedOAuthSession();
+
+    const outcome = await claimAuthSession({ sessionToken: 'secret-session-token' });
+
+    expect(outcome).toEqual({ ok: false, reason: 'wrong_purpose' });
+    expect(mockAuthSessionFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/__tests__/sessionAuthorizeSigned.test.ts
+++ b/packages/api/src/services/__tests__/sessionAuthorizeSigned.test.ts
@@ -16,9 +16,11 @@ const mockChallengeFindOne = jest.fn();
 const mockChallengeFindOneAndUpdate = jest.fn();
 const mockAuthSessionFindOne = jest.fn();
 const mockUserFindOne = jest.fn();
+const mockUserFindById = jest.fn();
 const mockApplicationFindById = jest.fn();
 const mockCreateSession = jest.fn();
 const mockVerifyChallengeResponse = jest.fn();
+const mockVerifyActingAs = jest.fn();
 
 jest.mock('../../models/AuthChallenge', () => ({
   __esModule: true,
@@ -34,8 +36,20 @@ jest.mock('../../models/AuthSession', () => ({
 }));
 jest.mock('../../models/User', () => ({
   __esModule: true,
-  User: { findOne: (...args: unknown[]) => mockUserFindOne(...args) },
-  default: { findOne: (...args: unknown[]) => mockUserFindOne(...args) },
+  User: {
+    findOne: (...args: unknown[]) => mockUserFindOne(...args),
+    findById: (...args: unknown[]) => mockUserFindById(...args),
+  },
+  default: {
+    findOne: (...args: unknown[]) => mockUserFindOne(...args),
+    findById: (...args: unknown[]) => mockUserFindById(...args),
+  },
+}));
+// The delegated-subject gate reuses the EXISTING act-as mechanism, imported
+// lazily by the service (mirroring session.service's managed-session re-check).
+jest.mock('../account.service', () => ({
+  __esModule: true,
+  accountService: { verifyActingAs: (...args: unknown[]) => mockVerifyActingAs(...args) },
 }));
 jest.mock('../../models/Application', () => ({
   __esModule: true,
@@ -213,5 +227,84 @@ describe('authorizeSessionWithSignedChallenge', () => {
     const second = await authorizeSessionWithSignedChallenge(baseInput({ challenge: 'chal-2' }));
 
     expect(second).toEqual({ ok: false, status: 404, message: 'Auth session not found or already processed' });
+  });
+});
+
+/**
+ * The Commons vault is the PRIMARY approval surface, so the delegated-subject
+ * permission gate has to hold here — not just on the bearer approval paths. The
+ * identity never becomes the organisation; it authorises the app to act as it,
+ * and only when it actually holds `account:act_as`.
+ */
+describe('authorizeSessionWithSignedChallenge — delegated subject (OAuth request)', () => {
+  const ORG_ID = '64f7c2a1b8e9d3f4a1c2b402';
+
+  function delegatedOAuthSession() {
+    return {
+      ...pendingSession(),
+      purpose: 'oauth_authorization',
+      oauth: {
+        redirectUri: 'https://mention.earth/oauth/callback',
+        codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+        codeChallengeMethod: 'S256',
+        scopes: ['user:read'],
+        subjectAccountId: { toString: () => ORG_ID },
+      },
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  function primeVerifiedSigner(session: unknown) {
+    mockChallengeFindOne.mockReturnValueOnce(leanChallenge());
+    mockVerifyChallengeResponse.mockReturnValueOnce(true);
+    mockChallengeFindOneAndUpdate.mockResolvedValueOnce({ _id: 'chal-id' });
+    mockAuthSessionFindOne.mockResolvedValueOnce(session);
+    mockUserFindOne.mockReturnValueOnce(leanUser({ _id: { toString: () => 'user-123' }, username: 'nate' }));
+  }
+
+  it('refuses (403) when the signer cannot act as the delegated subject', async () => {
+    const session = delegatedOAuthSession();
+    primeVerifiedSigner(session);
+    mockUserFindById.mockReturnValueOnce({
+      select: () => ({ lean: () => Promise.resolve({ kind: 'organization', accountStatus: 'active' }) }),
+    });
+    mockVerifyActingAs.mockResolvedValueOnce(null);
+
+    const outcome = await authorizeSessionWithSignedChallenge(baseInput());
+
+    expect(outcome).toEqual({
+      ok: false,
+      status: 403,
+      message: 'Not authorized to act as the requested account',
+    });
+    expect(mockVerifyActingAs).toHaveBeenCalledWith('user-123', ORG_ID);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(session.save).not.toHaveBeenCalled();
+    expect(session.status).toBe('pending');
+  });
+
+  it('approves a permitted delegated subject and mints NO session (the result is a code)', async () => {
+    const session = delegatedOAuthSession();
+    primeVerifiedSigner(session);
+    mockUserFindById.mockReturnValueOnce({
+      select: () => ({ lean: () => Promise.resolve({ kind: 'organization', accountStatus: 'active' }) }),
+    });
+    mockVerifyActingAs.mockResolvedValueOnce('admin');
+
+    const outcome = await authorizeSessionWithSignedChallenge(baseInput());
+
+    expect(outcome).toEqual({
+      ok: true,
+      sessionToken: 'secret-token',
+      userId: 'user-123',
+      username: 'nate',
+      publicKey: PUBLIC_KEY,
+    });
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    // WHICH identity approved is recorded on the request.
+    expect(session.status).toBe('authorized');
+    expect(session.authorizedBy).toBe(PUBLIC_KEY);
+    expect(session.authorizedSessionId).toBeNull();
+    expect(session.save).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/api/src/services/authSession.service.ts
+++ b/packages/api/src/services/authSession.service.ts
@@ -24,12 +24,23 @@
  */
 
 import type { Request } from 'express';
-import AuthSession, { type IAuthSession, type AuthSessionStatus } from '../models/AuthSession';
+import mongoose from 'mongoose';
+import AuthSession, {
+  type IAuthSession,
+  type AuthSessionStatus,
+  type IAuthSessionOAuthContext,
+} from '../models/AuthSession';
 import AuthChallenge from '../models/AuthChallenge';
 import { User } from '../models/User';
 import { Application } from '../models/Application';
+import { AppGrant } from '../models/AppGrant';
 import SignatureService from './signature.service';
 import sessionService from './session.service';
+import { issueAuthCode, AUTH_CODE_TTL_MS } from './oauthCode.service';
+import { isAllowedRedirectUri } from '../utils/oauthRedirect';
+import { isTrustedApplication } from '../utils/trustedApplication';
+import { isValidObjectId } from '../utils/validation';
+import type { AccountRole } from '../utils/accountRoles';
 import { logger } from '../utils/logger';
 
 export interface ClaimAuthSessionOptions {
@@ -38,7 +49,115 @@ export interface ClaimAuthSessionOptions {
 
 export type ClaimAuthSessionOutcome =
   | { ok: true; authSession: IAuthSession }
-  | { ok: false; reason: 'not_found' | 'expired' | 'cancelled' | 'pending' | 'already_consumed' };
+  | {
+      ok: false;
+      reason: 'not_found' | 'expired' | 'cancelled' | 'pending' | 'already_consumed' | 'wrong_purpose';
+    };
+
+/**
+ * The OAuth request binding of an OAuth-bound session, or null when the session
+ * is an ordinary device sign-in (or a row whose binding is incomplete — treated
+ * as absent, never as partially usable).
+ */
+export function resolveOAuthContext(
+  authSession: Pick<IAuthSession, 'purpose' | 'oauth'>
+): IAuthSessionOAuthContext | null {
+  if (authSession.purpose !== 'oauth_authorization') {
+    return null;
+  }
+  const oauth = authSession.oauth;
+  if (!oauth || typeof oauth.redirectUri !== 'string' || typeof oauth.codeChallenge !== 'string') {
+    return null;
+  }
+  if (oauth.codeChallengeMethod !== 'S256') {
+    return null;
+  }
+  return oauth;
+}
+
+/** Why a delegated subject was refused. Logged; never surfaced to the client. */
+export type DelegatedSubjectRejection =
+  | 'invalid_subject'
+  | 'not_found'
+  | 'personal_account'
+  | 'forbidden';
+
+export type DelegatedSubjectOutcome =
+  | { ok: true; role: AccountRole }
+  | { ok: false; reason: DelegatedSubjectRejection };
+
+/**
+ * Authorise an IDENTITY to approve an app acting AS another account.
+ *
+ * Identity and account are different concepts: the human never becomes the
+ * organisation, they authorise an application to act as it. The gate is the
+ * EXISTING act-as mechanism — `accountService.verifyActingAs` (effective
+ * membership, inherited through the account tree, carrying `account:act_as`) —
+ * the same predicate `POST /accounts/:id/switch` and the managed-session
+ * re-check use. No parallel permission system.
+ *
+ * Personal accounts are refused as subjects: assuming a human login would be
+ * impersonation, exactly as on the account-switch path.
+ *
+ * `account.service` is imported LAZILY (mirroring `session.service`) so this
+ * module's graph does not statically load the Account* models.
+ */
+export async function verifyDelegatedSubject(
+  identityUserId: string,
+  subjectAccountId: string
+): Promise<DelegatedSubjectOutcome> {
+  if (!isValidObjectId(subjectAccountId)) {
+    return { ok: false, reason: 'invalid_subject' };
+  }
+
+  const account = await User.findById(subjectAccountId)
+    .select('kind accountStatus')
+    .lean<{ kind?: string; accountStatus?: string } | null>();
+  if (!account || account.accountStatus === 'archived') {
+    return { ok: false, reason: 'not_found' };
+  }
+  if (!account.kind || account.kind === 'personal') {
+    return { ok: false, reason: 'personal_account' };
+  }
+
+  const { accountService } = await import('./account.service.js');
+  const role = await accountService.verifyActingAs(identityUserId, subjectAccountId);
+  if (!role) {
+    return { ok: false, reason: 'forbidden' };
+  }
+  return { ok: true, role };
+}
+
+/**
+ * Gate an approval against the session's OPTIONAL delegated subject. Sessions
+ * with no delegated subject pass straight through, so every approval path can
+ * call this unconditionally.
+ */
+async function gateApprovalDelegation(
+  authSession: Pick<IAuthSession, 'purpose' | 'oauth'>,
+  approvingUserId: string
+): Promise<{ ok: true } | { ok: false; reason: DelegatedSubjectRejection }> {
+  const subjectAccountId = resolveOAuthContext(authSession)?.subjectAccountId;
+  if (!subjectAccountId) {
+    return { ok: true };
+  }
+  const outcome = await verifyDelegatedSubject(approvingUserId, subjectAccountId.toString());
+  if (outcome.ok) {
+    return { ok: true };
+  }
+  return { ok: false, reason: outcome.reason };
+}
+
+/**
+ * An OAuth-bound session NEVER mints a session on approval: its result is an
+ * authorization code redeemed by the relying party at `POST /auth/oauth/token`.
+ * Minting one anyway would leave a live, unclaimable session for the approving
+ * identity on the RP's device, and would let the surface that only needs a code
+ * pick up an access token instead.
+ */
+function approvalMintsSession(authSession: Pick<IAuthSession, 'purpose'>): boolean {
+  return authSession.purpose !== 'oauth_authorization';
+}
 
 /**
  * Atomically claim an authorized AuthSession. Only an `authorized` row
@@ -63,6 +182,14 @@ export async function claimAuthSession(
   const existing = await AuthSession.findOne({ sessionToken });
   if (!existing) {
     return { ok: false, reason: 'not_found' };
+  }
+
+  // An OAuth authorization request is finalized into an authorization code via
+  // `POST /auth/session/finalize/:sessionToken`; it must never hand its holder
+  // an access token instead. Legacy rows carry no `purpose` and read as device
+  // sign-ins, so this changes nothing for them.
+  if (existing.purpose === 'oauth_authorization') {
+    return { ok: false, reason: 'wrong_purpose' };
   }
 
   const currentStatus = existing.status as AuthSessionStatus;
@@ -110,8 +237,16 @@ export interface AuthorizeSignedOptions {
 }
 
 export type AuthorizeSignedOutcome =
-  | { ok: true; sessionToken: string; sessionId: string; userId: string; username?: string; publicKey: string }
-  | { ok: false; status: 400 | 401 | 404; message: string };
+  | {
+      ok: true;
+      sessionToken: string;
+      /** Absent for an OAuth authorization request — those mint no session. */
+      sessionId?: string;
+      userId: string;
+      username?: string;
+      publicKey: string;
+    }
+  | { ok: false; status: 400 | 401 | 403 | 404; message: string };
 
 /**
  * Key-signed approval of a pending cross-app auth session (the "Sign in with
@@ -179,29 +314,49 @@ export async function authorizeSessionWithSignedChallenge(
   }
   const userId = user._id.toString();
 
-  // 4. Mint the session for the originating app, owned by the signer. When the
+  // 4. Delegated subject gate: when the request asks the identity to authorise
+  //    the app acting AS another account, the VERIFIED signer must actually hold
+  //    `account:act_as` over it. Refused before anything is bound.
+  const delegation = await gateApprovalDelegation(authSession, userId);
+  if (!delegation.ok) {
+    logger.warn('[AuthSession] Delegated subject refused on signed approval', {
+      authorizeCode: authorizeCode.substring(0, 8) + '...',
+      identityUserId: userId,
+      reason: delegation.reason,
+    });
+    return { ok: false, status: 403, message: 'Not authorized to act as the requested account' };
+  }
+
+  // 5. Mint the session for the originating app, owned by the signer. When the
   //    flow was started with a device binding (`deviceId` persisted at create
   //    time), pass it as the explicit deviceId so the session lands on the
-  //    originating device set instead of sprawling a fresh device.
-  const app = await Application.findById(authSession.applicationId);
-  const appLabel = app ? app.name : 'App';
-  const newSession = await sessionService.createSession(userId, req, {
-    deviceName: deviceName || `${appLabel} App`,
-    deviceFingerprint,
-    ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
-  });
+  //    originating device set instead of sprawling a fresh device. An OAuth
+  //    authorization request mints nothing here — see `approvalMintsSession`.
+  let sessionId: string | undefined;
+  if (approvalMintsSession(authSession)) {
+    const app = await Application.findById(authSession.applicationId);
+    const appLabel = app ? app.name : 'App';
+    const newSession = await sessionService.createSession(userId, req, {
+      deviceName: deviceName || `${appLabel} App`,
+      deviceFingerprint,
+      ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
+    });
+    sessionId = newSession.sessionId;
+  }
 
-  // 5. Bind the result onto the session row.
+  // 6. Bind the result onto the session row — including WHICH identity approved.
   authSession.status = 'authorized';
   authSession.authorizedBy = publicKey;
   authSession.authorizedUserId = user._id;
-  authSession.authorizedSessionId = newSession.sessionId;
+  if (sessionId) {
+    authSession.authorizedSessionId = sessionId;
+  }
   await authSession.save();
 
   return {
     ok: true,
     sessionToken: authSession.sessionToken,
-    sessionId: newSession.sessionId,
+    ...(sessionId ? { sessionId } : {}),
     userId,
     username: typeof user.username === 'string' ? user.username : undefined,
     publicKey,
@@ -219,8 +374,13 @@ export interface AuthorizeBearerOptions {
 }
 
 export type AuthorizeBearerOutcome =
-  | { ok: true; sessionToken: string; sessionId: string }
-  | { ok: false; status: 400 | 404; message: string };
+  | {
+      ok: true;
+      sessionToken: string;
+      /** Absent for an OAuth authorization request — those mint no session. */
+      sessionId?: string;
+    }
+  | { ok: false; status: 400 | 403 | 404; message: string };
 
 /**
  * Bearer approval of a pending cross-app auth session, keyed on the PUBLIC
@@ -259,6 +419,19 @@ export async function authorizeSessionWithBearer(
     return { ok: false, status: 400, message: 'Auth session has expired' };
   }
 
+  // Delegated subject gate — the authenticated approver must hold
+  // `account:act_as` over the account the app would act as. Checked BEFORE the
+  // atomic claim so a refusal leaves the request approvable by someone who does.
+  const delegation = await gateApprovalDelegation(existing, authenticatedUserId);
+  if (!delegation.ok) {
+    logger.warn('[AuthSession] Delegated subject refused on bearer approval', {
+      authorizeCode: authorizeCode.substring(0, 8) + '...',
+      identityUserId: authenticatedUserId,
+      reason: delegation.reason,
+    });
+    return { ok: false, status: 403, message: 'Not authorized to act as the requested account' };
+  }
+
   const claimed = await AuthSession.findOneAndUpdate(
     { _id: existing._id, status: 'pending', expiresAt: { $gt: new Date() } },
     {
@@ -285,6 +458,12 @@ export async function authorizeSessionWithBearer(
     });
   }
 
+  // An OAuth authorization request mints nothing here — its result is the
+  // authorization code produced by finalization.
+  if (!approvalMintsSession(claimed)) {
+    return { ok: true, sessionToken: claimed.sessionToken };
+  }
+
   const app = await Application.findById(claimed.applicationId);
   const appLabel = app ? app.name : 'App';
   const newSession = await sessionService.createSession(authenticatedUserId, req, {
@@ -299,4 +478,182 @@ export async function authorizeSessionWithBearer(
   await claimed.save();
 
   return { ok: true, sessionToken: claimed.sessionToken, sessionId: newSession.sessionId };
+}
+
+/** Options for {@link finalizeOAuthAuthorization}. */
+export interface FinalizeOAuthAuthorizationOptions {
+  /** The SECRET credential held only by the originating client. */
+  sessionToken: string;
+}
+
+/**
+ * Why a finalization was refused. Logged server-side ONLY — every failure is
+ * collapsed to one generic client error so nothing enumerates which precondition
+ * failed (RFC 6749 §5.2).
+ */
+export type FinalizeOAuthRejection =
+  | 'not_found'
+  | 'wrong_purpose'
+  | 'not_authorized'
+  | 'expired'
+  | 'already_finalized'
+  | 'application_unavailable'
+  | 'redirect_uri_unregistered'
+  | 'delegation_denied'
+  | 'issue_failed';
+
+export type FinalizeOAuthOutcome =
+  | { ok: true; code: string; redirectUri: string; expiresIn: number }
+  | { ok: false; reason: FinalizeOAuthRejection };
+
+/**
+ * Turn an APPROVED OAuth-bound `AuthSession` into the standard OAuth result: one
+ * short-lived, single-use `AuthCode`. This is where every delivery surface
+ * (popup, push, QR, verified app link) converges — there is no second code
+ * minter, and no access token is ever handed out to finalize a request.
+ *
+ * Single-use is structural, not advisory: the code's `_id` is RESERVED by the
+ * same atomic `findOneAndUpdate` that spends the session
+ * (`finalizedAuthCodeId: null` -> the reserved id, `authorized` -> `consumed`).
+ * Two concurrent finalizations cannot both match that filter, so exactly one
+ * ever reaches `issueAuthCode`. If minting then fails, the request stays spent
+ * and the user restarts — the correct fail-closed direction.
+ *
+ * Bindings are RE-verified at finalization, never assumed from bind time: the
+ * application must still be active, the redirect URI must still be registered,
+ * and a delegated subject's `account:act_as` permission must still hold.
+ */
+export async function finalizeOAuthAuthorization(
+  options: FinalizeOAuthAuthorizationOptions
+): Promise<FinalizeOAuthOutcome> {
+  const { sessionToken } = options;
+
+  const existing = await AuthSession.findOne({ sessionToken });
+  if (!existing) {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  const oauth = resolveOAuthContext(existing);
+  if (!oauth) {
+    return { ok: false, reason: 'wrong_purpose' };
+  }
+  if (existing.finalizedAuthCodeId) {
+    return { ok: false, reason: 'already_finalized' };
+  }
+  if (existing.status !== 'authorized') {
+    return { ok: false, reason: 'not_authorized' };
+  }
+  if (existing.expiresAt < new Date()) {
+    return { ok: false, reason: 'expired' };
+  }
+
+  // WHICH identity approved — recorded at approval time, never client-asserted.
+  const identityUserId = existing.authorizedUserId ? existing.authorizedUserId.toString() : '';
+  if (!identityUserId) {
+    return { ok: false, reason: 'not_authorized' };
+  }
+
+  const app = await Application.findOne({ _id: existing.applicationId, status: 'active' });
+  if (!app) {
+    return { ok: false, reason: 'application_unavailable' };
+  }
+  if (!isAllowedRedirectUri(app, oauth.redirectUri)) {
+    return { ok: false, reason: 'redirect_uri_unregistered' };
+  }
+
+  // The code is issued FOR the delegated subject when there is one; the
+  // approving identity is recorded alongside it, never merged into it.
+  const subjectAccountId = oauth.subjectAccountId ? oauth.subjectAccountId.toString() : '';
+  if (subjectAccountId) {
+    const delegation = await verifyDelegatedSubject(identityUserId, subjectAccountId);
+    if (!delegation.ok) {
+      logger.warn('[AuthSession] Delegated subject refused on finalize', {
+        identityUserId,
+        reason: delegation.reason,
+      });
+      return { ok: false, reason: 'delegation_denied' };
+    }
+  }
+
+  // ATOMIC single-use claim: reserve the code id AND spend the request in one
+  // update. The loser of a concurrent race matches nothing and mints nothing.
+  const codeId = new mongoose.Types.ObjectId();
+  const now = new Date();
+  const claimed = await AuthSession.findOneAndUpdate(
+    {
+      _id: existing._id,
+      purpose: 'oauth_authorization',
+      status: 'authorized',
+      finalizedAuthCodeId: null,
+    },
+    { $set: { finalizedAuthCodeId: codeId, status: 'consumed', consumedAt: now } },
+    { new: true }
+  );
+  if (!claimed) {
+    return { ok: false, reason: 'already_finalized' };
+  }
+
+  const grantUserId = subjectAccountId || identityUserId;
+
+  try {
+    const { code } = await issueAuthCode({
+      codeId,
+      userId: grantUserId,
+      appId: app._id.toString(),
+      redirectUri: oauth.redirectUri,
+      codeChallenge: oauth.codeChallenge,
+      codeChallengeMethod: 'S256',
+      scopes: oauth.scopes ?? [],
+      ...(subjectAccountId ? { operatedByUserId: identityUserId } : {}),
+      // Thread the originating RP device so the token exchange lands on the same
+      // DeviceSession the flow started from instead of sprawling a new device.
+      ...(existing.deviceId ? { deviceId: existing.deviceId } : {}),
+    });
+
+    // Same returning-user consent bookkeeping as `POST /auth/oauth/authorize`:
+    // only third-party grants are revocable "Connected apps" entries; trusted
+    // apps are auto-approved and never recorded. Best-effort — a bookkeeping
+    // failure must never invalidate an already-issued code.
+    if (!isTrustedApplication(app)) {
+      try {
+        await AppGrant.findOneAndUpdate(
+          { userId: grantUserId, applicationId: app._id },
+          {
+            $set: { lastUsedAt: now },
+            $addToSet: { scopes: { $each: oauth.scopes ?? [] } },
+            $setOnInsert: { firstGrantedAt: now },
+          },
+          { upsert: true, new: true }
+        );
+      } catch (error) {
+        logger.warn('[AuthSession] Failed to record AppGrant on finalize', {
+          applicationId: app._id.toString(),
+          err: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    logger.info('[AuthSession] OAuth authorization finalized', {
+      sessionToken: sessionToken.substring(0, 8) + '...',
+      applicationId: app._id.toString(),
+      identityUserId,
+      delegated: Boolean(subjectAccountId),
+    });
+
+    return {
+      ok: true,
+      code,
+      redirectUri: oauth.redirectUri,
+      expiresIn: Math.floor(AUTH_CODE_TTL_MS / 1000),
+    };
+  } catch (error) {
+    // The request is already spent — fail closed and make the user restart
+    // rather than leave a second minting opportunity open.
+    logger.error(
+      '[AuthSession] Authorization code mint failed after the request was spent',
+      error instanceof Error ? error : new Error(String(error)),
+      { sessionToken: sessionToken.substring(0, 8) + '...', applicationId: app._id.toString() }
+    );
+    return { ok: false, reason: 'issue_failed' };
+  }
 }

--- a/packages/api/src/services/oauthCode.service.ts
+++ b/packages/api/src/services/oauthCode.service.ts
@@ -56,6 +56,7 @@ export function canonicalizeOAuthRedirectUri(redirectUri: string): string {
 }
 
 export interface IssueCodeOptions {
+  /** The SUBJECT of the grant — the account the code authorizes access to. */
   userId: Types.ObjectId | string;
   appId: string;
   redirectUri: string;
@@ -64,6 +65,20 @@ export interface IssueCodeOptions {
   scopes?: string[];
   /** DeviceSession id from the authorizing bearer JWT. */
   deviceId?: string;
+  /**
+   * The OPERATOR identity when `userId` is a DELEGATED account (the identity
+   * approved the app to act as that account). Kept separate from `userId` so the
+   * two are never conflated: the session minted at exchange time is a managed
+   * session bound to this operator's `account:act_as` membership.
+   */
+  operatedByUserId?: Types.ObjectId | string;
+  /**
+   * Pre-allocated `_id` for the code document. Lets a caller RESERVE the code's
+   * identity inside an atomic single-use claim (see the OAuth-bound AuthSession
+   * finalization) before anything is minted, so a spent request can never mint a
+   * second code.
+   */
+  codeId?: Types.ObjectId | string;
   ttlMs?: number;
 }
 
@@ -79,6 +94,7 @@ export async function issueAuthCode(options: IssueCodeOptions): Promise<IssueCod
   const expiresAt = new Date(Date.now() + ttlMs);
 
   await AuthCode.create({
+    ...(options.codeId ? { _id: options.codeId } : {}),
     codeHash,
     userId: options.userId,
     appId: options.appId,
@@ -87,6 +103,7 @@ export async function issueAuthCode(options: IssueCodeOptions): Promise<IssueCod
     codeChallengeMethod: options.codeChallenge ? 'S256' : null,
     scopes: options.scopes ?? [],
     deviceId: options.deviceId ?? null,
+    operatedByUserId: options.operatedByUserId ?? null,
     expiresAt,
   });
 

--- a/packages/api/src/utils/oauthRedirect.ts
+++ b/packages/api/src/utils/oauthRedirect.ts
@@ -1,0 +1,39 @@
+/**
+ * OAuth redirect-URI allowlist check.
+ *
+ * The SINGLE authority for "is this redirect_uri registered for this
+ * Application" — shared by `POST /auth/oauth/authorize`, `GET /auth/oauth/consent`,
+ * the OAuth-bound `POST /auth/session/create` binding, and the finalization of an
+ * OAuth-bound `AuthSession`. Duplicating it per call site is how one path
+ * silently drifts into accepting a prefix match, so it lives here alone.
+ */
+
+import * as crypto from 'crypto';
+import { canonicalizeOAuthRedirectUri } from '../services/oauthCode.service';
+
+/**
+ * Validate a redirect URI against the Application allowlist using an exact
+ * match (per OAuth2 RFC 6749 §3.1.2). Partial / prefix matching is the source
+ * of countless open-redirect vulnerabilities — we never normalise away path or
+ * query for the comparison. Constant-time equality keeps the comparison from
+ * leaking the allowlist contents via timing.
+ *
+ * Origin-only https URLs are canonicalized so `https://app.example` and
+ * `https://app.example/` match the same registered apex origin.
+ */
+export function isAllowedRedirectUri(
+  app: { redirectUris?: string[] },
+  redirectUri: string
+): boolean {
+  const allowlist = app.redirectUris ?? [];
+  if (allowlist.length === 0) return false;
+  const provided = Buffer.from(canonicalizeOAuthRedirectUri(redirectUri));
+  let matched = false;
+  for (const allowed of allowlist) {
+    const allowedBuf = Buffer.from(canonicalizeOAuthRedirectUri(allowed));
+    if (allowedBuf.length === provided.length && crypto.timingSafeEqual(allowedBuf, provided)) {
+      matched = true;
+    }
+  }
+  return matched;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,8 +46,12 @@ export type { ServiceTokenResponse } from './mixins/OxyServices.auth';
 export type {
     CommonsSignInHandle,
     CommonsSignInStatus,
+    CommonsSignInPurpose,
+    CommonsOAuthContext,
     CommonsApprovalInfo,
+    CommonsApprovalSubjectAccount,
     CommonsSignInActionResult,
+    CommonsOAuthFinalizeResult,
 } from './mixins/OxyServices.auth';
 export type { ServiceApp, ServiceActingAsVerification } from './mixins/OxyServices.utility';
 export type {

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -59,11 +59,58 @@ export interface PublicKeyCheckResponse {
 // ===========================================================================
 
 /**
+ * How a "Sign in with Oxy" request finalizes once the approver authorizes it.
+ *
+ * ONE request (`AuthSession`) serves every delivery surface — popup, push, QR,
+ * deep link — so the purpose describes the FINALIZATION, never the transport:
+ *
+ * - `device_sign_in` — the classic device flow. The initiator exchanges its
+ *   secret `sessionToken` for the first access token via `claimSessionByToken`.
+ * - `oauth_authorization` — the request additionally carries an OAuth binding
+ *   ({@link CommonsOAuthContext}), so it finalizes into a single-use
+ *   authorization CODE via {@link OxyServicesAuthMixin.finalizeCommonsOAuth}.
+ *   The caller still performs the PKCE token exchange itself.
+ */
+export type CommonsSignInPurpose = 'device_sign_in' | 'oauth_authorization';
+
+/**
+ * OAuth binding attached to a "Sign in with Oxy" request so a single
+ * `AuthSession` can finalize into a standard OAuth authorization code instead of
+ * a device-flow session.
+ *
+ * Only the minimum request binding is carried here — everything else (the app's
+ * name, icon, registered redirect URIs, trust flags) is owned server-side by the
+ * `Application` the `clientId` resolves to and is never client-supplied.
+ *
+ * The PKCE `codeVerifier` NEVER appears here: only its S256 `codeChallenge`
+ * crosses the wire, exactly as in the redirect flow. The RP-owned OAuth `state`
+ * also stays with the relying party, which validates it locally.
+ */
+export interface CommonsOAuthContext {
+  /** Exact registered redirect URI the authorization code will be returned to. */
+  redirectUri: string;
+  /** PKCE `BASE64URL(SHA-256(codeVerifier))` (RFC 7636 §4.2); the verifier stays client-side. */
+  codeChallenge: string;
+  /** PKCE transformation method. Always `S256` — `plain` is not accepted. */
+  codeChallengeMethod: 'S256';
+  /** Space-delimited OAuth scope string; the server normalizes and validates it. */
+  scope?: string;
+  /**
+   * Optional delegated account the application will act AS (an organization or
+   * project the identity is a member of). The identity approving the request
+   * does not change; the server verifies the identity's permission to act as
+   * this account before finalizing.
+   */
+  subjectAccountId?: string;
+}
+
+/**
  * Handle returned by {@link OxyServicesAuthMixin.startCommonsSignIn} for a
  * relying-party app initiating a "Sign in with Oxy" flow.
  *
  * `sessionToken` is the SECRET, high-entropy device-flow credential — it stays
- * on the initiating client, is exchanged once via `claimSessionByToken`, and is
+ * on the initiating client, is exchanged once via `claimSessionByToken` (device
+ * sign-in) or {@link OxyServicesAuthMixin.finalizeCommonsOAuth} (OAuth), and is
  * NEVER placed in the QR/deep-link. `authorizeCode` is the PUBLIC handle carried
  * in `qrPayload`; the approver (Commons) resolves it via
  * {@link OxyServicesAuthMixin.getCommonsApprovalInfo}.
@@ -94,6 +141,24 @@ export interface CommonsSignInStatus {
 }
 
 /**
+ * The account an application will act AS once the request is approved, when the
+ * request delegates to an organization/project rather than the approver's own
+ * personal account. Resolved and sanitized server-side from the request's
+ * `subjectAccountId`, so it is safe to display in the approval UI.
+ *
+ * The identity approving stays the identity: Commons renders this as a distinct
+ * "will act as" line, never as a change of who is signing.
+ */
+export interface CommonsApprovalSubjectAccount {
+  /** The delegated account's id. */
+  id: string;
+  /** The delegated account's handle. */
+  username: string;
+  /** Optional human-readable name; absent when the account has no real name. */
+  displayName?: string;
+}
+
+/**
  * Server-resolved approval context shown by the approver (Commons) before
  * authorizing — the TRUSTED identity of the requesting app, resolved from the
  * `authorizeCode` server-side (never from the QR string).
@@ -113,6 +178,20 @@ export interface CommonsApprovalInfo {
    * "not verified") by {@link OxyServicesAuthMixin.getCommonsApprovalInfo}.
    */
   originVerified: boolean;
+  /**
+   * How this request finalizes. Always present — an unrecognized or missing
+   * server value degrades to `'device_sign_in'`, the behaviour every server has
+   * always had, so an older API never makes the approver believe it is granting
+   * an OAuth authorization.
+   */
+  purpose: CommonsSignInPurpose;
+  /**
+   * The delegated account the application will act as, or `null` when the
+   * request is for the approver's own account. Always present — a missing or
+   * malformed server value degrades to `null` (fail-safe to "no delegation"),
+   * so a partial payload can never imply a broader grant than was requested.
+   */
+  subjectAccount: CommonsApprovalSubjectAccount | null;
   /** Server-authoritative expiry (epoch ms or ISO-8601 string from the API). */
   expiresAt: number | string;
   /** Session lifecycle status. */
@@ -121,22 +200,65 @@ export interface CommonsApprovalInfo {
 
 /**
  * @internal Raw server response of `GET /auth/session/approve-info/:code`.
- * `originVerified` is typed loosely here because older servers may omit it (or
- * send a non-boolean); the SDK coerces it to a strict `boolean` when mapping
- * into {@link CommonsApprovalInfo}.
+ * `originVerified`, `purpose` and `subjectAccount` are typed loosely here
+ * because older servers may omit them (or send an unexpected shape); the SDK
+ * narrows each one fail-safe when mapping into {@link CommonsApprovalInfo}.
  */
 interface CommonsApprovalInfoResponse {
   application: PublicApplication | null;
   scopes: string[];
   boundOrigin?: string;
   originVerified?: unknown;
+  purpose?: unknown;
+  subjectAccount?: unknown;
   expiresAt: number | string;
   status: string;
+}
+
+/**
+ * @internal Narrow an untrusted `subjectAccount` from the approve-info response.
+ *
+ * Returns `null` unless the value is an object carrying a non-empty string `id`
+ * AND `username` — the two fields the approval UI needs to name the delegated
+ * account. A half-populated object is rejected whole rather than rendered with
+ * blanks, and `displayName` is only carried through when it is a string.
+ */
+function parseCommonsSubjectAccount(value: unknown): CommonsApprovalSubjectAccount | null {
+  if (value === null || typeof value !== 'object') {
+    return null;
+  }
+  const raw = value as Record<string, unknown>;
+  const { id, username, displayName } = raw;
+  if (typeof id !== 'string' || !id || typeof username !== 'string' || !username) {
+    return null;
+  }
+  return {
+    id,
+    username,
+    ...(typeof displayName === 'string' ? { displayName } : {}),
+  };
 }
 
 /** Result of approving / denying a "Sign in with Oxy" request. */
 export interface CommonsSignInActionResult {
   success: boolean;
+}
+
+/**
+ * Result of finalizing an approved, OAuth-bound "Sign in with Oxy" request.
+ *
+ * This is an authorization CODE, not a session: the caller still performs the
+ * standard PKCE token exchange (`exchangeOAuthCode`) with the `codeVerifier` it
+ * has held all along. No access token, refresh token, or device secret is ever
+ * produced by finalization.
+ */
+export interface CommonsOAuthFinalizeResult {
+  /** Single-use OAuth authorization code. */
+  code: string;
+  /** The exact registered redirect URI the request was bound to. */
+  redirectUri: string;
+  /** Lifetime of the authorization code, in seconds. */
+  expiresIn: number;
 }
 
 /** @internal Response shape of the extended `POST /auth/session/create`. */
@@ -721,11 +843,16 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
     //   A. Same-device shared-keychain SSO (`signInWithSharedIdentity`): a
     //      sibling native app silently mints its own session from the shared
     //      identity key. No user interaction.
-    //   B. QR / app-to-app handoff: a relying party (`startCommonsSignIn` +
-    //      `pollCommonsSignIn` + the existing `claimSessionByToken`) and the
-    //      approver / Commons (`getCommonsApprovalInfo` + `approveCommonsSignIn`
-    //      / `denyCommonsSignIn`). The approver signs with its PRIMARY local
-    //      key; the RP never sees the private key.
+    //   B. QR / app-to-app / popup / push handoff: a relying party
+    //      (`startCommonsSignIn` + `pollCommonsSignIn`, finalized with either
+    //      `claimSessionByToken` or `finalizeCommonsOAuth`) and the approver /
+    //      Commons (`getCommonsApprovalInfo` + `approveCommonsSignIn` /
+    //      `denyCommonsSignIn`). The approver signs with its PRIMARY local key;
+    //      the RP never sees the private key.
+    //
+    //      ONE request serves every delivery surface. The delivery surface is
+    //      not part of the model: only the request's purpose is, and it is fixed
+    //      at creation by whether an OAuth binding was attached.
     // =======================================================================
 
     /**
@@ -793,14 +920,28 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
      * returns the server-issued public `authorizeCode` + ready-to-render
      * `qrPayload`. Render the QR (web) / open the deep-link (same-device); the
      * approver resolves the code and authorizes. Then poll with
-     * {@link pollCommonsSignIn} and, on `authorized`, exchange the
-     * `sessionToken` via the existing `claimSessionByToken`.
+     * {@link pollCommonsSignIn} and finalize.
+     *
+     * ONE request serves every delivery surface, and how it finalizes is decided
+     * here by whether an OAuth binding is attached:
+     *   - no `oauth` (the default): a `device_sign_in` request — on `authorized`,
+     *     exchange the `sessionToken` via the existing `claimSessionByToken`.
+     *   - with `oauth`: an `oauth_authorization` request — on `authorized`, call
+     *     {@link finalizeCommonsOAuth} with the same `sessionToken` to mint the
+     *     single-use authorization code, then exchange it with PKCE.
      *
      * @param params.clientId - The RP's registered OAuth client id
      *   (ApplicationCredential publicKey); required so the server can resolve the
      *   requesting application's identity.
+     * @param params.oauth - Optional OAuth binding ({@link CommonsOAuthContext}).
+     *   Carries only the redirect URI, the PKCE S256 challenge, the requested
+     *   scope, and an optional delegated `subjectAccountId` — never the PKCE
+     *   verifier, the OAuth `state`, or any token.
      */
-    async startCommonsSignIn(params: { clientId: string }): Promise<CommonsSignInHandle> {
+    async startCommonsSignIn(params: {
+      clientId: string;
+      oauth?: CommonsOAuthContext;
+    }): Promise<CommonsSignInHandle> {
       try {
         // High-entropy opaque secret token (256-bit hex). Generated client-side
         // and held only here; the server stores it but never returns it in the
@@ -811,7 +952,15 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
         const res = await this.makeRequest<CommonsSessionCreateResponse>(
           'POST',
           '/auth/session/create',
-          { sessionToken, expiresAt, clientId: params.clientId },
+          {
+            sessionToken,
+            expiresAt,
+            clientId: params.clientId,
+            // Omitted entirely when absent so the device-sign-in body stays
+            // exactly what it has always been (the server reads presence, not a
+            // null, to decide the request's purpose).
+            ...(params.oauth ? { oauth: params.oauth } : {}),
+          },
           // Public/pre-session (no bearer): skip the preflight so a stale
           // near-expiry token cannot re-enter refreshAccessToken while the
           // refresh handler is already in flight (self-await hang).
@@ -834,8 +983,8 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
      * MECHANISM B (relying party) — poll a device-flow session for approval.
      *
      * Backstop for the auth socket. On `authorized` (with a `sessionId`), the
-     * caller exchanges the secret `sessionToken` via the existing
-     * `claimSessionByToken` to mint the first access token.
+     * caller finalizes: `claimSessionByToken` for a `device_sign_in` request,
+     * {@link finalizeCommonsOAuth} for an `oauth_authorization` one.
      *
      * @param sessionToken - The secret token from {@link startCommonsSignIn}.
      */
@@ -856,12 +1005,74 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
     }
 
     /**
+     * MECHANISM B (relying party) — finalize an APPROVED, OAuth-bound request
+     * into a single-use OAuth authorization code.
+     *
+     * The OAuth counterpart of `claimSessionByToken`: same secret credential,
+     * same single-use semantics, different output. Call it once the request the
+     * RP started with an `oauth` binding reports `authorized`; the server
+     * atomically mints exactly ONE `AuthCode` bound to the redirect URI, PKCE
+     * challenge, scopes, approving identity, and any delegated subject account
+     * the request was created with. A second call cannot mint another code.
+     *
+     * The result is an authorization CODE, never a token — the caller completes
+     * the flow with the ordinary PKCE exchange (`exchangeOAuthCode`) using the
+     * `codeVerifier` it never sent anywhere. Nothing here is exposed to the
+     * popup: the code travels back through the registered callback, and the
+     * main window owns the verifier.
+     *
+     * Like `claimSessionByToken`, this needs no Authorization header — the
+     * high-entropy SECRET `sessionToken` IS the credential. Never pass the
+     * public `authorizeCode` here; it is the approver's handle, not the
+     * initiator's. Every server-side failure (wrong/expired/already-finalized
+     * request, non-OAuth purpose, missing permission for the delegated account)
+     * surfaces as one generic error, so nothing about the request's state can be
+     * probed from outside.
+     *
+     * @param sessionToken - The secret token from {@link startCommonsSignIn}.
+     */
+    async finalizeCommonsOAuth(sessionToken: string): Promise<CommonsOAuthFinalizeResult> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          `/auth/session/finalize/${encodeURIComponent(sessionToken)}`,
+          undefined,
+          // Body-authenticated by the path's secret token (no bearer) — skip the
+          // preflight, exactly like the device-flow claim.
+          { cache: false, skipAuth: true },
+        );
+
+        if (res === null || typeof res !== 'object') {
+          throw new Error('auth/session/finalize returned an unexpected response shape');
+        }
+        const { code, redirectUri, expiresIn } = res as Record<string, unknown>;
+        // All three fields are load-bearing for the exchange that follows, so a
+        // partial payload is rejected outright rather than returned half-parsed.
+        if (
+          typeof code !== 'string' ||
+          !code ||
+          typeof redirectUri !== 'string' ||
+          !redirectUri ||
+          typeof expiresIn !== 'number' ||
+          !Number.isFinite(expiresIn)
+        ) {
+          throw new Error('auth/session/finalize returned an incomplete authorization code');
+        }
+
+        return { code, redirectUri, expiresIn };
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
      * MECHANISM B (approver / Commons) — resolve the TRUSTED identity of a
      * sign-in request from its public `authorizeCode`.
      *
-     * The returned `application` is resolved server-side and is the only safe
-     * thing to display in the approval UI — NEVER trust the app/name/origin
-     * strings carried in the QR payload. Public (no auth required).
+     * The returned `application` and `subjectAccount` are resolved server-side
+     * and are the only safe things to display in the approval UI — NEVER trust
+     * the app/name/origin strings carried in the QR payload. Public (no auth
+     * required).
      *
      * @param authorizeCode - The public code scanned from the QR / deep-link.
      */
@@ -883,6 +1094,13 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
           // missing or non-boolean value (older server, malformed response)
           // coerces to `false` so a stale server can never imply trust.
           originVerified: raw.originVerified === true,
+          // Same discipline: only the literal OAuth purpose opts into OAuth
+          // finalization. Anything else — including a server that predates this
+          // field — is the plain device sign-in it has always been.
+          purpose: raw.purpose === 'oauth_authorization' ? 'oauth_authorization' : 'device_sign_in',
+          // A missing/partial delegated account degrades to "no delegation"
+          // rather than a half-rendered "will act as" line.
+          subjectAccount: parseCommonsSubjectAccount(raw.subjectAccount),
           expiresAt: raw.expiresAt,
           status: raw.status,
         };

--- a/packages/core/src/mixins/__tests__/commonsSignIn.test.ts
+++ b/packages/core/src/mixins/__tests__/commonsSignIn.test.ts
@@ -71,6 +71,86 @@ describe('OxyServices — "Sign in with Oxy" handoff', () => {
       expect(handle.qrPayload).not.toContain('secret-session-token');
     });
 
+    it('omits the oauth key entirely when no OAuth binding is given (body byte-identical to a plain device sign-in)', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+      jest.spyOn(SignatureService, 'generateChallenge').mockResolvedValue('tok');
+      makeRequestSpy.mockResolvedValue({
+        authorizeCode: 'code-1',
+        qrPayload: 'oxycommons://approve?v=1&code=code-1',
+        status: 'pending',
+      });
+
+      await oxy.startCommonsSignIn({ clientId: 'oxy_dk_test' });
+
+      // `toHaveBeenCalledWith` ignores explicitly-undefined keys, so assert the
+      // literal key set: the server decides the request's purpose from the
+      // PRESENCE of `oauth`, and an `oauth: undefined` key would still serialize
+      // differently from the body this endpoint has always received.
+      const body = makeRequestSpy.mock.calls[0][2];
+      expect(Object.keys(body)).toEqual(['sessionToken', 'expiresAt', 'clientId']);
+    });
+
+    it('sends the OAuth binding verbatim when provided', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+      jest.spyOn(SignatureService, 'generateChallenge').mockResolvedValue('secret-session-token');
+      makeRequestSpy.mockResolvedValue({
+        authorizeCode: 'code-oauth',
+        qrPayload: 'oxycommons://approve?v=1&code=code-oauth',
+        status: 'pending',
+      });
+
+      const oauth = {
+        redirectUri: 'https://mention.earth',
+        codeChallenge: 'chal-s256',
+        codeChallengeMethod: 'S256' as const,
+        scope: 'openid profile',
+        subjectAccountId: 'acct-org',
+      };
+
+      const handle = await oxy.startCommonsSignIn({ clientId: 'oxy_dk_test', oauth });
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/auth/session/create',
+        {
+          sessionToken: 'secret-session-token',
+          expiresAt: 1700000300000,
+          clientId: 'oxy_dk_test',
+          oauth,
+        },
+        expect.objectContaining({ cache: false, skipAuth: true }),
+      );
+      // The PKCE verifier and the secret token never leave the initiator, and
+      // the QR still only carries the public code.
+      expect(JSON.stringify(makeRequestSpy.mock.calls[0][2])).not.toContain('codeVerifier');
+      expect(handle.qrPayload).not.toContain('secret-session-token');
+    });
+
+    it('carries an OAuth binding without a scope or delegated account unchanged', async () => {
+      jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
+      jest.spyOn(SignatureService, 'generateChallenge').mockResolvedValue('tok');
+      makeRequestSpy.mockResolvedValue({
+        authorizeCode: 'code-oauth',
+        qrPayload: 'oxycommons://approve?v=1&code=code-oauth',
+        status: 'pending',
+      });
+
+      await oxy.startCommonsSignIn({
+        clientId: 'oxy_dk_test',
+        oauth: {
+          redirectUri: 'https://mention.earth',
+          codeChallenge: 'chal-s256',
+          codeChallengeMethod: 'S256',
+        },
+      });
+
+      expect(makeRequestSpy.mock.calls[0][2].oauth).toEqual({
+        redirectUri: 'https://mention.earth',
+        codeChallenge: 'chal-s256',
+        codeChallengeMethod: 'S256',
+      });
+    });
+
     it('falls back to the client-proposed expiry when the server omits it', async () => {
       jest.spyOn(Date, 'now').mockReturnValue(1700000000000);
       jest.spyOn(SignatureService, 'generateChallenge').mockResolvedValue('tok');
@@ -101,6 +181,86 @@ describe('OxyServices — "Sign in with Oxy" handoff', () => {
     });
   });
 
+  describe('finalizeCommonsOAuth (relying party)', () => {
+    it('POSTs the finalize path with the SECRET sessionToken and no bearer', async () => {
+      makeRequestSpy.mockResolvedValue({
+        code: 'authcode-1',
+        redirectUri: 'https://mention.earth',
+        expiresIn: 60,
+      });
+
+      const result = await oxy.finalizeCommonsOAuth('secret session/token');
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        // The secret token is the credential in the path — encoded, never raw.
+        '/auth/session/finalize/secret%20session%2Ftoken',
+        undefined,
+        expect.objectContaining({ cache: false, skipAuth: true }),
+      );
+      // An authorization CODE, never a token: the caller still runs the PKCE
+      // exchange with the verifier it never sent.
+      expect(result).toEqual({
+        code: 'authcode-1',
+        redirectUri: 'https://mention.earth',
+        expiresIn: 60,
+      });
+    });
+
+    it('does not plant any token (finalization is not a session)', async () => {
+      makeRequestSpy.mockResolvedValue({
+        code: 'authcode-1',
+        redirectUri: 'https://mention.earth',
+        expiresIn: 60,
+      });
+
+      await oxy.finalizeCommonsOAuth('secret-session-token');
+
+      expect(oxy.getAccessToken()).toBeNull();
+    });
+
+    it.each([
+      ['a non-object body', 'authcode-1'],
+      ['a null body', null],
+    ])('rejects %s rather than returning it', async (_label, value) => {
+      makeRequestSpy.mockResolvedValue(value);
+
+      await expect(oxy.finalizeCommonsOAuth('secret-session-token')).rejects.toThrow(
+        /unexpected response shape/,
+      );
+    });
+
+    it.each([
+      ['a missing code', { redirectUri: 'https://mention.earth', expiresIn: 60 }],
+      ['an empty code', { code: '', redirectUri: 'https://mention.earth', expiresIn: 60 }],
+      ['a missing redirectUri', { code: 'authcode-1', expiresIn: 60 }],
+      ['an empty redirectUri', { code: 'authcode-1', redirectUri: '', expiresIn: 60 }],
+      ['a missing expiresIn', { code: 'authcode-1', redirectUri: 'https://mention.earth' }],
+      [
+        'a non-numeric expiresIn',
+        { code: 'authcode-1', redirectUri: 'https://mention.earth', expiresIn: '60' },
+      ],
+      [
+        'a non-finite expiresIn',
+        { code: 'authcode-1', redirectUri: 'https://mention.earth', expiresIn: Number.NaN },
+      ],
+    ])('rejects %s rather than returning a half-parsed result', async (_label, value) => {
+      makeRequestSpy.mockResolvedValue(value);
+
+      await expect(oxy.finalizeCommonsOAuth('secret-session-token')).rejects.toThrow(
+        /incomplete authorization code/,
+      );
+    });
+
+    it('surfaces a server rejection through the shared error handler', async () => {
+      makeRequestSpy.mockRejectedValue(new Error('Invalid or expired sign-in request'));
+
+      await expect(oxy.finalizeCommonsOAuth('secret-session-token')).rejects.toThrow(
+        'Invalid or expired sign-in request',
+      );
+    });
+  });
+
   describe('getCommonsApprovalInfo (approver)', () => {
     const baseInfo = {
       application: {
@@ -122,7 +282,12 @@ describe('OxyServices — "Sign in with Oxy" handoff', () => {
 
       const result = await oxy.getCommonsApprovalInfo('code-1');
 
-      expect(result).toEqual({ ...baseInfo, originVerified: true });
+      expect(result).toEqual({
+        ...baseInfo,
+        originVerified: true,
+        purpose: 'device_sign_in',
+        subjectAccount: null,
+      });
       expect(makeRequestSpy).toHaveBeenCalledWith(
         'GET',
         '/auth/session/approve-info/code-1',
@@ -137,6 +302,77 @@ describe('OxyServices — "Sign in with Oxy" handoff', () => {
       const result = await oxy.getCommonsApprovalInfo('code-1');
 
       expect(result.originVerified).toBe(false);
+    });
+
+    it('parses an OAuth-bound request with its delegated subject account', async () => {
+      makeRequestSpy.mockResolvedValue({
+        ...baseInfo,
+        originVerified: true,
+        purpose: 'oauth_authorization',
+        subjectAccount: { id: 'acct-org', username: 'oxy', displayName: 'The Oxy Collective' },
+      });
+
+      const result = await oxy.getCommonsApprovalInfo('code-1');
+
+      expect(result.purpose).toBe('oauth_authorization');
+      expect(result.subjectAccount).toEqual({
+        id: 'acct-org',
+        username: 'oxy',
+        displayName: 'The Oxy Collective',
+      });
+    });
+
+    it('keeps a delegated account without a displayName (omits the key rather than blanking it)', async () => {
+      makeRequestSpy.mockResolvedValue({
+        ...baseInfo,
+        subjectAccount: { id: 'acct-org', username: 'oxy' },
+      });
+
+      const result = await oxy.getCommonsApprovalInfo('code-1');
+
+      expect(result.subjectAccount).toEqual({ id: 'acct-org', username: 'oxy' });
+    });
+
+    it('degrades a server that omits purpose/subjectAccount to a plain device sign-in', async () => {
+      makeRequestSpy.mockResolvedValue(baseInfo);
+
+      const result = await oxy.getCommonsApprovalInfo('code-1');
+
+      expect(result.purpose).toBe('device_sign_in');
+      expect(result.subjectAccount).toBeNull();
+    });
+
+    it('coerces an unrecognized purpose to device_sign_in (never implies an OAuth grant)', async () => {
+      makeRequestSpy.mockResolvedValue({ ...baseInfo, purpose: 'something_else' });
+
+      const result = await oxy.getCommonsApprovalInfo('code-1');
+
+      expect(result.purpose).toBe('device_sign_in');
+    });
+
+    it.each([
+      ['a half-populated object', { id: 'acct-org' }],
+      ['a non-string id', { id: 7, username: 'oxy' }],
+      ['an empty username', { id: 'acct-org', username: '' }],
+      ['a non-object', 'acct-org'],
+      ['an explicit null', null],
+    ])('rejects %s subjectAccount whole (fail-safe to "no delegation")', async (_label, value) => {
+      makeRequestSpy.mockResolvedValue({ ...baseInfo, subjectAccount: value });
+
+      const result = await oxy.getCommonsApprovalInfo('code-1');
+
+      expect(result.subjectAccount).toBeNull();
+    });
+
+    it('drops a non-string displayName rather than rendering it', async () => {
+      makeRequestSpy.mockResolvedValue({
+        ...baseInfo,
+        subjectAccount: { id: 'acct-org', username: 'oxy', displayName: 42 },
+      });
+
+      const result = await oxy.getCommonsApprovalInfo('code-1');
+
+      expect(result.subjectAccount).toEqual({ id: 'acct-org', username: 'oxy' });
     });
 
     it('coerces a non-boolean originVerified to false', async () => {


### PR DESCRIPTION
Phase 3 of #691, on top of #696.

## Why

Two disjoint authorization flows existed: the OAuth code flow (`/auth/oauth/authorize` → `AuthCode`) and the Commons signed approval (`AuthSession` + `authorizeCode` + QR). Popup, push, QR and deep link cannot each grow their own business flow, so `AuthSession` is extended to carry an OAuth request and finalize into the standard authorization code. No competing request model; nothing already owned by `Application`, `AuthCode` or `DeviceSession` is duplicated.

The authoritative state machine stays small — `pending → authorized → consumed`, plus `cancelled` / `expired`. Delivery progress is not a status.

## Binding at creation

`POST /auth/session/create` gains optional:

```ts
oauth: { redirectUri; codeChallenge; codeChallengeMethod: 'S256'; scope?; subjectAccountId? }
```

The redirect URI must pass the same exact-match constant-time check the authorize endpoint uses — **403 with no `Location` header** on failure (RFC 6749 §3.1.2.4). Non-`S256` is refused. Scopes are normalized identically. That check now lives in one module both the route and the service import, instead of two copies drifting apart.

## Exactly one code, ever

`finalizedAuthCodeId` is a **reservation, not a post-hoc marker**: the code id is allocated and written in the same conditional update that consumes the session.

```ts
const codeId = new mongoose.Types.ObjectId();
const claimed = await AuthSession.findOneAndUpdate(
  { _id, purpose: 'oauth_authorization', status: 'authorized', finalizedAuthCodeId: null },
  { $set: { finalizedAuthCodeId: codeId, status: 'consumed', consumedAt: now } }, { new: true });
if (!claimed) return { ok: false, reason: 'already_finalized' };
await issueAuthCode({ codeId, ... });   // the one existing code minter, not a second
```

Losing the race, or a later `issueAuthCode` failure, both leave the request spent — the correct fail-closed direction for something that grants access. `POST /auth/session/finalize/:sessionToken` takes no bearer (the secret `sessionToken` is the credential, like `/auth/session/claim`), is rate-limited under `rl:auth:session-finalize:`, and collapses every rejection to `401 invalid_grant` with the reason only in the server log.

## Delegated accounts

A delegated authorization is the identity authorizing a **subject account**, never the identity becoming it. The code is issued for the subject with the approving identity recorded in `AuthCode.operatedByUserId`, and the existing `accountService.verifyActingAs` predicate — the same one `POST /accounts/:id/switch` uses — is re-checked at approval **and** at finalization. A personal account can never be a delegated subject; that would be impersonation. `POST /auth/oauth/token` threads the operator through to `createSession`, so a delegated session is a real managed session bound to live `act_as` membership and dies with revocation.

## One more fail-closed decision

An OAuth-purpose approval mints no session, and `/auth/session/claim` refuses `purpose: 'oauth_authorization'`. Otherwise a surface that only needs a code could pick up an access token, and every approval would strand a live session for the identity.

## SDK

`startCommonsSignIn({ clientId, oauth? })` (additive — the existing call shape is byte-identical), `CommonsApprovalInfo` gains `purpose` + sanitized `subjectAccount`, and `finalizeCommonsOAuth(sessionToken)` returns a **code, never a token**. Parsing is fail-safe in the safe direction: an unrecognised `purpose` degrades to `device_sign_in`, never to "you're granting an OAuth authorization".

## Tests

api 203 suites / 1911 pass (+41), core 98 suites / 1176 pass (+25). Including: unregistered redirect URI → 403 with no redirect; non-S256 refused; approve-info leaks no `sessionToken`/`redirectUri`/`codeChallenge`; **two concurrent finalizes yield exactly one `AuthCode`**, asserted at the model boundary; a finalized session cannot mint a second; the code stays single-use through `exchangeAuthCode` with PKCE; a delegated subject without permission is refused at both approval and finalize; `device_sign_in` sessions unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)