### PR TITLE
test(scopes): pin accounts:provision as privileged

### DIFF
--- a/packages/api/src/utils/__tests__/applicationScopes.test.ts
+++ b/packages/api/src/utils/__tests__/applicationScopes.test.ts
@@ -89,6 +89,22 @@ describe('scope classification helpers', () => {
     expect(isPrivilegedScope('signals:write')).toBe(true);
   });
 
+  /**
+   * `accounts:provision` mints accounts under, and grants membership to, users
+   * OTHER THAN the caller — an application acting for someone it names, with no
+   * bearer of theirs involved. That is authority beyond the app's own tenant, so
+   * it must never become self-grantable by an ordinary app owner.
+   *
+   * Deliberately argued from what the scope DOES, not from it being the only way
+   * to create a channel: a user creating one under their own account with their
+   * own bearer needs no scope at all, and pinning the rationale to that would
+   * make this comment false the moment that route changes.
+   */
+  it('recognises accounts:provision as a valid privileged scope', () => {
+    expect(isValidApplicationScope('accounts:provision')).toBe(true);
+    expect(isPrivilegedScope('accounts:provision')).toBe(true);
+  });
+
   it('treats a plain read scope as valid but not privileged', () => {
     expect(isValidApplicationScope('files:read')).toBe(true);
     expect(isPrivilegedScope('files:read')).toBe(false);


### PR DESCRIPTION
`accounts:provision` mints accounts under, and grants membership to, users **other than the caller** — an application acting for someone it names, with no bearer of theirs involved. That is authority beyond the app's own tenant, so it must never become self-grantable by an ordinary app owner.

Nothing asserted it: `applicationScopes.test.ts` covered `signals:write` and the payments pair, but not this one.

Mutation-tested — removing `accounts:provision` from `PRIVILEGED_APPLICATION_SCOPES` fails this test and nothing else.

## What this PR no longer does

It originally also granted Mention `accounts:provision` in the seed, on the premise that service provisioning was the only way a channel could be created. With the move to **(b)** — a signed-in user may create a channel under their own account, with their own bearer — that premise is gone, and the grant would be excess privilege. Dropped.

The service-scoped endpoints remain the right path for a backend provisioning on someone else's behalf; they are simply no longer the only one.

The test's rationale is deliberately argued from what the scope **does** rather than from it being the only door, so it stays true under either decision — the previous wording would have become false the moment that route changed.

## Verification

`applicationScopes.test.ts`: 16 passing. biome clean on the changed file. One file, additions only.
