### PR TITLE
fix(api): register the CrowdSource console origin as a redirect surface

### DIFF
--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -253,11 +253,21 @@ const SEED_APPS: SeedAppSpec[] = [
       'Official Oxy participatory moderation platform — reviewers are assigned cases by the server and review them blind.',
     websiteUrl: 'https://crowdsource.oxy.so',
     type: 'first_party',
-    // The reviewer app ships to the web only today (Cloudflare Pages project
-    // `crowdsource-frontend`). Its Expo `crowdsource://` deep-link scheme is
-    // registered here when a native build actually ships — an unused redirect
-    // surface is authority nobody asked for.
-    redirectUris: ['https://crowdsource.oxy.so'],
+    // Two web surfaces share this client, so each origin is listed: the
+    // reviewer app, and the Trust & Safety / developer console. Trust
+    // derivation (`dynamicOriginRegistry`) keys on the ORIGIN of each redirect
+    // URI, and the console is a distinct origin — without its own entry it
+    // gets neither the credentialed CORS lane nor an exact-match redirect,
+    // however official the parent application is.
+    //
+    // The console origin is registered ahead of its first deploy on purpose:
+    // it is already built and merged, and a redirect surface that only exists
+    // after a second round trip blocks the deploy rather than the reverse.
+    //
+    // Both frontends ship to the web only today. The Expo `crowdsource://`
+    // deep-link scheme is registered here when a native build actually ships —
+    // an unused redirect surface is authority nobody asked for.
+    redirectUris: ['https://crowdsource.oxy.so', 'https://console.crowdsource.oxy.so'],
     // Sign-in ONLY, so the default `['user:read']`. CrowdSource must never
     // carry `reputation:write`: it never moves an Oxy Trust figure itself, it
     // emits a decision and Oxy Trust's own consequence engine decides the


### PR DESCRIPTION
## What

Adds `https://console.crowdsource.oxy.so` to the `CrowdSource` entry in `packages/api/scripts/seed-oxy-applications.ts`.

## Why

CrowdSource's `Application` is **already registered and live in production** — client id `oxy_dk_2a44…6133`, `first_party` / `isOfficial: true`, scopes `['user:read']`. Only the *reviewer* origin is on its redirect allowlist.

Trust derivation (`dynamicOriginRegistry`) keys on the **origin** of each redirect URI, so `https://console.crowdsource.oxy.so` is a distinct origin that today receives neither the credentialed CORS lane nor an exact-match redirect — however official the parent application is.

Verified against production, both directions:

| Origin | `access-control-allow-origin` |
|---|---|
| `https://crowdsource.oxy.so` | present + `allow-credentials: true` |
| `https://console.crowdsource.oxy.so` | **absent** |
| `https://homiio.com` (control, registered) | present |
| `https://not-registered-crowdsource.example.com` (control) | absent |

The console origin is registered ahead of its first deploy on purpose: it is built and merged, and a redirect surface that only exists after a second round trip blocks the deploy rather than the reverse.

## Scopes — deliberately unchanged

Sign-in only, the default `['user:read']`. CrowdSource derives a reviewer profile from the Oxy user id and never moves an Oxy Trust figure itself, so it must not carry `reputation:write`. That matters beyond tidiness: a device sign-in's granted scopes **are** the application's scopes (`routes/auth.ts`, `scopes = appScopes` with no OAuth request), so widening here widens every grant. No file or federation scopes either.

## Safety

Redirect reconciliation is a non-destructive union (`unionRedirectUris`), so the existing entry and the already-issued client id are preserved on re-run.

## Deploy step (does NOT happen automatically)

Merging this does not change production. The seed is a one-shot task:

```
ONLY_APPS='CrowdSource' bun run packages/api/scripts/seed-oxy-applications.ts
```

`ONLY_APPS` bounds the blast radius to this one application and fails closed on an empty or unknown value.

## Validation

- `bun run --filter @oxyhq/api build` — exit 0.
- `scripts/` is **not** in the api `tsconfig.json` include set, so the package build does not cover this file. Typechecked it explicitly under the api compiler options: zero errors in `seed-oxy-applications.ts` (other scripts have pre-existing errors, which is why the directory is excluded).
- That gate was mutation-tested — injecting a bad type into the edited array produced `TS2322` naming the file, so it is not vacuous.
- `seedApplicationSelection.test.ts` — 17/17 pass.
- `bun.lock` byte-unchanged after a clean `bun install` (no manifest change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)