### PR TITLE
fix(api): make API Tests green again — runner memory, plus two regressions from the backfill split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,18 @@ jobs:
         run: bun run lint
         working-directory: ./packages/api
 
+      # `jest.config.js` sizes its worker pool from this machine's cores and RAM,
+      # because a fixed count that fits a 32-core workstation exhausts a
+      # 4-vCPU/16-GiB runner: the kernel takes the runner down mid-run and the
+      # job ends in exit 143 having printed no test results at all, which reads
+      # like a hung test rather than an exhausted machine. Print what it decided
+      # and what it decided it from, so the next time that shape changes the
+      # evidence is already in the log.
+      - name: Report test parallelism
+        run: |
+          node -e "const os=require('node:os');console.log('cpus=%d totalmem=%s GiB maxWorkers=%d',os.cpus().length,(os.totalmem()/1073741824).toFixed(1),require('./jest.config.js').maxWorkers)"
+        working-directory: ./packages/api
+
       - name: Run tests with coverage
         run: bun run test:coverage
         working-directory: ./packages/api

--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -7,6 +7,19 @@ export default defineConfig([
     ignores: ['dist/**', 'node_modules/**', 'coverage/**', '*.cjs', 'scripts/**'],
   },
   {
+    // `jest.config.js` is CommonJS — this package has no `"type": "module"` —
+    // so it reads node builtins with `require`, which the TS ruleset's
+    // ESM-only import rule flags. Every other jest config in this repo is
+    // `.cjs` and is already ignored above for exactly that reason; this one
+    // keeps the `.js` extension only because `.slugignore` and a dozen
+    // comments name it. Turn off the one rule that does not apply rather than
+    // renaming the file or dropping it from linting entirely.
+    files: ['jest.config.js'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+    },
+  },
+  {
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       ecmaVersion: 2022,

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -91,9 +91,21 @@ module.exports = {
   },
   transform: {
     '^.+\\.ts$': ['ts-jest', {
-      // Hybrid moduleKind in tsconfig emits TS151002 on every file; ignore it —
-      // isolatedModules is intentionally off for this package's tsc build.
-      diagnostics: { ignoreCodes: [151002] },
+      // OFF, not `{ ignoreCodes: [...] }`. The two are not "the same setting
+      // with a filter": `false` disables type-checking in the transform
+      // entirely, while ANY object turns the full check ON and merely excludes
+      // the listed codes. Narrowing it to silence the TS151002 config warning
+      // therefore enabled type-checking across a suite that has never had it,
+      // and 165 of 295 suites stopped running — TS2550 `Property 'cause' does
+      // not exist on type 'Error'` (a `lib` question), TS2307 for
+      // `@oxyhq/federation` (whose `dist` this job does not build), TS2339,
+      // TS7006. None of them is a test failure; the suites never execute.
+      //
+      // `tsc --noEmit` is where this package's types are gated. Turning the
+      // check on here as well is a defensible goal, but it is a real project —
+      // those 165 suites have to be fixed first — not a side effect of quieting
+      // a warning. The TS151002 line is noise on stderr and costs nothing.
+      diagnostics: false,
     }],
   },
   testMatch: ['**/__tests__/**/*.ts', '**/*.test.ts'],

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,16 +1,56 @@
+const { cpus, totalmem } = require('node:os');
+
+// Every worker opens its OWN Postgres pool against the one test server. With
+// `PG_MAX_POOL_SIZE = 8` (see `jest.globalSetup.ts`, where 8 is a floor set by
+// the backfill's own copy concurrency), 10 workers ask for at most 80
+// connections against a `max_connections` of 100 — under the ceiling with room
+// for the migrator's own session and a psql.
+//
+// Unbounded, jest forks one worker per core minus one, which on a 32-core
+// machine is 31 workers and up to 620 connections. The server then refuses
+// whichever worker happens to ask while it is saturated, so a different and
+// entirely innocent suite fails on each run. Five consecutive runs, five
+// different victims, every one green in isolation.
+const POSTGRES_WORKER_CEILING = 10;
+
+// That ceiling has to LOWER the worker count and never raise it. Written as a
+// bare `maxWorkers: 10` it did both, and on the machine CI actually runs on it
+// raised it: a GitHub-hosted `ubuntu-latest` runner has 4 vCPUs and 16 GiB, so
+// jest's own default there is 3 workers. Pinning 10 took the runner past its
+// memory and the kernel brought it down mid-run — five consecutive red runs on
+// `main`, each ending in `SIGTERM (Polite quit request)`, exit 143 and
+// `The runner has received a shutdown signal`, with not one test result
+// printed. That reads like a hung test rather than an exhausted machine, which
+// is what made it expensive to place.
+//
+// Measured on this suite in a cgroup held to the runner's shape (4 CPUs,
+// 16 GiB, no swap), peak ANONYMOUS bytes — page cache is reclaimable and does
+// not push a cgroup into OOM, so only anon counts: 3 workers = 7.06 GiB,
+// 10 workers = 13.68 GiB. Roughly a fixed 4.2 GiB for jest plus 0.95 GiB per
+// worker, because ts-jest holds a TypeScript program per worker and
+// `--coverage` instruments every file. 13.68 GiB does not fit in 16 GiB beside
+// the runner agent and the mongo and postgis service containers; 7.06 GiB does.
+const WORKER_BYTES = 1_000_000_000;
+const JEST_BASE_BYTES = 4_500_000_000;
+// A quarter of the machine left to the OS, docker and page cache.
+const MEMORY_BUDGET_FRACTION = 0.75;
+
+// The run has to be under all three ceilings, so take the smallest. On CI
+// (4 vCPUs, 16 GiB) that is the CPU bound at 3; on a 32-core workstation it is
+// the Postgres bound at 10, exactly as before. The memory bound only binds on a
+// machine with many cores and little RAM per core, where the CPU bound alone
+// would put us back where this started.
+const MAX_WORKERS = Math.min(
+  POSTGRES_WORKER_CEILING,
+  Math.max(1, cpus().length - 1),
+  Math.max(
+    1,
+    Math.floor((totalmem() * MEMORY_BUDGET_FRACTION - JEST_BASE_BYTES) / WORKER_BYTES)
+  )
+);
+
 module.exports = {
-  // Bounded because every worker opens its OWN Postgres pool against the one
-  // test server. With `PG_MAX_POOL_SIZE = 8` (see `jest.globalSetup.ts`, where
-  // 8 is a floor set by the backfill's own copy concurrency), 10 workers ask
-  // for at most 80 connections against a `max_connections` of 100 — under the
-  // ceiling with room for the migrator's own session and a psql.
-  //
-  // Unbounded, jest forks one worker per core minus one, which on a 32-core
-  // machine is 31 workers and up to 620 connections. The server then refuses
-  // whichever worker happens to ask while it is saturated, so a different and
-  // entirely innocent suite fails on each run. Five consecutive runs, five
-  // different victims, every one green in isolation.
-  maxWorkers: 10,
+  maxWorkers: MAX_WORKERS,
   preset: 'ts-jest',
   testEnvironment: 'node',
   // Creates ONE throwaway, fully-migrated Postgres database per run and points

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage --testPathIgnorePatterns='db/backfill/__tests__/(roundTrip|resolutions|reset|referentialIntegrity|orphanResolutions|bulkLoad)\\.test\\.ts'",
-    "test:backfill-integration": "jest --runInBand --maxWorkers=1 --testPathPattern='db/backfill/__tests__/(roundTrip|resolutions|reset|referentialIntegrity|orphanResolutions|bulkLoad)\\.test\\.ts'",
+    "test:backfill-integration": "jest --runInBand --testPathPattern='db/backfill/__tests__/(roundTrip|resolutions|reset|referentialIntegrity|orphanResolutions|bulkLoad)\\.test\\.ts'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck:scripts": "tsc -p tsconfig.scripts.json",


### PR DESCRIPTION
`API Tests` had been red on `main` for five consecutive runs. Fixing that exposed two more breaks that landed while I was working, so this PR is **three fixes in two commits**. Main is red for all three today.

---

## 1. The five-run failure: the worker pool was sized for a workstation

Not an assertion failure and not a timeout. From the CI logs ([run 30734136187](https://github.com/OxyHQ/OxyHQServices/actions/runs/30734136187)), jest printed **not one test result**, then:

```
error: script "test:coverage" was terminated by signal SIGTERM (Polite quit request)
##[error]The runner has received a shutdown signal.
##[error]Process completed with exit code 143.
```

Every post-step — including `Stop containers` — was `skipped`, which a normal step failure does not do. That is the runner being torn down. The delay varied between 3m09s and 12m27s across the five runs, so it was not a fixed timeout. The last green log is 1 MB of test output; each red one is ~128 KB of nothing but ts-jest warnings.

**Cause:** `maxWorkers: 10`, added by the Postgres port merge (`3bec29c7`). It was chosen as a **ceiling** — 10 workers x `PG_MAX_POOL_SIZE` 8 stays under Postgres' `max_connections` of 100, instead of the 31 a 32-core workstation would fork. As a bare constant it is also a **floor**, and on the machine CI runs on it raised the count: `ubuntu-latest` is 4 vCPUs / 15.6 GiB, where jest's own default is 3.

**Reproduction, which came before the fix.** Locally in a cgroup held to the runner's shape (4 CPUs, 16 GiB, no swap), against a real `postgis/postgis:17-3.5`. Peak **anonymous** bytes — page cache is reclaimable and does not drive a cgroup into OOM, so only anon counts:

| workers | peak anon | outcome |
|---|---|---|
| 10 (as-is) | **16.00 GiB - hit the cap** | killed, exit 143, **0 suites reported** |
| 3 | 7.06 GiB | green |

The 10-worker run reproduces CI byte-for-byte, down to the same `SIGTERM (Polite quit request)` and the total absence of test output. Uncapped, 10 workers needs **13.68 GiB** and passes — the suite is fine, it simply does not fit in 16 GiB beside the runner agent and the mongo and postgis service containers. The two points give ~4.2 GiB fixed plus ~0.95 GiB per worker (ts-jest holds a TypeScript program per worker; `--coverage` instruments every file).

**Fix:** take the smallest of three ceilings rather than one absolute — the Postgres connection ceiling, jest's own cores-1, and a memory budget.

| machine | workers |
|---|---|
| `ubuntu-latest` (4 vCPU / 15.6 GiB) | **3** |
| 8-core larger runner (32 GiB) | 7 |
| 32-core workstation (125 GiB) | **10** - unchanged |
| 16-core / 16 GiB | 8 (memory bound) |

**Confirmed in CI, not just locally:** the new `Report test parallelism` step printed `cpus=4 totalmem=15.6 GiB maxWorkers=3` on the first PR run, and that run's post-steps *ran* — no runner teardown. The OOM is gone.

---

## 2. `diagnostics: false` -> `{ ignoreCodes: [151002] }` turned type-checking ON

From `0efb4fc2`, to quiet the TS151002 config warning. Those are **not the same setting with a filter**: `false` disables type-checking in the transform, while *any object* enables the full check and merely excludes the listed codes.

So a change meant to remove log noise enabled type-checking across a suite that has never had it, and **165 of 295 suites stopped running** — `TS2550 Property 'cause' does not exist on type 'Error'` (a `lib` question), `TS2307` for `@oxyhq/federation` (whose `dist` this job does not build), TS2339, TS7006. Not one is a test failure; the suites never execute.

Verified pre-existing and independent of my change: on plain `origin/main@3906d123` with nothing of mine applied, those suites fail exactly this way locally; with `diagnostics: false` restored, the same two suites pass 73 tests.

`tsc --noEmit` still gates this package's types. Type-checking the test suite too is defensible, but it is a real project — those 165 suites must be fixed first — not a side effect of silencing a warning.

---

## 3. `test:backfill-integration` could never run

Also from `0efb4fc2`: the script passes both `--runInBand` and `--maxWorkers=1`, and jest refuses —

```
Both --runInBand and --maxWorkers were specified, only one is allowed.
```

The job dumped jest's usage text and exited 1 in **under a second**, every run, so those six suites have not executed since the split. `--runInBand` already means serial; the redundant flag is dropped. `--listTests` now resolves to exactly the six intended files.

---

## Verification

- **In CI:** the failure signature, its five-run consistency, the skipped post-steps, the green/red log-size contrast, `cpus=4 ... maxWorkers=3`, and the backfill job's one-second exit — all read from job logs, not inferred.
- **Locally**, against a real Postgres in a cgroup held to the runner's shape: the reproduction, the memory numbers, and **296 suites / 4242 tests green** on this branch.
- **Lint** is back to the pre-change baseline (0 errors, 92 warnings). The one eslint override is mutation-checked: without it, lint fails with 1 error.

**Deterministic, not flaky** — five for five, and the repro reproduces on demand.

**Scope note:** fixes 2 and 3 are not what I was asked to look at; they landed on `main` mid-investigation and `main` is red for them right now, so a PR claiming to fix `API Tests` that left them in place would not have produced a green pipeline. They are a separate commit and can be dropped independently.

One thing in the original report that turned out wrong: the merge that started this was not 17 files. Against the last green commit it is 516 files and ~229k insertions — the whole Mongo->Postgres port landing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
