### PR TITLE
fix(core): carry restrictedIds through getViewerGraph

### DIFF
--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -1046,6 +1046,7 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
           followingIds: graph?.followingIds || [],
           mutualIds: graph?.mutualIds || [],
           blockedIds: graph?.blockedIds || [],
+          restrictedIds: graph?.restrictedIds || [],
         };
       } catch (error) {
         throw this.handleError(error);


### PR DESCRIPTION
`main` cannot deploy right now. Adding `restrictedIds` to `ViewerGraph` left the one construction site behind, so the Docker build dies at `bun run --filter @oxyhq/core build`:

```
src/mixins/OxyServices.user.ts(1045,9): error TS2741: Property 'restrictedIds' is missing in type
'{ followingIds: string[]; mutualIds: string[]; blockedIds: string[]; }' but required in type 'ViewerGraph'.
```

That is step 51 of the Dockerfile, before the API image exists — so **every** deploy since is blocked, not just that change. Prod is still serving the previous image (`/health` → `operational`), so this is a blocked pipeline rather than an outage.

`|| []` matches its three siblings and is the right degradation: a client running against an API that predates the field gets an empty list rather than `undefined` leaking into callers that treat it as an array.

`tsc -p tsconfig.cjs.json` clean; core mixin suite 484 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)