### PR TITLE
fix(api): stop deleting subscriptions on expiry, derive entitlement from endDate

### DIFF
--- a/.github/workflows/run-drop-subscription-ttl-index.yml
+++ b/.github/workflows/run-drop-subscription-ttl-index.yml
@@ -1,0 +1,183 @@
+name: Drop the subscription TTL index
+
+# One-shot: drop the TTL index on `subscriptions.endDate`, which DELETED every
+# subscription row the moment its period ended (see
+# packages/api/scripts/drop-subscription-ttl-index.ts for the full story).
+#
+# Removing the declaration from the schema does NOT drop the live index —
+# Mongoose's `autoIndex` only ever CREATES declared indexes — so until this runs,
+# production keeps deleting rows even with the fixed code deployed.
+#
+# WHY IT IS SHAPED LIKE THIS (same reasoning as run-user-text-backfill.yml):
+#
+# 1. The database is on a PRIVATE VPC address, unreachable from a GitHub runner,
+#    so the script has to run as an ECS task INSIDE the VPC ("Fargate one-shot").
+#
+# 2. It reuses the LIVE service's task definition (same secrets, role, subnets,
+#    security groups) and only overrides the image + command, touching nothing the
+#    service runs. Building from `ref` lets it run from a branch before it merges.
+#
+# The script touches index METADATA only — it reads, writes and deletes no
+# document — and drops only an index on `{ endDate: 1 }` that actually carries
+# `expireAfterSeconds`. It is idempotent: a second run reports "already absent".
+#
+# ALWAYS run dry FIRST (`dry_run=true`, the default): it lists every index on the
+# collection and names exactly what it would drop, changing nothing.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or SHA to build the one-shot image from'
+        required: true
+        type: string
+        default: 'main'
+      dry_run:
+        description: 'Report what WOULD be dropped, change nothing'
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  # Never let two index operations touch the collection at once.
+  group: drop-subscription-ttl-index
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-2
+  APP: oxy-api
+  CLUSTER: oxy-cluster
+  SERVICE: oxy-api
+  DOCKERFILE: Dockerfile
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  drop-index:
+    # Same arch as the deployed image — the service runs linux/arm64.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Configure AWS credentials (OIDC, no stored keys)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push the one-shot image (its own tag; never `latest`)
+        id: image
+        env:
+          ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
+        run: |
+          set -euo pipefail
+          TAG="oneshot-subttl-$(git rev-parse --short HEAD)"
+          IMG="$ECR_REGISTRY/oxy/$APP:$TAG"
+          docker build -f "$DOCKERFILE" -t "$IMG" .
+          docker push "$IMG"
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+          echo "Built $IMG"
+
+      - name: Run the index drop as an ECS one-shot task
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Take the task definition and network config from the LIVE service, so
+          # the one-shot runs with the same secrets, roles, subnets and security
+          # groups the API already runs with. Nothing is hardcoded, and nothing
+          # drifts when the service is redeployed.
+          SERVICE_JSON=$(aws ecs describe-services \
+            --cluster "$CLUSTER" --services "$SERVICE" \
+            --query 'services[0]' --output json)
+
+          LIVE_TASK_DEF=$(echo "$SERVICE_JSON" | jq -r '.taskDefinition')
+          SUBNETS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.subnets | join(",")')
+          SEC_GROUPS=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.securityGroups | join(",")')
+          # Mirror the service's public-IP setting: the cluster's subnets are
+          # public with NO NAT gateway, so a task without a public IP cannot
+          # even pull its image from ECR.
+          ASSIGN_IP=$(echo "$SERVICE_JSON" | jq -r '.networkConfiguration.awsvpcConfiguration.assignPublicIp')
+
+          echo "live task definition: $LIVE_TASK_DEF"
+
+          aws ecs describe-task-definition --task-definition "$LIVE_TASK_DEF" \
+            --query 'taskDefinition' --output json > live-taskdef.json
+
+          CONTAINER=$(jq -r '.containerDefinitions[0].name' live-taskdef.json)
+
+          # A throwaway revision that differs from the live one ONLY by the image.
+          jq --arg img "$IMAGE" '
+            .containerDefinitions[0].image = $img
+            | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+                  .compatibilities, .registeredAt, .registeredBy, .deregisteredAt)
+          ' live-taskdef.json > oneshot-taskdef.json
+
+          ONESHOT_TASK_DEF=$(aws ecs register-task-definition \
+            --cli-input-json file://oneshot-taskdef.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+
+          echo "one-shot task definition: $ONESHOT_TASK_DEF"
+
+          # The script lives in packages/api/scripts (copied into the image) and is
+          # executed with bun, which interprets the TypeScript directly.
+          OVERRIDES=$(jq -nc \
+            --arg name "$CONTAINER" \
+            --arg dry "$DRY_RUN" \
+            '{containerOverrides:[{
+               name: $name,
+               command: ["bun","run","packages/api/scripts/drop-subscription-ttl-index.ts"],
+               environment: [
+                 {name:"DRY_RUN", value:$dry}
+               ]
+             }]}')
+
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "$CLUSTER" \
+            --task-definition "$ONESHOT_TASK_DEF" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[$SUBNETS],securityGroups=[$SEC_GROUPS],assignPublicIp=$ASSIGN_IP}" \
+            --overrides "$OVERRIDES" \
+            --started-by "gh-oneshot-subttl" \
+            --query 'tasks[0].taskArn' --output text)
+
+          echo "task: $TASK_ARN"
+          echo "Waiting for the task to stop…"
+          aws ecs wait tasks-stopped --cluster "$CLUSTER" --tasks "$TASK_ARN"
+
+          TASK_ID="${TASK_ARN##*/}"
+          LOG_OPTS=$(jq -r '.containerDefinitions[0].logConfiguration.options' live-taskdef.json)
+          LOG_GROUP=$(echo "$LOG_OPTS" | jq -r '."awslogs-group"')
+          LOG_PREFIX=$(echo "$LOG_OPTS" | jq -r '."awslogs-stream-prefix"')
+
+          echo "──────── one-shot output ────────"
+          aws logs get-log-events \
+            --log-group-name "$LOG_GROUP" \
+            --log-stream-name "$LOG_PREFIX/$CONTAINER/$TASK_ID" \
+            --start-from-head \
+            --query 'events[].message' --output text || echo "(no logs retrieved)"
+          echo "─────────────────────────────────"
+
+          EXIT_CODE=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].containers[0].exitCode' --output text)
+          REASON=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" \
+            --query 'tasks[0].stoppedReason' --output text)
+
+          echo "exit code: $EXIT_CODE  (stopped reason: $REASON)"
+
+          # A one-shot whose result you cannot see is a one-shot you have not run.
+          if [ "$EXIT_CODE" != "0" ]; then
+            echo "::error::Index-drop task exited with $EXIT_CODE"
+            exit 1
+          fi

