### PR TITLE
fix(accounts): `null` clears a bio or an avatar, as the SDK type has always said

### DIFF
--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -828,8 +828,8 @@ router.patch(
     const body = req.body as {
       username?: string;
       name?: { first?: string; last?: string; displayName?: string };
-      bio?: string;
-      avatar?: string;
+      bio?: string | null;
+      avatar?: string | null;
       description?: string;
       color?: string;
       links?: string[];
@@ -838,7 +838,13 @@ router.patch(
 
     const updated = await accountService.updateAccount(account.id, {
       ...body,
-      avatar: body.avatar !== undefined ? stripSensitiveUrlQueryParams(body.avatar) : undefined,
+      // `null` clears and must survive as `null`; only a real string is
+      // sanitised. Collapsing the two here would turn "remove my picture" into
+      // "leave it alone", which is silent and unreportable from the client.
+      avatar:
+        typeof body.avatar === 'string'
+          ? stripSensitiveUrlQueryParams(body.avatar)
+          : body.avatar,
     });
 
     const access = req.access;

--- a/packages/api/src/schemas/__tests__/updateAccountClear.test.ts
+++ b/packages/api/src/schemas/__tests__/updateAccountClear.test.ts
@@ -1,0 +1,87 @@
+import { updateAccountSchema } from '../account.schemas';
+
+/**
+ * `PATCH /accounts/:id` — clearing a field with `null`.
+ *
+ * The SDK's `UpdateAccountInput` types `bio` and `avatar` as `string | null` and
+ * documents `null` as the clear. This schema is `.strict()`, so until it accepted
+ * `null` the WHOLE request was rejected — an account with no bio and no picture
+ * could not save its NAME either, because the one field the caller set went down
+ * with the two they left empty. From the client that looked like "nothing saves".
+ *
+ * The fixtures that matter are the ones carrying `null`. A suite that only ever
+ * sends strings passes against a schema that rejects `null` and against one that
+ * accepts it — which is exactly how this shipped.
+ *
+ * Tested at the schema rather than through the route: the handler needs a live
+ * account context and a child count, and faking three layers to reach one
+ * `safeParse` would test the fake.
+ */
+describe('updateAccountSchema — clearing with null', () => {
+  /** The exact body the channel settings form sends with the other two empty. */
+  it('accepts a name alongside a null bio and a null avatar', () => {
+    const result = updateAccountSchema.safeParse({
+      name: { displayName: 'Daily News' },
+      bio: null,
+      avatar: null,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.bio).toBeNull();
+      expect(result.data.avatar).toBeNull();
+      expect(result.data.name).toEqual({ displayName: 'Daily News' });
+    }
+  });
+
+  it.each(['bio', 'avatar'] as const)('accepts %s cleared on its own', (field) => {
+    const result = updateAccountSchema.safeParse({ [field]: null });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data[field]).toBeNull();
+    }
+  });
+
+  it.each(['bio', 'avatar'] as const)('still accepts %s as a string', (field) => {
+    const result = updateAccountSchema.safeParse({ [field]: 'something' });
+    expect(result.success).toBe(true);
+  });
+
+  /**
+   * `null` and "absent" are different answers and the schema must keep them
+   * apart: one says remove it, the other says leave it alone. `updateAccount`
+   * branches on `!== undefined`, so collapsing them would make the clear
+   * unreachable while every request still succeeded.
+   */
+  it('keeps an omitted field distinct from a cleared one', () => {
+    const cleared = updateAccountSchema.safeParse({ bio: null });
+    const omitted = updateAccountSchema.safeParse({ name: { displayName: 'X' } });
+
+    expect(cleared.success && 'bio' in cleared.data).toBe(true);
+    expect(omitted.success && 'bio' in omitted.data).toBe(false);
+  });
+
+  /** The strictness that must survive the widening. */
+  it('still refuses an unknown field', () => {
+    expect(updateAccountSchema.safeParse({ nickname: 'nope' }).success).toBe(false);
+  });
+
+  it('still refuses a non-string, non-null bio', () => {
+    expect(updateAccountSchema.safeParse({ bio: 42 }).success).toBe(false);
+    expect(updateAccountSchema.safeParse({ bio: {} }).success).toBe(false);
+  });
+
+  it('still enforces the bio length bound', () => {
+    expect(updateAccountSchema.safeParse({ bio: 'x'.repeat(501) }).success).toBe(false);
+  });
+
+  /**
+   * `description`, `color` and `links` were NOT widened, deliberately: nothing
+   * types them as clearable, so accepting `null` there would be inventing a
+   * contract rather than honouring one.
+   */
+  it.each(['description', 'color'] as const)('does not accept null for %s', (field) => {
+    expect(updateAccountSchema.safeParse({ [field]: null }).success).toBe(false);
+  });
+});

--- a/packages/api/src/schemas/account.schemas.ts
+++ b/packages/api/src/schemas/account.schemas.ts
@@ -58,8 +58,13 @@ export const updateAccountSchema = z
   .object({
     username: z.string().trim().min(1).max(100).optional(),
     name: nameSchema,
-    bio: z.string().trim().max(500).optional(),
-    avatar: z.string().optional(),
+    // `null` CLEARS, and it has to be accepted here because the SDK's
+    // `UpdateAccountInput` types both as `string | null` and documents exactly
+    // that. Without `.nullable()` the schema rejects the WHOLE request, so an
+    // account with no bio and no picture could not save its NAME either — the
+    // one field the caller did set went down with the two they left empty.
+    bio: z.string().trim().max(500).nullable().optional(),
+    avatar: z.string().nullable().optional(),
     description: z.string().trim().max(1000).optional(),
     color: z.string().trim().max(32).optional(),
     links: z.array(z.string()).optional(),

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -523,8 +523,8 @@ export class AccountService {
     input: {
       username?: string;
       name?: { first?: string; last?: string; displayName?: string };
-      bio?: string;
-      avatar?: string;
+      bio?: string | null;
+      avatar?: string | null;
       description?: string;
       color?: string;
       links?: string[];


### PR DESCRIPTION
Editing a channel saved **nothing** — not the bio, not the picture, and **not the name either**.

The settings form sends `{ name, bio: null, avatar: null }` when the other two are empty. `updateAccountSchema` is `.strict()` and typed both as `.optional()` **without** `.nullable()`, so zod rejected the **whole request**. The one field the caller did set went down with the two they left blank, and the client got a 400 for a body its own types call valid.

## Three layers disagreed; only the middle one was wrong

| layer | says |
|---|---|
| `UpdateAccountInput` (SDK) | `bio?: string \| null`, `avatar?: string \| null`, `null` documented as the clear |
| `updateAccountSchema` (server) | **`null` rejected** |
| `accountService.updateAccount` | branches on `!== undefined`, stores `null` correctly |

Same shape as the `displayName` break earlier today: the SDK type and the server schema describing different contracts, with nothing compiling both together.

## `null` also has to survive the sanitiser

The avatar sanitiser ran on `!== undefined`, so a cleared avatar would have been handed to `stripSensitiveUrlQueryParams`. It now sanitises only a real string and passes `null` through. Collapsing the two would turn *"remove my picture"* into *"leave it alone"* — silent, and unreportable from the client because the request still answers 200.

`description`, `color` and `links` are deliberately **not** widened: nothing types them as clearable, so accepting `null` there would invent a contract rather than honour one.

## Tested at the schema, and mutation-verified

Not through the route: the handler needs a live account context and a child count, and faking three layers to reach one `safeParse` would test the fake.

Restoring `.optional()` without `.nullable()` fails **4 of 11** cases, including the exact body the form sends. **The seven that survive are the string and strictness cases** — a suite made only of those passes against both schemas, which is precisely how this shipped.

311 suites / 4460 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxyhqservices/pull/785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->