### PR TITLE
feat(auth): keep popup mode off the automatic redirect lanes (#691 phase 7a)

### DIFF
--- a/packages/services/src/ui/boot/__tests__/coldBootWebAuthMode.test.ts
+++ b/packages/services/src/ui/boot/__tests__/coldBootWebAuthMode.test.ts
@@ -1,0 +1,281 @@
+/**
+ * `runProviderColdBoot` — the `webAuthMode` transport gate (#691 phase 7).
+ *
+ * `webAuthMode: 'popup'` must never let the boot navigate the RP's top-level
+ * window: no silent `prompt=none` restore, no authorize redirect, a signed-out
+ * domain simply resolves signed out. `'redirect'` — still the default and the
+ * compatibility path — must behave exactly as before.
+ *
+ * Unlike `__tests__/boot/runProviderColdBoot.test.ts` (deadline + connectivity
+ * wiring, with `crossOriginRestore` stubbed out), this suite keeps the restore
+ * lane REAL so the redirect-mode assertions reach the actual navigation
+ * primitive — the thing popup mode has to suppress.
+ */
+
+import type { AuthStateStore, PersistedAuthState, SessionClient } from '@oxyhq/core';
+
+// Only `runSessionColdBoot` and the origin-CLASSIFICATION predicates are faked.
+// jsdom's `location` is non-configurable, so origin eligibility has to be driven
+// through the predicates (their real behaviour is covered by core's own tests);
+// everything else in core (PKCE, authorize-URL builder, handshake store) stays
+// real so the redirect-mode lane is exercised end to end.
+jest.mock('@oxyhq/core', () => {
+  const actual = jest.requireActual('@oxyhq/core');
+  return {
+    __esModule: true,
+    ...actual,
+    runSessionColdBoot: jest.fn(),
+    isLoopbackOrigin: jest.fn(() => false),
+    isOfficialWebOrigin: jest.fn(() => true),
+    isIdpHubOrigin: jest.fn(() => false),
+  };
+});
+
+// The ONLY top-level-window navigation primitive either lane can reach.
+jest.mock('../../components/oauthNavigation', () => ({
+  redirectToAuthorize: jest.fn(),
+}));
+
+// Spied but REAL: redirect mode must still perform the actual restore.
+jest.mock('../../utils/crossOriginRestore', () => {
+  const actual = jest.requireActual('../../utils/crossOriginRestore');
+  return {
+    __esModule: true,
+    ...actual,
+    maybeStartSilentOAuthRestore: jest.fn(actual.maybeStartSilentOAuthRestore),
+    consumeSilentOAuthError: jest.fn(actual.consumeSilentOAuthError),
+  };
+});
+
+jest.mock('../../utils/oauthReturn', () => {
+  const actual = jest.requireActual('../../utils/oauthReturn');
+  return {
+    __esModule: true,
+    ...actual,
+    tryCompleteOAuthReturn: jest.fn(async () => false),
+    consumeHubSyncFailure: jest.fn(actual.consumeHubSyncFailure),
+  };
+});
+
+import { runSessionColdBoot } from '@oxyhq/core';
+import { redirectToAuthorize } from '../../components/oauthNavigation';
+import {
+  clearCrossOriginRestoreGuards,
+  consumeSilentOAuthError,
+  maybeStartSilentOAuthRestore,
+} from '../../utils/crossOriginRestore';
+import { consumeHubSyncFailure, tryCompleteOAuthReturn } from '../../utils/oauthReturn';
+import { runProviderColdBoot, type RunProviderColdBootOptions } from '../runProviderColdBoot';
+
+const mockRunSessionColdBoot = runSessionColdBoot as jest.Mock;
+const mockRedirectToAuthorize = redirectToAuthorize as jest.Mock;
+const mockSilentRestore = maybeStartSilentOAuthRestore as jest.Mock;
+const mockConsumeSilentOAuthError = consumeSilentOAuthError as jest.Mock;
+const mockConsumeHubSyncFailure = consumeHubSyncFailure as jest.Mock;
+const mockTryCompleteOAuthReturn = tryCompleteOAuthReturn as jest.Mock;
+
+const CLIENT_ID = 'oxy_dk_test';
+
+/** An auth store holding no device credential — the signed-out domain case. */
+function makeEmptyAuthStore(): AuthStateStore {
+  return {
+    load: jest.fn(async (): Promise<PersistedAuthState | null> => null),
+    save: jest.fn(async () => undefined),
+    clear: jest.fn(async () => undefined),
+  } as unknown as AuthStateStore;
+}
+
+interface Harness {
+  options: RunProviderColdBootOptions;
+  commitSession: jest.Mock;
+  markAuthResolved: jest.Mock;
+  setTokenReady: jest.Mock;
+  sessionClientStart: jest.Mock;
+}
+
+function makeHarness(overrides: Partial<RunProviderColdBootOptions> = {}): Harness {
+  const commitSession = jest.fn(async () => undefined);
+  const markAuthResolved = jest.fn();
+  const setTokenReady = jest.fn();
+  const sessionClientStart = jest.fn(async () => undefined);
+
+  const options: RunProviderColdBootOptions = {
+    oxyServices: {} as RunProviderColdBootOptions['oxyServices'],
+    authStore: makeEmptyAuthStore(),
+    clientId: CLIENT_ID,
+    sessionClient: { start: sessionClientStart } as unknown as SessionClient,
+    syncDeviceCredentialToHost: jest.fn(async () => undefined),
+    commitSession,
+    markAuthResolved,
+    setTokenReady,
+    ...overrides,
+  };
+
+  return { options, commitSession, markAuthResolved, setTokenReady, sessionClientStart };
+}
+
+/** `runSessionColdBoot` finding no session at all — the signed-out domain. */
+function stubSignedOutBoot(): void {
+  mockRunSessionColdBoot.mockImplementation(async (opts: Parameters<typeof runSessionColdBoot>[0]) => {
+    await opts.onSignedOut?.('no_session');
+    return { kind: 'unauthenticated' } as const;
+  });
+}
+
+describe('runProviderColdBoot — webAuthMode transport gate (#691 phase 7)', () => {
+  beforeEach(() => {
+    mockRunSessionColdBoot.mockReset();
+    mockRedirectToAuthorize.mockClear();
+    mockSilentRestore.mockClear();
+    mockConsumeSilentOAuthError.mockClear();
+    mockConsumeHubSyncFailure.mockClear();
+    mockTryCompleteOAuthReturn.mockClear();
+    mockTryCompleteOAuthReturn.mockImplementation(async () => false);
+    globalThis.sessionStorage?.clear();
+    clearCrossOriginRestoreGuards();
+  });
+
+  describe("webAuthMode: 'popup'", () => {
+    it('never starts the silent restore and never navigates the top-level window', async () => {
+      stubSignedOutBoot();
+      const { options } = makeHarness({ webAuthMode: 'popup' });
+
+      await runProviderColdBoot(options);
+
+      expect(mockSilentRestore).not.toHaveBeenCalled();
+      expect(mockRedirectToAuthorize).not.toHaveBeenCalled();
+    });
+
+    it('resolves a domain with no local credential SIGNED OUT instead of bouncing', async () => {
+      stubSignedOutBoot();
+      const { options, markAuthResolved, commitSession, sessionClientStart } = makeHarness({
+        webAuthMode: 'popup',
+      });
+
+      await runProviderColdBoot(options);
+
+      // Auth resolution concluded (routing can settle), nothing was committed,
+      // and with no persisted credential the device socket is not started.
+      expect(markAuthResolved).toHaveBeenCalled();
+      expect(commitSession).not.toHaveBeenCalled();
+      expect(sessionClientStart).not.toHaveBeenCalled();
+      expect(mockRedirectToAuthorize).not.toHaveBeenCalled();
+    });
+
+    it('still completes an authorization code already on the URL (blocked-popup fallback)', async () => {
+      // A popup-mode app lands here whenever the browser blocked the popup and
+      // `startWebOAuthSignIn` fell back to a full-page redirect.
+      mockTryCompleteOAuthReturn.mockImplementation(async () => true);
+      const { options, markAuthResolved, setTokenReady } = makeHarness({ webAuthMode: 'popup' });
+
+      await runProviderColdBoot(options);
+
+      expect(mockTryCompleteOAuthReturn).toHaveBeenCalledTimes(1);
+      expect(setTokenReady).toHaveBeenLastCalledWith(true);
+      expect(markAuthResolved).toHaveBeenCalled();
+      // The device mint is short-circuited by the completed return leg.
+      expect(mockRunSessionColdBoot).not.toHaveBeenCalled();
+      expect(mockRedirectToAuthorize).not.toHaveBeenCalled();
+    });
+
+    it('commits the OAuth return WITHOUT hub sync', async () => {
+      mockTryCompleteOAuthReturn.mockImplementation(async () => true);
+      const { options } = makeHarness({ webAuthMode: 'popup' });
+
+      await runProviderColdBoot(options);
+
+      const commit = mockTryCompleteOAuthReturn.mock.calls[0][0] as {
+        commitSession: (input: unknown) => Promise<void>;
+      };
+      await commit.commitSession({ sessionId: 's1', userId: 'u1' });
+      expect(options.commitSession).toHaveBeenCalledWith(
+        { sessionId: 's1', userId: 'u1' },
+        { activate: true, hubSync: false },
+      );
+    });
+  });
+
+  describe("webAuthMode: 'redirect' (unchanged compatibility path)", () => {
+    it('starts the silent restore and navigates to the IdP with prompt=none', async () => {
+      stubSignedOutBoot();
+      const { options } = makeHarness({ webAuthMode: 'redirect' });
+
+      await runProviderColdBoot(options);
+
+      expect(mockSilentRestore).toHaveBeenCalledTimes(1);
+      expect(mockRedirectToAuthorize).toHaveBeenCalledTimes(1);
+      const url = new URL(mockRedirectToAuthorize.mock.calls[0][0] as string);
+      expect(url.origin + url.pathname).toBe('https://auth.oxy.so/authorize');
+      expect(url.searchParams.get('client_id')).toBe(CLIENT_ID);
+      expect(url.searchParams.get('prompt')).toBe('none');
+    });
+
+    it('is the DEFAULT when no webAuthMode is supplied', async () => {
+      stubSignedOutBoot();
+      const { options } = makeHarness();
+
+      await runProviderColdBoot(options);
+
+      expect(mockSilentRestore).toHaveBeenCalledTimes(1);
+      expect(mockRedirectToAuthorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT restore when the mint already resolved a session', async () => {
+      mockRunSessionColdBoot.mockImplementation(async (opts: Parameters<typeof runSessionColdBoot>[0]) => {
+        const session = { sessionId: 's1', userId: 'u1', accessToken: 'at', via: 'device-secret-mint' };
+        await opts.onSession?.(session);
+        return { kind: 'session', via: session.via, session } as const;
+      });
+      const { options, commitSession } = makeHarness({ webAuthMode: 'redirect' });
+
+      await runProviderColdBoot(options);
+
+      expect(commitSession).toHaveBeenCalledWith(
+        { sessionId: 's1', accessToken: 'at', userId: 'u1' },
+        { activate: false },
+      );
+      expect(mockSilentRestore).not.toHaveBeenCalled();
+      expect(mockRedirectToAuthorize).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('URL-cleanup consumers run in BOTH modes', () => {
+    it.each(['popup', 'redirect'] as const)(
+      'consumes the silent-OAuth error and hub-sync failure params (%s)',
+      async (webAuthMode) => {
+        stubSignedOutBoot();
+        const { options } = makeHarness({ webAuthMode });
+
+        await runProviderColdBoot(options);
+
+        expect(mockConsumeSilentOAuthError).toHaveBeenCalledTimes(1);
+        expect(mockConsumeHubSyncFailure).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it.each(['popup', 'redirect'] as const)(
+      'consumes an authorization code left on the URL (%s)',
+      async (webAuthMode) => {
+        stubSignedOutBoot();
+        const { options } = makeHarness({ webAuthMode });
+
+        await runProviderColdBoot(options);
+
+        expect(mockTryCompleteOAuthReturn).toHaveBeenCalledTimes(1);
+      },
+    );
+  });
+
+  describe('identity mode still skips both web OAuth lanes in either transport', () => {
+    it.each(['popup', 'redirect'] as const)('skips the return leg and the restore (%s)', async (webAuthMode) => {
+      stubSignedOutBoot();
+      const { options } = makeHarness({ webAuthMode, sessionMode: 'identity' });
+
+      await runProviderColdBoot(options);
+
+      expect(mockTryCompleteOAuthReturn).not.toHaveBeenCalled();
+      expect(mockSilentRestore).not.toHaveBeenCalled();
+      expect(mockRedirectToAuthorize).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/services/src/ui/boot/runProviderColdBoot.ts
+++ b/packages/services/src/ui/boot/runProviderColdBoot.ts
@@ -15,6 +15,8 @@ import {
 } from '../utils/crossOriginRestore';
 import { tryCompleteOAuthReturn, consumeHubSyncFailure } from '../utils/oauthReturn';
 import { isWebBrowser } from '../utils/isWebBrowser';
+import { allowsAutomaticIdpRedirect } from '../oauth/legacyRedirectLanes';
+import type { WebAuthMode } from '../oauth/types';
 import type { CommitInput } from '../context/oxyContextTypes';
 
 /** How long the cold boot waits for the post-boot SessionClient handoff (ms). */
@@ -94,6 +96,17 @@ export interface RunProviderColdBootOptions {
   sessionMode?: SessionMode;
   /** The identity binding required by `sessionMode: 'identity'`. */
   identity?: IdentityBinding;
+  /**
+   * How this provider's WEB sign-in reaches the IdP
+   * (`OxyProviderProps.webAuthMode`).
+   *
+   * A first-class INPUT to the boot, not a UI-only concern: `'popup'` forbids
+   * the automatic full-page `prompt=none` restore in step 3, so a domain with no
+   * local credential resolves SIGNED OUT instead of bouncing the top-level
+   * window to `auth.oxy.so`. See `allowsAutomaticIdpRedirect`.
+   * @default 'redirect'
+   */
+  webAuthMode?: WebAuthMode;
   sessionClient: SessionClient;
   syncDeviceCredentialToHost: () => Promise<void>;
   commitSession: (
@@ -116,6 +129,11 @@ export interface RunProviderColdBootOptions {
  * Steps 1 and 3 are ACCOUNT-MODE ONLY: both commit whichever account the IdP
  * resolves, which for an identity-bound client is somebody else's account by
  * construction. In `'identity'` mode the boot is exactly step 2.
+ *
+ * Step 3 is additionally REDIRECT-MODE ONLY: it navigates the top-level window
+ * with no user gesture behind it, which `webAuthMode: 'popup'` exists to
+ * eliminate. In popup mode the boot is steps 1 and 2, and a domain with no local
+ * credential simply resolves signed out. See `allowsAutomaticIdpRedirect`.
  */
 export async function runProviderColdBoot(opts: RunProviderColdBootOptions): Promise<void> {
   const {
@@ -126,6 +144,7 @@ export async function runProviderColdBoot(opts: RunProviderColdBootOptions): Pro
     authorizeBaseUrl,
     sessionMode = 'account',
     identity,
+    webAuthMode = 'redirect',
     sessionClient,
     syncDeviceCredentialToHost,
     commitSession,
@@ -138,9 +157,21 @@ export async function runProviderColdBoot(opts: RunProviderColdBootOptions): Pro
   setTokenReady(false);
 
   try {
+    // MODE-INDEPENDENT URL cleanup, deliberately so: both consume query params a
+    // PREVIOUS redirect-mode session left in the address bar (`?error=login_required`
+    // from a silent authorize, `?hub_sync=failed` from the hub) and restore the
+    // page the visit started on. Flipping an app to popup mode must not strand
+    // those params, so neither is gated on `webAuthMode`. Neither starts a
+    // navigation — they only rewrite the URL via `history.replaceState`.
     consumeSilentOAuthError();
     consumeHubSyncFailure();
 
+    // The redirect transport's RETURN leg — also NOT gated on `webAuthMode`. A
+    // popup-mode app legitimately lands here with `?code=` whenever the browser
+    // blocked the popup and `startWebOAuthSignIn` fell back to a full-page
+    // redirect (`popup-blocked` / `popup-navigation-failed`), and an app that
+    // switched modes mid-flight must not be stranded with a dead `?code=`
+    // either. It consumes a code already on the URL; it never starts one.
     const oauthCompleted = identityBound
       ? false
       : await tryCompleteOAuthReturn({
@@ -229,17 +260,30 @@ export async function runProviderColdBoot(opts: RunProviderColdBootOptions): Pro
       },
     });
 
-    // Silent cross-origin OAuth restore (web cross-app SSO). Gate it the SAME
-    // way the hub-sync WRITE side (`syncHubAfterSignIn`) gates: official web
-    // origins only, never the IdP hub itself, and — unlike the write side —
-    // never a loopback / local-dev origin (which must not be bounced to a hosted
-    // IdP on cold boot). The authorize endpoint is env-configurable so a
-    // local/staging app targets its own IdP instead of production.
+    // Silent cross-origin OAuth restore (web cross-app SSO): a full-page
+    // `prompt=none` bounce to the IdP when the mint found no local session.
+    //
+    // TRANSPORT gate (`allowsAutomaticIdpRedirect`): `webAuthMode: 'popup'`
+    // FORBIDS this lane. It navigates the top-level window with no user gesture
+    // behind it, which is precisely what popup mode exists to eliminate — a
+    // popup-mode domain without a local credential resolves signed out right
+    // here and waits for the user's next explicit "Continue with Oxy" (issue
+    // #691, "Cold boot and cross-domain behavior"). `'redirect'` — still the
+    // default and the compatibility path — reaches this lane unchanged, and this
+    // whole block disappears with the transport in phase 7b.
+    //
+    // ORIGIN gate: same as the hub-sync WRITE side (`syncHubAfterSignIn`) —
+    // official web origins only, never the IdP hub itself, and — unlike the
+    // write side — never a loopback / local-dev origin (which must not be
+    // bounced to a hosted IdP on cold boot). The authorize endpoint is
+    // env-configurable so a local/staging app targets its own IdP instead of
+    // production.
     const webOrigin = isWebBrowser()
       ? (globalThis as { location?: Location }).location?.origin
       : undefined;
     if (
       !identityBound &&
+      allowsAutomaticIdpRedirect(webAuthMode) &&
       clientId &&
       outcome.kind !== 'session' &&
       webOrigin &&

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -79,7 +79,7 @@ import type {
   CommitInput,
 } from './oxyContextTypes';
 import { DEFAULT_SESSION_VALIDITY_MS, loadUseFollowHook } from './oxyContextHelpers';
-import { commitDeviceSetAndResolve } from './commitSessionFlow';
+import { commitDeviceSetAndResolve, maybeSyncHubAfterCommit } from './commitSessionFlow';
 import { runPasskeyLogin, runPasskeyRegister, runPasskeyAdd } from './passkeyFlow';
 import {
   isPasskeySupported,
@@ -688,21 +688,20 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
         markAuthResolved: markAuthResolvedRef.current,
       });
 
-      if (options.activate && options.hubSync && hubSync && isWebBrowser()) {
-        try {
-          await syncHubAfterSignIn(oxyServices, { enabled: hubSync });
-        } catch (hubError) {
-          if (__DEV__) {
-            loggerUtil.debug(
-              'Hub sync after sign-in failed (non-fatal)',
-              { component: 'OxyContext', method: 'commitSession' },
-              hubError as unknown,
-            );
-          }
-        }
-      }
+      // Post-sign-in hub sync — a full-page redirect to auth.oxy.so. Gated HERE,
+      // inside the ONE commit funnel, so NO commit path (QR device flow,
+      // password/2FA through the account dialog, passkey, popup OAuth, cold
+      // boot) can bounce a `webAuthMode: 'popup'` tab to the IdP. See
+      // `maybeSyncHubAfterCommit` for the full gate list.
+      await maybeSyncHubAfterCommit({
+        activate: options.activate,
+        hubSyncRequested: options.hubSync === true,
+        hubSyncEnabled: hubSync,
+        webAuthMode,
+        syncHub: () => syncHubAfterSignIn(oxyServices, { enabled: hubSync }),
+      });
     },
-    [oxyServices, authStore, updateSessions, setActiveSessionId, sessionClient, sessionClientHost, syncFromClient, loginSuccess, logger, hubSync],
+    [oxyServices, authStore, updateSessions, setActiveSessionId, sessionClient, sessionClientHost, syncFromClient, loginSuccess, logger, hubSync, webAuthMode],
   );
   const commitSessionRef = useRef(commitSession);
   commitSessionRef.current = commitSession;
@@ -1047,6 +1046,10 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       authorizeBaseUrl,
       sessionMode,
       identity: identity?.binding,
+      // Popup mode forbids the boot's automatic full-page `prompt=none` restore:
+      // a domain with no local credential resolves signed out instead of
+      // navigating the tab to the IdP (see `allowsAutomaticIdpRedirect`).
+      webAuthMode,
       sessionClient,
       syncDeviceCredentialToHost,
       commitSession: (input, options) => commitSessionRef.current(input, options),
@@ -1067,6 +1070,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     authorizeBaseUrl,
     sessionMode,
     identity,
+    webAuthMode,
     syncDeviceCredentialToHost,
     sessionClient,
   ]);

--- a/packages/services/src/ui/context/__tests__/commitSessionFlow.test.ts
+++ b/packages/services/src/ui/context/__tests__/commitSessionFlow.test.ts
@@ -1,8 +1,11 @@
 import type { User } from '@oxyhq/core';
 import { logger } from '@oxyhq/core';
+import type { WebAuthMode } from '../../oauth/types';
 import {
   commitDeviceSetAndResolve,
+  maybeSyncHubAfterCommit,
   type CommitDeviceSetAndResolveDeps,
+  type MaybeSyncHubAfterCommitDeps,
 } from '../commitSessionFlow';
 
 // A resolved promise chain (addCurrentAccount -> start -> syncFromClient) settles
@@ -175,6 +178,92 @@ describe('commitDeviceSetAndResolve — cold boot (activate: false)', () => {
       { component: 'OxyContext', method: 'commitSession' },
       unauthorized,
     );
+  });
+});
+
+/**
+ * Post-sign-in hub sync is a FULL-PAGE redirect to auth.oxy.so. It runs from the
+ * ONE commit funnel, so gating it here gates every commit path at once —
+ * `webAuthMode: 'popup'` must never bounce the tab, whichever path signed the
+ * user in (#691 phase 7).
+ */
+describe('maybeSyncHubAfterCommit — webAuthMode transport gate (#691 phase 7)', () => {
+  const buildHubDeps = (
+    overrides: Partial<MaybeSyncHubAfterCommitDeps> = {},
+  ): MaybeSyncHubAfterCommitDeps => ({
+    activate: true,
+    hubSyncRequested: true,
+    hubSyncEnabled: true,
+    webAuthMode: 'redirect',
+    syncHub: jest.fn(async () => true),
+    ...overrides,
+  });
+
+  it("redirect mode: syncs the hub after a deliberate sign-in (unchanged)", async () => {
+    const deps = buildHubDeps();
+
+    await expect(maybeSyncHubAfterCommit(deps)).resolves.toBe(true);
+
+    expect(deps.syncHub).toHaveBeenCalledTimes(1);
+  });
+
+  it('popup mode: NEVER syncs the hub, even on an otherwise-eligible sign-in', async () => {
+    const deps = buildHubDeps({ webAuthMode: 'popup' });
+
+    await expect(maybeSyncHubAfterCommit(deps)).resolves.toBe(false);
+
+    expect(deps.syncHub).not.toHaveBeenCalled();
+  });
+
+  it('popup mode: no commit path can opt back in', async () => {
+    // Every commit path differs only in `activate` / `hubSyncRequested`; the
+    // transport gate outranks all of them.
+    for (const activate of [true, false]) {
+      for (const hubSyncRequested of [true, false]) {
+        const deps = buildHubDeps({ webAuthMode: 'popup', activate, hubSyncRequested });
+        await expect(maybeSyncHubAfterCommit(deps)).resolves.toBe(false);
+        expect(deps.syncHub).not.toHaveBeenCalled();
+      }
+    }
+  });
+
+  it.each(['popup', 'redirect'] as const)(
+    'never syncs on a cold-boot restore, in either mode (%s)',
+    async (webAuthMode: WebAuthMode) => {
+      const deps = buildHubDeps({ webAuthMode, activate: false });
+
+      await expect(maybeSyncHubAfterCommit(deps)).resolves.toBe(false);
+
+      expect(deps.syncHub).not.toHaveBeenCalled();
+    },
+  );
+
+  it('redirect mode: honours the per-commit opt-out (account switch / popup OAuth lanes)', async () => {
+    const deps = buildHubDeps({ hubSyncRequested: false });
+
+    await expect(maybeSyncHubAfterCommit(deps)).resolves.toBe(false);
+
+    expect(deps.syncHub).not.toHaveBeenCalled();
+  });
+
+  it('redirect mode: honours the provider-level hubSync opt-out', async () => {
+    const deps = buildHubDeps({ hubSyncEnabled: false });
+
+    await expect(maybeSyncHubAfterCommit(deps)).resolves.toBe(false);
+
+    expect(deps.syncHub).not.toHaveBeenCalled();
+  });
+
+  it('redirect mode: a failing hub sync is non-fatal and never rejects', async () => {
+    const deps = buildHubDeps({
+      syncHub: jest.fn(async () => {
+        throw new Error('hub ticket failed');
+      }),
+    });
+
+    await expect(maybeSyncHubAfterCommit(deps)).resolves.toBe(false);
+
+    expect(deps.syncHub).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/services/src/ui/context/commitSessionFlow.ts
+++ b/packages/services/src/ui/context/commitSessionFlow.ts
@@ -1,5 +1,8 @@
 import type { User } from '@oxyhq/core';
 import { logger as loggerUtil } from '@oxyhq/core';
+import { allowsAutomaticIdpRedirect } from '../oauth/legacyRedirectLanes';
+import type { WebAuthMode } from '../oauth/types';
+import { isWebBrowser } from '../utils/isWebBrowser';
 import { isUnauthorizedStatus } from './oxyContextHelpers';
 
 const LOG_CONTEXT = { component: 'OxyContext', method: 'commitSession' } as const;
@@ -122,4 +125,62 @@ export async function commitDeviceSetAndResolve(
   // task so first paint is not blocked behind those round-trips.
   await hydrateAndResolve();
   void reconcileDeviceSet().catch(logReconcileError);
+}
+
+export interface MaybeSyncHubAfterCommitDeps {
+  /** Deliberate sign-in (`true`) vs. a cold-boot / background commit (`false`). */
+  activate: boolean;
+  /** Per-commit opt-in — `commitSession`'s `options.hubSync`. */
+  hubSyncRequested: boolean;
+  /** Provider-level opt-out — `OxyProviderProps.hubSync`. */
+  hubSyncEnabled: boolean;
+  /**
+   * The provider's web sign-in transport — `OxyProviderProps.webAuthMode`.
+   * A first-class input: `'popup'` forbids the redirect outright.
+   */
+  webAuthMode: WebAuthMode;
+  /**
+   * Starts the full-page hop to `auth.oxy.so/sync`; resolves `true` when the
+   * navigation was actually started.
+   */
+  syncHub: () => Promise<boolean>;
+}
+
+/**
+ * Post-sign-in hub sync: plant this device's credential on the IdP hub so OTHER
+ * official origins can silently restore a session on their next cold boot.
+ *
+ * The tail of the ONE commit funnel (`commitSession`), extracted so every gate
+ * on this legacy lane lives — and is tested — in one place. Returns whether the
+ * full-page redirect was started; a failure is non-fatal and never propagates
+ * (the sign-in itself already succeeded).
+ *
+ * Four gates, all of which must pass:
+ * 1. `activate` — only a deliberate sign-in syncs; a cold-boot restore never does.
+ * 2. `hubSyncRequested` — the in-place lanes (account switch, popup OAuth) opt out.
+ * 3. `hubSyncEnabled` — the provider-level `hubSync` prop.
+ * 4. `allowsAutomaticIdpRedirect(webAuthMode)` — hub sync REPLACES the document
+ *    with `auth.oxy.so`, so `webAuthMode: 'popup'` forbids it: a redirect that
+ *    bounces the tab defeats the entire point of the mode, no matter which
+ *    commit path produced the session (issue #691, "Cold boot and cross-domain
+ *    behavior"). Redirect mode — the default and the compatibility path — is
+ *    unchanged, and this whole function disappears with it in phase 7b.
+ */
+export async function maybeSyncHubAfterCommit(
+  deps: MaybeSyncHubAfterCommitDeps,
+): Promise<boolean> {
+  const { activate, hubSyncRequested, hubSyncEnabled, webAuthMode, syncHub } = deps;
+
+  if (!activate || !hubSyncRequested || !hubSyncEnabled) return false;
+  if (!allowsAutomaticIdpRedirect(webAuthMode)) return false;
+  if (!isWebBrowser()) return false;
+
+  try {
+    return await syncHub();
+  } catch (hubError) {
+    if (__DEV__) {
+      loggerUtil.debug('Hub sync after sign-in failed (non-fatal)', LOG_CONTEXT, hubError);
+    }
+    return false;
+  }
 }

--- a/packages/services/src/ui/oauth/legacyRedirectLanes.ts
+++ b/packages/services/src/ui/oauth/legacyRedirectLanes.ts
@@ -1,0 +1,43 @@
+/**
+ * The legacy, redirect-mode-only lanes that navigate the RP's TOP-LEVEL window
+ * to the IdP without a user gesture.
+ *
+ * `webAuthMode: 'popup'` exists to guarantee exactly one thing: the relying
+ * party never leaves its route. Two mechanics in this SDK break that guarantee,
+ * because each replaces the whole document on its own initiative:
+ *
+ * 1. **Cold-boot silent restore** — a full-page `prompt=none` authorize bounce
+ *    to `auth.oxy.so` when the device-secret mint finds no local session
+ *    (`maybeStartSilentOAuthRestore`, called from `runProviderColdBoot`).
+ * 2. **Post-sign-in hub sync** — a full-page hop to `auth.oxy.so/sync` that
+ *    plants this device's credential on the IdP hub so OTHER origins can later
+ *    run lane 1 (`syncHubAfterSignIn`, called from the `commitSession` funnel).
+ *
+ * Both belong to the redirect transport and are kept only for the migration
+ * window (issue #691, "Cold boot and cross-domain behavior"). In popup mode a
+ * domain with no local credential simply resolves SIGNED OUT, and the user's
+ * next explicit "Continue with Oxy" opens the popup — from a real user gesture,
+ * never automatically.
+ *
+ * NOT covered here, and correctly enabled in BOTH modes: navigations the user
+ * asked for. When the browser blocks the popup, `startWebOAuthSignIn` still
+ * falls back to a full-page redirect rather than dead-ending the sign-in, and
+ * `tryCompleteOAuthReturn` still consumes a `?code=` that is already on the URL.
+ *
+ * PHASE 7b: once the pilot flips the default transport to `'popup'`, this
+ * predicate and BOTH lanes above are deleted outright. Grepping this symbol
+ * finds every site that has to go.
+ */
+
+import type { WebAuthMode } from './types';
+
+/**
+ * Whether a provider running `webAuthMode` may perform an SDK-initiated,
+ * non-gesture, full-page navigation to the IdP.
+ *
+ * `true` only for `'redirect'` — still the default and the compatibility path,
+ * whose behaviour must stay byte-for-byte unchanged.
+ */
+export function allowsAutomaticIdpRedirect(webAuthMode: WebAuthMode): boolean {
+  return webAuthMode === 'redirect';
+}


### PR DESCRIPTION
Phase 7a of #691, on top of #701.

## Why

Popup mode exists so the relying party's tab never leaves its route. Two SDK-initiated navigations would still have moved it: the silent full-page `prompt=none` restore on cold boot, and the post-login hub-sync bounce. The issue lists both explicitly under "Cold boot and cross-domain behavior" in popup mode.

## Gate, not deletion

`redirect` is still the default and the compatibility path, and its behaviour is byte-for-byte unchanged — same call order, same arguments, same non-fatal catch. The wholesale removal of `crossOriginRestore.ts`, `hubSync`, the `/sync` page and the hub-ticket endpoints waits for the pilot to flip the default, exactly as the issue sequences it ("keep legacy redirect behavior only during migration and remove it from the normal path after the pilot").

One shared predicate is the single deletion target for 7b — `grep -rn allowsAutomaticIdpRedirect` finds every site:

- `runProviderColdBoot.ts` — the silent `prompt=none` restore
- `commitSessionFlow.ts` — the hub-sync tail, extracted so it is deps-injected and unit-testable

The hub-sync gate lives in the **one** commit funnel rather than at the popup lane's own call site, so no path — QR device flow, passkey, password/2FA, cold boot, popup OAuth — can bounce the tab in popup mode.

## Deliberately NOT gated (documented in place)

- `consumeSilentOAuthError()` / `consumeHubSyncFailure()` run in both modes: they only `history.replaceState` away params a previous redirect-mode session left behind.
- `tryCompleteOAuthReturn` stays unconditional: a popup-mode app legitimately lands with `?code=` when the browser blocks the popup and the transport falls back to a redirect, and a mode switch must not strand a dead code in the address bar. It consumes a code already on the URL; it never starts a navigation, and already commits with `hubSync: false`.

I audited every top-level-navigation site in `src/` (`location.assign` / `location.href=` / `location.replace` / `redirectToAuthorize` / `syncHubAfterSignIn`): the only two SDK-initiated, non-gesture IdP navigations are the two now gated. Cold boot never touches `openOAuthPopup`/`openPasskeyHubPopup`, so "no automatic popups" holds by construction.

## Tests

508 pass. Popup mode: the restore starter is never called, the top-level window never navigates, a signed-out domain resolves signed out, and no commit path hub-syncs across the full `activate` × `hubSyncRequested` matrix. Redirect mode: the restore still runs and still navigates to `https://auth.oxy.so/authorize` with `prompt=none` (the suite keeps the restore lane **real**, so the assertion reaches the actual navigation primitive). URL-cleanup consumers run in both.

Mutation check: forcing the predicate to `return true` fails exactly the four popup-mode assertions and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->