### PR TITLE
chore(release): contracts 0.18.0, core 12.11.0, services 22.13.0 (#691)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -400,7 +400,7 @@
     },
     "packages/contracts": {
       "name": "@oxyhq/contracts",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "dependencies": {
         "zod": "^3.25.64",
       },
@@ -413,7 +413,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "12.10.9",
+      "version": "12.11.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -677,10 +677,10 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "22.12.11",
+      "version": "22.13.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
-        "@oxyhq/core": "^12.10.9",
+        "@oxyhq/core": "^12.11.0",
         "@simplewebauthn/browser": "^13.3.0",
         "color": "^4.2.3",
       },
@@ -729,7 +729,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": "^0.54.1",
-        "@oxyhq/core": "^12.10.9",
+        "@oxyhq/core": "^12.11.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@tanstack/query-async-storage-persister": "^5.101",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/contracts",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "OxyHQ API contracts — single source of truth for request/response Zod schemas and inferred types, shared by the backend and the client SDKs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "12.10.9",
+  "version": "12.11.0",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "22.12.11",
+  "version": "22.13.0",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -127,7 +127,7 @@
   },
   "dependencies": {
     "@oxyhq/contracts": "workspace:*",
-    "@oxyhq/core": "^12.10.9",
+    "@oxyhq/core": "^12.11.0",
     "@simplewebauthn/browser": "^13.3.0",
     "color": "^4.2.3"
   },
@@ -176,7 +176,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": "^0.54.1",
-    "@oxyhq/core": "^12.10.9",
+    "@oxyhq/core": "^12.11.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@tanstack/query-async-storage-persister": "^5.101",


### PR DESCRIPTION
Version bump for the #691 work, so the Mention pilot (Phase 6) can consume it from npm.

**Minor, not patch** — #691 added public API to all three: `sessionMode` and `webAuthMode` on the provider, the identity pin and delivery selection in core, an optional `accountId` on the device-token mint contract, and the two delivery-progress timestamps on the session-status contract.

`@oxyhq/contracts` needs the bump for a reason worth stating: its content on `main` had already diverged from the published `0.17.0` **under the same version number**, so anything installing it from npm was getting a schema that no longer matched the API.

`@oxyhq/services` now requires `@oxyhq/core@^12.11.0` rather than the older range. It imports the identity-pin store, the delivery selector and the session-mode types, none of which exist in `12.10.x` — a consumer resolving the old floor would have failed at runtime, not at install.

## Lockfile

Deliberately surgical: 5 lines. A plain `bun install` also re-resolved unrelated floating ranges (a spread of `@babel/*` patch upgrades), and that churn does not belong inside a release commit where it would be indistinguishable from the release itself. Only the workspace versions and the core range moved.

`bun install --frozen-lockfile` → `Checked 4099 installs across 2600 packages (no changes)`.

## Verified

`contracts` → `core` → `services` all build clean in that order from a fresh worktree at this commit.

npm currently has contracts `0.17.0`, core `12.10.6`, services `22.12.5`; the intermediate versions staged on `main` (`0.17.1`, `12.10.7-9`, `22.12.6-9`) were never published, so none of these numbers collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->