### PR TITLE
fix(core,services): stop two client-side identity caches serving pre-edit profiles

### DIFF
--- a/packages/core/src/mixins/OxyServices.accounts.ts
+++ b/packages/core/src/mixins/OxyServices.accounts.ts
@@ -37,6 +37,7 @@ import type { AccountKind, OrganizationCategory, ChildAccountKind } from '@oxyhq
 import type { SessionLoginResponse } from '../models/session';
 import type { OxyServicesBase } from '../OxyServices.base';
 import { normalizeUserIdentity } from '../utils/userIdentity';
+import { evictOxyIdentityCache } from '../utils/identityCacheSweep';
 import { CACHE_TIMES } from './mixinHelpers';
 
 // ---------------------------------------------------------------------------
@@ -736,6 +737,18 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
     /**
      * Update an account's mutable profile fields. Tree placement changes
      * (reparenting) go through the dedicated move endpoint, not here.
+     *
+     * An account IS a user, so this write changes identity — and a profile
+     * screen never reads `/accounts/<id>`. It reads `GET /users/<id>` and
+     * `GET /profiles/username/<handle>`, both cached for 5 minutes in the
+     * CALLER'S OWN process, so busting only the account-graph keys left every
+     * profile surface serving the pre-edit avatar and name for the full TTL
+     * with a perfectly healthy server (the cross-service `oxy:user:invalidate`
+     * signal does not help: it evicts BACKEND caches, and cannot reach a cache
+     * living in a browser tab). {@link evictOxyIdentityCache} owns that key
+     * list — see its docs for why the handle-keyed entries are prefix-swept
+     * (a RENAME leaves the old handle's entry unreachable by any targeted key).
+     *
      * @param accountId - The account's Mongo `_id`.
      * @param data - Subset of updatable profile fields.
      */
@@ -754,6 +767,16 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
         // data) so neither serves the pre-update snapshot.
         this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(accountId)}`);
         this._invalidateAccountLists();
+        // The parent's children list embeds this account's profile and is keyed
+        // by the PARENT id, so it is reachable only from the response node.
+        const parentAccountId = res.account?.parentAccountId;
+        if (parentAccountId) {
+          this.clearCacheEntry(
+            `GET:/accounts/${encodeURIComponent(parentAccountId)}/children`,
+          );
+        }
+        // Every identity read of this account, whichever key it lands under.
+        evictOxyIdentityCache(this, accountId);
         return res.account;
       } catch (error) {
         throw this.handleError(error);

--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -28,6 +28,7 @@ import {
 import { KeyManager } from '../crypto/keyManager';
 import { SignatureService } from '../crypto/signatureService';
 import { normalizeUserIdentity, normalizeUserIdentityOrNull } from '../utils/userIdentity';
+import { evictOxyIdentityCache } from '../utils/identityCacheSweep';
 import { logger } from '../logger';
 import { extractErrorStatus } from '../utils/errorUtils';
 
@@ -534,13 +535,15 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
     /**
      * Update user profile.
      *
-     * Invalidates the SDK-side response cache for every endpoint that
-     * returns the current user (`GET /users/me`, `GET /session/user/*`,
-     * `GET /users/<id>`, `GET /profiles/username/*`) so the next read
-     * doesn't return a stale snapshot. Without this, a follow-up
-     * `getUserBySession` call inside the 2-minute cache window can return
-     * the pre-update user — most visibly during onboarding, where it
-     * causes the username step to flicker back as if nothing was saved.
+     * Invalidates the SDK-side response cache for every endpoint that can
+     * return this user — the list is owned by {@link evictOxyIdentityCache}, so
+     * a new identity read is added in one place instead of to each writer
+     * separately (this method's own hand-written copy had already drifted from
+     * the server-side one, missing `GET /auth/lookup/*` and
+     * `GET /profiles/resolve`). Without the sweep a follow-up
+     * `getUserBySession` inside the cache window returns the pre-update user —
+     * most visibly during onboarding, where the username step flickers back as
+     * if nothing was saved.
      *
      * TanStack Query handles offline queuing automatically.
      */
@@ -550,15 +553,7 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
           await this.makeRequest<User>('PUT', '/users/me', updates, { cache: false }),
         );
 
