### PR TITLE
feat(auth): automatic Commons delivery for sign-in requests (#691 phase 4)

### DIFF
--- a/packages/api/jest.setup.cjs
+++ b/packages/api/jest.setup.cjs
@@ -12,6 +12,10 @@ const schemaInstance = {
   post: jest.fn(),
   virtual: jest.fn(() => ({ get: jest.fn() })),
   index: jest.fn(),
+  // `Schema.prototype.set` — used by models that configure `toJSON` transforms
+  // (e.g. PushToken). Without it, importing such a model throws at module load
+  // in any suite that does not explicitly mock it.
+  set: jest.fn(),
   methods: {},
   statics: {},
 };

--- a/packages/api/scripts/register-commons-clients.ts
+++ b/packages/api/scripts/register-commons-clients.ts
@@ -22,6 +22,12 @@
  *                            credential carries NO secret. Existing active public
  *                            production credentials are REUSED — never re-minted.
  *
+ * It also grants Commons the staff-only `identity:approval` capability, which is
+ * what makes its installs eligible targets for
+ * `POST /auth/session/deliver/:authorizeCode` (automatic push delivery of a
+ * pending sign-in request). Capabilities are UNIONed into an existing record,
+ * never stripped.
+ *
  * The "Oxy Auth" app is the SAME record seeded by
  * `scripts/seed-oxy-applications.ts` (idempotency key is name + owner). This
  * script reuses that record and its credential; the only delta is that it UNIONS
@@ -61,6 +67,10 @@ import { User } from '../src/models/User';
 import { permissionsForAccountRole } from '../src/utils/accountRoles';
 import { logger } from '../src/utils/logger';
 import type { ApplicationScope } from '../src/utils/applicationScopes';
+import {
+  IDENTITY_APPROVAL_CAPABILITY,
+  type ApplicationCapability,
+} from '../src/utils/applicationCapabilities';
 
 // ── Mirror routes/applications.ts credential generation EXACTLY ──────────────
 const CREDENTIAL_PUBLIC_KEY_PREFIX = 'oxy_dk_';
@@ -88,6 +98,12 @@ interface ClientSpec {
   type: IApplication['type'];
   redirectUris: string[];
   scopes: ApplicationScope[];
+  /**
+   * Staff-only platform capability flags. UNIONed into an existing record, never
+   * stripped. This is what makes a platform behaviour registry-driven instead of
+   * keyed off a hardcoded client id.
+   */
+  capabilities: ApplicationCapability[];
 }
 
 const CLIENTS: ClientSpec[] = [
@@ -102,6 +118,11 @@ const CLIENTS: ClientSpec[] = [
     // surface is the app's two deep-link schemes from packages/commons/app.json.
     redirectUris: ['commons://', 'oxycommons://'],
     scopes: ['user:read'],
+    // Commons IS the identity vault: it holds the local key and signs approvals,
+    // so its installs are the ones an authorization request may be pushed to.
+    // `POST /auth/session/deliver/:authorizeCode` resolves its targets from this
+    // capability — never from a hardcoded client id or bundle id.
+    capabilities: [IDENTITY_APPROVAL_CAPABILITY],
   },
   {
     key: 'AUTH_IDP_CLIENT_ID',
@@ -114,6 +135,9 @@ const CLIENTS: ClientSpec[] = [
     // origin as the redirect surface. UNIONed into any existing redirectUris.
     redirectUris: ['https://auth.oxy.so'],
     scopes: ['user:read'],
+    // The IdP is a browser shell, not an identity vault — it never holds a key
+    // and must never be a push-approval target.
+    capabilities: [],
   },
 ];
 
@@ -244,7 +268,7 @@ async function register(): Promise<void> {
           status: 'active',
           isOfficial: true,
           isInternal: spec.type === 'internal',
-          capabilities: [],
+          capabilities: spec.capabilities,
           redirectUris: spec.redirectUris,
           scopes: spec.scopes,
           ownerAccountId,
@@ -276,6 +300,13 @@ async function register(): Promise<void> {
       );
       if (mergedScopes.length !== (application.scopes ?? []).length) {
         application.scopes = mergedScopes;
+      }
+
+      const mergedCapabilities = Array.from(
+        new Set<string>([...(application.capabilities ?? []), ...spec.capabilities])
+      );
+      if (mergedCapabilities.length !== (application.capabilities ?? []).length) {
+        application.capabilities = mergedCapabilities;
       }
 
       if (application.isModified()) {

--- a/packages/api/src/models/AuthSession.ts
+++ b/packages/api/src/models/AuthSession.ts
@@ -117,6 +117,19 @@ export interface IAuthSession extends Document {
   authorizedBy?: string;     // Public key of the user who authorized
   authorizedUserId?: mongoose.Types.ObjectId; // MongoDB user ID of the authorizing IDENTITY
   authorizedSessionId?: string; // The actual session ID after authorization (device sign-in only)
+  /**
+   * DELIVERY PROGRESS — timestamps, never statuses. When the pending request was
+   * pushed to the approving identity's capable installs
+   * (`POST /auth/session/deliver/:authorizeCode`). Absent means no push was ever
+   * delivered (no capable install, or the client chose QR / deep link).
+   */
+  pushSentAt?: Date;
+  /**
+   * DELIVERY PROGRESS — when the approval surface first opened the request
+   * (`POST /auth/session/opened/:authorizeCode`). Written once, never cleared,
+   * and never a gate: the authoritative state machine is untouched by it.
+   */
+  openedAt?: Date;
   consumedAt?: Date;         // Timestamp when the sessionToken was exchanged for a token
   expiresAt: Date;
   createdAt: Date;
@@ -210,6 +223,17 @@ const AuthSessionSchema: Schema = new Schema(
     },
     deviceId: {
       type: String,
+      default: null,
+    },
+    // Delivery progress. Both default to null so the atomic "record once"
+    // updates can match on `null` (which also matches a missing field, so legacy
+    // rows behave as un-delivered / un-opened).
+    pushSentAt: {
+      type: Date,
+      default: null,
+    },
+    openedAt: {
+      type: Date,
       default: null,
     },
     consumedAt: {

--- a/packages/api/src/models/PushToken.ts
+++ b/packages/api/src/models/PushToken.ts
@@ -1,9 +1,30 @@
 import mongoose, { type Document, Schema } from 'mongoose';
 
+/**
+ * A single push-notification install: the pair (user, Expo push token).
+ *
+ * `deviceId` and `applicationId` SCOPE that install:
+ *
+ *  - `deviceId`      — the central device the install belongs to (same id space
+ *                      as `DeviceSession.deviceId`), so delivery can be reasoned
+ *                      about per device rather than per user.
+ *  - `applicationId` — the registered `Application` the install belongs to,
+ *                      resolved SERVER-side from the caller's `clientId` (an
+ *                      `ApplicationCredential.publicKey`) at registration time.
+ *                      It is the only trustworthy answer to "which app is this
+ *                      token for" — the client never asserts it directly.
+ *
+ * Both are OPTIONAL: rows predating the scoping (and any caller that registers
+ * without a `clientId`) carry neither and keep working exactly as before.
+ */
 export interface IPushToken extends Document {
   userId: mongoose.Types.ObjectId;
   token: string;
   platform: 'ios' | 'android' | 'web';
+  /** Central device id of the install, when the client supplied one. */
+  deviceId?: string;
+  /** Registered application the install belongs to, resolved from a `clientId`. */
+  applicationId?: mongoose.Types.ObjectId;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -26,6 +47,15 @@ const PushTokenSchema = new Schema(
       required: true,
       enum: ['ios', 'android', 'web'],
     },
+    deviceId: {
+      type: String,
+      default: null,
+    },
+    applicationId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Application',
+      default: null,
+    },
   },
   {
     timestamps: true,
@@ -34,6 +64,9 @@ const PushTokenSchema = new Schema(
 
 // Unique index: one token per user (prevents duplicate registrations)
 PushTokenSchema.index({ userId: 1, token: 1 }, { unique: true });
+
+// App-scoped delivery lookup: "this user's installs of these applications".
+PushTokenSchema.index({ userId: 1, applicationId: 1 });
 
 PushTokenSchema.set('toJSON', {
   virtuals: true,

--- a/packages/api/src/routes/__tests__/pushTokenRegistration.test.ts
+++ b/packages/api/src/routes/__tests__/pushTokenRegistration.test.ts
@@ -1,0 +1,306 @@
+/**
+ * POST/DELETE /notifications/push-token — device- and app-scoped registration.
+ *
+ * The install's owning application is resolved SERVER-side from the caller's
+ * `clientId` (an `ApplicationCredential.publicKey`) through the shared
+ * usable-credential predicate. A `clientId` that does not resolve to an active
+ * application is REJECTED — never silently stored as an unscoped token, because
+ * an unscoped token is invisible to every capability-scoped delivery decision.
+ *
+ * The pre-existing unscoped registration (no `deviceId`, no `clientId`) must keep
+ * working byte-for-byte: the email push registry predates the scoping.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const mockPushTokenFindOneAndUpdate = jest.fn();
+const mockPushTokenDeleteOne = jest.fn();
+const mockCredentialFindOne = jest.fn();
+const mockApplicationFindById = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+    req.user = { id: 'user-1' };
+    next();
+  },
+  serviceAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+  rejectQueryToken: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../controllers/notification.controller', () => ({
+  getNotifications: jest.fn(),
+  createNotification: jest.fn(),
+  markAsRead: jest.fn(),
+  markAllAsRead: jest.fn(),
+  deleteNotification: jest.fn(),
+  getUnreadCount: jest.fn(),
+}));
+
+jest.mock('../../models/PushToken', () => ({
+  __esModule: true,
+  PushToken: { findOneAndUpdate: mockPushTokenFindOneAndUpdate, deleteOne: mockPushTokenDeleteOne },
+  default: { findOneAndUpdate: mockPushTokenFindOneAndUpdate, deleteOne: mockPushTokenDeleteOne },
+}));
+
+jest.mock('../../models/ApplicationCredential', () => ({
+  __esModule: true,
+  ApplicationCredential: { findOne: mockCredentialFindOne },
+  default: { findOne: mockCredentialFindOne },
+}));
+
+jest.mock('../../models/Application', () => ({
+  __esModule: true,
+  Application: { findById: mockApplicationFindById },
+  default: { findById: mockApplicationFindById },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import notificationsRouter from '../notifications.routes';
+import { errorHandler } from '../../middleware/errorHandler';
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function request(
+  server: http.Server,
+  method: 'POST' | 'DELETE',
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }),
+        );
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/notifications', notificationsRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => { server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPushTokenFindOneAndUpdate.mockResolvedValue({});
+  mockPushTokenDeleteOne.mockResolvedValue({ deletedCount: 1 });
+});
+
+describe('POST /notifications/push-token — application scope', () => {
+  it('resolves clientId to its application and stores the scope', async () => {
+    mockCredentialFindOne.mockResolvedValue({
+      publicKey: 'oxy_dk_commons',
+      applicationId: 'app-commons',
+      status: 'active',
+    });
+    mockApplicationFindById.mockResolvedValue({ _id: 'app-commons', status: 'active' });
+
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[vault]',
+      platform: 'ios',
+      deviceId: 'device-abc',
+      clientId: 'oxy_dk_commons',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ registered: true });
+
+    expect(mockCredentialFindOne).toHaveBeenCalledWith({ publicKey: 'oxy_dk_commons' });
+    expect(mockApplicationFindById).toHaveBeenCalledWith('app-commons');
+
+    const [filter, update, options] = mockPushTokenFindOneAndUpdate.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, Record<string, unknown>>,
+      Record<string, unknown>,
+    ];
+    expect(filter).toEqual({ userId: 'user-1', token: 'ExponentPushToken[vault]' });
+    expect(Object.keys(update)).toEqual(['$set']);
+    expect(update.$set).toEqual({
+      userId: 'user-1',
+      token: 'ExponentPushToken[vault]',
+      platform: 'ios',
+      deviceId: 'device-abc',
+      applicationId: 'app-commons',
+    });
+    expect(options).toEqual({ upsert: true, new: true });
+  });
+
+  it('rejects a clientId whose credential is revoked, storing nothing', async () => {
+    mockCredentialFindOne.mockResolvedValue({
+      publicKey: 'oxy_dk_dead',
+      applicationId: 'app-commons',
+      status: 'revoked',
+    });
+
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[vault]',
+      platform: 'ios',
+      clientId: 'oxy_dk_dead',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockApplicationFindById).not.toHaveBeenCalled();
+    expect(mockPushTokenFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a clientId whose rotation grace has elapsed', async () => {
+    mockCredentialFindOne.mockResolvedValue({
+      publicKey: 'oxy_dk_stale',
+      applicationId: 'app-commons',
+      status: 'deprecated',
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[vault]',
+      platform: 'ios',
+      clientId: 'oxy_dk_stale',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockPushTokenFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown clientId, storing nothing', async () => {
+    mockCredentialFindOne.mockResolvedValue(null);
+
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[vault]',
+      platform: 'android',
+      clientId: 'oxy_dk_nope',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockPushTokenFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a clientId whose application is no longer active', async () => {
+    mockCredentialFindOne.mockResolvedValue({
+      publicKey: 'oxy_dk_commons',
+      applicationId: 'app-commons',
+      status: 'active',
+    });
+    mockApplicationFindById.mockResolvedValue({ _id: 'app-commons', status: 'suspended' });
+
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[vault]',
+      platform: 'ios',
+      clientId: 'oxy_dk_commons',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockPushTokenFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /notifications/push-token — unscoped registration still works', () => {
+  it('registers without deviceId/clientId exactly as before', async () => {
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[email]',
+      platform: 'web',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ registered: true });
+    expect(mockCredentialFindOne).not.toHaveBeenCalled();
+
+    const [filter, update] = mockPushTokenFindOneAndUpdate.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, Record<string, unknown>>,
+    ];
+    expect(filter).toEqual({ userId: 'user-1', token: 'ExponentPushToken[email]' });
+    expect(update.$set).toEqual({
+      userId: 'user-1',
+      token: 'ExponentPushToken[email]',
+      platform: 'web',
+    });
+  });
+
+  it('never writes an unwhitelisted field from the body', async () => {
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[email]',
+      platform: 'web',
+      userId: 'someone-else',
+      applicationId: 'app-forged',
+    });
+
+    expect(res.status).toBe(200);
+    const [, update] = mockPushTokenFindOneAndUpdate.mock.calls[0] as [
+      unknown,
+      Record<string, Record<string, unknown>>,
+    ];
+    expect(update.$set.userId).toBe('user-1');
+    expect(update.$set.applicationId).toBeUndefined();
+  });
+
+  it('rejects an unsupported platform', async () => {
+    const res = await request(server, 'POST', '/notifications/push-token', {
+      token: 'ExponentPushToken[email]',
+      platform: 'blackberry',
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockPushTokenFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing token', async () => {
+    const res = await request(server, 'POST', '/notifications/push-token', { platform: 'ios' });
+
+    expect(res.status).toBe(400);
+    expect(mockPushTokenFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /notifications/push-token', () => {
+  it('unregisters only the caller\'s own token', async () => {
+    const res = await request(server, 'DELETE', '/notifications/push-token', {
+      token: 'ExponentPushToken[vault]',
+      userId: 'someone-else',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ unregistered: true });
+    expect(mockPushTokenDeleteOne).toHaveBeenCalledWith({
+      userId: 'user-1',
+      token: 'ExponentPushToken[vault]',
+    });
+  });
+
+  it('rejects a missing token', async () => {
+    const res = await request(server, 'DELETE', '/notifications/push-token', {});
+
+    expect(res.status).toBe(400);
+    expect(mockPushTokenDeleteOne).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/routes/__tests__/sessionDeliver.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDeliver.test.ts
@@ -1,0 +1,427 @@
+/**
+ * POST /auth/session/deliver/:authorizeCode
+ * POST /auth/session/opened/:authorizeCode
+ * GET  /auth/session/status/:sessionToken  (delivery-progress projection)
+ *
+ * Phase 4 automatic Commons delivery, exercised end to end through the REAL
+ * route + REAL delivery service with only the data layer and the push transport
+ * mocked.
+ *
+ * The security contract these tests exist to pin:
+ *
+ *  - `deliver` REQUIRES a bearer, and the bearer is the control, not a
+ *    convenience: the delivery target is the AUTHENTICATED user, never anything
+ *    from the request body or the bound request. Oxy can therefore never be made
+ *    to push a sign-in prompt at someone by typing their username into an
+ *    unauthenticated browser.
+ *  - Only installs of an `Application` carrying the staff-controlled
+ *    `identity:approval` capability are targeted. No capable install ⇒ zero
+ *    targets, no send, and a 200 (the client falls back to QR).
+ *  - The response is counts only, and the push payload is exactly
+ *    `{ type, approvalUrl }`.
+ *  - `opened` needs no bearer (the public approval handle is the credential), is
+ *    idempotent, pending-only, and never moves `status`.
+ *  - Progress travels as TIMESTAMPS on the status endpoint; the socket emission
+ *    is a payload-free wake signal.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const mockAuthSessionFindOne = jest.fn();
+const mockAuthSessionUpdateOne = jest.fn();
+const mockApplicationFind = jest.fn();
+const mockApplicationFindById = jest.fn();
+const mockPushTokenFind = jest.fn();
+const mockSendPushToTokens = jest.fn();
+const mockEmitAuthSessionUpdate = jest.fn();
+const mockEmitAuthSessionProgress = jest.fn();
+
+/** Identity the mocked bearer middleware resolves for an authenticated request. */
+const mockBearerUser = { current: 'user-1' };
+
+jest.mock('../../middleware/auth', () => ({
+  // Behaves like the real middleware for the one property under test: without an
+  // Authorization header there is no authenticated principal and the request is
+  // rejected before the handler runs.
+  authMiddleware: (
+    req: { headers: Record<string, string | undefined>; user?: unknown },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void,
+  ) => {
+    if (!req.headers.authorization) {
+      res.status(401).json({ error: 'UNAUTHORIZED', message: 'Authentication required' });
+      return;
+    }
+    req.user = { _id: mockBearerUser.current, username: 'ada', publicKey: 'pk-1' };
+    next();
+  },
+  serviceAuthMiddleware: jest.fn(),
+  rejectQueryToken: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../models/AuthSession', () => ({
+  __esModule: true,
+  AuthSession: { findOne: mockAuthSessionFindOne, updateOne: mockAuthSessionUpdateOne },
+  default: { findOne: mockAuthSessionFindOne, updateOne: mockAuthSessionUpdateOne },
+}));
+jest.mock('../../models/Application', () => ({
+  __esModule: true,
+  Application: { find: mockApplicationFind, findById: mockApplicationFindById, findOne: jest.fn() },
+  default: { find: mockApplicationFind, findById: mockApplicationFindById, findOne: jest.fn() },
+}));
+jest.mock('../../models/PushToken', () => ({
+  __esModule: true,
+  PushToken: { find: mockPushTokenFind },
+  default: { find: mockPushTokenFind },
+}));
+jest.mock('../../services/push.service', () => ({
+  __esModule: true,
+  pushService: { sendPushToTokens: mockSendPushToTokens, sendPushNotification: jest.fn() },
+  default: { sendPushToTokens: mockSendPushToTokens, sendPushNotification: jest.fn() },
+}));
+jest.mock('../../utils/authSessionSocket', () => ({
+  emitAuthSessionUpdate: (...args: unknown[]) => mockEmitAuthSessionUpdate(...args),
+  emitAuthSessionProgress: (...args: unknown[]) => mockEmitAuthSessionProgress(...args),
+}));
+
+// Remaining static imports of routes/auth.ts — mocked so the real Mongoose
+// schemas never run under the global mongoose mock.
+jest.mock('../../models/Session', () => ({ __esModule: true, default: { findOne: jest.fn() } }));
+jest.mock('../../models/AuthCode', () => ({ __esModule: true, AuthCode: { create: jest.fn() }, default: { create: jest.fn() } }));
+jest.mock('../../models/ApplicationCredential', () => ({ __esModule: true, ApplicationCredential: { findOne: jest.fn() }, default: { findOne: jest.fn() } }));
+jest.mock('../../models/User', () => ({ __esModule: true, User: { findOne: jest.fn(), findById: jest.fn() }, default: { findOne: jest.fn(), findById: jest.fn() } }));
+jest.mock('../../models/AppGrant', () => ({
+  __esModule: true,
+  AppGrant: { findOne: jest.fn(), find: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn() },
+  default: { findOne: jest.fn(), find: jest.fn(), findOneAndUpdate: jest.fn(), deleteOne: jest.fn() },
+}));
+jest.mock('../../services/authSession.service', () => ({
+  claimAuthSession: jest.fn(),
+  authorizeSessionWithSignedChallenge: jest.fn(),
+  authorizeSessionWithBearer: jest.fn(),
+  finalizeOAuthAuthorization: jest.fn(),
+  resolveOAuthContext: jest.fn(() => null),
+  verifyDelegatedSubject: jest.fn(),
+}));
+jest.mock('../../services/session.service', () => ({ __esModule: true, default: { createSession: jest.fn() } }));
+jest.mock('../../services/oauthCode.service', () => ({ issueAuthCode: jest.fn(), exchangeAuthCode: jest.fn(), AUTH_CODE_TTL_MS: 60_000 }));
+jest.mock('../../services/signature.service', () => ({ __esModule: true, default: { verifyChallengeResponse: jest.fn(), isValidPublicKey: jest.fn() } }));
+jest.mock('../../utils/userTransform', () => ({ formatUserResponse: jest.fn() }));
+jest.mock('../../controllers/session.controller', () => ({
+  SessionController: {
+    register: jest.fn(), signUp: jest.fn(), signIn: jest.fn(), requestChallenge: jest.fn(),
+    verifyChallenge: jest.fn(), requestPasswordReset: jest.fn(), verifyRecoveryCode: jest.fn(),
+    resetPassword: jest.fn(), getUserByPublicKey: jest.fn(),
+  },
+}));
+jest.mock('../../utils/logger', () => ({ logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() } }));
+
+import authRouter from '../auth';
+import { errorHandler } from '../../middleware/errorHandler';
+import { IDENTITY_APPROVAL_CAPABILITY } from '../../utils/applicationCapabilities';
+
+interface JsonResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+async function request(
+  server: http.Server,
+  method: 'GET' | 'POST',
+  path: string,
+  options: { bearer?: string; payload?: Record<string, unknown> } = {},
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(options.payload ?? {});
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'content-length': String(Buffer.byteLength(body)),
+  };
+  if (options.bearer) {
+    headers.authorization = `Bearer ${options.bearer}`;
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = http.request({ method, host: '127.0.0.1', port: address.port, path, headers }, (res) => {
+      let raw = '';
+      res.on('data', (chunk) => { raw += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} }));
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+/** `.select(...).lean()` chain used by the delivery lookups. */
+function chain<T>(rows: T[]) {
+  return { select: () => ({ lean: () => Promise.resolve(rows) }) };
+}
+
+function pendingSession(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionToken: 'secret-session-token',
+    authorizeCode: 'code-1',
+    status: 'pending',
+    expiresAt: new Date(Date.now() + 3_600_000),
+    ...overrides,
+  };
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/auth', authRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => { server.close(done); });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockBearerUser.current = 'user-1';
+  mockAuthSessionUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mockSendPushToTokens.mockResolvedValue({ targeted: 1, accepted: 1 });
+});
+
+describe('POST /auth/session/deliver/:authorizeCode — bearer is the control', () => {
+  it('rejects an unauthenticated caller before any lookup', async () => {
+    const res = await request(server, 'POST', '/auth/session/deliver/code-1');
+
+    expect(res.status).toBe(401);
+    expect(mockAuthSessionFindOne).not.toHaveBeenCalled();
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+  });
+
+  it('targets the AUTHENTICATED identity, never a user named in the body', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+
+    const res = await request(server, 'POST', '/auth/session/deliver/code-1', {
+      bearer: 'token',
+      payload: { userId: 'victim-42', username: 'victim', identityUserId: 'victim-42' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockPushTokenFind).toHaveBeenCalledWith({
+      userId: 'user-1',
+      applicationId: { $in: ['app-commons'] },
+    });
+    expect(mockSendPushToTokens.mock.calls[0][0]).toMatchObject({ userId: 'user-1' });
+  });
+});
+
+describe('POST /auth/session/deliver/:authorizeCode — capability-scoped targeting', () => {
+  it('delivers to the identity\'s capable installs and answers with counts only', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault-1' }, { token: 'tok-vault-2' }]));
+    mockSendPushToTokens.mockResolvedValue({ targeted: 2, accepted: 2 });
+
+    const res = await request(server, 'POST', '/auth/session/deliver/code-1', { bearer: 'token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ delivered: true, targets: 2 });
+
+    expect(mockApplicationFind).toHaveBeenCalledWith({
+      status: 'active',
+      capabilities: IDENTITY_APPROVAL_CAPABILITY,
+    });
+
+    const push = mockSendPushToTokens.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(push.data).toEqual({
+      type: 'oxy_commons_auth_request',
+      approvalUrl: 'oxycommons://approve?v=1&code=code-1',
+    });
+
+    // The secret sessionToken is never exposed to the client on this path.
+    expect(JSON.stringify(res.body)).not.toContain('secret-session-token');
+  });
+
+  it('yields zero targets and sends nothing when the install lacks the capability', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    // The user HAS a vault install, but no application carries the capability,
+    // so the capability-scoped query resolves no eligible install.
+    mockApplicationFind.mockReturnValue(chain([]));
+
+    const res = await request(server, 'POST', '/auth/session/deliver/code-1', { bearer: 'token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ delivered: false, targets: 0 });
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+    expect(mockEmitAuthSessionProgress).not.toHaveBeenCalled();
+  });
+
+  it('yields zero targets when this identity has no capable install of its own', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([]));
+
+    const res = await request(server, 'POST', '/auth/session/deliver/code-1', { bearer: 'token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ delivered: false, targets: 0 });
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /auth/session/deliver/:authorizeCode — failures never break the flow', () => {
+  it('answers 200 with a well-formed body when the push transport fails', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+    mockSendPushToTokens.mockRejectedValue(new Error('expo unreachable'));
+
+    const res = await request(server, 'POST', '/auth/session/deliver/code-1', { bearer: 'token' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ delivered: false, targets: 1 });
+    expect(mockEmitAuthSessionProgress).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown authorizeCode', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(null);
+
+    const res = await request(server, 'POST', '/auth/session/deliver/nope', { bearer: 'token' });
+
+    expect(res.status).toBe(404);
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+  });
+
+  it('400s a request that is no longer pending', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession({ status: 'authorized' }));
+
+    const res = await request(server, 'POST', '/auth/session/deliver/code-1', { bearer: 'token' });
+
+    expect(res.status).toBe(400);
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /auth/session/deliver/:authorizeCode — progress signalling', () => {
+  it('wakes the waiting originator with a payload-free signal on its secret channel', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+
+    await request(server, 'POST', '/auth/session/deliver/code-1', { bearer: 'token' });
+
+    expect(mockEmitAuthSessionProgress).toHaveBeenCalledTimes(1);
+    expect(mockEmitAuthSessionProgress).toHaveBeenCalledWith('secret-session-token');
+    // Progress never travels as a status on the socket.
+    expect(mockEmitAuthSessionUpdate).not.toHaveBeenCalled();
+  });
+
+  it('records pushSentAt as a timestamp, leaving status untouched', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+
+    await request(server, 'POST', '/auth/session/deliver/code-1', { bearer: 'token' });
+
+    const [filter, update] = mockAuthSessionUpdateOne.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, Record<string, unknown>>,
+    ];
+    expect(filter).toEqual({ authorizeCode: 'code-1', status: 'pending', pushSentAt: null });
+    expect(Object.keys(update.$set)).toEqual(['pushSentAt']);
+  });
+});
+
+describe('POST /auth/session/opened/:authorizeCode', () => {
+  it('needs no bearer — the public approval handle is the credential', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+
+    const res = await request(server, 'POST', '/auth/session/opened/code-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ success: true });
+    expect(mockEmitAuthSessionProgress).toHaveBeenCalledWith('secret-session-token');
+  });
+
+  it('writes openedAt once, pending-only and unexpired-only, never status', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+
+    await request(server, 'POST', '/auth/session/opened/code-1');
+
+    const [filter, update] = mockAuthSessionUpdateOne.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, Record<string, unknown>>,
+    ];
+    expect(filter).toMatchObject({ authorizeCode: 'code-1', status: 'pending', openedAt: null });
+    expect(filter.expiresAt).toEqual({ $gt: expect.any(Date) });
+    expect(Object.keys(update.$set)).toEqual(['openedAt']);
+  });
+
+  it('is idempotent: a repeat call succeeds and emits nothing', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession({ openedAt: new Date() }));
+    mockAuthSessionUpdateOne.mockResolvedValue({ modifiedCount: 0 });
+
+    const res = await request(server, 'POST', '/auth/session/opened/code-1');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({ success: true });
+    expect(mockEmitAuthSessionProgress).not.toHaveBeenCalled();
+  });
+
+  it('404s an unknown authorizeCode', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(null);
+
+    const res = await request(server, 'POST', '/auth/session/opened/nope');
+
+    expect(res.status).toBe(404);
+    expect(mockAuthSessionUpdateOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /auth/session/status/:sessionToken — delivery progress projection', () => {
+  it('exposes pushSentAt and openedAt while leaving the status machine alone', async () => {
+    const pushSentAt = new Date('2026-07-27T10:00:00.000Z');
+    const openedAt = new Date('2026-07-27T10:00:05.000Z');
+    mockAuthSessionFindOne.mockResolvedValue({
+      ...pendingSession({ pushSentAt, openedAt }),
+      applicationId: 'app-commons',
+      authorizedSessionId: null,
+      authorizedBy: null,
+      authorizedUserId: null,
+      save: jest.fn(),
+    });
+    mockApplicationFindById.mockResolvedValue(null);
+
+    const res = await request(server, 'GET', '/auth/session/status/secret-session-token');
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.status).toBe('pending');
+    expect(data.pushSentAt).toBe('2026-07-27T10:00:00.000Z');
+    expect(data.openedAt).toBe('2026-07-27T10:00:05.000Z');
+  });
+
+  it('emits null timestamps for a request that was never pushed or opened', async () => {
+    mockAuthSessionFindOne.mockResolvedValue({
+      ...pendingSession(),
+      applicationId: 'app-commons',
+      authorizedSessionId: null,
+      authorizedBy: null,
+      authorizedUserId: null,
+      save: jest.fn(),
+    });
+    mockApplicationFindById.mockResolvedValue(null);
+
+    const res = await request(server, 'GET', '/auth/session/status/secret-session-token');
+
+    const data = res.body.data as Record<string, unknown>;
+    expect(data.pushSentAt).toBeNull();
+    expect(data.openedAt).toBeNull();
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -25,7 +25,7 @@ import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
 import { BadRequestError, NotFoundError, UnauthorizedError, ForbiddenError, InternalServerError } from '../utils/error';
 import { logger } from '../utils/logger';
 import SignatureService from '../services/signature.service';
-import { emitAuthSessionUpdate } from '../utils/authSessionSocket';
+import { emitAuthSessionUpdate, emitAuthSessionProgress } from '../utils/authSessionSocket';
 import { broadcastSessionAccountsChanged } from '../utils/socket';
 import webauthnRouter from './webauthn';
 import { validate } from '../middleware/validate';
@@ -42,6 +42,10 @@ import {
   resolveOAuthContext,
   verifyDelegatedSubject,
 } from '../services/authSession.service';
+import {
+  deliverAuthRequestToIdentityApps,
+  markAuthRequestOpened,
+} from '../services/authSessionDelivery.service';
 import { isAllowedRedirectUri } from '../utils/oauthRedirect';
 import Session from '../models/Session';
 import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils';
@@ -827,6 +831,21 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
  *                 expiresAt:
  *                   type: string
  *                   format: date-time
+ *                 pushSentAt:
+ *                   type: string
+ *                   format: date-time
+ *                   nullable: true
+ *                   description: >
+ *                     Delivery progress, not a status: when the pending request
+ *                     was pushed to the approving identity's capable installs.
+ *                     Null when no push was delivered.
+ *                 openedAt:
+ *                   type: string
+ *                   format: date-time
+ *                   nullable: true
+ *                   description: >
+ *                     Delivery progress, not a status: when the approval surface
+ *                     first opened the request. Written at most once.
  *                 sessionId:
  *                   type: string
  *                   nullable: true
@@ -906,6 +925,12 @@ router.get('/session/status/:sessionToken', validate({ params: authSessionTokenP
     sessionToken: authSession.sessionToken,
     application,
     expiresAt: authSession.expiresAt.toISOString(),
+    // Delivery progress as TIMESTAMPS — never statuses. This is the
+    // authoritative read-back for the socket's payload-free wake signal: the
+    // waiting client learns "pushed" / "opened in the vault" from here, so no
+    // progress data has to travel as trusted data on the socket.
+    pushSentAt: authSession.pushSentAt ? authSession.pushSentAt.toISOString() : null,
+    openedAt: authSession.openedAt ? authSession.openedAt.toISOString() : null,
     sessionId: authSession.authorizedSessionId || null,
     publicKey: authSession.authorizedBy || null,
     userId: authSession.authorizedUserId ? authSession.authorizedUserId.toString() : null,
@@ -1603,6 +1628,118 @@ router.post(
       authSession.status = 'cancelled';
       await authSession.save();
       emitAuthSessionUpdate(authSession.sessionToken, { status: 'cancelled' });
+    }
+
+    sendSuccess(res, { success: true });
+  }),
+);
+
+// ============================================
+// Automatic delivery to the identity vault
+// ============================================
+
+// Push delivery of a pending request. A legitimate flow hits this once (with at
+// most a retry or two if the user reloads the popup), so the cap is tight —
+// push is an outbound side effect and must not be cheaply amplifiable.
+const authSessionDeliverLimiter = rateLimit({
+  prefix: 'rl:auth:session-deliver:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 15,
+});
+
+// Progress ping from the approval surface. Public (keyed on the approval
+// handle), writes only a timestamp, so a slightly looser cap than the approval
+// endpoints it accompanies.
+const authSessionOpenedLimiter = rateLimit({
+  prefix: 'rl:auth:session-opened:',
+  windowMs: 60 * 1000,
+  max: process.env.NODE_ENV === 'development' ? 100 : 30,
+});
+
+/**
+ * POST /auth/session/deliver/:authorizeCode
+ *
+ * Bearer REQUIRED — and the bearer is the SECURITY CONTROL, not a convenience.
+ * Delivery targets the AUTHENTICATED user's own approval-capable installs and
+ * nothing else: the target identity is never resolved from the request body, the
+ * QR payload, or the bound `AuthSession`. That makes it impossible to make Oxy
+ * push a sign-in prompt at someone by typing their username or email into an
+ * unauthenticated browser.
+ *
+ * Eligible installs are those registered by an `Application` carrying the
+ * staff-controlled `identity:approval` capability — a registry decision, never a
+ * hardcoded client id or bundle id.
+ *
+ * The payload is exactly `{ type, approvalUrl }`: a type discriminator plus the
+ * PUBLIC approval handle. No application name, no origin, no scopes, no secrets
+ * — the vault re-fetches all authoritative display data from
+ * `GET /auth/session/approve-info/:authorizeCode`. The notification carries no
+ * action buttons, so it can only be opened or dismissed; approval always happens
+ * inside the vault, behind biometrics and a local-key signature.
+ *
+ * Responds with COUNTS only (`{ delivered, targets }`) — never device names,
+ * platforms, or any other install detail. `targets: 0` is a normal outcome (no
+ * vault install on any device) and the client falls back to the QR surface; a
+ * push transport failure degrades to exactly the same shape and never fails the
+ * auth flow.
+ */
+router.post(
+  '/session/deliver/:authorizeCode',
+  authMiddleware,
+  authSessionDeliverLimiter,
+  validate({ params: authorizeCodeParams }),
+  asyncHandler(async (req: AuthRequest, res) => {
+    const { authorizeCode } = req.params;
+
+    const authenticatedUser = req.user;
+    if (!authenticatedUser?._id) {
+      throw new UnauthorizedError('Authentication required');
+    }
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode,
+      identityUserId: authenticatedUser._id.toString(),
+    });
+
+    if (!outcome.ok) {
+      if (outcome.status === 404) throw new NotFoundError(outcome.message);
+      throw new BadRequestError(outcome.message);
+    }
+
+    if (outcome.delivered) {
+      // Pure wake signal on the originator's secret channel — the authoritative
+      // `pushSentAt` is read back from GET /auth/session/status.
+      emitAuthSessionProgress(outcome.sessionToken);
+    }
+
+    sendSuccess(res, { delivered: outcome.delivered, targets: outcome.targets });
+  }),
+);
+
+/**
+ * POST /auth/session/opened/:authorizeCode
+ *
+ * NO bearer — like `approve-info`, the PUBLIC single-use approval handle IS the
+ * credential. Records delivery progress only: `openedAt` is written at most once,
+ * only while the request is still pending and unexpired, and NEVER touches
+ * `status`. The authoritative state machine stays exactly
+ * `pending -> authorized -> consumed` / `cancelled` / `expired`.
+ */
+router.post(
+  '/session/opened/:authorizeCode',
+  authSessionOpenedLimiter,
+  validate({ params: authorizeCodeParams }),
+  asyncHandler(async (req, res) => {
+    const { authorizeCode } = req.params;
+
+    const outcome = await markAuthRequestOpened(authorizeCode);
+
+    if (!outcome.ok) {
+      throw new NotFoundError(outcome.message);
+    }
+
+    if (outcome.recorded) {
+      emitAuthSessionProgress(outcome.sessionToken);
     }
 
     sendSuccess(res, { success: true });

--- a/packages/api/src/routes/notifications.routes.ts
+++ b/packages/api/src/routes/notifications.routes.ts
@@ -22,9 +22,20 @@ import {
 } from '../middleware/auth';
 import { asyncHandler } from '../utils/asyncHandler';
 import { validate } from '../middleware/validate';
-import { createNotificationSchema, notificationIdParams } from '../schemas/notifications.schemas';
+import {
+  createNotificationSchema,
+  notificationIdParams,
+  registerPushTokenSchema,
+  unregisterPushTokenSchema,
+  type RegisterPushTokenBody,
+  type UnregisterPushTokenBody,
+} from '../schemas/notifications.schemas';
 import { PushToken } from '../models/PushToken';
+import { Application } from '../models/Application';
+import { ApplicationCredential } from '../models/ApplicationCredential';
+import { isCredentialUsable } from '../utils/credentialUsability';
 import { logger } from '../utils/logger';
+import type mongoose from 'mongoose';
 import type { NextFunction, Response } from 'express';
 
 const router = express.Router();
@@ -71,59 +82,110 @@ router.get('/unread-count', asyncHandler(getUnreadCount));
 
 // ─── Push Token Management ──────────────────────────────────────────
 
+/** Explicit write whitelist for a push-token upsert — never `req.body`. */
+interface PushTokenWrite {
+  userId: string;
+  token: string;
+  platform: 'ios' | 'android' | 'web';
+  deviceId?: string;
+  applicationId?: mongoose.Types.ObjectId;
+}
+
+/**
+ * Resolve a caller-supplied `clientId` (an `ApplicationCredential.publicKey`) to
+ * the active `Application` it belongs to, through the SAME usable-credential
+ * predicate every other credential-resolution site uses. Returns null when the
+ * credential is unknown, revoked / out of its rotation grace, or its application
+ * is not active — the caller REJECTS in that case rather than silently storing
+ * an unscoped token.
+ */
+async function resolveApplicationIdFromClientId(
+  clientId: string,
+): Promise<mongoose.Types.ObjectId | null> {
+  const credential = await ApplicationCredential.findOne({ publicKey: clientId });
+  if (!credential || !isCredentialUsable(credential)) {
+    return null;
+  }
+
+  const application = await Application.findById(credential.applicationId);
+  if (!application || application.status !== 'active') {
+    return null;
+  }
+
+  return application._id;
+}
+
 // Register a push token
-router.post('/push-token', asyncHandler(async (req: AuthRequest, res: Response) => {
-  const userId = req.user?.id;
-  if (!userId) {
-    return res.status(401).json({ error: 'UNAUTHORIZED', message: 'Authentication required' });
-  }
-
-  const { token, platform } = req.body;
-
-  if (!token || typeof token !== 'string') {
-    return res.status(400).json({ error: 'BAD_REQUEST', message: 'token is required' });
-  }
-
-  if (!platform || !['ios', 'android', 'web'].includes(platform)) {
-    return res.status(400).json({ error: 'BAD_REQUEST', message: 'platform must be ios, android, or web' });
-  }
-
-  try {
-    await PushToken.findOneAndUpdate(
-      { userId, token },
-      { userId, token, platform },
-      { upsert: true, new: true },
-    );
-
-    return res.status(200).json({ data: { registered: true } });
-  } catch (err: unknown) {
-    const errObj = err as { code?: number; message?: string };
-    // Ignore duplicate key errors (race condition safe)
-    if (errObj.code === 11000 || errObj.message?.includes('E11000')) {
-      return res.status(200).json({ data: { registered: true } });
+router.post(
+  '/push-token',
+  validate({ body: registerPushTokenSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'UNAUTHORIZED', message: 'Authentication required' });
     }
-    logger.error('Failed to register push token', err instanceof Error ? err : new Error(String(err)));
-    return res.status(500).json({ error: 'INTERNAL_SERVER_ERROR', message: 'Failed to register push token' });
-  }
-}));
+
+    const { token, platform, deviceId, clientId } = req.body as RegisterPushTokenBody;
+
+    const write: PushTokenWrite = { userId, token, platform };
+
+    if (deviceId !== undefined) {
+      write.deviceId = deviceId;
+    }
+
+    if (clientId !== undefined) {
+      const applicationId = await resolveApplicationIdFromClientId(clientId);
+      if (!applicationId) {
+        // One generic message for every rejection path so the response never
+        // enumerates which credentials exist or what state they are in.
+        return res.status(400).json({
+          error: 'BAD_REQUEST',
+          message: 'clientId does not resolve to an active application',
+        });
+      }
+      write.applicationId = applicationId;
+    }
+
+    try {
+      // Explicit `$set` of the whitelist above. Fields the caller did not send
+      // are left untouched, so re-registering an existing install never silently
+      // drops a scope it already carries.
+      await PushToken.findOneAndUpdate(
+        { userId, token },
+        { $set: write },
+        { upsert: true, new: true },
+      );
+
+      return res.status(200).json({ data: { registered: true } });
+    } catch (err: unknown) {
+      const errObj = err as { code?: number; message?: string };
+      // Ignore duplicate key errors (race condition safe)
+      if (errObj.code === 11000 || errObj.message?.includes('E11000')) {
+        return res.status(200).json({ data: { registered: true } });
+      }
+      logger.error('Failed to register push token', err instanceof Error ? err : new Error(String(err)));
+      return res.status(500).json({ error: 'INTERNAL_SERVER_ERROR', message: 'Failed to register push token' });
+    }
+  }),
+);
 
 // Unregister a push token
-router.delete('/push-token', asyncHandler(async (req: AuthRequest, res: Response) => {
-  const userId = req.user?.id;
-  if (!userId) {
-    return res.status(401).json({ error: 'UNAUTHORIZED', message: 'Authentication required' });
-  }
+router.delete(
+  '/push-token',
+  validate({ body: unregisterPushTokenSchema }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const userId = req.user?.id;
+    if (!userId) {
+      return res.status(401).json({ error: 'UNAUTHORIZED', message: 'Authentication required' });
+    }
 
-  const { token } = req.body;
+    const { token } = req.body as UnregisterPushTokenBody;
 
-  if (!token || typeof token !== 'string') {
-    return res.status(400).json({ error: 'BAD_REQUEST', message: 'token is required' });
-  }
+    await PushToken.deleteOne({ userId, token });
 
-  await PushToken.deleteOne({ userId, token });
-
-  return res.status(200).json({ data: { unregistered: true } });
-}));
+    return res.status(200).json({ data: { unregistered: true } });
+  }),
+);
 
 // Mark a notification as read
 router.put('/:id/read', validate({ params: notificationIdParams }), asyncHandler(markAsRead));

--- a/packages/api/src/schemas/notifications.schemas.ts
+++ b/packages/api/src/schemas/notifications.schemas.ts
@@ -16,3 +16,27 @@ export const createNotificationSchema = z.object({
 export const notificationIdParams = z.object({
   id: z.string().trim().min(1),
 });
+
+/**
+ * POST /notifications/push-token
+ *
+ * `deviceId` and `clientId` SCOPE the install. `clientId` is an
+ * `ApplicationCredential.publicKey` (`oxy_dk_…`) resolved SERVER-side to an
+ * active `Application` — the client never asserts an application id, and an
+ * unresolvable value is REJECTED rather than stored unscoped.
+ */
+export const registerPushTokenSchema = z.object({
+  token: z.string().trim().min(1).max(512),
+  platform: z.enum(['ios', 'android', 'web']),
+  deviceId: z.string().trim().min(1).max(128).optional(),
+  clientId: z.string().trim().min(1).max(128).optional(),
+});
+
+export type RegisterPushTokenBody = z.infer<typeof registerPushTokenSchema>;
+
+// DELETE /notifications/push-token
+export const unregisterPushTokenSchema = z.object({
+  token: z.string().trim().min(1).max(512),
+});
+
+export type UnregisterPushTokenBody = z.infer<typeof unregisterPushTokenSchema>;

--- a/packages/api/src/services/__tests__/authSessionDelivery.service.test.ts
+++ b/packages/api/src/services/__tests__/authSessionDelivery.service.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Automatic Commons delivery + delivery-progress bookkeeping.
+ *
+ * What must hold, whatever else changes:
+ *
+ *  - Delivery targets ONLY the identity handed to the service (the bearer's own
+ *    user id) and ONLY installs registered by an `Application` carrying the
+ *    staff-controlled `identity:approval` capability. No capability ⇒ zero
+ *    targets and NO send — a normal outcome, not an error.
+ *  - The push payload is exactly `{ type, approvalUrl }` — no application
+ *    metadata, no origin, no scopes, and never the secret `sessionToken`.
+ *  - A push transport failure degrades to a well-formed "nothing delivered"
+ *    result and never throws into the auth flow.
+ *  - Progress is written as TIMESTAMPS through conditional updates: `pushSentAt`
+ *    and `openedAt` never move `status`, and `openedAt` is written at most once,
+ *    only while the request is pending and unexpired.
+ */
+
+const mockAuthSessionFindOne = jest.fn();
+const mockAuthSessionUpdateOne = jest.fn();
+const mockApplicationFind = jest.fn();
+const mockPushTokenFind = jest.fn();
+const mockSendPushToTokens = jest.fn();
+
+jest.mock('../../models/AuthSession', () => ({
+  __esModule: true,
+  AuthSession: { findOne: mockAuthSessionFindOne, updateOne: mockAuthSessionUpdateOne },
+  default: { findOne: mockAuthSessionFindOne, updateOne: mockAuthSessionUpdateOne },
+}));
+
+jest.mock('../../models/Application', () => ({
+  __esModule: true,
+  Application: { find: mockApplicationFind },
+  default: { find: mockApplicationFind },
+}));
+
+jest.mock('../../models/PushToken', () => ({
+  __esModule: true,
+  PushToken: { find: mockPushTokenFind },
+  default: { find: mockPushTokenFind },
+}));
+
+jest.mock('../../services/push.service', () => ({
+  __esModule: true,
+  pushService: { sendPushToTokens: mockSendPushToTokens, sendPushNotification: jest.fn() },
+  default: { sendPushToTokens: mockSendPushToTokens, sendPushNotification: jest.fn() },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import {
+  deliverAuthRequestToIdentityApps,
+  markAuthRequestOpened,
+  buildApprovalUrl,
+  IDENTITY_APPROVAL_PUSH_TYPE,
+  IDENTITY_APPROVAL_PUSH_CHANNEL,
+} from '../authSessionDelivery.service';
+import { IDENTITY_APPROVAL_CAPABILITY } from '../../utils/applicationCapabilities';
+
+const IN_AN_HOUR = () => new Date(Date.now() + 3_600_000);
+const AN_HOUR_AGO = () => new Date(Date.now() - 3_600_000);
+
+/** `.select(...).lean()` chain used by both model lookups. */
+function chain<T>(rows: T[]) {
+  return { select: () => ({ lean: () => Promise.resolve(rows) }) };
+}
+
+function pendingSession(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionToken: 'secret-session-token',
+    authorizeCode: 'code-1',
+    status: 'pending',
+    expiresAt: IN_AN_HOUR(),
+    ...overrides,
+  };
+}
+
+/** Every key path in a nested object — used to prove the payload leaks nothing. */
+function collectKeyPaths(value: unknown, prefix = ''): string[] {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return [];
+  }
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return [path, ...collectKeyPaths(child, path)];
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthSessionUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+  mockSendPushToTokens.mockResolvedValue({ targeted: 1, accepted: 1 });
+});
+
+describe('deliverAuthRequestToIdentityApps — targeting', () => {
+  it('targets only the given identity and only capability-carrying applications', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'code-1',
+      identityUserId: 'user-1',
+    });
+
+    expect(mockApplicationFind).toHaveBeenCalledWith({
+      status: 'active',
+      capabilities: IDENTITY_APPROVAL_CAPABILITY,
+    });
+    expect(mockPushTokenFind).toHaveBeenCalledWith({
+      userId: 'user-1',
+      applicationId: { $in: ['app-commons'] },
+    });
+
+    expect(outcome).toEqual({
+      ok: true,
+      sessionToken: 'secret-session-token',
+      delivered: true,
+      targets: 1,
+    });
+  });
+
+  it('yields zero targets and sends nothing when no application carries the capability', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([]));
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'code-1',
+      identityUserId: 'user-1',
+    });
+
+    expect(mockPushTokenFind).not.toHaveBeenCalled();
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+    expect(outcome).toEqual({
+      ok: true,
+      sessionToken: 'secret-session-token',
+      delivered: false,
+      targets: 0,
+    });
+  });
+
+  it('yields zero targets and sends nothing when the identity has no capable install', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([]));
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'code-1',
+      identityUserId: 'user-1',
+    });
+
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+    expect(mockAuthSessionUpdateOne).not.toHaveBeenCalled();
+    expect(outcome).toMatchObject({ ok: true, delivered: false, targets: 0 });
+  });
+});
+
+describe('deliverAuthRequestToIdentityApps — payload', () => {
+  it('sends exactly { type, approvalUrl } and nothing else', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+
+    await deliverAuthRequestToIdentityApps({ authorizeCode: 'code-1', identityUserId: 'user-1' });
+
+    const call = mockSendPushToTokens.mock.calls[0][0] as {
+      userId: string;
+      tokens: string[];
+      title: string;
+      body: string;
+      channelId: string;
+      data: Record<string, unknown>;
+    };
+
+    // Recursive key set of the payload — nothing beyond the two allowed fields.
+    expect(collectKeyPaths(call.data).sort()).toEqual(['approvalUrl', 'type']);
+    expect(call.data).toEqual({
+      type: IDENTITY_APPROVAL_PUSH_TYPE,
+      approvalUrl: 'oxycommons://approve?v=1&code=code-1',
+    });
+    expect(IDENTITY_APPROVAL_PUSH_TYPE).toBe('oxy_commons_auth_request');
+
+    // The secret sessionToken never leaves the server on this path.
+    expect(JSON.stringify(call)).not.toContain('secret-session-token');
+
+    // The message itself carries no request-derived display data and no action
+    // category (approval can never happen from the notification shade).
+    expect(Object.keys(call).sort()).toEqual([
+      'body', 'channelId', 'data', 'title', 'tokens', 'userId',
+    ]);
+    expect(call.channelId).toBe(IDENTITY_APPROVAL_PUSH_CHANNEL);
+    expect(call.userId).toBe('user-1');
+    expect(call.tokens).toEqual(['tok-vault']);
+  });
+
+  it('percent-encodes the approval handle in the deep link', () => {
+    expect(buildApprovalUrl('a b&c')).toBe('oxycommons://approve?v=1&code=a%20b%26c');
+  });
+});
+
+describe('deliverAuthRequestToIdentityApps — failure never breaks the auth flow', () => {
+  it('returns a well-formed result when the push service throws', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+    mockSendPushToTokens.mockRejectedValue(new Error('expo unreachable'));
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'code-1',
+      identityUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({
+      ok: true,
+      sessionToken: 'secret-session-token',
+      delivered: false,
+      targets: 1,
+    });
+    // Nothing was delivered, so no progress is recorded.
+    expect(mockAuthSessionUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('reports delivered:false when no install accepted the message', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+    mockSendPushToTokens.mockResolvedValue({ targeted: 1, accepted: 0 });
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'code-1',
+      identityUserId: 'user-1',
+    });
+
+    expect(outcome).toMatchObject({ delivered: false, targets: 1 });
+    expect(mockAuthSessionUpdateOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('deliverAuthRequestToIdentityApps — request preconditions', () => {
+  it('404s an unknown authorizeCode without touching the push path', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(null);
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'nope',
+      identityUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, status: 404, message: 'Auth session not found' });
+    expect(mockApplicationFind).not.toHaveBeenCalled();
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+  });
+
+  it('400s and lazily expires a request whose TTL elapsed', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession({ expiresAt: AN_HOUR_AGO() }));
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'code-1',
+      identityUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, status: 400, message: 'Auth session has expired' });
+    expect(mockAuthSessionUpdateOne).toHaveBeenCalledWith(
+      { authorizeCode: 'code-1', status: 'pending' },
+      { $set: { status: 'expired' } },
+    );
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+  });
+
+  it('400s a request that is no longer pending', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession({ status: 'authorized' }));
+
+    const outcome = await deliverAuthRequestToIdentityApps({
+      authorizeCode: 'code-1',
+      identityUserId: 'user-1',
+    });
+
+    expect(outcome).toEqual({ ok: false, status: 400, message: 'Auth session is no longer pending' });
+    expect(mockSendPushToTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe('deliverAuthRequestToIdentityApps — progress is a timestamp', () => {
+  it('records pushSentAt once, conditioned on the request still being pending', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+    mockApplicationFind.mockReturnValue(chain([{ _id: 'app-commons' }]));
+    mockPushTokenFind.mockReturnValue(chain([{ token: 'tok-vault' }]));
+
+    await deliverAuthRequestToIdentityApps({ authorizeCode: 'code-1', identityUserId: 'user-1' });
+
+    expect(mockAuthSessionUpdateOne).toHaveBeenCalledTimes(1);
+    const [filter, update] = mockAuthSessionUpdateOne.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, Record<string, unknown>>,
+    ];
+    expect(filter).toEqual({ authorizeCode: 'code-1', status: 'pending', pushSentAt: null });
+    expect(Object.keys(update)).toEqual(['$set']);
+    expect(Object.keys(update.$set)).toEqual(['pushSentAt']);
+    expect(update.$set.pushSentAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('markAuthRequestOpened', () => {
+  it('404s an unknown authorizeCode', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(null);
+
+    const outcome = await markAuthRequestOpened('nope');
+
+    expect(outcome).toEqual({ ok: false, status: 404, message: 'Auth session not found' });
+    expect(mockAuthSessionUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('records openedAt once, pending-only, unexpired-only, and never touches status', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession());
+
+    const outcome = await markAuthRequestOpened('code-1');
+
+    expect(outcome).toEqual({ ok: true, sessionToken: 'secret-session-token', recorded: true });
+
+    const [filter, update] = mockAuthSessionUpdateOne.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, Record<string, unknown>>,
+    ];
+    expect(Object.keys(filter).sort()).toEqual(['authorizeCode', 'expiresAt', 'openedAt', 'status']);
+    expect(filter.authorizeCode).toBe('code-1');
+    expect(filter.status).toBe('pending');
+    expect(filter.openedAt).toBeNull();
+    expect(filter.expiresAt).toEqual({ $gt: expect.any(Date) });
+
+    expect(Object.keys(update)).toEqual(['$set']);
+    expect(Object.keys(update.$set)).toEqual(['openedAt']);
+    expect(update.$set.openedAt).toBeInstanceOf(Date);
+  });
+
+  it('is idempotent: a repeat call records nothing', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession({ openedAt: new Date() }));
+    mockAuthSessionUpdateOne.mockResolvedValue({ modifiedCount: 0 });
+
+    const outcome = await markAuthRequestOpened('code-1');
+
+    expect(outcome).toEqual({ ok: true, sessionToken: 'secret-session-token', recorded: false });
+  });
+
+  it('records nothing for an already-authorized request', async () => {
+    mockAuthSessionFindOne.mockResolvedValue(pendingSession({ status: 'authorized' }));
+    // The conditional update matches nothing — the DB, not a branch, enforces it.
+    mockAuthSessionUpdateOne.mockResolvedValue({ modifiedCount: 0 });
+
+    const outcome = await markAuthRequestOpened('code-1');
+
+    expect(outcome).toMatchObject({ ok: true, recorded: false });
+  });
+});

--- a/packages/api/src/services/__tests__/push.service.test.ts
+++ b/packages/api/src/services/__tests__/push.service.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Push service tests.
+ *
+ * Two things are pinned here:
+ *
+ *  1. **The email notification is byte-for-byte what it always was.** The
+ *     hardcoded `channelId: 'email'` became a caller-supplied channel; the wire
+ *     payload for the email caller must not have moved a single byte. The
+ *     expected request body below is an exact string, not a shape.
+ *  2. **The channel is caller-supplied and never defaulted**, and the explicit
+ *     token-targeting entry point delivers to exactly the tokens it is given
+ *     (used by identity-approval delivery, where the CALLER owns the targeting).
+ *
+ * Batching and `DeviceNotRegistered` pruning are exercised too — they must
+ * survive the parameterisation.
+ */
+
+const mockPushTokenFind = jest.fn();
+const mockPushTokenDeleteOne = jest.fn();
+
+jest.mock('../../models/PushToken', () => ({
+  __esModule: true,
+  PushToken: { find: mockPushTokenFind, deleteOne: mockPushTokenDeleteOne },
+  default: { find: mockPushTokenFind, deleteOne: mockPushTokenDeleteOne },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import { pushService } from '../push.service';
+
+/** `PushToken.find(...).select(...).lean()` chain. */
+function findChain(rows: { token: string }[]) {
+  return { select: () => ({ lean: () => Promise.resolve(rows) }) };
+}
+
+function okTickets(count: number) {
+  return {
+    ok: true,
+    json: () => Promise.resolve({ data: Array.from({ length: count }, () => ({ status: 'ok' })) }),
+  };
+}
+
+const originalFetch = global.fetch;
+let fetchMock: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fetchMock = jest.fn();
+  global.fetch = fetchMock as unknown as typeof fetch;
+  mockPushTokenDeleteOne.mockResolvedValue({ deletedCount: 1 });
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('pushService.sendPushNotification — email notification is unchanged', () => {
+  it('sends the exact same wire payload the email caller always sent', async () => {
+    mockPushTokenFind.mockReturnValue(findChain([{ token: 'ExponentPushToken[email-device]' }]));
+    fetchMock.mockResolvedValue(okTickets(1));
+
+    // Exactly what `email.service.ts` passes on an inbound non-spam message.
+    await pushService.sendPushNotification({
+      userId: 'user-1',
+      title: 'Ada Lovelace',
+      body: 'Analytical Engine notes',
+      channelId: 'email',
+      data: { messageId: 'msg-1', mailboxId: 'mbox-1' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('https://exp.host/--/api/v2/push/send');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toEqual({
+      'Accept': 'application/json',
+      'Accept-Encoding': 'gzip, deflate',
+      'Content-Type': 'application/json',
+    });
+
+    // Byte-for-byte: same keys, same order, same values as before the change.
+    expect(init.body).toBe(
+      '[{"to":"ExponentPushToken[email-device]","title":"Ada Lovelace","body":"Analytical Engine notes",'
+      + '"data":{"messageId":"msg-1","mailboxId":"mbox-1"},"sound":"default","channelId":"email"}]',
+    );
+  });
+
+  it('targets every install of the user and reports accepted counts', async () => {
+    mockPushTokenFind.mockReturnValue(findChain([{ token: 'tok-a' }, { token: 'tok-b' }]));
+    fetchMock.mockResolvedValue(okTickets(2));
+
+    const result = await pushService.sendPushNotification({
+      userId: 'user-1',
+      title: 'T',
+      body: 'B',
+      channelId: 'email',
+    });
+
+    expect(mockPushTokenFind).toHaveBeenCalledWith({ userId: 'user-1' });
+    expect(result).toEqual({ targeted: 2, accepted: 2 });
+  });
+
+  it('does not call the push API when the user has no installs', async () => {
+    mockPushTokenFind.mockReturnValue(findChain([]));
+
+    const result = await pushService.sendPushNotification({
+      userId: 'user-1',
+      title: 'T',
+      body: 'B',
+      channelId: 'email',
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ targeted: 0, accepted: 0 });
+  });
+});
+
+describe('pushService — caller-supplied channel', () => {
+  it('uses the channel the caller passed, with no default of its own', async () => {
+    fetchMock.mockResolvedValue(okTickets(1));
+
+    await pushService.sendPushToTokens({
+      userId: 'user-1',
+      tokens: ['tok-a'],
+      title: 'Sign-in request',
+      body: 'Open Commons to review this request.',
+      channelId: 'auth-approval',
+      data: { type: 'oxy_commons_auth_request', approvalUrl: 'oxycommons://approve?v=1&code=abc' },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const sent = JSON.parse(String(init.body)) as Array<Record<string, unknown>>;
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].channelId).toBe('auth-approval');
+    // No `categoryId` — an iOS category is what binds action buttons to a
+    // notification, and an approval notification must never carry one.
+    expect(Object.keys(sent[0]).sort()).toEqual(['body', 'channelId', 'data', 'sound', 'title', 'to']);
+  });
+});
+
+describe('pushService.sendPushToTokens — explicit targeting', () => {
+  it('delivers to exactly the tokens it was given (never a registry lookup)', async () => {
+    fetchMock.mockResolvedValue(okTickets(2));
+
+    const result = await pushService.sendPushToTokens({
+      userId: 'user-1',
+      tokens: ['tok-a', 'tok-b'],
+      title: 'T',
+      body: 'B',
+      channelId: 'auth-approval',
+    });
+
+    expect(mockPushTokenFind).not.toHaveBeenCalled();
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const sent = JSON.parse(String(init.body)) as Array<{ to: string }>;
+    expect(sent.map((m) => m.to)).toEqual(['tok-a', 'tok-b']);
+    expect(result).toEqual({ targeted: 2, accepted: 2 });
+  });
+
+  it('does not throw and reports zero accepted when the transport fails', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await expect(
+      pushService.sendPushToTokens({
+        userId: 'user-1',
+        tokens: ['tok-a'],
+        title: 'T',
+        body: 'B',
+        channelId: 'auth-approval',
+      }),
+    ).resolves.toEqual({ targeted: 1, accepted: 0 });
+  });
+
+  it('does not throw and reports zero accepted on a non-OK push API response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 502, json: () => Promise.resolve({}) });
+
+    await expect(
+      pushService.sendPushToTokens({
+        userId: 'user-1',
+        tokens: ['tok-a'],
+        title: 'T',
+        body: 'B',
+        channelId: 'auth-approval',
+      }),
+    ).resolves.toEqual({ targeted: 1, accepted: 0 });
+  });
+
+  it('prunes DeviceNotRegistered tokens and still counts the accepted ones', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        data: [
+          { status: 'ok' },
+          { status: 'error', details: { error: 'DeviceNotRegistered' } },
+        ],
+      }),
+    });
+
+    const result = await pushService.sendPushToTokens({
+      userId: 'user-1',
+      tokens: ['tok-live', 'tok-dead'],
+      title: 'T',
+      body: 'B',
+      channelId: 'auth-approval',
+    });
+
+    expect(mockPushTokenDeleteOne).toHaveBeenCalledTimes(1);
+    expect(mockPushTokenDeleteOne).toHaveBeenCalledWith({ userId: 'user-1', token: 'tok-dead' });
+    expect(result).toEqual({ targeted: 2, accepted: 1 });
+  });
+
+  it('batches at 100 messages per request', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(okTickets(100)));
+
+    const tokens = Array.from({ length: 150 }, (_, i) => `tok-${i}`);
+    await pushService.sendPushToTokens({
+      userId: 'user-1',
+      tokens,
+      title: 'T',
+      body: 'B',
+      channelId: 'auth-approval',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const first = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body)) as unknown[];
+    const second = JSON.parse(String((fetchMock.mock.calls[1][1] as RequestInit).body)) as unknown[];
+    expect(first).toHaveLength(100);
+    expect(second).toHaveLength(50);
+  });
+});

