### PR TITLE
fix(deploy): restore the deploy scripts to their cross-repo original

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -21,6 +21,7 @@ AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:-}"
 AWS_PARTITION="${AWS_PARTITION:-aws}"
 POST_DEPLOY_SMOKE_SCRIPT="${POST_DEPLOY_SMOKE_SCRIPT:-}"
 POST_DEPLOY_TASK_COMMAND_JSON="${POST_DEPLOY_TASK_COMMAND_JSON:-}"
+DEPLOY_HEAD_GUARD_SCRIPT="${DEPLOY_HEAD_GUARD_SCRIPT:-.github/scripts/require-current-main.sh}"
 
 if ! [[ "$MAX_WAIT_SECS" =~ ^[0-9]+$ ]] || (( MAX_WAIT_SECS < 1 )); then
   echo "::error::MAX_WAIT_SECS must be a positive integer."
@@ -36,6 +37,10 @@ if [[ "$RUN_MIGRATIONS" != "true" && "$RUN_MIGRATIONS" != "false" ]]; then
 fi
 if [[ -n "$POST_DEPLOY_SMOKE_SCRIPT" && ! -f "$POST_DEPLOY_SMOKE_SCRIPT" ]]; then
   echo "::error::POST_DEPLOY_SMOKE_SCRIPT does not exist: $POST_DEPLOY_SMOKE_SCRIPT"
+  exit 1
+fi
+if [[ -n "${DEPLOY_SHA:-}" && ! -f "$DEPLOY_HEAD_GUARD_SCRIPT" ]]; then
+  echo "::error::DEPLOY_HEAD_GUARD_SCRIPT does not exist: $DEPLOY_HEAD_GUARD_SCRIPT"
   exit 1
 fi
 if [[ -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]] &&
@@ -59,7 +64,7 @@ if ! jq -e '
     (
       .value
       | type == "string" and
-        test("^arn:aws(-[a-z]+)?:ssm:[a-z0-9-]+:[0-9]{12}:parameter/[A-Za-z0-9_.\\-/]+$")
+        test("^arn:aws(-[a-z]+)?:ssm:[a-z0-9-]+:[0-9]{12}:parameter/[A-Za-z0-9_./-]+$")
     )
   )
 ' <<<"$TASK_SECRET_OVERRIDES_JSON" >/dev/null; then
@@ -344,6 +349,11 @@ if [[ -n "$INTERNAL_METRICS_PARAMETER" ]]; then
       echo "::error::AWS_ACCOUNT_ID must be a 12-digit account id when INTERNAL_METRICS_PARAMETER is a parameter name."
       exit 1
     fi
+    # The hyphen is LAST on purpose. This is a POSIX bracket expression, where a
+    # backslash is an ordinary character rather than an escape, so the `\-/` that
+    # reads as an escaped hyphen in PCRE is really a reversed `\`-to-`/` range and
+    # the class then matches no hyphen at all. Every `/oxy/<app>/...` parameter
+    # path whose app name contains one was silently rejected.
     if [[ ! "$AWS_PARTITION" =~ ^aws(-[a-z]+)?$ ||
           ! "$INTERNAL_METRICS_PARAMETER" =~ ^/[A-Za-z0-9_./-]+$ ]]; then
       echo "::error::AWS partition or INTERNAL_METRICS_PARAMETER name is invalid."
@@ -466,6 +476,11 @@ if [[ "$RUN_MIGRATIONS" == "true" ]]; then
     '["bun","packages/backend/dist/scripts/migrate.js"]'; then
     exit 1
   fi
+fi
+
+if [[ -n "${DEPLOY_SHA:-}" ]]; then
+  echo "Re-verifying origin/main immediately before the ECS service update."
+  bash "$DEPLOY_HEAD_GUARD_SCRIPT"
 fi
 
 if ! aws ecs update-service \

--- a/.github/scripts/test-deploy-ecs-image.sh
+++ b/.github/scripts/test-deploy-ecs-image.sh
@@ -19,6 +19,10 @@ trap cleanup_test_directory EXIT
 
 export DEPLOY_TEST_LOG=""
 export DEPLOY_TEST_EXPECT_METRICS_ARN=false
