### PR TITLE
fix(api): remove the duplicate logger import breaking API Build

### DIFF
--- a/packages/api/src/controllers/analytics.controller.ts
+++ b/packages/api/src/controllers/analytics.controller.ts
@@ -39,8 +39,6 @@ export const getAnalytics = async (req: Request, res: Response) => {
   }
 };
 
-import { logger } from '../utils/logger';
-
 const ANALYTICS_INCREMENT_TYPES = new Set([
   'postViews',
   'profileViews',


### PR DESCRIPTION
`packages/api/src/controllers/analytics.controller.ts` imports `logger` twice — once in the import block at line 6, and once again at line 42, stranded between a function and a `const`. tsc fails with `TS2300: Duplicate identifier 'logger'`.

**`API Build` has been red on `main` since `d87ee3fa`**, and because PR checks run on the merge commit, every open pull request inherits the failure regardless of what it touches. PR #738 hit it while touching zero files under `packages/`.

The line-6 import is the correct one; the line-42 copy is deleted. Nothing else changes.

Verification is CI's own `API Build` job — the fresh worktree has no `node_modules` and a full install to re-run one typecheck locally was not worth ~900 MB into a shared tmpfs that ran out of space earlier tonight. The failure is a duplicate identifier and exactly one of the two declarations is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)