--- a/packages/api/src/services/authSessionDelivery.service.ts
+++ b/packages/api/src/services/authSessionDelivery.service.ts
@@ -1,0 +1,226 @@
+/**
+ * Automatic delivery of a pending authorization request to the approving
+ * identity's own vault installs, plus the delivery-progress bookkeeping that
+ * goes with it.
+ *
+ * Two rules define this module's security posture:
+ *
+ *  1. **The target user is NEVER derived from the request.** The caller passes
+ *     the identity resolved from a bearer token, and delivery targets that
+ *     user's OWN installs and nothing else. A push is therefore impossible to
+ *     trigger from a username or email typed into an unauthenticated browser.
+ *  2. **Eligibility is registry-based.** Only installs registered by an
+ *     `Application` carrying the {@link IDENTITY_APPROVAL_CAPABILITY} staff-only
+ *     capability are targeted — never a hardcoded client id, bundle id or app
+ *     name.
+ *
+ * Zero eligible installs is a NORMAL outcome (the client falls back to a QR),
+ * not an error, and a push transport failure degrades to exactly the same
+ * outcome — delivery must never fail the auth flow.
+ */
+
+import type mongoose from 'mongoose';
+import { AuthSession } from '../models/AuthSession';
+import { Application } from '../models/Application';
+import { PushToken } from '../models/PushToken';
+import { pushService } from './push.service';
+import { IDENTITY_APPROVAL_CAPABILITY } from '../utils/applicationCapabilities';
+import { logger } from '../utils/logger';
+
+/**
+ * Notification channel/category for approval requests. NOT an iOS `categoryId`:
+ * the notification carries no action buttons, so it can only be opened (which
+ * routes into the normal in-vault approval screen) or dismissed.
+ */
+export const IDENTITY_APPROVAL_PUSH_CHANNEL = 'auth-approval';
+
+/** Runtime type discriminator of the push payload, mirrored by the vault. */
+export const IDENTITY_APPROVAL_PUSH_TYPE = 'oxy_commons_auth_request';
+
+/**
+ * Static notification copy. Deliberately carries NO request-derived data — not
+ * the application name, not the origin, not the account. The vault re-fetches
+ * the authoritative application / scopes / origin / expiry from
+ * `GET /auth/session/approve-info/:authorizeCode` after the user opens it.
+ */
+const PUSH_TITLE = 'Sign-in request';
+const PUSH_BODY = 'Open Commons to review this request.';
+
+/**
+ * The ONLY payload delivered. Exactly two fields: a type discriminator and the
+ * deep link carrying the PUBLIC approval handle. No display data (which would be
+ * untrusted at the receiver anyway) and no secrets — never the `sessionToken`.
+ */
+export type IdentityApprovalPushPayload = {
+  type: typeof IDENTITY_APPROVAL_PUSH_TYPE;
+  approvalUrl: string;
+};
+
+export function buildApprovalUrl(authorizeCode: string): string {
+  return `oxycommons://approve?v=1&code=${encodeURIComponent(authorizeCode)}`;
+}
+
+export type DeliverAuthRequestOutcome =
+  | {
+      ok: true;
+      /** Secret channel of the waiting originator — for the socket wake ONLY. */
+      sessionToken: string;
+      /** At least one install accepted the push. */
+      delivered: boolean;
+      /** How many eligible installs were targeted. A COUNT — never PII. */
+      targets: number;
+    }
+  | { ok: false; status: 400 | 404; message: string };
+
+/**
+ * Resolve the push tokens of the user's installs that may approve an identity
+ * request. Returns an empty array when the user has no such install, or when no
+ * application currently carries the capability at all.
+ */
+async function resolveIdentityApprovalTokens(userId: string): Promise<string[]> {
+  const capableApps = await Application.find({
+    status: 'active',
+    capabilities: IDENTITY_APPROVAL_CAPABILITY,
+  })
+    .select('_id')
+    .lean<{ _id: mongoose.Types.ObjectId }[]>();
+
+  if (capableApps.length === 0) {
+    return [];
+  }
+
+  const installs = await PushToken.find({
+    userId,
+    applicationId: { $in: capableApps.map((app) => app._id) },
+  })
+    .select('token')
+    .lean<{ token: string }[]>();
+
+  return installs.map((install) => install.token);
+}
+
+/**
+ * Push a PENDING authorization request to the authenticated identity's own
+ * approval-capable installs.
+ *
+ * @param authorizeCode  Public approval handle of the request.
+ * @param identityUserId The AUTHENTICATED user — the sole delivery target.
+ */
+export async function deliverAuthRequestToIdentityApps(params: {
+  authorizeCode: string;
+  identityUserId: string;
+}): Promise<DeliverAuthRequestOutcome> {
+  const { authorizeCode, identityUserId } = params;
+
+  const authSession = await AuthSession.findOne({ authorizeCode });
+  if (!authSession) {
+    return { ok: false, status: 404, message: 'Auth session not found' };
+  }
+
+  if (authSession.expiresAt.getTime() <= Date.now()) {
+    // Same lazy expiry the sibling approval endpoints perform. Conditioned on
+    // `pending` so a concurrent approval is never overwritten.
+    await AuthSession.updateOne(
+      { authorizeCode, status: 'pending' },
+      { $set: { status: 'expired' } },
+    );
+    return { ok: false, status: 400, message: 'Auth session has expired' };
+  }
+
+  if (authSession.status !== 'pending') {
+    return { ok: false, status: 400, message: 'Auth session is no longer pending' };
+  }
+
+  const tokens = await resolveIdentityApprovalTokens(identityUserId);
+  if (tokens.length === 0) {
+    // Normal: this identity has no vault install on any device. The client falls
+    // back to the QR / deep-link surfaces.
+    return { ok: true, sessionToken: authSession.sessionToken, delivered: false, targets: 0 };
+  }
+
+  const payload: IdentityApprovalPushPayload = {
+    type: IDENTITY_APPROVAL_PUSH_TYPE,
+    approvalUrl: buildApprovalUrl(authorizeCode),
+  };
+
+  let accepted = 0;
+  try {
+    const dispatched = await pushService.sendPushToTokens({
+      userId: identityUserId,
+      tokens,
+      title: PUSH_TITLE,
+      body: PUSH_BODY,
+      channelId: IDENTITY_APPROVAL_PUSH_CHANNEL,
+      data: payload,
+    });
+    accepted = dispatched.accepted;
+  } catch (err) {
+    // The push service already swallows its own transport errors; this is the
+    // belt-and-braces guard that keeps a delivery problem from ever surfacing as
+    // an auth failure. The client simply falls back.
+    logger.warn('[AuthSession] Identity approval push failed', {
+      authorizeCode: authorizeCode.substring(0, 8) + '...',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  const delivered = accepted > 0;
+
+  if (delivered) {
+    // Progress is a TIMESTAMP, never a status — the state machine is untouched.
+    // Recorded once, and only while the request is still pending.
+    await AuthSession.updateOne(
+      { authorizeCode, status: 'pending', pushSentAt: null },
+      { $set: { pushSentAt: new Date() } },
+    );
+  }
+
+  return {
+    ok: true,
+    sessionToken: authSession.sessionToken,
+    delivered,
+    targets: tokens.length,
+  };
+}
+
+export type MarkAuthRequestOpenedOutcome =
+  | {
+      ok: true;
+      /** Secret channel of the waiting originator — for the socket wake ONLY. */
+      sessionToken: string;
+      /** True only on the FIRST record; a repeat call is a no-op. */
+      recorded: boolean;
+    }
+  | { ok: false; status: 404; message: string };
+
+/**
+ * Record that the approval surface opened a PENDING request.
+ *
+ * Idempotent (`openedAt` is written at most once) and pending-only, via a single
+ * conditional update: it can never move `status`, revive an expired request, or
+ * overwrite an earlier timestamp.
+ */
+export async function markAuthRequestOpened(
+  authorizeCode: string,
+): Promise<MarkAuthRequestOpenedOutcome> {
+  const authSession = await AuthSession.findOne({ authorizeCode });
+  if (!authSession) {
+    return { ok: false, status: 404, message: 'Auth session not found' };
+  }
+
+  const update = await AuthSession.updateOne(
+    {
+      authorizeCode,
+      status: 'pending',
+      openedAt: null,
+      expiresAt: { $gt: new Date() },
+    },
+    { $set: { openedAt: new Date() } },
+  );
+
+  return {
+    ok: true,
+    sessionToken: authSession.sessionToken,
+    recorded: (update.modifiedCount ?? 0) > 0,
+  };
+}

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -947,9 +947,15 @@ class EmailService {
     if (!isSpam) {
       const senderName = params.from.name || params.from.address;
       const pushBody = params.subject || '(no subject)';
-      pushService.sendPushNotification(userId, senderName, pushBody, {
-        messageId: message._id.toString(),
-        mailboxId: mailbox._id.toString(),
+      pushService.sendPushNotification({
+        userId,
+        title: senderName,
+        body: pushBody,
+        channelId: 'email',
+        data: {
+          messageId: message._id.toString(),
+          mailboxId: mailbox._id.toString(),
+        },
       }).catch((err) => {
         logger.warn('Push notification failed', { userId, error: String(err) });
       });

--- a/packages/api/src/services/push.service.ts
+++ b/packages/api/src/services/push.service.ts
@@ -3,6 +3,19 @@
  *
  * Sends push notifications via the Expo Push API.
  * Uses a simple HTTP POST — no SDK dependency required on the backend.
+ *
+ * The notification channel/category is ALWAYS caller-supplied: this service has
+ * no notion of what a message is about, so it never picks a channel of its own.
+ * Two delivery shapes sit on top of one internal dispatcher:
+ *
+ *  - {@link sendPushNotification} — every install registered by the user.
+ *  - {@link sendPushToTokens}     — an explicitly resolved subset of installs
+ *                                   (e.g. only the user's identity-approval
+ *                                   apps), where the CALLER owns the targeting.
+ *
+ * Neither ever throws: push is an auxiliary channel and must not fail the flow
+ * that triggered it. Failures are logged and reported through the returned
+ * counters.
  */
 
 import { PushToken } from '../models/PushToken';
@@ -27,84 +40,164 @@ interface ExpoPushTicket {
   details?: Record<string, unknown>;
 }
 
+/** What a caller wants delivered, minus the targeting. */
+interface PushMessageContent {
+  title: string;
+  body: string;
+  /**
+   * Android notification channel id (and, for Expo, the logical category of the
+   * message). REQUIRED and never defaulted — the service has no way to know what
+   * a message is about.
+   *
+   * NOTE: deliberately NOT an iOS `categoryId`. A category is what binds
+   * interactive ACTION BUTTONS to a notification; approval-style notifications
+   * must only ever open or dismiss, never approve from the notification shade.
+   */
+  channelId: string;
+  data?: Record<string, unknown>;
+}
+
+/** Outcome of a delivery attempt. Counts only — never device or token detail. */
+export interface PushDispatchResult {
+  /** Installs the attempt targeted. */
+  targeted: number;
+  /** Installs whose message the Expo push service accepted (`ok` ticket). */
+  accepted: number;
+}
+
 /**
- * Send a push notification to all registered devices for a user.
- * Fire-and-forget — callers should not await this in critical paths.
+ * Deliver `content` to an explicit set of push tokens.
+ *
+ * Batches at the Expo-recommended 100 messages per request and prunes tokens the
+ * push service reports as `DeviceNotRegistered`. Never throws.
  */
-async function sendPushNotification(
+async function dispatch(
   userId: string,
-  title: string,
-  body: string,
-  data?: Record<string, unknown>,
-): Promise<void> {
-  try {
-    const tokens = await PushToken.find({ userId }).select('token').lean();
+  tokens: string[],
+  content: PushMessageContent,
+): Promise<PushDispatchResult> {
+  const result: PushDispatchResult = { targeted: tokens.length, accepted: 0 };
 
-    if (tokens.length === 0) {
-      return;
-    }
+  if (tokens.length === 0) {
+    return result;
+  }
 
-    const messages: ExpoPushMessage[] = tokens.map((t) => ({
-      to: t.token,
-      title,
-      body,
-      data,
-      sound: 'default' as const,
-      channelId: 'email',
-    }));
+  const messages: ExpoPushMessage[] = tokens.map((token) => ({
+    to: token,
+    title: content.title,
+    body: content.body,
+    data: content.data,
+    sound: 'default' as const,
+    channelId: content.channelId,
+  }));
 
-    // Expo recommends batching up to 100 notifications per request
-    const chunks = chunkArray(messages, 100);
+  // Expo recommends batching up to 100 notifications per request
+  const chunks = chunkArray(messages, 100);
 
-    for (const chunk of chunks) {
-      try {
-        const response = await fetch(EXPO_PUSH_URL, {
-          method: 'POST',
-          headers: {
-            'Accept': 'application/json',
-            'Accept-Encoding': 'gzip, deflate',
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(chunk),
+  for (const chunk of chunks) {
+    try {
+      const response = await fetch(EXPO_PUSH_URL, {
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Accept-Encoding': 'gzip, deflate',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(chunk),
+      });
+
+      if (!response.ok) {
+        logger.warn('Expo push API returned non-OK status', {
+          status: response.status,
+          userId,
         });
+        continue;
+      }
 
-        if (!response.ok) {
-          logger.warn('Expo push API returned non-OK status', {
-            status: response.status,
-            userId,
-          });
-          continue;
-        }
+      const payload = await response.json() as { data: ExpoPushTicket[] };
 
-        const result = await response.json() as { data: ExpoPushTicket[] };
+      if (payload.data) {
+        for (let i = 0; i < payload.data.length; i++) {
+          const ticket = payload.data[i];
 
-        // Clean up invalid tokens (DeviceNotRegistered)
-        if (result.data) {
-          for (let i = 0; i < result.data.length; i++) {
-            const ticket = result.data[i];
-            if (
-              ticket.status === 'error' &&
-              ticket.details &&
-              (ticket.details as Record<string, unknown>).error === 'DeviceNotRegistered'
-            ) {
-              const invalidToken = chunk[i].to;
-              logger.info('Removing invalid push token', { userId, token: invalidToken });
-              await PushToken.deleteOne({ userId, token: invalidToken });
-            }
+          if (ticket.status === 'ok') {
+            result.accepted++;
+            continue;
+          }
+
+          // Clean up invalid tokens (DeviceNotRegistered)
+          if (
+            ticket.details &&
+            (ticket.details as Record<string, unknown>).error === 'DeviceNotRegistered'
+          ) {
+            const invalidToken = chunk[i].to;
+            logger.info('Removing invalid push token', { userId, token: invalidToken });
+            await PushToken.deleteOne({ userId, token: invalidToken });
           }
         }
-      } catch (err) {
-        logger.warn('Failed to send push notification chunk', {
-          userId,
-          error: err instanceof Error ? err.message : String(err),
-        });
       }
+    } catch (err) {
+      logger.warn('Failed to send push notification chunk', {
+        userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
+  }
+
+  return result;
+}
+
+/**
+ * Send a push notification to ALL registered installs for a user.
+ * Fire-and-forget — callers should not await this in critical paths.
+ */
+async function sendPushNotification(params: {
+  userId: string;
+  title: string;
+  body: string;
+  channelId: string;
+  data?: Record<string, unknown>;
+}): Promise<PushDispatchResult> {
+  const { userId, title, body, channelId, data } = params;
+
+  try {
+    const tokens = await PushToken.find({ userId }).select('token').lean<{ token: string }[]>();
+
+    return await dispatch(userId, tokens.map((t) => t.token), { title, body, channelId, data });
   } catch (err) {
     logger.warn('Failed to send push notification', {
       userId,
       error: err instanceof Error ? err.message : String(err),
     });
+    return { targeted: 0, accepted: 0 };
+  }
+}
+
+/**
+ * Send a push notification to an EXPLICIT subset of a user's installs.
+ *
+ * The caller owns the targeting — and therefore the authorization decision
+ * behind it; this only delivers. `userId` is still required so a token the push
+ * service rejects is pruned from the right owner's registry.
+ */
+async function sendPushToTokens(params: {
+  userId: string;
+  tokens: string[];
+  title: string;
+  body: string;
+  channelId: string;
+  data?: Record<string, unknown>;
+}): Promise<PushDispatchResult> {
+  const { userId, tokens, title, body, channelId, data } = params;
+
+  try {
+    return await dispatch(userId, tokens, { title, body, channelId, data });
+  } catch (err) {
+    logger.warn('Failed to send push notification', {
+      userId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { targeted: tokens.length, accepted: 0 };
   }
 }
 
@@ -121,6 +214,7 @@ function chunkArray<T>(arr: T[], size: number): T[][] {
 
 export const pushService = {
   sendPushNotification,
+  sendPushToTokens,
 };
 
 export default pushService;

--- a/packages/api/src/utils/applicationCapabilities.ts
+++ b/packages/api/src/utils/applicationCapabilities.ts
@@ -1,0 +1,44 @@
+/**
+ * Platform capability vocabulary for `Application.capabilities`.
+ *
+ * Capabilities are STAFF-CONTROLLED, opaque platform flags: the Console /
+ * member-RBAC update path silently drops them for non-staff callers (see
+ * `middleware/requireStaff.ts` and `routes/applications.ts`), so a self-service
+ * third-party app can never grant itself one. That makes the capability list the
+ * REGISTRY-BASED answer to "which registered application may act as X" — the
+ * same shape of authority as `isTrustedApplication()`. Never gate a platform
+ * behaviour on a hardcoded client id, bundle id or application name.
+ *
+ * Intentionally dependency-free (no Mongoose) so it is trivially unit-testable
+ * and importable without loading a model.
+ */
+
+export const APPLICATION_CAPABILITIES = [
+  /**
+   * The application is an IDENTITY-APPROVAL surface: a vault that holds the
+   * user's local identity key and can review and cryptographically sign an
+   * authorization request (today: Commons by Oxy). Push delivery of a pending
+   * sign-in request targets ONLY installs registered by an application carrying
+   * this capability.
+   */
+  'identity:approval',
+] as const;
+
+export type ApplicationCapability = (typeof APPLICATION_CAPABILITIES)[number];
+
+/** See the vocabulary entry above. */
+export const IDENTITY_APPROVAL_CAPABILITY: ApplicationCapability = 'identity:approval';
+
+/**
+ * Predicate: does this application carry `capability`?
+ *
+ * Accepts a bare shape (not a Mongoose document) so callers can test lean query
+ * results. A missing / non-array `capabilities` reads as "no capabilities" —
+ * fails closed.
+ */
+export function hasApplicationCapability(
+  application: { capabilities?: string[] | null },
+  capability: ApplicationCapability
+): boolean {
+  return Array.isArray(application.capabilities) && application.capabilities.includes(capability);
+}

--- a/packages/api/src/utils/authSessionSocket.ts
+++ b/packages/api/src/utils/authSessionSocket.ts
@@ -37,3 +37,23 @@ export function emitAuthSessionUpdate(sessionToken: string, payload: {
   const room = `auth:${sessionToken}`;
   authSessionNamespace.to(room).emit('auth_update', payload);
 }
+
+/**
+ * Emit a pure WAKE signal for a request whose authoritative status has NOT
+ * changed — delivery progress only (the request was pushed to the identity
+ * vault, or the vault opened it).
+ *
+ * The payload is deliberately EMPTY. Clients already treat `auth_update` as a
+ * signal and re-read the authoritative state from
+ * `GET /auth/session/status/:sessionToken`, which is where `pushSentAt` /
+ * `openedAt` are exposed. Progress must never travel as trusted data on the
+ * socket, and no token, secret or PII may ever be emitted here.
+ */
+export function emitAuthSessionProgress(sessionToken: string): void {
+  if (!authSessionNamespace) {
+    logger.warn('Auth session namespace not initialized');
+    return;
+  }
+
+  authSessionNamespace.to(`auth:${sessionToken}`).emit('auth_update', {});
+}

--- a/packages/commons/__mocks__/oxyhq-services.ts
+++ b/packages/commons/__mocks__/oxyhq-services.ts
@@ -12,8 +12,11 @@ import { useEffect, useSyncExternalStore } from 'react';
 interface MockOxyServices {
   updateProfile?: jest.Mock;
   getCommonsApprovalInfo?: jest.Mock;
+  markCommonsApprovalOpened?: jest.Mock;
   approveCommonsSignIn?: jest.Mock;
   denyCommonsSignIn?: jest.Mock;
+  registerPushToken?: jest.Mock;
+  unregisterPushToken?: jest.Mock;
   getPublicKey?: jest.Mock;
   getPublicCard?: jest.Mock;
   getReputationBalance?: jest.Mock;
@@ -42,10 +45,22 @@ interface MockOxyServices {
   notifyNodeIngest?: jest.Mock;
 }
 
+interface MockSessionClient {
+  getState: () => { deviceId: string } | null;
+}
+
 interface MockOxyState {
   user: { id?: string; username?: string; languages?: string[]; avatar?: string | null } | null;
   isAuthenticated: boolean;
   isAuthResolved: boolean;
+  /**
+   * The SDK's "a usable bearer is planted" verdict — the gate consumer apps use
+   * before any private (bearer-authed) call. Defaults to `false`; tests that
+   * exercise a private-API path set it explicitly.
+   */
+  canUsePrivateApi: boolean;
+  /** Device-session client; `null` when no device state has been resolved. */
+  sessionClient: MockSessionClient | null;
   isLoading: boolean;
   /** The active UI locale, as the real SDK derives it. */
   currentLanguage: string;
@@ -64,6 +79,8 @@ function makeDefaultState(): MockOxyState {
     // i.e. after the SDK's device-first cold boot has concluded. Set it to
     // `false` explicitly to exercise the still-resolving ("checking") window.
     isAuthResolved: true,
+    canUsePrivateApi: false,
+    sessionClient: null,
     isLoading: false,
     currentLanguage: 'en-US',
     currentLanguages: [],

--- a/packages/commons/__tests__/account/delete-account-flow.test.ts
+++ b/packages/commons/__tests__/account/delete-account-flow.test.ts
@@ -18,6 +18,7 @@ describe('runAccountDeletion', () => {
 
   function makeDeps() {
     return {
+      retirePushToken: jest.fn<Promise<unknown>, []>(async () => ({ status: 'retired' })),
       deleteAccount: jest.fn<Promise<unknown>, [string]>(async () => ({ message: 'ok' })),
       purgeIdentity: jest.fn<Promise<void>, []>(async () => undefined),
       signOutAll: jest.fn<Promise<void>, []>(async () => undefined),
@@ -35,9 +36,13 @@ describe('runAccountDeletion', () => {
     expect(result.localIdentityPurged).toBe(true);
   });
 
-  it('purges the local identity BEFORE signing out', async () => {
+  it('retires the push token first, then purges the local identity BEFORE signing out', async () => {
     const deps = makeDeps();
     const order: string[] = [];
+    deps.retirePushToken.mockImplementation(async () => {
+      order.push('retirePushToken');
+      return { status: 'retired' };
+    });
     deps.deleteAccount.mockImplementation(async () => {
       order.push('deleteAccount');
       return { message: 'ok' };
@@ -51,7 +56,23 @@ describe('runAccountDeletion', () => {
 
     await runAccountDeletion(CONFIRM, deps);
 
-    expect(order).toEqual(['deleteAccount', 'purgeIdentity', 'signOutAll']);
+    // The push registry scopes a retirement to the identity holding the bearer,
+    // so it MUST happen before the account is deleted and the session dropped —
+    // otherwise this device keeps a live registration for an identity it no
+    // longer holds and gets woken by that identity's sign-in requests.
+    expect(order).toEqual(['retirePushToken', 'deleteAccount', 'purgeIdentity', 'signOutAll']);
+  });
+
+  it('still deletes the account when retiring the push token fails', async () => {
+    const deps = makeDeps();
+    deps.retirePushToken.mockRejectedValue(new Error('push registry unreachable'));
+
+    const result = await runAccountDeletion(CONFIRM, deps);
+
+    expect(deps.deleteAccount).toHaveBeenCalledTimes(1);
+    expect(deps.purgeIdentity).toHaveBeenCalledTimes(1);
+    expect(deps.signOutAll).toHaveBeenCalledTimes(1);
+    expect(result.localIdentityPurged).toBe(true);
   });
 
   it('does NOT purge the local identity when the server delete fails', async () => {
@@ -65,6 +86,14 @@ describe('runAccountDeletion', () => {
     // the user must NOT be signed out.
     expect(deps.purgeIdentity).not.toHaveBeenCalled();
     expect(deps.signOutAll).not.toHaveBeenCalled();
+  });
+
+  it('retires the push token exactly once', async () => {
+    const deps = makeDeps();
+
+    await runAccountDeletion(CONFIRM, deps);
+
+    expect(deps.retirePushToken).toHaveBeenCalledTimes(1);
   });
 
   it('still signs out and reports a non-fatal warning when the local purge fails after a successful delete', async () => {

--- a/packages/commons/__tests__/hooks/useAuthRequestNotifications.test.tsx
+++ b/packages/commons/__tests__/hooks/useAuthRequestNotifications.test.tsx
@@ -1,0 +1,150 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { __getMockRouter } from '@/__mocks__/expo-router';
+import { COMMONS_AUTH_REQUEST_PUSH_TYPE } from '@/lib/notifications/auth-request-push';
+
+const mockSubscribe = jest.fn<Promise<() => void>, [(data: unknown) => void]>();
+const mockTakeLaunchNotificationData = jest.fn<Promise<unknown>, []>();
+
+jest.mock('@/lib/notifications/device-notifications', () => ({
+  subscribeToNotificationResponses: (listener: (data: unknown) => void) => mockSubscribe(listener),
+  takeLaunchNotificationData: () => mockTakeLaunchNotificationData(),
+}));
+
+// Imported AFTER jest.mock so the hook sees the patched adapter.
+// eslint-disable-next-line import/first
+import {
+  coldLaunchApprovalCode,
+  useAuthRequestNotifications,
+} from '@/hooks/notifications/useAuthRequestNotifications';
+
+const router = __getMockRouter();
+
+function pushPayload(approvalUrl: string): Record<string, unknown> {
+  return { type: COMMONS_AUTH_REQUEST_PUSH_TYPE, approvalUrl };
+}
+
+/**
+ * Tapping an auth-request push may do EXACTLY ONE thing: open the existing
+ * approval route with the authorize code. It must never approve, and it must
+ * never carry anything from the (untrusted) payload into the app.
+ *
+ * NOTE: the module-level claim ledger is per app session, so each test uses its
+ * own authorize code — the same way two real notifications carry two codes.
+ */
+describe('useAuthRequestNotifications', () => {
+  let emit: ((data: unknown) => void) | null = null;
+  let unsubscribe: jest.Mock;
+
+  beforeEach(() => {
+    router.push.mockClear();
+    router.replace.mockClear();
+    emit = null;
+    unsubscribe = jest.fn();
+    mockSubscribe.mockReset().mockImplementation(async (listener) => {
+      emit = listener;
+      return unsubscribe;
+    });
+    mockTakeLaunchNotificationData.mockReset().mockResolvedValue(null);
+  });
+
+  it('does not listen while the router gate is unresolved', async () => {
+    renderHook(() => useAuthRequestNotifications(false));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('opens the approval route with ONLY the authorize code', async () => {
+    renderHook(() => useAuthRequestNotifications(true));
+    await waitFor(() => expect(emit).not.toBeNull());
+
+    act(() => {
+      emit?.({
+        ...pushPayload('oxycommons://approve?v=1&code=warm-1&app=Evil%20Bank'),
+        appName: 'Evil Bank',
+        body: 'Approve now',
+      });
+    });
+
+    expect(router.push).toHaveBeenCalledTimes(1);
+    const [target] = router.push.mock.calls[0] as [{ pathname: string; params: Record<string, string> }];
+    expect(target.pathname).toBe('/approve');
+    expect(target.params).toEqual({ code: 'warm-1' });
+    // Nothing from the payload rides along — not the app name, not the origin.
+    expect(Object.keys(target.params)).toEqual(['code']);
+  });
+
+  it.each([
+    ['a foreign scheme', 'evil://approve?code=drop-1'],
+    ['a missing code', 'oxycommons://approve?v=1'],
+    ['a non-approval route', 'oxycommons://attest?subject=did:web:oxy.so:u:1'],
+  ])('drops %s and navigates nowhere', async (_label, approvalUrl) => {
+    renderHook(() => useAuthRequestNotifications(true));
+    await waitFor(() => expect(emit).not.toBeNull());
+
+    act(() => {
+      emit?.(pushPayload(approvalUrl));
+    });
+
+    expect(router.push).not.toHaveBeenCalled();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('drops a push that is not a Commons auth request', async () => {
+    renderHook(() => useAuthRequestNotifications(true));
+    await waitFor(() => expect(emit).not.toBeNull());
+
+    act(() => {
+      emit?.({ type: 'marketing', approvalUrl: 'oxycommons://approve?code=drop-2' });
+      emit?.(null);
+      emit?.('oxycommons://approve?code=drop-3');
+    });
+
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes on unmount', async () => {
+    const { unmount } = renderHook(() => useAuthRequestNotifications(true));
+    await waitFor(() => expect(emit).not.toBeNull());
+
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('coldLaunchApprovalCode', () => {
+  beforeEach(() => {
+    mockTakeLaunchNotificationData.mockReset().mockResolvedValue(null);
+  });
+
+  it('resolves the code carried by the launching notification', async () => {
+    mockTakeLaunchNotificationData.mockResolvedValue(
+      pushPayload('oxycommons://approve?v=1&code=cold-1'),
+    );
+
+    await expect(coldLaunchApprovalCode()).resolves.toBe('cold-1');
+  });
+
+  it('claims the code so the warm listener cannot route the same tap twice', async () => {
+    mockTakeLaunchNotificationData.mockResolvedValue(
+      pushPayload('oxycommons://approve?code=cold-2'),
+    );
+
+    await expect(coldLaunchApprovalCode()).resolves.toBe('cold-2');
+    // A second reader of the SAME launching tap gets nothing.
+    await expect(coldLaunchApprovalCode()).resolves.toBeNull();
+  });
+
+  it('resolves null when nothing launched the app', async () => {
+    await expect(coldLaunchApprovalCode()).resolves.toBeNull();
+  });
+
+  it('resolves null for an unparseable launching payload', async () => {
+    mockTakeLaunchNotificationData.mockResolvedValue(pushPayload('evil://approve?code=cold-3'));
+
+    await expect(coldLaunchApprovalCode()).resolves.toBeNull();
+  });
+});

--- a/packages/commons/__tests__/hooks/useCommonsApproval.test.tsx
+++ b/packages/commons/__tests__/hooks/useCommonsApproval.test.tsx
@@ -31,6 +31,7 @@ const SAMPLE_INFO = {
 
 interface ServiceOverrides {
   getCommonsApprovalInfo?: jest.Mock;
+  markCommonsApprovalOpened?: jest.Mock;
   approveCommonsSignIn?: jest.Mock;
   denyCommonsSignIn?: jest.Mock;
 }
@@ -38,6 +39,7 @@ interface ServiceOverrides {
 function installServices(overrides: ServiceOverrides = {}) {
   const services = {
     getCommonsApprovalInfo: jest.fn(async () => SAMPLE_INFO),
+    markCommonsApprovalOpened: jest.fn(async () => undefined),
     approveCommonsSignIn: jest.fn(async () => ({ success: true })),
     denyCommonsSignIn: jest.fn(async () => ({ success: true })),
     ...overrides,
@@ -139,6 +141,44 @@ describe('useCommonsApproval', () => {
 
     await waitFor(() => expect(result.current.state).toBe('error'));
     expect(result.current.errorMessage).toMatch(/could not be resolved/i);
+  });
+
+  it('reports the approval screen as OPENED so the waiting desktop can show progress', async () => {
+    const services = installServices();
+    const { result } = renderHook(() => useCommonsApproval('code-1', 'reason'));
+
+    await waitFor(() => expect(result.current.state).toBe('ready'));
+    expect(services.markCommonsApprovalOpened).toHaveBeenCalledWith('code-1');
+  });
+
+  it('does not report progress when there is no code to report', async () => {
+    const services = installServices();
+    renderHook(() => useCommonsApproval(undefined, 'reason'));
+
+    await waitFor(() => expect(services.getCommonsApprovalInfo).not.toHaveBeenCalled());
+    expect(services.markCommonsApprovalOpened).not.toHaveBeenCalled();
+  });
+
+  it('approves normally even when the progress signal fails', async () => {
+    // The progress line is best-effort: losing it must never cost the user the
+    // approval itself.
+    const services = installServices({
+      markCommonsApprovalOpened: jest.fn(async () => {
+        throw new Error('progress endpoint down');
+      }),
+    });
+    authenticateMock.mockResolvedValue({ success: true });
+    const { result } = renderHook(() => useCommonsApproval('code-1', 'reason'));
+
+    await waitFor(() => expect(result.current.state).toBe('ready'));
+    expect(result.current.errorMessage).toBeNull();
+
+    await act(async () => {
+      await result.current.approve();
+    });
+
+    expect(services.approveCommonsSignIn).toHaveBeenCalledWith({ authorizeCode: 'code-1' });
+    expect(result.current.state).toBe('approved');
   });
 
   it('enters the error state when the session is no longer pending', async () => {

--- a/packages/commons/__tests__/hooks/usePushRegistration.test.tsx
+++ b/packages/commons/__tests__/hooks/usePushRegistration.test.tsx
@@ -1,0 +1,147 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { __resetOxyState, __setOxyState } from '@/__mocks__/oxyhq-services';
+import { OXY_CLIENT_ID } from '@/constants/oxy';
+
+const mockHasNotificationPermission = jest.fn<Promise<boolean>, []>();
+const mockGetExpoPushToken = jest.fn<Promise<string | null>, []>();
+
+// Replace the native adapter so the REAL orchestration + Commons client-id
+// wiring runs, without loading `expo-notifications`.
+jest.mock('@/lib/notifications/device-notifications', () => ({
+  hasNotificationPermission: () => mockHasNotificationPermission(),
+  getExpoPushToken: () => mockGetExpoPushToken(),
+  pushTokenPlatform: () => 'android',
+  requestNotificationPermission: () => Promise.resolve(false),
+}));
+
+// Imported AFTER jest.mock so the hook sees the patched adapter.
+// eslint-disable-next-line import/first
+import { usePushRegistration } from '@/hooks/notifications/usePushRegistration';
+
+const EXPO_TOKEN = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]';
+
+interface PushMocks {
+  registerPushToken: jest.Mock;
+  unregisterPushToken: jest.Mock;
+}
+
+function installSession(
+  overrides: { canUsePrivateApi?: boolean; userId?: string; deviceId?: string } = {},
+): PushMocks {
+  const services: PushMocks = {
+    registerPushToken: jest.fn(async () => undefined),
+    unregisterPushToken: jest.fn(async () => undefined),
+  };
+  __setOxyState({
+    isAuthenticated: overrides.canUsePrivateApi ?? false,
+    canUsePrivateApi: overrides.canUsePrivateApi ?? false,
+    user: { id: overrides.userId ?? 'user-1', username: 'nate' },
+    oxyServices: services,
+    sessionClient: overrides.deviceId
+      ? { getState: () => ({ deviceId: overrides.deviceId ?? '' }) }
+      : null,
+  });
+  return services;
+}
+
+/**
+ * Registration is what lets a desktop "Continue with Oxy" reach this phone, so
+ * the hook's contract is entirely about NOT firing too early: a bearer-authed
+ * call before the session resolves is a guaranteed 401, and a registration
+ * without the OS permission is one the user never agreed to.
+ */
+describe('usePushRegistration', () => {
+  beforeEach(() => {
+    __resetOxyState();
+    mockHasNotificationPermission.mockReset().mockResolvedValue(true);
+    mockGetExpoPushToken.mockReset().mockResolvedValue(EXPO_TOKEN);
+  });
+
+  it('does not register before a session exists', async () => {
+    const services = installSession({ canUsePrivateApi: false });
+
+    renderHook(() => usePushRegistration());
+
+    // Give any stray async work a chance to run before asserting the negative.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(services.registerPushToken).not.toHaveBeenCalled();
+  });
+
+  it('registers once the session resolves, scoped to the Commons client id', async () => {
+    const services = installSession({ canUsePrivateApi: false });
+
+    renderHook(() => usePushRegistration());
+    expect(services.registerPushToken).not.toHaveBeenCalled();
+
+    act(() => {
+      __setOxyState({ isAuthenticated: true, canUsePrivateApi: true });
+    });
+
+    await waitFor(() => expect(services.registerPushToken).toHaveBeenCalledTimes(1));
+    expect(services.registerPushToken).toHaveBeenCalledWith({
+      expoPushToken: EXPO_TOKEN,
+      platform: 'android',
+      clientId: OXY_CLIENT_ID,
+    });
+  });
+
+  it("threads the device session's deviceId when one is available", async () => {
+    const services = installSession({ canUsePrivateApi: true, deviceId: 'device-9' });
+
+    renderHook(() => usePushRegistration());
+
+    await waitFor(() => expect(services.registerPushToken).toHaveBeenCalledTimes(1));
+    expect(services.registerPushToken).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceId: 'device-9' }),
+    );
+  });
+
+  it('does not register while the OS permission is not granted', async () => {
+    mockHasNotificationPermission.mockResolvedValue(false);
+    const services = installSession({ canUsePrivateApi: true });
+
+    renderHook(() => usePushRegistration());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(services.registerPushToken).not.toHaveBeenCalled();
+  });
+
+  it('never prompts for the permission — onboarding owns the single dialog', async () => {
+    const services = installSession({ canUsePrivateApi: true });
+
+    renderHook(() => usePushRegistration());
+
+    await waitFor(() => expect(services.registerPushToken).toHaveBeenCalledTimes(1));
+    // The adapter's request-permission entry point is not part of this path.
+    expect(mockHasNotificationPermission).toHaveBeenCalled();
+  });
+
+  it('registers at most once per identity, across re-renders', async () => {
+    const services = installSession({ canUsePrivateApi: true });
+
+    const { rerender } = renderHook(() => usePushRegistration());
+    await waitFor(() => expect(services.registerPushToken).toHaveBeenCalledTimes(1));
+
+    rerender();
+    rerender();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(services.registerPushToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a registration failure — push is a convenience, not a gate', async () => {
+    const services = installSession({ canUsePrivateApi: true });
+    services.registerPushToken.mockRejectedValue(new Error('offline'));
+
+    const { result } = renderHook(() => usePushRegistration());
+
+    await waitFor(() => expect(services.registerPushToken).toHaveBeenCalledTimes(1));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/commons/__tests__/notifications/auth-request-push.test.ts
+++ b/packages/commons/__tests__/notifications/auth-request-push.test.ts
@@ -1,0 +1,111 @@
+import {
+  authRequestCodeFromPush,
+  claimAuthRequestCode,
+  COMMONS_AUTH_REQUEST_PUSH_TYPE,
+} from '@/lib/notifications/auth-request-push';
+
+/**
+ * The "Sign in with Oxy" push payload is attacker-influencable. These tests pin
+ * the two properties that make tapping one safe:
+ *
+ *   1. NOTHING but the authorize code is ever extracted — no app name, no
+ *      origin, no message — so there is nothing from the payload a screen could
+ *      render.
+ *   2. Anything that is not a valid Commons approval link produces `null`, and
+ *      `null` means the tap is dropped without navigating anywhere.
+ */
+describe('authRequestCodeFromPush', () => {
+  const validPayload = {
+    type: COMMONS_AUTH_REQUEST_PUSH_TYPE,
+    approvalUrl: 'oxycommons://approve?v=1&code=abc123',
+  };
+
+  it('extracts the authorize code from a well-formed payload', () => {
+    expect(authRequestCodeFromPush(validPayload)).toBe('abc123');
+  });
+
+  it('accepts the alternate app scheme and the universal link', () => {
+    expect(
+      authRequestCodeFromPush({
+        type: COMMONS_AUTH_REQUEST_PUSH_TYPE,
+        approvalUrl: 'commons://approve?code=scheme-2',
+      }),
+    ).toBe('scheme-2');
+    expect(
+      authRequestCodeFromPush({
+        type: COMMONS_AUTH_REQUEST_PUSH_TYPE,
+        approvalUrl: 'https://commons.oxy.so/approve?code=universal',
+      }),
+    ).toBe('universal');
+  });
+
+  it('returns ONLY the code — never any other field carried in the payload', () => {
+    const result = authRequestCodeFromPush({
+      ...validPayload,
+      approvalUrl:
+        'oxycommons://approve?v=1&code=abc123&app=Evil%20Bank&origin=https%3A%2F%2Fevil.example&title=Approve%20now',
+      appName: 'Evil Bank',
+      body: 'Tap to approve',
+    });
+
+    expect(result).toBe('abc123');
+    expect(typeof result).toBe('string');
+  });
+
+  it.each([
+    ['a foreign scheme', 'evil://approve?code=abc123'],
+    ['a look-alike host', 'https://commons.oxy.so.evil.example/approve?code=abc123'],
+    ['an http universal link', 'http://commons.oxy.so/approve?code=abc123'],
+    ['a different Commons route', 'oxycommons://attest?subject=did:web:oxy.so:u:1'],
+    ['a missing code', 'oxycommons://approve?v=1'],
+    ['an empty code', 'oxycommons://approve?code='],
+    ['a bare string', 'abc123'],
+    ['an empty string', ''],
+  ])('drops %s', (_label, approvalUrl) => {
+    expect(
+      authRequestCodeFromPush({ type: COMMONS_AUTH_REQUEST_PUSH_TYPE, approvalUrl }),
+    ).toBeNull();
+  });
+
+  it('drops an already-expired approval link', () => {
+    expect(
+      authRequestCodeFromPush({
+        type: COMMONS_AUTH_REQUEST_PUSH_TYPE,
+        approvalUrl: `oxycommons://approve?code=stale&exp=${Date.now() - 60_000}`,
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['a foreign notification type', { type: 'marketing', approvalUrl: validPayload.approvalUrl }],
+    ['a missing type', { approvalUrl: validPayload.approvalUrl }],
+    ['a non-string approvalUrl', { type: COMMONS_AUTH_REQUEST_PUSH_TYPE, approvalUrl: 42 }],
+    ['a missing approvalUrl', { type: COMMONS_AUTH_REQUEST_PUSH_TYPE }],
+  ])('drops %s', (_label, payload) => {
+    expect(authRequestCodeFromPush(payload)).toBeNull();
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'oxycommons://approve?code=abc123'],
+    ['a number', 7],
+    ['an array', [{ type: COMMONS_AUTH_REQUEST_PUSH_TYPE, approvalUrl: 'oxycommons://approve?code=x' }]],
+  ])('drops a payload that is %s', (_label, payload) => {
+    expect(authRequestCodeFromPush(payload)).toBeNull();
+  });
+});
+
+describe('claimAuthRequestCode', () => {
+  it('lets exactly one caller own a code per app session', () => {
+    expect(claimAuthRequestCode('single-use-1')).toBe(true);
+    expect(claimAuthRequestCode('single-use-1')).toBe(false);
+    expect(claimAuthRequestCode('single-use-1')).toBe(false);
+  });
+
+  it('tracks codes independently', () => {
+    expect(claimAuthRequestCode('single-use-2')).toBe(true);
+    expect(claimAuthRequestCode('single-use-3')).toBe(true);
+    expect(claimAuthRequestCode('single-use-2')).toBe(false);
+  });
+});

--- a/packages/commons/__tests__/notifications/device-notifications.test.ts
+++ b/packages/commons/__tests__/notifications/device-notifications.test.ts
@@ -1,0 +1,191 @@
+import { Platform } from 'react-native';
+
+/**
+ * `expo-notifications` is stubbed so the adapter's real logic runs against a
+ * controllable module. The single most important assertion in this file is that
+ * `getDevicePushTokenAsync` is NEVER called: a raw APNs/FCM token registers
+ * "successfully" and then silently fails at delivery forever, so the only way to
+ * make that class of bug impossible is to never obtain one.
+ */
+jest.mock(
+  'expo-notifications',
+  () => ({
+    __esModule: true,
+    getPermissionsAsync: jest.fn(),
+    requestPermissionsAsync: jest.fn(),
+    getExpoPushTokenAsync: jest.fn(),
+    getDevicePushTokenAsync: jest.fn(),
+    getLastNotificationResponse: jest.fn(),
+    clearLastNotificationResponse: jest.fn(),
+    addNotificationResponseReceivedListener: jest.fn(),
+  }),
+  { virtual: true },
+);
+
+interface NotificationsStub {
+  getPermissionsAsync: jest.Mock;
+  requestPermissionsAsync: jest.Mock;
+  getExpoPushTokenAsync: jest.Mock;
+  getDevicePushTokenAsync: jest.Mock;
+  getLastNotificationResponse: jest.Mock;
+  clearLastNotificationResponse: jest.Mock;
+  addNotificationResponseReceivedListener: jest.Mock;
+}
+
+const notifications = jest.requireMock('expo-notifications') as NotificationsStub;
+
+// eslint-disable-next-line import/first
+import {
+  getExpoPushToken,
+  hasNotificationPermission,
+  pushTokenPlatform,
+  requestNotificationPermission,
+  subscribeToNotificationResponses,
+  takeLaunchNotificationData,
+} from '@/lib/notifications/device-notifications';
+
+const EXPO_TOKEN = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]';
+const RAW_DEVICE_TOKEN = '740f4707bebcf74f9b7c25d48e3358945f6aa01da5ddb387462c7eaf61bb78ad';
+
+function notificationResponse(data: unknown) {
+  return { notification: { request: { content: { data } } } };
+}
+
+describe('device notifications adapter', () => {
+  const originalOS = Platform.OS;
+
+  beforeEach(() => {
+    Platform.OS = 'ios';
+    notifications.getPermissionsAsync.mockReset();
+    notifications.requestPermissionsAsync.mockReset();
+    notifications.getExpoPushTokenAsync.mockReset();
+    notifications.getDevicePushTokenAsync.mockReset();
+    notifications.getLastNotificationResponse.mockReset();
+    notifications.clearLastNotificationResponse.mockReset();
+    notifications.addNotificationResponseReceivedListener.mockReset();
+
+    notifications.getPermissionsAsync.mockResolvedValue({ granted: true, status: 'granted' });
+    notifications.requestPermissionsAsync.mockResolvedValue({ granted: true, status: 'granted' });
+    notifications.getExpoPushTokenAsync.mockResolvedValue({ type: 'expo', data: EXPO_TOKEN });
+    notifications.getDevicePushTokenAsync.mockResolvedValue({ type: 'apns', data: RAW_DEVICE_TOKEN });
+    notifications.getLastNotificationResponse.mockReturnValue(null);
+    notifications.addNotificationResponseReceivedListener.mockReturnValue({ remove: jest.fn() });
+  });
+
+  afterEach(() => {
+    Platform.OS = originalOS;
+  });
+
+  describe('getExpoPushToken', () => {
+    it('mints an EXPO push token and never touches the raw device token', async () => {
+      await expect(getExpoPushToken()).resolves.toBe(EXPO_TOKEN);
+
+      expect(notifications.getExpoPushTokenAsync).toHaveBeenCalledTimes(1);
+      expect(notifications.getDevicePushTokenAsync).not.toHaveBeenCalled();
+    });
+
+    it('resolves null (never a partial/garbage token) when the mint fails', async () => {
+      notifications.getExpoPushTokenAsync.mockRejectedValue(new Error('no EAS projectId'));
+
+      await expect(getExpoPushToken()).resolves.toBeNull();
+    });
+
+    it('resolves null for an empty token', async () => {
+      notifications.getExpoPushTokenAsync.mockResolvedValue({ type: 'expo', data: '' });
+
+      await expect(getExpoPushToken()).resolves.toBeNull();
+    });
+  });
+
+  describe('permissions', () => {
+    it('checks the permission without ever prompting', async () => {
+      await expect(hasNotificationPermission()).resolves.toBe(true);
+
+      expect(notifications.getPermissionsAsync).toHaveBeenCalledTimes(1);
+      expect(notifications.requestPermissionsAsync).not.toHaveBeenCalled();
+    });
+
+    it('reports a denied permission as not granted', async () => {
+      notifications.getPermissionsAsync.mockResolvedValue({ granted: false, status: 'denied' });
+
+      await expect(hasNotificationPermission()).resolves.toBe(false);
+    });
+
+    it('does not show a second system dialog when already granted', async () => {
+      await expect(requestNotificationPermission()).resolves.toBe(true);
+
+      expect(notifications.requestPermissionsAsync).not.toHaveBeenCalled();
+    });
+
+    it('prompts exactly once when the permission is undetermined', async () => {
+      notifications.getPermissionsAsync.mockResolvedValue({
+        granted: false,
+        status: 'undetermined',
+      });
+
+      await expect(requestNotificationPermission()).resolves.toBe(true);
+
+      expect(notifications.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('takeLaunchNotificationData', () => {
+    it('returns the launching payload and clears it so it cannot be handled twice', async () => {
+      const data = { type: 'oxy_commons_auth_request', approvalUrl: 'oxycommons://approve?code=a' };
+      notifications.getLastNotificationResponse.mockReturnValue(notificationResponse(data));
+
+      await expect(takeLaunchNotificationData()).resolves.toEqual(data);
+      expect(notifications.clearLastNotificationResponse).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when no notification launched the app', async () => {
+      await expect(takeLaunchNotificationData()).resolves.toBeNull();
+      expect(notifications.clearLastNotificationResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('subscribeToNotificationResponses', () => {
+    it('forwards the raw payload of a tapped notification and unsubscribes cleanly', async () => {
+      const remove = jest.fn();
+      notifications.addNotificationResponseReceivedListener.mockReturnValue({ remove });
+      const received: unknown[] = [];
+
+      const unsubscribe = await subscribeToNotificationResponses((data) => received.push(data));
+
+      const [listener] = notifications.addNotificationResponseReceivedListener.mock.calls[0] as [
+        (response: ReturnType<typeof notificationResponse>) => void,
+      ];
+      listener(notificationResponse({ type: 'oxy_commons_auth_request' }));
+
+      expect(received).toEqual([{ type: 'oxy_commons_auth_request' }]);
+
+      unsubscribe();
+      expect(remove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('platform gating', () => {
+    it('maps the running platform to the registry tag', () => {
+      Platform.OS = 'ios';
+      expect(pushTokenPlatform()).toBe('ios');
+      Platform.OS = 'android';
+      expect(pushTokenPlatform()).toBe('android');
+      Platform.OS = 'macos';
+      expect(pushTokenPlatform()).toBeNull();
+    });
+
+    it('never loads the native module on web', async () => {
+      Platform.OS = 'web';
+
+      await expect(hasNotificationPermission()).resolves.toBe(false);
+      await expect(getExpoPushToken()).resolves.toBeNull();
+      await expect(takeLaunchNotificationData()).resolves.toBeNull();
+      const unsubscribe = await subscribeToNotificationResponses(() => undefined);
+      unsubscribe();
+
+      expect(notifications.getPermissionsAsync).not.toHaveBeenCalled();
+      expect(notifications.getExpoPushTokenAsync).not.toHaveBeenCalled();
+      expect(notifications.addNotificationResponseReceivedListener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/commons/__tests__/notifications/push-registration.test.ts
+++ b/packages/commons/__tests__/notifications/push-registration.test.ts
@@ -1,0 +1,153 @@
+import type { PushTokenPlatform, RegisterPushTokenInput } from '@oxyhq/core';
+import {
+  registerInstallationPushToken,
+  retireInstallationPushToken,
+  type PushTokenEnvironment,
+  type PushTokenRegistry,
+} from '@/lib/notifications/push-registration';
+
+/**
+ * Push registration is what makes "Continue with Oxy" on a desktop able to WAKE
+ * the vault instead of falling back to a QR — so the contract that matters is
+ * what is allowed to leave the device, and when.
+ *
+ * The orchestration takes every side effect as an injected collaborator, so the
+ * rules below are asserted without a device, a permission dialog, or a network.
+ */
+const EXPO_TOKEN = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]';
+/** What `getDevicePushTokenAsync()` yields — an APNs token. NEVER registrable. */
+const RAW_DEVICE_TOKEN = '740f4707bebcf74f9b7c25d48e3358945f6aa01da5ddb387462c7eaf61bb78ad';
+
+function makeRegistry(): PushTokenRegistry & {
+  registerPushToken: jest.Mock<Promise<void>, [RegisterPushTokenInput]>;
+  unregisterPushToken: jest.Mock<Promise<void>, [string]>;
+} {
+  return {
+    registerPushToken: jest.fn<Promise<void>, [RegisterPushTokenInput]>(async () => undefined),
+    unregisterPushToken: jest.fn<Promise<void>, [string]>(async () => undefined),
+  };
+}
+
+function makeEnvironment(overrides: Partial<PushTokenEnvironment> = {}): PushTokenEnvironment {
+  return {
+    hasNotificationPermission: jest.fn<Promise<boolean>, []>(async () => true),
+    getExpoPushToken: jest.fn<Promise<string | null>, []>(async () => EXPO_TOKEN),
+    pushTokenPlatform: jest.fn<PushTokenPlatform | null, []>(() => 'android'),
+    ...overrides,
+  };
+}
+
+const OPTIONS = { clientId: 'oxy_dk_commons', deviceId: 'device-1' };
+
+describe('registerInstallationPushToken', () => {
+  it('registers the Expo push token, scoped to the calling application', async () => {
+    const registry = makeRegistry();
+
+    const outcome = await registerInstallationPushToken(registry, makeEnvironment(), OPTIONS);
+
+    expect(outcome).toEqual({ status: 'registered', expoPushToken: EXPO_TOKEN });
+    expect(registry.registerPushToken).toHaveBeenCalledTimes(1);
+    expect(registry.registerPushToken).toHaveBeenCalledWith({
+      expoPushToken: EXPO_TOKEN,
+      platform: 'android',
+      clientId: OPTIONS.clientId,
+      deviceId: OPTIONS.deviceId,
+    });
+  });
+
+  it('omits deviceId entirely when the device session has not resolved one', async () => {
+    const registry = makeRegistry();
+
+    await registerInstallationPushToken(registry, makeEnvironment(), {
+      clientId: OPTIONS.clientId,
+    });
+
+    expect(registry.registerPushToken).toHaveBeenCalledWith({
+      expoPushToken: EXPO_TOKEN,
+      platform: 'android',
+      clientId: OPTIONS.clientId,
+    });
+  });
+
+  it('sends an Expo push token — never a raw APNs/FCM device token', async () => {
+    const registry = makeRegistry();
+
+    await registerInstallationPushToken(registry, makeEnvironment(), OPTIONS);
+
+    const [input] = registry.registerPushToken.mock.calls[0];
+    expect(input.expoPushToken).toMatch(/^Expo(nent)?PushToken\[.+\]$/);
+    expect(input.expoPushToken).not.toBe(RAW_DEVICE_TOKEN);
+  });
+
+  it('waits for the OS permission — nothing is sent while it is not granted', async () => {
+    const registry = makeRegistry();
+    const environment = makeEnvironment({
+      hasNotificationPermission: jest.fn<Promise<boolean>, []>(async () => false),
+    });
+
+    const outcome = await registerInstallationPushToken(registry, environment, OPTIONS);
+
+    expect(outcome).toEqual({ status: 'skipped', reason: 'permission-not-granted' });
+    expect(registry.registerPushToken).not.toHaveBeenCalled();
+    // A token is not even minted without permission.
+    expect(environment.getExpoPushToken).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing when no token can be minted', async () => {
+    const registry = makeRegistry();
+
+    const outcome = await registerInstallationPushToken(
+      registry,
+      makeEnvironment({ getExpoPushToken: jest.fn<Promise<string | null>, []>(async () => null) }),
+      OPTIONS,
+    );
+
+    expect(outcome).toEqual({ status: 'skipped', reason: 'no-token' });
+    expect(registry.registerPushToken).not.toHaveBeenCalled();
+  });
+
+  it('sends nothing on a platform Oxy does not deliver push to', async () => {
+    const registry = makeRegistry();
+    const environment = makeEnvironment({
+      pushTokenPlatform: jest.fn<PushTokenPlatform | null, []>(() => null),
+    });
+
+    const outcome = await registerInstallationPushToken(registry, environment, OPTIONS);
+
+    expect(outcome).toEqual({ status: 'skipped', reason: 'unsupported-platform' });
+    expect(registry.registerPushToken).not.toHaveBeenCalled();
+    expect(environment.hasNotificationPermission).not.toHaveBeenCalled();
+  });
+
+  it('propagates a registry rejection so the caller can log it', async () => {
+    const registry = makeRegistry();
+    registry.registerPushToken.mockRejectedValue(new Error('registerPushToken expects an Expo push token'));
+
+    await expect(
+      registerInstallationPushToken(registry, makeEnvironment(), OPTIONS),
+    ).rejects.toThrow(/Expo push token/);
+  });
+});
+
+describe('retireInstallationPushToken', () => {
+  it("retires this installation's token", async () => {
+    const registry = makeRegistry();
+
+    const outcome = await retireInstallationPushToken(registry, makeEnvironment());
+
+    expect(outcome).toEqual({ status: 'retired', expoPushToken: EXPO_TOKEN });
+    expect(registry.unregisterPushToken).toHaveBeenCalledWith(EXPO_TOKEN);
+  });
+
+  it('does nothing when there is no token to retire', async () => {
+    const registry = makeRegistry();
+
+    const outcome = await retireInstallationPushToken(
+      registry,
+      makeEnvironment({ getExpoPushToken: jest.fn<Promise<string | null>, []>(async () => null) }),
+    );
+
+    expect(outcome).toEqual({ status: 'skipped', reason: 'no-token' });
+    expect(registry.unregisterPushToken).not.toHaveBeenCalled();
+  });
+});

--- a/packages/commons/app/(tabs)/(settings)/delete-account.tsx
+++ b/packages/commons/app/(tabs)/(settings)/delete-account.tsx
@@ -13,6 +13,7 @@ import { alert, toast } from '@oxyhq/bloom';
 import { KeyManager } from '@oxyhq/core';
 import { useTranslation } from '@/lib/i18n';
 import { runAccountDeletion } from '@/lib/account/delete-account-flow';
+import { retireVaultPushToken } from '@/lib/notifications/push-registration';
 import { ONBOARDING_IDENTITY_QUERY_KEY, ONBOARDING_COMPLETE_QUERY_KEY, ONBOARDING_FLOW_QUERY_KEY } from '@/hooks/useOnboardingStatus';
 import { persistOnboardingComplete, persistOnboardingFlow } from '@/hooks/identity/identityStore';
 
@@ -65,11 +66,16 @@ export default function DeleteAccountScreen() {
         return;
       }
 
-      // Server-side delete → purge the local identity (primary + backup) →
-      // sign out. The purge runs ONLY after the server confirms deletion, so a
-      // failed delete never strands the user without their keys. See
-      // `runAccountDeletion` for the full ordering/safety contract.
+      // Retire the push token (bearer still valid) → server-side delete → purge
+      // the local identity (primary + backup) → sign out. The purge runs ONLY
+      // after the server confirms deletion, so a failed delete never strands the
+      // user without their keys. See `runAccountDeletion` for the full
+      // ordering/safety contract.
       const { localIdentityPurged } = await runAccountDeletion(confirmText, {
+        // Must precede the delete: the registry scopes the retirement to the
+        // authenticated identity, so this device would otherwise keep a live
+        // registration for the account being destroyed.
+        retirePushToken: () => retireVaultPushToken(oxyServices),
         deleteAccount: (text) => oxyServices.deleteAccount(text),
         // skipBackup=true (no point backing up keys for a deleted account),
         // force=true (also purges the backup slot, no re-prompt), and

--- a/packages/commons/app/_layout.tsx
+++ b/packages/commons/app/_layout.tsx
@@ -35,6 +35,11 @@ import {
 import { LocaleProvider, useTranslation } from '@/lib/i18n';
 import { MinimalErrorFallback } from '@/components/error-fallback';
 import { OXY_CLIENT_ID } from '@/constants/oxy';
+import { usePushRegistration } from '@/hooks/notifications/usePushRegistration';
+import {
+  coldLaunchApprovalCode,
+  useAuthRequestNotifications,
+} from '@/hooks/notifications/useAuthRequestNotifications';
 import {
   preventNativeSplashAutoHide,
   useHideNativeSplashWhenReady,
@@ -120,6 +125,39 @@ function scanTargetFromColdLaunch(url: string): ScanReplayHref | null {
   return segment === 'approve'
     ? { pathname: '/approve', params }
     : { pathname: '/(scan)/attest', params };
+}
+
+/**
+ * The cold-launch handoff target, from EITHER source that can start Commons
+ * with an intent: a system deep link, or a tapped "Sign in with Oxy" push
+ * (issue #691, Phase 4).
+ *
+ * One resolver feeding the ONE replay below, so the push path inherits the
+ * "wait until the routing gate settles, then navigate exactly once" behavior
+ * instead of growing a parallel mechanism. The deep link wins when both are
+ * present: it is the more specific intent (it can also address `attest`), and
+ * the push only ever carries an approval code the link form already covers.
+ *
+ * Never rejects — both sources swallow their own failures — so the replay's
+ * readiness flag always flips.
+ */
+async function resolveColdLaunchTarget(): Promise<ScanReplayHref | null> {
+  let url: string | null = null;
+  try {
+    url = await Linking.getInitialURL();
+  } catch (error) {
+    logger.warn('[commons] cold-launch deep link could not be read', {
+      component: 'AppStackContent',
+    }, error);
+  }
+
+  const fromDeepLink = url ? scanTargetFromColdLaunch(url) : null;
+  if (fromDeepLink) {
+    return fromDeepLink;
+  }
+
+  const code = await coldLaunchApprovalCode();
+  return code ? { pathname: '/approve', params: { code } } : null;
 }
 
 export default function RootLayout() {
@@ -303,30 +341,35 @@ function AppStackContent() {
   const splashReady = appReady || fallbackElapsed;
   useHideNativeSplashWhenReady(splashReady);
 
-  // ── Cold-start `(scan)` deep-link replay ───────────────────────────────────
+  // ── Cold-start handoff replay (deep link OR tapped auth-request push) ──────
   // On a warm start the `(scan)` redirect gate is already resolved, so an
   // `oxycommons://approve|attest` link routes straight through. On a COLD start
   // the gate is `needsAuth === true` while `status === 'checking'`, so the root
   // Stack bounces `(scan)` → `(auth)` and the incoming intent is discarded once
-  // the gate settles. We capture the cold-launch URL once, then — after the gate
-  // has resolved to an authenticated device — `router.replace()` to it exactly
-  // once. If the gate instead resolves to `needsAuth` (no local identity), we
-  // drop the intent and let the normal onboarding flow proceed.
+  // the gate settles. We capture the cold-launch target once, then — after the
+  // gate has resolved to an authenticated device — `router.replace()` to it
+  // exactly once. If the gate instead resolves to `needsAuth` (no local
+  // identity), we drop the intent and let the normal onboarding flow proceed.
   //
-  // `getInitialURL()` is cold-launch-only. Capturing into a ref + a resolved
-  // flag (state) makes the replay race-free: it fires only once BOTH the initial
-  // URL has been read AND the gate has settled, guarded by a ref so later
-  // renders never re-navigate.
+  // `resolveColdLaunchTarget()` is cold-launch-only and covers BOTH intent
+  // sources (see its doc). Capturing into a ref + a resolved flag (state) makes
+  // the replay race-free: it fires only once BOTH the launch target has been
+  // read AND the gate has settled, guarded by a ref so later renders never
+  // re-navigate.
   const pendingScanTargetRef = useRef<ScanReplayHref | null>(null);
   const scanReplayDoneRef = useRef(false);
   const [initialUrlResolved, setInitialUrlResolved] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    void Linking.getInitialURL()
-      .then((url) => {
-        if (cancelled) return;
-        pendingScanTargetRef.current = url ? scanTargetFromColdLaunch(url) : null;
+    void resolveColdLaunchTarget()
+      .then((target) => {
+        if (!cancelled) pendingScanTargetRef.current = target;
+      })
+      .catch((error: unknown) => {
+        logger.error('[commons] cold-launch handoff resolution failed', error, {
+          component: 'AppStackContent',
+        });
       })
       .finally(() => {
         if (!cancelled) setInitialUrlResolved(true);
@@ -339,7 +382,7 @@ function AppStackContent() {
   useEffect(() => {
     if (scanReplayDoneRef.current) return;
     if (!initialUrlResolved || !splashReady) return;
-    // Both the captured URL and the routing gate are now settled — act once.
+    // Both the captured target and the routing gate are now settled — act once.
     scanReplayDoneRef.current = true;
     const target = pendingScanTargetRef.current;
     pendingScanTargetRef.current = null;
@@ -347,6 +390,17 @@ function AppStackContent() {
       router.replace(target);
     }
   }, [initialUrlResolved, splashReady, needsAuth]);
+
+  // Keep this installation reachable by push for the signed-in vault identity,
+  // so "Continue with Oxy" on a desktop can wake the phone instead of falling
+  // back to a QR. No-ops until a session + the OS permission both exist.
+  usePushRegistration();
+
+  // Warm auth-request pushes. Gated on the SAME settled signal the replay uses:
+  // before that, `/approve` would be bounced by the `needsAuth` guard, and the
+  // cold-launch path (which has already claimed the launching tap's code by the
+  // time `initialUrlResolved` flips) owns that window.
+  useAuthRequestNotifications(initialUrlResolved && splashReady && !needsAuth);
 
   return (
     <SafeAreaProvider>

--- a/packages/commons/hooks/auth/useAuthHandlers.ts
+++ b/packages/commons/hooks/auth/useAuthHandlers.ts
@@ -2,10 +2,12 @@ import { useState, useCallback } from 'react';
 import { useRouter } from 'expo-router';
 import Constants from 'expo-constants';
 import type { OxyServices, User } from '@oxyhq/core';
-import { KeyManager } from '@oxyhq/core';
+import { KeyManager, logger } from '@oxyhq/core';
 import { useAuthStore, useUpdateProfile } from '@oxyhq/services';
 import { checkIfOffline } from '@/utils/auth/networkUtils';
 import { isNetworkOrTimeoutError, extractAuthErrorMessage, handleAuthError } from '@/utils/auth/errorUtils';
+import { requestNotificationPermission } from '@/lib/notifications/device-notifications';
+import { registerVaultPushToken } from '@/lib/notifications/push-registration';
 import { STORE_UPDATE_DELAY_MS } from '@/constants/auth';
 import { useTranslation } from '@/lib/i18n';
 
@@ -213,8 +215,15 @@ export function useAuthHandlers({
   }, [completeSignIn]);
 
   /**
-   * Handle notification permission request and complete onboarding
-   * User should already be authenticated at this point
+   * Handle the notification permission request and complete onboarding.
+   * The user is authenticated by this point (we sign in first if not).
+   *
+   * This is the ONE place Commons prompts for notifications, and it is also
+   * where a fresh grant is turned into a real push registration: without a
+   * registered Expo push token the platform cannot wake this vault, so
+   * "Continue with Oxy" on a desktop would have no way to reach the phone
+   * (issue #691, Phase 4). The root-level `usePushRegistration` re-checks on
+   * every later cold boot — it never prompts, so the user is never asked twice.
    */
   const handleRequestNotifications = useCallback(async () => {
     if (!isAuthenticated) {
@@ -224,32 +233,36 @@ export function useAuthHandlers({
       }
     }
 
+    // Push notifications don't exist in Expo Go (SDK 53+) — skip straight to
+    // the vault rather than prompting for a permission that buys nothing.
     if (isExpoGo()) {
       router.push('/(tabs)/(id)');
       return;
     }
 
+    setIsRequestingNotifications(true);
+    setAuthError(null);
     try {
-      setIsRequestingNotifications(true);
-      setAuthError(null);
-
-      const Notifications: typeof import('expo-notifications') = await import('expo-notifications');
-      const { status: existingStatus } = await Notifications.getPermissionsAsync();
-
-      if (existingStatus === 'granted') {
-        router.push('/(tabs)/(id)');
-        return;
+      // Short-circuits when already granted, so a resumed onboarding shows at
+      // most one system dialog.
+      const granted = await requestNotificationPermission();
+      if (granted && oxyServices) {
+        // Fire-and-forget: a failed registration costs the user the push
+        // convenience, never their onboarding. The QR handoff still works.
+        void registerVaultPushToken(oxyServices).catch((error: unknown) => {
+          logger.warn(
+            '[commons] onboarding push token registration failed',
+            { component: 'useAuthHandlers' },
+            error,
+          );
+        });
       }
-
-      await Notifications.requestPermissionsAsync();
-      router.push('/(tabs)/(id)');
-    } catch (err: unknown) {
-      handleAuthError(err, 'requestNotifications');
-      router.push('/(tabs)/(id)');
     } finally {
       setIsRequestingNotifications(false);
     }
-  }, [isAuthenticated, router, setAuthError, completeSignIn]);
+
+    router.push('/(tabs)/(id)');
+  }, [isAuthenticated, router, setAuthError, completeSignIn, oxyServices]);
 
   return {
     handleSignIn,

--- a/packages/commons/hooks/commons-signin/useCommonsApproval.ts
+++ b/packages/commons/hooks/commons-signin/useCommonsApproval.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useOxy } from '@oxyhq/services';
-import { getCommonsApprovalBlockingReason, type CommonsApprovalInfo } from '@oxyhq/core';
+import { getCommonsApprovalBlockingReason, logger, type CommonsApprovalInfo } from '@oxyhq/core';
 import { authenticate } from '@/lib/biometricAuth';
 
 /**
@@ -76,6 +76,21 @@ export function useCommonsApproval(
     let cancelled = false;
     setState('loading');
     setErrorMessage(null);
+
+    // Progress-only signal so the waiting relying party can show "Opened in
+    // Commons" the moment the user actually lands here (issue #691, Phase 4).
+    // It never approves and never advances the authorization state machine, so
+    // it is fired alongside — never before or instead of — the identity fetch,
+    // is never awaited, and a rejection is logged and otherwise ignored: a
+    // missed progress line must never cost the user their approval.
+    void oxyServices.markCommonsApprovalOpened(code).catch((error: unknown) => {
+      logger.warn(
+        '[commons] could not report the approval screen as opened',
+        { component: 'useCommonsApproval' },
+        error,
+      );
+    });
+
     oxyServices
       .getCommonsApprovalInfo(code)
       .then((result) => {

--- a/packages/commons/hooks/notifications/useAuthRequestNotifications.ts
+++ b/packages/commons/hooks/notifications/useAuthRequestNotifications.ts
@@ -1,0 +1,85 @@
+import { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import { logger } from '@oxyhq/core';
+import {
+  authRequestCodeFromPush,
+  claimAuthRequestCode,
+} from '@/lib/notifications/auth-request-push';
+import {
+  subscribeToNotificationResponses,
+  takeLaunchNotificationData,
+} from '@/lib/notifications/device-notifications';
+
+const LOG_CONTEXT = { component: 'useAuthRequestNotifications' } as const;
+
+/**
+ * Resolve the approval code carried by the notification that COLD-LAUNCHED the
+ * app, claiming it so the warm listener cannot route the same tap twice.
+ *
+ * Deliberately a plain async function, not a hook: the cold-launch handoff is
+ * replayed by the ONE existing replay path in `app/_layout.tsx` (which also
+ * owns `Linking.getInitialURL()` and the "wait until the routing gate settles"
+ * logic). A push tap is just another source feeding that path — never a second
+ * replay mechanism.
+ *
+ * Never rejects: a launch that carries no notification, an unavailable native
+ * module, or an unparseable payload all resolve to `null`.
+ */
+export async function coldLaunchApprovalCode(): Promise<string | null> {
+  const data = await takeLaunchNotificationData();
+  const code = authRequestCodeFromPush(data);
+  if (!code) {
+    return null;
+  }
+  return claimAuthRequestCode(code) ? code : null;
+}
+
+/**
+ * Route a tapped "Sign in with Oxy" push to the EXISTING approval screen.
+ *
+ * SECURITY: tapping can only OPEN `/approve` with the code. It never approves —
+ * approval still requires the biometric gate plus the on-device identity
+ * signature — and nothing from the payload is passed along or rendered: the
+ * approval screen re-resolves the requesting application server-side from the
+ * code alone. A payload that is not a valid Commons auth request is dropped
+ * silently and navigates nowhere.
+ *
+ * @param enabled - Gate the subscription on the router being ready to accept
+ *   the navigation. While the root Stack is still resolving its `(auth)` /
+ *   `(tabs)` decision it bounces `/approve`, which would silently swallow the
+ *   tap; the cold-launch replay in `app/_layout.tsx` owns that window instead.
+ *   Passing the SAME resolved signal guarantees the cold-launch code has been
+ *   claimed before this listener can act on a replayed launching tap.
+ */
+export function useAuthRequestNotifications(enabled: boolean): void {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let unsubscribe: (() => void) | null = null;
+
+    void subscribeToNotificationResponses((data) => {
+      const code = authRequestCodeFromPush(data);
+      if (!code || !claimAuthRequestCode(code)) return;
+      // ONLY the code travels to the route — no payload strings, ever.
+      router.push({ pathname: '/approve', params: { code } });
+    })
+      .then((off) => {
+        if (cancelled) {
+          off();
+          return;
+        }
+        unsubscribe = off;
+      })
+      .catch((error: unknown) => {
+        logger.warn('[commons] could not listen for auth-request pushes', LOG_CONTEXT, error);
+      });
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [enabled, router]);
+}

--- a/packages/commons/hooks/notifications/usePushRegistration.ts
+++ b/packages/commons/hooks/notifications/usePushRegistration.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import { useOxy } from '@oxyhq/services';
+import { logger } from '@oxyhq/core';
+import { registerVaultPushToken } from '@/lib/notifications/push-registration';
+
+const LOG_CONTEXT = { component: 'usePushRegistration' } as const;
+
+/**
+ * Keeps this installation reachable by the platform for the signed-in vault
+ * identity (issue #691, Phase 4).
+ *
+ * Mounted ONCE, at the root, inside `OxyProvider`. It is deliberately a
+ * side-effect-only hook: there is no derived state a screen could read, and
+ * nothing here belongs on the render path.
+ *
+ * ── Preconditions (both are hard, not hints) ───────────────────────────────
+ *   - A SESSION: `registerPushToken` is bearer-authed, so we wait for
+ *     `canUsePrivateApi` (the SDK's own "a usable bearer is planted" verdict)
+ *     rather than racing the device-first cold boot with a doomed 401.
+ *   - PERMISSION: checked, never requested. Onboarding owns the single system
+ *     prompt (`useAuthHandlers`), which registers immediately on a fresh grant;
+ *     this hook covers every subsequent cold boot without re-asking.
+ *
+ * ── Retirement is NOT done here, on purpose ────────────────────────────────
+ * `DELETE /notifications/push-token` is scoped to the identity holding the
+ * bearer, so a token can only be retired WHILE its own session is alive. By the
+ * time this hook could observe a sign-out or an identity swap, that bearer is
+ * already gone and the call would delete the wrong row (or nothing). Retirement
+ * therefore lives at the one place Commons deliberately gives up a vault
+ * identity — the account-deletion sequence, which retires as its FIRST step
+ * (`runAccountDeletion`). See `retireInstallationPushToken`.
+ */
+export function usePushRegistration(): void {
+  const { canUsePrivateApi, user, oxyServices, sessionClient } = useOxy();
+  const userId = user?.id ?? null;
+
+  /**
+   * The identity this hook has already attempted a registration for, so a
+   * re-render (or a `canUsePrivateApi` flicker across a token refresh) cannot
+   * turn a one-shot registration into a request loop. Reset on failure so a
+   * later dependency change may retry.
+   */
+  const attemptedForRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!canUsePrivateApi || !userId) return;
+    if (attemptedForRef.current === userId) return;
+    attemptedForRef.current = userId;
+
+    void (async () => {
+      try {
+        const outcome = await registerVaultPushToken(
+          oxyServices,
+          sessionClient?.getState()?.deviceId,
+        );
+        if (outcome.status === 'skipped') {
+          // An expected steady state (permission declined, no EAS project id,
+          // an unsupported platform) — diagnostic, not operational.
+          logger.debug('[commons] push registration skipped', {
+            ...LOG_CONTEXT,
+            reason: outcome.reason,
+          });
+        }
+      } catch (error) {
+        // Best-effort by design: a vault that cannot be woken by push still
+        // approves sign-ins by QR. Clear the marker so a later session/device
+        // change can retry.
+        attemptedForRef.current = null;
+        logger.warn('[commons] push token registration failed', LOG_CONTEXT, error);
+      }
+    })();
+  }, [canUsePrivateApi, userId, oxyServices, sessionClient]);
+}

--- a/packages/commons/lib/account/delete-account-flow.ts
+++ b/packages/commons/lib/account/delete-account-flow.ts
@@ -2,8 +2,11 @@
  * Account-deletion sequence (identity-safety critical).
  *
  * Encapsulates the exact ordering required to delete an Oxy account without
- * leaving "zombie" key material on the device:
+ * leaving "zombie" key material — or a "zombie" push registration — on the
+ * device:
  *
+ *   0. Retire this installation's push token, while the outgoing identity's
+ *      bearer is still valid.
  *   1. Delete the account server-side (signed request).
  *   2. ONLY if (1) succeeded — purge the local identity key AND its backup.
  *   3. Sign out of all local sessions.
@@ -13,6 +16,16 @@
  * native screen or mocking the entire UI tree. The screen is a thin caller.
  *
  * INVARIANTS (enforced + tested):
+ *   - `retirePushToken` runs **first**, before the account is deleted and long
+ *     before sign-out. `DELETE /notifications/push-token` is scoped to the
+ *     identity holding the bearer, so this is the only moment at which the
+ *     outgoing identity's registration can actually be removed. Retiring it
+ *     later (or after the vault has been re-onboarded with a different
+ *     identity) would delete the wrong row and leave this device woken by
+ *     sign-in requests for an identity it no longer holds.
+ *   - A `retirePushToken` failure is **non-fatal** and never blocks deletion —
+ *     an unreachable push registry must not trap a user who wants their account
+ *     gone. Deleting the account also makes the stale row undeliverable.
  *   - The local identity is purged **only** inside the success branch of the
  *     server delete. If the server delete throws/rejects, `purgeIdentity` is
  *     NEVER called — the user keeps the keys for an account that still exists.
@@ -33,6 +46,12 @@ import { logger } from '@oxyhq/core';
  * native modules, and so the screen wires in the live SDK / KeyManager.
  */
 export interface AccountDeletionDeps {
+  /**
+   * Retire this installation's push token for the identity being deleted.
+   * Runs FIRST, while that identity's bearer is still valid — see the
+   * invariants above. Failures are swallowed.
+   */
+  retirePushToken: () => Promise<unknown>;
   /**
    * Delete the account server-side. Must reject if the server did not delete
    * the account — rejection is the signal that the local identity MUST be
@@ -73,6 +92,21 @@ export async function runAccountDeletion(
   confirmText: string,
   deps: AccountDeletionDeps,
 ): Promise<AccountDeletionResult> {
+  // Step 0: stop this installation from being woken for an identity it is about
+  // to give up. This has to happen while the outgoing bearer is still valid —
+  // the registry scopes the delete to the authenticated identity, so there is
+  // no later moment at which this row can be removed. Best-effort: a push
+  // registry that is down must never block a deletion the user asked for.
+  try {
+    await deps.retirePushToken();
+  } catch (error) {
+    logger.warn(
+      'Could not retire this device\'s push token before deleting the account. It may keep receiving sign-in requests until it expires.',
+      { component: 'DeleteAccountScreen' },
+      error instanceof Error ? error : new Error(String(error)),
+    );
+  }
+
   // Step 1: server-side delete. If this throws, it propagates to the caller
   // and NOTHING below runs — the local identity is left fully intact.
   await deps.deleteAccount(confirmText);

--- a/packages/commons/lib/notifications/auth-request-push.ts
+++ b/packages/commons/lib/notifications/auth-request-push.ts
@@ -1,0 +1,78 @@
+/**
+ * The UNTRUSTED "Sign in with Oxy" push payload (issue #691, Phase 4).
+ *
+ * When a desktop starts a "Continue with Oxy" request, the platform delivers a
+ * deliberately minimal notification to the user's known Commons installation:
+ *
+ *   { type: 'oxy_commons_auth_request',
+ *     approvalUrl: 'oxycommons://approve?v=1&code=<authorizeCode>' }
+ *
+ * SECURITY — the payload is attacker-influencable and carries NOTHING worth
+ * displaying:
+ *   - The notification has no approve action. Tapping it can only OPEN the
+ *     existing approval route; approval itself still requires the biometric
+ *     gate + the on-device identity signature.
+ *   - Nothing from the payload is ever rendered. The approval screen re-resolves
+ *     the requesting application server-side from the code
+ *     (`getCommonsApprovalInfo`), which is the only trusted identity source.
+ *   - The `approvalUrl` is parsed with the SAME strict, dependency-free
+ *     {@link parseApprovalLink} the QR scanner and deep links use, so the
+ *     accepted scheme/host set is defined exactly once. Anything else — a
+ *     foreign scheme, a missing code, a stale link, a non-string — yields `null`
+ *     and the tap is dropped without navigating anywhere.
+ */
+
+import { parseApprovalLink } from '@/lib/commons-signin/parse-approval-link';
+
+/** The only `data.type` Commons acts on. Any other push is not ours. */
+export const COMMONS_AUTH_REQUEST_PUSH_TYPE = 'oxy_commons_auth_request';
+
+/**
+ * Extract the public authorize code from a notification's `content.data`.
+ *
+ * @param data - The raw, untrusted payload from the notification response.
+ * @returns The authorize code, or `null` when this is not a usable Commons
+ *   auth-request push (which the caller must treat as "do nothing").
+ */
+export function authRequestCodeFromPush(data: unknown): string | null {
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    return null;
+  }
+
+  const { type, approvalUrl } = data as { type?: unknown; approvalUrl?: unknown };
+  if (type !== COMMONS_AUTH_REQUEST_PUSH_TYPE || typeof approvalUrl !== 'string') {
+    return null;
+  }
+
+  const parsed = parseApprovalLink(approvalUrl);
+  // `expired` is dropped alongside `invalid` on purpose: a stale link has
+  // nothing left to approve, and the whole point of this surface is that an
+  // untrusted payload can only ever produce a usable code or nothing at all.
+  return parsed.ok ? parsed.code : null;
+}
+
+/**
+ * Codes this app session has already routed to the approval screen.
+ *
+ * An authorize code is single-use, so handling one twice in a session is always
+ * a duplicate — which is reachable because the OS can hand the SAME launching
+ * tap to both the cold-launch replay and a freshly attached response listener.
+ * Claiming is the tiebreaker: whichever path gets there first navigates, the
+ * other no-ops. Module-scoped and only ever touched from event handlers /
+ * effects, never during render.
+ */
+const claimedAuthRequestCodes = new Set<string>();
+
+/**
+ * Claim a code for navigation.
+ *
+ * @returns `true` when the caller owns this code and should navigate; `false`
+ *   when it was already handled in this app session.
+ */
+export function claimAuthRequestCode(code: string): boolean {
+  if (claimedAuthRequestCodes.has(code)) {
+    return false;
+  }
+  claimedAuthRequestCodes.add(code);
+  return true;
+}

--- a/packages/commons/lib/notifications/device-notifications.ts
+++ b/packages/commons/lib/notifications/device-notifications.ts
@@ -1,0 +1,190 @@
+/**
+ * The ONLY place Commons touches `expo-notifications`.
+ *
+ * Everything here is native-only and loaded through a dynamic `import()`, so a
+ * web bundle (Commons ships none, but the guard keeps the module honest) and a
+ * build without the native module degrade to "notifications unavailable" rather
+ * than throwing at module-evaluation time.
+ *
+ * ## The token is an EXPO push token — never a raw device token
+ *
+ * {@link getExpoPushToken} calls `getExpoPushTokenAsync()`, which returns the
+ * `ExponentPushToken[…]` handle Expo's push service delivers through.
+ * `getDevicePushTokenAsync()` — the raw APNs/FCM token — is deliberately NOT
+ * used anywhere: registering one of those looks entirely successful and then
+ * every push silently fails at delivery time. `@oxyhq/core`'s
+ * `registerPushToken` rejects a raw device token before sending, and this module
+ * is the reason it never has to.
+ */
+
+import { Platform } from 'react-native';
+import { logger } from '@oxyhq/core';
+import type { PushTokenPlatform } from '@oxyhq/core';
+
+type NotificationsModule = typeof import('expo-notifications');
+
+const LOG_CONTEXT = { component: 'device-notifications' } as const;
+
+/**
+ * Load `expo-notifications`, or `null` when it cannot serve this platform/build.
+ *
+ * The dynamic import is intentional: the module registry caches it, so repeated
+ * calls are cheap, and no module-level mutable cache is introduced here.
+ */
+async function loadNotifications(): Promise<NotificationsModule | null> {
+  if (Platform.OS === 'web') {
+    return null;
+  }
+  try {
+    return await import('expo-notifications');
+  } catch (error) {
+    logger.warn(
+      '[commons] expo-notifications is unavailable in this build — push is disabled',
+      LOG_CONTEXT,
+      error,
+    );
+    return null;
+  }
+}
+
+/**
+ * The platform tag the push-token registry stores this installation under, or
+ * `null` on a platform Oxy does not deliver push to.
+ */
+export function pushTokenPlatform(): PushTokenPlatform | null {
+  if (Platform.OS === 'ios' || Platform.OS === 'android' || Platform.OS === 'web') {
+    return Platform.OS;
+  }
+  return null;
+}
+
+/**
+ * Whether the OS notification permission is ALREADY granted.
+ *
+ * Never prompts — onboarding owns the single permission request
+ * ({@link requestNotificationPermission}), so the app can re-check on every cold
+ * boot without ever asking the user twice.
+ */
+export async function hasNotificationPermission(): Promise<boolean> {
+  const notifications = await loadNotifications();
+  if (!notifications) {
+    return false;
+  }
+  try {
+    const permissions = await notifications.getPermissionsAsync();
+    return permissions.granted === true;
+  } catch (error) {
+    logger.warn('[commons] could not read the notification permission', LOG_CONTEXT, error);
+    return false;
+  }
+}
+
+/**
+ * Prompt for the OS notification permission. Onboarding is the only caller.
+ *
+ * @returns Whether notifications are granted after the prompt (already-granted
+ *   installations resolve `true` without a second system dialog).
+ */
+export async function requestNotificationPermission(): Promise<boolean> {
+  const notifications = await loadNotifications();
+  if (!notifications) {
+    return false;
+  }
+  try {
+    const existing = await notifications.getPermissionsAsync();
+    if (existing.granted === true) {
+      return true;
+    }
+    const requested = await notifications.requestPermissionsAsync();
+    return requested.granted === true;
+  } catch (error) {
+    logger.warn('[commons] notification permission request failed', LOG_CONTEXT, error);
+    return false;
+  }
+}
+
+/**
+ * This installation's Expo push token (`ExponentPushToken[…]`), or `null` when
+ * it cannot be minted (no permission, no EAS project id, offline).
+ *
+ * Deliberately `getExpoPushTokenAsync` — see the module header for why the raw
+ * device-token variant is never used. The project id is resolved by
+ * `expo-notifications` itself from the app config, so there is no second,
+ * drifting copy of that lookup here.
+ */
+export async function getExpoPushToken(): Promise<string | null> {
+  const notifications = await loadNotifications();
+  if (!notifications) {
+    return null;
+  }
+  try {
+    const token = await notifications.getExpoPushTokenAsync();
+    return token.data.length > 0 ? token.data : null;
+  } catch (error) {
+    logger.warn('[commons] could not mint an Expo push token', LOG_CONTEXT, error);
+    return null;
+  }
+}
+
+/**
+ * Take the payload of the notification that COLD-LAUNCHED the app, if any.
+ *
+ * "Take" is literal: the response is cleared from `expo-notifications` once
+ * read, so a listener attached later in the same launch is not handed the same
+ * tap again. (The claim ledger in `auth-request-push.ts` is the belt to this
+ * braces — clearing is best-effort across OS/module versions.)
+ *
+ * @returns The raw `content.data` of the launching notification, or `null`.
+ */
+export async function takeLaunchNotificationData(): Promise<unknown> {
+  const notifications = await loadNotifications();
+  if (!notifications) {
+    return null;
+  }
+  try {
+    const response = notifications.getLastNotificationResponse();
+    if (!response) {
+      return null;
+    }
+    const data: unknown = response.notification.request.content.data;
+    try {
+      notifications.clearLastNotificationResponse();
+    } catch (clearError) {
+      logger.warn(
+        '[commons] could not clear the launching notification response',
+        LOG_CONTEXT,
+        clearError,
+      );
+    }
+    return data;
+  } catch (error) {
+    logger.warn('[commons] could not read the launching notification', LOG_CONTEXT, error);
+    return null;
+  }
+}
+
+/**
+ * Subscribe to notification TAPS (responses) while the app is running.
+ *
+ * @param listener - Receives the raw, untrusted `content.data` of the tapped
+ *   notification. Parsing/validation is the caller's job.
+ * @returns An unsubscribe function. Safe to call even if the subscription could
+ *   not be established.
+ */
+export async function subscribeToNotificationResponses(
+  listener: (data: unknown) => void,
+): Promise<() => void> {
+  const notifications = await loadNotifications();
+  if (!notifications) {
+    return () => undefined;
+  }
+  try {
+    const subscription = notifications.addNotificationResponseReceivedListener((response) => {
+      listener(response.notification.request.content.data);
+    });
+    return () => subscription.remove();
+  } catch (error) {
+    logger.warn('[commons] could not subscribe to notification taps', LOG_CONTEXT, error);
+    return () => undefined;
+  }
+}

--- a/packages/commons/lib/notifications/push-registration.ts
+++ b/packages/commons/lib/notifications/push-registration.ts
@@ -1,0 +1,150 @@
+/**
+ * Registering (and retiring) this installation with the Oxy push registry.
+ *
+ * Why this exists at all: without a registered push token the platform cannot
+ * reach the vault, so "Continue with Oxy" on a desktop has no way to wake the
+ * user's phone and the only fallback is a QR (issue #691, Phase 4).
+ *
+ * The orchestration is pure — every side effect is injected — so the two rules
+ * that matter are testable without a device:
+ *   1. Nothing is sent until the OS permission is granted AND a token exists.
+ *   2. The token that IS sent came from `getExpoPushTokenAsync`; `@oxyhq/core`
+ *      rejects anything else before a request leaves the client.
+ *
+ * Registration additionally requires a SESSION — `registerPushToken` is
+ * bearer-authed — which is the caller's precondition (`usePushRegistration`
+ * gates on `canUsePrivateApi`).
+ */
+
+import type { PushTokenPlatform, RegisterPushTokenInput } from '@oxyhq/core';
+import { OXY_CLIENT_ID } from '@/constants/oxy';
+import {
+  getExpoPushToken,
+  hasNotificationPermission,
+  pushTokenPlatform,
+} from './device-notifications';
+
+/** The `@oxyhq/core` surface this module drives (satisfied by `OxyServices`). */
+export interface PushTokenRegistry {
+  registerPushToken: (input: RegisterPushTokenInput) => Promise<void>;
+  unregisterPushToken: (expoPushToken: string) => Promise<void>;
+}
+
+/** Device facts the orchestration reads. Injected so tests need no native modules. */
+export interface PushTokenEnvironment {
+  /** Whether the OS notification permission is already granted. Must not prompt. */
+  hasNotificationPermission: () => Promise<boolean>;
+  /** This installation's Expo push token, or null when one cannot be minted. */
+  getExpoPushToken: () => Promise<string | null>;
+  /** Platform tag for the registry, or null on an unsupported platform. */
+  pushTokenPlatform: () => PushTokenPlatform | null;
+}
+
+export type PushRegistrationOutcome =
+  | { status: 'registered'; expoPushToken: string }
+  | { status: 'skipped'; reason: 'unsupported-platform' | 'permission-not-granted' | 'no-token' };
+
+export type PushRetirementOutcome =
+  | { status: 'retired'; expoPushToken: string }
+  | { status: 'skipped'; reason: 'no-token' };
+
+/**
+ * Register this installation's Expo push token for the currently signed-in
+ * identity, scoped to the Commons application.
+ *
+ * The `clientId` scope is what makes targeted delivery possible: the server
+ * resolves it to the Commons `Application` (which carries the staff-granted
+ * `identity:approval` capability) and delivers approval requests only to that
+ * application's registrations — never to every push token the identity owns.
+ *
+ * Idempotent server-side, so a cold-boot re-registration is free.
+ *
+ * @throws Whatever `registerPushToken` throws — including the explicit rejection
+ *   of a non-Expo token. Callers treat push registration as best-effort and log.
+ */
+export async function registerInstallationPushToken(
+  registry: PushTokenRegistry,
+  environment: PushTokenEnvironment,
+  options: { clientId: string; deviceId?: string },
+): Promise<PushRegistrationOutcome> {
+  const platform = environment.pushTokenPlatform();
+  if (!platform) {
+    return { status: 'skipped', reason: 'unsupported-platform' };
+  }
+
+  // Permission first: minting a token without it fails on iOS anyway, and a
+  // registration the user never consented to is not one we want to hold.
+  if (!(await environment.hasNotificationPermission())) {
+    return { status: 'skipped', reason: 'permission-not-granted' };
+  }
+
+  const expoPushToken = await environment.getExpoPushToken();
+  if (!expoPushToken) {
+    return { status: 'skipped', reason: 'no-token' };
+  }
+
+  const input: RegisterPushTokenInput = {
+    expoPushToken,
+    platform,
+    clientId: options.clientId,
+    ...(options.deviceId ? { deviceId: options.deviceId } : {}),
+  };
+  await registry.registerPushToken(input);
+
+  return { status: 'registered', expoPushToken };
+}
+
+/**
+ * Retire this installation's push token from the identity that currently holds
+ * the bearer.
+ *
+ * MUST be called while that identity's session is still live. The server scopes
+ * `DELETE /notifications/push-token` to the authenticated user, so a retirement
+ * attempted AFTER the session is gone (or after a different identity has taken
+ * over the vault) cannot remove the outgoing identity's row — it would delete
+ * the wrong one or nothing at all. That is precisely why the account-deletion
+ * sequence retires the token as its FIRST step rather than after signing out.
+ *
+ * Permission is not re-checked: retiring is strictly a cleanup, and a device
+ * whose permission was revoked simply has no token to retire.
+ *
+ * @throws Whatever `unregisterPushToken` throws; callers treat it as non-fatal.
+ */
+export async function retireInstallationPushToken(
+  registry: PushTokenRegistry,
+  environment: Pick<PushTokenEnvironment, 'getExpoPushToken'>,
+): Promise<PushRetirementOutcome> {
+  const expoPushToken = await environment.getExpoPushToken();
+  if (!expoPushToken) {
+    return { status: 'skipped', reason: 'no-token' };
+  }
+
+  await registry.unregisterPushToken(expoPushToken);
+  return { status: 'retired', expoPushToken };
+}
+
+/** The real device environment, bound once so call sites stay declarative. */
+const deviceEnvironment: PushTokenEnvironment = {
+  hasNotificationPermission,
+  getExpoPushToken,
+  pushTokenPlatform,
+};
+
+/**
+ * {@link registerInstallationPushToken} bound to this device and to Commons'
+ * registered `clientId`.
+ */
+export function registerVaultPushToken(
+  registry: PushTokenRegistry,
+  deviceId?: string,
+): Promise<PushRegistrationOutcome> {
+  return registerInstallationPushToken(registry, deviceEnvironment, {
+    clientId: OXY_CLIENT_ID,
+    ...(deviceId ? { deviceId } : {}),
+  });
+}
+
+/** {@link retireInstallationPushToken} bound to this device. */
+export function retireVaultPushToken(registry: PushTokenRegistry): Promise<PushRetirementOutcome> {
+  return retireInstallationPushToken(registry, deviceEnvironment);
+}

--- a/packages/contracts/src/sessionStatus.ts
+++ b/packages/contracts/src/sessionStatus.ts
@@ -98,6 +98,14 @@ export type PublicApplicationResponse = z.infer<typeof publicApplicationSchema>;
  * current producer and are never `null`, but stay `.optional()` so the contract
  * tolerates leaner shapes from other producers of this same payload without a
  * coordinated bump.
+ *
+ * `pushSentAt` / `openedAt` are DELIVERY PROGRESS, not authorization state: they
+ * let a waiting surface render "Check Commons on your phone" → "Opened in
+ * Commons" without inventing competing statuses. `status` remains the only
+ * authority on whether the request is pending, authorized, cancelled or expired.
+ * Both are `.nullable().optional()` for the same reason as `sessionId` — the
+ * producer always emits the key with `null` until that step happens, and an
+ * older API that omits them entirely must degrade, not fail the parse.
  */
 export const sessionStatusSchema = z.object({
     status: z.string(),
@@ -113,6 +121,8 @@ export const sessionStatusSchema = z.object({
      * OAuth-bound sessions finalize into an authorization code (no `sessionId`).
      */
     purpose: z.enum(['device_sign_in', 'oauth_authorization']).optional(),
+    pushSentAt: z.string().nullable().optional(),
+    openedAt: z.string().nullable().optional(),
 });
 
 export type SessionStatusResponse = z.infer<typeof sessionStatusSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,14 @@ export {
   getCommonsApprovalBlockingReason,
   parseCommonsApprovalExpiresAt,
 } from './utils/commonsApproval';
+// Automatic "Sign in with Oxy" delivery selection — ONE pure decision that maps
+// the caller's facts onto exactly one primary route (open Commons / await push / QR).
+export { selectCommonsDelivery } from './utils/commonsDelivery';
+export type {
+    CommonsDeliveryFacts,
+    CommonsDeliveryPlatform,
+    CommonsDeliveryRoute,
+} from './utils/commonsDelivery';
 export type { ServiceTokenResponse } from './mixins/OxyServices.auth';
 // "Sign in with Oxy" — handoff (Workstream C)
 export type {
@@ -52,7 +60,13 @@ export type {
     CommonsApprovalSubjectAccount,
     CommonsSignInActionResult,
     CommonsOAuthFinalizeResult,
+    CommonsDeliveryResult,
 } from './mixins/OxyServices.auth';
+// Push-token registration (Expo push tokens — never raw APNs/FCM device tokens).
+export type {
+    PushTokenPlatform,
+    RegisterPushTokenInput,
+} from './mixins/OxyServices.notifications';
 export type { ServiceApp, ServiceActingAsVerification } from './mixins/OxyServices.utility';
 export type {
     ContactDiscoveryMatch,

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -128,7 +128,16 @@ export interface CommonsSignInHandle {
   status: string;
 }
 
-/** Poll result for a "Sign in with Oxy" device-flow session (`GET /auth/session/status`). */
+/**
+ * Poll result for a "Sign in with Oxy" device-flow session
+ * (`GET /auth/session/status`).
+ *
+ * The authoritative state machine stays small — `pending → authorized →
+ * consumed`, plus `cancelled` / `expired` — and lives in `status`. Delivery
+ * PROGRESS (`pushSentAt`, `openedAt`) is carried as timestamps beside it, never
+ * as competing statuses, so a progress signal can never be mistaken for an
+ * authorization.
+ */
 export interface CommonsSignInStatus {
   /** True once an approver has authorized the session. */
   authorized: boolean;
@@ -143,6 +152,37 @@ export interface CommonsSignInStatus {
    * `device_sign_in` so an older API never misroutes an OAuth finalize.
    */
   purpose?: CommonsSignInPurpose;
+  /**
+   * ISO-8601 timestamp of when the request was pushed to a known Commons
+   * installation, or `null` when no push has been sent (including on a server
+   * that predates delivery progress). Progress only — it never implies the push
+   * was received, opened, or approved.
+   */
+  pushSentAt: string | null;
+  /**
+   * ISO-8601 timestamp of when the approval route was opened in Commons, or
+   * `null` when it has not been opened. Reported by the approver via
+   * {@link OxyServicesAuthMixin.markCommonsApprovalOpened}; it is an
+   * un-authenticated progress hint used only to advance the waiting UI, and is
+   * NEVER evidence that the request was approved.
+   */
+  openedAt: string | null;
+}
+
+/**
+ * Outcome of asking Oxy to deliver a pending sign-in request to the identity's
+ * known Commons installations (`POST /auth/session/deliver/:authorizeCode`).
+ *
+ * `targets: 0` is a NORMAL outcome, not a failure: it simply means no capable
+ * Commons installation is registered, so push is not a usable route and the
+ * caller shows the QR instead. Feed `targets` into `selectCommonsDelivery`
+ * (`utils/commonsDelivery`) rather than branching on it ad hoc.
+ */
+export interface CommonsDeliveryResult {
+  /** Whether the server dispatched the request to at least one installation. */
+  delivered: boolean;
+  /** How many eligible Commons installations it was dispatched to (`0` is normal). */
+  targets: number;
 }
 
 /**
@@ -242,6 +282,23 @@ function parseCommonsSubjectAccount(value: unknown): CommonsApprovalSubjectAccou
     username,
     ...(typeof displayName === 'string' ? { displayName } : {}),
   };
+}
+
+/**
+ * @internal Narrow an untrusted delivery-progress timestamp from the status
+ * response.
+ *
+ * Returns the ISO-8601 string unchanged when it is a real, parseable instant,
+ * and `null` for everything else — absent (an older API that has no delivery
+ * progress at all), empty, non-string, or unparseable. Progress is advisory, so
+ * degrading to "no progress yet" is always safe; surfacing a garbage timestamp
+ * to the waiting UI is not.
+ */
+function parseCommonsProgressTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || !value) {
+    return null;
+  }
+  return Number.isFinite(Date.parse(value)) ? value : null;
 }
 
 /** Result of approving / denying a "Sign in with Oxy" request. */
@@ -991,11 +1048,17 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
      * caller finalizes: `claimSessionByToken` for a `device_sign_in` request,
      * {@link finalizeCommonsOAuth} for an `oauth_authorization` one.
      *
+     * Every field is narrowed fail-safe. `authorized` counts only as a literal
+     * `true`, the identifiers only as non-empty strings, and the delivery
+     * progress timestamps degrade to `null` when absent or unparseable — so a
+     * partial or older-API payload can advance the waiting UI at most, never
+     * make it believe a request was approved.
+     *
      * @param sessionToken - The secret token from {@link startCommonsSignIn}.
      */
     async pollCommonsSignIn(sessionToken: string): Promise<CommonsSignInStatus> {
       try {
-        return await this.makeRequest<CommonsSignInStatus>(
+        const res = await this.makeRequest<unknown>(
           'GET',
           `/auth/session/status/${encodeURIComponent(sessionToken)}`,
           undefined,
@@ -1003,6 +1066,105 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
           // if ever reached while a refresh is pending, would re-enter
           // refreshAccessToken and await the very promise it runs inside.
           { cache: false, retry: false, skipAuth: true }
+        );
+
+        if (res === null || typeof res !== 'object') {
+          throw new Error('auth/session/status returned an unexpected response shape');
+        }
+        const { authorized, sessionId, publicKey, status, pushSentAt, openedAt } =
+          res as Record<string, unknown>;
+
+        return {
+          authorized: authorized === true,
+          ...(typeof sessionId === 'string' && sessionId ? { sessionId } : {}),
+          ...(typeof publicKey === 'string' && publicKey ? { publicKey } : {}),
+          ...(typeof status === 'string' && status ? { status } : {}),
+          pushSentAt: parseCommonsProgressTimestamp(pushSentAt),
+          openedAt: parseCommonsProgressTimestamp(openedAt),
+        };
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * MECHANISM B (relying party) — ask Oxy to DELIVER a pending sign-in request
+     * to the identity's known Commons installations.
+     *
+     * This is the automatic half of "one intention, one primary action": rather
+     * than offering the user a menu of transports, the caller asks for delivery
+     * and lets the answer pick the route. Pass the returned `targets` to
+     * `selectCommonsDelivery` (`utils/commonsDelivery`) — `targets: 0` means no
+     * capable Commons installation is registered, which is a NORMAL outcome that
+     * resolves to the QR route, not an error to surface.
+     *
+     * **Requires a bearer.** Delivery is only allowed when Oxy already knows the
+     * intended identity from a trusted authenticated context — a request that
+     * merely carries a username or email typed into an unauthenticated browser
+     * must never be able to ring somebody's phone.
+     *
+     * The push it sends carries only `{ type, approvalUrl }` where the URL holds
+     * the public `authorizeCode` — no display data, no secrets. Commons resolves
+     * everything it shows from `getCommonsApprovalInfo`.
+     *
+     * @param authorizeCode - The public code from {@link startCommonsSignIn}.
+     */
+    async deliverCommonsSignIn(authorizeCode: string): Promise<CommonsDeliveryResult> {
+      try {
+        const res = await this.makeRequest<unknown>(
+          'POST',
+          `/auth/session/deliver/${encodeURIComponent(authorizeCode)}`,
+          undefined,
+          // Bearer REQUIRED (unlike its public siblings): the identity to
+          // deliver to comes from the authenticated caller, never the code.
+          { cache: false },
+        );
+
+        if (res === null || typeof res !== 'object') {
+          throw new Error('auth/session/deliver returned an unexpected response shape');
+        }
+        const { delivered, targets } = res as Record<string, unknown>;
+        // Both fields drive the route choice, so a partial payload is rejected
+        // outright rather than defaulted into a route the server never chose.
+        if (
+          typeof delivered !== 'boolean' ||
+          typeof targets !== 'number' ||
+          !Number.isInteger(targets) ||
+          targets < 0
+        ) {
+          throw new Error('auth/session/deliver returned an incomplete delivery result');
+        }
+
+        return { delivered, targets };
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * MECHANISM B (approver / Commons) — report that the approval route was
+     * OPENED, so the waiting relying party can show "Opened in Commons".
+     *
+     * Progress only. It is idempotent, applies to a `pending` request alone, and
+     * records a timestamp (`openedAt`) — it never approves, authorizes, or
+     * advances the authorization state machine. Public, like the other approver
+     * handles: the approver has only the public `authorizeCode` at this point
+     * and has not yet signed anything.
+     *
+     * Best-effort by nature — a failure here costs the user only a progress
+     * line, so callers are free to ignore a rejection and continue to the
+     * approval screen.
+     *
+     * @param authorizeCode - The public code scanned from the QR / deep-link / push.
+     */
+    async markCommonsApprovalOpened(authorizeCode: string): Promise<void> {
+      try {
+        await this.makeRequest<unknown>(
+          'POST',
+          `/auth/session/opened/${encodeURIComponent(authorizeCode)}`,
+          undefined,
+          // Public (no bearer) — skip the preflight, exactly like approve-info.
+          { cache: false, skipAuth: true },
         );
       } catch (error) {
         throw this.handleError(error);

--- a/packages/core/src/mixins/OxyServices.notifications.ts
+++ b/packages/core/src/mixins/OxyServices.notifications.ts
@@ -1,0 +1,142 @@
+/**
+ * Push Notification Registration Mixin
+ *
+ * Registers this installation's push token with Oxy so the platform can reach
+ * the signed-in identity — most importantly to deliver a "Sign in with Oxy"
+ * approval request to a known Commons installation (issue #691, Phase 4)
+ * instead of forcing the user onto a QR.
+ *
+ * This lives in `@oxyhq/core` because push registration is cross-cutting: every
+ * Oxy app that wants to receive platform notifications performs the exact same
+ * bearer-authenticated register/unregister pair. App-local copies drift (see the
+ * token-kind hazard below), so there is ONE implementation here.
+ *
+ * ## The token is an EXPO PUSH TOKEN
+ *
+ * `registerPushToken` takes the token returned by
+ * `Notifications.getExpoPushTokenAsync()` — the `ExponentPushToken[…]` handle —
+ * because the server delivers through Expo's push service, which only accepts
+ * that form.
+ *
+ * It does NOT take `getDevicePushTokenAsync()`'s raw APNs/FCM device token.
+ * Registering one of those looks completely successful (the row is stored, the
+ * endpoint returns 200) and then every push silently fails at delivery time,
+ * which is exactly the failure mode this surface is written to make impossible:
+ * the token is validated here, at the call site, so a raw device token is
+ * rejected immediately with an explicit error rather than becoming a dead
+ * registration nobody notices.
+ *
+ * Acquiring the token (permission prompt, `expo-notifications`) is the app's
+ * job — `@oxyhq/core` never imports an `expo-*` module.
+ */
+import type { OxyServicesBase } from '../OxyServices.base';
+
+/**
+ * Platform the push token was minted on. Mirrors the enum the server accepts;
+ * a value outside it is rejected server-side.
+ */
+export type PushTokenPlatform = 'ios' | 'android' | 'web';
+
+/**
+ * Shape of an Expo push token: `ExponentPushToken[…]` (what
+ * `getExpoPushTokenAsync()` returns today) or the equivalent `ExpoPushToken[…]`
+ * spelling. Deliberately plain ASCII — `@oxyhq/core` ships to Hermes, where
+ * Unicode property escapes throw at runtime.
+ */
+const EXPO_PUSH_TOKEN_PATTERN = /^Expo(nent)?PushToken\[[^[\]\s]+\]$/;
+
+/** Registration input for {@link OxyServicesNotificationsMixin.registerPushToken}. */
+export interface RegisterPushTokenInput {
+  /**
+   * The **Expo push token** for this installation — `ExponentPushToken[…]`,
+   * from `Notifications.getExpoPushTokenAsync()`.
+   *
+   * NOT the raw APNs/FCM token from `getDevicePushTokenAsync()`; that form is
+   * rejected before any request is sent.
+   */
+  expoPushToken: string;
+  /** Platform this token was minted on. */
+  platform: PushTokenPlatform;
+  /**
+   * Optional device-first `deviceId` this installation is registered under, so
+   * the server can retire the token when that device session goes away instead
+   * of pushing to an installation that has signed out.
+   */
+  deviceId?: string;
+  /**
+   * Optional registered OAuth client id (the caller's credential `publicKey`,
+   * `oxy_dk_…`) identifying WHICH application this installation is. The server
+   * resolves it to the registering `Application` and rejects an unusable one.
+   *
+   * This is what makes "deliver the approval request to a known Commons
+   * installation" possible: delivery targets the Commons application's
+   * registrations, never every push token the identity owns.
+   */
+  clientId?: string;
+}
+
+export function OxyServicesNotificationsMixin<T extends typeof OxyServicesBase>(Base: T) {
+  return class extends Base {
+    /**
+     * Register this installation's **Expo** push token for the authenticated
+     * identity (`POST /notifications/push-token`, bearer required).
+     *
+     * Idempotent server-side: re-registering the same token for the same
+     * identity refreshes the existing row rather than creating a duplicate, so
+     * callers can safely re-register on every cold boot.
+     *
+     * @throws When `expoPushToken` is not an Expo push token — a raw APNs/FCM
+     *   device token fails here rather than becoming a silently undeliverable
+     *   registration.
+     */
+    async registerPushToken(input: RegisterPushTokenInput): Promise<void> {
+      try {
+        if (!EXPO_PUSH_TOKEN_PATTERN.test(input.expoPushToken)) {
+          throw new Error(
+            'registerPushToken expects an Expo push token ("ExponentPushToken[...]", from getExpoPushTokenAsync). ' +
+              'A raw APNs/FCM device token from getDevicePushTokenAsync cannot be delivered to.',
+          );
+        }
+
+        await this.makeRequest<unknown>(
+          'POST',
+          '/notifications/push-token',
+          {
+            token: input.expoPushToken,
+            platform: input.platform,
+            // Omitted entirely when absent so the body stays exactly what the
+            // endpoint has always received (the server reads presence).
+            ...(input.deviceId ? { deviceId: input.deviceId } : {}),
+            ...(input.clientId ? { clientId: input.clientId } : {}),
+          },
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Retire an **Expo** push token for the authenticated identity
+     * (`DELETE /notifications/push-token`, bearer required).
+     *
+     * Call it when the user turns notifications off, when the vault identity is
+     * replaced, and on sign-out — otherwise the installation keeps receiving
+     * approval requests for an identity it no longer holds.
+     *
+     * @param expoPushToken - The exact token previously registered.
+     */
+    async unregisterPushToken(expoPushToken: string): Promise<void> {
+      try {
+        await this.makeRequest<unknown>(
+          'DELETE',
+          '/notifications/push-token',
+          { token: expoPushToken },
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+  };
+}

--- a/packages/core/src/mixins/__tests__/commonsSignIn.test.ts
+++ b/packages/core/src/mixins/__tests__/commonsSignIn.test.ts
@@ -5,13 +5,20 @@
  * run with no network. We assert the exact request bodies the RP and the
  * approver send — these are the load-bearing coordination points with the C2
  * server endpoints — plus the native-vs-web behaviour of the shared-key SSO.
+ *
+ * Also covers Phase 4 (automatic delivery, issue #691): push-token
+ * registration, the bearer-authenticated `deliver` call, the un-authenticated
+ * `opened` progress signal, and the pure route selector — including the
+ * degrade-to-QR behaviour every ambiguous input must produce.
  */
 
 import type { SessionLoginResponse } from '../../models/session';
 import type { ChallengeResponse } from '../OxyServices.auth';
+import type { CommonsDeliveryPlatform } from '../../utils/commonsDelivery';
 import { OxyServices } from '../../OxyServices';
 import { KeyManager } from '../../crypto/keyManager';
 import { SignatureService } from '../../crypto/signatureService';
+import { selectCommonsDelivery } from '../../utils/commonsDelivery';
 
 const challengeFixture: ChallengeResponse = {
   challenge: 'chal-xyz',
@@ -171,12 +178,224 @@ describe('OxyServices — "Sign in with Oxy" handoff', () => {
 
       const result = await oxy.pollCommonsSignIn('secret-session-token');
 
-      expect(result).toEqual({ authorized: true, sessionId: 's1' });
+      // Delivery progress degrades to null on a server that reports none.
+      expect(result).toEqual({
+        authorized: true,
+        sessionId: 's1',
+        pushSentAt: null,
+        openedAt: null,
+      });
       expect(makeRequestSpy).toHaveBeenCalledWith(
         'GET',
         '/auth/session/status/secret-session-token',
         undefined,
         expect.objectContaining({ cache: false, retry: false }),
+      );
+    });
+
+    it('carries delivery progress timestamps through unchanged', async () => {
+      makeRequestSpy.mockResolvedValue({
+        authorized: false,
+        status: 'pending',
+        pushSentAt: '2026-07-27T10:00:00.000Z',
+        openedAt: '2026-07-27T10:00:12.000Z',
+      });
+
+      const result = await oxy.pollCommonsSignIn('secret-session-token');
+
+      expect(result).toEqual({
+        authorized: false,
+        status: 'pending',
+        pushSentAt: '2026-07-27T10:00:00.000Z',
+        openedAt: '2026-07-27T10:00:12.000Z',
+      });
+    });
+
+    it('degrades safely when an older API omits the progress timestamps entirely', async () => {
+      makeRequestSpy.mockResolvedValue({ authorized: false, status: 'pending' });
+
+      const result = await oxy.pollCommonsSignIn('secret-session-token');
+
+      expect(result.pushSentAt).toBeNull();
+      expect(result.openedAt).toBeNull();
+      // The pre-existing contract is untouched by the addition.
+      expect(result.authorized).toBe(false);
+      expect(result.status).toBe('pending');
+    });
+
+    it.each([
+      ['an explicit null', null],
+      ['an empty string', ''],
+      ['an unparseable string', 'soon'],
+      ['a number (epoch ms, not the ISO contract)', 1700000000000],
+      ['an object', { at: '2026-07-27T10:00:00.000Z' }],
+      ['a boolean', true],
+    ])('drops %s progress timestamp rather than surfacing it', async (_label, value) => {
+      makeRequestSpy.mockResolvedValue({
+        authorized: false,
+        status: 'pending',
+        pushSentAt: value,
+        openedAt: value,
+      });
+
+      const result = await oxy.pollCommonsSignIn('secret-session-token');
+
+      expect(result.pushSentAt).toBeNull();
+      expect(result.openedAt).toBeNull();
+    });
+
+    it('parses each progress timestamp independently', async () => {
+      makeRequestSpy.mockResolvedValue({
+        authorized: false,
+        status: 'pending',
+        pushSentAt: '2026-07-27T10:00:00.000Z',
+        openedAt: 'not-a-date',
+      });
+
+      const result = await oxy.pollCommonsSignIn('secret-session-token');
+
+      expect(result.pushSentAt).toBe('2026-07-27T10:00:00.000Z');
+      expect(result.openedAt).toBeNull();
+    });
+
+    it('counts only a literal true as authorized and drops empty identifiers', async () => {
+      makeRequestSpy.mockResolvedValue({
+        authorized: 'yes',
+        sessionId: '',
+        publicKey: 42,
+        status: 'pending',
+      });
+
+      const result = await oxy.pollCommonsSignIn('secret-session-token');
+
+      expect(result).toEqual({
+        authorized: false,
+        status: 'pending',
+        pushSentAt: null,
+        openedAt: null,
+      });
+    });
+
+    it.each([
+      ['a non-object body', 'pending'],
+      ['a null body', null],
+    ])('rejects %s rather than returning a half-parsed status', async (_label, value) => {
+      makeRequestSpy.mockResolvedValue(value);
+
+      await expect(oxy.pollCommonsSignIn('secret-session-token')).rejects.toThrow(
+        /unexpected response shape/,
+      );
+    });
+  });
+
+  describe('deliverCommonsSignIn (relying party)', () => {
+    it('POSTs the deliver path WITH a bearer (never skipAuth)', async () => {
+      makeRequestSpy.mockResolvedValue({ delivered: true, targets: 2 });
+
+      const result = await oxy.deliverCommonsSignIn('code with/slash');
+
+      expect(result).toEqual({ delivered: true, targets: 2 });
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/auth/session/deliver/code%20with%2Fslash',
+        undefined,
+        { cache: false },
+      );
+      // Delivery only happens for an identity Oxy already knows from a trusted
+      // authenticated context, so the bearer preflight must NOT be skipped.
+      expect(makeRequestSpy.mock.calls[0][3]).not.toHaveProperty('skipAuth');
+    });
+
+    it('treats zero targets as a normal outcome, not a failure', async () => {
+      makeRequestSpy.mockResolvedValue({ delivered: false, targets: 0 });
+
+      const result = await oxy.deliverCommonsSignIn('code-1');
+
+      // No throw, no coercion — the caller routes this to QR.
+      expect(result).toEqual({ delivered: false, targets: 0 });
+      expect(selectCommonsDelivery({
+        platform: 'desktop',
+        commonsAvailable: false,
+        pushTargets: result.targets,
+      })).toBe('qr');
+    });
+
+    it('routes a positive target count to the push wait', async () => {
+      makeRequestSpy.mockResolvedValue({ delivered: true, targets: 1 });
+
+      const result = await oxy.deliverCommonsSignIn('code-1');
+
+      expect(selectCommonsDelivery({
+        platform: 'desktop',
+        commonsAvailable: false,
+        pushTargets: result.targets,
+      })).toBe('await-push');
+    });
+
+    it.each([
+      ['a non-object body', 'delivered'],
+      ['a null body', null],
+    ])('rejects %s rather than returning it', async (_label, value) => {
+      makeRequestSpy.mockResolvedValue(value);
+
+      await expect(oxy.deliverCommonsSignIn('code-1')).rejects.toThrow(
+        /unexpected response shape/,
+      );
+    });
+
+    it.each([
+      ['a missing delivered', { targets: 1 }],
+      ['a non-boolean delivered', { delivered: 'true', targets: 1 }],
+      ['a missing targets', { delivered: true }],
+      ['a non-numeric targets', { delivered: true, targets: '1' }],
+      ['a fractional targets', { delivered: true, targets: 1.5 }],
+      ['a NaN targets', { delivered: true, targets: Number.NaN }],
+      ['a non-finite targets', { delivered: true, targets: Number.POSITIVE_INFINITY }],
+      ['a negative targets', { delivered: true, targets: -1 }],
+    ])('rejects %s rather than returning a half-parsed result', async (_label, value) => {
+      makeRequestSpy.mockResolvedValue(value);
+
+      await expect(oxy.deliverCommonsSignIn('code-1')).rejects.toThrow(
+        /incomplete delivery result/,
+      );
+    });
+
+    it('surfaces a server rejection through the shared error handler', async () => {
+      makeRequestSpy.mockRejectedValue(new Error('Invalid or expired sign-in request'));
+
+      await expect(oxy.deliverCommonsSignIn('code-1')).rejects.toThrow(
+        'Invalid or expired sign-in request',
+      );
+    });
+  });
+
+  describe('markCommonsApprovalOpened (approver)', () => {
+    it('POSTs /auth/session/opened/:authorizeCode with NO bearer', async () => {
+      makeRequestSpy.mockResolvedValue(undefined);
+
+      await expect(oxy.markCommonsApprovalOpened('code-1')).resolves.toBeUndefined();
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/auth/session/opened/code-1',
+        undefined,
+        { cache: false, skipAuth: true },
+      );
+    });
+
+    it('encodes the public code in the path', async () => {
+      makeRequestSpy.mockResolvedValue(undefined);
+
+      await oxy.markCommonsApprovalOpened('code with/slash');
+
+      expect(makeRequestSpy.mock.calls[0][1]).toBe('/auth/session/opened/code%20with%2Fslash');
+    });
+
+    it('surfaces a server rejection through the shared error handler', async () => {
+      makeRequestSpy.mockRejectedValue(new Error('Sign-in request is not pending'));
+
+      await expect(oxy.markCommonsApprovalOpened('code-1')).rejects.toThrow(
+        'Sign-in request is not pending',
       );
     });
   });
@@ -617,5 +836,205 @@ describe('OxyServices — "Sign in with Oxy" handoff', () => {
       expect(result).toBeNull();
       expect(verifyChallengeSpy).not.toHaveBeenCalled();
     });
+  });
+
+  describe('registerPushToken / unregisterPushToken', () => {
+    const expoToken = 'ExponentPushToken[abc123XYZ]';
+
+    it('POSTs the Expo push token with a bearer', async () => {
+      makeRequestSpy.mockResolvedValue({ registered: true });
+
+      await expect(
+        oxy.registerPushToken({ expoPushToken: expoToken, platform: 'ios' }),
+      ).resolves.toBeUndefined();
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/notifications/push-token',
+        { token: expoToken, platform: 'ios' },
+        { cache: false },
+      );
+      // Push registration is per-identity — the bearer preflight must run.
+      expect(makeRequestSpy.mock.calls[0][3]).not.toHaveProperty('skipAuth');
+    });
+
+    it('omits deviceId/clientId entirely when not provided', async () => {
+      makeRequestSpy.mockResolvedValue({ registered: true });
+
+      await oxy.registerPushToken({ expoPushToken: expoToken, platform: 'android' });
+
+      // `toHaveBeenCalledWith` ignores explicitly-undefined keys, so assert the
+      // literal key set: the server reads PRESENCE of these optional fields.
+      expect(Object.keys(makeRequestSpy.mock.calls[0][2])).toEqual(['token', 'platform']);
+    });
+
+    it('sends deviceId and clientId when provided', async () => {
+      makeRequestSpy.mockResolvedValue({ registered: true });
+
+      await oxy.registerPushToken({
+        expoPushToken: expoToken,
+        platform: 'ios',
+        deviceId: 'dev-1',
+        clientId: 'oxy_dk_commons',
+      });
+
+      expect(makeRequestSpy.mock.calls[0][2]).toEqual({
+        token: expoToken,
+        platform: 'ios',
+        deviceId: 'dev-1',
+        clientId: 'oxy_dk_commons',
+      });
+    });
+
+    it('accepts the ExpoPushToken spelling as well', async () => {
+      makeRequestSpy.mockResolvedValue({ registered: true });
+
+      await oxy.registerPushToken({ expoPushToken: 'ExpoPushToken[abc123]', platform: 'web' });
+
+      expect(makeRequestSpy).toHaveBeenCalled();
+    });
+
+    it.each([
+      // The exact inbox hazard: getDevicePushTokenAsync's raw FCM/APNs token.
+      ['a raw FCM token', 'fMEP0vJqS0y5:APA91bH-longopaquestring'],
+      ['a raw APNs hex token', '740f4707bebcf74f9b7c25d48e3358945f6aa01da5ddb387462c7eaf61bb78ad'],
+      ['an empty string', ''],
+      ['a truncated wrapper', 'ExponentPushToken['],
+      ['an empty wrapper', 'ExponentPushToken[]'],
+      ['a token with whitespace inside', 'ExponentPushToken[abc 123]'],
+      ['surrounding whitespace', ' ExponentPushToken[abc123] '],
+    ])('rejects %s without sending a request', async (_label, token) => {
+      await expect(
+        oxy.registerPushToken({ expoPushToken: token, platform: 'ios' }),
+      ).rejects.toThrow(/Expo push token/);
+
+      expect(makeRequestSpy).not.toHaveBeenCalled();
+    });
+
+    it('DELETEs the token on unregister', async () => {
+      makeRequestSpy.mockResolvedValue({ unregistered: true });
+
+      await expect(oxy.unregisterPushToken(expoToken)).resolves.toBeUndefined();
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'DELETE',
+        '/notifications/push-token',
+        { token: expoToken },
+        { cache: false },
+      );
+    });
+
+    it('surfaces a server rejection through the shared error handler', async () => {
+      makeRequestSpy.mockRejectedValue(new Error('Unknown client'));
+
+      await expect(
+        oxy.registerPushToken({ expoPushToken: expoToken, platform: 'ios' }),
+      ).rejects.toThrow('Unknown client');
+    });
+  });
+});
+
+describe('selectCommonsDelivery — automatic delivery selection', () => {
+  const platforms: CommonsDeliveryPlatform[] = ['mobile', 'desktop', 'unknown'];
+
+  it('opens Commons on mobile when a verified Commons link is available', () => {
+    expect(
+      selectCommonsDelivery({ platform: 'mobile', commonsAvailable: true, pushTargets: 0 }),
+    ).toBe('open-commons');
+  });
+
+  it('prefers opening Commons over a push that also has targets', () => {
+    // Rule 1 wins outright — the identity is already reachable on this device,
+    // so nobody's other phone should ring.
+    expect(
+      selectCommonsDelivery({ platform: 'mobile', commonsAvailable: true, pushTargets: 3 }),
+    ).toBe('open-commons');
+  });
+
+  it('awaits the push on mobile without a verified Commons link', () => {
+    expect(
+      selectCommonsDelivery({ platform: 'mobile', commonsAvailable: false, pushTargets: 1 }),
+    ).toBe('await-push');
+  });
+
+  it('awaits the push on a desktop with a known Commons installation', () => {
+    expect(
+      selectCommonsDelivery({ platform: 'desktop', commonsAvailable: false, pushTargets: 2 }),
+    ).toBe('await-push');
+  });
+
+  it('shows the QR on an unknown desktop browser', () => {
+    expect(
+      selectCommonsDelivery({ platform: 'desktop', commonsAvailable: false, pushTargets: 0 }),
+    ).toBe('qr');
+  });
+
+  it('never deep-links from desktop even when a Commons link is claimed available', () => {
+    // A custom-scheme navigation that does not resolve is a dead end, so a
+    // desktop caller falls through to push/QR regardless.
+    expect(
+      selectCommonsDelivery({ platform: 'desktop', commonsAvailable: true, pushTargets: 0 }),
+    ).toBe('qr');
+    expect(
+      selectCommonsDelivery({ platform: 'desktop', commonsAvailable: true, pushTargets: 1 }),
+    ).toBe('await-push');
+  });
+
+  it('never deep-links from an unknown platform (degrades to push, then QR)', () => {
+    expect(
+      selectCommonsDelivery({ platform: 'unknown', commonsAvailable: true, pushTargets: 0 }),
+    ).toBe('qr');
+    expect(
+      selectCommonsDelivery({ platform: 'unknown', commonsAvailable: true, pushTargets: 1 }),
+    ).toBe('await-push');
+    expect(
+      selectCommonsDelivery({ platform: 'unknown', commonsAvailable: false, pushTargets: 0 }),
+    ).toBe('qr');
+  });
+
+  it('treats zero targets as QR on every platform (a normal outcome, not an error)', () => {
+    for (const platform of platforms) {
+      expect(selectCommonsDelivery({ platform, commonsAvailable: false, pushTargets: 0 })).toBe(
+        'qr',
+      );
+    }
+  });
+
+  it.each([
+    ['a negative count', -1],
+    ['a fractional count', 0.5],
+    ['a fractional count above one', 1.5],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+  ])('degrades %s to QR rather than a push nobody will answer', (_label, pushTargets) => {
+    expect(selectCommonsDelivery({ platform: 'desktop', commonsAvailable: false, pushTargets })).toBe(
+      'qr',
+    );
+  });
+
+  it('is pure — the same facts always yield the same route', () => {
+    const facts = {
+      platform: 'desktop' as const,
+      commonsAvailable: false,
+      pushTargets: 1,
+    };
+
+    expect(selectCommonsDelivery(facts)).toBe('await-push');
+    expect(selectCommonsDelivery(facts)).toBe('await-push');
+    // ...and it does not mutate the caller's facts.
+    expect(facts).toEqual({ platform: 'desktop', commonsAvailable: false, pushTargets: 1 });
+  });
+
+  it('covers every (platform × commonsAvailable × targets) combination with one route', () => {
+    const routes = new Set<string>();
+    for (const platform of platforms) {
+      for (const commonsAvailable of [true, false]) {
+        for (const pushTargets of [0, 1]) {
+          routes.add(selectCommonsDelivery({ platform, commonsAvailable, pushTargets }));
+        }
+      }
+    }
+    // Exactly the three primary routes — no chained/compound outcome exists.
+    expect([...routes].sort()).toEqual(['await-push', 'open-commons', 'qr']);
   });
 });

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -25,6 +25,7 @@ import { OxyServicesUtilityMixin } from './OxyServices.utility';
 import { OxyServicesFeaturesMixin } from './OxyServices.features';
 import { OxyServicesTopicsMixin } from './OxyServices.topics';
 import { OxyServicesContactsMixin } from './OxyServices.contacts';
+import { OxyServicesNotificationsMixin } from './OxyServices.notifications';
 import { OxyServicesAppDataMixin } from './OxyServices.appData';
 import { OxyServicesCivicMixin } from './OxyServices.civic';
 import { OxyServicesNodesMixin } from './OxyServices.nodes';
@@ -60,6 +61,7 @@ type AllMixinInstances =
   & InstanceType<ReturnType<typeof OxyServicesFeaturesMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesTopicsMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesContactsMixin<typeof OxyServicesBase>>>
+  & InstanceType<ReturnType<typeof OxyServicesNotificationsMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesAppDataMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesCivicMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesNodesMixin<typeof OxyServicesBase>>>
@@ -126,6 +128,10 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     OxyServicesFeaturesMixin,
     OxyServicesTopicsMixin,
     OxyServicesContactsMixin,
+    // Push-token registration: the one SDK-owned register/unregister pair every
+    // Oxy app uses, and what lets a "Sign in with Oxy" request be delivered to a
+    // known Commons installation instead of falling back to a QR.
+    OxyServicesNotificationsMixin,
     OxyServicesAppDataMixin,
     // Civic / Commons "Oxy ID" (public signed cards, Oxy ID QR payload)
     OxyServicesCivicMixin,

--- a/packages/core/src/utils/commonsDelivery.ts
+++ b/packages/core/src/utils/commonsDelivery.ts
@@ -1,0 +1,100 @@
+/**
+ * Automatic "Sign in with Oxy" delivery selection (issue #691, Phase 4).
+ *
+ * The user performs ONE action ("Continue with Oxy"); Oxy — not the user —
+ * decides how the approval request reaches their Commons identity. This module
+ * is that decision, and nothing else: a single pure function mapping the facts
+ * the caller has gathered onto exactly ONE primary route.
+ *
+ * Deliberate design constraints:
+ *
+ *  - **Pure.** No I/O, no platform sniffing, no clock, no globals. Every input
+ *    is passed in by the caller, which is what makes the decision exhaustively
+ *    unit-testable and identical on web, native, and server.
+ *  - **One route, never a chain.** The result is the PRIMARY route only.
+ *    Alternatives stay hidden behind a "Having trouble?" affordance and are
+ *    revealed by the UI only once the primary route fails or is unavailable —
+ *    the SDK never silently cascades from one delivery surface to the next.
+ *  - **Fail-safe to QR.** QR is the route that works with no prior knowledge of
+ *    the device, so every ambiguous or malformed input degrades to it rather
+ *    than to a route that could leave the user staring at a dead end.
+ *
+ * Every route drives the SAME `AuthSession`, resolved from the same public
+ * `authorizeCode`; the route only decides how that code travels.
+ */
+
+/**
+ * The kind of surface the sign-in was initiated from.
+ *
+ * `'unknown'` is a first-class value, not an error: a caller that cannot
+ * confidently classify the surface must say so rather than guess, and an
+ * unknown surface never opts into the deep-link route (a custom-scheme
+ * navigation that does not resolve is a dead end with no automatic way back).
+ */
+export type CommonsDeliveryPlatform = 'mobile' | 'desktop' | 'unknown';
+
+/**
+ * The single primary route chosen for this request.
+ *
+ *  - `'open-commons'` — navigate to the verified Commons app/universal link on
+ *    THIS device and let the user confirm there.
+ *  - `'await-push'` — the request was pushed to a known Commons installation;
+ *    show "Check Commons on your phone" and wait for the authorization.
+ *  - `'qr'` — render the QR carrying the public `authorizeCode` for the user to
+ *    scan with Commons on another device.
+ */
+export type CommonsDeliveryRoute = 'open-commons' | 'await-push' | 'qr';
+
+/**
+ * The facts the caller must gather before asking for a route. All of them are
+ * observations, never decisions — the caller owns the platform detection, the
+ * app-link verification, and the delivery round-trip; this module owns only the
+ * choice between them.
+ */
+export interface CommonsDeliveryFacts {
+  /** Which surface the sign-in was initiated from (see {@link CommonsDeliveryPlatform}). */
+  platform: CommonsDeliveryPlatform;
+  /**
+   * `true` only when a VERIFIED Commons app/universal link can be opened on
+   * this very device (an installed, link-verified Commons). "The user probably
+   * has Commons somewhere" is not this fact — that is what `pushTargets`
+   * expresses.
+   */
+  commonsAvailable: boolean;
+  /**
+   * How many eligible Commons installations the server said it delivered the
+   * request to — the `targets` field of `deliverCommonsSignIn`. Zero is a
+   * NORMAL outcome (no capable Commons install is registered for this
+   * identity), never an error; it simply means push is not a usable route.
+   */
+  pushTargets: number;
+}
+
+/**
+ * Choose the ONE primary delivery route for a "Sign in with Oxy" request.
+ *
+ * Decision order (issue #691, "Automatic delivery selection"):
+ *
+ *  1. Mobile with a verified Commons link available → open Commons directly.
+ *     No push is needed when the identity is already reachable on this device.
+ *  2. At least one eligible Commons installation was pushed to → await the push.
+ *  3. Otherwise → QR.
+ *
+ * A caller that already knows it is on step 1 does not need to call
+ * `deliverCommonsSignIn` at all; every other caller runs the delivery
+ * round-trip first and passes its `targets` in here.
+ *
+ * `pushTargets` is server-derived, so it is validated rather than trusted: a
+ * negative, fractional, non-finite, or otherwise malformed count is treated as
+ * "no targets" and degrades to QR instead of parking the user on a "check your
+ * phone" screen that nothing will ever wake.
+ */
+export function selectCommonsDelivery(facts: CommonsDeliveryFacts): CommonsDeliveryRoute {
+  if (facts.platform === 'mobile' && facts.commonsAvailable) {
+    return 'open-commons';
+  }
+  if (Number.isInteger(facts.pushTargets) && facts.pushTargets >= 1) {
+    return 'await-push';
+  }
+  return 'qr';
+}


### PR DESCRIPTION
Phase 4 of #691, on top of #697.

## Why

A desktop user clicking "Continue with Oxy" had exactly one route: read a QR off the screen with their phone. There was no way to simply *reach* the phone, because push existed only for inbound email — Commons asked for notification permission during onboarding and then never obtained or registered a token, so `PushToken` held no Commons rows at all.

## Automatic selection

One pure function over facts the caller supplies, returning **one** primary route:

```ts
selectCommonsDelivery({ platform, commonsAvailable, pushTargets })
  → 'open-commons' | 'await-push' | 'qr'
```

Mobile with a verified Commons link → open Commons; a known eligible install → await the push; otherwise QR. No chained automatic fallbacks. A non-integer or negative target count degrades to QR rather than parking someone on a "check your phone" screen nothing will wake.

## Who may be pushed — the bearer is the control

The issue forbids pushing based on a username or email typed into an unauthenticated browser. So `POST /auth/session/deliver/:authorizeCode` **requires a bearer** and targets only *that same authenticated user's own* installs — the target user is never resolved from a request body or a QR payload.

The set is narrowed further by the staff-controlled `identity:approval` capability on the registering `Application` — registry-based, not a hardcoded client id, bundle id or app name. No capable install ⇒ zero targets, a normal outcome that falls back to QR, never an error. Push transport failures never fail the auth flow.

## The notification is a doorbell, not a decision

```ts
{ type: 'oxy_commons_auth_request', approvalUrl: 'oxycommons://approve?v=1&code=<authorizeCode>' }
```

No application name, no scopes, no origin, no secret. Commons re-fetches all display data from `approve-info`, so a forged or replayed notification cannot make the vault render an attacker's branding. No `categoryId` is set, so an approve action button is not even possible — tapping only opens the existing approval route. A test asserts the recursive key set is exactly those two keys.

## Progress without new statuses

`pushSentAt` / `openedAt` are timestamps on `AuthSession`; the authoritative machine stays `pending → authorized → consumed` / `cancelled` / `expired`. The `/auth-session` socket payload remains a **pure wake signal** and the timestamps are read back from the status endpoint, so nothing trusted travels over the realtime channel. `POST /auth/session/opened/:authorizeCode` is idempotent and `pending`-only.

## Commons client

Registers an **Expo** push token — never a raw APNs/FCM token, which the SDK rejects before sending (that mismatch is a live bug in `packages/inbox`, deliberately not copied). Reuses the existing cold-launch deep-link replay instead of growing a second one. A malformed or foreign-scheme approval URL is dropped silently and navigates nowhere.

Token retirement sits where a bearer still exists and the identity is deliberately given up (`runAccountDeletion`, step 0). Retiring post-hoc from a session watcher would be provably wrong: `DELETE /notifications/push-token` is scoped to the bearer, so after sign-out it 401s, and after an identity swap it would delete the *new* identity's row while the stale one survived.

## Tests

api 207 suites / 1962 pass (+51), core 98 suites / 1233 pass (+59), commons 58 suites / 504 pass (+67), contracts 162 pass.

## Deploy step (required)

`bun run register:commons-clients` must run in prod to union `identity:approval` onto the Commons `Application`. Until it does, `deliver` correctly returns `{ delivered: false, targets: 0 }` for everyone and every client falls back to QR.

## Known gaps (deliberate)

- No app-global `setNotificationHandler`, so an auth request arriving while Commons is **foregrounded** shows no banner. Installing one changes behaviour for every notification type; small follow-up.
- Commons' `extra.eas.projectId` is still `''` (a known A0 prereq), so `getExpoPushTokenAsync()` throws until a project id exists. The adapter catches it and registration skips with `no-token` — no crash, no push, QR fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)