### PR TITLE
feat(accounts)!: let a signed-in person create their own channel account

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -421,7 +421,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "17.1.0",
+      "version": "18.0.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -692,7 +692,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "26.1.0",
+      "version": "26.2.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",
@@ -746,7 +746,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.59.0",
-        "@oxyhq/core": "^17.0.3",
+        "@oxyhq/core": "^17.0.3 || ^18.0.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": ">=11.4.1",
         "@tanstack/query-async-storage-persister": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -508,7 +508,7 @@
     },
     "packages/federation": {
       "name": "@oxyhq/federation",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@oxyhq/core": "workspace:^",
       },

--- a/packages/api/src/routes/__tests__/accountsCreate.test.ts
+++ b/packages/api/src/routes/__tests__/accountsCreate.test.ts
@@ -1,9 +1,13 @@
 /**
  * POST /accounts — user-scoped account creation guards.
  *
- * Channel accounts are minted only through the service provisioning surface
- * (`POST /accounts/service/channels`); the user-facing create route must refuse
- * `kind: 'channel'` so a bearer with `children:create` cannot bypass that gate.
+ * Every CHILD kind is creatable here with the caller's own bearer, `channel`
+ * included. A channel was once refused, on the reasoning that channels are
+ * service-provisioned only — but what keeps a channel safe does not depend on
+ * who creates it: `createChildAccount` writes no auth method, and
+ * `POST /accounts/:id/switch` refuses the kind, so no session can ever have a
+ * channel as its subject. `personal` stays refused, by the schema: it is a human
+ * login, minted at signup.
  */
 
 import express from 'express';
