### PR TITLE
chore(commons): bump versionCode to 3

### DIFF
--- a/packages/commons/app.config.js
+++ b/packages/commons/app.config.js
@@ -28,7 +28,7 @@ module.exports = {
         backgroundImage: './assets/images/android-icon-background.png',
         monochromeImage: './assets/images/android-icon-monochrome.png',
       },
-      versionCode: 2,
+      versionCode: 3,
       predictiveBackGestureEnabled: true,
       softwareKeyboardLayoutMode: 'resize',
       permissions: [


### PR DESCRIPTION
Play rejected the versionCode 2 bundle for Commons with *"Version code 2 has already been used"* — one had been uploaded earlier, and Play never lets a versionCode be reused, not even after the release is deleted.

Bumping it here rather than only in the artifact, so the next person to build Commons does not hit the same wall.

One line, `packages/commons/app.config.js`. The AAB actually uploaded to internal testing was built from this value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)