### PR TITLE
fix(inbox): empty sender avatars, and stop seeding the system labels

### DIFF
--- a/packages/api/scripts/drop-seeded-system-labels.ts
+++ b/packages/api/scripts/drop-seeded-system-labels.ts
@@ -1,0 +1,61 @@
+#!/usr/bin/env bun
+/**
+ * One-time migration: delete the per-user copies of the system labels.
+ *
+ * Why it exists:
+ *   The eight built-in labels (Personal, Work, Finance, …) used to be seeded
+ *   into `labels` for every user by `ensureDefaultLabels`. They are constants
+ *   now (`src/constants/systemLabels.ts`) and `listLabels` returns them
+ *   directly, so the seeded rows are dead weight: identical for every account,
+ *   never edited, and now shadowed by their constant.
+ *
+ * Behavior:
+ *   - Deletes `labels` rows whose name matches a system label, case-insensitively.
+ *   - Leaves `Message.labels` untouched: messages reference labels BY NAME, and
+ *     the names are unchanged, so every existing assignment keeps working.
+ *   - Leaves user-created labels alone, including one that merely shares a
+ *     colour or order with a system label.
+ *   - Idempotent — safe to re-run; a second run deletes nothing.
+ *
+ * Run:
+ *   cd packages/api && bun run scripts/drop-seeded-system-labels.ts
+ *
+ * Optional env:
+ *   MONGODB_URI    Mongo connection string (required)
+ *   DRY_RUN=true   Report what would be deleted without writing
+ */
+
+import mongoose from 'mongoose';
+import { Label } from '../src/models/Label';
+import { SYSTEM_LABELS } from '../src/constants/systemLabels';
+
+const DRY_RUN = process.env.DRY_RUN === 'true';
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) throw new Error('MONGODB_URI is required');
+
+  await mongoose.connect(uri);
+
+  // Exact names, matched case-insensitively via a collation so the query uses
+  // the same comparison the service does.
+  const names = SYSTEM_LABELS.map((l) => l.name);
+  const filter = { name: { $in: names } };
+
+  const matched = await Label.countDocuments(filter).collation({ locale: 'en', strength: 2 });
+  const owners = (await Label.distinct('userId', filter)).length;
+
+  if (DRY_RUN) {
+    console.log(`[dry-run] would delete ${matched} seeded label rows across ${owners} users`);
+  } else {
+    const { deletedCount } = await Label.deleteMany(filter).collation({ locale: 'en', strength: 2 });
+    console.log(`deleted ${deletedCount} seeded label rows across ${owners} users`);
+  }
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/api/src/constants/systemLabels.ts
+++ b/packages/api/src/constants/systemLabels.ts
@@ -1,0 +1,58 @@
+/**
+ * The labels every mailbox has.
+ *
+ * These are part of the product, not user data: the same eight names, colours
+ * and order for everyone, referenced by name from `Message.labels` and from the
+ * default bundles' `matchLabels`. Writing a copy of them into `labels` for each
+ * user bought nothing — the rows were never edited, never differed between
+ * accounts, and had to be lazily re-seeded on every write path in case a user
+ * had somehow missed them. They live here instead; the collection now holds
+ * only the labels a user actually made.
+ *
+ * `_id` is a stable synthetic id (`system:<name>`) so a client can key a list
+ * on it exactly like a real label. It is deliberately not an ObjectId: nothing
+ * should be able to look one of these up in the database.
+ */
+
+export interface SystemLabel {
+  _id: string;
+  name: string;
+  color: string;
+  order: number;
+  system: true;
+}
+
+/** Prefix of every synthetic system-label id. */
+const SYSTEM_ID_PREFIX = 'system:';
+
+/** Whether `labelId` addresses a system label rather than a stored one. */
+export function isSystemLabelId(labelId: string): boolean {
+  return labelId.startsWith(SYSTEM_ID_PREFIX);
+}
+
+const DEFINITIONS: ReadonlyArray<{ name: string; color: string }> = [
+  { name: 'Personal', color: '#1A73E8' },
+  { name: 'Work', color: '#34A853' },
+  { name: 'Finance', color: '#FBBC04' },
+  { name: 'Shopping', color: '#EA4335' },
+  { name: 'Travel', color: '#9334E6' },
+  { name: 'Social', color: '#E8710A' },
+  { name: 'Updates', color: '#607D8B' },
+  { name: 'Forums', color: '#795548' },
+];
+
+export const SYSTEM_LABELS: ReadonlyArray<SystemLabel> = DEFINITIONS.map((l, order) => ({
+  _id: `${SYSTEM_ID_PREFIX}${l.name.toLowerCase()}`,
+  name: l.name,
+  color: l.color,
+  order,
+  system: true,
+}));
+
+/** Lower-cased system label names, for case-insensitive comparison. */
+const SYSTEM_NAMES = new Set(SYSTEM_LABELS.map((l) => l.name.toLowerCase()));
+
+/** Whether `name` is one of the system labels, ignoring case and surrounding space. */
+export function isSystemLabel(name: string): boolean {
+  return SYSTEM_NAMES.has(name.trim().toLowerCase());
+}