+# The SSM parameter path a case feeds to INTERNAL_METRICS_PARAMETER, and from
+# which the mocked register-task-definition derives the ARN it demands. A case
+# overrides it to cover a path shape the default does not.
+export DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
 export DEPLOY_TEST_TASK_EXIT_CODE=0
 export DEPLOY_TEST_EXPECT_TASK_SECRET_ARN=false
 export DEPLOY_TEST_SERVICE_DESIRED_COUNT=1
@@ -29,7 +33,7 @@ aws() {
     "failures": [],
     "services": [{
       "status": "ACTIVE",
-      "taskDefinition": "arn:aws:ecs:test:task-definition/oxy-api-test:1",
+      "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:1",
       "desiredCount": 1,
       "networkConfiguration": {
         "awsvpcConfiguration": {
@@ -40,14 +44,14 @@ aws() {
       "launchType": "FARGATE",
       "deployments": [
         {
-          "taskDefinition": "arn:aws:ecs:test:task-definition/oxy-api-test:2",
+          "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:2",
           "status": "PRIMARY",
           "rolloutState": "COMPLETED",
           "runningCount": 1,
           "desiredCount": 1
         },
         {
-          "taskDefinition": "arn:aws:ecs:test:task-definition/oxy-api-test:1",
+          "taskDefinition": "arn:aws:ecs:test:task-definition/mention-test:1",
           "status": "PRIMARY",
           "rolloutState": "COMPLETED",
           "runningCount": 1,
@@ -74,7 +78,7 @@ aws() {
             "$describe_count" == "2" ]]; then
         service_json="$(jq '
           .services[0].deployments |= map(
-              if .taskDefinition == "arn:aws:ecs:test:task-definition/oxy-api-test:2"
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
               then
                 .rolloutState = "IN_PROGRESS"
                 | .desiredCount = 0
@@ -88,7 +92,7 @@ aws() {
         service_json="$(jq '
           .services[0].desiredCount = 0
           | .services[0].deployments |= map(
-              if .taskDefinition == "arn:aws:ecs:test:task-definition/oxy-api-test:2"
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
               then .desiredCount = 0 | .runningCount = 0
               else .
               end
@@ -98,7 +102,7 @@ aws() {
               "$describe_count" == "2" ]]; then
         service_json="$(jq '
           .services[0].deployments |= map(
-              if .taskDefinition == "arn:aws:ecs:test:task-definition/oxy-api-test:2"
+              if .taskDefinition == "arn:aws:ecs:test:task-definition/mention-test:2"
               then .desiredCount = 0 | .runningCount = 0
               else .
               end
@@ -109,19 +113,19 @@ aws() {
       ;;
     "ecs describe-task-definition")
       printf '%s\n' '{
-        "family": "oxy-api-test",
+        "family": "mention-test",
         "networkMode": "awsvpc",
         "requiresCompatibilities": ["FARGATE"],
         "cpu": "256",
         "memory": "512",
         "containerDefinitions": [{
-          "name": "oxy-api-test",
-          "image": "example.invalid/oxy-api-test:old",
+          "name": "mention-test",
+          "image": "example.invalid/mention-test:old",
           "essential": true,
           "logConfiguration": {
             "logDriver": "awslogs",
             "options": {
-              "awslogs-group": "/ecs/oxy-api-test",
+              "awslogs-group": "/ecs/mention-test",
               "awslogs-stream-prefix": "ecs"
             }
           }
@@ -140,16 +144,31 @@ aws() {
           fi
           previous_argument="$argument"
         done
-        jq -e '
+        # The verdict is written to the log rather than left to `set -e`. A
+        # command that fails in the MIDDLE of this function does not abort the
+        # run -- measured, and it holds whether the function is exported or
+        # local -- because the caller consumes it as `v="$(aws ...)"` and only
+        # the function's LAST command reaches that assignment's exit status. An
+        # assertion whose only effect is its own exit status therefore cannot
+        # fail, which is what this one did: pointing it at an ARN no case uses
+        # left the suite green. Logging a distinct token instead puts the
+        # mismatch in the expected.log diff, where it names itself.
+        if jq -e \
+          --arg expected \
+          "arn:aws:ssm:test:123456789012:parameter${DEPLOY_TEST_METRICS_PARAMETER}" \
+          '
           .containerDefinitions[]
-          | select(.name == "oxy-api-test")
+          | select(.name == "mention-test")
           | .secrets[]
           | select(
               .name == "INTERNAL_METRICS_TOKEN" and
-              .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/oxy-api/INTERNAL_METRICS_TOKEN"
+              .valueFrom == $expected
             )
-        ' "$input_json" >/dev/null
-        printf 'metrics:arn\n' >>"$DEPLOY_TEST_LOG"
+        ' "$input_json" >/dev/null; then
+          printf 'metrics:arn\n' >>"$DEPLOY_TEST_LOG"
+        else
+          printf 'metrics:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
+        fi
       fi
       if [[ "$DEPLOY_TEST_EXPECT_TASK_SECRET_ARN" == "true" ]]; then
         local previous_argument=""
@@ -162,18 +181,23 @@ aws() {
           fi
           previous_argument="$argument"
         done
-        jq -e '
+        # Same reason as the metrics assertion above: log the verdict, do not
+        # rely on this function's exit status.
+        if jq -e '
           .containerDefinitions[]
-          | select(.name == "oxy-api-test")
+          | select(.name == "mention-test")
           | .secrets[]
           | select(
-              .name == "EXTRA_TASK_SECRET" and
-              .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/oxy-api/EXTRA_TASK_SECRET"
+              .name == "MENTION_MCP_JWT_SECRET" and
+              .valueFrom == "arn:aws:ssm:test:123456789012:parameter/oxy/mention-mcp/MENTION_MCP_JWT_SECRET"
             )
-        ' "$input_json" >/dev/null
-        printf 'task-secret:arn\n' >>"$DEPLOY_TEST_LOG"
+        ' "$input_json" >/dev/null; then
+          printf 'task-secret:arn\n' >>"$DEPLOY_TEST_LOG"
+        else
+          printf 'task-secret:arn:MISMATCH\n' >>"$DEPLOY_TEST_LOG"
+        fi
       fi
-      printf '%s\n' "arn:aws:ecs:test:task-definition/oxy-api-test:2"
+      printf '%s\n' "arn:aws:ecs:test:task-definition/mention-test:2"
       ;;
     "ecs update-service")
       local previous_argument=""
@@ -202,7 +226,7 @@ aws() {
       printf 'reconcile\n' >>"$DEPLOY_TEST_LOG"
       printf '%s\n' '{
         "failures": [],
-        "tasks": [{"taskArn": "arn:aws:ecs:test:task/oxy-api-reconcile"}]
+        "tasks": [{"taskArn": "arn:aws:ecs:test:task/mention-reconcile"}]
       }'
       ;;
     "ecs describe-tasks")
@@ -212,7 +236,7 @@ aws() {
           "lastStatus": "STOPPED",
           "stoppedReason": "Essential container exited",
           "containers": [{
-            "name": "oxy-api-test",
+            "name": "mention-test",
             "exitCode": %s
           }]
         }]
@@ -270,10 +294,10 @@ run_release() {
   local -a release_environment=(
     AWS_REGION=test
     AWS_ACCOUNT_ID=123456789012
-    CLUSTER=oxy-api-test
-    APP=oxy-api-test
-    CONTAINER_NAME=oxy-api-test
-    IMAGE_URI="example.invalid/oxy-api-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    CLUSTER=mention-test
+    APP=mention-test
+    CONTAINER_NAME=mention-test
+    IMAGE_URI="example.invalid/mention-test@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     MAX_WAIT_SECS=5
     POLL_INTERVAL=1
     RUN_MIGRATIONS="$run_migrations"
@@ -282,12 +306,12 @@ run_release() {
   )
   if [[ "$inject_internal_metrics" == "true" ]]; then
     release_environment+=(
-      INTERNAL_METRICS_PARAMETER=/oxy/oxy-api/INTERNAL_METRICS_TOKEN
+      INTERNAL_METRICS_PARAMETER="$DEPLOY_TEST_METRICS_PARAMETER"
     )
   fi
   if [[ "$inject_task_secret" == "true" ]]; then
     release_environment+=(
-      TASK_SECRET_OVERRIDES_JSON='{"EXTRA_TASK_SECRET":"arn:aws:ssm:test:123456789012:parameter/oxy/oxy-api/EXTRA_TASK_SECRET"}'
+      TASK_SECRET_OVERRIDES_JSON='{"MENTION_MCP_JWT_SECRET":"arn:aws:ssm:test:123456789012:parameter/oxy/mention-mcp/MENTION_MCP_JWT_SECRET"}'
     )
   fi
 
@@ -308,7 +332,7 @@ run_release() {
 run_release success true false true
 printf '%s\n' \
   metrics:arn \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/success/expected.log"
@@ -316,10 +340,27 @@ diff -u \
   "$test_directory/success/expected.log" \
   "$test_directory/success/aws.log"
 
+# A hyphen in the parameter path is its own case because it is its own bug: the
+# bracket expression validating this name once matched every character EXCEPT a
+# hyphen, so /oxy/mention/... deployed and /oxy/oxy-api/... did not. Mention's
+# own path has no hyphen, which is why nothing here caught it. Keep both.
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention-mcp/INTERNAL_METRICS_TOKEN
+run_release hyphenated-metrics-parameter true false true
+DEPLOY_TEST_METRICS_PARAMETER=/oxy/mention/INTERNAL_METRICS_TOKEN
+printf '%s\n' \
+  metrics:arn \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  smoke \
+  reconcile \
+  >"$test_directory/hyphenated-metrics-parameter/expected.log"
+diff -u \
+  "$test_directory/hyphenated-metrics-parameter/expected.log" \
+  "$test_directory/hyphenated-metrics-parameter/aws.log"
+
 run_release explicit-task-secret true false false 0 true
 printf '%s\n' \
   task-secret:arn \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/explicit-task-secret/expected.log"
@@ -329,11 +370,11 @@ diff -u \
 
 run_release reconciliation-failure false false false 1
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
   smoke \
   reconcile \
   tasklogs \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:1:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
   >"$test_directory/reconciliation-failure/expected.log"
 diff -u \
   "$test_directory/reconciliation-failure/expected.log" \
@@ -368,7 +409,7 @@ fi
 
 run_release transient-zero-deployment true false false 0 false 1 transient-zero-deployment
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
   smoke \
   reconcile \
   >"$test_directory/transient-zero-deployment/expected.log"
@@ -382,21 +423,21 @@ grep -F \
 
 run_release zero-service-during-deploy false false false 0 false 1 zero-service-during-deploy
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:2:desired=1' \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:1:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
   >"$test_directory/zero-service-during-deploy/expected.log"
 diff -u \
   "$test_directory/zero-service-during-deploy/expected.log" \
   "$test_directory/zero-service-during-deploy/aws.log"
 grep -F \
-  "service oxy-api-test reached desiredCount=0 during the deployment rollout" \
+  "service mention-test reached desiredCount=0 during the deployment rollout" \
   "$test_directory/zero-service-during-deploy/output.log" \
   >/dev/null
 
 run_release completed-zero-deployment false false false 0 false 1 completed-zero-deployment
 printf '%s\n' \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:2:desired=1' \
-  'service:arn:aws:ecs:test:task-definition/oxy-api-test:1:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:2:desired=1' \
+  'service:arn:aws:ecs:test:task-definition/mention-test:1:desired=1' \
   >"$test_directory/completed-zero-deployment/expected.log"
 diff -u \
   "$test_directory/completed-zero-deployment/expected.log" \


### PR DESCRIPTION
> **Rebased onto `216b7fe5`.** #763 fixed the workflow and merged first; the workflow half of this PR is dropped as superseded. What remains is the two files #763 did not touch — and they had drifted from the copies in the other five repos.

```
.github/scripts/deploy-ecs-image.sh        +16/-1
.github/scripts/test-deploy-ecs-image.sh   +81/-40
```

## Byte-identity restored

Both files go back to blobs **`0dd66acd`** (`deploy-ecs-image.sh`) and **`9430a460`** (`test-deploy-ecs-image.sh`) — now identical in Mention, Alia, Allo, Homiio, Syra and here, mode included. That is what makes future drift checkable with `git rev-parse HEAD:<path>` instead of by reading six files. On `main` today they are `013cd6a4` / `9940af5a`.

Three things come back with them.

## 1. The harness's two ARN assertions could not fail

Measured on pristine `origin/main`, not inferred from the sibling repo:

```
$ # metrics ARN assertion pointed at a path no case uses
$ bash .github/scripts/test-deploy-ecs-image.sh
Deployment script transaction tests passed.        # exit 0
$ # same for the task-secret assertion
Deployment script transaction tests passed.        # exit 0
```

`jq -e`'s exit status was discarded. A command failing in the **middle** of a shell function consumed as `v="$(aws …)"` does not abort the run — only the function's last command reaches that assignment's exit status, and here that was a `printf`. Reproduced minimally, and it holds whether the function is exported or local, `case`-wrapped or not; a control with the failure as the last command *does* abort. `jq` had been returning 4 the whole time with nothing reading it.

Both now log a distinct token, so a mismatch lands in the `expected.log` diff and names itself.

## 2. A hyphenated-path case, and one idiom for the bracket class

`hyphenated-metrics-parameter` runs alongside the existing plain-path case, and the expected ARN is derived from the path the case feeds in rather than hardcoded in the mock.

The **jq** copy of the SSM class was never broken — Oniguruma honours `\-` — but it is the spelling that trapped the bash copy into rejecting every hyphenated path, so it is normalised to hyphen-last. One file carrying both idioms is how that bug recurs.

**Latent for oxy-api, and worth saying so:** this workflow passes no `INTERNAL_METRICS_PARAMETER` (and no `TASK_SECRET_OVERRIDES_JSON`), so the validator is never reached here today. It earns its place through byte-identity and through the next caller that does pass one — not because oxy-api is currently broken by it.

## 3. The `DEPLOY_HEAD_GUARD_SCRIPT` block #760 trimmed

Inert here — `main`'s workflow never sets `DEPLOY_SHA` (verified: no occurrence in the file) — and **verified inert rather than assumed**, by driving the *merged* workflow's own deploy step against this script with a mocked `aws`:

```
DESCRIBE service=oxy-api
REGISTER family=oxy-oxy-api container=oxy-api \
         image=…/oxy/oxy-api@sha256:7c…  secretsKept=DATABASE_URL
UPDATE   service=oxy-api taskdef=…/oxy-oxy-api:9
ECS rollout reached a healthy steady state
```

The mutable `:latest` is replaced with the digest, `DATABASE_URL` survives the re-render, no guard fires. And the guard is not vacuous — setting `DEPLOY_SHA` produces:

```
::error::DEPLOY_HEAD_GUARD_SCRIPT does not exist: .github/scripts/require-current-main.sh
```

which is the better failure than a silently skipped check.

## Verification

Mutation-tested on this rebased branch — not carried over from the pre-rebase run — each failing and naming the right thing, then restored byte-identical (`md5sum -c`):

| mutation | before | after |
|---|---|---|
| expected metrics ARN → `/bogus/NEVER` | **passed** (false green) | `-metrics:arn` / `+metrics:arn:MISMATCH` |
| expected task-secret ARN → `/bogus/NEVER` | **passed** (false green) | `-task-secret:arn` / `+task-secret:arn:MISMATCH` |
| bash class reverted to `[A-Za-z0-9_.\-/]` | n/a (no case covered it) | `Expected hyphenated-metrics-parameter to succeed` |

`Deploy Script Tests` in `ci.yml` already runs this harness on every PR, so the new case is gated here.

## Note on CI

`API Tests` is red and **that is pre-existing, not from this PR** — no file here is reachable from it. It has failed on every `CI/CD Pipeline` run on `main` since `3bec29c7` ("Merge origin/main into the Postgres port"), green on `4e58ce3a` immediately before, dying with `script "test:coverage" was terminated by signal SIGTERM`, exit 143, 8–12 minutes in. The variable duration points at a timeout or OOM rather than an assertion. Tracked separately.

A follow-up sweep will rename the harness's fixture family to something app-neutral across all six repos at once; doing it in this PR would re-diverge the file it is restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
