### PR TITLE
feat(api,core,contracts): tell consumers when Oxy identity changes

### DIFF
--- a/packages/api/src/services/__tests__/user.service.bulkUnfollow.test.ts
+++ b/packages/api/src/services/__tests__/user.service.bulkUnfollow.test.ts
@@ -110,9 +110,16 @@ describe('UserService.bulkUnfollow', () => {
       { userId: targetDeleted.toHexString(), success: true, wasFollowing: true },
       { userId: targetRaced.toHexString(), success: true, wasFollowing: false },
     ]);
-    expect(mockUserCacheInvalidate).toHaveBeenCalledWith(currentUserId);
-    expect(mockUserCacheInvalidate).toHaveBeenCalledWith(targetDeleted.toHexString());
-    expect(mockUserCacheInvalidate).not.toHaveBeenCalledWith(targetRaced.toHexString());
+    // Tagged `'graph'` so nothing goes on the cross-service invalidation
+    // channel: this call moves up to 200 edges and none of them touch identity.
+    // Asserting the tag (not just the id) is what keeps a future edit from
+    // silently turning one bulk unfollow into a 200-message broadcast.
+    expect(mockUserCacheInvalidate).toHaveBeenCalledWith(currentUserId, 'graph');
+    expect(mockUserCacheInvalidate).toHaveBeenCalledWith(targetDeleted.toHexString(), 'graph');
+    expect(mockUserCacheInvalidate).not.toHaveBeenCalledWith(
+      targetRaced.toHexString(),
+      'graph',
+    );
   });
 
   it('does not decrement counters when all observed follows were already removed by a race', async () => {

--- a/packages/api/src/services/user.service.ts
+++ b/packages/api/src/services/user.service.ts
@@ -1163,8 +1163,11 @@ export class UserService {
         graphCache.invalidate(followerId),
         graphCache.invalidate(targetId),
       ]);
-      userCache.invalidate(followerId);
-      userCache.invalidate(targetId);
+      // `'graph'` — only the follow counts moved. Identity is untouched, so this
+      // is not broadcast to other backends; follows are far too frequent to put
+      // on a channel every Oxy service subscribes to.
+      userCache.invalidate(followerId, 'graph');
+      userCache.invalidate(targetId, 'graph');
     }
 
     const counts = await this.readFollowCounts(targetId, followerId);
@@ -1215,8 +1218,9 @@ export class UserService {
         graphCache.invalidate(followerId),
         graphCache.invalidate(targetId),
       ]);
-      userCache.invalidate(followerId);
-      userCache.invalidate(targetId);
+      // Counts only — not broadcast. See `followUser`.
+      userCache.invalidate(followerId, 'graph');
+      userCache.invalidate(targetId, 'graph');
     }
 
     const counts = await this.readFollowCounts(targetId, followerId);
@@ -1422,9 +1426,12 @@ export class UserService {
         graphCache.invalidate(currentUserId),
         ...newlyFollowedIds.map((id) => graphCache.invalidate(id)),
       ]);
-      userCache.invalidate(currentUserId);
+      // Counts only — not broadcast. See `followUser`. This is the site the
+      // suppression exists for: one bulk call moves up to 200 edges, which
+      // would otherwise be a 200-message burst every subscriber discards.
+      userCache.invalidate(currentUserId, 'graph');
       for (const id of newlyFollowedIds) {
-        userCache.invalidate(id);
+        userCache.invalidate(id, 'graph');
       }
     }
 
@@ -1564,9 +1571,10 @@ export class UserService {
           graphCache.invalidate(currentUserId),
           ...actuallyRemovedIds.map((id) => graphCache.invalidate(id)),
         ]);
-        userCache.invalidate(currentUserId);
+        // Counts only — not broadcast. See `bulkFollow`.
+        userCache.invalidate(currentUserId, 'graph');
         for (const id of actuallyRemovedIds) {
-          userCache.invalidate(id);
+          userCache.invalidate(id, 'graph');
         }
       }
     }
