### PR TITLE
fix(api): stop the seed clobbering Application.capabilities; bound runs with ONLY_APPS; register CrowdSource

### DIFF
--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -23,10 +23,17 @@
  * Run (inside the oxy-api image, working dir /app):
  *   bun run packages/api/scripts/seed-oxy-applications.ts
  *
+ * Register/reconcile ONE application, leaving every other record untouched:
+ *   ONLY_APPS='CrowdSource' bun run packages/api/scripts/seed-oxy-applications.ts
+ *
  * Env:
  *   MONGODB_URI   required (injected by ECS from SSM)
  *   OXY_USERNAME  owner username to resolve (default 'oxy')
  *   DRY_RUN=true  plan only, no writes
+ *   ONLY_APPS     comma-separated application names this run may touch. Unset
+ *                 seeds the whole list. Set-but-empty, or naming an application
+ *                 that is not in SEED_APPS, ABORTS before any write — see
+ *                 `src/scripts/seedApplicationSelection.ts`.
  */
 
 import crypto from 'crypto';
@@ -41,6 +48,7 @@ import {
   unionValidScopes,
   type ApplicationScope,
 } from '../src/utils/applicationScopes';
+import { selectSeedApplications } from '../src/scripts/seedApplicationSelection';
 
 // ── Mirror routes/applications.ts credential generation EXACTLY ──────────────
 const CREDENTIAL_PUBLIC_KEY_PREFIX = 'oxy_dk_';
@@ -238,6 +246,24 @@ const SEED_APPS: SeedAppSpec[] = [
       'https://hub.moovo.now',
     ],
   },
