### PR TITLE
chore(services): 23.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -687,7 +687,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "23.0.0",
+      "version": "23.0.1",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "^13.0.0",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "23.0.0",
+  "version": "23.0.1",
   "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
23.0.0 shipped without the fix it was supposed to carry.

The published 23.0.0 tarball has **no `./notifications` export** and its barrel still re-exports the push adapter — verified against the tarball, not the repo. `origin/main` does carry the fix (#723). So the released artefact still has the defect, and since npm never allows republishing a version, the fix ships as 23.0.1.

Worth noting how it happened, because the rule already exists for it: publishing from a state that isn't the committed one burns the version number permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)