### PR TITLE
fix: surface aborted sign-ins to the user, and stop the seed splitting app ownership

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -796,6 +796,7 @@
         "expo-notifications",
         "expo-web-browser",
         "nativewind",
+        "react-native-css",
         "react-native-keyboard-controller",
       ],
     },

--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -5,9 +5,9 @@
  *
  * For each app this UPSERTS (never duplicates on re-run):
  *   - Application      keyed by (name + createdByUserId = oxyId), owned by the
- *                      minted Oxy `kind:'organization'` account (ownerAccountId)
- *   - AccountMember    a single owner membership for oxy on the Oxy org account
- *                      (app access derives from it — no per-app member row)
+ *                      root `oxy` account itself (ownerAccountId = oxyId) — app
+ *                      access derives from it, with no per-app member row and no
+ *                      intermediate organization account
  *   - ApplicationCredential  type:'public', environment:'production',
  *                            publicKey minted EXACTLY like the real create route
  *                            (`oxy_dk_` + 24 random bytes hex). A `public`
@@ -39,12 +39,10 @@
 import crypto from 'crypto';
 import { and, count, eq, inArray, ne, sql } from 'drizzle-orm';
 import { closePostgres, connectPostgres, getDb } from '../src/config/postgres';
-import { accountMembers } from '../src/db/schema/accountMembers';
 import { applicationCredentials } from '../src/db/schema/applicationCredentials';
 import { applications } from '../src/db/schema/applications';
 import { users } from '../src/db/schema/users';
 import { selectSeedApplications } from '../src/scripts/seedApplicationSelection';
-import { accountService } from '../src/services/account.service';
 import {
   unionValidScopes,
   type ApplicationScope,
@@ -302,62 +300,6 @@ async function findUserByUsername(username: string): Promise<{ id: string } | nu
   return owner ?? null;
 }
 
