### PR TITLE
chore(release): @oxyhq/core 17.0.3, @oxyhq/services 26.0.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -421,7 +421,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "17.0.2",
+      "version": "17.0.3",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -692,7 +692,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "26.0.4",
+      "version": "26.0.5",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",
@@ -746,7 +746,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.59.0",
-        "@oxyhq/core": "^17.0.2",
+        "@oxyhq/core": "^17.0.3",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": ">=11.4.1",
         "@tanstack/query-async-storage-persister": "catalog:",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "17.0.2",
+  "version": "17.0.3",
   "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "26.0.4",
+  "version": "26.0.5",
   "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -190,7 +190,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.59.0",
-    "@oxyhq/core": "^17.0.2",
+    "@oxyhq/core": "^17.0.3",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": ">=11.4.1",
     "@tanstack/query-async-storage-persister": "catalog:",


### PR DESCRIPTION
Version bump so the aborted-sign-in toast from #775 can reach consumers.

- `@oxyhq/core` 17.0.2 → **17.0.3** — adds the `signin.errors.*` locale keys (en-US, es-ES; every other locale falls back to English per-key, so none render a raw key).
- `@oxyhq/services` 26.0.4 → **26.0.5** — the `OxySignInButton` failure toast.
- Services' `@oxyhq/core` **peer** range `^17.0.2` → `^17.0.3`: the button reads those strings through `translate`, so 26.0.5 on an older core would show the raw `signin.errors.notConfigured` key as the toast title.

`bun.lock` moves exactly three lines (the two workspace versions and the peer range), stable across a repeat install. The lockfile was NOT regenerated from scratch — this repo sets `minimumReleaseAge = 604800`, so a from-scratch resolve would roll back anything published in the last week.

Verified: core 1416 tests, services 577 tests, both builds green, and the built artifacts carry the fix (`dist/{cjs,esm}/i18n/locales/es-ES.json` has the strings; `lib/module/ui/components/OxySignInButton.js` reads them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)