-        // Bust every cached representation of the current user. We use a
-        // prefix sweep rather than an enumeration because the SDK never
-        // tracks the set of active session IDs centrally.
-        this.clearCacheByPrefix('GET:/session/user/');
-        this.clearCacheByPrefix('GET:/users/me');
-        this.clearCacheByPrefix('GET:/profiles/username/');
-        if (result?.id) {
-          this.clearCacheEntry(`GET:/users/${result.id}`);
-        }
+        evictOxyIdentityCache(this, result?.id);
 
         return result;
       } catch (error) {
@@ -615,10 +610,9 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
         const result = await this.makeRequest<PrivacySettings>('PATCH', `/privacy/${id}/privacy`, settings, {
           cache: false,
         });
-        this.clearCacheByPrefix('GET:/session/user/');
-        this.clearCacheByPrefix('GET:/users/me');
-        this.clearCacheByPrefix('GET:/profiles/username/');
-        this.clearCacheEntry(`GET:/users/${id}`);
+        // Privacy settings ride the user DTO, so every identity read goes stale
+        // too — same key list as any other profile write.
+        evictOxyIdentityCache(this, id);
         this.clearCacheEntry(`GET:/privacy/${id}/privacy`);
         return result;
       } catch (error) {

--- a/packages/core/src/mixins/__tests__/identityWriteCacheInvalidation.test.ts
+++ b/packages/core/src/mixins/__tests__/identityWriteCacheInvalidation.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Identity-cache invalidation for the profile WRITERS, against the REAL
+ * response cache.
+ *
+ * An account IS a user, and a profile screen never reads `/accounts/<id>` — it
+ * reads `GET /users/<id>` and `GET /profiles/username/<handle>`, both cached for
+ * five minutes in the caller's own process. `updateAccount` used to bust only
+ * the account-graph keys, so for up to five minutes after an edit a refetch
+ * handed back the PRE-EDIT profile from the client's own cache, with a
+ * perfectly healthy server ("I changed my channel's picture and it doesn't
+ * update until I reload the page").
+ *
+ * These tests drive the real `HttpService` cache over a mocked `fetch` rather
+ * than spying on `clearCacheEntry` / `clearCacheByPrefix`, because a spy proves
+ * only that SOME string was passed — not that the entry a read actually lands
+ * under was evicted. The load-bearing case is the RENAME: an implementation
+ * that busts the exact key for the handle in the write RESPONSE passes every
+ * assertion about the new handle while leaving the OLD handle's entry serving
+ * the pre-rename profile until its TTL. Both handles are warmed here so the two
+ * implementations disagree.
+ *
+ * `updateProfile` is covered here too, because it carried a SECOND, drifted
+ * hand-written copy of the same key list — it swept four of the six keys,
+ * missing `GET:/auth/lookup/` and `GET:/profiles/resolve`. Both writers now
+ * share one enumeration (`utils/identityCacheSweep`), and this is where that is
+ * asserted from the outside.
+ */
+
+import { OxyServices } from '../../OxyServices';
+import type { AccountNode } from '../OxyServices.accounts';
+
+/**
+ * A non-verified JWT whose payload decodes to the given claims — enough for the
+ * cache's identity tag and the bearer preflight (`jwtDecode` never checks a
+ * signature).
+ */
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (obj: Record<string, unknown>): string =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url({
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...payload,
+  })}.sig`;
+}
+
+/** A JSON `Response` in the API's `{ data: ... }` success envelope. */
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const ACCOUNT_ID = 'acc1';
+const PARENT_ID = 'root1';
+const OLD_USERNAME = 'oldhandle';
+const NEW_USERNAME = 'newhandle';
+
+/** The write response: the account after a rename + a new picture. */
+const renamedNode: AccountNode = {
+  accountId: ACCOUNT_ID,
+  kind: 'channel',
+  parentAccountId: PARENT_ID,
+  account: {
+    id: ACCOUNT_ID,
+    publicKey: 'pk-acc1',
+    username: NEW_USERNAME,
+    name: { displayName: 'Renamed Channel' },
+    avatar: 'file_new',
+  },
+  relationship: 'owner',
+  callerMembership: null,
+};
+
+describe('updateAccount identity-cache invalidation (real cache)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+  let oxy: OxyServices;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    oxy = new OxyServices({
+      baseURL: 'http://test.invalid',
+      enableRetry: false,
+      requestTimeout: 1000,
+    });
+    oxy.httpService.setTokens(makeJwt({ userId: 'operator-1' }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Warm every cache entry an account can be served under, plus one unrelated
+   * entry that must SURVIVE. Returns the number of network calls made, so each
+   * assertion below can be expressed as "did this read hit the network again".
+   */
+  async function warmCaches(): Promise<number> {
+    // The profile screen's two reads, under the handle it had BEFORE the edit
+    // and under the id.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, username: OLD_USERNAME }));
+    await oxy.getProfileByUsername(OLD_USERNAME);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, username: OLD_USERNAME }));
+    await oxy.getUserById(ACCOUNT_ID);
+
+    // The handle the account is ABOUT to be renamed to may already be warm (a
+    // 404-shaped read, a previous holder, a same-session preview). Warming it
+    // is what makes the old-handle assertion below non-vacuous: an
+    // implementation that busts only the response's handle passes for this one.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, username: NEW_USERNAME }));
+    await oxy.getProfileByUsername(NEW_USERNAME);
+
+    // The pre-session login lookup (carries avatar + display name) and handle
+    // resolution — two keys the SDK's own profile-write sweep had drifted away
+    // from, and which no test previously covered from a write.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ exists: true, username: OLD_USERNAME }));
+    await oxy.lookupUsername(OLD_USERNAME);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, username: OLD_USERNAME }));
+    await oxy.resolveProfile(`@${OLD_USERNAME}@test.invalid`);
+
+    // The account-graph reads.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ account: renamedNode }));
+    await oxy.getAccount(ACCOUNT_ID);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [renamedNode] }));
+    await oxy.listAccounts();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [renamedNode] }));
+    await oxy.listChildAccounts(PARENT_ID);
+
+    // An unrelated cached read. It must survive — the vacuity floor that tells
+    // a targeted sweep from a blanket `clearCache()`.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ count: 3 }));
+    await oxy.httpService.get('/notifications/unread-count', { cache: true });
+
+    return fetchMock.mock.calls.length;
+  }
+
+  /** Perform the rename + picture change. */
+  async function performUpdate(): Promise<void> {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ account: renamedNode }));
+    await oxy.updateAccount(ACCOUNT_ID, {
+      username: NEW_USERNAME,
+      avatar: 'file_new',
+    });
+  }
+
+  it('warms every read it later asserts on (control: all are cache hits before the write)', async () => {
+    const warmed = await warmCaches();
+
+    // Re-issue every read with no queued response. A cache MISS would call
+    // `fetch`, which now resolves `undefined` and throws — so a green run here
+    // is proof that each entry really is resident, and that the assertions
+    // below are measuring eviction rather than a cache that was never warm.
+    await oxy.getProfileByUsername(OLD_USERNAME);
+    await oxy.getProfileByUsername(NEW_USERNAME);
+    await oxy.getUserById(ACCOUNT_ID);
+    await oxy.lookupUsername(OLD_USERNAME);
+    await oxy.resolveProfile(`@${OLD_USERNAME}@test.invalid`);
+    await oxy.getAccount(ACCOUNT_ID);
+    await oxy.listAccounts();
+    await oxy.listChildAccounts(PARENT_ID);
+    await oxy.httpService.get('/notifications/unread-count', { cache: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(warmed);
+  });
+
+  it('evicts the OLD handle, not just the handle in the write response', async () => {
+    await warmCaches();
+    await performUpdate();
+    const afterWrite = fetchMock.mock.calls.length;
+
+    // THE assertion. `updateAccount` cannot know the pre-rename handle — it is
+    // in neither the request nor the response — so only a PREFIX sweep of
+    // `GET:/profiles/username/` reaches it. A targeted `clearCacheEntry` for
+    // the response's handle leaves this entry serving the pre-rename profile.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, username: NEW_USERNAME }));
+    const refetched = await oxy.getProfileByUsername(OLD_USERNAME);
+
+    expect(fetchMock).toHaveBeenCalledTimes(afterWrite + 1);
+    expect(refetched.username).toBe(NEW_USERNAME);
+  });
+
+  it('evicts the by-id profile read the account detail page uses', async () => {
+    await warmCaches();
+    await performUpdate();
+    const afterWrite = fetchMock.mock.calls.length;
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, avatar: 'file_new' }));
+    const refetched = await oxy.getUserById(ACCOUNT_ID);
+
+    expect(fetchMock).toHaveBeenCalledTimes(afterWrite + 1);
+    expect(refetched.avatar).toBe('file_new');
+  });
+
+  it('evicts the new handle, the login lookup, and handle resolution', async () => {
+    await warmCaches();
+    await performUpdate();
+    let calls = fetchMock.mock.calls.length;
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, username: NEW_USERNAME }));
+    await oxy.getProfileByUsername(NEW_USERNAME);
+    expect(fetchMock).toHaveBeenCalledTimes(++calls);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ exists: false, username: OLD_USERNAME }));
+    await oxy.lookupUsername(OLD_USERNAME);
+    expect(fetchMock).toHaveBeenCalledTimes(++calls);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, username: NEW_USERNAME }));
+    await oxy.resolveProfile(`@${OLD_USERNAME}@test.invalid`);
+    expect(fetchMock).toHaveBeenCalledTimes(++calls);
+  });
+
+  it('evicts the account detail, the account lists, and the PARENT children list', async () => {
+    await warmCaches();
+    await performUpdate();
+    let calls = fetchMock.mock.calls.length;
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ account: renamedNode }));
+    await oxy.getAccount(ACCOUNT_ID);
+    expect(fetchMock).toHaveBeenCalledTimes(++calls);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [renamedNode] }));
+    await oxy.listAccounts();
+    expect(fetchMock).toHaveBeenCalledTimes(++calls);
+
+    // Keyed by the PARENT id, which is reachable only from the response node —
+    // the child's own id does not build this key.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ accounts: [renamedNode] }));
+    await oxy.listChildAccounts(PARENT_ID);
+    expect(fetchMock).toHaveBeenCalledTimes(++calls);
+  });
+
+  it('leaves unrelated cached reads alone (it is a sweep, not a cache wipe)', async () => {
+    await warmCaches();
+    await performUpdate();
+    const afterWrite = fetchMock.mock.calls.length;
+
+    // No queued response: a miss would call `fetch` and throw.
+    const cached = await oxy.httpService.get<{ count: number }>(
+      '/notifications/unread-count',
+      { cache: true },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(afterWrite);
+    expect(cached.count).toBe(3);
+  });
+
+  it('does not sweep when the write fails', async () => {
+    await warmCaches();
+    const warmed = fetchMock.mock.calls.length;
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'forbidden' }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    await expect(
+      oxy.updateAccount(ACCOUNT_ID, { avatar: 'file_new' }),
+    ).rejects.toThrow();
+
+    // The failed PATCH is one call; every read below must still be a cache hit.
+    await oxy.getProfileByUsername(OLD_USERNAME);
+    await oxy.getUserById(ACCOUNT_ID);
+    await oxy.getAccount(ACCOUNT_ID);
+
+    expect(fetchMock).toHaveBeenCalledTimes(warmed + 1);
+  });
+
+  it('still sweeps the identity keys when the response carries no parent', async () => {
+    await warmCaches();
+    const rootNode: AccountNode = { ...renamedNode, parentAccountId: null };
+    fetchMock.mockResolvedValueOnce(jsonResponse({ account: rootNode }));
+    await oxy.updateAccount(ACCOUNT_ID, { avatar: 'file_new' });
+    const afterWrite = fetchMock.mock.calls.length;
+
+    // A root account has no children list to bust, but its identity keys go
+    // stale exactly the same way — the `parentAccountId` guard must not gate
+    // the identity sweep.
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: ACCOUNT_ID, avatar: 'file_new' }));
+    await oxy.getUserById(ACCOUNT_ID);
+
+    expect(fetchMock).toHaveBeenCalledTimes(afterWrite + 1);
+  });
+});
+
+describe('updateProfile identity-cache invalidation (real cache)', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+  let oxy: OxyServices;
+
+  const SELF_ID = 'me-1';
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    oxy = new OxyServices({
+      baseURL: 'http://test.invalid',
+      enableRetry: false,
+      requestTimeout: 1000,
+    });
+    oxy.httpService.setTokens(makeJwt({ userId: SELF_ID }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  /**
+   * The two keys `updateProfile`'s own hand-written sweep MISSED. They are the
+   * whole point of this block — a test that only re-checked `GET:/users/me` and
+   * `GET:/profiles/username/` would have passed against the drifted version.
+   */
+  it('evicts the login lookup and handle resolution, not just the keys it used to know', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ exists: true, username: 'alice', avatar: 'old' }));
+    await oxy.lookupUsername('alice');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'old' }));
+    await oxy.resolveProfile('@alice@test.invalid');
+
+    // Control: both are warm (a miss would call the un-queued mock and throw).
+    await oxy.lookupUsername('alice');
+    await oxy.resolveProfile('@alice@test.invalid');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'new' }));
+    await oxy.updateProfile({ avatar: 'new' });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ exists: true, username: 'alice', avatar: 'new' }));
+    await oxy.lookupUsername('alice');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'new' }));
+    await oxy.resolveProfile('@alice@test.invalid');
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('still evicts the self, by-id and handle reads it always did', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'old' }));
+    await oxy.getCurrentUser();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'old' }));
+    await oxy.getUserById(SELF_ID);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'old' }));
+    await oxy.getProfileByUsername('alice');
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'old' }));
+    await oxy.getUserBySession('sess-1');
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'new' }));
+    await oxy.updateProfile({ avatar: 'new' });
+
+    let calls = 5;
+    for (const read of [
+      () => oxy.getCurrentUser(),
+      () => oxy.getUserById(SELF_ID),
+      () => oxy.getProfileByUsername('alice'),
+      () => oxy.getUserBySession('sess-1'),
+    ]) {
+      fetchMock.mockResolvedValueOnce(jsonResponse({ id: SELF_ID, avatar: 'new' }));
+      await read();
+      expect(fetchMock).toHaveBeenCalledTimes(++calls);
+    }
+  });
+});

--- a/packages/core/src/server/__tests__/userInvalidation.test.ts
+++ b/packages/core/src/server/__tests__/userInvalidation.test.ts
@@ -2,10 +2,11 @@ import { OXY_USER_INVALIDATION_CHANNEL } from '@oxyhq/contracts';
 
 import {
   createOxyUserInvalidationHandler,
-  evictOxyIdentityCache,
   publishOxyUserInvalidation,
-  type OxyIdentityCacheEvictor,
 } from '../userInvalidation';
+// The key enumeration this subscriber sweeps is platform-neutral and shared
+// with the client mixins — see `utils/identityCacheSweep` and its own suite.
+import type { OxyIdentityCacheEvictor } from '../../utils/identityCacheSweep';
 
 function makePublisher() {
   const calls: Array<{ channel: string; message: string }> = [];
@@ -198,23 +199,5 @@ describe('@oxyhq/core/server createOxyUserInvalidationHandler', () => {
 
   it('is a no-op with no options configured', () => {
     expect(() => createOxyUserInvalidationHandler()(validMessage)).not.toThrow();
-  });
-});
-
-describe('@oxyhq/core/server evictOxyIdentityCache', () => {
-  it('clears the exact by-id entry and the handle-keyed prefixes', () => {
-    // The by-id key is exact. The handle-keyed ones cannot be derived from an
-    // id without the lookup being invalidated, so they are swept by prefix.
-    const { evictor, entries, prefixes } = makeEvictor();
-    evictOxyIdentityCache(evictor, 'abc123');
-
-    expect(entries).toEqual(['GET:/users/abc123']);
-    expect(prefixes).toEqual([
-      'GET:/session/user/',
-      'GET:/users/me',
-      'GET:/auth/lookup/',
-      'GET:/profiles/username/',
-      'GET:/profiles/resolve',
-    ]);
   });
 });

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -86,14 +86,17 @@ export { verifySecret } from './verifySecret';
 // changes, every consuming backend sweeps its caches instead of waiting out a TTL.
 export {
   createOxyUserInvalidationHandler,
-  evictOxyIdentityCache,
   publishOxyUserInvalidation,
 } from './userInvalidation';
 export type {
-  OxyIdentityCacheEvictor,
   OxyInvalidationPublisher,
   OxyUserInvalidationHandlerOptions,
 } from './userInvalidation';
+// The identity-key enumeration itself is platform-neutral (`src/utils/`) so the
+// client mixins and this Node-only subscriber sweep the SAME list — a second
+// copy is what let `updateAccount` and `updateProfile` drift apart.
+export { evictOxyIdentityCache, oxyUserByIdCacheKey, OXY_IDENTITY_CACHE_PREFIXES } from '../utils/identityCacheSweep';
+export type { OxyIdentityCacheEvictor } from '../utils/identityCacheSweep';
 
 // Registrable-apex (eTLD+1) derivation via the Public Suffix List — the SINGLE
 // SOURCE OF TRUTH shared with the IdP worker and the client FAPI auto-detect.

--- a/packages/core/src/server/userInvalidation.ts
+++ b/packages/core/src/server/userInvalidation.ts
@@ -6,10 +6,10 @@
  * Every Oxy backend caches Oxy identity, and none of them find out when it
  * changes. The `OxyServices` GET response cache holds `GET /users/:id` and
  * `GET /profiles/username/:name` for five minutes; it is swept when THIS process
- * writes the profile (see the `clearCacheEntry` calls in the user mixin) and
- * never when somebody else does — which is the normal case, since profiles are
- * edited in Oxy's own apps. So an avatar or display-name change is invisible to
- * every consuming backend for up to five minutes, per process.
+ * writes the profile (the `evictOxyIdentityCache` calls in the user and accounts
+ * mixins) and never when somebody else does — which is the normal case, since
+ * profiles are edited in Oxy's own apps. So an avatar or display-name change is
+ * invisible to every consuming backend for up to five minutes, per process.
  *
  * oxy-api broadcasts {@link OXY_USER_INVALIDATION_CHANNEL} on the shared Valkey
  * when a user's identity changes. This module is the consumer half: it parses
@@ -58,6 +58,10 @@ import {
   type OxyUserChangeReason,
   type OxyUserInvalidationEvent,
 } from '@oxyhq/contracts';
+import {
+  evictOxyIdentityCache,
+  type OxyIdentityCacheEvictor,
+} from '../utils/identityCacheSweep';
 
 /**
  * The publish surface of a Redis client. Both `ioredis` and `node-redis`
@@ -65,15 +69,6 @@ import {
  */
 export interface OxyInvalidationPublisher {
   publish(channel: string, message: string): unknown;
-}
-
-/**
- * The cache-eviction surface of an {@link OxyServices} instance. Declared
- * structurally so this Node-only module does not pull in the client.
- */
-export interface OxyIdentityCacheEvictor {
-  clearCacheEntry(key: string): void;
-  clearCacheByPrefix(prefix: string): number;
 }
 
 /**
@@ -201,27 +196,4 @@ export function createOxyUserInvalidationHandler(
       onError?.(error, raw);
     }
   };
-}
-
-/**
- * Sweep an `OxyServices` GET response cache of everything that could carry the
- * given user's identity.
- *
- * The by-id entry is exact. The by-username and resolve entries are keyed by
- * HANDLE, which cannot be derived from an id without the very lookup we are
- * invalidating, so those are swept by prefix — the same imprecision the SDK
- * already accepts when it sweeps its own cache after a local profile write, and
- * bounded by the fact that over-eviction costs a refetch and can never serve
- * wrong data.
- */
-export function evictOxyIdentityCache(oxy: OxyIdentityCacheEvictor, userId: string): void {
-  // Match the sweep the user mixin runs after a local profile write — session-
-  // bound and /users/me entries are keyed without the user id, so they must be
-  // prefix-swept on cross-service invalidation too.
-  oxy.clearCacheByPrefix('GET:/session/user/');
-  oxy.clearCacheByPrefix('GET:/users/me');
-  oxy.clearCacheByPrefix('GET:/auth/lookup/');
-  oxy.clearCacheEntry(`GET:/users/${userId}`);
-  oxy.clearCacheByPrefix('GET:/profiles/username/');
-  oxy.clearCacheByPrefix('GET:/profiles/resolve');
 }

--- a/packages/core/src/utils/__tests__/identityCacheSweep.test.ts
+++ b/packages/core/src/utils/__tests__/identityCacheSweep.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The identity cache-key enumeration, checked against the keys REAL reads
+ * produce.
+ *
+ * A list-equality assertion on `OXY_IDENTITY_CACHE_PREFIXES` alone would be
+ * satisfied forever by a typo (`GET:/profile/username/`) — it pins the list's
+ * shape, not its correctness. So the load-bearing test here drives each prefix
+ * from the SDK method that actually reads under it, over the real
+ * `HttpService` cache, and asserts the sweep evicts every one. A prefix that
+ * stops matching its read fails here rather than in production.
+ *
+ * The list is shared by every profile writer (`updateProfile`,
+ * `updatePrivacySettings`, `updateAccount`) and by the Node-only
+ * `oxy:user:invalidate` subscriber in `@oxyhq/core/server`, precisely because
+ * two hand-written copies of it had already drifted apart.
+ */
+
+import { OxyServices } from '../../OxyServices';
+import {
+  OXY_IDENTITY_CACHE_PREFIXES,
+  evictOxyIdentityCache,
+  oxyUserByIdCacheKey,
+  type OxyIdentityCacheEvictor,
+} from '../identityCacheSweep';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (obj: Record<string, unknown>): string =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url({
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...payload,
+  })}.sig`;
+}
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function makeRecordingEvictor() {
+  const entries: string[] = [];
+  const prefixes: string[] = [];
+  const evictor: OxyIdentityCacheEvictor = {
+    clearCacheEntry: (key) => {
+      entries.push(key);
+    },
+    clearCacheByPrefix: (prefix) => {
+      prefixes.push(prefix);
+      return 0;
+    },
+  };
+  return { evictor, entries, prefixes };
+}
+
+describe('evictOxyIdentityCache — the key list', () => {
+  it('sweeps every identity prefix and the exact by-id entry', () => {
+    const { evictor, entries, prefixes } = makeRecordingEvictor();
+    evictOxyIdentityCache(evictor, 'abc123');
+
+    expect(prefixes).toEqual([
+      'GET:/session/user/',
+      'GET:/users/me',
+      'GET:/auth/lookup/',
+      'GET:/profiles/username/',
+      'GET:/profiles/resolve',
+    ]);
+    expect(prefixes).toEqual([...OXY_IDENTITY_CACHE_PREFIXES]);
+    expect(entries).toEqual([oxyUserByIdCacheKey('abc123')]);
+  });
+
+  it('sweeps the prefixes but writes no by-id entry when the id is unknown', () => {
+    const { evictor, entries, prefixes } = makeRecordingEvictor();
+    evictOxyIdentityCache(evictor);
+
+    expect(prefixes).toEqual([...OXY_IDENTITY_CACHE_PREFIXES]);
+    expect(entries).toEqual([]);
+  });
+
+  it('treats an empty-string id as unknown rather than building `GET:/users/`', () => {
+    // `GET:/users/` would be a prefix-shaped key handed to an EXACT-match
+    // deleter, so it evicts nothing while looking like it evicted something.
+    const { evictor, entries } = makeRecordingEvictor();
+    evictOxyIdentityCache(evictor, '');
+    expect(entries).toEqual([]);
+  });
+});
+
+describe('evictOxyIdentityCache — every prefix matches a real read', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let fetchMock: jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+  let oxy: OxyServices;
+
+  const USER_ID = 'user-77';
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = jest.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    oxy = new OxyServices({
+      baseURL: 'http://test.invalid',
+      enableRetry: false,
+      requestTimeout: 1000,
+    });
+    oxy.httpService.setTokens(makeJwt({ userId: USER_ID }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  /** One real read per swept key, each warmed into the real response cache. */
+  const reads: ReadonlyArray<{
+    key: string;
+    warm: (client: OxyServices) => Promise<unknown>;
+  }> = [
+    { key: 'GET:/session/user/', warm: (c) => c.getUserBySession('sess-1') },
+    { key: 'GET:/users/me', warm: (c) => c.getCurrentUser() },
+    { key: 'GET:/auth/lookup/', warm: (c) => c.lookupUsername('alice') },
+    { key: 'GET:/profiles/username/', warm: (c) => c.getProfileByUsername('alice') },
+    { key: 'GET:/profiles/resolve', warm: (c) => c.resolveProfile('@alice@test.invalid') },
+    { key: 'GET:/users/<id>', warm: (c) => c.getUserById(USER_ID) },
+  ];
+
+  it('covers every prefix in the list with a read (no prefix goes unexercised)', () => {
+    // Vacuity floor: adding a prefix to the list without adding the read that
+    // exercises it fails HERE, rather than silently shrinking the test below.
+    expect(reads).toHaveLength(OXY_IDENTITY_CACHE_PREFIXES.length + 1);
+    for (const prefix of OXY_IDENTITY_CACHE_PREFIXES) {
+      expect(reads.some((read) => read.key === prefix)).toBe(true);
+    }
+  });
+
+  it.each(reads)('evicts the entry warmed by $key', async ({ warm }) => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: USER_ID, username: 'alice' }));
+    await warm(oxy);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Control: the entry really is warm (a miss would call the un-queued mock).
+    await warm(oxy);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    evictOxyIdentityCache(oxy, USER_ID);
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: USER_ID, username: 'alice-2' }));
+    await warm(oxy);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/utils/identityCacheSweep.ts
+++ b/packages/core/src/utils/identityCacheSweep.ts
@@ -1,0 +1,104 @@
+/**
+ * THE enumeration of `OxyServices` GET-cache keys that can carry a single
+ * account's identity, and the one sweep that clears them.
+ *
+ * WHY THIS IS ONE LIST
+ * --------------------
+ * An Oxy account is readable under SEVERAL cache keys, and a write that only
+ * busts the key it happens to know about leaves every other one serving the
+ * pre-write snapshot for up to its TTL — from the caller's OWN in-memory cache,
+ * with a perfectly healthy server. That failure has already shipped twice with
+ * two different sets of keys:
+ *
+ *   - `updateAccount` busted `GET:/accounts/<id>` and the account lists, but a
+ *     profile screen reads `GET:/profiles/username/<name>` and
+ *     `GET:/users/<id>`, so a channel's new picture stayed invisible for the
+ *     full 5-minute profile TTL.
+ *   - `updateProfile` busted four of the six keys below, missing
+ *     `GET:/auth/lookup/` (the login-flow avatar/display-name lookup) and
+ *     `GET:/profiles/resolve` (handle resolution) — two independently-drifted
+ *     copies of a list that has to agree.
+ *
+ * So the list lives here, once, and every writer calls
+ * {@link evictOxyIdentityCache}. Adding a new identity read means adding its key
+ * HERE and every writer inherits it.
+ *
+ * WHERE THE LINE IS DRAWN
+ * -----------------------
+ * These are the SINGLE-PROFILE reads — the account is the subject of the
+ * response and is addressable by id, handle, or session. Reads that merely
+ * CONTAIN an account among many (`GET:/profiles/search`,
+ * `GET:/users/<other>/followers`, `GET:/profiles/<other>/similar`) are
+ * deliberately NOT swept: an account cannot be located in them without the very
+ * lookup being invalidated, so sweeping them means sweeping the whole namespace
+ * on every identity change — a real cost on a backend consuming the
+ * cross-service invalidation signal, for a surface where a stale thumbnail
+ * expires on its own in ~2 minutes.
+ *
+ * WHY PREFIXES RATHER THAN EXACT KEYS
+ * -----------------------------------
+ * Only the by-id key can be built from a user id. The handle-keyed and
+ * session-keyed entries cannot — deriving a handle from an id needs the lookup
+ * we are invalidating, and the SDK never tracks active session ids centrally.
+ * Prefix sweeping is also what makes a USERNAME CHANGE correct: the entry under
+ * the OLD handle is unreachable by construction (nothing in the write response
+ * carries it), and a sweep targeted at the new handle alone would leave the old
+ * one serving the pre-rename profile until its TTL. Over-eviction costs a
+ * refetch; under-eviction serves wrong data.
+ *
+ * Platform-neutral by construction (no imports, no `OxyServices` reference) so
+ * the client mixins and the Node-only `@oxyhq/core/server` invalidation
+ * subscriber can share it without either pulling in the other.
+ */
+
+/**
+ * The cache-eviction surface of an `OxyServices` instance. Declared
+ * structurally so this module stays free of any client import.
+ */
+export interface OxyIdentityCacheEvictor {
+  clearCacheEntry(key: string): void;
+  clearCacheByPrefix(prefix: string): number;
+}
+
+/**
+ * Cache-key PREFIXES under which an account's identity can be served, for the
+ * reads whose key cannot be derived from a user id. Swept wholesale.
+ */
+export const OXY_IDENTITY_CACHE_PREFIXES: readonly string[] = [
+  // `getUserBySession` — keyed by session id, which the SDK never enumerates.
+  'GET:/session/user/',
+  // `getCurrentUser` (and `GET:/users/me/graph`, harmlessly included).
+  'GET:/users/me',
+  // `lookupUsername` — the pre-session login lookup; carries avatar + display name.
+  'GET:/auth/lookup/',
+  // `getProfileByUsername` — keyed by handle, including the pre-rename handle.
+  'GET:/profiles/username/',
+  // `resolveProfile` — keyed by fediverse handle in the query payload.
+  'GET:/profiles/resolve',
+];
+
+/**
+ * Build the exact cache key `getUserById` reads under. The only identity key
+ * derivable from a user id, so the only one that does not need a prefix sweep.
+ */
+export function oxyUserByIdCacheKey(userId: string): string {
+  return `GET:/users/${userId}`;
+}
+
+/**
+ * Sweep an `OxyServices` GET response cache of everything that could carry the
+ * given account's identity.
+ *
+ * @param oxy    - Anything exposing the SDK's two eviction methods.
+ * @param userId - The account whose by-id entry to drop. Optional: a caller
+ *                 that does not know the id still clears every handle-, session-
+ *                 and self-keyed entry, which is the majority of the surface.
+ */
+export function evictOxyIdentityCache(oxy: OxyIdentityCacheEvictor, userId?: string): void {
+  for (const prefix of OXY_IDENTITY_CACHE_PREFIXES) {
+    oxy.clearCacheByPrefix(prefix);
+  }
+  if (userId) {
+    oxy.clearCacheEntry(oxyUserByIdCacheKey(userId));
+  }
+}

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -173,9 +173,19 @@ export {
 // SDK's user query cache under both keys it owns (by-id + viewer-scoped
 // by-username). Consumers route ALL cache seeds (feed / list / search / profile
 // hydration) through this so a sparse source can never strip a field an
-// authoritative fetch already stored.
-export { upsertCachedUser, upsertCachedUsers } from './ui/hooks/queries/userCache';
-export type { CacheableUser } from './ui/hooks/queries/userCache';
+// authoritative fetch already stored. A write that DELIBERATELY empties a field
+// ("remove my picture") says so with `{ cleared: [...] }` — the payload cannot
+// express it, see the module docs.
+export {
+    upsertCachedUser,
+    upsertCachedUsers,
+    CLEARABLE_USER_FIELDS,
+} from './ui/hooks/queries/userCache';
+export type {
+    CacheableUser,
+    ClearableUserField,
+    UpsertCachedUserOptions,
+} from './ui/hooks/queries/userCache';
 
 // Mutation status aggregator (for "Syncing..." indicators)
 export { useMutationStatus } from './ui/hooks/useMutationStatus';

--- a/packages/services/src/ui/hooks/queries/__tests__/userCacheClear.test.ts
+++ b/packages/services/src/ui/hooks/queries/__tests__/userCacheClear.test.ts
@@ -1,0 +1,275 @@
+/**
+ * userCache — DELIBERATE CLEARS vs sparse sources.
+ *
+ * `upsertCachedUser` refuses an empty incoming value so a sparse feed/post/list
+ * author can never blank a field the authoritative profile fetch stored. That is
+ * right for a projection and wrong for a user who just removed their picture,
+ * and the payload cannot tell the two apart: oxy-api's `formatUserResponse`
+ * emits a cleared field as `undefined`, which `JSON.stringify` drops, so a
+ * cleared avatar and an uncarried one arrive byte-identical. The caller declares
+ * the difference with `{ cleared: [...] }`.
+ *
+ * WHAT MAKES THIS SUITE NON-VACUOUS
+ * ---------------------------------
+ * Every assertion here is paired: the SAME incoming payload is upserted once
+ * WITHOUT `cleared` and once WITH it, and the two must disagree. A suite whose
+ * fixtures only ever passed `cleared` could not tell "the guard was removed"
+ * from "the clear works", which is the whole risk — dropping the guard would
+ * blank real avatars across every Oxy app. The `does not` half of each pair is
+ * what pins the guard; `userCache.test.ts` keeps its own anti-degradation
+ * coverage independently.
+ */
+
+import { QueryClient } from '@tanstack/react-query';
+import {
+  CLEARABLE_USER_FIELDS,
+  upsertCachedUser,
+  upsertCachedUsers,
+} from '../userCache';
+import type { CacheableUser, ClearableUserField } from '../userCache';
+import { queryKeys } from '../queryKeys';
+import { useAuthStore } from '../../../stores/authStore';
+
+function makeClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function readById(qc: QueryClient, id: string): CacheableUser | undefined {
+  return qc.getQueryData<CacheableUser>(queryKeys.users.detail(id));
+}
+
+function readByUsername(
+  qc: QueryClient,
+  username: string,
+  viewerId: string,
+): CacheableUser | undefined {
+  return qc.getQueryData<CacheableUser>(
+    queryKeys.users.byUsername(username, viewerId),
+  );
+}
+
+/** A warm, fully-populated entry — what an authoritative profile fetch stored. */
+function seedFullEntry(qc: QueryClient, viewerId = ''): void {
+  const full = {
+    id: 'u1',
+    username: 'alice',
+    name: { displayName: 'Alice A', first: 'Alice' },
+    avatar: 'file_old',
+    bio: 'old bio',
+    description: 'old description',
+    color: 'teal',
+    organizationCategory: 'agency',
+    _count: { followers: 10, following: 5 },
+  };
+  qc.setQueryData(queryKeys.users.detail('u1'), full);
+  qc.setQueryData(queryKeys.users.byUsername('alice', viewerId), {
+    ...full,
+    relationship: { isFollowing: true, followsYou: true },
+  });
+}
+
+/**
+ * The write response for an account that just emptied everything, in the shape
+ * oxy-api's `formatUserResponse` actually produces — MEASURED, not assumed:
+ *
+ *   {"id":"acc1","publicKey":"pk","username":"chan","name":{},"languages":[]}
+ *
+ * The two details that matter and are easy to get wrong: every cleared scalar is
+ * OMITTED (serialized as `undefined`, which `JSON.stringify` drops), while
+ * `name` survives as a PRESENT-but-EMPTY object. Writing this fixture as
+ * `{ id, username }` instead — with no `name` key — routes `mergeName` down its
+ * "incoming absent" branch and leaves the "incoming present, displayName empty"
+ * branch untested; mutation-testing caught exactly that. Nothing in this object
+ * says "cleared", which is the whole point.
+ */
+const clearedResponse: CacheableUser = { id: 'u1', username: 'alice', name: {} };
+
+/**
+ * The same clear expressed the way a caller echoing its own REQUEST would send
+ * it: `UserProfileUpdate` clears a display name with `''`. It must land on the
+ * same result as the response shape above.
+ */
+const clearedByEmptyString: CacheableUser = {
+  id: 'u1',
+  username: 'alice',
+  name: { displayName: '' },
+};
+
+beforeEach(() => {
+  useAuthStore.setState({ user: null });
+});
+
+describe('upsertCachedUser — a declared clear empties the field', () => {
+  it.each(
+    CLEARABLE_USER_FIELDS.filter(
+      (field): field is Exclude<ClearableUserField, 'name.displayName'> =>
+        field !== 'name.displayName',
+    ),
+  )('drops a stale `%s` only when the caller declares it cleared', (field) => {
+    // WITHOUT the declaration: the guard holds, the stored value survives.
+    const guarded = makeClient();
+    seedFullEntry(guarded);
+    upsertCachedUser(guarded, clearedResponse, '');
+    expect(readById(guarded, 'u1')?.[field]).toBeDefined();
+
+    // WITH it: the same payload now empties exactly that field.
+    const cleared = makeClient();
+    seedFullEntry(cleared);
+    upsertCachedUser(cleared, clearedResponse, '', { cleared: [field] });
+    expect(readById(cleared, 'u1')?.[field]).toBeUndefined();
+  });
+
+  // Three `name` shapes, because `mergeName` branches on them and a single
+  // fixture leaves one branch untested (mutation-verified): the measured
+  // response carries `name: {}`, a request echo carries `name: {displayName:''}`,
+  // and a caller passing a bare object carries no `name` key at all.
+  it.each([
+    ['present but empty (the measured oxy-api shape)', clearedResponse],
+    ['an explicit empty displayName (the request shape)', clearedByEmptyString],
+    ['no `name` key at all', { id: 'u1', username: 'alice' } as CacheableUser],
+  ])(
+    'drops a stale display name only when declared — incoming name %s',
+    (_label, incoming) => {
+      const guarded = makeClient();
+      seedFullEntry(guarded);
+      upsertCachedUser(guarded, incoming, '');
+      expect(readById(guarded, 'u1')?.name).toEqual({
+        displayName: 'Alice A',
+        first: 'Alice',
+      });
+
+      const cleared = makeClient();
+      seedFullEntry(cleared);
+      upsertCachedUser(cleared, incoming, '', {
+        cleared: ['name.displayName'],
+      });
+      // `first` is not what was cleared and must survive — a clear is per-field,
+      // not "drop the whole `name` object".
+      expect(readById(cleared, 'u1')?.name).toEqual({ first: 'Alice' });
+    },
+  );
+
+  it('never lets the "Unknown user" sentinel survive a declared display-name clear', () => {
+    // The ghost-author sentinel is not a real value, so it must not block the
+    // clear either — it is "empty" for this purpose, exactly as it is for the
+    // anti-degradation guard.
+    const qc = makeClient();
+    seedFullEntry(qc);
+    upsertCachedUser(
+      qc,
+      { id: 'u1', username: 'alice', name: { displayName: 'Unknown user' } },
+      '',
+      { cleared: ['name.displayName'] },
+    );
+    expect(readById(qc, 'u1')?.name).toEqual({ first: 'Alice' });
+  });
+
+  it('clears under the by-username key too, not just by-id', () => {
+    const qc = makeClient();
+    seedFullEntry(qc, 'viewer-1');
+    upsertCachedUser(qc, clearedResponse, 'viewer-1', { cleared: ['avatar'] });
+
+    expect(readByUsername(qc, 'alice', 'viewer-1')?.avatar).toBeUndefined();
+    expect(readById(qc, 'u1')?.avatar).toBeUndefined();
+  });
+
+  it('clears ONLY the declared fields, leaving every other one intact', () => {
+    const qc = makeClient();
+    seedFullEntry(qc);
+    upsertCachedUser(qc, clearedResponse, '', { cleared: ['avatar'] });
+
+    const entry = readById(qc, 'u1');
+    expect(entry?.avatar).toBeUndefined();
+    // Vacuity floor: if a clear were implemented as "drop everything absent
+    // from the payload", all of these would be gone too and the test above
+    // would still pass.
+    expect(entry?.bio).toBe('old bio');
+    expect(entry?.description).toBe('old description');
+    expect(entry?.color).toBe('teal');
+    expect(entry?.name).toEqual({ displayName: 'Alice A', first: 'Alice' });
+    expect(entry?._count).toEqual({ followers: 10, following: 5 });
+  });
+
+  it('never drops the viewer relationship, whatever is declared', () => {
+    // `relationship` is not declarable (it is absent from CLEARABLE_USER_FIELDS)
+    // and is server-derived, never user-emptied. Dropping it is the
+    // "Follows you tag vanishes" bug this module exists to prevent.
+    const qc = makeClient();
+    seedFullEntry(qc, 'viewer-1');
+    upsertCachedUser(qc, clearedResponse, 'viewer-1', {
+      cleared: [...CLEARABLE_USER_FIELDS],
+    });
+
+    expect(readByUsername(qc, 'alice', 'viewer-1')?.relationship).toEqual({
+      isFollowing: true,
+      followsYou: true,
+    });
+    expect(readByUsername(qc, 'alice', 'viewer-1')?.username).toBe('alice');
+  });
+});
+
+describe('upsertCachedUser — a declared clear never beats a real value', () => {
+  it('keeps a meaningful incoming value for a field declared cleared', () => {
+    // The server-COMPOSED display name case: clearing the EXPLICIT name makes
+    // oxy-api return the composed one, which must be stored rather than
+    // blanked. Same rule for every field: `cleared` lowers the guard, it does
+    // not force an erasure.
+    const qc = makeClient();
+    seedFullEntry(qc);
+
+    upsertCachedUser(
+      qc,
+      {
+        id: 'u1',
+        username: 'alice',
+        name: { displayName: 'Alice Anderson' },
+        avatar: 'file_new',
+      },
+      '',
+      { cleared: ['name.displayName', 'avatar'] },
+    );
+
+    expect(readById(qc, 'u1')?.name).toEqual({
+      displayName: 'Alice Anderson',
+      first: 'Alice',
+    });
+    expect(readById(qc, 'u1')?.avatar).toBe('file_new');
+  });
+
+  it('treats an explicit null and an empty string as cleared, not as values', () => {
+    // oxy-api omits a cleared field, but `UpdateAccountInput` clears with `null`
+    // and `UserProfileUpdate` clears with `''`, so a caller echoing its own
+    // request must land on the same result as one passing the response.
+    for (const empty of [null, '', '   ']) {
+      const qc = makeClient();
+      seedFullEntry(qc);
+      upsertCachedUser(qc, { id: 'u1', username: 'alice', avatar: empty }, '', {
+        cleared: ['avatar'],
+      });
+      expect(readById(qc, 'u1')?.avatar).toBeUndefined();
+    }
+  });
+
+  it('is a no-op on a cold slot (nothing stale to drop)', () => {
+    const qc = makeClient();
+    upsertCachedUser(qc, clearedResponse, '', { cleared: ['avatar'] });
+
+    expect(readById(qc, 'u1')).toMatchObject({ id: 'u1', username: 'alice' });
+    expect(readById(qc, 'u1')?.avatar).toBeUndefined();
+    // The cold-slot stale-seed contract still holds.
+    expect(qc.getQueryState(queryKeys.users.detail('u1'))?.dataUpdatedAt).toBe(0);
+  });
+});
+
+describe('upsertCachedUsers — the batch path stays guarded', () => {
+  it('takes no clear declaration and never empties a field', () => {
+    // A batch is a multi-user projection: exactly the sparse source the guard
+    // exists for. If it ever grows a `cleared` option this test should fail.
+    const qc = makeClient();
+    seedFullEntry(qc);
+
+    upsertCachedUsers(qc, [{ id: 'u1', username: 'alice', avatar: null }], '');
+
+    expect(readById(qc, 'u1')?.avatar).toBe('file_old');
+  });
+});

--- a/packages/services/src/ui/hooks/queries/userCache.ts
+++ b/packages/services/src/ui/hooks/queries/userCache.ts
@@ -36,6 +36,33 @@
  *     never overwritten by a degraded/empty one (empty username, the
  *     `'Unknown user'` ghost-author sentinel, `null` avatar).
  *
+ * EXPRESSING A DELIBERATE CLEAR ("remove my picture")
+ * ---------------------------------------------------
+ * The anti-degradation rule above is right for a sparse source and wrong for a
+ * user who just emptied the field — and the two are NOT distinguishable from the
+ * payload. Measured against oxy-api's canonical serializer (`formatUserResponse`
+ * in `packages/api/src/utils/userTransform.ts`, which passes every field through
+ * `typeof value === 'string' ? value : undefined`): an account whose avatar,
+ * bio and display name were all just CLEARED serializes to
+ * `{"id":…,"publicKey":…,"username":…,"name":{},"languages":[]}` — byte-identical
+ * to the same account read as a sparse projection. There is no `null` and no
+ * `''` on the wire to key on. The information that a field was deliberately
+ * emptied exists ONLY at the call site that performed the write.
+ *
+ * So the caller declares it: `upsertCachedUser(qc, user, viewerId, { cleared:
+ * ['avatar'] })`. For a declared field an incoming EMPTY value means the field
+ * IS empty and the stale value is dropped; a MEANINGFUL incoming value still
+ * wins as usual (so `{ cleared: ['name.displayName'] }` on a personal account,
+ * where clearing the explicit name makes the server return the COMPOSED one,
+ * keeps the composed name rather than blanking it).
+ *
+ * A blanket "this source is authoritative, treat every absent field as cleared"
+ * flag was considered and rejected: because the two payloads are byte-identical,
+ * such a flag is an unverifiable promise about provenance, and the failure mode
+ * of getting it wrong is blanking real identity data in every Oxy app. Naming
+ * the fields states something the caller actually observed — which fields the
+ * user emptied — and bounds the damage to exactly those.
+ *
  * It is a cache write only — zero network, one `setQueryData` per key.
  */
 