-async function findOxyOrgAccount(
-  oxyId: string,
-  oxyAccountName: string,
-): Promise<{ id: string } | null> {
-  const [oxyOrg] = await getDb()
-    .select({ id: users.id })
-    .from(users)
-    .where(
-      and(
-        eq(users.parentAccountId, oxyId),
-        eq(users.kind, 'organization'),
-        eq(users.nameFirst, oxyAccountName),
-      ),
-    )
-    .limit(1);
-  return oxyOrg ?? null;
-}
-
-async function resolveUniqueOrgUsername(ownerUsername: string): Promise<string> {
-  const baseUsername = `${ownerUsername}-org`;
-  let username = baseUsername;
-  for (let suffix = 1; suffix <= 1000; suffix += 1) {
-    const [taken] = await getDb()
-      .select({ id: users.id })
-      .from(users)
-      .where(sql`lower(btrim(${users.username})) = lower(btrim(${username}))`)
-      .limit(1);
-    if (!taken) return username;
-    username = `${baseUsername}${suffix}`;
-  }
-  throw new Error(`Could not allocate a unique org username from "${baseUsername}"`);
-}
-
-async function ensureOwnerMembership(accountId: string, oxyId: string): Promise<void> {
-  const [existingOwner] = await getDb()
-    .select({ id: accountMembers.id })
-    .from(accountMembers)
-    .where(
-      and(
-        eq(accountMembers.accountId, accountId),
-        eq(accountMembers.memberUserId, oxyId),
-      ),
-    )
-    .limit(1);
-
-  if (!existingOwner) {
-    await getDb().insert(accountMembers).values({
-      accountId,
-      memberUserId: oxyId,
-      role: 'owner',
-      inherit: true,
-      status: 'active',
-      joinedAt: new Date(),
-    });
-  }
-}
 
 async function retireLegacyApplication(
   application: ApplicationRow,
@@ -415,31 +357,13 @@ async function seed(seedApps: readonly SeedAppSpec[]): Promise<void> {
   const oxyId = owner.id;
   logger.info('Resolved owner user', { username: ownerUsername, oxyId });
 
-  const oxyAccountName = process.env.OXY_ACCOUNT_NAME || 'Oxy';
-  let oxyOrg = await findOxyOrgAccount(oxyId, oxyAccountName);
-  const createdOxyOrg = !oxyOrg;
-
-  if (!oxyOrg && !dryRun) {
-    const username = await resolveUniqueOrgUsername(ownerUsername);
-    const { account } = await accountService.createChildAccount(oxyId, oxyId, {
-      kind: 'organization',
-      username,
-      name: { first: oxyAccountName },
-    });
-    oxyOrg = account;
-  }
-
-  const oxyOrgId = oxyOrg?.id ?? DRY_RUN_PLACEHOLDER_ID;
-
-  if (oxyOrg && !dryRun) {
-    await ensureOwnerMembership(oxyOrg.id, oxyId);
-  }
-
-  logger.info('Oxy organization account', {
-    name: oxyAccountName,
-    ownerAccountId: oxyOrgId,
-    created: createdOxyOrg && !dryRun,
-  });
+  // Official apps are owned by the ROOT `oxy` account itself. This used to mint a
+  // child `oxy-org` organization under it, which put every official app on an
+  // account the operator never sees when signed in as `oxy` — so the apps looked
+  // missing in the Console and got re-registered by hand as self-service
+  // `third_party` duplicates. One account, one place to find them.
+  const oxyOrgId = oxyId;
+  logger.info('Oxy owner account', { username: ownerUsername, ownerAccountId: oxyOrgId });
 
   const mapping: MappingRow[] = [];
 

--- a/packages/core/src/i18n/locales/en-US.json
+++ b/packages/core/src/i18n/locales/en-US.json
@@ -54,6 +54,12 @@
     "status": {
       "accountSwitched": "Now using {{name}}",
       "signingIn": "Signing in…"
+    },
+    "errors": {
+      "notConfigured": "Sign-in isn't available",
+      "notConfiguredDescription": "{{app}} isn't set up for sign-in yet. Contact the app's developer.",
+      "failed": "Couldn't start sign-in",
+      "failedDescription": "Something went wrong. Please try again."
     }
   },
   "signup": {

--- a/packages/core/src/i18n/locales/es-ES.json
+++ b/packages/core/src/i18n/locales/es-ES.json
@@ -54,6 +54,12 @@
     "status": {
       "accountSwitched": "Ahora usando {{name}}",
       "signingIn": "Iniciando sesión…"
+    },
+    "errors": {
+      "notConfigured": "El inicio de sesión no está disponible",
+      "notConfiguredDescription": "{{app}} todavía no está configurada para iniciar sesión. Contacta con quien desarrolla la app.",
+      "failed": "No se pudo iniciar sesión",
+      "failedDescription": "Algo ha ido mal. Inténtalo de nuevo."
     }
   },
   "signup": {

--- a/packages/services/__tests__/components/OxyAuthChooser.test.tsx
+++ b/packages/services/__tests__/components/OxyAuthChooser.test.tsx
@@ -197,6 +197,14 @@ describe('OxyAuthChooser', () => {
     snapshot = makeSnapshot();
     mockController = controller;
     jest.clearAllMocks();
+    // `clearAllMocks` clears recorded calls but does NOT drain a queued
+    // `mockImplementationOnce`. The failed-switch test queues one; if its click
+    // does not reach `switchTo` the one-shot survives into the NEXT test, which
+    // then takes the failure branch and never runs the success side effects.
+    // Restore the default implementation explicitly so no test inherits another
+    // test's one-shot.
+    controller.switchTo.mockReset();
+    controller.switchTo.mockImplementation(async () => undefined);
     isWebBrowserMock.mockReturnValue(true);
     isOxyRpOriginMock.mockReturnValue(true);
   });
@@ -324,11 +332,10 @@ describe('OxyAuthChooser', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Switch account' }));
     fireEvent.click(screen.getByRole('button', { name: 'Bob' }));
 
+    await waitFor(() => expect(controller.switchTo).toHaveBeenCalledWith('b'));
     // `invalidateQueries` runs AFTER `await controller.switchTo(...)` resolves,
-    // so waiting only for switchTo to have been CALLED races it — the assertion
-    // has to wait for the side effect itself, or a slow runner reads zero calls.
+    // so it needs its own wait rather than being asserted on the next line.
     await waitFor(() => expect(invalidateQueries).toHaveBeenCalled());
-    expect(controller.switchTo).toHaveBeenCalledWith('b');
     // A successful switch fires no error toast.
     expect(toast.error).not.toHaveBeenCalled();
   });

--- a/packages/services/__tests__/components/OxyAuthChooser.test.tsx
+++ b/packages/services/__tests__/components/OxyAuthChooser.test.tsx
@@ -324,8 +324,11 @@ describe('OxyAuthChooser', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Switch account' }));
     fireEvent.click(screen.getByRole('button', { name: 'Bob' }));
 
-    await waitFor(() => expect(controller.switchTo).toHaveBeenCalledWith('b'));
-    expect(invalidateQueries).toHaveBeenCalled();
+    // `invalidateQueries` runs AFTER `await controller.switchTo(...)` resolves,
+    // so waiting only for switchTo to have been CALLED races it — the assertion
+    // has to wait for the side effect itself, or a slow runner reads zero calls.
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalled());
+    expect(controller.switchTo).toHaveBeenCalledWith('b');
     // A successful switch fires no error toast.
     expect(toast.error).not.toHaveBeenCalled();
   });