@@ -1667,9 +1675,11 @@ export class UserService {
 
     blockCache.invalidateUser(userId);
     restrictCache.invalidateUser(userId);
+    // The subject's account is going away — that IS an identity change, so it
+    // broadcasts. The counterparties only lose an edge, so they do not.
     userCache.invalidate(userId);
     for (const counterpartyId of [...followedCounterpartyIds, ...followerCounterpartyIds]) {
-      userCache.invalidate(counterpartyId);
+      userCache.invalidate(counterpartyId, 'graph');
     }
     const graphIdsToInvalidate = new Set<string>([
       userId,

--- a/packages/api/src/utils/__tests__/userCacheInvalidation.test.ts
+++ b/packages/api/src/utils/__tests__/userCacheInvalidation.test.ts
@@ -1,0 +1,129 @@
+/**
+ * `userCache.invalidate` broadcast tests.
+ *
+ * `invalidate` is the chokepoint every user-state write in oxy-api already goes
+ * through, which is why the cross-service invalidation signal hangs off it
+ * rather than off ~25 individual call sites. These tests pin the two properties
+ * that make that safe:
+ *
+ *  - The DEFAULT broadcasts. A writer that does not classify itself
+ *    over-invalidates (a wasted eviction downstream) instead of leaving
+ *    consumers serving stale identity nobody can tell is stale.
+ *  - `'graph'` puts NOTHING on the wire. Follow churn is high-frequency and one
+ *    bulk call moves up to 200 edges; suppressing at the publisher is what keeps
+ *    that from becoming a burst every Oxy backend receives and discards.
+ *
+ * Local + Redis eviction must happen for BOTH reasons — only the fan-out differs.
+ */
+
+jest.mock('../logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+let redisHandle: unknown = null;
+jest.mock('../../config/redis', () => ({
+  __esModule: true,
+  getRedisClient: () => redisHandle,
+}));
+
+import { OXY_USER_INVALIDATION_CHANNEL } from '@oxyhq/contracts';
+
+import userCache from '../userCache';
+
+interface FakeRedis {
+  status: string;
+  del: jest.Mock;
+  publish: jest.Mock;
+}
+
+function makeRedis(status = 'ready'): FakeRedis {
+  return {
+    status,
+    del: jest.fn().mockResolvedValue(1),
+    publish: jest.fn().mockResolvedValue(1),
+  };
+}
+
+describe('userCache.invalidate — cross-service broadcast', () => {
+  let redis: FakeRedis;
+
+  beforeEach(() => {
+    redis = makeRedis();
+    redisHandle = redis;
+    userCache.clear();
+  });
+
+  afterEach(() => {
+    redisHandle = null;
+    jest.clearAllMocks();
+  });
+
+  it('broadcasts by default, on the contract channel', () => {
+    userCache.invalidate('user-1');
+
+    expect(redis.publish).toHaveBeenCalledTimes(1);
+    const [channel, message] = redis.publish.mock.calls[0];
+    expect(channel).toBe(OXY_USER_INVALIDATION_CHANNEL);
+    expect(JSON.parse(message)).toEqual({
+      userId: 'user-1',
+      reason: 'profile',
+      at: expect.any(Number),
+    });
+  });
+
+  it('broadcasts an explicit profile change', () => {
+    userCache.invalidate('user-1', 'profile');
+    expect(redis.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes NOTHING for graph churn', () => {
+    userCache.invalidate('user-1', 'graph');
+    expect(redis.publish).not.toHaveBeenCalled();
+  });
+
+  it('still evicts locally and in Redis for graph churn', () => {
+    // Suppression is about the fan-out only. oxy-api's own caches must still
+    // drop the row, or follow counts would go stale inside oxy-api itself.
+    userCache.invalidate('user-1', 'graph');
+    expect(redis.del).toHaveBeenCalledWith('user:user-1');
+  });
+
+  it('evicts and broadcasts for a profile change', () => {
+    userCache.invalidate('user-1', 'profile');
+    expect(redis.del).toHaveBeenCalledWith('user:user-1');
+    expect(redis.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing at all for an empty user id', () => {
+    userCache.invalidate('');
+    expect(redis.del).not.toHaveBeenCalled();
+    expect(redis.publish).not.toHaveBeenCalled();
+  });
+
+  it('does not publish when Redis is unconfigured', () => {
+    redisHandle = null;
+    expect(() => userCache.invalidate('user-1')).not.toThrow();
+  });
+
+  it('does not publish when the client is not ready', () => {
+    redisHandle = makeRedis('connecting');
+    expect(() => userCache.invalidate('user-1')).not.toThrow();
+    expect((redisHandle as FakeRedis).publish).not.toHaveBeenCalled();
+  });
+
+  it('never lets a publish failure escape the write path', async () => {
+    // `invalidate` runs after a committed database write, on the request path.
+    // A broadcast failure must never turn a completed profile update into a 500.
+    redis.publish.mockRejectedValue(new Error('redis down'));
+
+    expect(() => userCache.invalidate('user-1')).not.toThrow();
+    await Promise.resolve();
+  });
+
+  it('never lets a synchronously throwing publish escape', () => {
+    redis.publish.mockImplementation(() => {
+      throw new Error('redis down');
+    });
+    expect(() => userCache.invalidate('user-1')).not.toThrow();
+  });
+});

--- a/packages/api/src/utils/userCache.ts
+++ b/packages/api/src/utils/userCache.ts
@@ -1,3 +1,6 @@
+import type { OxyUserChangeReason } from '@oxyhq/contracts';
+import { publishOxyUserInvalidation } from '@oxyhq/core/server';
+
 import { getRedisClient } from '../config/redis';
 import type { IUser } from '../models/User';
 import { logger } from './logger';
@@ -73,7 +76,25 @@ class UserCache {
     }
   }
 
-  invalidate(userId: string): void {
+  /**
+   * Drop this user from the local map and from Redis, and — when the change is
+   * one consumers care about — broadcast it so every other Oxy backend can drop
+   * its own copy instead of waiting out a TTL.
+   *
+   * This method is the chokepoint the whole ecosystem's identity freshness hangs
+   * off, and it got that job by already having it: every route that mutates user
+   * state already calls it, and the house rule already requires new ones to. A
+   * second "and also notify" call at each of those ~25 sites would be one more
+   * thing to forget, which is exactly how the staleness this fixes came about.
+   *
+   * @param userId - The user whose cached record is now wrong.
+   * @param reason - What kind of change this was. DEFAULTS to `'profile'`, the
+   *   broadcast-worthy one, so a caller that does not classify itself
+   *   over-broadcasts (a wasted eviction) rather than under-broadcasts (stale
+   *   identity nobody can see is stale). Only high-frequency, non-identity
+   *   churn should opt down to `'graph'`.
+   */
+  invalidate(userId: string, reason: OxyUserChangeReason = 'profile'): void {
     if (!userId) return;
     this.local.delete(userId);
 
@@ -83,6 +104,20 @@ class UserCache {
         logger.warn('userCache: Redis del failed', {
           component: LOG_COMPONENT,
           userId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
+
+      // Fire-and-forget: this runs after a committed write, on the request path.
+      // The helper swallows its own failures, and a lost message costs a consumer
+      // its TTL — never correctness — so nothing here may surface as an error.
+      // `getRedisClient()` is never put in subscriber mode (the Socket.IO adapter
+      // takes `duplicate()`s), so PUBLISH on it is legal.
+      publishOxyUserInvalidation(redis, userId, reason, (err: unknown) => {
+        logger.warn('userCache: invalidation publish failed', {
+          component: LOG_COMPONENT,
+          userId,
+          reason,
           err: err instanceof Error ? err.message : String(err),
         });
       });

--- a/packages/contracts/src/__tests__/userInvalidation.test.ts
+++ b/packages/contracts/src/__tests__/userInvalidation.test.ts
@@ -1,0 +1,73 @@
+import {
+  OXY_PUBLISHED_USER_CHANGE_REASONS,
+  OXY_USER_CHANGE_REASONS,
+  OXY_USER_INVALIDATION_CHANNEL,
+  isPublishedOxyUserChangeReason,
+  oxyUserInvalidationEventSchema,
+} from '../index';
+
+describe('@oxyhq/contracts userInvalidation', () => {
+  it('pins the channel name', () => {
+    // Both sides subscribe/publish by this literal; a rename is a silent
+    // "invalidation never arrives", so it is pinned rather than derived.
+    expect(OXY_USER_INVALIDATION_CHANNEL).toBe('oxy:user:invalidate');
+  });
+
+  it('classifies graph churn as non-broadcast and profile changes as broadcast', () => {
+    expect(isPublishedOxyUserChangeReason('profile')).toBe(true);
+    expect(isPublishedOxyUserChangeReason('graph')).toBe(false);
+  });
+
+  it('keeps every published reason inside the reason union', () => {
+    // Guards the two lists drifting apart: a published reason the union does not
+    // contain could never be produced, and would type-check anyway.
+    for (const reason of OXY_PUBLISHED_USER_CHANGE_REASONS) {
+      expect(OXY_USER_CHANGE_REASONS).toContain(reason);
+    }
+  });
+
+  it('accepts a well-formed event', () => {
+    const parsed = oxyUserInvalidationEventSchema.safeParse({
+      userId: '6981c9178fcdefaf81988ffb',
+      reason: 'profile',
+      at: 1_754_000_000_000,
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects a non-broadcast reason on the wire', () => {
+    // The suppression is meant to happen at the publisher. If a `graph` event
+    // ever reaches the channel it is a bug, and the schema is the thing that
+    // says so rather than a subscriber silently discarding it.
+    const parsed = oxyUserInvalidationEventSchema.safeParse({
+      userId: '6981c9178fcdefaf81988ffb',
+      reason: 'graph',
+      at: 1_754_000_000_000,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a payload missing an id, or carrying an empty one', () => {
+    expect(
+      oxyUserInvalidationEventSchema.safeParse({ reason: 'profile', at: 1 }).success,
+    ).toBe(false);
+    expect(
+      oxyUserInvalidationEventSchema.safeParse({ userId: '', reason: 'profile', at: 1 })
+        .success,
+    ).toBe(false);
+  });
+
+  it('rejects a non-integer or negative timestamp', () => {
+    const base = { userId: 'u1', reason: 'profile' as const };
+    expect(oxyUserInvalidationEventSchema.safeParse({ ...base, at: -1 }).success).toBe(false);
+    expect(oxyUserInvalidationEventSchema.safeParse({ ...base, at: 1.5 }).success).toBe(false);
+  });
+
+  it('carries no profile data', () => {
+    // The channel is readable by every Oxy backend. This asserts the payload
+    // stays an id + a reason + a clock, so nobody can widen it into a
+    // profile-broadcast without the test saying so.
+    const shape = oxyUserInvalidationEventSchema.shape;
+    expect(Object.keys(shape).sort()).toEqual(['at', 'reason', 'userId']);
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -80,6 +80,20 @@ export {
 export type { InboxEmailPushData } from './inboxPush';
 
 export {
+    OXY_USER_INVALIDATION_CHANNEL,
+    OXY_USER_CHANGE_REASONS,
+    OXY_PUBLISHED_USER_CHANGE_REASONS,
+    isPublishedOxyUserChangeReason,
+    oxyUserInvalidationEventSchema,
+} from './userInvalidation';
+
+export type {
+    OxyUserChangeReason,
+    PublishedOxyUserChangeReason,
+    OxyUserInvalidationEvent,
+} from './userInvalidation';
+
+export {
     // Schemas
     recommendationExcludeTypeSchema,
     recommendationBoostSchema,

--- a/packages/contracts/src/userInvalidation.ts
+++ b/packages/contracts/src/userInvalidation.ts
@@ -1,0 +1,100 @@
+/**
+ * Canonical contract for the Oxy user-invalidation broadcast.
+ *
+ * Oxy owns identity, but consumers cache it: Mention keeps a Redis summary per
+ * post author, and every backend using `@oxyhq/core` holds the SDK's own GET
+ * response cache. Both go stale the moment a profile is edited, and neither has
+ * any way to find out — the writer is a different process in a different repo.
+ * This is the signal that tells them.
+ *
+ * The channel name and the payload shape are wire contracts between oxy-api (the
+ * publisher) and every consuming backend (the subscribers), so they live here
+ * rather than in either side. A hand-typed copy of the channel name fails as
+ * "the invalidation never arrives" — silently, because pub/sub has no delivery
+ * receipt and a message nobody is listening for is indistinguishable from a
+ * message nobody sent.
+ *
+ * DELIVERY IS AT-MOST-ONCE, AND THAT IS THE DESIGN. Every consumer's cache still
+ * carries its own TTL, so a dropped message degrades to exactly the behaviour
+ * before this signal existed and never to something worse. That property is what
+ * makes a bare Redis PUBLISH sufficient here and an outbox, retries, delivery
+ * receipts and payload signatures unnecessary. Do not treat a received event as
+ * authoritative for anything except "re-read this user from Oxy".
+ *
+ * PRIVACY — the payload carries NO user data, only an id, a reason and a
+ * timestamp. The channel rides the shared Valkey that every Oxy backend can
+ * subscribe to, so anything placed on it is readable by every service in the
+ * ecosystem. Never add a name, handle, email, avatar or any profile field: a
+ * subscriber that wants the new values re-reads them from Oxy through its normal
+ * authenticated path, where the usual authorization applies.
+ *
+ * Platform-agnostic — zod only, no react/react-native/expo.
+ */
+
+import { z } from 'zod';
+
+/** Redis pub/sub channel carrying user-invalidation events. */
+export const OXY_USER_INVALIDATION_CHANNEL = 'oxy:user:invalidate';
+
+/**
+ * Why a user record changed, as classified by the writer in oxy-api.
+ *
+ * - `profile` — anything a consumer renders or caches as IDENTITY: display name,
+ *   username, avatar, bio, verification, federation fields, account status. This
+ *   is the DEFAULT for every writer, so a site that forgets to classify itself
+ *   over-invalidates (correct, marginally slower) rather than under-invalidates
+ *   (silently wrong). Keep that asymmetry if you add a reason.
+ * - `graph` — follow-edge churn only (follower/following counts). High frequency,
+ *   and bulk follow/unfollow moves up to 200 edges in one call. Nothing renders
+ *   identity from it and a stale count is harmless to ranking, so it is NOT
+ *   broadcast — see {@link OXY_PUBLISHED_USER_CHANGE_REASONS}.
+ */
+export const OXY_USER_CHANGE_REASONS = ['profile', 'graph'] as const;
+
+export type OxyUserChangeReason = (typeof OXY_USER_CHANGE_REASONS)[number];
+
+/**
+ * The reasons that are actually put on the wire.
+ *
+ * A reason absent from this list is a local cache eviction in oxy-api and
+ * nothing more: no message is published at all, rather than a message every
+ * subscriber receives and discards. The distinction matters at bulk-follow
+ * scale, where the discarded variant is a 200-message burst on a channel every
+ * Oxy backend is subscribed to.
+ *
+ * This is deliberately a shared list rather than a check inside the publisher:
+ * a subscriber needs to know what it can receive, and the schema below rejects
+ * anything else, so publisher and subscriber cannot drift into disagreeing about
+ * which events exist. Adding a reason therefore forces an explicit decision about
+ * whether it broadcasts.
+ */
+export const OXY_PUBLISHED_USER_CHANGE_REASONS = ['profile'] as const;
+
+export type PublishedOxyUserChangeReason =
+  (typeof OXY_PUBLISHED_USER_CHANGE_REASONS)[number];
+
+/** Whether a change of this kind is broadcast to consumers at all. */
+export function isPublishedOxyUserChangeReason(
+  reason: OxyUserChangeReason,
+): reason is PublishedOxyUserChangeReason {
+  return (OXY_PUBLISHED_USER_CHANGE_REASONS as readonly string[]).includes(reason);
+}
+
+/**
+ * A single user-invalidation event.
+ *
+ * `at` is the publisher's epoch-ms clock, carried for diagnosis (measuring
+ * end-to-end propagation, spotting a wedged subscriber) — never for ordering or
+ * conflict resolution. Two Oxy tasks publish from unsynchronised clocks, and the
+ * event says only "re-read this user", which is idempotent and order-independent.
+ */
+export const oxyUserInvalidationEventSchema = z.object({
+  /** The Oxy user whose record changed. */
+  userId: z.string().min(1),
+  /** Why it changed. Only broadcast reasons appear on the wire. */
+  reason: z.enum(OXY_PUBLISHED_USER_CHANGE_REASONS),
+  /** Publisher's epoch-ms timestamp. Diagnostic only. */
+  at: z.number().int().nonnegative(),
+});
+
+export type OxyUserInvalidationEvent = z.infer<typeof oxyUserInvalidationEventSchema>;

--- a/packages/core/src/server/__tests__/userInvalidation.test.ts
+++ b/packages/core/src/server/__tests__/userInvalidation.test.ts
@@ -1,0 +1,208 @@
+import { OXY_USER_INVALIDATION_CHANNEL } from '@oxyhq/contracts';
+
+import {
+  createOxyUserInvalidationHandler,
+  evictOxyIdentityCache,
+  publishOxyUserInvalidation,
+  type OxyIdentityCacheEvictor,
+} from '../userInvalidation';
+
+function makePublisher() {
+  const calls: Array<{ channel: string; message: string }> = [];
+  return {
+    calls,
+    publish(channel: string, message: string) {
+      calls.push({ channel, message });
+      return Promise.resolve(1);
+    },
+  };
+}
+
+function makeEvictor() {
+  const entries: string[] = [];
+  const prefixes: string[] = [];
+  const evictor: OxyIdentityCacheEvictor = {
+    clearCacheEntry: (key) => {
+      entries.push(key);
+    },
+    clearCacheByPrefix: (prefix) => {
+      prefixes.push(prefix);
+      return 0;
+    },
+  };
+  return { evictor, entries, prefixes };
+}
+
+describe('@oxyhq/core/server publishOxyUserInvalidation', () => {
+  it('publishes a profile change on the contract channel', () => {
+    const publisher = makePublisher();
+    const published = publishOxyUserInvalidation(publisher, 'user-1', 'profile');
+
+    expect(published).toBe(true);
+    expect(publisher.calls).toHaveLength(1);
+    expect(publisher.calls[0].channel).toBe(OXY_USER_INVALIDATION_CHANNEL);
+
+    const payload = JSON.parse(publisher.calls[0].message);
+    expect(payload.userId).toBe('user-1');
+    expect(payload.reason).toBe('profile');
+    expect(typeof payload.at).toBe('number');
+  });
+
+  it('puts NOTHING on the wire for graph churn', () => {
+    // The whole point of the suppression: not a message subscribers discard,
+    // but no message at all. Bulk follow moves up to 200 edges per call.
+    const publisher = makePublisher();
+    const published = publishOxyUserInvalidation(publisher, 'user-1', 'graph');
+
+    expect(published).toBe(false);
+    expect(publisher.calls).toHaveLength(0);
+  });
+
+  it('publishes nothing for an empty user id', () => {
+    const publisher = makePublisher();
+    expect(publishOxyUserInvalidation(publisher, '', 'profile')).toBe(false);
+    expect(publisher.calls).toHaveLength(0);
+  });
+
+  it('never throws when the client throws synchronously', () => {
+    const boom = new Error('redis down');
+    const publisher = {
+      publish() {
+        throw boom;
+      },
+    };
+    const onError = jest.fn();
+
+    expect(() => publishOxyUserInvalidation(publisher, 'user-1', 'profile', onError)).not.toThrow();
+    expect(publishOxyUserInvalidation(publisher, 'user-1', 'profile', onError)).toBe(false);
+    expect(onError).toHaveBeenCalledWith(boom);
+  });
+
+  it('never surfaces a rejected publish as an unhandled rejection', async () => {
+    const boom = new Error('publish rejected');
+    const publisher = {
+      publish: () => Promise.reject(boom),
+    };
+    const onError = jest.fn();
+
+    // Returns true — the message was handed to the client; the failure is async.
+    expect(publishOxyUserInvalidation(publisher, 'user-1', 'profile', onError)).toBe(true);
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledWith(boom);
+  });
+
+  it('tolerates a client whose publish returns a non-promise', () => {
+    const calls: string[] = [];
+    const publisher = {
+      publish: (_channel: string, message: string) => {
+        calls.push(message);
+        return 1;
+      },
+    };
+    expect(publishOxyUserInvalidation(publisher, 'user-1', 'profile')).toBe(true);
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe('@oxyhq/core/server createOxyUserInvalidationHandler', () => {
+  const validMessage = JSON.stringify({ userId: 'user-1', reason: 'profile', at: 1 });
+
+  it('sweeps the SDK identity cache for the invalidated user', () => {
+    const { evictor, entries, prefixes } = makeEvictor();
+    createOxyUserInvalidationHandler({ oxy: evictor })(validMessage);
+
+    expect(entries).toEqual(['GET:/users/user-1']);
+    expect(prefixes).toEqual(['GET:/profiles/username/', 'GET:/profiles/resolve']);
+  });
+
+  it('hands the parsed event to app-specific eviction', () => {
+    const onInvalidate = jest.fn();
+    createOxyUserInvalidationHandler({ onInvalidate })(validMessage);
+
+    expect(onInvalidate).toHaveBeenCalledWith({ userId: 'user-1', reason: 'profile', at: 1 });
+  });
+
+  it('drops an unparseable message without throwing', () => {
+    const onInvalidate = jest.fn();
+    const onError = jest.fn();
+    const handle = createOxyUserInvalidationHandler({ onInvalidate, onError });
+
+    expect(() => handle('not json at all')).not.toThrow();
+    expect(onInvalidate).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('drops a message that fails the contract schema', () => {
+    const onInvalidate = jest.fn();
+    const onError = jest.fn();
+    const handle = createOxyUserInvalidationHandler({ onInvalidate, onError });
+
+    handle(JSON.stringify({ userId: 'user-1', reason: 'graph', at: 1 }));
+    handle(JSON.stringify({ reason: 'profile', at: 1 }));
+
+    expect(onInvalidate).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledTimes(2);
+  });
+
+  it('never throws when app eviction throws', () => {
+    // The handler runs inside the Redis client's message dispatch. An escape
+    // there kills the subscription — silently and permanently — which is far
+    // worse than losing the one message that caused it.
+    const boom = new Error('app eviction failed');
+    const onError = jest.fn();
+    const handle = createOxyUserInvalidationHandler({
+      onInvalidate: () => {
+        throw boom;
+      },
+      onError,
+    });
+
+    expect(() => handle(validMessage)).not.toThrow();
+    expect(onError).toHaveBeenCalledWith(boom, validMessage);
+  });
+
+  it('never throws when app eviction rejects', async () => {
+    const boom = new Error('async eviction failed');
+    const onError = jest.fn();
+    const handle = createOxyUserInvalidationHandler({
+      onInvalidate: () => Promise.reject(boom),
+      onError,
+    });
+
+    expect(() => handle(validMessage)).not.toThrow();
+    await Promise.resolve();
+    expect(onError).toHaveBeenCalledWith(boom, validMessage);
+  });
+
+  it('still runs app eviction when the SDK sweep throws', () => {
+    const onInvalidate = jest.fn();
+    const onError = jest.fn();
+    const evictor: OxyIdentityCacheEvictor = {
+      clearCacheEntry: () => {
+        throw new Error('sweep failed');
+      },
+      clearCacheByPrefix: () => 0,
+    };
+
+    createOxyUserInvalidationHandler({ oxy: evictor, onInvalidate, onError })(validMessage);
+
+    expect(onInvalidate).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('is a no-op with no options configured', () => {
+    expect(() => createOxyUserInvalidationHandler()(validMessage)).not.toThrow();
+  });
+});
+
+describe('@oxyhq/core/server evictOxyIdentityCache', () => {
+  it('clears the exact by-id entry and the handle-keyed prefixes', () => {
+    // The by-id key is exact. The handle-keyed ones cannot be derived from an
+    // id without the lookup being invalidated, so they are swept by prefix.
+    const { evictor, entries, prefixes } = makeEvictor();
+    evictOxyIdentityCache(evictor, 'abc123');
+
+    expect(entries).toEqual(['GET:/users/abc123']);
+    expect(prefixes).toEqual(['GET:/profiles/username/', 'GET:/profiles/resolve']);
+  });
+});

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -82,6 +82,19 @@ export type {
 // Constant-time secret comparison.
 export { verifySecret } from './verifySecret';
 
+// Cross-service user-invalidation signal: oxy-api publishes when identity
+// changes, every consuming backend sweeps its caches instead of waiting out a TTL.
+export {
+  createOxyUserInvalidationHandler,
+  evictOxyIdentityCache,
+  publishOxyUserInvalidation,
+} from './userInvalidation';
+export type {
+  OxyIdentityCacheEvictor,
+  OxyInvalidationPublisher,
+  OxyUserInvalidationHandlerOptions,
+} from './userInvalidation';
+
 // Registrable-apex (eTLD+1) derivation via the Public Suffix List — the SINGLE
 // SOURCE OF TRUTH shared with the IdP worker and the client FAPI auto-detect.
 // Pure host handling (no browser deps), so it is safe on the server subpath and

--- a/packages/core/src/server/userInvalidation.ts
+++ b/packages/core/src/server/userInvalidation.ts
@@ -1,0 +1,221 @@
+/**
+ * Oxy user-invalidation publish/consume helpers for Oxy backends.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Every Oxy backend caches Oxy identity, and none of them find out when it
+ * changes. The `OxyServices` GET response cache holds `GET /users/:id` and
+ * `GET /profiles/username/:name` for five minutes; it is swept when THIS process
+ * writes the profile (see the `clearCacheEntry` calls in the user mixin) and
+ * never when somebody else does — which is the normal case, since profiles are
+ * edited in Oxy's own apps. So an avatar or display-name change is invisible to
+ * every consuming backend for up to five minutes, per process.
+ *
+ * oxy-api broadcasts {@link OXY_USER_INVALIDATION_CHANNEL} on the shared Valkey
+ * when a user's identity changes. This module is the consumer half: it parses
+ * and validates the event, sweeps the SDK's own cache, and hands the event to
+ * app-specific eviction. Wiring it is two lines and every backend that does so
+ * stops serving stale identity.
+ *
+ * WHY THE TRANSPORT IS THE CALLER'S JOB
+ * -------------------------------------
+ * This module deliberately does NOT take a Redis client. ioredis and node-redis
+ * disagree about how to subscribe — node-redis passes the listener to
+ * `subscribe(channel, listener)`, ioredis takes `subscribe(channel)` and then
+ * emits `'message'` on the client — and a helper that accepted "a client" would
+ * have to sniff which library it was handed. That kind of detection is exactly
+ * what breaks silently when a consumer upgrades a client library.
+ *
+ * So the split is: this module owns parsing, validation, dispatch and the
+ * never-throw guarantee (the parts that are easy to get wrong and identical
+ * everywhere), and the caller owns its own client's two-line subscribe idiom
+ * (trivial, but library-specific).
+ *
+ *     // node-redis
+ *     await subscriber.subscribe(
+ *       OXY_USER_INVALIDATION_CHANNEL,
+ *       createOxyUserInvalidationHandler({ oxy: oxyClient }),
+ *     );
+ *
+ *     // ioredis
+ *     const handle = createOxyUserInvalidationHandler({ oxy: oxyClient });
+ *     await subscriber.subscribe(OXY_USER_INVALIDATION_CHANNEL);
+ *     subscriber.on('message', (_channel, raw) => handle(raw));
+ *
+ * Subscribe on EVERY task, not just an elected leader. The SDK cache this sweeps
+ * is per-process in-memory, so a leader-only subscriber would leave every other
+ * task stale — and leader-gating would add a failure mode (leader down means no
+ * invalidation anywhere) to a signal whose whole point is that losing it is
+ * merely slow, never wrong.
+ *
+ * Node-only; exported solely from `@oxyhq/core/server`.
+ */
+
+import {
+  OXY_USER_INVALIDATION_CHANNEL,
+  isPublishedOxyUserChangeReason,
+  oxyUserInvalidationEventSchema,
+  type OxyUserChangeReason,
+  type OxyUserInvalidationEvent,
+} from '@oxyhq/contracts';
+
+/**
+ * The publish surface of a Redis client. Both `ioredis` and `node-redis`
+ * satisfy this structurally, so neither library is a dependency here.
+ */
+export interface OxyInvalidationPublisher {
+  publish(channel: string, message: string): unknown;
+}
+
+/**
+ * The cache-eviction surface of an {@link OxyServices} instance. Declared
+ * structurally so this Node-only module does not pull in the client.
+ */
+export interface OxyIdentityCacheEvictor {
+  clearCacheEntry(key: string): void;
+  clearCacheByPrefix(prefix: string): number;
+}
+
+/**
+ * Broadcast that an Oxy user's record changed.
+ *
+ * Returns `true` when a message was put on the wire and `false` when the reason
+ * is not a broadcast one ({@link isPublishedOxyUserChangeReason}) — the latter is
+ * a deliberate no-op, not a failure. Suppressing at the publisher rather than
+ * letting every subscriber discard matters at bulk-follow scale, where a single
+ * call moves up to 200 edges.
+ *
+ * NEVER THROWS AND NEVER RETURNS A REJECTED PROMISE. This is called from inside
+ * cache invalidation, which itself runs after a successful database write on the
+ * request path: a publish failure must not turn a completed profile update into
+ * a 500. A dropped message costs a consumer its TTL and nothing more.
+ *
+ * @param publisher - A connected Redis client. Must NOT be a client currently in
+ *                    subscriber mode — Redis forbids `PUBLISH` on a subscribed
+ *                    connection, so pass the publisher half of a pub/sub pair.
+ * @param userId    - The Oxy user whose record changed.
+ * @param reason    - How the record changed. See {@link OxyUserChangeReason}.
+ * @param onError   - Optional diagnostic sink for a failed publish.
+ */
+export function publishOxyUserInvalidation(
+  publisher: OxyInvalidationPublisher,
+  userId: string,
+  reason: OxyUserChangeReason,
+  onError?: (error: unknown) => void,
+): boolean {
+  if (!userId || !isPublishedOxyUserChangeReason(reason)) {
+    return false;
+  }
+
+  const event: OxyUserInvalidationEvent = { userId, reason, at: Date.now() };
+
+  try {
+    const result = publisher.publish(OXY_USER_INVALIDATION_CHANNEL, JSON.stringify(event));
+    // node-redis returns a promise; ioredis returns a promise too, but a mocked
+    // or synchronous client may return anything. Only attach a rejection handler
+    // when there is actually something thenable to reject.
+    if (isPromiseLike(result)) {
+      Promise.resolve(result).catch((error: unknown) => onError?.(error));
+    }
+    return true;
+  } catch (error) {
+    onError?.(error);
+    return false;
+  }
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+/** Options for {@link createOxyUserInvalidationHandler}. */
+export interface OxyUserInvalidationHandlerOptions {
+  /**
+   * The backend's `OxyServices` instance. When supplied, its GET response cache
+   * is swept for the invalidated user — this is the whole reason a backend that
+   * has no cache of its own still benefits from subscribing.
+   */
+  oxy?: OxyIdentityCacheEvictor;
+  /**
+   * App-specific eviction (e.g. a Redis identity cache the app maintains itself).
+   * May be async; a rejection is routed to `onError` and never escapes.
+   */
+  onInvalidate?: (event: OxyUserInvalidationEvent) => void | Promise<void>;
+  /** Diagnostic sink for an unparseable message or a failing `onInvalidate`. */
+  onError?: (error: unknown, raw: string) => void;
+}
+
+/**
+ * Build the message handler for {@link OXY_USER_INVALIDATION_CHANNEL}.
+ *
+ * The returned function NEVER THROWS and never returns a rejected promise. It
+ * runs inside the Redis client's message dispatch, where an exception either
+ * takes down the subscriber connection or surfaces as an unhandled rejection —
+ * and losing the subscription is strictly worse than losing one message, because
+ * it is silent and permanent.
+ *
+ * A message that fails schema validation is dropped, not retried: the payload is
+ * produced by a contract both sides compile against, so a malformed one means a
+ * version skew or an unrelated publisher on the channel, neither of which a retry
+ * fixes.
+ */
+export function createOxyUserInvalidationHandler(
+  options: OxyUserInvalidationHandlerOptions = {},
+): (raw: string) => void {
+  const { oxy, onInvalidate, onError } = options;
+
+  return (raw: string): void => {
+    let event: OxyUserInvalidationEvent;
+    try {
+      const parsed = oxyUserInvalidationEventSchema.safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        onError?.(parsed.error, raw);
+        return;
+      }
+      event = parsed.data;
+    } catch (error) {
+      onError?.(error, raw);
+      return;
+    }
+
+    if (oxy) {
+      try {
+        evictOxyIdentityCache(oxy, event.userId);
+      } catch (error) {
+        // A cache sweep must never cost us the app-specific eviction below.
+        onError?.(error, raw);
+      }
+    }
+
+    if (!onInvalidate) return;
+    try {
+      const result = onInvalidate(event);
+      if (isPromiseLike(result)) {
+        Promise.resolve(result).catch((error: unknown) => onError?.(error, raw));
+      }
+    } catch (error) {
+      onError?.(error, raw);
+    }
+  };
+}
+
+/**
+ * Sweep an `OxyServices` GET response cache of everything that could carry the
+ * given user's identity.
+ *
+ * The by-id entry is exact. The by-username and resolve entries are keyed by
+ * HANDLE, which cannot be derived from an id without the very lookup we are
+ * invalidating, so those are swept by prefix — the same imprecision the SDK
+ * already accepts when it sweeps its own cache after a local profile write, and
+ * bounded by the fact that over-eviction costs a refetch and can never serve
+ * wrong data.
+ */
+export function evictOxyIdentityCache(oxy: OxyIdentityCacheEvictor, userId: string): void {
+  oxy.clearCacheEntry(`GET:/users/${userId}`);
+  oxy.clearCacheByPrefix('GET:/profiles/username/');
+  oxy.clearCacheByPrefix('GET:/profiles/resolve');
+}


### PR DESCRIPTION
## What

Oxy owns identity; every consumer caches it; nothing has ever told them when it changes.

- Mention holds a 10-minute Redis summary per post author.
- Every backend on `@oxyhq/core` holds the SDK's own 5-minute GET cache, swept **only** when that process writes the profile and never when somebody else does — the normal case, since profiles are edited in Oxy's own apps.

So a display-name or avatar edit is invisible ecosystem-wide for minutes, to **every** viewer, not just the editor.

oxy-api now publishes on `oxy:user:invalidate` (the shared Valkey both sides already run pub/sub on for the Socket.IO adapter — zero infra change). Consumers subscribe and drop their copy instead of waiting out a TTL.

## Design notes

**At-most-once delivery is deliberate.** Every consumer's TTL stays, so a lost message degrades to exactly the old behaviour and never worse. That is what makes a bare `PUBLISH` sufficient, and an outbox / retries / delivery receipts / payload signatures unnecessary for a cache eviction.

**The publisher hangs off `userCache.invalidate()`** because that is already the chokepoint — all ~25 user-state writers call it and the house rule already requires new ones to. A separate "and also notify" call at each site would be one more thing to forget, which is how this staleness arose.

**`reason` defaults to `'profile'`** so a writer that does not classify itself over-broadcasts (a wasted eviction) rather than under-broadcasts (stale identity nobody can tell is stale).

**`'graph'` publishes NOTHING**, rather than something subscribers discard — bulk follow/unfollow moves up to 200 edges per call on a channel every Oxy backend subscribes to. Local + Redis eviction still happens for `'graph'`; only the fan-out is suppressed.

**The payload carries an id, a reason and a clock — never profile data.** The channel rides the shared Valkey any Oxy service can read; a subscriber wanting new values re-reads them through its normal authenticated path.

## Verification

Unit suites all green: contracts 215, core 1413, api 2413.

Mutation-tested, both directions failing exactly their guarding test:
- remove the suppression gate in core → `puts NOTHING on the wire for graph churn` fails
- flip the `userCache` default to `'graph'` → `broadcasts by default` fails

Plus a **live cross-library round trip** — ioredis 5.11.1 publishing (what oxy-api runs) to node-redis 5.12.1 subscribing (what Mention runs), over a real Redis, against the built artefact rather than TS source.

The first version of that check asserted "nothing hit the wire" by watching handler delivery, and **passed against a build with the gate removed** — the contract schema rejects `'graph'` before the handler sees it, so the check could not see messages that were genuinely on the wire. It now counts raw channel deliveries; stripping the gate fails it with `raw grew by 200`.

## Scope

Publisher only. No consumer subscribes yet — publishing to a channel nobody listens on is a no-op, so this ships publisher-first, which is the safe order. The Mention subscriber follows separately.

No version bumps and no lockfile change: `@oxyhq/contracts` and `@oxyhq/core` are already `workspace:*` deps of the API, and the oxy-api image builds both from workspace source, so the deploy needs no npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)