--- a/packages/api/src/controllers/__tests__/emailProxy.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/emailProxy.controller.test.ts
@@ -22,6 +22,8 @@ jest.mock('../../utils/logger', () => ({
 type MockResponse = {
   setHeader: jest.Mock;
   send: jest.Mock;
+  status: jest.Mock;
+  end: jest.Mock;
 };
 
 function makeReq(url: string): Request {
@@ -30,10 +32,14 @@ function makeReq(url: string): Request {
 }
 
 function makeRes(): MockResponse {
-  return {
+  const res = {
     setHeader: jest.fn(),
     send: jest.fn(),
+    status: jest.fn(),
+    end: jest.fn(),
   };
+  res.status.mockReturnValue(res);
+  return res;
 }
 
 function makeSafeFetchResult(
@@ -121,5 +127,24 @@ describe('email proxy SSRF protections', () => {
     );
     expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
     expect(res.send).toHaveBeenCalledWith(expect.any(Buffer));
+  });
+
+  it('reports an upstream 404 as 404, never as a transparent GIF', async () => {
+    // A sender avatar falls back to `https://<domain>/favicon.ico`, which is
+    // emitted without probing. When that 404s, answering with the transparent
+    // GIF is a *successful* image response: the client's onError never fires
+    // and an invisible pixel is painted over the initials placeholder, leaving
+    // an empty avatar. The GIF is only for a tracking pixel we blocked.
+    mockSafeFetch.mockResolvedValue(
+      makeSafeFetchResult(404, Buffer.alloc(0), { 'content-type': 'text/html' }, 'https://sender.example/favicon.ico'),
+    );
+    const res = makeRes();
+
+    await proxyResource(makeReq('https://sender.example/favicon.ico'), res as unknown as ExpressResponse);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.end).toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
+    expect(res.setHeader).not.toHaveBeenCalledWith('Content-Type', 'image/gif');
   });
 });

--- a/packages/api/src/controllers/emailProxy.controller.ts
+++ b/packages/api/src/controllers/emailProxy.controller.ts
@@ -163,8 +163,8 @@ setInterval(() => {
 
 // ─── Response Helpers ─────────────────────────────────────────────
 
-/** Empty 404 for an unservable font — see `wantsFont`. */
-function sendMissingFont(res: ExpressResponse, cacheTime = 86400): void {
+/** Empty 404 for a resource the upstream does not have. */
+function sendNotFound(res: ExpressResponse, cacheTime = 86400): void {
   res.setHeader('Cache-Control', `public, max-age=${cacheTime}`);
   res.status(404).end();
 }
@@ -221,7 +221,7 @@ export async function proxyResource(req: Request, res: ExpressResponse): Promise
   // Block tracking URLs
   if (isTrackingUrl(url)) {
     logger.debug('Blocked tracking URL', { url: decodedUrl });
-    return wantsFont ? sendMissingFont(res) : sendTransparentGif(res);
+    return wantsFont ? sendNotFound(res) : sendTransparentGif(res);
   }
 
   // Check cache
@@ -246,7 +246,13 @@ export async function proxyResource(req: Request, res: ExpressResponse): Promise
 
     try {
       if (status < 200 || status >= 300) {
-        return wantsFont ? sendMissingFont(res, 3600) : sendTransparentGif(res, 3600);
+        // The upstream does not have this resource. Answering with the
+        // transparent GIF would be a successful-looking image, which is how a
+        // sender avatar whose /favicon.ico 404s ends up as an invisible pixel
+        // painted over the initials placeholder — the caller never learns the
+        // fetch failed. The GIF stays reserved for what it is for: a tracking
+        // pixel we deliberately blocked.
+        return sendNotFound(res, 3600);
       }
 
       const contentTypeHeader = headers['content-type'];
@@ -272,7 +278,7 @@ export async function proxyResource(req: Request, res: ExpressResponse): Promise
       // Block tracking pixels (very small images)
       if (buffer.length < TRACKING_PIXEL_THRESHOLD) {
         logger.debug('Blocked tracking pixel', { url: decodedUrl, size: buffer.length });
-        return wantsFont ? sendMissingFont(res) : sendTransparentGif(res);
+        return wantsFont ? sendNotFound(res) : sendTransparentGif(res);
       }
 
       // Use correct MIME when upstream sends generic octet-stream for fonts
@@ -301,7 +307,7 @@ export async function proxyResource(req: Request, res: ExpressResponse): Promise
     }
 
     if (wantsFont) {
-      sendMissingFont(res);
+      sendNotFound(res);
       return;
     }
     sendTransparentGif(res);

--- a/packages/api/src/services/__tests__/emailService.inboundAttachments.test.ts
+++ b/packages/api/src/services/__tests__/emailService.inboundAttachments.test.ts
@@ -153,7 +153,6 @@ function stageHappyPath(): void {
   );
 
   jest.spyOn(svc, 'ensureMailboxes').mockResolvedValue(undefined);
-  jest.spyOn(svc, 'ensureDefaultLabels').mockResolvedValue(undefined);
   jest.spyOn(svc, 'enforceQuota').mockResolvedValue(undefined);
   jest.spyOn(svc, 'getMailboxBySpecialUse').mockResolvedValue({
     _id: { toString: () => MAILBOX_ID },

--- a/packages/api/src/services/__tests__/emailService.systemLabels.test.ts
+++ b/packages/api/src/services/__tests__/emailService.systemLabels.test.ts
@@ -1,0 +1,107 @@
+/**
+ * System labels are constants, not rows in `labels`.
+ *
+ * The risk that comes with that: any code path that validates a label by
+ * looking it up in the collection now rejects the eight built-in ones, because
+ * they have no row to find. These tests pin the paths where that would be
+ * user-visible.
+ *
+ * Covered:
+ *   1. Applying a built-in label to a message succeeds without a row.
+ *   2. A genuinely unknown label is still rejected.
+ *   3. A built-in and a user-made label can be applied in the same call.
+ */
+
+const mockLabelFind = jest.fn();
+const mockMessageFindOne = jest.fn();
+const mockMessageUpdateOne = jest.fn();
+
+jest.mock('../assetServiceSingleton', () => ({ assetService: {} }));
+jest.mock('../../models/User', () => ({ __esModule: true, default: {} }));
+jest.mock('../../models/Mailbox', () => ({ Mailbox: {} }));
+jest.mock('../../models/Message', () => ({
+  Message: {
+    findOne: (...args: unknown[]) => mockMessageFindOne(...args),
+    updateOne: (...args: unknown[]) => mockMessageUpdateOne(...args),
+  },
+}));
+jest.mock('../../models/Label', () => ({
+  Label: { find: (...args: unknown[]) => mockLabelFind(...args) },
+}));
+jest.mock('../../models/Bundle', () => ({ Bundle: {} }));
+jest.mock('../../models/Reminder', () => ({ Reminder: {} }));
+jest.mock('../../models/Contact', () => ({ Contact: {} }));
+jest.mock('../../models/EmailTemplate', () => ({ EmailTemplate: {} }));
+jest.mock('../../models/EmailFilter', () => ({ EmailFilter: {} }));
+jest.mock('../senderAvatar.service', () => ({ getAvatarPathsBatch: jest.fn() }));
+jest.mock('../aiLabeling.service', () => ({ aiLabelingService: {} }));
+jest.mock('../cardExtraction.service', () => ({ cardExtractionService: {} }));
+jest.mock('../smtp.outbound', () => ({ __esModule: true, smtpOutbound: { send: jest.fn() }, default: {} }));
+jest.mock('../push.service', () => ({ pushService: {} }));
+jest.mock('../../utils/logger', () => ({
+  logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { emailService } from '../email.service';
+
+const USER_ID = '507f1f77bcf86cd799439011';
+const MESSAGE_ID = '507f1f77bcf86cd799439012';
+
+/** `Label.find(...).select(...).lean()` resolving to `rows`. */
+function labelRows(rows: Array<{ name: string }>) {
+  return { select: () => ({ lean: () => Promise.resolve(rows) }) };
+}
+
+/** `Message.findOne(...).select(...).lean()` / `.lean({virtuals})`. */
+function messageDoc(doc: unknown) {
+  return {
+    select: () => ({ lean: () => Promise.resolve(doc) }),
+    lean: () => Promise.resolve(doc),
+  };
+}
+
+describe('emailService.updateMessageLabels — system labels have no row', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockMessageFindOne.mockReturnValue(messageDoc({ _id: MESSAGE_ID }));
+    mockMessageUpdateOne.mockResolvedValue({});
+    mockLabelFind.mockReturnValue(labelRows([]));
+  });
+
+  it('applies a built-in label without looking for a row', async () => {
+    await expect(
+      emailService.updateMessageLabels(USER_ID, MESSAGE_ID, ['Work'], []),
+    ).resolves.toBeDefined();
+
+    // No lookup at all: every name was a system label.
+    expect(mockLabelFind).not.toHaveBeenCalled();
+    expect(mockMessageUpdateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: MESSAGE_ID }),
+      { $addToSet: { labels: { $each: ['Work'] } } },
+    );
+  });
+
+  it('still rejects a label that exists neither as a constant nor as a row', async () => {
+    await expect(
+      emailService.updateMessageLabels(USER_ID, MESSAGE_ID, ['Nonexistent'], []),
+    ).rejects.toThrow(/Labels not found: Nonexistent/);
+
+    expect(mockMessageUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it('accepts a built-in and a user-made label together, looking up only the latter', async () => {
+    mockLabelFind.mockReturnValue(labelRows([{ name: 'Recipes' }]));
+
+    await expect(
+      emailService.updateMessageLabels(USER_ID, MESSAGE_ID, ['Work', 'Recipes'], []),
+    ).resolves.toBeDefined();
+
+    expect(mockLabelFind).toHaveBeenCalledWith(
+      expect.objectContaining({ name: { $in: ['Recipes'] } }),
+    );
+    expect(mockMessageUpdateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: MESSAGE_ID }),
+      { $addToSet: { labels: { $each: ['Work', 'Recipes'] } } },
+    );
+  });
+});

--- a/packages/api/src/services/aiLabeling.service.ts
+++ b/packages/api/src/services/aiLabeling.service.ts
@@ -7,6 +7,7 @@
 
 import axios from 'axios';
 import { Label } from '../models/Label';
+import { SYSTEM_LABELS, isSystemLabel } from '../constants/systemLabels';
 import { Message } from '../models/Message';
 import { AI_LABELING_CONFIG } from '../config/email.config';
 import { logger } from '../utils/logger';
@@ -88,11 +89,16 @@ class AiLabelingService {
         return;
       }
 
-      // Fetch user's labels
-      const labels = await Label.find({ userId }).select('name').lean();
-      if (labels.length === 0) return;
-
-      const labelNames = labels.map((l) => l.name);
+      // The classifier chooses among the system labels plus whatever the user
+      // has added. The system ones have no rows behind them, so querying the
+      // collection alone would leave a user who never made a label with
+      // nothing to classify into.
+      const custom = await Label.find({ userId }).select('name').lean();
+      const labelNames = [
+        ...SYSTEM_LABELS.map((l) => l.name),
+        ...custom.map((l) => l.name).filter((name) => !isSystemLabel(name)),
+      ];
+      if (labelNames.length === 0) return;
 
       // Fetch message content for classification
       const message = await Message.findOne({ _id: messageId, userId })

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -12,6 +12,7 @@ import { safeFetch, SsrfRejection } from '@oxyhq/core/server';
 import { Mailbox, type IMailbox } from '../models/Mailbox';
 import { Message, type IMessage, type IEmailAddress, type IAttachment } from '../models/Message';
 import { Label } from '../models/Label';
+import { SYSTEM_LABELS, isSystemLabel, isSystemLabelId } from '../constants/systemLabels';
 import { Bundle } from '../models/Bundle';
 import User, { type IUser } from '../models/User';
 import { getAvatarPathsBatch } from './senderAvatar.service';
@@ -133,43 +134,6 @@ class EmailService {
     { name: 'Updates', icon: 'bell-outline', color: '#607D8B', matchLabels: ['Updates'], order: 2 },
     { name: 'Forums', icon: 'forum-outline', color: '#795548', matchLabels: ['Forums'], order: 3 },
   ];
-
-  private static readonly DEFAULT_LABELS = [
-    { name: 'Personal', color: '#1A73E8', order: 0 },
-    { name: 'Work', color: '#34A853', order: 1 },
-    { name: 'Finance', color: '#FBBC04', order: 2 },
-    { name: 'Shopping', color: '#EA4335', order: 3 },
-    { name: 'Travel', color: '#9334E6', order: 4 },
-    { name: 'Social', color: '#E8710A', order: 5 },
-    { name: 'Updates', color: '#607D8B', order: 6 },
-    { name: 'Forums', color: '#795548', order: 7 },
-  ];
-
-  /**
-   * Seed default labels for a user if they have none.
-   * Uses the same lazy-provisioning pattern as ensureMailboxes().
-   */
-  async ensureDefaultLabels(userId: string): Promise<void> {
-    const count = await Label.countDocuments({ userId });
-    if (count > 0) return;
-
-    const docs = EmailService.DEFAULT_LABELS.map((l) => ({
-      userId: new mongoose.Types.ObjectId(userId),
-      name: l.name,
-      color: l.color,
-      order: l.order,
-    }));
-
-    try {
-      await Label.insertMany(docs, { ordered: false });
-      logger.info('Default labels seeded', { userId });
-    } catch (err: any) {
-      // Ignore duplicate key errors (race condition safe)
-      if (err.code !== 11000 && !err.message?.includes('E11000')) {
-        throw err;
-      }
-    }
-  }
 
   async ensureMailboxes(userId: string): Promise<void> {
     const existing = await Mailbox.find({ userId });
@@ -817,7 +781,6 @@ class EmailService {
 
     const userId = user._id.toString();
     await this.ensureMailboxes(userId);
-    await this.ensureDefaultLabels(userId);
 
     // Check quota
     await this.enforceQuota(userId, params.rawSize);
@@ -1436,10 +1399,18 @@ class EmailService {
   // ─── Labels ──────────────────────────────────────────────────────────
 
   async listLabels(userId: string): Promise<any[]> {
-    return Label.find({ userId }).sort({ order: 1, name: 1 }).lean({ virtuals: true });
+    const custom = await Label.find({ userId }).sort({ order: 1, name: 1 }).lean({ virtuals: true });
+    // A row left over from when the system labels were seeded per user is
+    // shadowed by its constant, so the list never shows the same name twice.
+    const own = custom
+      .filter((l: any) => !isSystemLabel(l.name))
+      .map((l: any) => ({ ...l, system: false }));
+    return [...SYSTEM_LABELS, ...own];
   }
 
   async createLabel(userId: string, name: string, color: string): Promise<any> {
+    if (isSystemLabel(name)) throw new BadRequestError(`Label "${name.trim()}" already exists`);
+
     const existing = await Label.findOne({ userId, name }).collation({ locale: 'en', strength: 2 });
     if (existing) throw new BadRequestError(`Label "${name}" already exists`);
 
@@ -1454,6 +1425,11 @@ class EmailService {
   }
 
   async updateLabel(userId: string, labelId: string, updates: { name?: string; color?: string }): Promise<any> {
+    if (isSystemLabelId(labelId)) throw new BadRequestError('System labels cannot be edited');
+    if (updates.name && isSystemLabel(updates.name)) {
+      throw new BadRequestError(`Label "${updates.name.trim()}" already exists`);
+    }
+
     const label = await Label.findOneAndUpdate(
       { _id: labelId, userId },
       { $set: updates },
@@ -1464,6 +1440,8 @@ class EmailService {
   }
 
   async deleteLabel(userId: string, labelId: string): Promise<void> {
+    if (isSystemLabelId(labelId)) throw new BadRequestError('System labels cannot be deleted');
+
     const label = await Label.findOne({ _id: labelId, userId });
     if (!label) throw new NotFoundError('Label not found');
 
@@ -1913,7 +1891,6 @@ class EmailService {
     if (!user || !user.username) throw new BadRequestError('User must have a username');
 
     await this.ensureMailboxes(userId);
-    await this.ensureDefaultLabels(userId);
     await this.enforceQuota(
       userId,
       files.reduce((total, file) => total + file.buffer.length, 0),

--- a/packages/api/src/services/email.service.ts
+++ b/packages/api/src/services/email.service.ts
@@ -1454,11 +1454,14 @@ class EmailService {
   }
 
   async updateMessageLabels(userId: string, messageId: string, add: string[], remove: string[]): Promise<any> {
-    // Validate that labels being added actually exist for this user
-    if (add.length > 0) {
-      const existingLabels = await Label.find({ userId, name: { $in: add } }).select('name').lean();
+    // Validate that labels being added actually exist for this user. A system
+    // label is valid without a row behind it — that is the whole point of it
+    // being a constant — so only the rest are looked up.
+    const unknown = add.filter((name) => !isSystemLabel(name));
+    if (unknown.length > 0) {
+      const existingLabels = await Label.find({ userId, name: { $in: unknown } }).select('name').lean();
       const existingNames = new Set(existingLabels.map((l) => l.name));
-      const missing = add.filter((name) => !existingNames.has(name));
+      const missing = unknown.filter((name) => !existingNames.has(name));
       if (missing.length > 0) {
         throw new BadRequestError(`Labels not found: ${missing.join(', ')}`);
       }

--- a/packages/inbox/components/settings/sections/LabelsSection.tsx
+++ b/packages/inbox/components/settings/sections/LabelsSection.tsx
@@ -178,34 +178,44 @@ export function LabelsSection() {
                       <Text style={[styles.labelName, { color: colors.text }]} numberOfLines={1}>
                         {label.name}
                       </Text>
-                      <Pressable
-                        onPress={() => {
-                          setEditingLabelId(label._id);
-                          setEditingLabelName(label.name);
-                        }}
-                        style={styles.iconBtn}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Rename ${label.name}`}
-                      >
-                        <Pencil_Stroke2_Corner0_Rounded
-                          size="sm"
-                          style={{ color: colors.icon }}
-                        />
-                      </Pressable>
-                      <Pressable
-                        onPress={() => {
-                          setLabelPendingDelete({ id: label._id, name: label.name });
-                          deleteConfirm.open();
-                        }}
-                        style={styles.iconBtn}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Delete ${label.name}`}
-                      >
-                        <Trash_Stroke2_Corner0_Rounded
-                          size="sm"
-                          style={{ color: colors.error }}
-                        />
-                      </Pressable>
+                      {/* System labels ship with the product: no rename, no
+                          delete, and the server rejects both anyway. */}
+                      {label.system ? (
+                        <Text style={[styles.systemTag, { color: colors.secondaryText }]}>
+                          Built-in
+                        </Text>
+                      ) : (
+                        <>
+                          <Pressable
+                            onPress={() => {
+                              setEditingLabelId(label._id);
+                              setEditingLabelName(label.name);
+                            }}
+                            style={styles.iconBtn}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Rename ${label.name}`}
+                          >
+                            <Pencil_Stroke2_Corner0_Rounded
+                              size="sm"
+                              style={{ color: colors.icon }}
+                            />
+                          </Pressable>
+                          <Pressable
+                            onPress={() => {
+                              setLabelPendingDelete({ id: label._id, name: label.name });
+                              deleteConfirm.open();
+                            }}
+                            style={styles.iconBtn}
+                            accessibilityRole="button"
+                            accessibilityLabel={`Delete ${label.name}`}
+                          >
+                            <Trash_Stroke2_Corner0_Rounded
+                              size="sm"
+                              style={{ color: colors.error }}
+                            />
+                          </Pressable>
+                        </>
+                      )}
                     </>
                   )}
                 </View>
@@ -296,6 +306,9 @@ const styles = StyleSheet.create({
     width: 14,
     height: 14,
     borderRadius: 7,
+  },
+  systemTag: {
+    fontSize: 12,
   },
   labelName: {
     flex: 1,

--- a/packages/inbox/hooks/queries/useLabels.ts
+++ b/packages/inbox/hooks/queries/useLabels.ts
@@ -51,6 +51,8 @@ export function useCreateLabel() {
         name,
         color,
         order: Number.MAX_SAFE_INTEGER,
+        // A user-created label is never a system one.
+        system: false,
       };
       const { prev } = await optimisticLabels(queryClient, (labels) => [...labels, optimistic]);
       return { prev };

--- a/packages/inbox/schemas/emailSchemas.ts
+++ b/packages/inbox/schemas/emailSchemas.ts
@@ -143,10 +143,13 @@ export const MailboxSchema = z.object({
 
 export const LabelSchema = z.object({
   _id: z.string(),
-  userId: z.string(),
+  /** Absent on system labels, which are constants rather than stored rows. */
+  userId: z.string().optional(),
   name: z.string(),
   color: z.string(),
   order: z.number(),
+  /** Part of the product; cannot be renamed, recoloured or deleted. */
+  system: z.boolean().default(false),
 });
 
 export const PaginationSchema = z.object({


### PR DESCRIPTION
Two fixes from the same session.

## Empty sender avatars

`senderAvatar.service.ts` falls back to `https://<domain>/favicon.ico`, emitted **without probing the host** (deliberate — the API does not probe sender-controlled hosts). When that favicon 404s, the proxy answered with its transparent 1×1 GIF. That is a *successful* image response: the client's `onError` never fires, so an invisible pixel gets painted over the initials placeholder and the avatar reads as an empty hole.

Measured against production before changing anything:

| domain | upstream | proxy returned |
|---|---|---|
| `github.com` | 200, 6518b | 200 real icon ✓ |
| `updates.notion.so` | no response | 400 → initials ✓ |
| `example.com` | **404** | **200 `image/gif` 42b** ✗ |

An upstream 404 now comes back as an empty 404. The transparent GIF stays reserved for what justifies it: a tracking pixel we deliberately blocked, and a transient fetch failure.

New regression test, **verified by mutation** — reverting the fix makes it fail, restoring it makes it pass.

## System labels are constants, not rows

`ensureDefaultLabels` seeded eight labels (Personal, Work, Finance, …) into `labels` for every user, lazily re-checked on two separate write paths. They were identical for every account and never edited, so the rows bought nothing.

- They live in `packages/api/src/constants/systemLabels.ts` now, with a synthetic `_id` (`system:work`) that is deliberately **not** an ObjectId so nothing can look one up in the database.
- `listLabels` returns the constants plus the user's own labels.
- Creating, renaming or deleting a system label is rejected server-side; Settings renders them as "Built-in" with no edit/delete control.
- **Messages are untouched.** `Message.labels` holds names, not ObjectIds, and the names did not change — every existing assignment keeps working.
- `scripts/drop-seeded-system-labels.ts` removes the already-seeded rows (idempotent, `DRY_RUN=true` supported). Needs a one-shot ECS run after deploy. Until then `listLabels` filters them, so no name ever appears twice.

## Verification
- `packages/api`: `bun run build` clean, 8 email suites / 26 tests pass.
- `tsc --noEmit` clean in `packages/api` and `packages/inbox`.
- The stale `jest.spyOn(svc, 'ensureDefaultLabels')` in the inbound-attachments suite is removed along with the method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->