### PR TITLE
chore(release): contracts 0.19.0, core 13.0.0, services 23.0.0 (#691 phase 7b)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -403,7 +403,7 @@
     },
     "packages/contracts": {
       "name": "@oxyhq/contracts",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "dependencies": {
         "zod": "^3.25.64",
       },
@@ -416,7 +416,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "12.11.2",
+      "version": "13.0.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -685,10 +685,10 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "22.13.1",
+      "version": "23.0.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
-        "@oxyhq/core": "^12.11.0",
+        "@oxyhq/core": "^13.0.0",
         "@simplewebauthn/browser": "^13.3.0",
         "color": "^4.2.3",
       },
@@ -739,7 +739,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.59.0",
-        "@oxyhq/core": "^12.11.0",
+        "@oxyhq/core": "^13.0.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": "^11.4.1",
         "@tanstack/query-async-storage-persister": "^5.101",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/contracts",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "OxyHQ API contracts — single source of truth for request/response Zod schemas and inferred types, shared by the backend and the client SDKs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "12.11.2",
+  "version": "13.0.0",
   "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "22.13.1",
+  "version": "23.0.0",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -127,7 +127,7 @@
   },
   "dependencies": {
     "@oxyhq/contracts": "workspace:*",
-    "@oxyhq/core": "^12.11.0",
+    "@oxyhq/core": "^13.0.0",
     "@simplewebauthn/browser": "^13.3.0",
     "color": "^4.2.3"
   },
@@ -178,7 +178,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.59.0",
-    "@oxyhq/core": "^12.11.0",
+    "@oxyhq/core": "^13.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": "^11.4.1",
     "@tanstack/query-async-storage-persister": "^5.101",


### PR DESCRIPTION
Release for #722.

**Major for core and services** — this removes public API rather than adding it: `syncHubAfterSignIn`, the hub-ticket client methods, the hub-origin helpers (`buildIdpHubOrigin`, `isIdpHubOrigin`, `buildHubSyncUrl`, `parseHubSyncReturnUrl`, `normalizeOfficialReturnOrigin`), the two silent-restore storage keys, `prompt: 'none'`, and the `hubSync` prop.

`webAuthMode`'s default also flips to `'popup'`, which changes cold-boot behaviour for any consumer that never set it — a behavioural break even where nothing fails to compile. That alone justifies the major.

`services` now requires `@oxyhq/core@^13.0.0`; it would otherwise resolve a core that still exports the lanes it no longer calls.

`contracts` takes a minor — on 0.x that is the breaking bump — and drops the four orphaned hub-ticket schemas.

Worth noting: `services@22.13.1` on `main` had already diverged from the published tarball of that same version. Bumping is what stops that repeating.

The lockfile edit is surgical (4 files, 10 lines). A plain `bun install` re-resolves unrelated floating ranges, and that churn does not belong in a release commit where it is indistinguishable from the release itself. `bun install --frozen-lockfile` passes.

Blast radius for the `hubSync` removal: only `packages/auth` ever passed it (removed in #722), and no repo outside this monorepo references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)