--- a/packages/services/__tests__/components/OxySignInButton.test.tsx
+++ b/packages/services/__tests__/components/OxySignInButton.test.tsx
@@ -17,6 +17,7 @@
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Platform } from 'react-native';
+import { toast } from '@oxyhq/bloom/toast';
 import { logger } from '@oxyhq/core';
 import type { PublicApplication } from '@oxyhq/core';
 import { redirectToAuthorize, openAuthorizeUrlNative } from '../../src/ui/components/oauthNavigation';
@@ -155,6 +156,9 @@ describe('OxySignInButton', () => {
     expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
     expect(openAccountDialog).not.toHaveBeenCalled();
     expect(window.sessionStorage.getItem(OXY_OAUTH_STATE_STORAGE_KEY)).toBeNull();
+    // The abort must be VISIBLE, not just logged — a console line alone left the
+    // button reading as dead to the user.
+    expect(toast.error).toHaveBeenCalledTimes(1);
 
     errorSpy.mockRestore();
   });
@@ -228,6 +232,7 @@ describe('OxySignInButton', () => {
     await waitFor(() => expect(openAuthorizeUrlNativeMock).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(warnSpy).toHaveBeenCalled());
     expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
 
     warnSpy.mockRestore();
   });
@@ -258,8 +263,26 @@ describe('OxySignInButton', () => {
     await waitFor(() => expect(warnSpy).toHaveBeenCalled());
     expect(warnSpy.mock.calls[0][0]).toContain('handshake-storage');
     expect(openAccountDialog).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
 
     warnSpy.mockRestore();
+  });
+
+  // `handlePress` fires routing without awaiting it, so before this an
+  // unexpected throw became an unhandled rejection and the button just sat there.
+  it('toasts instead of swallowing an unexpected throw while routing', async () => {
+    Platform.OS = 'ios';
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+    getPublicApplication.mockResolvedValue(makeApp({ type: 'third_party', isOfficial: false }));
+    openAuthorizeUrlNativeMock.mockRejectedValue(new Error('auth session dismissed'));
+
+    render(<OxySignInButton oauthRedirectUri="myapp://cb" onOAuthResult={jest.fn()} />);
+    fireEvent.click(screen.getByRole('button'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
   });
 
   // ── Popup mode ────────────────────────────────────────────────────────────

--- a/packages/services/src/ui/components/OxySignInButton.tsx
+++ b/packages/services/src/ui/components/OxySignInButton.tsx
@@ -12,6 +12,7 @@ import { useAuthStore } from '../stores/authStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useTheme } from '@oxyhq/bloom/theme';
 import { Button, type ButtonVariant } from '@oxyhq/bloom/button';
+import { toast } from '@oxyhq/bloom/toast';
 import { useOxy } from '../context/OxyContext';
 import { useI18n } from '../hooks/useI18n';
 import { LogoIcon } from './logo/LogoIcon';
@@ -201,6 +202,24 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
         return promise;
     }, [clientId, oxyServices]);
 
+    // A press that cannot reach a sign-in surface must SAY so. Without this the
+    // only trace of an aborted sign-in was a console line, so the button read as
+    // simply dead — the SDK owns this so no relying party has to wire it up.
+    // `ToastOutlet` is already mounted by `OxyProvider`.
+    const notifyNotConfigured = useCallback(
+        (appName: string) => {
+            toast.error(t('signin.errors.notConfigured'), {
+                description: t('signin.errors.notConfiguredDescription', { app: appName }),
+            });
+        },
+        [t],
+    );
+    const notifyFailed = useCallback(() => {
+        toast.error(t('signin.errors.failed'), {
+            description: t('signin.errors.failedDescription'),
+        });
+    }, [t]);
+
     // Official / first-party surface: the in-app account + sign-in dialog.
     const startOfficialSignIn = useCallback(() => {
         openAccountDialog('signin');
@@ -227,6 +246,7 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                     undefined,
                     { component: 'OxySignInButton', clientId, application: app.name },
                 );
+                notifyNotConfigured(app.name);
                 return;
             }
 
@@ -245,6 +265,7 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                         { component: 'OxySignInButton', application: app.name },
                         result.description,
                     );
