### PR TITLE
chore(release): contracts 0.22.0, core 17.1.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -692,7 +692,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "26.0.2",
+      "version": "26.1.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "^17.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -408,7 +408,7 @@
     },
     "packages/contracts": {
       "name": "@oxyhq/contracts",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "dependencies": {
         "zod": "^3.25.64",
       },
@@ -421,7 +421,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "17.0.2",
+      "version": "17.1.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/contracts",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "OxyHQ API contracts — single source of truth for request/response Zod schemas and inferred types, shared by the backend and the client SDKs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oxyhq/core",
-  "version": "17.0.2",
-  "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
+  "version": "17.1.0",
+  "description": "OxyHQ SDK Foundation — API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oxyhq/services",
-  "version": "26.0.2",
-  "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
+  "version": "26.1.0",
+  "description": "OxyHQ Expo/React Native SDK — UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/commonjs/index.d.ts",


### PR DESCRIPTION
Releases the `channel` account kind (#776) so Mention can consume it.

Contracts moves first and publishes first: it now owns the account-kind vocabulary that the Drizzle schema, the Mongoose model, the SDK union and the create-account validator all derive from, and `core` depends on it via `workspace:^` — which `bun pm pack` rewrites to a caret on the **local** version. Publishing core against a contracts version not yet on the registry ships a manifest nobody can install.

Lockfile committed in the same commit as the manifests, per the house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)