### PR TITLE
fix(core)!: model the two reputation-balance views in the types

### DIFF
--- a/docs/reputation/README.md
+++ b/docs/reputation/README.md
@@ -43,7 +43,8 @@ Three MongoDB models back the ledger (`packages/api/src/models/`):
   physical | penalty | other`. `sourceActionId` gives idempotency.
 - **`ReputationBalance`** (`reputationbalances`) — a cached per-user snapshot:
   `total`, `positive`, `negative`, `breakdown`, `reliability`, `trustTier`,
-  `influence`; recalculated on demand.
+  `influence`; recalculated on demand. Read back in **two views** — see
+  [Who may read a balance](#who-may-read-a-balance).
 - **`ReputationDispute`** (`reputationdisputes`) — dispute lifecycle.
 
 Reversals never delete: `reverseTransaction` marks the original `reversed` and
@@ -60,7 +61,49 @@ Trust tiers (top-down precedence): `restricted` (`total < 0` OR
 Influence is clamped to `[0.1, 3.0]` (base `= clamp(0.1 + total/500)`), with a
 per-context moderation factor; `restricted` floors all weights to 0.1.
 
+### Who may read a balance
+
+`GET /reputation/:userId/balance` needs no token — the public trust signal stays
+public — but the RESPONSE IS VIEW-SPLIT by caller:
+
+| Caller | Serializer | Fields |
+| --- | --- | --- |
+| The subject, or platform staff | `serializeBalance` | everything |
+| Anyone else, including anonymous | `serializePublicBalance` | `userId`, `total`, `trustTier` |
+
+Withheld from a third party: `reliability` (the platform's internal abuse
+verdict — `abuseScore ≥ 0.5` is a sanction), `influence` (a live readout of what
+an account is worth to ranking / reporting / moderation), `positive` /
+`negative` / `breakdown` (they split the total into points earned versus
+penalties accrued, exposing sanction history the total alone hides), and
+`recalculatedAt` / `updatedAt` (a timing oracle for the subject's last
+reputation event). `trustTier` stays public because it is the contribution
+ladder this system exists to publish, and the leaderboard already emits it.
+
+The neighbouring reads are gated harder — `GET /:userId/transactions` and
+`GET /:userId/influence` are owner-or-staff and answer **403** to a third party,
+because transaction `metadata` names third parties (the attestor who physically
+met the subject, the staking voucher, the juror roster of a resolved
+validation).
+
+Enforced by `packages/api/src/routes/__tests__/reputationReadAuthz.test.ts`.
+
 ### SDK (`OxyServices.reputation.ts`)
+
+The view split is in the types, so a caller cannot read a field the server did
+not send them:
+
+- **`getMyReputationBalance()`** → `ReputationBalance` (the full shape). The
+  common case, and the ergonomic path: no id to pass, no narrowing to do. Throws
+  rather than half-populating if the request was not authenticated as the
+  subject — including when the server answers `200` with the public view because
+  the token was absent or lapsed.
+- **`getReputationBalance(userId)`** → `ReputationBalanceView`, the union
+  `ReputationBalance | ReputationBalanceSummary`. Only `userId` / `total` /
+  `trustTier` are reachable without narrowing; reach the rest (as the subject or
+  as staff) with the `isFullReputationBalance(balance)` type guard.
+- **`recalculateReputation(userId)`** → `ReputationBalance`. Staff-gated, so
+  always the full view.
 
 Reads: `getReputationBalance(userId)`, `getReputationTransactions(userId, limit?, offset?)`,
 `getReputationInfluence(userId, context?)`, `getReputationLeaderboard`,
@@ -71,7 +114,7 @@ only, sweep the `GET:/reputation/` cache): `awardReputation`,
 `resolveReputationDispute`, `getReputationDisputeQueue`. Exported unions:
 `ReputationCategory`, `TrustTier`, `ReputationTransactionStatus`,
 `ReputationTargetEntityType`, `ReputationDisputeStatus`,
-`ReputationInfluenceContext`.
+`ReputationInfluenceContext`, `ReputationBalanceView`.
 
 > **Pending:** the karma→reputation migration
 > (`scripts/migrate-karma-to-reputation.ts`) must run as a one-shot ECS task —

--- a/packages/api/src/routes/reputation.routes.ts
+++ b/packages/api/src/routes/reputation.routes.ts
@@ -161,6 +161,13 @@ function serializeTransaction(
  * `reliability` scoring, the `influence` weights that drive ranking and
  * moderation, and the positive/negative/per-category decomposition of the
  * total. None of that is public; third parties get {@link serializePublicBalance}.
+ *
+ * MIRRORED CLIENT-SIDE as `ReputationBalance` in
+ * `packages/core/src/mixins/OxyServices.reputation.ts`. The two serializers are
+ * two SDK types (`ReputationBalance` / `ReputationBalanceSummary`) and a union
+ * over them, so moving a field between them here without moving it there hands
+ * every SDK consumer a type that says a field is present when it is not. Change
+ * both, in one commit.
  */
 function serializeBalance(
   balance: Awaited<ReturnType<typeof reputationService.getBalance>>
@@ -202,6 +209,9 @@ function serializeBalance(
  * exists to publish, and the leaderboard already emits it. Note it doubles as
  * the punitive `restricted` marker, so a sanctioned account remains
  * publicly identifiable as such by tier.
+ *
+ * MIRRORED CLIENT-SIDE as `ReputationBalanceSummary` — see
+ * {@link serializeBalance}.
  */
 function serializePublicBalance(
   balance: Awaited<ReturnType<typeof reputationService.getBalance>>

--- a/packages/commons/__mocks__/oxyhq-services.ts
+++ b/packages/commons/__mocks__/oxyhq-services.ts
@@ -22,6 +22,7 @@ interface MockOxyServices {
   getPublicKey?: jest.Mock;
   getPublicCard?: jest.Mock;
   getReputationBalance?: jest.Mock;
+  getMyReputationBalance?: jest.Mock;
   getReputationTransactions?: jest.Mock;
   getFileDownloadUrl?: jest.Mock;
   getCurrentUserId?: jest.Mock;

--- a/packages/commons/__tests__/hooks/useCivicReputation.test.tsx
+++ b/packages/commons/__tests__/hooks/useCivicReputation.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * The reputation screen renders `breakdown`, `influence` and `reliability`, and
+ * the API serves those ONLY to the balance's own subject. So the one thing
+ * these tests pin is that the hook reads the SIGNED-IN user's balance and never
+ * asks for one by id — `getReputationBalance(someId)` would still compile at the
+ * call site (it returns the public-view union) and would come back stripped for
+ * anybody but yourself.
+ */
+
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReputationBalance } from '@oxyhq/core';
+import { __resetOxyState, __setOxyState } from '@/__mocks__/oxyhq-services';
+import { useCivicReputation, useReputationSources } from '@/hooks/useCivicReputation';
+
+const BALANCE: ReputationBalance = {
+  userId: 'me',
+  total: 120,
+  positive: 150,
+  negative: -30,
+  breakdown: { content: 80, social: 40, trust: 0, moderation: 0, physical: 0, penalties: 30 },
+  trustTier: 'trusted',
+  influence: {
+    defaultWeight: 1,
+    reportWeight: 1,
+    moderationWeight: 1,
+    rankingFeedbackWeight: 0.8,
+  },
+  reliability: {
+    accurateReports: 2,
+    rejectedReports: 0,
+    reportAccuracyScore: 1,
+    abuseScore: 0,
+  },
+  recalculatedAt: '2026-06-16T00:00:00.000Z',
+  updatedAt: '2026-06-16T00:00:00.000Z',
+};
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useCivicReputation', () => {
+  beforeEach(() => {
+    __resetOxyState();
+  });
+
+  it('reads the signed-in user own balance, never one by id', async () => {
+    const getMyReputationBalance = jest.fn(async () => BALANCE);
+    const getReputationBalance = jest.fn(async () => BALANCE);
+    __setOxyState({
+      isAuthenticated: true,
+      user: { id: 'me' },
+      oxyServices: { getMyReputationBalance, getReputationBalance },
+    });
+
+    const { result } = renderHook(() => useCivicReputation('me'), { wrapper: makeWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getMyReputationBalance).toHaveBeenCalledTimes(1);
+    expect(getMyReputationBalance).toHaveBeenCalledWith();
+    // The subject-only fields the screen depends on survive the round trip.
+    expect(result.current.data?.reliability.reportAccuracyScore).toBe(1);
+    expect(getReputationBalance).not.toHaveBeenCalled();
+  });
+
+  it('is disabled (never fetches) when there is no user id', () => {
+    const getMyReputationBalance = jest.fn(async () => BALANCE);
+    __setOxyState({ oxyServices: { getMyReputationBalance } });
+
+    const { result } = renderHook(() => useCivicReputation(null), { wrapper: makeWrapper() });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getMyReputationBalance).not.toHaveBeenCalled();
+  });
+
+  it('derives the four sources from the balance breakdown', () => {
+    const { result } = renderHook(() => useReputationSources(BALANCE));
+
+    expect(result.current?.map((source) => source.key)).toEqual([
+      'realLife',
+      'peerCivic',
+      'apps',
+      'penalties',
+    ]);
+  });
+});

--- a/packages/commons/hooks/useCivicReputation.ts
+++ b/packages/commons/hooks/useCivicReputation.ts
@@ -1,10 +1,16 @@
 /**
- * React Query wrapper around a user's reputation balance, plus the derived
- * "by source" view the civic reputation screen renders.
+ * React Query wrapper around the SIGNED-IN user's reputation balance, plus the
+ * derived "by source" view the civic reputation screen renders.
  *
- * `oxyServices.getReputationBalance(userId)` returns the canonical balance
- * (total, per-category breakdown, trust tier, influence, reliability). The
- * source split (Real life / Peer-civic / Apps / Penalties) is derived
+ * `oxyServices.getMyReputationBalance()` returns the canonical balance (total,
+ * per-category breakdown, trust tier, influence, reliability). It is the
+ * subject-view read, and deliberately so: the API serves `breakdown` /
+ * `influence` / `reliability` ONLY to the balance's own subject and to platform
+ * staff, and this screen renders all three. Asking for them by user id
+ * (`getReputationBalance(id)`) would compile but come back without them for
+ * anyone but yourself.
+ *
+ * The source split (Real life / Peer-civic / Apps / Penalties) is derived
  * client-side from `breakdown` via `deriveReputationSources` — the schema is not
  * changed. Offline-first by the same `civic`-namespaced React Query mechanism as
  * `useCivicCard`.
@@ -23,9 +29,12 @@ const BALANCE_STALE_TIME_MS = 5 * 60 * 1000;
 const BALANCE_GC_TIME_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Query a user's reputation balance.
+ * Query the signed-in user's own reputation balance.
  *
- * @param userId - The subject account's id, or `null` (query disabled).
+ * @param userId - The signed-in account's id, or `null` (query disabled). Scopes
+ *   the cache entry so a switched account does not read the previous one's
+ *   snapshot; the READ itself always resolves whoever the SDK is authenticated
+ *   as, so no id is passed to it.
  */
 export function useCivicReputation(
   userId: string | null,
@@ -38,10 +47,7 @@ export function useCivicReputation(
       if (!oxyServices) {
         throw new Error('OxyServices not initialized');
       }
-      if (!userId) {
-        throw new Error('No user id to resolve a balance for');
-      }
-      return oxyServices.getReputationBalance(userId);
+      return oxyServices.getMyReputationBalance();
     },
     enabled: Boolean(oxyServices) && Boolean(userId),
     staleTime: BALANCE_STALE_TIME_MS,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -180,7 +180,9 @@ export type {
     ReputationBalanceBreakdown,
     ReputationInfluence,
     ReputationReliability,
+    ReputationBalanceSummary,
     ReputationBalance,
+    ReputationBalanceView,
     ReputationDispute,
     ReputationRule,
     ReputationLeaderboardEntry,
@@ -192,6 +194,8 @@ export type {
     UpsertReputationRuleInput,
     ReverseReputationTransactionInput,
 } from './mixins/OxyServices.reputation';
+
+export { isFullReputationBalance } from './mixins/OxyServices.reputation';
 
 // ---------------------------------------------------------------------------
 // Self-sovereign identity (DID, signed records, auth-method ↔ VM mapping,

--- a/packages/core/src/mixins/OxyServices.reputation.ts
+++ b/packages/core/src/mixins/OxyServices.reputation.ts
@@ -12,11 +12,17 @@
  * their `active` transactions, augmented with a trust tier, capped influence
  * weights, and reliability signals.
  *
+ * A balance is served in TWO views (see {@link ReputationBalanceView}): the
+ * subject and platform staff get the whole thing, a third party gets the public
+ * trust signal only. The two are distinct types here so a caller cannot read a
+ * field the server did not send them.
+ *
  * Reference users by their Mongo `_id` (or publicKey, which the API resolves),
  * transactions by their `id`, and disputes by their `id`.
  */
 import type { OxyServicesBase } from '../OxyServices.base';
 import type { User } from '../models/interfaces';
+import { OxyAuthenticationError } from '../OxyServices.errors';
 import { CACHE_TIMES } from './mixinHelpers';
 
 // =============================================================================
@@ -165,20 +171,46 @@ export interface ReputationReliability {
 }
 
 /**
- * Cached, recomputable snapshot of a user's reputation. Shape mirrors the
- * `/reputation/:userId/balance` response (which omits internal `lastTransactionId`
- * and `createdAt`).
+ * The PUBLIC view of a user's reputation — everything a caller who is neither
+ * the subject nor platform staff receives from `GET /reputation/:userId/balance`.
+ * Mirrors the API's `serializePublicBalance`.
+ *
+ * Deliberately limited to the two signals the already-public
+ * `GET /reputation/leaderboard` publishes per user, so an untokened read of a
+ * balance exposes no class of signal that is not public already. `trustTier`
+ * stays public because it is the contribution ladder this system exists to
+ * publish — note it doubles as the punitive `restricted` marker.
  */
-export interface ReputationBalance {
+export interface ReputationBalanceSummary {
   userId: string;
   /** Net lifetime total across all active transactions. */
   total: number;
+  trustTier: TrustTier;
+}
+
+/**
+ * The SUBJECT view of a user's reputation — the cached, recomputable snapshot in
+ * full, served only to the subject themselves and to platform staff. Mirrors the
+ * API's `serializeBalance` (which omits the internal `lastTransactionId` and
+ * `createdAt`).
+ *
+ * Everything beyond {@link ReputationBalanceSummary} is the platform's internal
+ * judgement about the person and is withheld from third parties: `reliability`
+ * (the abuse verdict), `influence` (what the account is worth to ranking,
+ * reporting and moderation), the `positive` / `negative` / `breakdown`
+ * decomposition (which exposes sanction history the total alone hides), and the
+ * timestamps (a timing oracle for the subject's last reputation event).
+ *
+ * Reach this type by reading YOUR OWN balance (`getMyReputationBalance`), by
+ * narrowing a {@link ReputationBalanceView} with {@link isFullReputationBalance},
+ * or from the staff-only `recalculateReputation`.
+ */
+export interface ReputationBalance extends ReputationBalanceSummary {
   /** Sum of positive points only. */
   positive: number;
   /** Sum of negative points only (a negative number). */
   negative: number;
   breakdown: ReputationBalanceBreakdown;
-  trustTier: TrustTier;
   influence: ReputationInfluence;
   reliability: ReputationReliability;
   /** ISO timestamp the snapshot was last recomputed at. */
@@ -186,6 +218,93 @@ export interface ReputationBalance {
   /** ISO last-update timestamp. */
   updatedAt: string;
 }
+
+/**
+ * What `GET /reputation/:userId/balance` may return for an ARBITRARY subject:
+ * the full {@link ReputationBalance} when the caller is that subject or staff,
+ * the {@link ReputationBalanceSummary} otherwise.
+ *
+ * The server decides at request time from the caller's token, so a client asking
+ * for someone else's balance cannot know statically which view it will get —
+ * hence the union. Reading anything past `userId` / `total` / `trustTier`
+ * requires narrowing with {@link isFullReputationBalance}.
+ */
+export type ReputationBalanceView = ReputationBalance | ReputationBalanceSummary;
+
+/**
+ * Every field the full {@link ReputationBalance} carries beyond the public
+ * {@link ReputationBalanceSummary}. The runtime discriminant between the two
+ * views — the API sends this set all-or-nothing.
+ */
+const FULL_BALANCE_FIELDS = [
+  'positive',
+  'negative',
+  'breakdown',
+  'influence',
+  'reliability',
+  'recalculatedAt',
+  'updatedAt',
+] as const satisfies readonly (keyof Omit<ReputationBalance, keyof ReputationBalanceSummary>)[];
+
+/**
+ * Whether a balance came back as the SUBJECT view, and so carries the
+ * breakdown / influence / reliability blocks.
+ *
+ * Checks every extra field rather than one representative: the point of the
+ * guard is that the caller then dereferences those blocks, so a partial payload
+ * must not narrow.
+ *
+ * @param balance - A balance from `getReputationBalance`.
+ */
+export function isFullReputationBalance(
+  balance: ReputationBalanceView,
+): balance is ReputationBalance {
+  return FULL_BALANCE_FIELDS.every((field) => field in balance);
+}
+
+/** Compile-time assertion helper: fails to instantiate unless `T` is `true`. */
+type AssertTrue<T extends true> = T;
+
+/**
+ * THE INVARIANT THIS MODULE EXISTS TO HOLD, checked by the compiler.
+ *
+ * `keyof` a union is the keys COMMON to its members, so a private field is only
+ * `keyof ReputationBalanceView` if the PUBLIC view declares it too. Should
+ * anyone widen {@link ReputationBalanceSummary} — or collapse the union back to
+ * a single shape — one of these arms becomes `false` and `tsc` fails, rather
+ * than a consumer silently regaining `balance.reliability.x` on a stranger's
+ * balance and crashing at runtime.
+ *
+ * This lives in the source, NOT in `__tests__`: `ts-jest` runs with
+ * `diagnostics: false` and `tsconfig.json` excludes the test folder, so a
+ * type-level assertion written there could never fail. `bun run typescript` and
+ * `build:types` both check this file.
+ */
+type _PrivateFieldsAreUnreachableOnTheView = AssertTrue<
+  'reliability' extends keyof ReputationBalanceView
+    ? false
+    : 'influence' extends keyof ReputationBalanceView
+      ? false
+      : 'breakdown' extends keyof ReputationBalanceView
+        ? false
+        : 'positive' extends keyof ReputationBalanceView
+          ? false
+          : true
+>;
+
+/**
+ * The other half: the public trust signal must stay reachable with NO
+ * narrowing, so the common "show a tier and a total" render never needs a guard.
+ */
+type _PublicFieldsStayReachableOnTheView = AssertTrue<
+  'userId' extends keyof ReputationBalanceView
+    ? 'total' extends keyof ReputationBalanceView
+      ? 'trustTier' extends keyof ReputationBalanceView
+        ? true
+        : false
+      : false
+    : false
+>;
 
 /**
  * A user-initiated dispute against a specific reputation transaction. Ids are
@@ -350,13 +469,21 @@ export function OxyServicesReputationMixin<T extends typeof OxyServicesBase>(Bas
     }
 
     /**
-     * Get a user's cached reputation balance — derived totals, per-category
-     * breakdown, trust tier, capped influence weights, and reliability signals.
+     * Get ANY user's reputation balance, in whichever view the server serves the
+     * caller.
+     *
+     * A third party gets `userId`, `total` and `trustTier` and nothing else, so
+     * the return type is a {@link ReputationBalanceView} union: narrow it with
+     * {@link isFullReputationBalance} before touching `breakdown`, `influence`
+     * or `reliability`. To read your OWN balance, call
+     * {@link getMyReputationBalance} instead — it returns the full shape with no
+     * narrowing.
+     *
      * @param userId - The subject user's `_id` or publicKey.
      */
-    async getReputationBalance(userId: string): Promise<ReputationBalance> {
+    async getReputationBalance(userId: string): Promise<ReputationBalanceView> {
       try {
-        return await this.makeRequest<ReputationBalance>(
+        return await this.makeRequest<ReputationBalanceView>(
           'GET',
           `/reputation/${encodeURIComponent(userId)}/balance`,
           undefined,
@@ -365,6 +492,48 @@ export function OxyServicesReputationMixin<T extends typeof OxyServicesBase>(Bas
       } catch (error) {
         throw this.handleError(error);
       }
+    }
+
+    /**
+     * Get the SIGNED-IN user's own reputation balance, in full.
+     *
+     * The subject view is the only one carrying `breakdown`, `influence` and
+     * `reliability`, and the subject is the common caller, so this is the
+     * ergonomic path: no id to pass, no narrowing to do.
+     *
+     * Throws rather than returning a half-populated object when the request was
+     * not authenticated as the subject — with no signed-in user, and when the
+     * server answered `200` with the public view anyway (which it does for an
+     * absent or lapsed token, since the endpoint's auth is optional). Both mean
+     * the private blocks are simply absent, and a thrown error is the only
+     * honest report of that.
+     */
+    async getMyReputationBalance(): Promise<ReputationBalance> {
+      const userId = this.getCurrentUserId();
+      if (!userId) {
+        throw new OxyAuthenticationError(
+          'Reading your own reputation balance requires a signed-in user',
+        );
+      }
+
+      let balance: ReputationBalanceView;
+      try {
+        balance = await this.makeRequest<ReputationBalanceView>(
+          'GET',
+          `/reputation/${encodeURIComponent(userId)}/balance`,
+          undefined,
+          { cache: true, cacheTTL: CACHE_TIMES.MEDIUM },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+
+      if (!isFullReputationBalance(balance)) {
+        throw new OxyAuthenticationError(
+          'The reputation balance came back as the public view — the request was not authenticated as its subject',
+        );
+      }
+      return balance;
     }
 
     /**
@@ -604,6 +773,10 @@ export function OxyServicesReputationMixin<T extends typeof OxyServicesBase>(Bas
     /**
      * Force a recompute of a user's balance snapshot from their active ledger
      * (staff only). Invalidates cached reputation reads.
+     *
+     * Staff-gated, so the response is always the full subject view — no
+     * narrowing needed.
+     *
      * @param userId - The subject user's `_id` or publicKey.
      */
     async recalculateReputation(userId: string): Promise<ReputationBalance> {

--- a/packages/core/src/mixins/__tests__/reputation.test.ts
+++ b/packages/core/src/mixins/__tests__/reputation.test.ts
@@ -10,8 +10,12 @@
  */
 
 import { OxyServices } from '../../OxyServices';
+import { OxyAuthenticationError } from '../../OxyServices.errors';
+import { isFullReputationBalance } from '../OxyServices.reputation';
 import type {
   ReputationBalance,
+  ReputationBalanceSummary,
+  ReputationBalanceView,
   ReputationTransaction,
   ReputationDispute,
   ReputationRule,
@@ -22,6 +26,41 @@ import type {
 const setAccessTokenForTest = (oxy: OxyServices): void => {
   oxy.httpService.setTokens('test-token');
 };
+
+/** An unsigned JWT carrying just the `userId` claim `getCurrentUserId` decodes. */
+const signedInToken = (userId: string): string => {
+  const encode = (value: object): string =>
+    Buffer.from(JSON.stringify(value))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+  return `${encode({ alg: 'none', typ: 'JWT' })}.${encode({ userId })}.`;
+};
+
+/**
+ * The fields the SUBJECT view adds. Mirrors the private list the API's
+ * `reputationReadAuthz` test asserts absent from the public view.
+ */
+const FULL_BALANCE_FIELD_NAMES = [
+  'positive',
+  'negative',
+  'breakdown',
+  'influence',
+  'reliability',
+  'recalculatedAt',
+  'updatedAt',
+] as const;
+
+/*
+ * The COMPILE-TIME half of this guarantee — that no private field is reachable
+ * on `ReputationBalanceView` without narrowing — is asserted in the SOURCE file,
+ * not here: `ts-jest` runs with `diagnostics: false` and `tsconfig.json`
+ * excludes `**\/__tests__`, so a type-level assertion written in this file could
+ * never fail. See `_PrivateFieldsAreUnreachableOnTheView` in
+ * `src/mixins/OxyServices.reputation.ts`, which `bun run typescript` and
+ * `build:types` both check.
+ */
 
 const balanceFixture: ReputationBalance = {
   userId: 'u1',
@@ -51,6 +90,13 @@ const balanceFixture: ReputationBalance = {
   },
   recalculatedAt: '2026-06-16T00:00:00.000Z',
   updatedAt: '2026-06-16T00:00:00.000Z',
+};
+
+/** What the API serves a caller who is neither the subject nor staff. */
+const summaryFixture: ReputationBalanceSummary = {
+  userId: 'u1',
+  total: 120,
+  trustTier: 'trusted',
 };
 
 const transactionFixture: ReputationTransaction = {
@@ -120,6 +166,74 @@ describe('OxyServices.reputation', () => {
       makeRequestSpy.mockResolvedValue(balanceFixture);
       await oxy.getReputationBalance('a b/c');
       expect(makeRequestSpy.mock.calls[0][1]).toBe('/reputation/a%20b%2Fc/balance');
+    });
+
+    it('passes the public view through unchanged for a third-party subject', async () => {
+      makeRequestSpy.mockResolvedValue(summaryFixture);
+
+      const result = await oxy.getReputationBalance('someone-else');
+
+      expect(result).toEqual(summaryFixture);
+      expect(isFullReputationBalance(result)).toBe(false);
+    });
+  });
+
+  describe('isFullReputationBalance', () => {
+    it('narrows the subject view', () => {
+      const view: ReputationBalanceView = balanceFixture;
+      expect(isFullReputationBalance(view)).toBe(true);
+      if (isFullReputationBalance(view)) {
+        // Reachable ONLY through the guard — the point of the narrowing.
+        expect(view.reliability.reportAccuracyScore).toBe(1);
+        expect(view.influence.reportWeight).toBe(1.0);
+        expect(view.breakdown.content).toBe(80);
+      }
+    });
+
+    it('rejects the public view', () => {
+      expect(isFullReputationBalance(summaryFixture)).toBe(false);
+    });
+
+    it('rejects a payload missing any single private field', () => {
+      for (const field of FULL_BALANCE_FIELD_NAMES) {
+        const partial = { ...balanceFixture };
+        delete (partial as Record<string, unknown>)[field];
+        expect(isFullReputationBalance(partial as ReputationBalanceView)).toBe(false);
+      }
+    });
+  });
+
+  describe('getMyReputationBalance', () => {
+    it('reads the signed-in user id from the token and returns the full shape', async () => {
+      oxy.httpService.setTokens(signedInToken('me-123'));
+      makeRequestSpy.mockResolvedValue(balanceFixture);
+
+      const result = await oxy.getMyReputationBalance();
+
+      // Typed as the full balance with no narrowing — the ergonomic path.
+      expect(result.reliability.abuseScore).toBe(0);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'GET',
+        '/reputation/me-123/balance',
+        undefined,
+        expect.objectContaining({ cache: true }),
+      );
+    });
+
+    it('throws without a signed-in user, and never issues the request', async () => {
+      oxy.httpService.clearTokens();
+
+      await expect(oxy.getMyReputationBalance()).rejects.toThrow(OxyAuthenticationError);
+      expect(makeRequestSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws when the server answers 200 with the public view', async () => {
+      // What an absent or lapsed token gets: the endpoint's auth is optional, so
+      // the read succeeds and silently omits every private block.
+      oxy.httpService.setTokens(signedInToken('me-123'));
+      makeRequestSpy.mockResolvedValue(summaryFixture);
+
+      await expect(oxy.getMyReputationBalance()).rejects.toThrow(OxyAuthenticationError);
     });
   });
 


### PR DESCRIPTION
Follow-up to #716. That PR view-split `GET /reputation/:userId/balance` on the server; the SDK type was not updated, so `@oxyhq/core` currently promises consumers fields the API no longer sends them.

## The divergence, verified

`packages/api/src/routes/reputation.routes.ts` on `main` serves the balance through two serializers, chosen per request:

| Caller | Serializer | Fields |
| --- | --- | --- |
| The subject, or platform staff | `serializeBalance` | everything |
| Anyone else, including anonymous | `serializePublicBalance` | `userId`, `total`, `trustTier` |

`ReputationBalance` in `packages/core/src/mixins/OxyServices.reputation.ts` still declared **seven** fields as required that the public view omits: `positive`, `negative`, `breakdown`, `influence`, `reliability`, **`recalculatedAt`** and **`updatedAt`**. (The last two are easy to miss — they are in the `PRIVATE_FIELDS` list `reputationReadAuthz.test.ts` asserts absent, but not in the usual summary of the split.)

So this compiled, and threw:

```ts
const balance = await oxy.getReputationBalance(someoneElsesId);
balance.reliability.reportAccuracyScore; // TypeError at runtime
```

## The shape

Three types instead of one, mirroring the two serializers:

- **`ReputationBalanceSummary`** — `userId` / `total` / `trustTier`. What a third party gets.
- **`ReputationBalance`** — extends it with the private blocks. Keeps its name and meaning, so consumers already reading `.reliability` off it (the subject surfaces) keep compiling.
- **`ReputationBalanceView`** — `ReputationBalance | ReputationBalanceSummary`, what `getReputationBalance(userId)` returns. `keyof` a union is the keys common to its members, so nothing past the public three is reachable without narrowing via the exported `isFullReputationBalance()` guard.

The union rather than "just return the summary" because staff genuinely do receive the full payload; typing it away would push a staff console into a cast. The guard is the honest way to express "the server decided this at request time".

**Ergonomics — the reason this doesn't get worked around with a cast.** The common caller reads their OWN balance, and for them nothing changes shape and nothing needs narrowing: the new `getMyReputationBalance()` takes no id and returns `ReputationBalance` directly. `recalculateReputation()` is staff-gated and keeps returning the full type too.

`getMyReputationBalance()` throws rather than half-populating when the read was not authenticated as the subject. That is not defensive noise: the route uses `optionalAuthMiddleware`, so an absent or lapsed token gets **200 with the public view**, not a 401. Without the check, a token that lapsed mid-session would hand the Commons standing card an object whose `influence` is `undefined` — the same crash, one layer down. React Query surfaces the throw as `isError`, which both consumer surfaces already render.

## What stops this recurring

A `keyof`-based compile-time assertion (`_PrivateFieldsAreUnreachableOnTheView`) fails `tsc` if anyone widens the public view or collapses the union. It lives in the **source**, deliberately not in `__tests__` — core's `ts-jest` runs with `diagnostics: false` and `tsconfig.json` excludes the test folder, so a type-level assertion written there could never fail. Mutation-tested: adding `reliability` to `ReputationBalanceSummary` makes `bun run typescript` fail on both that assertion and the `satisfies` constraint on `FULL_BALANCE_FIELDS`.

The API serializers now carry a reciprocal pointer at the SDK types, since the missing link between them is what let this ship.

## Consumer inventory

Every `getReputationBalance` call site in `~/Oxy`, and what it reads:

| Call site | Subject | Reads | Status |
| --- | --- | --- | --- |
| `packages/commons/hooks/useCivicReputation.ts` → `StandingSection` | **own** (`user.id ?? getCurrentUserId()`) | `total`, `trustTier`, `breakdown`, `influence`, `reliability` | **Fixed here** — moved to `getMyReputationBalance()` |
| `packages/services/.../ProfileScreen.tsx` | **third party** (the profile being viewed) | `total` only | Fine — `total` is public, and was public before #716 |
| `packages/services/.../trust/TrustCenterScreen.tsx` | own (`user.id`) | `total`, `trustTier` | Fine, compiles unchanged |
| `packages/services/.../trust/TrustRewardsScreen.tsx` | own (`user.id`) | `total` | Fine, compiles unchanged |
| `CrowdSource-chrome/.../ReputationWidget.tsx` | own (`user.id`) | `total`, `trustTier` | Fine, compiles unchanged; pinned at `@oxyhq/core@^13.0.0` |

**No production bug found.** `StandingSection` is the only surface reading `reliability` / `influence`, and it is reached solely from the Commons reputation tab, which resolves the signed-in user's own id — confirmed by reading the screen, not inferred from the component. Nothing anywhere reads a third party's private blocks. `@oxyhq/services` typechecks against the new core with **zero** changes, which independently confirms its three screens touch only public-view fields.

Neighbouring reads are unaffected: `getReputationTransactions` / `getReputationInfluence` are called with the caller's own id everywhere, and #716 gates those with a hard 403 rather than a stripped 200.

## Version impact — this is a major for `@oxyhq/core`

`getReputationBalance(userId)` narrows from `ReputationBalance` to `ReputationBalanceView`. **13.2.0 → 14.0.0.** The version is deliberately not bumped in this PR so it can be folded into a considered release rather than shipping a second major on its own.

In-repo call sites that break: **one**, `packages/commons/hooks/useCivicReputation.ts`, fixed here. `@oxyhq/services` needs no source change, so it needs only a dependency bump, not a major of its own. CrowdSource is insulated by its `^13.0.0` range and compiles unchanged whenever it moves to 14.

## Should `@oxyhq/contracts` own this?

**Yes, eventually — and deliberately not in this PR.** Two reasons to keep it in core for now:

1. Nothing about reputation lives in contracts today: the API has its own mongoose model and hand-written serializers returning `Record<string, unknown>`, and imports no reputation type from anywhere. Moving one interface across achieves nothing on its own — the value is the whole family (~15 types) moving *and* the API annotating `serializeBalance(): ReputationBalance` / `serializePublicBalance(): ReputationBalanceSummary`. That is what would have made #716 fail to compile instead of silently diverging, and it is a change to the API package as much as to core.
2. Contracts must be republished before core can import a new symbol from it, so that migration cannot land as a typing fix — it needs its own release sequence.

Recommend a follow-up that moves the reputation type family to `@oxyhq/contracts` and types the API serializers against it, which converts this whole bug class into a build failure.

## Testing

Each package's own `test` script, all green, run against a `bun install` in a clean worktree off `origin/main`:

- `@oxyhq/core` — 1311 passed / 99 suites; `bun run typescript` clean; `biome lint` shows the same 2 pre-existing errors as `main` on the touched files, 0 new
- `@oxyhq/api` — 2124 passed / 220 suites (incl. the 15 `reputationReadAuthz` cases from #716); `tsc --noEmit` clean
- `@oxyhq/services` — 552 passed / 63 suites; `bun run typescript` clean with no source change
- `commons` — 564 passed / 63 suites; `tsc --noEmit` clean

Mutation-tested rather than assumed, since a type-level guard that cannot fail is worse than none:

- Widening `ReputationBalanceSummary` with `reliability` → `tsc` fails (2 errors)
- `isFullReputationBalance` forced to `return true` → 4 tests fail
- Dropping the public-view throw in `getMyReputationBalance` → 1 test fails
- Reverting Commons' hook to `getReputationBalance(userId)` → commons `tsc` fails
- Reverting the hook's SDK call in the new commons test → that test fails

And the acceptance test from the brief, as a scratch probe compiled against the built types — exactly one error, on exactly the line that must not compile:

```
src/__probe_consumer.ts(9,18): error TS2339: Property 'reliability' does not exist on type 'ReputationBalanceView'.
  Property 'reliability' does not exist on type 'ReputationBalanceSummary'.
```

while `getMyReputationBalance().reliability.x`, `recalculateReputation().influence.x`, the narrowed third-party read, and the public `total`/`trustTier`/`userId` read all compile.

No `as any`, no `@ts-ignore`, no `!` assertions. Staged by explicit path; no lockfile or build artefacts touched.