--- a/packages/api/scripts/drop-subscription-ttl-index.ts
+++ b/packages/api/scripts/drop-subscription-ttl-index.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+/**
+ * One-shot: drop the TTL index that was DELETING subscription rows.
+ *
+ * `models/Subscription.ts` used to declare
+ * `index({ endDate: 1 }, { expireAfterSeconds: 0 })`. A Mongo TTL index deletes
+ * the document; it does not mark it. Every subscription row was therefore
+ * destroyed the moment its `endDate` passed — `status: 'expired'` was
+ * unreachable, no subscription history survived, and `autoRenew: true` rows were
+ * deleted rather than renewed.
+ *
+ * Removing the declaration does NOT remove the live index: Mongoose's
+ * `autoIndex` only ever CREATES declared indexes, it never drops undeclared
+ * ones. Until this runs, production keeps deleting rows even with the fixed code
+ * deployed. This script is the second half of that fix.
+ *
+ * SAFETY
+ *   - Drops ONLY an index on `{ endDate: 1 }` that actually carries
+ *     `expireAfterSeconds`. A plain (non-TTL) `endDate` index is left alone, and
+ *     no other index is ever considered.
+ *   - Idempotent: re-running once the index is gone reports "already absent" and
+ *     writes nothing. Safe if the collection does not exist yet.
+ *   - No document is read, written or deleted — this only touches index metadata.
+ *   - DRY_RUN=1 (or DRY_RUN=true) prints exactly what would be dropped and exits.
+ *
+ * The replacement indexes (`{ userId, status, endDate }`, `{ status, endDate }`)
+ * are declared on the schema, so the running API creates them via `autoIndex`.
+ *
+ * Run (inside the oxy-api image, working dir /app):
+ *   bun run packages/api/scripts/drop-subscription-ttl-index.ts
+ * Or from packages/api:
+ *   bun run scripts/drop-subscription-ttl-index.ts
+ *
+ * Env:
+ *   MONGODB_URI   Mongo connection string (required)
+ *   DRY_RUN=1     Report the plan, change nothing
+ */
+
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+
+dotenv.config();
+
+const COLLECTION = 'subscriptions';
+
+async function main(): Promise<void> {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    throw new Error('MONGODB_URI is required');
+  }
+  const dryRun = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
+
+  await mongoose.connect(uri);
+  try {
+    const db = mongoose.connection.db;
+    if (!db) {
+      throw new Error('No database handle after connect');
+    }
+
+    const collections = await db.listCollections({ name: COLLECTION }).toArray();
+    if (collections.length === 0) {
+      console.log(`${COLLECTION}: collection does not exist — nothing to drop`);
+      return;
+    }
+
+    const indexes = await db.collection(COLLECTION).indexes();
+    const ttlIndexes = indexes.filter((index) => {
+      const key = index.key as Record<string, unknown> | undefined;
+      const keyFields = Object.keys(key ?? {});
+      return (
+        index.expireAfterSeconds !== undefined &&
+        keyFields.length === 1 &&
+        key?.endDate === 1
+      );
+    });
+
+    console.log(`${COLLECTION}: ${indexes.length} indexes present`);
+    for (const index of indexes) {
+      const ttl = index.expireAfterSeconds === undefined
+        ? ''
+        : ` (TTL expireAfterSeconds=${index.expireAfterSeconds})`;
+      console.log(`  - ${index.name}: ${JSON.stringify(index.key)}${ttl}`);
+    }
+
+    if (ttlIndexes.length === 0) {
+      console.log(`${COLLECTION}: no endDate TTL index — already absent, nothing to do`);
+      return;
+    }
+
+    for (const index of ttlIndexes) {
+      const name = index.name;
+      if (typeof name !== 'string') {
+        throw new Error(`Refusing to drop an unnamed index: ${JSON.stringify(index)}`);
+      }
+      if (dryRun) {
+        console.log(`[DRY_RUN] would drop TTL index ${name} on ${COLLECTION}`);
+        continue;
+      }
+      await db.collection(COLLECTION).dropIndex(name);
+      console.log(`dropped TTL index ${name} on ${COLLECTION}`);
+    }
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/api/src/controllers/__tests__/subscription.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/subscription.controller.test.ts
@@ -2,7 +2,7 @@ const mockFindOneAndUpdate = jest.fn();
 const mockFindByIdAndUpdate = jest.fn();
 const mockInvalidate = jest.fn();
 const mockBillingFindOne = jest.fn();
-const mockSubscriptionFindOne = jest.fn();
+const mockFindCurrentSubscription = jest.fn();
 const mockStripeSubscriptionsUpdate = jest.fn();
 
 jest.mock('../../models/BillingSubscription', () => ({
@@ -15,9 +15,15 @@ jest.mock('../../models/BillingSubscription', () => ({
 jest.mock('../../models/Subscription', () => ({
   __esModule: true,
   default: {
-    findOne: (...args: unknown[]) => mockSubscriptionFindOne(...args),
     findOneAndUpdate: (...args: unknown[]) => mockFindOneAndUpdate(...args),
   },
+}));
+
+// The "which row represents this user's standing" decision (and its lazy expiry)
+// belongs to the lifecycle service and is covered by its own suite.
+jest.mock('../../services/subscriptionLifecycle.service', () => ({
+  __esModule: true,
+  findCurrentSubscription: (...args: unknown[]) => mockFindCurrentSubscription(...args),
 }));
 
 jest.mock('../../models/User', () => ({
@@ -66,7 +72,7 @@ describe('getSubscription', () => {
         updatedAt: new Date('2026-01-01T00:00:00.000Z'),
       }),
     });
-    mockSubscriptionFindOne.mockResolvedValue(null);
+    mockFindCurrentSubscription.mockResolvedValue(null);
 
     const json = jest.fn();
     const req = {
@@ -86,6 +92,23 @@ describe('getSubscription', () => {
       status: 'active',
       userId: 'user-1',
     }));
+  });
+
+  it('reads the legacy row through the lifecycle service so history cannot masquerade as current', async () => {
+    mockBillingFindOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+    mockFindCurrentSubscription.mockResolvedValue(null);
+
+    const json = jest.fn();
+    const req = {
+      params: { userId: 'user-1' },
+      user: { _id: { toString: () => 'user-1' } },
+    } as unknown as AuthRequest;
+    const res = { json, status: jest.fn().mockReturnThis() } as unknown as Response;
+
+    await getSubscription(req, res);
+
+    expect(mockFindCurrentSubscription).toHaveBeenCalledWith('user-1');
+    expect(json).toHaveBeenCalledWith({ plan: 'basic' });
   });
 });
 
@@ -136,15 +159,18 @@ describe('cancelSubscription', () => {
   });
 
   it('cancels a legacy-only subscription and revokes analytics sharing', async () => {
+    const endDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
     mockBillingFindOne.mockResolvedValue(null);
     mockFindOneAndUpdate.mockResolvedValue({
       userId: 'user-1',
       status: 'canceled',
       plan: 'pro',
+      endDate,
       toJSON: () => ({
         userId: 'user-1',
         status: 'canceled',
         plan: 'pro',
+        endDate,
       }),
     });
 
@@ -158,10 +184,12 @@ describe('cancelSubscription', () => {
     await cancelSubscription(req, res);
 
     expect(mockStripeSubscriptionsUpdate).not.toHaveBeenCalled();
+    // Only an IN-FORCE row can be cancelled: a row that already lapsed is
+    // history, and rewriting it to `canceled` would falsify why it ended.
     expect(mockFindOneAndUpdate).toHaveBeenCalledWith(
-      { userId: 'user-1', status: { $ne: 'canceled' } },
+      { userId: 'user-1', status: { $ne: 'canceled' }, endDate: { $gt: expect.any(Date) } },
       { status: 'canceled' },
-      { new: true },
+      { new: true, sort: { endDate: -1 } },
     );
     expect(mockFindByIdAndUpdate).toHaveBeenCalledWith('user-1', {
       $set: { 'privacySettings.analyticsSharing': false },

--- a/packages/api/src/controllers/subscription.controller.ts
+++ b/packages/api/src/controllers/subscription.controller.ts
@@ -7,6 +7,8 @@ import { logger } from '../utils/logger';
 import { ForbiddenError, UnauthorizedError } from '../utils/error';
 import userCache from '../utils/userCache';
 import { formatSubscriptionResponse } from '../utils/subscriptionResponse';
+import { inForceSubscriptionFilter } from '../utils/subscriptionStatus';
+import { findCurrentSubscription } from '../services/subscriptionLifecycle.service';
 import { getStripe } from '../utils/stripeClient';
 
 function assertOwnership(req: AuthRequest, userId: string): void {
@@ -27,7 +29,10 @@ export const getSubscription = async (req: AuthRequest, res: Response) => {
         userId,
         status: { $in: ['active', 'trialing'] },
       }).lean(),
-      Subscription.findOne({ userId }),
+      // Lapsed rows are retained as history now that nothing deletes them, so
+      // the current standing has to be picked deliberately rather than by
+      // whichever row `findOne` happens to return.
+      findCurrentSubscription(userId),
     ]);
     res.json(formatSubscriptionResponse(billingSubscription, legacySubscription));
   } catch (error) {
@@ -60,10 +65,13 @@ export const cancelSubscription = async (req: AuthRequest, res: Response) => {
       await billingSubscription.save();
     }
 
+    // Only a subscription that is still in force can be cancelled — an already
+    // lapsed row is history, and flipping it to `canceled` would rewrite why it
+    // ended.
     const legacySubscription = await Subscription.findOneAndUpdate(
-      { userId, status: { $ne: 'canceled' } },
+      { userId, ...inForceSubscriptionFilter() },
       { status: 'canceled' },
-      { new: true },
+      { new: true, sort: { endDate: -1 } },
     );
 
     if (!billingSubscription && !legacySubscription) {

--- a/packages/api/src/models/Subscription.ts
+++ b/packages/api/src/models/Subscription.ts
@@ -1,9 +1,22 @@
 import mongoose, { type Document, Schema } from "mongoose";
 
+/**
+ * Lifecycle states of a legacy subscription row.
+ *
+ * `active`   — in force (see `utils/subscriptionStatus.ts` for the authoritative rule)
+ * `canceled` — terminal; the user cancelled it and it grants nothing from that moment
+ * `expired`  — its `endDate` has passed
+ *
+ * A subscription row is NEVER deleted when it lapses: it becomes `expired` and is
+ * kept as history (billing disputes, renewals, analytics all read it). See the
+ * note on the index block below.
+ */
+export type SubscriptionStatus = "active" | "canceled" | "expired";
+
 export interface ISubscription extends Document {
   userId: mongoose.Types.ObjectId;
   plan: "basic" | "pro" | "business";
-  status: "active" | "canceled" | "expired";
+  status: SubscriptionStatus;
   startDate: Date;
   endDate: Date;
   autoRenew: boolean;
@@ -70,7 +83,20 @@ const SubscriptionSchema = new Schema({
 SubscriptionSchema.index({ userId: 1 });
 // Index for querying active subscriptions
 SubscriptionSchema.index({ status: 1 });
-// TTL index to automatically expire subscriptions
-SubscriptionSchema.index({ endDate: 1 }, { expireAfterSeconds: 0 });
+// Serves both halves of the lifecycle: the "is this row in force right now"
+// lookup (`utils/subscriptionStatus.ts`) and the periodic status reconciliation
+// sweep (`services/subscriptionLifecycle.service.ts`), which both filter on
+// status + endDate.
+SubscriptionSchema.index({ userId: 1, status: 1, endDate: -1 });
+SubscriptionSchema.index({ status: 1, endDate: 1 });
+
+// NEVER add a TTL index on `endDate`. A Mongo TTL index DELETES the document; it
+// does not mark it. This collection previously carried
+// `index({ endDate: 1 }, { expireAfterSeconds: 0 })`, which destroyed every
+// subscription the moment its period ended — making `status: 'expired'`
+// unreachable, erasing all subscription history, and deleting auto-renewing rows
+// instead of renewing them. Lapsing is a STATUS TRANSITION here, owned by
+// `services/subscriptionLifecycle.service.ts`. `models/__tests__/subscription.indexes.test.ts`
+// fails if a TTL index reappears on this schema.
 
 export default mongoose.model<ISubscription>("Subscription", SubscriptionSchema);

--- a/packages/api/src/models/__tests__/subscription.indexes.test.ts
+++ b/packages/api/src/models/__tests__/subscription.indexes.test.ts
@@ -1,0 +1,32 @@
+// The global jest.setup.cjs mocks `mongoose` wholesale; the real Subscription
+// schema — the index declarations under test — only builds against the actual
+// module, so restore it for this suite.
+jest.mock('mongoose', () => {
+  const actual = jest.requireActual('mongoose');
+  return { __esModule: true, ...actual, default: actual };
+});
+
+import Subscription from '../Subscription';
+
+describe('Subscription indexes', () => {
+  it('declares no TTL index: a lapsed subscription is expired, never deleted', () => {
+    const ttlIndexes = Subscription.schema
+      .indexes()
+      .filter(([, options]) => options?.expireAfterSeconds !== undefined);
+
+    // A TTL index DELETES the document. One on `endDate` destroyed every
+    // subscription row the moment its period ended — no history, no reachable
+    // `expired` status, and auto-renewing rows deleted instead of renewed.
+    expect(ttlIndexes).toEqual([]);
+  });
+
+  it('indexes status + endDate for the in-force lookup and the lifecycle sweep', () => {
+    const indexes = Subscription.schema.indexes();
+
+    expect(indexes).toContainEqual([{ status: 1, endDate: 1 }, expect.any(Object)]);
+    expect(indexes).toContainEqual([
+      { userId: 1, status: 1, endDate: -1 },
+      expect.any(Object),
+    ]);
+  });
+});

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -66,6 +66,10 @@ import nodeRoutes from './routes/nodes';
 import { sweepValidations } from './services/civic/validator.service';
 import { sweepPersonhoodAudits } from './services/civic/personhoodAudit.service';
 import { sweepNodeLiveness } from './services/nodeRegistry.service';
+import {
+  SUBSCRIPTION_SWEEP_INTERVAL_MS,
+  sweepSubscriptionStatuses,
+} from './services/subscriptionLifecycle.service';
 import { VALIDATION_SWEEP_INTERVAL_MS, PERSONHOOD_AUDIT_SWEEP_INTERVAL_MS } from './utils/civic.constants';
 import { NODE_LIVENESS_SWEEP_INTERVAL_MS } from './utils/nodes.constants';
 import didRoutes from './routes/did';
@@ -886,6 +890,18 @@ if (require.main === module) {
         );
       }, NODE_LIVENESS_SWEEP_INTERVAL_MS);
       nodeLivenessSweep.unref();
+
+      // Reconcile the stored `status` of legacy subscription rows with what their
+      // dates say (active <-> expired). Entitlements never depend on this — every
+      // premium gate derives from `endDate` vs now — so a missed tick only delays
+      // a reporting value, never grants or revokes access. Unref'd + failures
+      // logged, like the sweeps above.
+      const subscriptionSweep = setInterval(() => {
+        sweepSubscriptionStatuses().catch((err) =>
+          logger.error('Subscription status sweep failed', err instanceof Error ? err : new Error(String(err))),
+        );
+      }, SUBSCRIPTION_SWEEP_INTERVAL_MS);
+      subscriptionSweep.unref();
 
       // Start SMTP inbound server if enabled
       if (getEnvBoolean('SMTP_ENABLED', false)) {

--- a/packages/api/src/services/__tests__/subscriptionLifecycle.service.test.ts
+++ b/packages/api/src/services/__tests__/subscriptionLifecycle.service.test.ts
@@ -1,0 +1,170 @@
+const mockFindOne = jest.fn();
+const mockUpdateMany = jest.fn();
+const mockDeleteMany = jest.fn();
+const mockDeleteOne = jest.fn();
+const mockFindOneAndDelete = jest.fn();
+
+jest.mock('../../models/Subscription', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: unknown[]) => mockFindOne(...args),
+    updateMany: (...args: unknown[]) => mockUpdateMany(...args),
+    // Present so a sweep that DELETED instead of expiring would still run — and
+    // fail the "never deletes" assertions below with the offending call named,
+    // rather than blowing up on an undefined method.
+    deleteMany: (...args: unknown[]) => mockDeleteMany(...args),
+    deleteOne: (...args: unknown[]) => mockDeleteOne(...args),
+    findOneAndDelete: (...args: unknown[]) => mockFindOneAndDelete(...args),
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import type { ISubscription } from '../../models/Subscription';
+import {
+  findCurrentSubscription,
+  sweepSubscriptionStatuses,
+} from '../subscriptionLifecycle.service';
+
+const NOW = new Date('2026-07-31T12:00:00.000Z');
+const LAPSED = new Date('2026-06-30T12:00:00.000Z');
+const RUNNING = new Date('2026-08-31T12:00:00.000Z');
+
+interface FakeSubscription {
+  userId: string;
+  plan: string;
+  status: 'active' | 'canceled' | 'expired';
+  endDate: Date;
+  save: jest.Mock;
+}
+
+function fakeSubscription(
+  status: FakeSubscription['status'],
+  endDate: Date,
+): FakeSubscription {
+  return {
+    userId: 'user-1',
+    plan: 'pro',
+    status,
+    endDate,
+    save: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** `findOne(...).sort(...)` — the query shape the service uses. */
+function sortsTo(document: FakeSubscription | null) {
+  return { sort: jest.fn().mockResolvedValue(document) };
+}
+
+function asSubscription(document: FakeSubscription): ISubscription {
+  return document as unknown as ISubscription;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUpdateMany.mockResolvedValue({ modifiedCount: 0 });
+  // Deliberately shape-compatible with an update result: a sweep rewritten to
+  // DELETE must run to completion and be caught by the explicit "never deleted"
+  // assertion, naming the offending call — not die on an incidental TypeError
+  // that would read the same whatever the implementation did.
+  const deleteResult = { deletedCount: 0, modifiedCount: 0 };
+  mockDeleteMany.mockResolvedValue(deleteResult);
+  mockDeleteOne.mockResolvedValue(deleteResult);
+  mockFindOneAndDelete.mockResolvedValue(null);
+});
+
+describe('sweepSubscriptionStatuses', () => {
+  it('EXPIRES a subscription whose period has ended — it never deletes it', async () => {
+    mockUpdateMany.mockResolvedValue({ modifiedCount: 3 });
+
+    const result = await sweepSubscriptionStatuses(NOW);
+
+    // Asserted FIRST so that a sweep which removed rows fails naming the delete
+    // it performed, rather than failing on a missing update further down.
+    // The whole point of the fix: a lapsed subscription becomes history, not a
+    // hole where a paying customer's record used to be.
+    expect(mockDeleteMany).not.toHaveBeenCalled();
+    expect(mockDeleteOne).not.toHaveBeenCalled();
+    expect(mockFindOneAndDelete).not.toHaveBeenCalled();
+
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      { status: 'active', endDate: { $lte: NOW } },
+      { $set: { status: 'expired' } },
+    );
+    expect(result.expired).toBe(3);
+  });
+
+  it('reactivates an expired row whose endDate was pushed forward by a renewal', async () => {
+    await sweepSubscriptionStatuses(NOW);
+
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      { status: 'expired', endDate: { $gt: NOW } },
+      { $set: { status: 'active' } },
+    );
+  });
+
+  it('never touches a cancelled row', async () => {
+    await sweepSubscriptionStatuses(NOW);
+
+    for (const [filter] of mockUpdateMany.mock.calls) {
+      expect(filter.status).not.toBe('canceled');
+    }
+  });
+
+  it('is a no-op over already reconciled data', async () => {
+    await expect(sweepSubscriptionStatuses(NOW)).resolves.toEqual({
+      expired: 0,
+      reactivated: 0,
+    });
+  });
+});
+
+describe('findCurrentSubscription', () => {
+  it('expires a lapsed row on read (lazy expiry) instead of reporting it active', async () => {
+    const lapsed = fakeSubscription('active', LAPSED);
+    mockFindOne
+      .mockReturnValueOnce(sortsTo(null)) // no in-force row
+      .mockReturnValueOnce(sortsTo(lapsed)); // most recent row
+
+    const current = await findCurrentSubscription('user-1', NOW);
+
+    expect(current).toBe(asSubscription(lapsed));
+    expect(lapsed.status).toBe('expired');
+    expect(lapsed.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers the in-force row over retained history', async () => {
+    const running = fakeSubscription('active', RUNNING);
+    mockFindOne.mockReturnValueOnce(sortsTo(running));
+
+    const current = await findCurrentSubscription('user-1', NOW);
+
+    expect(current).toBe(asSubscription(running));
+    expect(mockFindOne).toHaveBeenCalledTimes(1);
+    expect(mockFindOne).toHaveBeenCalledWith({
+      userId: 'user-1',
+      status: { $ne: 'canceled' },
+      endDate: { $gt: NOW },
+    });
+    // Already accurate — no write on the read path.
+    expect(running.save).not.toHaveBeenCalled();
+  });
+
+  it('leaves a cancelled row cancelled', async () => {
+    const cancelled = fakeSubscription('canceled', LAPSED);
+    mockFindOne.mockReturnValueOnce(sortsTo(null)).mockReturnValueOnce(sortsTo(cancelled));
+
+    await findCurrentSubscription('user-1', NOW);
+
+    expect(cancelled.status).toBe('canceled');
+    expect(cancelled.save).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the user never had a subscription', async () => {
+    mockFindOne.mockReturnValue(sortsTo(null));
+
+    await expect(findCurrentSubscription('user-1', NOW)).resolves.toBeNull();
+  });
+});

--- a/packages/api/src/services/subscriptionLifecycle.service.ts
+++ b/packages/api/src/services/subscriptionLifecycle.service.ts
@@ -1,0 +1,111 @@
+import Subscription, { type ISubscription } from '../models/Subscription';
+import {
+  deriveSubscriptionStatus,
+  inForceSubscriptionFilter,
+} from '../utils/subscriptionStatus';
+import { logger } from '../utils/logger';
+
+/**
+ * Subscription lifecycle (legacy `Subscription` collection).
+ *
+ * A lapsed subscription is EXPIRED, never deleted — the row is the only record
+ * that a user ever held a paid plan, and billing disputes, renewals and analytics
+ * all read it. (This collection used to carry a TTL index on `endDate`, which
+ * deleted the document outright the moment the period ended; see the note in
+ * `models/Subscription.ts`.)
+ *
+ * Two mechanisms keep the stored `status` honest, mirroring `DevicePairingSession`:
+ *
+ *   1. LAZY EXPIRY ON READ — {@link findCurrentSubscription} persists the derived
+ *      status whenever it reads a row whose stored value has drifted, so an
+ *      owner-facing read never reports a stale status and never has to wait for a
+ *      sweep tick.
+ *   2. THE SWEEP — {@link sweepSubscriptionStatuses} reconciles rows nobody reads,
+ *      so reporting queries that filter on `status` stay accurate.
+ *
+ * Neither is load-bearing for ENTITLEMENTS: every entitlement check derives from
+ * `endDate` vs now (`utils/subscriptionStatus.ts`), so there is no window in which
+ * a not-yet-reconciled row grants paid features.
+ */
+
+/** How often the reconciliation sweep runs (see `server.ts`). */
+export const SUBSCRIPTION_SWEEP_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes
+
+/**
+ * Persist the derived status when the stored one has drifted (lazy expiry on
+ * read). Returns the same document, with an accurate `status`.
+ */
+async function reconcileStoredStatus(
+  subscription: ISubscription,
+  now: Date,
+): Promise<ISubscription> {
+  const derived = deriveSubscriptionStatus(subscription, now);
+  if (subscription.status !== derived) {
+    subscription.status = derived;
+    await subscription.save();
+  }
+  return subscription;
+}
+
+/**
+ * The subscription row that represents a user's current standing: the in-force
+ * one if there is any, otherwise the most recent by `endDate`.
+ *
+ * Rows are retained now that lapsing no longer deletes them, so a plain
+ * `findOne({ userId })` can surface an ancient lapsed row while a live one
+ * exists — this picks deliberately instead.
+ */
+export async function findCurrentSubscription(
+  userId: string,
+  now: Date = new Date(),
+): Promise<ISubscription | null> {
+  const current =
+    (await Subscription.findOne({ userId, ...inForceSubscriptionFilter(now) }).sort({
+      endDate: -1,
+    })) ?? (await Subscription.findOne({ userId }).sort({ endDate: -1 }));
+
+  return current ? reconcileStoredStatus(current, now) : null;
+}
+
+export interface SubscriptionSweepResult {
+  /** Rows whose period had ended while still marked `active`. */
+  expired: number;
+  /** Rows marked `expired` whose `endDate` now lies in the future (a renewal). */
+  reactivated: number;
+}
+
+/**
+ * Reconcile stored `status` with the derived truth for every drifted row.
+ *
+ * Idempotent — a second run over reconciled data modifies nothing — and it only
+ * ever moves rows between `active` and `expired`. `canceled` is terminal and is
+ * never touched, and no row is ever removed.
+ */
+export async function sweepSubscriptionStatuses(
+  now: Date = new Date(),
+): Promise<SubscriptionSweepResult> {
+  const [lapsed, renewed] = await Promise.all([
+    Subscription.updateMany(
+      { status: 'active', endDate: { $lte: now } },
+      { $set: { status: 'expired' } },
+    ),
+    Subscription.updateMany(
+      { status: 'expired', endDate: { $gt: now } },
+      { $set: { status: 'active' } },
+    ),
+  ]);
+
+  const result: SubscriptionSweepResult = {
+    expired: lapsed.modifiedCount,
+    reactivated: renewed.modifiedCount,
+  };
+
+  if (result.expired > 0 || result.reactivated > 0) {
+    logger.info('Subscription status sweep reconciled rows', {
+      expired: result.expired,
+      reactivated: result.reactivated,
+    });
+  }
+
+  return result;
+}

--- a/packages/api/src/utils/__tests__/subscriptionPlan.test.ts
+++ b/packages/api/src/utils/__tests__/subscriptionPlan.test.ts
@@ -18,6 +18,7 @@ import {
   isPremiumSubscriptionPlan,
   resolveUserSubscriptionPlan,
 } from '../subscriptionPlan';
+import { inForceSubscriptionFilter } from '../subscriptionStatus';
 
 const mockBillingSubscription = BillingSubscription as jest.Mocked<typeof BillingSubscription>;
 const mockSubscription = Subscription as jest.Mocked<typeof Subscription>;
@@ -51,6 +52,31 @@ describe('resolveUserSubscriptionPlan', () => {
     });
 
     await expect(resolveUserSubscriptionPlan('user-1')).resolves.toBe('business');
+  });
+
+  it('asks for rows that are in force by DATE, never for a stored active status', async () => {
+    // A lapsed row keeps `status: 'active'` until the lifecycle sweep reconciles
+    // it. Querying on that stored value is what would hand a premium entitlement
+    // to a subscription whose period has already ended.
+    const now = new Date('2026-07-31T12:00:00.000Z');
+    (mockBillingSubscription.findOne as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      }),
+    });
+    (mockSubscription.findOne as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      }),
+    });
+
+    await resolveUserSubscriptionPlan('user-1', now);
+
+    expect(mockSubscription.findOne).toHaveBeenCalledWith({
+      userId: 'user-1',
+      ...inForceSubscriptionFilter(now),
+      plan: { $in: ['pro', 'business'] },
+    });
   });
 
   it('returns basic when neither billing nor legacy has a premium plan', async () => {

--- a/packages/api/src/utils/__tests__/subscriptionResponse.test.ts
+++ b/packages/api/src/utils/__tests__/subscriptionResponse.test.ts
@@ -1,6 +1,30 @@
 import { formatSubscriptionResponse } from '../subscriptionResponse';
 import type { IBillingSubscription } from '../../models/BillingSubscription';
-import type { ISubscription } from '../../models/Subscription';
+import type { ISubscription, SubscriptionStatus } from '../../models/Subscription';
+
+/** Fixed clock so the derived-status cases never become time bombs. */
+const NOW = new Date('2026-01-15T00:00:00.000Z');
+
+function legacyRow(status: SubscriptionStatus, endDate: Date): ISubscription {
+  return {
+    plan: 'pro',
+    status,
+    userId: { toString: () => 'user-1' },
+    startDate: new Date('2025-12-01T00:00:00.000Z'),
+    endDate,
+    autoRenew: true,
+    toJSON() {
+      return {
+        plan: 'pro',
+        status,
+        userId: 'user-1',
+        startDate: new Date('2025-12-01T00:00:00.000Z'),
+        endDate,
+        autoRenew: true,
+      };
+    },
+  } as unknown as ISubscription;
+}
 
 describe('formatSubscriptionResponse', () => {
   it('prefers an active billing subscription over legacy rows', () => {
@@ -74,30 +98,32 @@ describe('formatSubscriptionResponse', () => {
   });
 
   it('falls back to legacy subscription rows when billing is absent', () => {
-    const legacy = {
-      plan: 'pro',
-      status: 'active',
-      userId: { toString: () => 'user-1' },
-      startDate: new Date('2025-12-01T00:00:00.000Z'),
-      endDate: new Date('2026-01-01T00:00:00.000Z'),
-      autoRenew: true,
-      toJSON() {
-        return {
-          plan: 'pro',
-          status: 'active',
-          userId: 'user-1',
-          startDate: this.startDate,
-          endDate: this.endDate,
-          autoRenew: true,
-        };
-      },
-    } as unknown as ISubscription;
+    const legacy = legacyRow('active', new Date('2026-02-01T00:00:00.000Z'));
 
-    expect(formatSubscriptionResponse(null, legacy)).toMatchObject({
+    expect(formatSubscriptionResponse(null, legacy, NOW)).toMatchObject({
       plan: 'pro',
       status: 'active',
       userId: 'user-1',
       autoRenew: true,
+    });
+  });
+
+  it('reports a lapsed legacy row as expired, not as its stored active status', () => {
+    // The row is still stored `active` — the lifecycle sweep has not reached it
+    // yet. The response must not tell the owner they still hold a paid plan.
+    const legacy = legacyRow('active', new Date('2025-12-01T00:00:00.000Z'));
+
+    expect(formatSubscriptionResponse(null, legacy, NOW)).toMatchObject({
+      plan: 'pro',
+      status: 'expired',
+    });
+  });
+
+  it('keeps a cancelled legacy row cancelled', () => {
+    const legacy = legacyRow('canceled', new Date('2026-02-01T00:00:00.000Z'));
+
+    expect(formatSubscriptionResponse(null, legacy, NOW)).toMatchObject({
+      status: 'canceled',
     });
   });
 

--- a/packages/api/src/utils/__tests__/subscriptionStatus.test.ts
+++ b/packages/api/src/utils/__tests__/subscriptionStatus.test.ts
@@ -1,0 +1,79 @@
+import type { SubscriptionLifecycleFields } from '../subscriptionStatus';
+import {
+  deriveSubscriptionStatus,
+  inForceSubscriptionFilter,
+  isSubscriptionInForce,
+} from '../subscriptionStatus';
+
+const NOW = new Date('2026-07-31T12:00:00.000Z');
+const YESTERDAY = new Date('2026-07-30T12:00:00.000Z');
+const TOMORROW = new Date('2026-08-01T12:00:00.000Z');
+
+function row(
+  status: SubscriptionLifecycleFields['status'],
+  endDate: Date,
+): SubscriptionLifecycleFields {
+  return { status, endDate };
+}
+
+describe('isSubscriptionInForce', () => {
+  it('grants while the period is still running', () => {
+    expect(isSubscriptionInForce(row('active', TOMORROW), NOW)).toBe(true);
+  });
+
+  it('does NOT grant once the period has ended, even while stored as active', () => {
+    // The row keeps `status: 'active'` until the lifecycle sweep reconciles it.
+    // Trusting that stored value is exactly how a lapsed subscription would keep
+    // handing out paid entitlements.
+    expect(isSubscriptionInForce(row('active', YESTERDAY), NOW)).toBe(false);
+  });
+
+  it('treats the instant of expiry as no longer in force', () => {
+    expect(isSubscriptionInForce(row('active', NOW), NOW)).toBe(false);
+  });
+
+  it('never grants for a cancelled row, whatever its dates say', () => {
+    expect(isSubscriptionInForce(row('canceled', TOMORROW), NOW)).toBe(false);
+  });
+
+  it('grants again when a renewal pushes endDate forward on an expired row', () => {
+    expect(isSubscriptionInForce(row('expired', TOMORROW), NOW)).toBe(true);
+  });
+
+  it('does not grant when endDate is unusable', () => {
+    const malformed = { status: 'active', endDate: new Date('not-a-date') } as SubscriptionLifecycleFields;
+    expect(isSubscriptionInForce(malformed, NOW)).toBe(false);
+  });
+});
+
+describe('deriveSubscriptionStatus', () => {
+  it('reports a lapsed row as expired rather than echoing its stored status', () => {
+    expect(deriveSubscriptionStatus(row('active', YESTERDAY), NOW)).toBe('expired');
+  });
+
+  it('reports a running row as active', () => {
+    expect(deriveSubscriptionStatus(row('expired', TOMORROW), NOW)).toBe('active');
+  });
+
+  it('keeps cancelled terminal', () => {
+    expect(deriveSubscriptionStatus(row('canceled', TOMORROW), NOW)).toBe('canceled');
+    expect(deriveSubscriptionStatus(row('canceled', YESTERDAY), NOW)).toBe('canceled');
+  });
+});
+
+describe('inForceSubscriptionFilter', () => {
+  it('selects on dates and excludes cancelled rows', () => {
+    expect(inForceSubscriptionFilter(NOW)).toEqual({
+      status: { $ne: 'canceled' },
+      endDate: { $gt: NOW },
+    });
+  });
+
+  it('reads `now` rather than pinning a boot-time clock', () => {
+    const later = new Date('2026-09-01T00:00:00.000Z');
+    expect(inForceSubscriptionFilter(later)).toEqual({
+      status: { $ne: 'canceled' },
+      endDate: { $gt: later },
+    });
+  });
+});

--- a/packages/api/src/utils/subscriptionPlan.ts
+++ b/packages/api/src/utils/subscriptionPlan.ts
@@ -1,6 +1,7 @@
 import type { Types } from 'mongoose';
 import BillingSubscription from '../models/BillingSubscription';
 import Subscription from '../models/Subscription';
+import { inForceSubscriptionFilter } from './subscriptionStatus';
 
 export type SubscriptionPlanTier = 'basic' | 'pro' | 'business';
 
@@ -19,9 +20,15 @@ function normalizePlanName(planName: string | undefined | null): SubscriptionPla
  * Stripe writes to `BillingSubscription`; the legacy `Subscription` collection
  * may still hold rows from before the billing cutover. Check billing first, then
  * fall back to legacy so premium gates stay accurate for paying subscribers.
+ *
+ * The legacy lookup filters on DATES (`inForceSubscriptionFilter`), never on the
+ * stored `status`: a lapsed row keeps `status: 'active'` until the lifecycle sweep
+ * reconciles it, and trusting that value would grant paid entitlements — premium
+ * profile colour, the larger storage quota — inside that window.
  */
 export async function resolveUserSubscriptionPlan(
   userId: string | Types.ObjectId,
+  now: Date = new Date(),
 ): Promise<SubscriptionPlanTier> {
   const userIdString = String(userId);
 
@@ -39,7 +46,7 @@ export async function resolveUserSubscriptionPlan(
   try {
     const legacySubscription = await Subscription.findOne({
       userId,
-      status: 'active',
+      ...inForceSubscriptionFilter(now),
       plan: { $in: ['pro', 'business'] },
     })
       .select('plan')

--- a/packages/api/src/utils/subscriptionResponse.ts
+++ b/packages/api/src/utils/subscriptionResponse.ts
@@ -1,10 +1,11 @@
 import type { IBillingSubscription } from '../models/BillingSubscription';
-import type { ISubscription } from '../models/Subscription';
+import type { ISubscription, SubscriptionStatus } from '../models/Subscription';
 import type { SubscriptionPlanTier } from './subscriptionPlan';
+import { deriveSubscriptionStatus } from './subscriptionStatus';
 
 export interface SubscriptionResponse {
   plan: SubscriptionPlanTier;
-  status?: 'active' | 'canceled' | 'expired';
+  status?: SubscriptionStatus;
   userId?: string;
   startDate?: string;
   endDate?: string;
@@ -44,6 +45,10 @@ function toIsoString(value: Date | string | undefined): string | undefined {
  *
  * Stripe writes to `BillingSubscription`; the legacy `Subscription` collection
  * may still hold rows from before the billing cutover. Billing wins.
+ *
+ * A legacy row's reported `status` is DERIVED from its dates rather than echoed
+ * from storage, so a row that lapsed since the last lifecycle reconciliation is
+ * reported as `expired` rather than as still active.
  */
 export function formatSubscriptionResponse(
   billing: Pick<
@@ -58,6 +63,7 @@ export function formatSubscriptionResponse(
     | 'updatedAt'
   > | null,
   legacy: ISubscription | null,
+  now: Date = new Date(),
 ): SubscriptionResponse {
   if (billing) {
     return {
@@ -76,7 +82,10 @@ export function formatSubscriptionResponse(
     const json = typeof legacy.toJSON === 'function' ? legacy.toJSON() : legacy;
     return {
       plan: normalizePlanName(json.plan),
-      status: json.status,
+      status: deriveSubscriptionStatus(
+        { status: json.status, endDate: json.endDate },
+        now,
+      ),
       userId: json.userId?.toString?.() ?? String(json.userId),
       startDate: toIsoString(json.startDate),
       endDate: toIsoString(json.endDate),

--- a/packages/api/src/utils/subscriptionStatus.ts
+++ b/packages/api/src/utils/subscriptionStatus.ts
@@ -1,0 +1,62 @@
+import type { FilterQuery } from 'mongoose';
+import type { ISubscription, SubscriptionStatus } from '../models/Subscription';
+
+/**
+ * The lifecycle rule for the legacy `Subscription` collection — the single
+ * definition of "is this subscription in force right now", shared by the
+ * entitlement lookup (`utils/subscriptionPlan.ts`), the response serializer
+ * (`utils/subscriptionResponse.ts`), the owner-facing controller
+ * (`controllers/subscription.controller.ts`) and the reconciliation sweep
+ * (`services/subscriptionLifecycle.service.ts`).
+ *
+ * The rule is DERIVED FROM DATES, never read off the stored `status`. A row can
+ * legitimately sit past its `endDate` with `status: 'active'` between sweeps, and
+ * an entitlement check that trusted the stored value would hand out paid features
+ * inside that window. `status` is a materialized projection of this rule kept
+ * accurate for reporting and queries — it is never the authority.
+ *
+ * `canceled` is terminal and set by an explicit user action, so it is never
+ * re-derived from dates.
+ *
+ * Pure module: it imports the model only for its TYPES, so importing it never
+ * registers a Mongoose model or pulls a connection into a consumer.
+ */
+
+/** The fields the lifecycle rule reads — everything else about a row is irrelevant to it. */
+export type SubscriptionLifecycleFields = Pick<ISubscription, 'status' | 'endDate'>;
+
+/**
+ * Whether the subscription grants its paid entitlements at `now`.
+ *
+ * A row with no usable `endDate` grants nothing: a subscription that cannot say
+ * when it ends cannot be shown to be in force.
+ */
+export function isSubscriptionInForce(
+  subscription: SubscriptionLifecycleFields,
+  now: Date = new Date(),
+): boolean {
+  if (subscription.status === 'canceled') {
+    return false;
+  }
+  const endsAt = new Date(subscription.endDate).getTime();
+  return Number.isFinite(endsAt) && endsAt > now.getTime();
+}
+
+/** The status the row SHOULD hold at `now`, given its dates. */
+export function deriveSubscriptionStatus(
+  subscription: SubscriptionLifecycleFields,
+  now: Date = new Date(),
+): SubscriptionStatus {
+  if (subscription.status === 'canceled') {
+    return 'canceled';
+  }
+  return isSubscriptionInForce(subscription, now) ? 'active' : 'expired';
+}
+
+/**
+ * Mongo filter selecting the rows that are in force at `now` — the query-side
+ * twin of {@link isSubscriptionInForce}. Both must move together.
+ */
+export function inForceSubscriptionFilter(now: Date = new Date()): FilterQuery<ISubscription> {
+  return { status: { $ne: 'canceled' }, endDate: { $gt: now } };
+}


### PR DESCRIPTION
## Summary

`models/Subscription.ts` declared a Mongo TTL index — `SubscriptionSchema.index({ endDate: 1 }, { expireAfterSeconds: 0 })`. A Mongo TTL index **deletes** the document once the indexed field is in the past; it does not mark it. The enum already had a `'expired'` status value, so the author plainly meant to transition the row, not destroy it.

The practical effect: every subscription row was deleted the moment its `endDate` passed.

- No subscription history survives past its lapse — no record a user ever held a plan, no data for billing disputes, renewals, or analytics.
- `autoRenew: true` rows were deleted instead of renewed.
- `status: 'expired'` was unreachable — nothing had ever transitioned a row to it, because the row was gone before anything could.
- A lapsed `pro` subscriber silently dropped to free-tier storage limits (`storage.controller.ts`) with zero audit trail of what happened or when.

**Already-deleted history is largely unrecoverable.** The daily `mongodump` only contains a row that still existed at the moment it ran — anything that lapsed before the oldest retained snapshot is in no backup at all. `BillingSubscription` (the Stripe-era collection) was never touched by this index — that billing history is intact. This bug only affected the legacy `Subscription` collection.

## What this change does

1. **Removes the TTL index** and replaces it with two regular indexes (`{status,endDate}`, `{userId,status,endDate}}`) that serve the entitlement lookup and the reconciliation sweep. `models/__tests__/subscription.indexes.test.ts` fails if a TTL index reappears on this schema.
2. **Derives entitlement from `endDate` vs now, never from the stored `status`.** This part was not optional: `resolveUserSubscriptionPlan` filtered on `status: 'active'`, and nothing in the codebase ever wrote `status: 'expired'` — the TTL deletion was the *only* mechanism that had ever terminated paid entitlement. Removing the index alone, without this, would have converted a data-loss bug into "paid features forever" for every already-lapsed row. `utils/subscriptionStatus.ts` is the single definition of "is this subscription in force right now," shared by the entitlement check, the response serializer, and the owner-facing controller.
3. **Keeps `status` accurate for reporting** via lazy expiry-on-read (`findCurrentSubscription`) plus an `unref()`'d 15-minute sweep (`subscriptionLifecycle.service.ts`), mirroring the existing `DevicePairingSession` pattern. Neither is load-bearing for entitlement — a missed sweep tick only delays a reporting value, never grants or revokes access.
4. **Adds `packages/api/scripts/drop-subscription-ttl-index.ts`** (one-shot, `DRY_RUN=1` by default) and **`.github/workflows/run-drop-subscription-ttl-index.yml`** (`workflow_dispatch`, `dry_run: true` default) to drop the now-undeclared but still-live index in production. Removing the schema declaration does **not** drop a live index — Mongoose's `autoIndex` only ever *creates* declared indexes, it never drops undeclared ones — so until that workflow runs, production keeps deleting rows even with this fix deployed.

## Deploy order

Code first, index drop second. Dropping the index before this code ships would leave already-lapsed rows sitting at `status: 'active'` indefinitely, granting `pro` forever under the old status-only check.

**The index-drop workflow is not being run as part of this PR.** Nate is approving and running it separately after this merges and deploys.

## Test plan

- [x] `bun run test` (packages/api) — 238/238 suites, 2333/2333 tests passing, including new coverage: `subscription.indexes.test.ts` (regression guard against a TTL index reappearing), `subscriptionStatus.test.ts`, `subscriptionLifecycle.service.test.ts`
- [x] `bunx tsc --noEmit` (packages/api) — clean
- [x] `bun run build` (packages/api) — clean
- [x] `bun install` + `git diff --exit-code -- bun.lock` — no drift (no package.json touched by this change)
- [ ] Deploy, then separately run `run-drop-subscription-ttl-index.yml` with `dry_run: true` first, verify its output names exactly one TTL index on `endDate`, then re-run with `dry_run: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)