### PR TITLE
fix(deploy): take the image digest from the build, not an ECR lookup

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -130,32 +130,26 @@ jobs:
       - name: Login to ECR
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push (linux/arm64)
         id: build
-        run: |
-          IMG=$ECR_REGISTRY/oxy/$APP
-          docker build -f "$DOCKERFILE" -t "$IMG:${{ github.sha }}" -t "$IMG:latest" .
-          docker push "$IMG:${{ github.sha }}"
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE }}
+          platforms: linux/arm64
+          push: true
           # :latest is still moved, but nothing that deploys reads it. It exists
           # so a from-scratch `terraform apply` -- whose app-service module
           # declares `<repo>:latest` as the task definition's bootstrap image --
           # creates the service on a current build rather than an ancient one.
-          docker push "$IMG:latest"
-
-          # Resolve the digest from the per-commit tag, which no other build
-          # ever reuses. This is the artefact the rollout pins: a tag is a
-          # mutable pointer, and a task definition pinned to one silently
-          # re-pulls whatever that tag means at task-placement time.
-          DIGEST=$(aws ecr describe-images \
-            --repository-name "oxy/$APP" \
-            --image-ids imageTag=${{ github.sha }} \
-            --query 'imageDetails[0].imageDigest' --output text)
-          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::ECR returned no usable digest for ${{ github.sha }} (got: ${DIGEST:-<empty>})"
-            exit 1
-          fi
-          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
-          echo "Resolved ${{ github.sha }} -> $DIGEST"
+          tags: |
+            ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}:${{ github.sha }}
+            ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}:latest
+          provenance: true
+          sbom: true
 
       - name: Register immutable task definition and deploy
         env:


### PR DESCRIPTION
Closes the `AccessDeniedException` that #760 introduced. oxy-api deploys are failing loudly at the digest lookup:

```
An error occurred (AccessDeniedException) when calling the DescribeImages operation:
User: arn:aws:sts::237343248947:assumed-role/oxy-github-deploy/GitHubActions is not
authorized to perform: ecr:DescribeImages on resource:
arn:aws:ecr:us-west-2:237343248947:repository/oxy/oxy-api
```

#760 verified the role's **ECS** grants (`RegisterTaskDefinition`, `UpdateService`, `DescribeTaskDefinition`, `DescribeServices`, `PassRole` — all present). The rollout then also needed an **ECR read**, and that was missed.

## Why not just grant `ecr:DescribeImages`

That works, but needs a Terraform change plus an apply, and adds a permission to a deploy role. Taking the digest from the build is better on its own merits and needs neither:

- The push already computes the digest; `docker/build-push-action` exposes it as `steps.build.outputs.digest`.
- That value is **definitionally the artefact this run just pushed**. A lookup by tag can race a concurrent push and hand back an image another run built — precisely the class of bug #760 exists to remove.
- Taken as a **step output, not parsed from the push log**, so a change in docker's stdout format cannot silently feed a wrong digest into production.

There is now **no `ecr:*` API call anywhere in the deploy path**; the only ECR interaction left is the docker push itself.

This also stops oxy-api being a third shape — it adopts the build step Mention already runs (buildx + `build-push-action`, provenance + SBOM).

## Verification — control, not assumption

Mention has run this exact mechanism in production for months, so its live data is the control. Its task-definition image reference comes from `steps.build.outputs.digest`; ECR resolves the same tag to the same digest:

```
$ aws ecs describe-task-definition --task-definition oxy-mention:120 \
    --query taskDefinition.containerDefinitions[0].image
.../oxy/mention@sha256:549ce13f7466ea3c6f21dd8858e2cbbc5ab03b52bbda6c4c63d8e2d6b51942e0

$ aws ecr describe-images --repository-name oxy/mention \
    --image-ids imageTag=8de160e8dcba1ce1411895f39b954a5542a2ae28 \
    --query imageDetails[0].imageDigest
sha256:549ce13f7466ea3c6f21dd8858e2cbbc5ab03b52bbda6c4c63d8e2d6b51942e0   # MATCH
```

That revision is the live one (`runningCount 2/2`, `rolloutState COMPLETED`), and it is an `application/vnd.oci.image.index.v1+json` — so attestation indexes pull fine on **the same `oxy-ecs-execution` / `oxy-ecs-task` roles oxy-api uses**, verified identical on both task definitions.

An empty digest cannot deploy anything — mutation-tested rather than assumed:

```
IMAGE_URI=".../oxy/oxy-api@"            -> ::error::IMAGE_URI must pin an immutable OCI digest  (exit 1)
IMAGE_URI=".../oxy/oxy-api@sha256:aaa…" -> passes the guard, proceeds to the AWS call
```

`bash .github/scripts/test-deploy-ecs-image.sh` → `Deployment script transaction tests passed.` (exit 0), gated by the `Deploy Script Tests` job.

**Not verified by deploying** — that needs a merge. After this lands, `describe-services … taskDefinition` should read `oxy-oxy-api:9`, with image `…/oxy/oxy-api@sha256:<digest of this commit>`.

## For the other four backends

`alia`, `allo`, `homiio` and `syra` pin `:latest`, which CI does push, so they deploy by mutable-tag luck today. They would each hit this same `DescribeImages` wall the moment the digest shape is ported. **This is the shape to port** — it needs no IAM change for any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)