### PR TITLE
docs(api): the local dev base URL follows oxy-api to 4100

### DIFF
--- a/packages/api/docs/index.mdx
+++ b/packages/api/docs/index.mdx
@@ -21,7 +21,7 @@ Endpoints are grouped by domain (Authentication, Users, Sessions, Devices, Priva
 | Environment | URL |
 |-------------|-----|
 | Production | `https://api.oxy.so` |
-| Local development | `http://localhost:3001` |
+| Local development | `http://localhost:4100` |
 
 All examples below assume production.
 


### PR DESCRIPTION
Missed by the port-map commit (a5ede2c9): `packages/api/docs/index.mdx` still advertised `http://localhost:3001` as the local dev base URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)