@@ -114,17 +118,65 @@ describe('POST /accounts', () => {
 
   beforeEach(() => {
     mockCreateChildAccount.mockReset();
+    // The route destructures `{ account, membership }` and builds an AccountNode
+    // from it, so a bare `jest.fn()` returning undefined would throw before any
+    // status could be asserted — a 500 that reads like a refusal.
+    mockCreateChildAccount.mockImplementation(
+      async (_parentId: string, _actorId: string, input: { kind: string; username: string }) => ({
+        account: {
+          id: 'acct-new',
+          kind: input.kind,
+          username: input.username,
+          parentAccountId: OPERATOR_ID,
+          rootAccountId: OPERATOR_ID,
+        },
+        membership: { role: 'owner', permissions: ['children:create'] },
+      })
+    );
   });
 
-  it('refuses to create a channel account (400)', async () => {
+  it('creates a channel account with the caller\'s own bearer', async () => {
     const res = await request(server, {
       kind: 'channel',
       username: 'daily-news',
       name: { displayName: 'Daily News' },
     });
 
+    expect(res.status).toBe(201);
+    // The kind reaches the service unchanged — the route neither rewrites it nor
+    // routes a channel somewhere else.
+    expect(mockCreateChildAccount).toHaveBeenCalledWith(
+      OPERATOR_ID,
+      OPERATOR_ID,
+      expect.objectContaining({ kind: 'channel', username: 'daily-news' })
+    );
+  });
+
+  it.each(['organization', 'project', 'bot'])(
+    'still creates a %s account, unchanged',
+    async (kind) => {
+      const res = await request(server, { kind, username: `acct-${kind}` });
+
+      expect(res.status).toBe(201);
+      expect(mockCreateChildAccount).toHaveBeenCalledWith(
+        OPERATOR_ID,
+        OPERATOR_ID,
+        expect.objectContaining({ kind })
+      );
+    }
+  );
+
+  /**
+   * `personal` is the one kind this route must never mint: it is a human login,
+   * created at signup. It is refused by the SCHEMA (`childAccountKindSchema`),
+   * not by a handler check — which is why it is asserted here rather than
+   * assumed. Without it, a suite that only ever sends creatable kinds cannot
+   * tell a route that validates its input from one that does not.
+   */
+  it('refuses a personal account (400)', async () => {
+    const res = await request(server, { kind: 'personal', username: 'someone' });
+
     expect(res.status).toBe(400);
-    expect(res.body.message).toMatch(/service provisioning/i);
     expect(mockCreateChildAccount).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -768,12 +768,6 @@ router.post(
       organizationCategory?: OrganizationCategory;
     };
 
-    if (body.kind === 'channel') {
-      throw new BadRequestError(
-        'Channel accounts can only be created through service provisioning'
-      );
-    }
-
     const parentAccountId = body.parentAccountId ?? userId;
 
     // The caller must be allowed to create children on the chosen parent.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "17.1.0",
+  "version": "18.0.0",
   "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -136,7 +136,6 @@ export type {
     AccountCredentialWithSecret,
     RotateAccountCredentialResult,
     ListAccountsOptions,
-    UserCreatableAccountKind,
     CreateAccountInput,
     UpdateAccountInput,
     ProvisionChannelInput,

--- a/packages/core/src/mixins/OxyServices.accounts.ts
+++ b/packages/core/src/mixins/OxyServices.accounts.ts
@@ -33,7 +33,7 @@
  * registers the switched session into the operator's device-set directly).
  */
 import type { User } from '../models/interfaces';
-import type { AccountKind, OrganizationCategory } from '@oxyhq/contracts';
+import type { AccountKind, OrganizationCategory, ChildAccountKind } from '@oxyhq/contracts';
 import type { SessionLoginResponse } from '../models/session';
 import type { OxyServicesBase } from '../OxyServices.base';
 import { normalizeUserIdentity } from '../utils/userIdentity';
@@ -146,13 +146,23 @@ export interface ListAccountsOptions {
   tree?: boolean;
 }
 
-/** Kinds a signed-in user may create via `POST /accounts`. Channels are service-provisioned only. */
-export type UserCreatableAccountKind = 'organization' | 'project' | 'bot';
-
 /** Input accepted by `createAccount`. */
 export interface CreateAccountInput {
-  /** Classification of the new account. `personal` and `channel` are not creatable here. */
-  kind: UserCreatableAccountKind;
+  /**
+   * Classification of the new account. Every CHILD kind is creatable here with
+   * the caller's own bearer, `channel` included: a signed-in person has already
+   * proven who they are, and minting a child under their own tree is the same
+   * operation whichever kind it is.
+   *
+   * `channel` used to be excluded, on the reasoning that channels are
+   * service-provisioned only. What actually makes a channel safe does not depend
+   * on who creates it: `createChildAccount` writes no auth method, so it is born
+   * with no login, and `POST /accounts/:id/switch` refuses it via
+   * `isActAsEligibleKind`, so no session can ever have a channel as its subject
+   * and therefore no bearer exists that could add one. `personal` is excluded
+   * because it is a human login, minted at signup.
+   */
+  kind: ChildAccountKind;
   /**
    * Parent account `_id` to nest the new account under. Omitted → the API roots
    * it under the caller's personal account.

--- a/packages/federation/package.json
+++ b/packages/federation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/federation",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Oxy Federation — the app-agnostic ActivityPub identity + follow engine substrate: the network-connector contract, normalized cross-network DTOs, HTTP signatures, actor resolution, the outbound delivery transport + follow lifecycle, the inbound dispatcher, and the webfinger/actor/inbox Express routers. Domain-parameterized so every Oxy app backend federates under its own domain.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "26.1.0",
+  "version": "26.2.0",
   "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
@@ -190,7 +190,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.59.0",
-    "@oxyhq/core": "^17.0.3",
+    "@oxyhq/core": "^17.0.3 || ^18.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": ">=11.4.1",
     "@tanstack/query-async-storage-persister": "catalog:",

--- a/packages/services/src/ui/screens/CreateAccountScreen.tsx
+++ b/packages/services/src/ui/screens/CreateAccountScreen.tsx
@@ -21,12 +21,18 @@ type UsernameStatus = 'idle' | 'checking' | 'available' | 'taken' | 'invalid';
  * Kind of account this screen can create.
  *
  * A strict subset of what `POST /accounts` accepts, not `Exclude<AccountKind,
- * 'personal'>`: this screen SWITCHES INTO the account it just created, so it can
- * only offer kinds an operator may act as. `personal` is a signup-minted root,
- * and a `channel` is a content identity nobody occupies — creating one is
- * Mention's job, through the API. Spelling the subset out here is what keeps a
- * newly-added kind from silently inheriting the `project` label in
- * {@link kindLabel}'s fallback.
+ * 'personal'>`: this screen CREATES AND ENTERS in one gesture, so it can only
+ * offer kinds an operator may act as — `isActAsEligibleKind` is the same
+ * predicate the server enforces on `POST /accounts/:id/switch`.
+ *
+ * So `channel` is absent here even though `POST /accounts` accepts it from any
+ * signed-in caller: a channel is a content identity nobody occupies, and
+ * offering it would create the account and then fail the switch. The reason is
+ * this screen's own shape, NOT a rule about who may create a channel — that rule
+ * changed once already, and a comment tied to it would now be false.
+ *
+ * Spelling the subset out here is what keeps a newly-added kind from silently
+ * inheriting the `project` label in {@link kindLabel}'s fallback.
  */
 type CreatableAccountKind = Extract<AccountKind, 'organization' | 'project' | 'bot'>;
 

--- a/packages/services/src/ui/screens/CreateAccountScreen.tsx
+++ b/packages/services/src/ui/screens/CreateAccountScreen.tsx
@@ -245,6 +245,13 @@ const CreateAccountScreen: React.FC<BaseScreenProps> = ({
       // Switch INTO the new account (real-session switch — the whole app becomes
       // it). Best-effort: creation already succeeded, so a switch hiccup should
       // not surface as a create failure.
+      //
+      // That trade holds for a TRANSIENT failure and only for one. A kind the
+      // server refuses outright fails DETERMINISTICALLY — `/switch` answers 403
+      // every time, never sometimes — and this swallow would turn it into a
+      // created account, no switch, and no error anywhere. Which is why
+      // `CreatableAccountKind` above is a subset of what `POST /accounts`
+      // accepts rather than of what it rejects.
       if (account.accountId) {
         await switchToAccount(account.accountId).catch(() => undefined);
       }


### PR DESCRIPTION
`POST /accounts` refused `kind: 'channel'` and pointed the caller at service provisioning. **The guard carried no stated reason**, and the security argument in the commit that added it (`8730111f`) is about why the SERVICE routes are safe — not about why a person may not create their own channel.

## What keeps a channel safe does not depend on who creates it

- `createChildAccount` writes no auth method → a channel is born with no login, whoever mints it.
- `POST /accounts/:id/switch` refuses the kind via `isActAsEligibleKind` → no session can ever have a channel as its subject, so no bearer exists that could add an auth method to one. That property is untouched.

Minting a child under your own tree is the same operation whichever kind it is. Gating one kind behind a privileged, staff-only scope made adopting channels cost every app a scope request for "create a child account".

## Breaking

`UserCreatableAccountKind` is removed. With `channel` included it is identical to `ChildAccountKind`, and a type that aliases another is a shim this codebase does not keep — `CreateAccountInput.kind` names `ChildAccountKind` directly. Public type removal ⇒ **core 18.0.0**.

`@oxyhq/services` needs no code change and never referenced the removed type, so its peer range **widens** rather than moves — `^17.0.3 || ^18.0.0` — a minor (**26.2.0**).

The service-scoped provisioning endpoints stay; they are no longer the only door.

## Test

Inverted, plus the negative case that makes it non-vacuous: `personal` is still refused — by the schema, not by a handler check — so a suite made only of creatable kinds could not tell a route that validates its input from one that does not. The mock now returns a usable account, since a bare `jest.fn()` made the route throw on destructuring and produced a 500 that read like a refusal.

5 passing. `packages/api` typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)