### PR TITLE
fix(api): seed the origins the apps actually serve from

### DIFF
--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -173,9 +173,9 @@ const SEED_APPS: SeedAppSpec[] = [
   {
     name: 'Allo',
     description: 'Official Oxy encrypted messaging app.',
-    websiteUrl: 'https://allo.oxy.so',
+    websiteUrl: 'https://allo.you',
     type: 'first_party',
-    redirectUris: ['https://allo.oxy.so'],
+    redirectUris: ['https://allo.you', 'https://allo.oxy.so'],
   },
   {
     name: 'Alia',
@@ -187,9 +187,9 @@ const SEED_APPS: SeedAppSpec[] = [
   {
     name: 'Syra',
     description: 'Official Oxy app.',
-    websiteUrl: 'https://syra.oxy.so',
+    websiteUrl: 'https://syra.fm',
     type: 'first_party',
-    redirectUris: ['https://syra.oxy.so'],
+    redirectUris: ['https://syra.fm'],
   },
   {
     name: 'TNP',


### PR DESCRIPTION
## Symptom

Syra: `POST https://api.oxy.so/auth/session/create` → `403 Application origin is not allowed`.

## Why

`POST /auth/session/create` gates on the browser Origin, but **only for trusted apps**:

```ts
if (!oauthContext && isTrustedApplication(resolvedApp) && hasBrowserContext(req)) {
  if (!boundOrigin || (!applicationAllowsOrigin(resolvedApp, boundOrigin) && !isLoopbackOrigin(boundOrigin)))
    throw new ForbiddenError('Application origin is not allowed');
}
```

Syra's client id used to resolve to a duplicate `third_party` row, so the gate was skipped entirely and a wrong registry never showed. Merging that duplicate into the official `first_party` app (#775) made the gate apply — and the official record named `syra.oxy.so`, a host that no longer resolves, while Syra actually serves from `syra.fm`.

The same class of mismatch was latent elsewhere. Measured against the live gate:

| Origin | host | gate before | gate after |
|---|---|---|---|
| `https://syra.fm` | 200 | 403 | **200** |
| `https://dashboard.mercaria.co` | 200 | 403 | **200** |
| `https://pos.mercaria.co` | 200 | 403 | **200** |
| `https://fairco.in` | 200 | 403 | **200** |
| `https://allo.oxy.so` | 200 | 403 | **200** |
| `https://evil.example` | — | 403 | 403 (control) |
| `https://dashboard.mercaria.co` with the **Oxy Website** client | — | — | 403 (cross-app control) |

Mercaria's and Oxy Website's extra origins were already declared in `SEED_APPS` and simply never made it into the database, so registering them restores committed intent rather than widening trust. `console.crowdsource.oxy.so` is declared but does not resolve, so it was left alone.

## This change

Production was corrected directly (union, never replace). This commit fixes the seed so a future run cannot put the stale hosts back — `unionRedirectUris` only ever adds, so a wrong entry there is permanent once applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)