### PR TITLE
fix(api): stop leaking reputation ledgers and abuse scores

### DIFF
--- a/packages/api/src/routes/__tests__/reputationReadAuthz.test.ts
+++ b/packages/api/src/routes/__tests__/reputationReadAuthz.test.ts
@@ -1,0 +1,330 @@
+/**
+ * /reputation READ authorization tests.
+ *
+ * Two distinct leaks are guarded here:
+ *
+ *  - `GET /:userId/transactions` used to serve ANY user's ledger to ANY
+ *    authenticated caller. Transaction `metadata` names third parties (the
+ *    attestor who physically met the subject, the staking voucher, the full
+ *    juror roster of a resolved validation), so the ledger is owner-or-staff.
+ *  - `GET /:userId/balance` used to serve `reliability` (abuseScore,
+ *    reportAccuracyScore, report counts) and the `influence` weights to
+ *    ANONYMOUS callers, for any subject enumerable by id or publicKey. The
+ *    endpoint stays public but the response is view-split.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+const mockAuthMiddleware = jest.fn();
+const mockOptionalAuthMiddleware = jest.fn();
+const mockListTransactions = jest.fn();
+const mockGetBalance = jest.fn();
+const mockResolveUserIdToObjectId = jest.fn();
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (...args: unknown[]) => mockAuthMiddleware(...args),
+  serviceAuthMiddleware: jest.fn(),
+}));
+
+jest.mock('../../middleware/optionalAuth', () => ({
+  optionalAuthMiddleware: (...args: unknown[]) => mockOptionalAuthMiddleware(...args),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../utils/validation', () => ({
+  resolveUserIdToObjectId: (...args: unknown[]) => mockResolveUserIdToObjectId(...args),
+  validatePagination: (_limit: unknown, _offset: unknown, _max: number, defaultLimit: number) => ({
+    limit: defaultLimit,
+    offset: 0,
+  }),
+}));
+
+jest.mock('../../services/reputation.service', () => ({
+  __esModule: true,
+  default: {
+    listTransactions: (...args: unknown[]) => mockListTransactions(...args),
+    getBalance: (...args: unknown[]) => mockGetBalance(...args),
+    award: jest.fn(),
+    createDispute: jest.fn(),
+    upsertRule: jest.fn(),
+    listEnabledRules: jest.fn(),
+    getLeaderboard: jest.fn(),
+    getInfluence: jest.fn(),
+    listDisputesForUser: jest.fn(),
+    listOpenDisputes: jest.fn(),
+    reverseTransaction: jest.fn(),
+    voidTransaction: jest.fn(),
+    recalculateBalance: jest.fn(),
+    resolveDispute: jest.fn(),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import reputationRouter from '../reputation.routes';
+import { errorHandler } from '../../middleware/errorHandler';
+
+const SUBJECT_ID = '64aaaaaaaaaaaaaaaaaaaaaa';
+const OTHER_ID = '64bbbbbbbbbbbbbbbbbbbbbb';
+const STAFF_ID = '64cccccccccccccccccccccc';
+
+/** The caller each mocked auth middleware attaches, or `null` for anonymous. */
+interface TestCaller {
+  _id: string;
+  isStaff?: boolean;
+}
+
+interface JsonResponse {
+  status: number;
+  body: {
+    error?: string;
+    message?: string;
+    data?: Record<string, unknown> | Record<string, unknown>[];
+  };
+}
+
+function getJson(server: http.Server, path: string): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: 'GET',
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        // Close each socket after its response so the server has no lingering
+        // keep-alive connections at teardown (`server.close` resolves cleanly).
+        headers: { connection: 'close' },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => { raw += chunk; });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: raw.length > 0 ? JSON.parse(raw) : {} });
+          } catch (err) {
+            reject(err);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Point both mocked auth middlewares at `caller` for the next request. */
+function signInAs(caller: TestCaller | null): void {
+  mockAuthMiddleware.mockImplementation((req, res, next) => {
+    if (!caller) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    req.user = caller;
+    next();
+  });
+  mockOptionalAuthMiddleware.mockImplementation((req, _res, next) => {
+    if (caller) {
+      req.user = caller;
+    }
+    next();
+  });
+}
+
+/** A balance carrying every sensitive field the serializers may expose. */
+function balanceFixture() {
+  return {
+    userId: { toString: () => SUBJECT_ID },
+    total: 120,
+    positive: 200,
+    negative: -80,
+    breakdown: { content: 100, penalty: -80, trust: 100 },
+    trustTier: 'trusted',
+    influence: {
+      defaultWeight: 0.34,
+      reportWeight: 0.29,
+      moderationWeight: 0.34,
+      rankingFeedbackWeight: 0.34,
+    },
+    reliability: {
+      abuseScore: 0.62,
+      reportAccuracyScore: 0.25,
+      accurateReports: 1,
+      rejectedReports: 3,
+    },
+    recalculatedAt: new Date('2026-07-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+  };
+}
+
+let server: http.Server;
+
+beforeAll((done) => {
+  process.env.ACCESS_TOKEN_SECRET = 'test-secret';
+  const app = express();
+  app.use(express.json());
+  app.use('/reputation', reputationRouter);
+  app.use(errorHandler);
+  server = app.listen(0, '127.0.0.1', done);
+});
+
+afterAll((done) => {
+  server.close(done);
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolveUserIdToObjectId.mockImplementation((userId: string) => Promise.resolve(userId));
+  mockGetBalance.mockResolvedValue(balanceFixture());
+  mockListTransactions.mockResolvedValue({
+    items: [
+      {
+        _id: { toString: () => 'txn1' },
+        userId: { toString: () => SUBJECT_ID },
+        points: 40,
+        actionType: 'peer_validated',
+        category: 'trust',
+        status: 'active',
+        reason: 'Validated by a randomly-selected jury of peers',
+        metadata: { voterUserIds: ['juror-a', 'juror-b'] },
+        createdAt: new Date('2026-07-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+      },
+    ],
+    total: 1,
+  });
+});
+
+describe('GET /reputation/:userId/transactions ownership gate', () => {
+  it('refuses an authenticated caller reading someone else\'s ledger', async () => {
+    signInAs({ _id: OTHER_ID });
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/transactions`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/your own/i);
+    expect(mockListTransactions).not.toHaveBeenCalled();
+  });
+
+  it('never leaks juror identities to a non-owner', async () => {
+    signInAs({ _id: OTHER_ID });
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/transactions`);
+
+    expect(JSON.stringify(res.body)).not.toContain('juror-a');
+  });
+
+  it('serves the subject their own ledger', async () => {
+    signInAs({ _id: SUBJECT_ID });
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/transactions`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(mockListTransactions).toHaveBeenCalledWith(SUBJECT_ID, expect.any(Number), 0);
+  });
+
+  it('serves staff another user\'s ledger', async () => {
+    signInAs({ _id: STAFF_ID, isStaff: true });
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/transactions`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+
+  it('rejects an anonymous caller', async () => {
+    signInAs(null);
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/transactions`);
+
+    expect(res.status).toBe(401);
+    expect(mockListTransactions).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /reputation/:userId/balance view split', () => {
+  /** Fields that are the platform's internal judgement about the subject. */
+  const PRIVATE_FIELDS = [
+    'reliability',
+    'influence',
+    'breakdown',
+    'positive',
+    'negative',
+    'recalculatedAt',
+    'updatedAt',
+  ];
+
+  it('withholds the sensitive fields from an anonymous caller', async () => {
+    signInAs(null);
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/balance`);
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, unknown>;
+    for (const field of PRIVATE_FIELDS) {
+      expect(data).not.toHaveProperty(field);
+    }
+    // Belt and braces: no abuse signal may survive anywhere in the payload.
+    expect(JSON.stringify(res.body)).not.toContain('abuseScore');
+    expect(JSON.stringify(res.body)).not.toContain('0.62');
+  });
+
+  it('keeps the public trust signal readable without a token', async () => {
+    signInAs(null);
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/balance`);
+
+    expect(res.body.data).toEqual({
+      userId: SUBJECT_ID,
+      total: 120,
+      trustTier: 'trusted',
+    });
+  });
+
+  it('withholds the sensitive fields from an authenticated third party', async () => {
+    signInAs({ _id: OTHER_ID });
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/balance`);
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, unknown>;
+    for (const field of PRIVATE_FIELDS) {
+      expect(data).not.toHaveProperty(field);
+    }
+  });
+
+  it('serves the subject their own full balance', async () => {
+    signInAs({ _id: SUBJECT_ID });
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/balance`);
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, unknown>;
+    for (const field of PRIVATE_FIELDS) {
+      expect(data).toHaveProperty(field);
+    }
+    expect(data.reliability).toMatchObject({ abuseScore: 0.62 });
+    expect(data.influence).toMatchObject({ reportWeight: 0.29 });
+  });
+
+  it('serves staff another user\'s full balance', async () => {
+    signInAs({ _id: STAFF_ID, isStaff: true });
+
+    const res = await getJson(server, `/reputation/${SUBJECT_ID}/balance`);
+
+    expect(res.status).toBe(200);
+    const data = res.body.data as Record<string, unknown>;
+    for (const field of PRIVATE_FIELDS) {
+      expect(data).toHaveProperty(field);
+    }
+  });
+});

--- a/packages/api/src/routes/reputation.routes.ts
+++ b/packages/api/src/routes/reputation.routes.ts
@@ -7,6 +7,8 @@ import {
   type AuthRequest,
   type ServiceAuthRequest,
 } from '../middleware/auth';
+import type { AuthenticatedRequest } from '../middleware/authUtils';
+import { optionalAuthMiddleware } from '../middleware/optionalAuth';
 import { requireStaff } from '../middleware/requireStaff';
 import { validate } from '../middleware/validate';
 import { rateLimit } from '../middleware/rateLimiter';
@@ -152,7 +154,14 @@ function serializeTransaction(
   };
 }
 
-/** Shape a balance for the HTTP response. */
+/**
+ * Shape a balance for its SUBJECT (or platform staff).
+ *
+ * Carries the platform's internal judgements about the person — the
+ * `reliability` scoring, the `influence` weights that drive ranking and
+ * moderation, and the positive/negative/per-category decomposition of the
+ * total. None of that is public; third parties get {@link serializePublicBalance}.
+ */
 function serializeBalance(
   balance: Awaited<ReturnType<typeof reputationService.getBalance>>
 ): Record<string, unknown> {
@@ -167,6 +176,40 @@ function serializeBalance(
     reliability: balance.reliability,
     recalculatedAt: balance.recalculatedAt,
     updatedAt: balance.updatedAt,
+  };
+}
+
+/**
+ * Shape a balance for a caller who is NEITHER its subject nor staff — including
+ * an anonymous one.
+ *
+ * Deliberately limited to the fields the already-public `GET
+ * /reputation/leaderboard` publishes per user (`total` + `trustTier`), so an
+ * untokened read of `/:userId/balance` exposes no class of signal that is not
+ * public already. Everything else is withheld:
+ *  - `reliability` — `abuseScore`, `reportAccuracyScore` and the confirmed /
+ *    rejected report counts are the platform's internal abuse verdict on the
+ *    person. `abuseScore >= ABUSE_RESTRICT_THRESHOLD` is a sanction.
+ *  - `influence` — the moderation / report / ranking weights. Publishing them
+ *    hands a manipulator a live readout of what their account is worth and how
+ *    much any countermeasure has cost them.
+ *  - `positive` / `negative` / `breakdown` — split the total into points earned
+ *    versus penalties accrued, exposing sanction history the total alone hides.
+ *  - `recalculatedAt` / `updatedAt` — a timing oracle for when the subject last
+ *    had a reputation event.
+ *
+ * `trustTier` stays public because it is the contribution ladder this system
+ * exists to publish, and the leaderboard already emits it. Note it doubles as
+ * the punitive `restricted` marker, so a sanctioned account remains
+ * publicly identifiable as such by tier.
+ */
+function serializePublicBalance(
+  balance: Awaited<ReturnType<typeof reputationService.getBalance>>
+): Record<string, unknown> {
+  return {
+    userId: balance.userId.toString(),
+    total: balance.total,
+    trustTier: balance.trustTier,
   };
 }
 
@@ -240,15 +283,29 @@ router.get(
   })
 );
 
-/** GET /reputation/:userId/balance — derived totals + tier + influence. */
+/**
+ * GET /reputation/:userId/balance — derived totals + tier.
+ *
+ * Readable without a token so the public trust signal stays public, but the
+ * RESPONSE IS VIEW-SPLIT: the subject themselves and platform staff get the
+ * full balance, everyone else gets {@link serializePublicBalance}. Auth is
+ * therefore optional rather than required — an invalid or absent token simply
+ * resolves to the public view instead of rejecting the request.
+ */
 router.get(
   '/:userId/balance',
   readLimiter,
   validate({ params: reputationUserIdParams }),
-  asyncHandler(async (req, res) => {
+  optionalAuthMiddleware,
+  asyncHandler(async (req: AuthenticatedRequest, res) => {
     const userObjectId = await resolveUserIdToObjectId(req.params.userId);
     const balance = await reputationService.getBalance(userObjectId);
-    sendSuccess(res, serializeBalance(balance));
+    const isSubject = req.user?._id === userObjectId;
+    const isStaff = req.user?.isStaff === true;
+    sendSuccess(
+      res,
+      isSubject || isStaff ? serializeBalance(balance) : serializePublicBalance(balance)
+    );
   })
 );
 
@@ -344,13 +401,24 @@ function requireUserId(req: AuthRequest): string {
   return userId;
 }
 
-/** GET /reputation/:userId/transactions — paginated ledger (auth). */
+/**
+ * GET /reputation/:userId/transactions — paginated ledger (own or staff).
+ *
+ * A transaction's `metadata` names the THIRD PARTIES behind the award — the
+ * attestor who physically met the subject, the voucher who staked on them, the
+ * jury that validated them — so the ledger is readable only by its own subject
+ * and platform staff, never by an arbitrary authenticated caller.
+ */
 router.get(
   '/:userId/transactions',
   readLimiter,
   validate({ params: reputationUserIdParams, query: reputationPaginationQuery }),
-  asyncHandler(async (req, res) => {
+  asyncHandler(async (req: AuthRequest, res) => {
+    const callerId = requireUserId(req);
     const userObjectId = await resolveUserIdToObjectId(req.params.userId);
+    if (userObjectId !== callerId && req.user?.isStaff !== true) {
+      throw new ForbiddenError('You can only view your own transactions');
+    }
     const { limit, offset } = validatePagination(
       req.query.limit,
       req.query.offset,


### PR DESCRIPTION
Two read paths on `/reputation` returned data about a user to callers with no claim to it. Both are live on `api.oxy.so`. Scoped strictly to these two — nothing else is touched.

## B1 (critical) — any authenticated user could read any user's reputation ledger

`GET /reputation/:userId/transactions` resolved the `:userId` param and returned that user's transactions with **no comparison against the caller**.

The blast radius is not the point totals — it is `metadata`, which shipped code fills with *third parties'* identities:

| written by | field | what it discloses |
|---|---|---|
| `services/civic/realLife.service.ts` | `attestorUserId` + `context` | who physically met whom, in what context, when |
| `services/civic/personhood.service.ts` | `voucherUserId` | the web-of-trust graph |
| `services/civic/validator.service.ts` | `voterUserIds` | the **full juror roster** of every resolved validation |

The juror roster is the worst of the three: publishing it to any account that asks defeats the anti-collusion premise the civic jury is built on, and opens a direct retaliation channel against jurors. The serializer also emits `reason`, `targetEntityId`/`targetEntityType`, `sourceActionId`/`sourceActionType`, `applicationId`, `credentialId`, `createdByUserId` and `reviewedByUserId`.

**Fix:** the owner-or-staff check that the disputes route 35 lines below already uses, applied verbatim:

```ts
const callerId = requireUserId(req);
const userObjectId = await resolveUserIdToObjectId(req.params.userId);
if (userObjectId !== callerId && req.user?.isStaff !== true) {
  throw new ForbiddenError('You can only view your own transactions');
}
```

## B2 (high) — abuse signals served to anonymous callers

`GET /reputation/:userId/balance` is registered 92 lines **before** the router's `router.use(authMiddleware)`, and `csrfProtection` short-circuits on safe methods, so it was no barrier. `serializeBalance` emitted `reliability` (`abuseScore`, `reportAccuracyScore`, `accurateReports`, `rejectedReports`) and all four `influence` weights unconditionally, to anyone, with no token.

`:userId` accepts a **publicKey** as well as an ObjectId, so subjects were enumerable. `abuseScore >= 0.5` forces the `restricted` tier — a sanctioning verdict, published untokened.

**Fix:** the endpoint stays public, but the response is view-split behind `optionalAuthMiddleware`. Subject and staff get the full balance; everyone else gets `serializePublicBalance` — `userId`, `total`, `trustTier`.

That set is not a guess: it is exactly what the already-public `GET /reputation/leaderboard` publishes per user, so an untokened balance read now exposes no *class* of signal that was not already public. Everything else is withheld, and why:

- `reliability` — the platform's internal abuse verdict on the person.
- `influence` — the moderation/report/ranking weights; publishing them hands a manipulator a live readout of what their account is worth and how much a countermeasure cost them.
- `positive` / `negative` / `breakdown` — split the total into points earned vs penalties accrued, exposing sanction history the total alone hides.
- `recalculatedAt` / `updatedAt` — a timing oracle for when the subject last had a reputation event. Ambiguous rather than clearly sensitive, so withheld by default.

Auth is *optional*, not required: an absent or invalid token resolves to the public view rather than rejecting, so the public trust signal stays readable without a token.

## No consumer breaks

Every reader of the balance endpoint was checked before changing its shape:

| consumer | subject | fields read | effect |
|---|---|---|---|
| `services/.../ProfileScreen.tsx:81` | **third party** | `balance.total` only — narrowed to `{ total }` at the call site | none, `total` stays public |
| `services/.../trust/TrustCenterScreen.tsx:39` | own | `total`, `trustTier`, own transactions | none, owner view |
| `services/.../trust/TrustRewardsScreen.tsx:100` | own | `total` | none, owner view |
| `commons/.../StandingSection.tsx:119-120` | own | `influence`, `reliability`, `breakdown` | none, owner view |
| `commons/useReputationActivity` + `useReputationHeatmap` | own | transactions | none, passes the new owner check |

The single third-party balance reader takes `total` alone, which is why keeping `total` in the public view matters. No sequencing or staged rollout is needed.

## Tests

New: `packages/api/src/routes/__tests__/reputationReadAuthz.test.ts` (10 tests).

Mutation-tested against the unfixed route — exactly the 5 leak-guarding tests fail, and the 5 positive-path tests still pass, so they are not vacuous in either direction:

```
✕ refuses an authenticated caller reading someone else's ledger
✕ never leaks juror identities to a non-owner
✓ serves the subject their own ledger
✓ serves staff another user's ledger
✓ rejects an anonymous caller
✕ withholds the sensitive fields from an anonymous caller
✕ keeps the public trust signal readable without a token
✕ withholds the sensitive fields from an authenticated third party
✓ serves the subject their own full balance
✓ serves staff another user's full balance

Tests: 5 failed, 5 passed, 10 total
```

The anonymous-balance failure against unfixed code reads:

```
Expected path: not "reliability"
Received value: {"abuseScore": 0.62, "accurateReports": 1,
                 "rejectedReports": 3, "reportAccuracyScore": 0.25}
```

Full `packages/api` suite on this branch: **213 suites / 2042 tests passed**. `tsc --noEmit` clean, `eslint` clean.

## Residual, reported not fixed (out of scope)

- `GET /reputation/:userId/influence` still returns any subject's `influence` weights to any *authenticated* caller. B2 closes the anonymous hole; that route is the same signal behind a login. Worth a follow-up.
- `voterUserIds` lives on the **subject's own** transaction, so the subject still sees their own jury's roster even under the correct owner-only view. Closing that means changing what is written into `metadata`, not who may read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)