### PR TITLE
fix(auth): stub getNormalizedUserHandle, and stop the core mock rotting again

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -416,7 +416,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "14.0.0",
+      "version": "15.0.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -690,10 +690,10 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "23.2.0",
+      "version": "23.3.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
-        "@oxyhq/core": "^14.0.0",
+        "@oxyhq/core": "^15.0.0",
         "@simplewebauthn/browser": "^13.3.0",
         "color": "^4.2.3",
       },
@@ -744,7 +744,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.59.0",
-        "@oxyhq/core": "^13.0.0",
+        "@oxyhq/core": "^15.0.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": ">=11.4.1",
         "@tanstack/query-async-storage-persister": "^5.101",

--- a/packages/auth/lib/__tests__/core-mock-surface.test.ts
+++ b/packages/auth/lib/__tests__/core-mock-surface.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The `@oxyhq/core` test mock must cover every value the app actually imports.
+ *
+ * `setup-core-source.ts` stubs `@oxyhq/core` with an explicit ALLOWLIST of pure
+ * helpers, because importing the real entry pulls optional React Native modules
+ * bun cannot parse. An allowlist that is maintained by hand drifts, and this
+ * particular drift is close to invisible: a missing name does not fail one
+ * assertion, it makes bun abort the ENTIRE importing test file with
+ * `SyntaxError: Export named '…' not found in module …/core/dist/esm/index.js`.
+ * Those cases then simply do not run. When `hub-passkey.tsx` moved from
+ * `getAccountDisplayName` to `getNormalizedUserHandle`, the suite reported
+ * "120 pass, 1 fail" — four `hub-passkey` cases had silently left the run, and
+ * the error text pointed at core's built output rather than at this allowlist,
+ * which sent the first diagnosis at the build.
+ *
+ * So: scan the app's own source for value imports of `@oxyhq/core` and assert
+ * the mocked module actually provides each one. Type-only imports are skipped —
+ * they are erased before runtime and never reach the module registry.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import * as mockedCore from '@oxyhq/core';
+
+/** App source roots. `__tests__` is excluded — test files may stub freely. */
+const APP_SOURCE_ROOTS = ['src', 'components', 'lib', 'hooks'];
+
+const SOURCE_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Floors that make a broken traversal fail instead of passing vacuously. If a
+ * refactor legitimately drops below these, re-count and lower them deliberately
+ * — do not delete the check.
+ */
+const MIN_FILES_SCANNED = 20;
+const MIN_VALUE_IMPORTS = 5;
+
+/** Every `.ts`/`.tsx` file under the app source roots, excluding test folders. */
+function collectSourceFiles(): string[] {
+    const packageRoot = join(import.meta.dir, '..', '..');
+    const found: string[] = [];
+
+    const walk = (dir: string): void => {
+        let entries: string[];
+        try {
+            entries = readdirSync(dir);
+        } catch {
+            return; // A root that does not exist in this package layout.
+        }
+        for (const entry of entries) {
+            if (entry === 'node_modules' || entry === '__tests__') continue;
+            const full = join(dir, entry);
+            if (statSync(full).isDirectory()) {
+                walk(full);
+            } else if (SOURCE_EXTENSIONS.some((ext) => entry.endsWith(ext))) {
+                found.push(full);
+            }
+        }
+    };
+
+    for (const root of APP_SOURCE_ROOTS) walk(join(packageRoot, root));
+    return found;
+}
+
+/**
+ * `import { a, b as c, type D } from "@oxyhq/core"` — including multi-line.
+ *
+ * The specifier list is `[^{}]*`, NOT a lazy `[\s\S]*?`: lazy matching happily
+ * starts at an EARLIER import's brace and runs to core's closing one, so a file
+ * whose first import is `{ useCallback } from "react"` yields `useCallback` as a
+ * "core import". That produced three phantom names on the first run of this
+ * scanner. Excluding braces confines each match to a single import clause.
+ */
+const CORE_IMPORT = /import\s+(type\s+)?\{([^{}]*)\}\s*from\s*["']@oxyhq\/core["']/g;
+
+/**
+ * The VALUE names a file imports from `@oxyhq/core`. Returns the imported name
+ * (the left side of `as`), since that is the key the module must expose.
+ */
+function valueImportsFrom(source: string): string[] {
+    const names: string[] = [];
+    for (const match of source.matchAll(CORE_IMPORT)) {
+        if (match[1]) continue; // `import type { … }` — erased before runtime.
+        for (const raw of match[2].split(',')) {
+            const specifier = raw.trim();
+            if (specifier.length === 0) continue;
+            if (specifier.startsWith('type ')) continue; // inline type specifier
+            names.push(specifier.split(/\s+as\s+/)[0].trim());
+        }
+    }
+    return names;
+}
+
+describe('@oxyhq/core test mock surface', () => {
+    const files = collectSourceFiles();
+
+    const imported = new Map<string, string[]>();
+    for (const file of files) {
+        for (const name of valueImportsFrom(readFileSync(file, 'utf8'))) {
+            const sites = imported.get(name) ?? [];
+            sites.push(file);
+            imported.set(name, sites);
+        }
+    }
+
+    it('scanned a plausible amount of app source', () => {
+        expect(files.length).toBeGreaterThanOrEqual(MIN_FILES_SCANNED);
+        expect(imported.size).toBeGreaterThanOrEqual(MIN_VALUE_IMPORTS);
+    });
+
+    it('provides every value the app imports from @oxyhq/core', () => {
+        const missing = [...imported.entries()]
+            .filter(([name]) => !(name in mockedCore))
+            .map(([name, sites]) => `${name} (imported by ${sites.join(', ')})`);
+
+        expect(
+            missing,
+            `setup-core-source.ts does not stub these @oxyhq/core exports, so bun will abort ` +
+                `the whole test file that imports them:\n  ${missing.join('\n  ')}`,
+        ).toEqual([]);
+    });
+
+    /*
+     * The other direction. A stub nobody imports is dead weight that outlives
+     * the call site it was added for (`getAccountDisplayName` did), and it makes
+     * the allowlist read as broader coverage than it has.
+     */
+    it('stubs nothing the app no longer imports', () => {
+        const unused = Object.keys(mockedCore).filter((name) => !imported.has(name));
+        expect(unused).toEqual([]);
+    });
+});

--- a/packages/auth/lib/__tests__/setup-core-source.ts
+++ b/packages/auth/lib/__tests__/setup-core-source.ts
@@ -3,7 +3,7 @@
  * workspace build.
  *
  * Auth component tests import `@oxyhq/core` at runtime (`login-form.tsx` →
- * `isOxyRpOrigin`, `hub-passkey.tsx` → `getAccountDisplayName`, i18n helpers,
+ * `isOxyRpOrigin`, `hub-passkey.tsx` → `getNormalizedUserHandle`, i18n helpers,
  * etc.). The package `exports` point at `dist/`, so an unbuilt workspace fails
  * with `Cannot find module '@oxyhq/core'`.
  *
@@ -11,19 +11,26 @@
  * transitively pulls optional RN modules. Instead, re-export only the small
  * pure helpers auth actually uses, via relative paths into `packages/core/src`.
  *
+ * THIS IS AN ALLOWLIST, and an allowlist silently rots: adding a `@oxyhq/core`
+ * value import to app source without adding it here makes `bun test` abort the
+ * WHOLE importing test file with `SyntaxError: Export named '…' not found`, so
+ * its cases vanish from the run rather than failing loudly — that is how
+ * `getNormalizedUserHandle` took four `hub-passkey` cases out of CI. Keep it in
+ * step with app source; `core-mock-surface.test.ts` fails the build if it drifts.
+ *
  * TEST-ONLY: never affects the Vite app build.
  */
 import { mock } from "bun:test"
 import { getCommonsApprovalBlockingReason } from "../../../core/src/utils/commonsApproval"
 import { isOxyRpOrigin } from "../../../core/src/utils/webauthnOrigin"
-import { getAccountDisplayName } from "../../../core/src/utils/accountUtils"
+import { getNormalizedUserHandle } from "../../../core/src/utils/userHandle"
 import { translate } from "../../../core/src/i18n"
 import { getBaseLanguage, normalizeLocale } from "../../../core/src/utils/languageUtils"
 import { selectCommonsDelivery } from "../../../core/src/utils/commonsDelivery"
 
 mock.module("@oxyhq/core", () => ({
     isOxyRpOrigin,
-    getAccountDisplayName,
+    getNormalizedUserHandle,
     getCommonsApprovalBlockingReason,
     translate,
     getBaseLanguage,


### PR DESCRIPTION
**`Auth Tests` is red on `main`** (run [30430767821](https://github.com/OxyHQ/OxyHQServices/actions/runs/30430767821) at `018c0af8`), which also fails every open PR — `pull_request` checks run on the merge commit, so #731 inherits it.

## It is not the build, and not build order

The error reads:

```
SyntaxError: Export named 'getNormalizedUserHandle' not found in module
  .../packages/core/dist/esm/index.js
```

which points squarely at core's ESM output. The output is fine. On a clean checkout of `main`, after `bun install` and the job's own `contracts → protocol → core → services` build:

- `packages/core/dist/esm/index.js:39` — `export { getCanonicalUserHandle, getNormalizedUserHandle, } from './utils/userHandle.js';`
- `packages/core/dist/esm/utils/userHandle.js:16` — `export function getNormalizedUserHandle(user)`

Both present, build exit 0. The `auth-test` job already builds contracts before core (ci.yml L241–244), so the "contracts `dist` predates core's imports" theory does not apply here either. I reproduced the failure on plain `origin/main` with no changes of mine, which is what ruled both out.

**The real cause is the test-time module mock.** `packages/auth/lib/__tests__/setup-core-source.ts` replaces `@oxyhq/core` with an explicit allowlist of pure helpers, because importing the real entry pulls optional RN modules bun cannot parse. `018c0af8` changed `hub-passkey.tsx` from `getAccountDisplayName` to `getNormalizedUserHandle` and did not add the new name to that list. Bun reports the *resolved* path of the mocked specifier, which is why the message accuses the built file.

## Why this needs more than the missing line

A name absent from the allowlist does not fail one assertion — it makes bun abort the **entire importing test file**. The suite reported `120 pass, 1 fail`: four `hub-passkey` cases had silently stopped running, and the count still looked broadly healthy. That is the "a check that cannot distinguish success from failure" shape from `AGENTS.md`, and a hand-maintained allowlist will drift into it again.

`core-mock-surface.test.ts` scans the app's own source (`src`, `components`, `lib`, `hooks`; `__tests__` excluded) for **value** imports of `@oxyhq/core` — type-only specifiers are erased before runtime and never reach the module registry — and asserts the mocked module provides each one. It also fails on stubs nothing imports any more: `getAccountDisplayName` had already outlived its last call site, and is dropped here.

A vacuity floor (`MIN_FILES_SCANNED`, `MIN_VALUE_IMPORTS`) means a broken traversal fails rather than passing on an empty scan.

## Mutation evidence

| Mutation | Result |
| --- | --- |
| Drop `getNormalizedUserHandle` from the allowlist (re-creates the CI bug exactly) | fails, naming both the export **and** `src/pages/hub-passkey.tsx` |
| Re-add a stub nothing imports | fails, naming `getAccountDisplayName` |
| Point the scan at a non-existent root | vacuity floor fails |

The scanner's own first draft was wrong in the way `AGENTS.md` warns about, and I fixed it **before** it became a gate: a lazy `[\s\S]*?` for the specifier list matched from an *earlier* import's brace through to core's closing one, so a file whose first import was `{ useCallback } from "react"` reported `useCallback` as a core import — three phantom names. Now `[^{}]*`, which confines each match to one import clause. The comment on the regex records why.

## Testing

`packages/auth` — **127 pass / 0 fail** (was 120 pass / 1 fail / 1 error); `bunx tsc --noEmit` clean. Run via the package's own `bun run test`, which is `bun test` — not Jest.

Also regenerates `bun.lock`, which `018c0af8` left desynced after bumping core to `15.0.0` and services to `23.3.0` in `package.json` only. No `--frozen-lockfile` gate is active in CI today, so it did not red-fail; it is still the rule in `AGENTS.md` being bypassed, and this is the third instance today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)