### PR TITLE
fix(docker): narrowing the workspace subset must not drop the catalog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ WORKDIR /app
 # Remove bun.lock since the workspace change invalidates it — bun will
 # resolve fresh dependencies (still deterministic from package.json versions).
 COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/contracts','packages/protocol','packages/federation','packages/core','packages/api']; delete p.patchedDependencies; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
+# The subset is written as the OBJECT form on purpose: narrowing `workspaces`
+# to an array drops `workspaces.catalog` with it, and every `"catalog:"`
+# reference in these manifests then fails to resolve — `bun install` here has
+# no lockfile to fall back on, so the build dies at dependency resolution.
+RUN node -e "const p=require('./package.json'); p.workspaces={packages:['packages/contracts','packages/protocol','packages/federation','packages/core','packages/api'], catalog:(p.workspaces&&p.workspaces.catalog)||{}}; delete p.patchedDependencies; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
 
 # Copy package.json files for dependency resolution
 COPY packages/api/package.json packages/api/
@@ -62,7 +66,11 @@ WORKDIR /app
 
 # Copy workspace root and override workspaces
 COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/contracts','packages/protocol','packages/federation','packages/core','packages/api']; delete p.patchedDependencies; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
+# The subset is written as the OBJECT form on purpose: narrowing `workspaces`
+# to an array drops `workspaces.catalog` with it, and every `"catalog:"`
+# reference in these manifests then fails to resolve — `bun install` here has
+# no lockfile to fall back on, so the build dies at dependency resolution.
+RUN node -e "const p=require('./package.json'); p.workspaces={packages:['packages/contracts','packages/protocol','packages/federation','packages/core','packages/api'], catalog:(p.workspaces&&p.workspaces.catalog)||{}}; delete p.patchedDependencies; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
 COPY packages/api/package.json packages/api/
 COPY packages/core/package.json packages/core/
 COPY packages/protocol/package.json packages/protocol/

--- a/packages/node/Dockerfile
+++ b/packages/node/Dockerfile
@@ -44,7 +44,11 @@ WORKDIR /app
 # monorepo lockfile (the subset does not match the full-repo lock — bun resolves
 # deterministically from the package.json versions). Mirrors the api Dockerfile.
 COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/contracts','packages/protocol','packages/core','packages/node']; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
+# The subset is written as the OBJECT form on purpose: narrowing `workspaces`
+# to an array drops `workspaces.catalog` with it, and every `"catalog:"`
+# reference in these manifests then fails to resolve — `bun install` here has
+# no lockfile to fall back on, so the build dies at dependency resolution.
+RUN node -e "const p=require('./package.json'); p.workspaces={packages:['packages/contracts','packages/protocol','packages/core','packages/node'], catalog:(p.workspaces&&p.workspaces.catalog)||{}}; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
 
 # package.json files first for dependency resolution caching
 COPY packages/node/package.json packages/node/
@@ -82,7 +86,11 @@ ENV npm_config_node_gyp=/usr/local/lib/node_modules/node-gyp/bin/node-gyp.js
 WORKDIR /app
 
 COPY package.json ./
-RUN node -e "const p=require('./package.json'); p.workspaces=['packages/contracts','packages/protocol','packages/core','packages/node']; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
+# The subset is written as the OBJECT form on purpose: narrowing `workspaces`
+# to an array drops `workspaces.catalog` with it, and every `"catalog:"`
+# reference in these manifests then fails to resolve — `bun install` here has
+# no lockfile to fall back on, so the build dies at dependency resolution.
+RUN node -e "const p=require('./package.json'); p.workspaces={packages:['packages/contracts','packages/protocol','packages/core','packages/node'], catalog:(p.workspaces&&p.workspaces.catalog)||{}}; require('fs').writeFileSync('package.json', JSON.stringify(p, null, 2));"
 COPY packages/node/package.json packages/node/
 COPY packages/core/package.json packages/core/
 COPY packages/protocol/package.json packages/protocol/


### PR DESCRIPTION
`Deploy to AWS` failed on the first push after #749, at `bun install`:

```
error: elliptic@catalog: failed to resolve
error: express@catalog: failed to resolve
error: helmet@catalog: failed to resolve      (…and seven more)
ERROR: process "/bin/sh -c bun install" did not complete successfully
```

Nothing was deployed — the build never produced an image, so the running service is still the previous one.

## Cause

Both image builds copy the monorepo root `package.json` and then rewrite `workspaces` to just the packages that image needs:

```js
p.workspaces = ['packages/contracts', 'packages/protocol', …]
```

Written as an array, that assignment also deletes `workspaces.catalog`. Every `"catalog:"` reference in the copied manifests then has nothing to resolve against — and these builds install *without a lockfile* on purpose ("workspace subset doesn't match the full monorepo lock"), so there is no fallback.

## Fix

Write the subset as the object form, carrying the catalog through:

```js
p.workspaces = { packages: [...], catalog: (p.workspaces && p.workspaces.catalog) || {} }
```

which is all that assignment ever meant to do — narrow the package list.

`packages/node/Dockerfile` has the same two rewrites and the same latent break. No workflow builds it today, so it is fixed here rather than found later.

## Verification

- `docker build` of the full API image (both stages) — succeeds
- control: the same build with `origin/main`'s Dockerfile against this tree — fails with the exact `catalog: failed to resolve` errors from the CI log

That control is the point: it shows this is the fix, not a coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)