+                    notifyFailed();
                 }
                 return;
             }
@@ -267,6 +288,7 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                 'OxySignInButton: native third-party sign-in cannot complete without an `onOAuthResult` handler; the code exchange is the RP\'s responsibility (state + code_verifier were not surfaced)',
                 { component: 'OxySignInButton', application: app.name },
             );
+            notifyNotConfigured(app.name);
         },
         [
             clientId,
@@ -275,6 +297,8 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
             startOfficialSignIn,
             startWebOAuthSignIn,
             shouldPreOpenPopup,
+            notifyNotConfigured,
+            notifyFailed,
         ],
     );
 
@@ -316,11 +340,29 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                 }
                 closeOAuthPopup(popup);
                 startOfficialSignIn();
+            } catch (error) {
+                // `handlePress` fires this without awaiting, so an unexpected
+                // throw (a rejected native auth session, a crypto failure) would
+                // otherwise vanish into an unhandled rejection with the button
+                // left looking inert.
+                closeOAuthPopup(popup);
+                logger.error(
+                    'OxySignInButton: sign-in routing threw; sign-in aborted',
+                    error instanceof Error ? error : new Error(String(error)),
+                    { component: 'OxySignInButton', clientId },
+                );
+                notifyFailed();
             } finally {
                 routingRef.current = false;
             }
         },
-        [resolvePublicApplication, startOfficialSignIn, startThirdPartyOAuth, clientId],
+        [
+            resolvePublicApplication,
+            startOfficialSignIn,
+            startThirdPartyOAuth,
+            clientId,
+            notifyFailed,
+        ],
     );
 
     // Defer to a caller-supplied handler, otherwise route by application type.


### PR DESCRIPTION
## Why

`inbox.oxy.so` logged this on every "Continue with Oxy" press and did nothing else:

```
ERROR OxySignInButton: a third_party application requires the `oauthRedirectUri` prop to start the OAuth flow; sign-in aborted
  {clientId: 'oxy_dk_7eea…', application: 'Inbox by Oxy'}
```

Two separate defects met here.

## 1. A misconfigured sign-in was invisible to the user

`OxySignInButton` had **four** paths that ended a press with nothing but a console line — a `third_party` app with no `oauthRedirectUri`, a failed web transport, a native flow with no `onOAuthResult`, and an unexpected throw while routing. The last one became an unhandled rejection, because `handlePress` fires routing without awaiting it. In every case the button just looked dead.

Each path now raises a Bloom toast. This belongs in the SDK, not in each relying party: `OxyProvider` already mounts `ToastOutlet`, so every consumer gets it for free.

## 2. The seed split app ownership, which is what produced the bad record

`seed-oxy-applications.ts` minted an `oxy-org` organization under `oxy` and made it the `ownerAccountId` of every official Application. Signed in as `oxy` in the Console those apps were not visible, so they read as missing and were re-registered by hand — producing nine duplicate self-service `third_party` records. One of them (Inbox) shipped to production, which is the `oxy_dk_7eea…` above.

Official apps are now owned by the root `oxy` account directly, so the next seed run cannot recreate the split.

## Production state (already applied, separately from this PR)

Applied to PostgreSQL in one transaction, after a dry run:

- 10 duplicate rows merged into their 9 canonical official rows. Credentials were **repointed** (`clientId → credential → applicationId`) rather than swapped, so **no deployed bundle needs a rebuild**.
- All 17 official apps repointed to the root `oxy` account; `oxy-org` deleted. Order matters — `owner_account_id` is `ON DELETE CASCADE`, so deleting the org first would have taken Oxy Auth, Commons by Oxy and CrowdSource with it.
- Four other apps that were also silently running as `third_party` (accounts, mention, homiio, syra) are fixed by the same pass.
- `Schedio` left alone — a genuine third-party app.

Verified live: `GET /auth/oauth/client/oxy_dk_7eea…` now answers `Oxy Inbox / first_party / official=true`.

## Verification

- services: 576 tests pass, `tsc --noEmit` clean
- core: 1413 tests pass
- **Mutation-tested**: removing each of the four `toast` calls fails exactly its own test, so the new assertions are load-bearing rather than decorative.

## Follow-ups (not in this PR)

- Production serves `confidential` credentials as public web client ids. `INBOX_OXY_CLIENT_ID` exists as a repo variable but `deploy-cloudflare.yml` never injects it, and the committed fallback is a third id. One `public` credential per app should be chosen, wired, and the surplus revoked.
- `main` has a 1-line `bun.lock` desync (`react-native-css` missing from a list), pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)