### PR TITLE
chore(dev): take 4100/81xx in the per-app local dev port map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -973,14 +973,14 @@ Local dev is a **Bun workspace monorepo** (`bun@1.3.14`, on `PATH` via `/usr/loc
 **Build shared libs before running apps:** the API and the web apps resolve `@oxyhq/contracts`, `@oxyhq/protocol`, `@oxyhq/core`, and `@oxyhq/services` from their built output (`dist/` / `lib/`), NOT from source. Built output persists in the VM snapshot, but after changing any of those packages' source you must rebuild them (e.g. `bun run core:build`, `bun run services:build`, or `bun run build:all`) or downstream `bun --watch`/Vite dev servers fail to resolve the workspace dep (Vite reports `@oxyhq/services ... could not be resolved`). The API dev server needs contracts+protocol+core built; the web apps additionally need `@oxyhq/services` built.
 
 **Run the stack (dev mode):**
-- API: `bun run api:dev` → Express + Socket.IO on **:3001** (`GET /health` → `{"status":"operational"}`). Hot-reloads via `bun --watch`.
-- Auth IdP web app: `VITE_OXY_API_URL=http://localhost:3001 bun run --filter auth dev` → Vite on **:3002**. Point every web/Expo frontend at the local API via its own env var (`auth`: `VITE_OXY_API_URL`; `console`: `VITE_OXY_URL`; Expo apps: `EXPO_PUBLIC_API_URL`). Loopback origins are trusted on the credentialed CORS lane, so `http://localhost:*` can hit the local API directly.
+- API: `bun run api:dev` → Express + Socket.IO on **:4100** (`GET /health` → `{"status":"operational"}`). Hot-reloads via `bun --watch`.
+- Auth IdP web app: `VITE_OXY_API_URL=http://localhost:4100 bun run --filter auth dev` → Vite on **:8105**. Point every web/Expo frontend at the local API via its own env var (`auth`: `VITE_OXY_API_URL`; `console`: `VITE_OXY_URL`; Expo apps: `EXPO_PUBLIC_API_URL`). Loopback origins are trusted on the credentialed CORS lane, so `http://localhost:*` can hit the local API directly.
 
 **Hello-world sanity check (auth end-to-end, no S3/Redis needed):**
 ```bash
-curl -s -X POST http://localhost:3001/auth/signup -H 'Content-Type: application/json' \
+curl -s -X POST http://localhost:4100/auth/signup -H 'Content-Type: application/json' \
   -d '{"email":"devtest@example.com","username":"devtester","password":"HelloWorld123!","name":{"first":"Dev","last":"Tester"}}'
-curl -s -X POST http://localhost:3001/auth/login -H 'Content-Type: application/json' \
+curl -s -X POST http://localhost:4100/auth/login -H 'Content-Type: application/json' \
   -d '{"identifier":"devtester","password":"HelloWorld123!"}'
 ```
 Signup passwords must include a special character (server-enforced, beyond the Zod `min(8)`). Both return a device-first session (`accessToken` + `deviceSecret`); use the token as `Authorization: Bearer` against `GET /users/me`. The `auth` web app drives the same flow through its multi-step login form.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -238,7 +238,7 @@ The API includes Socket.IO for real-time features:
 
 ```javascript
 // Connect to Socket.IO
-const socket = io('http://localhost:3001', {
+const socket = io('http://localhost:4100', {
   auth: {
     token: 'your_jwt_token'
   }
@@ -271,7 +271,7 @@ For detailed integration examples, see the **[examples directory](./docs/example
 
 Health check endpoint:
 ```bash
-curl http://localhost:3001/health
+curl http://localhost:4100/health
 ```
 
 ## Storage Usage

--- a/packages/api/openapi.base.yaml
+++ b/packages/api/openapi.base.yaml
@@ -11,7 +11,7 @@ info:
 servers:
   - url: https://api.oxy.so
     description: Production
-  - url: http://localhost:3001
+  - url: http://localhost:4100
     description: Local development
 tags:
   - name: Authentication

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -11,7 +11,7 @@
       "description": "Production"
     },
     {
-      "url": "http://localhost:3001",
+      "url": "http://localhost:4100",
       "description": "Local development"
     }
   ],

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -59,7 +59,10 @@ export interface RequiredEnvVars {
  * Optional environment variables with defaults
  */
 export const ENV_DEFAULTS = {
-  PORT: '3001',
+  // Local dev default only — ECS injects PORT explicitly (oxy-infra
+  // terraform-uswest2/app-services.tf sets it to 8080). 4100 is oxy-api's slot
+  // in the per-app port map so several Oxy backends can run side by side.
+  PORT: '4100',
   NODE_ENV: 'development',
   AWS_REGION: 'us-east-1',
 } as const;

--- a/packages/api/src/config/swagger.ts
+++ b/packages/api/src/config/swagger.ts
@@ -11,7 +11,7 @@ const options: swaggerJsdoc.Options = {
     },
     servers: [
       {
-        url: 'http://localhost:3001',
+        url: 'http://localhost:4100',
         description: 'Development server',
       },
       {

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -818,8 +818,12 @@ app.use((_req: express.Request, res: express.Response) => {
 // Must be registered last so it catches errors from all routes and middleware above
 app.use(errorHandler);
 
-// Only call listen if this module is run directly
-const PORT = getEnvNumber('PORT', 3001);
+// Only call listen if this module is run directly.
+// The 4100 default is a LOCAL DEV default only — ECS injects PORT explicitly
+// (oxy-infra terraform-uswest2/app-services.tf sets it to 8080). 4100 is
+// oxy-api's slot in the per-app port map so several Oxy backends can run
+// side by side on one machine.
+const PORT = getEnvNumber('PORT', 4100);
 if (require.main === module) {
   // Wait for MongoDB connection before starting server
   // This prevents queries from executing before the database is ready

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -14,9 +14,9 @@ There is no landing page at `/`.
 ## API Base URL
 
 The web app calls the API directly. In development it defaults to
-`http://localhost:3001`. Override with:
+`http://localhost:4100`. Override with:
 
-- `VITE_OXY_API_URL` (preferred) — Example: `http://localhost:3001`
+- `VITE_OXY_API_URL` (preferred) — Example: `http://localhost:4100`
 - `VITE_OXY_AUTH_URL` (legacy alias)
 
 ## Development
@@ -32,8 +32,8 @@ bun run dev
 ```
 
 Default ports:
-- Auth web: http://localhost:3002
-- API: http://localhost:3001
+- Auth web: http://localhost:8105
+- API: http://localhost:4100
 
 ## Flow Overview
 

--- a/packages/auth/lib/oxy-api-client.ts
+++ b/packages/auth/lib/oxy-api-client.ts
@@ -1,5 +1,5 @@
 const PRODUCTION_API_URL = "https://api.oxy.so"
-const LOCAL_API_URL = "http://localhost:3001"
+const LOCAL_API_URL = "http://localhost:4100"
 
 export function getApiBaseUrl(): string {
   const envUrl =

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite --port 3002",
+    "dev": "vite --port 8105",
     "dev:pages": "wrangler pages dev dist",
     "build": "bun ../core/scripts/writePagesHeaders.ts public && vite build",
     "test": "bun test lib/__tests__ components/__tests__",

--- a/packages/auth/vite.config.ts
+++ b/packages/auth/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig(({ mode }) => ({
     "process.env.NODE_ENV": JSON.stringify(mode),
   },
   server: {
-    port: 3002,
+    port: 8105,
     strictPort: true,
   },
   build: {

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev --port 3000",
+    "dev": "vite dev --port 8106",
     "build": "bun ../core/scripts/writePagesHeaders.ts public && vite build",
     "preview": "vite preview",
     "test": "vitest run --passWithNoTests",

--- a/packages/test-app-expo/app/_layout.tsx
+++ b/packages/test-app-expo/app/_layout.tsx
@@ -9,7 +9,7 @@ import { OxyProvider } from '@oxyhq/services';
 import { BloomThemeProvider, useNavigationTheme } from '@oxyhq/bloom/theme';
 import { ConnectionStatusToasts } from '@oxyhq/bloom/connection-status';
 
-const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3001';
+const API_URL = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:4100';
 const AUTH_REDIRECT_URI = Linking.createURL('/');
 // Public OAuth client id (the registered `ApplicationCredential` publicKey) —
 // drives the app-identity flow when passed to `OxyProvider`. Env-with-default


### PR DESCRIPTION
oxy-api's backend defaulted to 3001, which collided with Mercaria and Alia. It
now defaults to 4100. The Expo apps already sat inside this repo's 81xx block
(commons 8101, accounts 8102, inbox 8103, test-app-expo 8104) and are unchanged;
the two Vite dev servers move into it — auth 3002 -> 8105, console 3000 -> 8106.

Production is unaffected: every deployed service sets PORT explicitly in its
ECS task definition (oxy-infra/terraform-uswest2), so only the local dev
default moves. No Dockerfile, terraform, task definition or CI workflow is
touched by this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)