+  {
+    name: 'CrowdSource',
+    description:
+      'Official Oxy participatory moderation platform — reviewers are assigned cases by the server and review them blind.',
+    websiteUrl: 'https://crowdsource.oxy.so',
+    type: 'first_party',
+    // The reviewer app ships to the web only today (Cloudflare Pages project
+    // `crowdsource-frontend`). Its Expo `crowdsource://` deep-link scheme is
+    // registered here when a native build actually ships — an unused redirect
+    // surface is authority nobody asked for.
+    redirectUris: ['https://crowdsource.oxy.so'],
+    // Sign-in ONLY, so the default `['user:read']`. CrowdSource must never
+    // carry `reputation:write`: it never moves an Oxy Trust figure itself, it
+    // emits a decision and Oxy Trust's own consequence engine decides the
+    // effect. Granting it here would also widen every device sign-in grant,
+    // because a device sign-in's granted scopes ARE the application's scopes
+    // (`routes/auth.ts` — `scopes = appScopes` when there is no OAuth request).
+  },
 ];
 
 interface MappingRow {
@@ -281,6 +307,16 @@ async function seed(): Promise<void> {
   if (dryRun) {
     logger.info('DRY RUN — no writes will be performed');
   }
+
+  // Resolved BEFORE anything is read or minted, so an unknown/empty ONLY_APPS
+  // aborts without having created the Oxy organization account or its owner
+  // membership as a side effect of a run that was never going to be valid.
+  const seedApps = selectSeedApplications(SEED_APPS, process.env.ONLY_APPS);
+  logger.info('Seeding applications', {
+    selected: seedApps.map((spec) => spec.name),
+    of: SEED_APPS.length,
+    filtered: seedApps.length !== SEED_APPS.length,
+  });
 
   const owner = await User.findOne({ username: ownerUsername }).select('_id username').lean();
   if (!owner?._id) {
@@ -359,7 +395,7 @@ async function seed(): Promise<void> {
   let legacyCredentialsRevoked = 0;
   let credentialsReused = 0;
 
-  for (const spec of SEED_APPS) {
+  for (const spec of seedApps) {
     let createdApplication = false;
     let createdCredential = false;
 
@@ -493,7 +529,9 @@ async function seed(): Promise<void> {
 
   logger.info('Seed summary', {
     dryRun,
-    apps: SEED_APPS.length,
+    // The apps this run actually touched, not the size of the canonical list —
+    // a bounded run must not report the blast radius it deliberately avoided.
+    apps: seedApps.length,
     appsCreated,
     appsUpdated,
     credentialsCreated,

--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -300,7 +300,7 @@ async function retireLegacyApplication(
   return result.modifiedCount ?? 0;
 }
 
-async function seed(): Promise<void> {
+async function seed(seedApps: readonly SeedAppSpec[]): Promise<void> {
   const dryRun = process.env.DRY_RUN === 'true';
   const ownerUsername = process.env.OXY_USERNAME || 'oxy';
 
@@ -308,10 +308,6 @@ async function seed(): Promise<void> {
     logger.info('DRY RUN — no writes will be performed');
   }
 
-  // Resolved BEFORE anything is read or minted, so an unknown/empty ONLY_APPS
-  // aborts without having created the Oxy organization account or its owner
-  // membership as a side effect of a run that was never going to be valid.
-  const seedApps = selectSeedApplications(SEED_APPS, process.env.ONLY_APPS);
   logger.info('Seeding applications', {
     selected: seedApps.map((spec) => spec.name),
     of: SEED_APPS.length,
@@ -556,11 +552,16 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Resolved BEFORE connecting: a misspelled ONLY_APPS should cost nothing and
+  // must never reach the database — not even to mint the Oxy organization
+  // account as a side effect of a run that was never going to be valid.
+  const seedApps = selectSeedApplications(SEED_APPS, process.env.ONLY_APPS);
+
   await mongoose.connect(uri);
   logger.info('Connected to MongoDB');
 
   try {
-    await seed();
+    await seed(seedApps);
   } finally {
     await mongoose.connection.close();
     logger.info('MongoDB connection closed');

--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -387,7 +387,6 @@ async function seed(): Promise<void> {
       status: 'active' as const,
       isOfficial: true,
       isInternal: spec.type === 'internal',
-      capabilities: [] as string[],
       redirectUris: spec.redirectUris,
       scopes: spec.scopes ?? (['user:read'] as ApplicationScope[]),
       ownerAccountId: oxyOrgId,
@@ -399,6 +398,9 @@ async function seed(): Promise<void> {
         application = await Application.create({
           name: spec.name,
           createdByUserId: oxyId,
+          // A brand-new official app holds no platform capabilities. Existing
+          // records are never reconciled on this field — see below.
+          capabilities: [],
           ...desiredAppFields,
         });
       }
@@ -412,7 +414,16 @@ async function seed(): Promise<void> {
       application.status = desiredAppFields.status;
       application.isOfficial = desiredAppFields.isOfficial;
       application.isInternal = desiredAppFields.isInternal;
-      application.capabilities = desiredAppFields.capabilities;
+      // `capabilities` is deliberately NOT reconciled. `SeedAppSpec` has no
+      // capabilities field, so this script declares no intent about them — an
+      // authoritative overwrite here would silently STRIP a staff grant made
+      // elsewhere. Concretely: `scripts/register-commons-clients.ts` unions
+      // `identity:approval` onto "Commons by Oxy", and
+      // `services/authSessionDelivery.service.ts` selects push-delivery targets
+      // by exactly that capability — so a re-run of this seed would leave a
+      // pending sign-in request with zero eligible devices. Removing a
+      // capability is an explicit staff operation, never a side effect of a
+      // rebuild (same reasoning as `unionValidScopes` for scopes).
       application.redirectUris = desiredAppFields.redirectUris;
       // Additive union: keep any valid already-granted scope so a re-run never
       // silently revokes an out-of-band grant (e.g. Mention's signals:write).

--- a/packages/api/src/scripts/__tests__/seedApplicationSelection.test.ts
+++ b/packages/api/src/scripts/__tests__/seedApplicationSelection.test.ts
@@ -1,0 +1,130 @@
+/**
+ * THE INVARIANT of `ONLY_APPS`: a run is bounded to exactly the applications
+ * named, or it refuses to run at all. It never silently reconciles nothing, and
+ * it never silently reconciles everything.
+ *
+ * Why this suite exists: `scripts/seed-oxy-applications.ts` reconciles EVERY
+ * official application on every run, and some of what it reconciles is an
+ * authoritative replacement. Registering one new application therefore carried
+ * the blast radius of all the others, and the script's `DRY_RUN` cannot warn
+ * about it (its whole reconcile block lives inside `if (!dryRun)`, so a dry run
+ * reports `appsUpdated: 0` for every existing app no matter what the real run
+ * would change — the same bug `registerCommonsClientsPlan.test.ts` pins for the
+ * sibling script). `ONLY_APPS` removes the blast radius instead of improving the
+ * warning about it, so the guard rails on it are the safety property.
+ *
+ * The failure this pins hardest is the QUIET one: every rejection below could
+ * instead have been "select nothing and report success", which is the exact
+ * shape of a decorative safety net.
+ */
+
+import { selectSeedApplications } from '../seedApplicationSelection';
+
+/** Stands in for the real SEED_APPS: only `name` is load-bearing here. */
+const ENTRIES = [
+  { name: 'Oxy Accounts', type: 'first_party' },
+  { name: 'Commons by Oxy', type: 'first_party' },
+  { name: 'CrowdSource', type: 'first_party' },
+] as const;
+
+describe('selectSeedApplications', () => {
+  describe('unset — the long-standing behaviour is unchanged', () => {
+    it('returns the whole canonical list', () => {
+      expect(selectSeedApplications(ENTRIES, undefined)).toEqual([...ENTRIES]);
+    });
+
+    it('returns a copy, so a caller cannot mutate the canonical list', () => {
+      const selected = selectSeedApplications(ENTRIES, undefined);
+      expect(selected).not.toBe(ENTRIES);
+    });
+  });
+
+  describe('bounding a run', () => {
+    it('selects exactly the one application named', () => {
+      expect(selectSeedApplications(ENTRIES, 'CrowdSource')).toEqual([
+        { name: 'CrowdSource', type: 'first_party' },
+      ]);
+    });
+
+    it('does NOT select the applications it was not given — the whole point', () => {
+      const selected = selectSeedApplications(ENTRIES, 'CrowdSource').map((e) => e.name);
+      expect(selected).not.toContain('Commons by Oxy');
+      expect(selected).not.toContain('Oxy Accounts');
+    });
+
+    it('selects several, and tolerates whitespace around the separators', () => {
+      expect(
+        selectSeedApplications(ENTRIES, ' CrowdSource , Oxy Accounts ').map((e) => e.name)
+      ).toEqual(['Oxy Accounts', 'CrowdSource']);
+    });
+
+    it('returns canonical order, never the order the operator typed', () => {
+      expect(
+        selectSeedApplications(ENTRIES, 'CrowdSource,Oxy Accounts').map((e) => e.name)
+      ).toEqual(['Oxy Accounts', 'CrowdSource']);
+    });
+
+    it('de-duplicates a repeated name instead of seeding it twice', () => {
+      expect(
+        selectSeedApplications(ENTRIES, 'CrowdSource,CrowdSource').map((e) => e.name)
+      ).toEqual(['CrowdSource']);
+    });
+
+    it('preserves an internal space in a name (the separator is a comma)', () => {
+      expect(selectSeedApplications(ENTRIES, 'Commons by Oxy').map((e) => e.name)).toEqual([
+        'Commons by Oxy',
+      ]);
+    });
+  });
+
+  describe('fails closed — a rejection is never a silent no-op', () => {
+    it('throws when set but empty, rather than seeding everything', () => {
+      expect(() => selectSeedApplications(ENTRIES, '')).toThrow(/names no application/);
+    });
+
+    it('throws on whitespace only', () => {
+      expect(() => selectSeedApplications(ENTRIES, '   ')).toThrow(/names no application/);
+    });
+
+    it('throws on separators only', () => {
+      expect(() => selectSeedApplications(ENTRIES, ' , , ')).toThrow(/names no application/);
+    });
+
+    it('throws on an unknown name instead of selecting nothing', () => {
+      expect(() => selectSeedApplications(ENTRIES, 'Crowdsource')).toThrow(
+        /unknown application\(s\): \[Crowdsource\]/
+      );
+    });
+
+    it('names the valid options, so a typo is self-correcting', () => {
+      expect(() => selectSeedApplications(ENTRIES, 'Nope')).toThrow(/CrowdSource/);
+    });
+
+    it('rejects the WHOLE run when one of several names is unknown', () => {
+      // Partial success is the dangerous outcome: the operator reads "done" and
+      // the application they cared about was never touched.
+      expect(() => selectSeedApplications(ENTRIES, 'CrowdSource,Nope')).toThrow(
+        /unknown application\(s\): \[Nope\]/
+      );
+    });
+
+    it('is case-sensitive, because `name` is the idempotency key', () => {
+      // A near-miss identifies a DIFFERENT application (or none): matching it
+      // loosely would reconcile the wrong record under the right-looking name.
+      expect(() => selectSeedApplications(ENTRIES, 'crowdsource')).toThrow(/unknown/);
+    });
+
+    it('does not substring-match a longer name', () => {
+      expect(() => selectSeedApplications(ENTRIES, 'Crowd')).toThrow(/unknown/);
+    });
+  });
+
+  describe('vacuity floor', () => {
+    it('the fixture actually distinguishes selected from unselected', () => {
+      // If ENTRIES ever collapsed to one entry, every "does not select" test
+      // above would pass for the wrong reason.
+      expect(ENTRIES.length).toBeGreaterThan(1);
+      expect(selectSeedApplications(ENTRIES, 'CrowdSource').length).toBeLessThan(ENTRIES.length);
+    });
+  });
+});

--- a/packages/api/src/scripts/seedApplicationSelection.ts
+++ b/packages/api/src/scripts/seedApplicationSelection.ts
@@ -1,0 +1,81 @@
+/**
+ * Bound a `scripts/seed-oxy-applications.ts` run to an explicit subset of the
+ * canonical seed list.
+ *
+ * The seed reconciles EVERY official application on every run, and several of
+ * the fields it reconciles are authoritative replacements (`redirectUris`), so
+ * registering ONE new application otherwise carries the blast radius of all the
+ * others. `ONLY_APPS` removes that blast radius instead of merely warning about
+ * it: the operator names the applications the run may touch, and the invocation
+ * itself is the audit record.
+ *
+ * FAILS CLOSED, deliberately. Every rejected input below could instead have been
+ * "quietly reconcile nothing", and that is the same failure shape as a dry run
+ * reporting `appsUpdated: 0` before a real run changes something — a no-op that
+ * reads as success, which the next operator then trusts. So:
+ *
+ *  - An unset `ONLY_APPS` means "the whole canonical list", the long-standing
+ *    behaviour, unchanged.
+ *  - A SET but empty / whitespace-only value throws. It is never read as "all":
+ *    the dangerous misreading is an operator who meant to bound the run, passed
+ *    a variable that happened to be empty, and got the full-blast-radius run.
+ *  - An unknown name throws and names both what it could not match and what it
+ *    could have — a typo must not silently shrink the run to nothing (or, worse,
+ *    to some other app).
+ *
+ * Pure and dependency-free (no Mongoose, no env access) so the decision is unit
+ * testable without a database, mirroring `registerCommonsClientsPlan.ts`.
+ */
+
+/** The only thing this module needs of a seed entry: its idempotency key. */
+export interface NamedSeedEntry {
+  name: string;
+}
+
+/**
+ * Resolve the seed entries a run may touch.
+ *
+ * @param entries   The canonical seed list, in canonical order.
+ * @param rawOnlyApps  The raw `ONLY_APPS` env value: `undefined` when unset, or
+ *   a comma-separated list of application names to restrict the run to.
+ * @returns The selected entries, in the canonical list's own order (never the
+ *   order they were requested in — the seed's behaviour must not depend on how
+ *   an operator happened to type the filter).
+ * @throws When `rawOnlyApps` is set but selects nothing, or names an entry that
+ *   is not in `entries`.
+ */
+export function selectSeedApplications<T extends NamedSeedEntry>(
+  entries: readonly T[],
+  rawOnlyApps: string | undefined
+): T[] {
+  if (rawOnlyApps === undefined) {
+    return [...entries];
+  }
+
+  const requested = rawOnlyApps
+    .split(',')
+    .map((name) => name.trim())
+    .filter((name) => name.length > 0);
+
+  if (requested.length === 0) {
+    throw new Error(
+      'ONLY_APPS was set but names no application. Unset it to seed every ' +
+        'application, or name the ones this run may touch — it is never read ' +
+        'as "all".'
+    );
+  }
+
+  // Exact, case-sensitive match: `name` IS the idempotency key (with
+  // createdByUserId), so a near-miss is a different application, not this one.
+  const known = new Set(entries.map((entry) => entry.name));
+  const unknown = requested.filter((name) => !known.has(name));
+  if (unknown.length > 0) {
+    throw new Error(
+      `ONLY_APPS names unknown application(s): [${unknown.join(', ')}]. ` +
+        `Known applications: [${entries.map((entry) => entry.name).join(', ')}].`
+    );
+  }
+
+  const selected = new Set(requested);
+  return entries.filter((entry) => selected.has(entry.name));
+}


### PR DESCRIPTION
Two independent changes to `packages/api/scripts/seed-oxy-applications.ts`, plus the seed entry that motivated looking at it. **Do not merge yet** — the production run is not authorized.

## 1. The bug: the seed silently strips `Application.capabilities`

`desiredAppFields` reconciled `capabilities` authoritatively from a hardcoded `[]` — but `SeedAppSpec` has **no** capabilities field, so that `[]` was a default, never a declaration. Any re-run therefore emptied the array on every official app.

**The concrete casualty is Commons.** `scripts/register-commons-clients.ts` unions the staff-only `identity:approval` capability onto "Commons by Oxy", and `services/authSessionDelivery.service.ts:83` resolves push-delivery targets by exactly that capability. A seed run would strip it and leave every pending sign-in request with **zero eligible devices** — nothing errors, nothing logs, the request simply never arrives. The kind of failure nobody notices until someone cannot sign in.

**`DRY_RUN` could not have caught it.** The whole reconcile block lives inside `if (!dryRun)`, so a dry run computes nothing and reports `appsUpdated: 0` for every existing application regardless of what the real run would do. That is the *same* bug `src/scripts/__tests__/registerCommonsClientsPlan.test.ts` was written to pin for the sibling script — which documents a production incident where a dry run said `appsUpdated: 0` and the real run seconds later granted `identity:approval` and said `appsUpdated: 2`. The sibling script was fixed; this one was not.

**Fix:** set `capabilities: []` only when *creating* an application, and never touch the field on an existing one. Removing a capability stays an explicit staff operation instead of a side effect of a rebuild — the same reasoning that already made scopes use `unionValidScopes`.

This stands on its own merits and is worth landing independently of CrowdSource needing a client.

## 2. `ONLY_APPS` — bound a run instead of warning about it

The seed reconciles every official app on every run, and `redirectUris` is an authoritative replacement, so registering one entry rewrites sixteen records it was never asked to touch. Rather than make `DRY_RUN` faithful (worth doing, but separate work), this removes the blast radius:

```bash
ONLY_APPS='CrowdSource' bun run packages/api/scripts/seed-oxy-applications.ts
```

The decision is a pure module, `src/scripts/seedApplicationSelection.ts`, unit tested without a database — same shape as `registerCommonsClientsPlan.ts`. It **fails closed** on every input that could otherwise become a quiet no-op, because a no-op that reads as success is the same failure shape as the decorative dry run:

| Input | Behaviour |
|---|---|
| unset | the whole canonical list — unchanged behaviour |
| set but empty / whitespace / `,` | **throws.** Never read as "all": the dangerous misreading is an operator who meant to bound the run and passed a variable that happened to be empty |
| unknown name | **throws**, naming what it could not match *and* the valid options |
| one of several names unknown | rejects the **whole** run — partial success reads as "done" while the app the operator cared about was never touched |
| wrong case / substring | not matched — `name` is the idempotency key, so a near-miss is a different application |

17 tests. Both guards are **mutation-tested**: disabling the empty-value check fails exactly the 3 tests that guard it, disabling the unknown-name check fails exactly 5, and restoring returns 17/17. There is also a vacuity floor so a collapsed fixture cannot make the "does not select" assertions pass for the wrong reason.

## 3. The CrowdSource seed entry

`first_party`, redirect surface `https://crowdsource.oxy.so` **only**. The reviewer app ships to Cloudflare Pages; its Expo `crowdsource://` deep link gets registered when a native build actually ships, since `normaliseOrigin` admits custom schemes into the trusted set verbatim and an unused redirect surface is authority nobody asked for.

`scopes` is omitted, so it takes the `['user:read']` default — the minimum for sign-in.

**It must not carry `reputation:write`.** That scope gates *two* different authorities: the reputation ledger (`routes/reputation.routes.ts:43`) and civic validation juries (`routes/civic.ts:57`). And a device sign-in's granted scopes **are** the application's scopes (`routes/auth.ts:1405-1408`, `scopes = appScopes` when there is no OAuth request), so granting it would widen every sign-in rather than just a service credential. It would also contradict CrowdSource's own one-way reputation invariant.

For the record, since a prior audit claimed otherwise: the seed does **not** grant `['user:read', 'reputation:write']` to every official app. The default is `['user:read']`, the minted credential is hardcoded to `['user:read']`, and Homiio is the only entry declaring `reputation:write` (one commit, `07396c15`).

## Verification

- `bunx jest src/scripts/__tests__/seedApplicationSelection.test.ts` → 17/17
- mutation tests on both fail-closed guards (above)
- `tsc --noEmit -p packages/api/tsconfig.json` → clean for the new module; ad-hoc `tsc` on the script → clean
- script parses and resolves every import in its final state (runs to the `MONGODB_URI is required` guard)
- Biome reports 4 pre-existing style findings in this script on lines 39/324/325/549, none inside these hunks, flagged only because the repo ships no `biome.json` and Biome fell back to defaults

**No production mutation.** Nothing has been run against the production database; no application has been created; no secret appears anywhere in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)