@@ -77,6 +104,45 @@ export interface CacheableUser {
 
 /** The degraded display-name sentinel (ghost-author rule). */
 const DEGRADED_DISPLAY_NAME = "Unknown user";
+
+/**
+ * The profile fields a user can genuinely EMPTY through a real Oxy write, and
+ * for which "empty" is a state every renderer already handles.
+ *
+ * Deliberately a closed list rather than "any field": a clear DELETES data from
+ * the cache, so the blast radius of a mistaken declaration is bounded here
+ * instead of resting on each call site. `username` is absent because an account
+ * always has one; `_count` and `relationship` are absent because they are
+ * server-derived, never user-emptied — and dropping a viewer `relationship` is
+ * the exact "Follows you vanishes" bug this module exists to prevent.
+ *
+ * Each entry is clearable through a shipped write path: `avatar`, `bio`,
+ * `description` and `name.displayName` via `UserProfileUpdate` (`''` clears) and
+ * `UpdateAccountInput` (`null` clears), `color` and `organizationCategory` via
+ * their nullable fields.
+ */
+export const CLEARABLE_USER_FIELDS = [
+	"avatar",
+	"bio",
+	"description",
+	"color",
+	"organizationCategory",
+	"name.displayName",
+] as const;
+
+/** A field nameable in {@link UpsertCachedUserOptions.cleared}. */
+export type ClearableUserField = (typeof CLEARABLE_USER_FIELDS)[number];
+
+/** Options for {@link upsertCachedUser}. */
+export interface UpsertCachedUserOptions {
+	/**
+	 * Fields the write that produced this user DELIBERATELY emptied. For each,
+	 * an incoming empty value stops meaning "this source does not carry it" and
+	 * starts meaning "it is empty" — so the stale value is dropped rather than
+	 * preserved. Everything not named here keeps the anti-degradation guard.
+	 */
+	cleared?: readonly ClearableUserField[];
+}
 
 /** A cache entry always carries a resolved string `id`. */
 type CachedUser = CacheableUser & { id: string; name?: UserNameResponse };
@@ -142,23 +208,55 @@ function normalizeIncoming(user: CacheableUser): CachedUser | null {
 	return cached.id ? cached : null;
 }
 
-/** Merge two `name` objects field-by-field, with anti-degradation on `displayName`. */
+/**
+ * Copy a name WITHOUT its `displayName`. The key must end up ABSENT rather than
+ * present-and-`undefined`: consumers render `name.displayName` directly and fall
+ * back to the handle when it is missing, and a present-but-undefined key also
+ * changes what a later merge sees.
+ */
+function omitDisplayName(name: UserNameResponse): UserNameResponse {
+	const result: UserNameResponse = {};
+	for (const [key, value] of Object.entries(name)) {
+		if (key !== "displayName") result[key] = value;
+	}
+	return result;
+}
+
+/**
+ * Merge two `name` objects field-by-field, with anti-degradation on
+ * `displayName`.
+ *
+ * `clearDisplayName` is the declared-clear escape hatch: the incoming value
+ * still wins whenever it is meaningful (an account that clears its explicit
+ * display name gets the server-COMPOSED one back, which must not be discarded),
+ * and only a genuinely empty incoming value drops the stored one.
+ *
+ * Both incoming shapes reach the clear, and they are separate branches: the
+ * measured oxy-api response carries `name` as a PRESENT-but-empty object, while
+ * a caller passing a bare user object may carry no `name` key at all.
+ */
 function mergeName(
 	existing: UserNameResponse | undefined,
 	incoming: UserNameResponse | undefined,
+	clearDisplayName: boolean,
 ): UserNameResponse | undefined {
-	if (incoming === undefined) return existing;
+	if (incoming === undefined) {
+		if (!clearDisplayName || existing === undefined) return existing;
+		return omitDisplayName(existing);
+	}
 	if (existing === undefined) return incoming;
 	const merged: UserNameResponse = { ...existing };
 	for (const [key, value] of Object.entries(incoming)) {
 		if (key === "displayName") continue;
 		if (isMeaningful(value)) merged[key] = value;
 	}
-	// Never let an empty / `'Unknown user'` displayName overwrite a real one.
+	// Never let an empty / `'Unknown user'` displayName overwrite a real one —
+	// unless the caller declared that the user cleared it.
 	if (isMeaningfulDisplayName(incoming.displayName)) {
 		merged.displayName = incoming.displayName;
+		return merged;
 	}
-	return merged;
+	return clearDisplayName ? omitDisplayName(merged) : merged;
 }
 
 /** Merge `_count` field-by-field so a partial count never replaces a fuller one. */
@@ -203,13 +301,22 @@ function mergeRelationship(
  * When `includeRelationship` is false (the viewer-independent by-id key), the
  * viewer-relative `relationship` field is never read, written, or preserved —
  * only the by-username key carries it (`useUserByUsername`).
+ *
+ * `cleared` names the fields the write deliberately emptied. It is applied
+ * AFTER the merge, because the merge loop can only ever COPY a meaningful value
+ * — an emptied field is absent from `incoming` (see the module docs: oxy-api
+ * omits it entirely) and would otherwise survive from `existing` untouched.
  */
 function mergeUsers(
 	existing: CachedUser,
 	incoming: CachedUser,
-	options?: { includeRelationship?: boolean },
+	options?: {
+		includeRelationship?: boolean;
+		cleared?: readonly ClearableUserField[];
+	},
 ): CachedUser {
 	const includeRelationship = options?.includeRelationship ?? true;
+	const cleared = options?.cleared;
 	const merged: CachedUser = { ...existing };
 	for (const [key, value] of Object.entries(incoming)) {
 		if (key === "name" || key === "_count" || key === "relationship") continue;
@@ -219,7 +326,11 @@ function mergeUsers(
 		}
 		if (isMeaningful(value)) merged[key] = value;
 	}
-	const name = mergeName(existing.name, incoming.name);
+	const name = mergeName(
+		existing.name,
+		incoming.name,
+		cleared?.includes("name.displayName") ?? false,
+	);
 	if (name !== undefined) merged.name = name;
 	const count = mergeCount(existing._count, incoming._count);
 	if (count !== undefined) merged._count = count;
@@ -232,6 +343,12 @@ function mergeUsers(
 	} else {
 		merged.relationship = undefined;
 	}
+	if (cleared) {
+		for (const field of cleared) {
+			if (field === "name.displayName") continue; // handled by `mergeName`.
+			if (!isMeaningful(incoming[field])) delete merged[field];
+		}
+	}
 	return merged;
 }
 
@@ -240,9 +357,15 @@ function upsertOneKey(
 	queryClient: QueryClient,
 	key: readonly unknown[],
 	incoming: CachedUser,
-	options: { includeRelationship: boolean },
+	options: {
+		includeRelationship: boolean;
+		cleared?: readonly ClearableUserField[];
+	},
 ): void {
-	const mergeOpts = { includeRelationship: options.includeRelationship };
+	const mergeOpts = {
+		includeRelationship: options.includeRelationship,
+		cleared: options.cleared,
+	};
 	const existing = queryClient.getQueryData<CacheableUser>(key);
 	if (existing === undefined) {
 		// Cold slot: seed the full incoming object, STALE, so react-query refetches
@@ -284,20 +407,27 @@ function resolveViewerId(viewerId?: string): string {
  * @param user        A `User`-shaped object (may be sparse).
  * @param viewerId    The active viewer id for the by-username key. Defaults to
  *                    the current auth-store user id.
+ * @param options     `cleared` names the fields the write deliberately emptied
+ *                    — the ONLY way "remove my picture" can propagate, since a
+ *                    cleared field and an uncarried one are byte-identical on
+ *                    the wire (see the module docs).
  */
 export function upsertCachedUser(
 	queryClient: QueryClient,
 	user: CacheableUser,
 	viewerId?: string,
+	options?: UpsertCachedUserOptions,
 ): void {
 	const incoming = normalizeIncoming(user);
 	if (!incoming) return;
+	const cleared = options?.cleared;
 
 	// By-id identity entry (read by `useUserById`). Not viewer-scoped — never store
 	// the viewer-relative `relationship` here or one viewer's follow state leaks
 	// into every other viewer's by-id cache entry.
 	upsertOneKey(queryClient, queryKeys.users.detail(incoming.id), incoming, {
 		includeRelationship: false,
+		cleared,
 	});
 
 	const username = incoming.username;
@@ -307,7 +437,10 @@ export function upsertCachedUser(
 		// the key through the SAME helper the hook uses so username normalization
 		// (`trim().toLowerCase()`) matches byte-for-byte.
 		const key = queryKeys.users.byUsername(username, resolveViewerId(viewerId));
-		upsertOneKey(queryClient, key, incoming, { includeRelationship: true });
+		upsertOneKey(queryClient, key, incoming, {
+			includeRelationship: true,
+			cleared,
+		});
 	}
 }
 
@@ -315,6 +448,10 @@ export function upsertCachedUser(
  * Batch merge-upsert many users at once (for a feed / list / search response).
  * Resolves the viewer id once and upserts each user cumulatively — a user that
  * appears twice merges both slices into the single cache entry.
+ *
+ * Takes NO `cleared`, deliberately: a batch is a multi-user projection, so it is
+ * exactly the sparse source the anti-degradation guard exists for, and one
+ * declaration could not be true of every user in the array anyway.
  */
 export function upsertCachedUsers(
 	queryClient: QueryClient,


### PR DESCRIPTION
## Summary

Two client-side identity caches were serving pre-edit data, and neither was where you would look.

**Gap 1.** `updateAccount` invalidated `GET:/accounts/<id>` and the account lists. A profile screen never reads that key — `useUserByUsername` goes to `GET:/profiles/username/<handle>`, cached 5 minutes in the client's own SDK instance. So the refetch that followed an edit **overwrote** the freshly-merged entry with the pre-edit profile. A second, independently drifted copy of the same list was found in `updateProfile`, missing `GET:/auth/lookup/` and `GET:/profiles/resolve` — keys the server-side `evictOxyIdentityCache` already had. Two hand-written lists that had to agree and didn't. Now one enumeration in `packages/core/src/utils/identityCacheSweep.ts`, used by `updateAccount`, `updateProfile`, `updatePrivacySettings` and the Node-only `@oxyhq/core/server` subscriber. A username rename is reachable only by a prefix sweep, since the OLD handle appears in neither the request nor the response.

**Gap 2 — and the reported mechanism was wrong, saying so here.** The guard in `upsertCachedUser` (which lives in `@oxyhq/services`, not core) refuses `null`/`''` as degraded — but **neither ever arrives**. oxy-api's `formatUserResponse` drops cleared scalars entirely, so an account that just cleared its avatar, bio and display name serializes byte-identically to the same account read as a sparse projection (measured, `IDENTICAL: true`; `name` survives as `{}`). Keying a clear off an incoming `null` therefore could not have worked, and a blanket `authoritative` flag would have been an unverifiable promise that risked blanking real identity across every Oxy app. The design instead is `upsertCachedUser(qc, user, viewerId, { cleared: ['avatar'] })`: a closed `CLEARABLE_USER_FIELDS` list bounds the blast radius, and `cleared` LOWERS the guard rather than forcing erasure, so a meaningful incoming value still wins. The sparse-source refusal is intact and proven — removing it fails 14 assertions.

**Deliberately not swept:** list reads that merely contain an account (`GET:/profiles/search`, `GET:/users/<other>/followers`, `GET:/profiles/<other>/similar`). An account is unlocatable in them without the lookup being invalidated, so covering them means sweeping the whole namespace on every identity change, including on every backend consuming the pub/sub signal. A stale search thumbnail expires on its own in about two minutes.

**Consumer follow-up, noting it for whoever bumps Mention next:** `packages/frontend/app/(app)/c/[username]/settings.tsx:218` must pass `{ cleared: [...] }` for instant clear propagation. Without it, gap 1's fix already makes the clear correct one refetch later; gap 2 removes the flash of the old picture.

## Test plan

Gates already run by the implementing agent (not re-run here):
- [x] core: 104 suites / 1435 tests (baseline 102/1416)
- [x] services: 67/593 (baseline 66/577)
- [x] services lint: 0, tsc: clean
- [x] core biome lint: 208 errors, matches measured 208 baseline (delta 0 — red on `main` independent of this change)
- [x] contracts, protocol, federation built first; `packages/{api,federation,node,protocol}` typecheck at 0

No version bump, nothing published to npm — that's a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)