### PR TITLE
fix(api): make a video's thumbnail resolve instead of 404 (+ bound the ffmpeg poster decode)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,19 @@ jobs:
           npm install -g node-gyp@11.5.0
           echo "npm_config_node_gyp=$(npm root -g)/node-gyp/bin/node-gyp.js" >> "$GITHUB_ENV"
 
+      # The video-poster variant tests decode a real clip, so ffmpeg/ffprobe must
+      # be present. The runner image happens to ship them today, but the API
+      # image installs them explicitly (`apk add ffmpeg` in the Dockerfile) and
+      # the tests depend on them just as explicitly — leaving it to the runner's
+      # incidental contents is how a suite starts failing on an image bump for a
+      # reason nobody can place.
+      - name: Install ffmpeg (video variant tests)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+          ffmpeg -version | head -1
+          ffprobe -version | head -1
+
       - name: Install dependencies
         run: bun install
 

--- a/packages/api/src/routes/__tests__/cdnVideoImageVariant.test.ts
+++ b/packages/api/src/routes/__tests__/cdnVideoImageVariant.test.ts
@@ -1,0 +1,334 @@
+/**
+ * `GET /cdn/:id?variant=<size>` for a VIDEO file — end-to-end.
+ *
+ * The regression this pins: an image SIZE variant name asked of a video file
+ * used to be fatal. `assetService.ensureVariant` handled `image/*` and the
+ * single `video/*` + `poster` pair and threw for everything else, and the public
+ * CDN origin turns a throwing probe into a 404 carrying no bytes — so every
+ * consumer that resolved a bare file id through the synchronous, mime-blind
+ * `getFileDownloadUrl(id, 'thumb')` got a placeholder for a video and a
+ * thumbnail for an image. A size name now means "an image of this asset at that
+ * size" for every mime, which for a video is a render of its poster frame.
+ *
+ * This exercises the WHOLE chain for real — express route → `getPublicCdnUrl`
+ * → `ensureVariant` → `ensureVideoImageVariant` → `ensureVideoPoster` → a real
+ * ffmpeg decode over HTTP → a real Sharp resize → the variant key the 302 points
+ * at. Only S3 and the Mongo model are substituted, by an in-memory object store
+ * and a plain document, so the bytes asserted at the end are the bytes the
+ * pipeline actually produced.
+ *
+ * ffmpeg reads the video over `http://127.0.0.1:<port>` rather than from disk,
+ * which is also what proves the poster decode's protocol whitelist admits a
+ * legitimate object-store URL instead of breaking it.
+ *
+ * The control cases matter as much as the happy path: a variant name that is
+ * not a real size must STILL 404 (so a passing assertion here cannot be
+ * explained by the route having become permissive), and the poster must be
+ * decoded exactly once across several requested sizes.
+ */
+
+import express from 'express';
+import http from 'http';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import type { AddressInfo } from 'net';
+import sharp from 'sharp';
+
+import type { S3Service } from '../../services/s3Service';
+import type { IFile } from '../../models/File';
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../../services/mediaPrivacyService', () => ({ mediaPrivacyService: {} }));
+jest.mock('../../utils/fileCache', () => ({
+  __esModule: true,
+  default: { invalidate: jest.fn(), set: jest.fn(), get: jest.fn() },
+}));
+
+// `commitVariants` persists through `File.updateOne(...).exec()`; the variant
+// bookkeeping is asserted on the in-memory document instead of a DB.
+jest.mock('../../models/File', () => ({
+  File: {
+    updateOne: jest.fn(() => ({ exec: jest.fn(() => Promise.resolve({})) })),
+    findById: jest.fn(() => Promise.resolve(null)),
+    findOne: jest.fn(() => Promise.resolve(null)),
+  },
+  FileVisibility: {},
+}));
+
+const mockGetFile = jest.fn();
+const mockGetPublicCdnUrl = jest.fn();
+
+jest.mock('../../services/assetServiceSingleton', () => ({
+  assetService: {
+    getFile: (...args: unknown[]) => mockGetFile(...args),
+    getPublicCdnUrl: (...args: unknown[]) => mockGetPublicCdnUrl(...args),
+  },
+  s3Service: {},
+}));
+
+import { AssetService } from '../../services/assetService';
+import cdnRouter from '../cdn';
+import { errorHandler } from '../../middleware/errorHandler';
+
+const VIDEO_FILE_ID = '64c0000000000000000000c1';
+const VIDEO_SHA256 = 'c'.repeat(64);
+const VIDEO_STORAGE_KEY = 'public/content/2026/08/cc/sample.mp4';
+const VIDEO_WIDTH = 540;
+const VIDEO_HEIGHT = 960;
+
+/** In-memory stand-in for S3, addressed by storage key exactly as the real one is. */
+class InMemoryObjectStore {
+  readonly objects = new Map<string, { buffer: Buffer; contentType?: string }>();
+  /** Every key handed to ffmpeg as a presigned URL, in call order. */
+  readonly presignedFor: string[] = [];
+  private origin = '';
+
+  setOrigin(origin: string): void {
+    this.origin = origin;
+  }
+
+  put(key: string, buffer: Buffer, contentType?: string): void {
+    this.objects.set(key, { buffer, contentType });
+  }
+
+  urlFor(key: string): string {
+    this.presignedFor.push(key);
+    return `${this.origin}/${encodeURIComponent(key)}`;
+  }
+}
+
+/** Adapt the in-memory store to the S3Service surface the services call. */
+function asS3Service(store: InMemoryObjectStore): S3Service {
+  return {
+    getPresignedDownloadUrl: async (key: string): Promise<string> => store.urlFor(key),
+    downloadBuffer: async (key: string): Promise<Buffer> => {
+      const found = store.objects.get(key);
+      if (!found) {
+        throw new Error(`No such object: ${key}`);
+      }
+      return found.buffer;
+    },
+    uploadBuffer: async (key: string, buffer: Buffer, options?: { contentType?: string }): Promise<void> => {
+      store.put(key, buffer, options?.contentType);
+    },
+    fileExists: async (key: string): Promise<boolean> => store.objects.has(key),
+  } as unknown as S3Service;
+}
+
+/**
+ * Serve the object store over HTTP with byte-range support — ffmpeg seeks an
+ * mp4 with ranged requests, so a server that ignores `Range` would silently
+ * change what is being tested.
+ */
+function startObjectServer(store: InMemoryObjectStore): Promise<http.Server> {
+  const server = http.createServer((req, res) => {
+    const key = decodeURIComponent((req.url ?? '/').replace(/^\//, '').split('?')[0]);
+    const found = store.objects.get(key);
+    if (!found) {
+      res.writeHead(404).end();
+      return;
+    }
+
+    const total = found.buffer.length;
+    const range = req.headers.range;
+    const match = typeof range === 'string' ? /^bytes=(\d*)-(\d*)$/.exec(range) : null;
+    if (match) {
+      const start = match[1] ? Number.parseInt(match[1], 10) : 0;
+      const end = match[2] ? Number.parseInt(match[2], 10) : total - 1;
+      const slice = found.buffer.subarray(start, Math.min(end, total - 1) + 1);
+      res.writeHead(206, {
+        'Content-Type': found.contentType ?? 'application/octet-stream',
+        'Content-Length': String(slice.length),
+        'Content-Range': `bytes ${start}-${start + slice.length - 1}/${total}`,
+        'Accept-Ranges': 'bytes',
+      });
+      res.end(slice);
+      return;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': found.contentType ?? 'application/octet-stream',
+      'Content-Length': String(total),
+      'Accept-Ranges': 'bytes',
+    });
+    res.end(found.buffer);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+interface RawResponse {
+  status: number;
+  location?: string;
+}
+
+/** Issue a request WITHOUT following redirects so the 302 itself is assertable. */
+function requestNoFollow(server: http.Server, urlPath: string): Promise<RawResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method: 'GET', host: '127.0.0.1', port: address.port, path: urlPath },
+      (res) => {
+        res.resume();
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, location: res.headers.location }));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** A real 540×960 H.264 clip, so the decode under test has genuine bytes. */
+function buildSampleVideo(): Buffer {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oxy-variant-test-'));
+  const output = path.join(dir, 'sample.mp4');
+  try {
+    execFileSync(
+      'ffmpeg',
+      [
+        '-hide_banner', '-loglevel', 'error',
+        '-f', 'lavfi',
+        '-i', `testsrc=size=${VIDEO_WIDTH}x${VIDEO_HEIGHT}:rate=10:duration=2`,
+        '-c:v', 'libx264',
+        '-pix_fmt', 'yuv420p',
+        '-movflags', '+faststart',
+        '-y', output,
+      ],
+      { stdio: 'pipe' }
+    );
+    return fs.readFileSync(output);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeVideoFile(): IFile {
+  return {
+    _id: VIDEO_FILE_ID,
+    sha256: VIDEO_SHA256,
+    mime: 'video/mp4',
+    status: 'active',
+    visibility: 'public',
+    storageKey: VIDEO_STORAGE_KEY,
+    variants: [],
+  } as unknown as IFile;
+}
+
+let store: InMemoryObjectStore;
+let objectServer: http.Server;
+let apiServer: http.Server;
+let videoFile: IFile;
+
+beforeAll(async () => {
+  store = new InMemoryObjectStore();
+  store.put(VIDEO_STORAGE_KEY, buildSampleVideo(), 'video/mp4');
+
+  objectServer = await startObjectServer(store);
+  const objectAddress = objectServer.address() as AddressInfo;
+  store.setOrigin(`http://127.0.0.1:${objectAddress.port}`);
+
+  // The real service, over the in-memory store: `ensureVariant` and the whole
+  // VariantService beneath it run unmodified.
+  const assetService = new AssetService(asS3Service(store));
+  mockGetPublicCdnUrl.mockImplementation((file: IFile, variant?: string) =>
+    assetService.getPublicCdnUrl(file, variant)
+  );
+
+  const app = express();
+  app.use('/cdn', cdnRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    apiServer = app.listen(0, '127.0.0.1', resolve);
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => objectServer.close(() => resolve()));
+  await new Promise<void>((resolve) => apiServer.close(() => resolve()));
+});
+
+beforeEach(() => {
+  // One document shared across the requests in a test file so a variant
+  // generated by an earlier assertion is visible to a later one, exactly as the
+  // persisted document would be.
+  videoFile = videoFile ?? makeVideoFile();
+  mockGetFile.mockResolvedValue(videoFile);
+});
+
+describe('GET /cdn/:id?variant=<size> for a video file', () => {
+  it('302s ?variant=thumb to a real webp rendered from the poster frame', async () => {
+    const res = await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=thumb`);
+
+    expect(res.status).toBe(302);
+    expect(res.location).toMatch(/\/thumb\.webp$/);
+
+    // The redirect target must be an object that actually exists in storage,
+    // located by the SAME key the variant recorded — not merely a well-formed URL.
+    const stored = store.objects.get(
+      `public/variants/${new Date().getFullYear()}/${String(new Date().getMonth() + 1).padStart(2, '0')}/cc/${VIDEO_SHA256}/thumb.webp`
+    );
+    expect(stored).toBeDefined();
+    expect(stored?.contentType).toBe('image/webp');
+
+    const meta = await sharp(stored?.buffer).metadata();
+    expect(meta.format).toBe('webp');
+    // `thumb` is 256×256 fit-inside, so a 540×960 portrait clip yields a
+    // 144×256 poster render — the video's aspect ratio, never a square crop.
+    expect(meta.height).toBe(256);
+    expect(meta.width).toBe(144);
+  }, 60_000);
+
+  it('serves a size that is meaningfully smaller than the full poster', async () => {
+    await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=w320`);
+
+    const poster = [...store.objects.entries()].find(([key]) => key.endsWith('/poster.jpg'));
+    const w320 = [...store.objects.entries()].find(([key]) => key.endsWith('/w320.webp'));
+    expect(poster).toBeDefined();
+    expect(w320).toBeDefined();
+
+    const posterBytes = poster?.[1].buffer.length ?? 0;
+    const w320Bytes = w320?.[1].buffer.length ?? 0;
+    expect(posterBytes).toBeGreaterThan(0);
+    expect(w320Bytes).toBeGreaterThan(0);
+    // The point of the sized render: a feed card stops paying for a 1920px frame.
+    expect(w320Bytes).toBeLessThan(posterBytes);
+  }, 60_000);
+
+  it('decodes the poster only once no matter how many sizes are requested', async () => {
+    const before = store.presignedFor.filter((key) => key === VIDEO_STORAGE_KEY).length;
+
+    await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=w96`);
+    await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=w128`);
+    await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=w640`);
+
+    // The poster already exists by now (earlier tests generated it), so no
+    // further presign of the SOURCE VIDEO — the only reason to touch it — occurs.
+    const after = store.presignedFor.filter((key) => key === VIDEO_STORAGE_KEY).length;
+    expect(after).toBe(before);
+
+    for (const size of ['w96', 'w128', 'w640']) {
+      expect([...store.objects.keys()].some((key) => key.endsWith(`/${size}.webp`))).toBe(true);
+    }
+  }, 60_000);
+
+  it('still 404s a variant name that is not a real size (control)', async () => {
+    const res = await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=not-a-real-size`);
+
+    expect(res.status).toBe(404);
+    expect(res.location).toBeUndefined();
+    expect([...store.objects.keys()].some((key) => key.includes('not-a-real-size'))).toBe(false);
+  }, 60_000);
+
+  it('still serves the poster under its own name', async () => {
+    const res = await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=poster`);
+
+    expect(res.status).toBe(302);
+    expect(res.location).toMatch(/\/poster\.jpg$/);
+  }, 60_000);
+});

--- a/packages/api/src/services/__tests__/variantService.imageVariants.test.ts
+++ b/packages/api/src/services/__tests__/variantService.imageVariants.test.ts
@@ -180,3 +180,76 @@ describe('VariantService imageVariants — w128 variant', () => {
     );
   });
 });
+
+/**
+ * The same size taxonomy applied to a VIDEO, rendered from its poster frame.
+ *
+ * These cover the branch that needs no ffmpeg — the poster already exists, so
+ * only the Sharp resize runs. The decode itself (and the whole HTTP path down
+ * from `GET /cdn/:id?variant=…`) is covered end to end with a real clip in
+ * `src/routes/__tests__/cdnVideoImageVariant.test.ts`.
+ */
+describe('VariantService.ensureVideoImageVariant — sizes derived from the poster', () => {
+  const POSTER_KEY = 'public/variants/2026/08/bb/poster.jpg';
+
+  function makeVideoFileWithPoster(): IFile {
+    return {
+      _id: 'test-video-id',
+      sha256: 'b'.repeat(64),
+      mime: 'video/mp4',
+      visibility: 'public',
+      storageKey: 'public/content/2026/08/bb/original.mp4',
+      variants: [{ type: 'poster', key: POSTER_KEY, readyAt: new Date() }],
+    } as unknown as IFile;
+  }
+
+  /**
+   * A poster-shaped source: portrait, like the vertical clips that dominate the
+   * corpus, so a square output would be visible in the assertion.
+   */
+  async function makePortraitJpeg(width: number, height: number): Promise<Buffer> {
+    return sharp({
+      create: { width, height, channels: 3, background: { r: 30, g: 90, b: 160 } },
+    })
+      .jpeg()
+      .toBuffer();
+  }
+
+  it('renders a size from the existing poster instead of re-decoding the video', async () => {
+    const poster = await makePortraitJpeg(1080, 1920);
+    const fakeS3 = makeFakeS3(poster);
+    // The poster is already ready in storage, so the reuse probe must find it.
+    fakeS3.fileExists.mockImplementation((key: string) => Promise.resolve(key === POSTER_KEY));
+
+    const service = new VariantService(fakeS3 as unknown as S3Service);
+    const variant = await service.ensureVideoImageVariant(makeVideoFileWithPoster(), 'w320');
+
+    expect(variant.type).toBe('w320');
+    // The POSTER is the source — never the video's own storage key, which sharp
+    // could not decode anyway.
+    expect(fakeS3.downloadBuffer).toHaveBeenCalledWith(POSTER_KEY);
+
+    const uploaded = fakeS3.uploads.find(u => u.key.endsWith('/w320.webp'));
+    expect(uploaded).toBeDefined();
+    const meta = await sharp(uploaded?.buffer).metadata();
+    expect(meta.format).toBe('webp');
+    expect(meta.width).toBe(320);
+    // Aspect preserved (1080×1920 → 320×569), so a portrait video is never
+    // squashed into a square thumbnail.
+    expect(meta.height).toBe(569);
+  });
+
+  it('rejects a variant key that is not a real size (keeps the 404 for a bogus name)', async () => {
+    const poster = await makePortraitJpeg(1080, 1920);
+    const fakeS3 = makeFakeS3(poster);
+    fakeS3.fileExists.mockImplementation((key: string) => Promise.resolve(key === POSTER_KEY));
+
+    const service = new VariantService(fakeS3 as unknown as S3Service);
+
+    await expect(
+      service.ensureVideoImageVariant(makeVideoFileWithPoster(), 'not-a-real-variant'),
+    ).rejects.toThrow(/Unsupported video image variant/);
+    // A rejected name must never reach storage.
+    expect(fakeS3.uploads).toHaveLength(0);
+  });
+});

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -450,8 +450,18 @@ export class AssetService {
       return variant;
     }
 
-    if (fileObj.mime.startsWith('video/') && variantType === 'poster') {
-      const variant = await this.variantService.ensureVideoPoster(fileObj);
+    if (fileObj.mime.startsWith('video/')) {
+      if (variantType === 'poster') {
+        const variant = await this.variantService.ensureVideoPoster(fileObj);
+        return variant;
+      }
+      // A SIZE name (`thumb`, `w320`, …) asked of a video means "an image of
+      // this asset at that size", which for a video is a render of its poster
+      // frame. Callers hold a bare file id and cannot know the mime — the URL
+      // builder they use is synchronous and lexical — so refusing a size name
+      // here is what turned every video thumbnail into a 404. A name that is
+      // not a real size still throws, preserving the 404 for a bogus variant.
+      const variant = await this.variantService.ensureVideoImageVariant(fileObj, variantType);
       return variant;
     }
 

--- a/packages/api/src/services/variantService.ts
+++ b/packages/api/src/services/variantService.ts
@@ -170,6 +170,42 @@ try {
   // Logger might not be initialized yet, ignore
 }
 
+/**
+ * Hard wall-clock ceiling for a single poster-frame decode before the ffmpeg
+ * process is SIGKILLed.
+ *
+ * Poster extraction is reachable from the UNAUTHENTICATED public CDN origin
+ * (`GET /cdn/:id?variant=…` → `assetService.ensureVariant`), so a stuck or
+ * pathological decode must not be able to pin a worker indefinitely. The frame
+ * is cached in S3 afterwards, so this cost is paid at most once per file.
+ */
+const POSTER_FFMPEG_TIMEOUT_MS = 30_000;
+
+/**
+ * Cap on the JPEG bytes buffered from ffmpeg's stdout. A single frame is orders
+ * of magnitude smaller than this; the cap exists so a crafted input that makes
+ * ffmpeg stream unbounded output cannot exhaust the process heap.
+ */
+const POSTER_MAX_OUTPUT_BYTES = 32 * 1024 * 1024; // 32 MiB
+
+/**
+ * The protocols ffmpeg is allowed to open for a poster decode, derived from the
+ * input URL's OWN scheme.
+ *
+ * The input is a presigned object URL we just built, so the exact protocol it
+ * needs is known — and `file` is never among them. That matters because the
+ * bytes ffmpeg demuxes are USER-UPLOADED: a crafted container (HLS/DASH
+ * playlist, or any format carrying an external reference) can name a URL for
+ * ffmpeg to open, and the resulting frame is then published at a public CDN
+ * key. Without a whitelist, `file:///etc/passwd` is such a reference. Deriving
+ * the list rather than hardcoding it keeps a deployment pointed at an
+ * `http://` S3-compatible endpoint (local MinIO) working, while a production
+ * `https://` endpoint additionally denies cleartext `http` targets.
+ */
+function posterProtocolWhitelist(inputUrl: string): string {
+  return inputUrl.startsWith('http://') ? 'http,tcp' : 'https,tls,tcp';
+}
+
 export interface VariantConfigWithType extends VariantConfig {
   type: string;
 }
@@ -637,6 +673,13 @@ export class VariantService {
       // Generate poster with scaling to max 1920px while maintaining exact aspect ratio
       // Stream output directly to stdout (memory) - no temp files
       const args = [
+        // Global options must precede `-i`. `-nostdin` so a decode can never
+        // block waiting on a stdin that will never be written, and the protocol
+        // whitelist so a crafted container cannot make ffmpeg open a local file
+        // or an unrelated network target (see `posterProtocolWhitelist`).
+        '-loglevel', 'error',
+        '-nostdin',
+        '-protocol_whitelist', posterProtocolWhitelist(videoUrl),
         '-i', videoUrl, // Use S3 presigned URL directly
         '-ss', timeSeconds.toString(),
         '-vframes', '1',
@@ -662,22 +705,56 @@ export class VariantService {
         scaleFilter
       });
       
-      const ffmpegProcess = spawn(ffmpegPath, args);
+      // Node kills the process itself once the wall-clock ceiling elapses; the
+      // `close` handler below sees a null exit code and a signal.
+      const ffmpegProcess = spawn(ffmpegPath, args, {
+        timeout: POSTER_FFMPEG_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+      });
 
       let stderr = '';
       const stdoutChunks: Buffer[] = [];
+      let stdoutBytes = 0;
+      let outputOverflowed = false;
 
       ffmpegProcess.stderr.on('data', (data) => {
         stderr += data.toString();
       });
 
-      ffmpegProcess.stdout.on('data', (data) => {
+      ffmpegProcess.stdout.on('data', (data: Buffer) => {
+        if (outputOverflowed) {
+          return;
+        }
+        stdoutBytes += data.length;
+        if (stdoutBytes > POSTER_MAX_OUTPUT_BYTES) {
+          // Stop buffering and tear the decode down; `close` reports the reason.
+          outputOverflowed = true;
+          stdoutChunks.length = 0;
+          ffmpegProcess.kill('SIGKILL');
+          return;
+        }
         stdoutChunks.push(data);
       });
 
-      ffmpegProcess.on('close', async (code) => {
+      ffmpegProcess.on('close', async (code, signal) => {
+        if (outputOverflowed) {
+          logger.error('Poster generation exceeded the output cap', {
+            maxOutputBytes: POSTER_MAX_OUTPUT_BYTES,
+          });
+          reject(new Error('Poster generation aborted: output exceeded the maximum allowed size'));
+          return;
+        }
+
         if (code !== 0) {
-          logger.error('Poster generation failed', { code, stderr: stderr.substring(0, 500) });
+          logger.error('Poster generation failed', { code, signal, stderr: stderr.substring(0, 500) });
+          if (code === null) {
+            reject(
+              new Error(
+                `Poster generation aborted after ${POSTER_FFMPEG_TIMEOUT_MS}ms (signal ${String(signal)})`
+              )
+            );
+            return;
+          }
           reject(new Error(`Poster generation failed with code ${code}: ${stderr.substring(0, 200)}`));
           return;
         }
@@ -1269,33 +1346,101 @@ export class VariantService {
         metadata // Pass metadata to preserve exact aspect ratio
       );
 
-      // Update file variants
-      const idx = file.variants.findIndex(v => v.type === 'poster');
-      if (idx >= 0) file.variants[idx] = posterVariant;
-      else file.variants.push(posterVariant);
-
-      try {
-        await this.commitVariants(file);
-      } catch (error) {
-        logger.warn('Failed committing poster variant, retrying', { fileId: file._id, error });
-        // Retry once with fresh document
-        const fresh = await File.findById(file._id);
-        if (fresh) {
-          const idx2 = fresh.variants.findIndex(v => v.type === 'poster');
-          if (idx2 >= 0) fresh.variants[idx2] = posterVariant;
-          else fresh.variants.push(posterVariant);
-          try {
-            await File.updateOne({ _id: fresh._id }, { $set: { variants: fresh.variants } });
-          } catch (err2) {
-            logger.error('Retry failed committing poster variant', { fileId: file._id, error: err2 });
-          }
-        }
-      }
+      await this.upsertVariant(file, posterVariant);
 
       return posterVariant;
     } catch (error) {
       logger.error('Error ensuring video poster', { fileId: file._id, error });
       throw error;
+    }
+  }
+
+  /**
+   * Render a sized image variant from an already-in-memory source image and
+   * upload it under this file's variant key.
+   *
+   * Shared by BOTH image-variant paths — the source is the canonical original
+   * for an image file, and the extracted poster frame for a video — so the two
+   * cannot drift in format, quality or sizing. `rotate()` applies the source's
+   * EXIF orientation before resizing; it is a no-op on an ffmpeg-produced
+   * poster, which carries none.
+   */
+  private async renderAndUploadImageVariant(
+    file: IFile,
+    config: VariantConfigWithType,
+    sourceBuffer: Buffer
+  ): Promise<IFileVariant> {
+    const format = config.format || 'webp';
+    let pipeline = sharp(sourceBuffer, { failOn: 'none' })
+      .rotate()
+      .resize({ width: config.width, height: config.height, fit: 'inside', withoutEnlargement: true });
+    if (format === 'webp') pipeline = pipeline.webp({ quality: config.quality ?? 82 });
+    if (format === 'jpeg') pipeline = pipeline.jpeg({ quality: config.quality ?? 82 });
+    if (format === 'png') pipeline = pipeline.png();
+
+    const out = await pipeline.toBuffer();
+    // The output mime deliberately need not match the source's: the key carries
+    // its own `format` and the upload sets `contentType` explicitly, which is
+    // what lets a `video/*` file own an `image/webp` variant (the `poster`
+    // variant has always relied on the same property).
+    const key = this.generateVariantKey(file.sha256, config.type, format, file.visibility);
+    await this.s3Service.uploadBuffer(key, out, {
+      contentType: format === 'jpeg' ? 'image/jpeg' : `image/${format}`,
+    });
+
+    const imgMeta = await sharp(out).metadata();
+    return {
+      type: config.type,
+      key,
+      width: imgMeta.width || config.width || 0,
+      height: imgMeta.height || config.height || 0,
+      readyAt: new Date(),
+      size: out.length,
+      metadata: { format, quality: config.quality }
+    };
+  }
+
+  /**
+   * Persist a freshly generated variant onto the file document, replacing any
+   * entry of the same type.
+   *
+   * Retries once against a re-read document so a concurrent write to a
+   * DIFFERENT variant of the same file cannot drop this one. A failed retry is
+   * logged, never thrown: the bytes are already in S3, so losing the
+   * bookkeeping costs a regeneration on the next request, not the request in
+   * flight.
+   */
+  private async upsertVariant(file: IFile, variant: IFileVariant): Promise<void> {
+    const idx = file.variants.findIndex(v => v.type === variant.type);
+    if (idx >= 0) file.variants[idx] = variant;
+    else file.variants.push(variant);
+
+    try {
+      await this.commitVariants(file);
+      return;
+    } catch (error) {
+      logger.warn('Failed committing ensured variant, retrying fetch & update', {
+        fileId: file._id,
+        variantType: variant.type,
+        error,
+      });
+    }
+
+    const fresh = await File.findById(file._id);
+    if (!fresh) {
+      return;
+    }
+    const freshIdx = fresh.variants.findIndex(v => v.type === variant.type);
+    if (freshIdx >= 0) fresh.variants[freshIdx] = variant;
+    else fresh.variants.push(variant);
+    try {
+      await File.updateOne({ _id: fresh._id }, { $set: { variants: fresh.variants } });
+    } catch (retryError) {
+      logger.error('Retry failed committing ensured variant', {
+        fileId: file._id,
+        variantType: variant.type,
+        error: retryError,
+      });
     }
   }
 
@@ -1314,51 +1459,48 @@ export class VariantService {
       throw new Error(`Unsupported image variant: ${variantType}`);
     }
 
-    const originalBuffer = await this.s3Service.downloadBuffer(file.storageKey);
-    let pipeline = sharp(originalBuffer, { failOn: 'none' }).rotate();
-    pipeline = pipeline.resize({ width: config.width, height: config.height, fit: 'inside', withoutEnlargement: true });
-    const format = (config.format || 'webp');
-  if (format === 'webp') pipeline = pipeline.webp({ quality: config.quality ?? 82 });
-  if (format === 'jpeg') pipeline = pipeline.jpeg({ quality: config.quality ?? 82 });
-  if (format === 'png') pipeline = pipeline.png();
+    const sourceBuffer = await this.s3Service.downloadBuffer(file.storageKey);
+    const variant = await this.renderAndUploadImageVariant(file, config, sourceBuffer);
+    await this.upsertVariant(file, variant);
 
-    const out = await pipeline.toBuffer();
-    const key = this.generateVariantKey(file.sha256, variantType, format, file.visibility);
-    await this.s3Service.uploadBuffer(key, out, {
-      contentType: format === 'jpeg' ? 'image/jpeg' : `image/${format}`,
-    });
+    return variant;
+  }
 
-    const imgMeta = await sharp(out).metadata();
-    const variant: IFileVariant = {
-      type: variantType,
-      key,
-      width: imgMeta.width || config.width || 0,
-      height: imgMeta.height || config.height || 0,
-      readyAt: new Date(),
-      size: out.length,
-      metadata: { format, quality: config.quality }
-    };
-
-    // Upsert in DB
-    const idx = file.variants.findIndex(v => v.type === variantType);
-    if (idx >= 0) file.variants[idx] = variant;
-    else file.variants.push(variant);
-    try {
-      await this.commitVariants(file);
-    } catch (error) {
-      logger.warn('Failed committing single ensured variant, retrying fetch & update', { fileId: file._id, variantType, error });
-      // Retry once with fresh document to mitigate race conditions
-      const fresh = await File.findById(file._id);
-      if (fresh) {
-        const idx2 = fresh.variants.findIndex(v => v.type === variantType);
-        if (idx2 >= 0) fresh.variants[idx2] = variant; else fresh.variants.push(variant);
-        try {
-          await File.updateOne({ _id: fresh._id }, { $set: { variants: fresh.variants } });
-        } catch (err2) {
-          logger.error('Retry failed committing ensured variant', { fileId: file._id, variantType, error: err2 });
-        }
-      }
+  /**
+   * Ensure a sized IMAGE variant of a VIDEO — the same `w96`…`w2048`/`thumb`
+   * sizes an image file offers, rendered from that video's poster frame.
+   *
+   * Why this exists: `getFileDownloadUrl(id, variant)` is a synchronous, purely
+   * lexical URL builder, so a caller holding a bare file id CANNOT know whether
+   * it addresses an image or a video. Before this, a size name was fatal for a
+   * video — `assetService.ensureVariant` threw, and the public CDN origin turned
+   * that into a 404 carrying no bytes at all, which is why a cached video
+   * rendered a placeholder where an image rendered a thumbnail. A size name
+   * therefore now means "an image of this asset at that size" for EVERY mime,
+   * which for a video is its poster frame.
+   *
+   * Deriving from the poster rather than re-decoding holds this to ONE ffmpeg
+   * pass per file however many sizes are requested: the poster is generated once
+   * (or reused when upload-time generation already produced it) and each size is
+   * a Sharp resize of those bytes. Generation stays LAZY — the first request for
+   * a size materialises it, every later request is served the cached S3 object —
+   * so the existing corpus needs no backfill.
+   */
+  async ensureVideoImageVariant(file: IFile, variantType: string): Promise<IFileVariant> {
+    const existing = await this.getUsableReadyVariant(file, variantType);
+    if (existing) {
+      return existing;
     }
+
+    const config = this.imageVariants.find(v => v.type === variantType);
+    if (!config) {
+      throw new Error(`Unsupported video image variant: ${variantType}`);
+    }
+
+    const poster = await this.ensureVideoPoster(file);
+    const sourceBuffer = await this.s3Service.downloadBuffer(poster.key);
+    const variant = await this.renderAndUploadImageVariant(file, config, sourceBuffer);
+    await this.upsertVariant(file, variant);
 
     return variant;
   }


### PR DESCRIPTION
## The bug

`getFileDownloadUrl(id, variant)` is a synchronous, purely lexical URL builder, so a caller holding a bare file id **cannot know whether it addresses an image or a video**. Asking for a size name was nonetheless fatal for a video: `ensureVariant` handled `image/*` and the single `video/*` + `poster` pair and threw for everything else (`packages/api/src/services/assetService.ts:468`), and `routes/cdn.ts:79-86` turns a throwing probe into a **404 carrying no bytes** — never a fallback.

Measured against production before this change:

```
IMAGE 6a689588abe6d1a081112436  ?variant=thumb   -> 302
VIDEO 6a390d4b9d8fecf98a320181  ?variant=thumb   -> 404
VIDEO 6a390d4b9d8fecf98a320181  ?variant=poster  -> 302  (real JPEG 1080x1920, 242,919 B)
```

Full name matrix as it stood — an unknown name is a hard 404 for both mimes:

| variant | image file | video file |
|---|---|---|
| `w96 w128 thumb w320 w640 w1280 w2048` | 302 | **404** |
| `poster`, `hls_master` | 404 | 302 |
| `full`, `large`, `original` | 404 | 404 |

**Oxy has always generated a video poster frame** — it is just named `poster`, not `thumb`. There was no generation gap. The genuine gap is the other half: a video had **no sized render at all**, so the only working option served a 242 KB / 1080x1920 JPEG into a ~130px grid cell.

Downstream effect: a Mention video shipped a camera-icon placeholder, and caching a federated video into Oxy made its poster *worse* — before caching it came from Mention's own ffmpeg endpoint and worked; afterwards the resolver switched to the native `cloud.oxy.so` path and got the 404.

## The change

A size name now means "an image of this asset at that size" for **every** mime, which for a video is a render of its poster frame.

- `services/variantService.ts` — new `ensureVideoImageVariant`; extracted `renderAndUploadImageVariant` and `upsertVariant`, each of which was already duplicated across the two ensure paths and would otherwise have been copied a third time.
- `services/assetService.ts` — `ensureVariant` routes a video's non-`poster` name there. A name that is not a real size still throws, so a bogus variant keeps its 404.
- `.github/workflows/ci.yml` — explicit ffmpeg install for `api-test` rather than relying on the runner image's incidental contents.

Properties:

- **No backfill, no queue.** Generation is lazy — the first request for a size materialises it, every later request is served the cached S3 object. The existing corpus self-heals on first request.
- **Uploads unchanged.** No eager generation added; upload-time behaviour is byte-for-byte as before.
- **One ffmpeg pass per file, not per size** — sizes are Sharp resizes of the poster bytes. Pinned by a test.
- **Storage needed no change.** `generateVariantKey(sha256, type, format, visibility)` already takes `format` explicitly and `uploadBuffer` sets `contentType` explicitly; the `poster` variant (video/mp4 in → image/jpeg out) has always relied on that, so a differing output mime was already accommodated.

## SECURITY — a hardening fix rides along in this PR

This was not in the original brief and should not be discovered later by someone reading the diff.

`generatePosterFrame` had **no timeout, no output cap, and no protocol whitelist**, while being reachable **unauthenticated** from the public CDN origin (`GET /cdn/:id?variant=…`) and demuxing **user-uploaded bytes**. A crafted container (HLS/DASH playlist, or any format carrying an external reference) could name a URL for ffmpeg to open — including `file:///etc/passwd` — and the resulting frame is then **published at a public CDN key the attacker can read**. This PR widens the set of variant names that reach that decode, so bounding it is a precondition, not a nicety.

Added:

- `-protocol_whitelist` **derived from the input URL's own scheme**, with `file` never included. Derived rather than hardcoded so a deployment pointed at an `http://` S3-compatible endpoint (local MinIO) keeps working, while a production `https://` endpoint additionally denies cleartext `http` targets.
- A 30s wall-clock ceiling with `SIGKILL`, so a stuck or pathological decode cannot pin a worker.
- A 32 MiB cap on buffered stdout, so a crafted input cannot exhaust the process heap.
- `-nostdin` and `-loglevel error`.

## Verification — the control is the evidence

Real HTTP request → real express route → real `getPublicCdnUrl` → real `ensureVariant` → real ffmpeg → real Sharp. Only S3 and the Mongo model are substituted.

**Control: the new test against unmodified `origin/main`** — it reproduces the production symptom exactly:

```
FAIL src/routes/__tests__/cdnVideoImageVariant.test.ts
  ✕ 302s ?variant=thumb to a real webp rendered from the poster frame
  ✕ serves a size that is meaningfully smaller than the full poster
  ✕ decodes the poster only once no matter how many sizes are requested
  ✓ still 404s a variant name that is not a real size (control)
  ✓ still serves the poster under its own name

  ● 302s ?variant=thumb to a real webp rendered from the poster frame

    expect(received).toBe(expected) // Object.is equality

    Expected: 302
    Received: 404

      266 |     const res = await requestNoFollow(apiServer, `/cdn/${VIDEO_FILE_ID}?variant=thumb`);
      267 |
    > 268 |     expect(res.status).toBe(302);
          |                        ^

Tests:       3 failed, 2 passed, 5 total
```

3 fail, and the 2 that pass are precisely the two control cases that must pass either way — so the check discriminates rather than being vacuous.

With the change:

```
PASS src/routes/__tests__/cdnVideoImageVariant.test.ts
  ✓ 302s ?variant=thumb to a real webp rendered from the poster frame (154 ms)
  ✓ serves a size that is meaningfully smaller than the full poster (21 ms)
  ✓ decodes the poster only once no matter how many sizes are requested (53 ms)
  ✓ still 404s a variant name that is not a real size (control) (1 ms)
  ✓ still serves the poster under its own name (1 ms)
```

**Against real production bytes**, not just a synthetic clip: downloaded the actual 6,016,175-byte `6a390d4b9d8fecf98a320181` (h264 720x1280), ran the pipeline from scratch with no pre-existing poster — all 5 pass, and the produced bytes are a genuine video frame at `144x256`, **11,780 B against the 242,919 B poster (95% smaller)**. That run is deliberately not committed: a committed test must not depend on the network.

Full gates: `bun run build` exit 0, `tsc --noEmit` exit 0, eslint clean on changed files, full suite **240 suites / 2427 tests passing**.

## Notes

- No `@oxyhq/contracts` or `@oxyhq/core` change — deliberately, a Mention SDK bump is mid-flight against exactly those.
- `full` was **not** aliased. It exists in neither taxonomy and never has; Allo and Syra passing it is a separate bug with its own owner.
- Not fixed here: `360p`/`720p`/`1080p` also 404 on that production file even though upload-time generation should have produced them, and `ensureVariant` cannot regenerate them lazily. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)