### PR TITLE
perf(transparency): O(log n) inclusion proofs (keep the tree's levels)

### DIFF
--- a/packages/api/src/services/transparency.service.ts
+++ b/packages/api/src/services/transparency.service.ts
@@ -23,6 +23,7 @@
  */
 
 import {
+  buildTransparencyTree,
   buildTransparencyTreeFromHeads,
   checkpointHash,
   inclusionProof,
@@ -30,6 +31,7 @@ import {
   transparencyLeafHash,
   type TransparencyCheckpointFields,
   type TransparencyHeadEntry,
+  type TransparencyTree,
 } from '@oxyhq/protocol';
 import type {
   TransparencyCheckpoint as TransparencyCheckpointDto,
@@ -54,15 +56,18 @@ import { logger } from '../utils/logger';
  */
 export const MAX_CHECKPOINT_SUBJECTS = 50_000;
 
-/** How many checkpoints' derived leaf hashes stay cached in-process. */
-const LEAF_CACHE_LIMIT = 2;
+/** How many checkpoints' derived trees stay cached in-process. */
+const TREE_CACHE_LIMIT = 2;
 
 /**
- * Derived leaf hashes per checkpoint index, so serving repeated proofs for one
- * checkpoint does not re-hash the whole snapshot each time. Bounded, and purely
- * derived from immutable committed data — never a source of truth.
+ * The derived Merkle tree per checkpoint index, so serving repeated proofs for
+ * one checkpoint neither re-hashes the snapshot nor rebuilds the tree. Bounded,
+ * and purely derived from immutable committed data — never a source of truth.
+ *
+ * Caching the whole tree rather than just its leaves is what keeps a proof
+ * O(log n): the interior levels are already there to read siblings from.
  */
-const leafCache = new Map<number, string[]>();
+const treeCache = new Map<number, TransparencyTree>();
 
 /** The five fields every co-signer signs — the checkpoint's immutable body. */
 export function checkpointSignedFields(
@@ -222,9 +227,9 @@ export async function listCheckpoints(
   return docs.map(toDto);
 }
 
-/** Leaf hashes for a checkpoint's committed snapshot, memoized per index. */
-async function leavesFor(doc: ITransparencyCheckpoint): Promise<string[]> {
-  const cached = leafCache.get(doc.index);
+/** The Merkle tree over a checkpoint's committed snapshot, memoized per index. */
+async function treeFor(doc: ITransparencyCheckpoint): Promise<TransparencyTree> {
+  const cached = treeCache.get(doc.index);
   if (cached) {
     return cached;
   }
@@ -237,14 +242,15 @@ async function leavesFor(doc: ITransparencyCheckpoint): Promise<string[]> {
       }),
     ),
   );
-  if (leafCache.size >= LEAF_CACHE_LIMIT) {
-    const oldest = leafCache.keys().next();
+  const tree = await buildTransparencyTree(leaves);
+  if (treeCache.size >= TREE_CACHE_LIMIT) {
+    const oldest = treeCache.keys().next();
     if (!oldest.done) {
-      leafCache.delete(oldest.value);
+      treeCache.delete(oldest.value);
     }
   }
-  leafCache.set(doc.index, leaves);
-  return leaves;
+  treeCache.set(doc.index, tree);
+  return tree;
 }
 
 /**
@@ -270,15 +276,15 @@ export async function getInclusionProof(
   }
 
   const entry = doc.snapshot[leafIndex];
-  const leaves = await leavesFor(doc);
+  const tree = await treeFor(doc);
 
   return {
     checkpoint: toDto(doc),
     subjectDid: entry.subjectDid,
     seq: entry.seq,
     headRecordId: entry.headRecordId,
-    leaf: leaves[leafIndex],
+    leaf: tree.levels[0][leafIndex],
     leafIndex,
-    proof: await inclusionProof(leaves, leafIndex),
+    proof: inclusionProof(tree, leafIndex),
   };
 }

--- a/packages/protocol/src/__tests__/transparency.test.ts
+++ b/packages/protocol/src/__tests__/transparency.test.ts
@@ -53,6 +53,34 @@ function heads(n: number): TransparencyHeadEntry[] {
   }));
 }
 
+/**
+ * RFC 6962 §2.1 MTH, transcribed directly from the spec — the independent
+ * oracle the production bottom-up build is checked against.
+ *
+ * `buildTransparencyTree` builds levels iteratively (pair adjacent, carry a
+ * trailing odd node up) because that lets it keep the interior nodes for cheap
+ * proofs. This recursive split-at-the-largest-power-of-two definition is the
+ * normative one, and the equivalence between the two is an assumption the
+ * commitment rests on — so it is TESTED, never assumed.
+ */
+async function rfc6962MerkleTreeHash(leaves: string[]): Promise<string> {
+  if (leaves.length === 0) {
+    return EMPTY_TRANSPARENCY_ROOT;
+  }
+  if (leaves.length === 1) {
+    return leaves[0];
+  }
+  let k = 1;
+  while (k * 2 < leaves.length) {
+    k *= 2;
+  }
+  const [left, right] = await Promise.all([
+    rfc6962MerkleTreeHash(leaves.slice(0, k)),
+    rfc6962MerkleTreeHash(leaves.slice(k)),
+  ]);
+  return sha256(`oxy.transparency.node.v1:${left}${right}`);
+}
+
 describe('transparencyLeafHash', () => {
   it('is deterministic for the same head', async () => {
     expect(await transparencyLeafHash(HEAD_A)).toBe(await transparencyLeafHash(HEAD_A));
@@ -121,6 +149,22 @@ describe('buildTransparencyTree', () => {
     const tree = await buildTransparencyTree(l);
     expect(tree.root).toBe(await sha256(`oxy.transparency.node.v1:${left}${l[2]}`));
   });
+
+  it('matches the RFC 6962 recursive definition at every size from 0 to 40', async () => {
+    for (let size = 0; size <= 40; size++) {
+      const leaves = await Promise.all(heads(size).map(transparencyLeafHash));
+      const tree = await buildTransparencyTree(leaves);
+      expect(tree.root).toBe(await rfc6962MerkleTreeHash(leaves));
+      expect(tree.levels[0]).toEqual(leaves);
+    }
+  });
+
+  it('keeps the leaf level independent of the caller array', async () => {
+    const leaves = await Promise.all(heads(3).map(transparencyLeafHash));
+    const tree = await buildTransparencyTree(leaves);
+    leaves[0] = 'f'.repeat(64);
+    expect(tree.levels[0][0]).not.toBe('f'.repeat(64));
+  });
 });
 
 describe('buildTransparencyTreeFromHeads', () => {
@@ -144,13 +188,13 @@ describe('buildTransparencyTreeFromHeads', () => {
 });
 
 describe('verifyInclusionProof', () => {
-  it('verifies every leaf of every tree size from 1 to 9', async () => {
-    for (let size = 1; size <= 9; size++) {
+  it('verifies every leaf of every tree size from 1 to 40', async () => {
+    for (let size = 1; size <= 40; size++) {
       const entries = heads(size);
       const tree = await buildTransparencyTreeFromHeads(entries);
       for (let index = 0; index < size; index++) {
         const leaf = await transparencyLeafHash(entries[index]);
-        const proof = await inclusionProof(tree.leaves, index);
+        const proof = inclusionProof(tree, index);
         await expect(
           verifyInclusionProof({ leaf, index, treeSize: size, proof, root: tree.root }),
         ).resolves.toBe(true);
@@ -161,7 +205,7 @@ describe('verifyInclusionProof', () => {
   it('verifies from the leaf alone, without the rest of the leaf set', async () => {
     const entries = heads(7);
     const tree = await buildTransparencyTreeFromHeads(entries);
-    const proof = await inclusionProof(tree.leaves, 5);
+    const proof = inclusionProof(tree, 5);
     const leaf = await transparencyLeafHash(entries[5]);
     // Only the verifier's own leaf, its index, the tree size, the path and the
     // signed root — the full leaf set is never needed.
@@ -173,7 +217,7 @@ describe('verifyInclusionProof', () => {
   it('fails when the head record id was tampered with after the checkpoint', async () => {
     const entries = heads(5);
     const tree = await buildTransparencyTreeFromHeads(entries);
-    const proof = await inclusionProof(tree.leaves, 2);
+    const proof = inclusionProof(tree, 2);
     const tamperedLeaf = await transparencyLeafHash({ ...entries[2], headRecordId: 'f'.repeat(64) });
     await expect(
       verifyInclusionProof({ leaf: tamperedLeaf, index: 2, treeSize: 5, proof, root: tree.root }),
@@ -183,7 +227,7 @@ describe('verifyInclusionProof', () => {
   it('fails when a chain was rolled back to an earlier seq', async () => {
     const entries = heads(5);
     const tree = await buildTransparencyTreeFromHeads(entries);
-    const proof = await inclusionProof(tree.leaves, 3);
+    const proof = inclusionProof(tree, 3);
     const rolledBack = await transparencyLeafHash({ ...entries[3], seq: entries[3].seq - 1 });
     await expect(
       verifyInclusionProof({ leaf: rolledBack, index: 3, treeSize: 5, proof, root: tree.root }),
@@ -193,7 +237,7 @@ describe('verifyInclusionProof', () => {
   it('fails when the proof is replayed at a different index', async () => {
     const entries = heads(6);
     const tree = await buildTransparencyTreeFromHeads(entries);
-    const proof = await inclusionProof(tree.leaves, 1);
+    const proof = inclusionProof(tree, 1);
     const leaf = await transparencyLeafHash(entries[1]);
     await expect(
       verifyInclusionProof({ leaf, index: 2, treeSize: 6, proof, root: tree.root }),
@@ -204,7 +248,7 @@ describe('verifyInclusionProof', () => {
     const entries = heads(4);
     const tree = await buildTransparencyTreeFromHeads(entries);
     const otherTree = await buildTransparencyTreeFromHeads(heads(5));
-    const proof = await inclusionProof(tree.leaves, 0);
+    const proof = inclusionProof(tree, 0);
     const leaf = await transparencyLeafHash(entries[0]);
     await expect(
       verifyInclusionProof({ leaf, index: 0, treeSize: 4, proof, root: otherTree.root }),
@@ -214,7 +258,7 @@ describe('verifyInclusionProof', () => {
   it('fails when the proof path is truncated', async () => {
     const entries = heads(8);
     const tree = await buildTransparencyTreeFromHeads(entries);
-    const proof = await inclusionProof(tree.leaves, 0);
+    const proof = inclusionProof(tree, 0);
     await expect(
       verifyInclusionProof({
         leaf: await transparencyLeafHash(entries[0]),
@@ -229,7 +273,7 @@ describe('verifyInclusionProof', () => {
   it('rejects an index outside the tree instead of verifying', async () => {
     const entries = heads(3);
     const tree = await buildTransparencyTreeFromHeads(entries);
-    await expect(inclusionProof(tree.leaves, 3)).rejects.toThrow(/index/i);
+    expect(() => inclusionProof(tree, 3)).toThrow(/index/i);
   });
 });
 

--- a/packages/protocol/src/transparency/tree.ts
+++ b/packages/protocol/src/transparency/tree.ts
@@ -20,6 +20,12 @@
  * as an interior node), an odd level splits so the LEFT subtree is the largest
  * power of two below the size, and a single-leaf tree's root is the leaf itself.
  *
+ * A built tree keeps every LEVEL, not just its leaves, because that is what
+ * makes serving proofs cheap: {@link inclusionProof} reads siblings straight out
+ * of the levels instead of re-hashing subtrees, so one build amortizes over all
+ * the proofs cut from it (a checkpoint is built once and proved thousands of
+ * times, once per subject that audits it).
+ *
  * Crucially, {@link verifyInclusionProof} needs only the verifier's OWN leaf,
  * its index, the tree size, the audit path, and the signed root — never the
  * other leaves. So a device or node can audit its own history against a
@@ -62,12 +68,16 @@ export interface TransparencyHeadEntry {
   headRecordId: string;
 }
 
-/** A built tree: its commitment plus the ordered leaf hashes proofs are cut from. */
+/** A built tree: its commitment plus every level proofs are cut from. */
 export interface TransparencyTree {
   root: string;
   treeSize: number;
-  /** Leaf hashes in committed order. */
-  leaves: string[];
+  /**
+   * Every level bottom-up: `levels[0]` is the leaf hashes in committed order,
+   * each next level is the one below it paired up, and the last is `[root]`
+   * (empty for a zero-leaf tree).
+   */
+  levels: string[][];
 }
 
 /** A tree built from head entries, with the leaf index of every subject. */
@@ -112,39 +122,41 @@ async function nodeHash(left: string, right: string): Promise<string> {
   return sha256(`${NODE_PREFIX}${left}${right}`);
 }
 
-/** The largest power of two strictly below `n` (RFC 6962's split point; `n > 1`). */
-function splitPoint(n: number): number {
-  let k = 1;
-  while (k * 2 < n) {
-    k *= 2;
-  }
-  return k;
-}
-
-/** The Merkle tree hash of a leaf-hash slice (RFC 6962 MTH). */
-async function merkleTreeHash(leaves: string[]): Promise<string> {
-  if (leaves.length === 0) {
-    return EMPTY_TRANSPARENCY_ROOT;
-  }
-  if (leaves.length === 1) {
-    return leaves[0];
-  }
-  const k = splitPoint(leaves.length);
-  const [left, right] = await Promise.all([
-    merkleTreeHash(leaves.slice(0, k)),
-    merkleTreeHash(leaves.slice(k)),
-  ]);
-  return nodeHash(left, right);
-}
-
 /**
  * Build a tree over already-hashed leaves, in the given order.
+ *
+ * Levels are built bottom-up, each one pairing the level below and carrying a
+ * trailing odd node up unchanged — which yields exactly RFC 6962's tree, whose
+ * recursive definition splits at the largest power of two below the size.
+ * `transparency.test.ts` pins that equivalence against a direct transcription of
+ * the RFC's MTH for every size up to 40, so the shape can never silently drift.
  *
  * The order IS part of the commitment — prefer
  * {@link buildTransparencyTreeFromHeads}, which owns the canonical ordering.
  */
 export async function buildTransparencyTree(leaves: string[]): Promise<TransparencyTree> {
-  return { root: await merkleTreeHash(leaves), treeSize: leaves.length, leaves: [...leaves] };
+  const levels: string[][] = [[...leaves]];
+  let current = levels[0];
+  while (current.length > 1) {
+    const pairCount = Math.floor(current.length / 2);
+    const parents = await Promise.all(
+      Array.from({ length: pairCount }, (_unused, pair) =>
+        nodeHash(current[pair * 2], current[pair * 2 + 1]),
+      ),
+    );
+    if (current.length % 2 === 1) {
+      parents.push(current[current.length - 1]);
+    }
+    levels.push(parents);
+    current = parents;
+  }
+
+  const top = levels[levels.length - 1];
+  return {
+    root: top.length === 1 ? top[0] : EMPTY_TRANSPARENCY_ROOT,
+    treeSize: leaves.length,
+    levels,
+  };
 }
 
 /**
@@ -177,23 +189,29 @@ export async function buildTransparencyTreeFromHeads(
 }
 
 /**
- * The audit path proving `index` is committed in a tree over `leaves`
- * (RFC 6962 PATH): each step is the sibling subtree hash, leaf-adjacent first.
+ * The audit path proving `index` is committed in `tree` (RFC 6962 PATH): each
+ * step is the sibling subtree hash, leaf-adjacent first.
+ *
+ * Pure index arithmetic over the tree's levels — no hashing, so cutting a proof
+ * costs O(log n) array reads however large the checkpoint is.
  */
-export async function inclusionProof(leaves: string[], index: number): Promise<string[]> {
-  if (!Number.isInteger(index) || index < 0 || index >= leaves.length) {
-    throw new Error(`Leaf index ${index} is outside a tree of ${leaves.length} leaves`);
+export function inclusionProof(tree: TransparencyTree, index: number): string[] {
+  if (!Number.isInteger(index) || index < 0 || index >= tree.treeSize) {
+    throw new Error(`Leaf index ${index} is outside a tree of ${tree.treeSize} leaves`);
   }
-  if (leaves.length === 1) {
-    return [];
+
+  const proof: string[] = [];
+  let position = index;
+  for (let level = 0; level < tree.levels.length - 1; level += 1) {
+    const nodes = tree.levels[level];
+    const sibling = position % 2 === 0 ? position + 1 : position - 1;
+    // A trailing odd node is carried up unpaired, so it contributes no step.
+    if (sibling < nodes.length) {
+      proof.push(nodes[sibling]);
+    }
+    position = Math.floor(position / 2);
   }
-  const k = splitPoint(leaves.length);
-  if (index < k) {
-    const path = await inclusionProof(leaves.slice(0, k), index);
-    return [...path, await merkleTreeHash(leaves.slice(k))];
-  }
-  const path = await inclusionProof(leaves.slice(k), index - k);
-  return [...path, await merkleTreeHash(leaves.slice(0, k))];
+  return proof;
 }
 
 /**


### PR DESCRIPTION
Quality pass over the transparency code merged in #693, from a 4-angle cleanup
review (reuse / simplification / efficiency / altitude). Three angles came back
clean; this is the one real finding.

## The problem
`TransparencyTree` kept only its leaves, so `inclusionProof` re-hashed whole
sibling subtrees at every level — ~n hashes per proof, the same cost as building
the tree. Every subject audits every checkpoint, so serving one period was
O(n²) hashing. At the `MAX_CHECKPOINT_SUBJECTS = 50_000` ceiling that is ~50k
sha256 per proof request, blocking the event loop for tens of ms each.

## The fix
- `buildTransparencyTree` retains every level (bottom-up: pair adjacent nodes,
  carry a trailing odd node up unchanged).
- `inclusionProof(tree, index)` is pure index arithmetic over those levels —
  O(log n) array reads, zero hashing, and synchronous.
- `transparency.service.ts` caches the built tree per checkpoint instead of just
  the leaves, so the interior nodes a proof reads are already in memory.

Same roots, same proofs, same wire format — only the cost changes.

## The equivalence is tested, not assumed
The bottom-up shape must equal RFC 6962's recursive split-at-the-largest-power-
of-two definition or two verifiers would compute different roots. So the RFC MTH
is transcribed into the test file as an independent oracle and checked at every
size from 0 to 40, and every leaf of every size 1..40 now has its proof verified
(was 1..9).

## Verification
- `packages/protocol`: 131 tests pass (8 suites), dual CJS/ESM/types build clean
- `packages/api`: transparency service + routes + queue suites, 36 tests pass
- `packages/api` type-checks against the new protocol types

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->