### PR TITLE
fix(federation): stop announcing every Oxy account as a Person

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -510,6 +510,7 @@
       "name": "@oxyhq/federation",
       "version": "0.11.0",
       "dependencies": {
+        "@oxyhq/contracts": "workspace:^",
         "@oxyhq/core": "workspace:^",
       },
       "devDependencies": {

--- a/packages/federation/package.json
+++ b/packages/federation/package.json
@@ -92,6 +92,7 @@
     }
   },
   "dependencies": {
+    "@oxyhq/contracts": "workspace:^",
     "@oxyhq/core": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/federation/src/__tests__/actorObject.test.ts
+++ b/packages/federation/src/__tests__/actorObject.test.ts
@@ -1,7 +1,12 @@
+import { ACCOUNT_KINDS } from '@oxyhq/contracts';
 import {
   AP_CONTEXT,
   createLocalActorBuilder,
   createUrlBuilders,
+  AP_ACTOR_TYPES,
+  isApActorType,
+  LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND,
+  localActorTypeForAccountKind,
   type ActorMediaResolver,
 } from '../index';
 
@@ -116,6 +121,130 @@ describe('createLocalActorBuilder (golden actor vector)', () => {
     expect(warnings[0]).toContain('Omitting actor image');
     expect(JSON.stringify(actor)).not.toContain('"icon"');
     expect(JSON.stringify(actor)).not.toContain('"image"');
+  });
+});
+
+/**
+ * The RECOGNITION vocabulary, which is a different question from what we emit:
+ * an inbound `Update` carrying a profile is dispatched on it, so a type missing
+ * here means that class of account's profile edits are applied to NOTHING, with
+ * no error raised anywhere.
+ *
+ * `Group` and `Organization` are the two that matter and the two most likely to
+ * be "tidied" out, since this engine never emits `Group` at all: a Lemmy
+ * community IS a `Group`, and a Mention channel is now an `Organization`.
+ */
+describe('AS2 actor recognition vocabulary', () => {
+  it('recognizes all five AS2 actor types', () => {
+    expect([...AP_ACTOR_TYPES].sort()).toEqual([
+      'Application',
+      'Group',
+      'Organization',
+      'Person',
+      'Service',
+    ]);
+    for (const type of AP_ACTOR_TYPES) {
+      expect(isApActorType(type)).toBe(true);
+    }
+  });
+
+  it('separates actors from the content objects sharing the dispatch', () => {
+    // The inbound Update handler is `if (Note|Article) … else if (isApActorType)`,
+    // so a predicate that answered true for content would route an edited post
+    // into an actor refetch.
+    expect(isApActorType('Note')).toBe(false);
+    expect(isApActorType('Article')).toBe(false);
+    expect(isApActorType(undefined)).toBe(false);
+    expect(isApActorType('person')).toBe(false);
+  });
+
+  it('covers every type the emitted subset draws from', () => {
+    for (const emitted of Object.values(LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND)) {
+      expect(isApActorType(emitted)).toBe(true);
+    }
+  });
+});
+
+/**
+ * The actor `type` is the ONE field that varies by account kind, and it is a
+ * public claim about what an account IS — a `Person` is a human being. These
+ * assertions are written so that a mapping which collapsed to a single constant
+ * (the easiest way to break this by accident) cannot pass:
+ *
+ *  - the per-kind table names BOTH sides of every branch, so a fixture set made
+ *    only of channels could not tell "channels are Service" from "everything is
+ *    Service";
+ *  - the coverage assertion is driven by contracts' own `ACCOUNT_KINDS`, so a
+ *    kind added upstream fails here rather than silently inheriting `Person`;
+ *  - the distinct-value floor fails any constant mapping outright.
+ */
+describe('actor type by Oxy account kind', () => {
+  it('maps each kind to the AS2 type announced for it', () => {
+    expect(localActorTypeForAccountKind('personal')).toBe('Person');
+    expect(localActorTypeForAccountKind('organization')).toBe('Organization');
+    expect(localActorTypeForAccountKind('project')).toBe('Organization');
+    expect(localActorTypeForAccountKind('bot')).toBe('Service');
+    expect(localActorTypeForAccountKind('channel')).toBe('Organization');
+  });
+
+  it('never announces a human-curated channel as automated', () => {
+    // `Service` is what Mastodon writes for "this is an automated account"
+    // (account.rb:224) and is half of `bot?` (account.rb:90) — the Automated
+    // badge, the SimilarProfilesSource exclusion and Lemmy's `bot_account`.
+    // A channel is curated by people; only `bot` may claim automation.
+    expect(localActorTypeForAccountKind('channel')).not.toBe('Service');
+    expect(localActorTypeForAccountKind('bot')).toBe('Service');
+    // `Group` is never emitted for anything: Lemmy would reclassify the actor as
+    // a community that silently never receives content, and PeerTube rejects a
+    // `Group` lacking `attributedTo` outright.
+    expect(Object.values(LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND)).not.toContain('Group');
+  });
+
+  it('covers every account kind contracts defines, with more than one answer', () => {
+    // Coverage: driven by the upstream vocabulary, so a new kind fails here.
+    expect(Object.keys(LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND).sort()).toEqual([...ACCOUNT_KINDS].sort());
+    // Vacuity floor: a mapping that returned one constant would pass every
+    // single-kind assertion above and fail this.
+    const answers = ACCOUNT_KINDS.map((kind) => localActorTypeForAccountKind(kind));
+    expect(new Set(answers).size).toBe(3);
+    // And specifically: the two kinds either side of the channel decision differ.
+    expect(localActorTypeForAccountKind('channel')).not.toBe(
+      localActorTypeForAccountKind('personal'),
+    );
+  });
+
+  it('falls back to Person for an absent, null, or unrecognized kind', () => {
+    expect(localActorTypeForAccountKind(undefined)).toBe('Person');
+    expect(localActorTypeForAccountKind(null)).toBe('Person');
+    // Version skew: an Oxy API that knows a kind this package does not must not
+    // produce `type: undefined` — a malformed actor Mastodon negative-caches.
+    expect(localActorTypeForAccountKind('venue')).toBe('Person');
+    expect(localActorTypeForAccountKind(7)).toBe('Person');
+  });
+
+  it('emits the kind-derived type from the builder, keeping key order frozen', () => {
+    // A channel: NOT a person, and the whole point of the change.
+    const channel = buildActor({ ...PARAMS, kind: 'channel' });
+    expect(channel.type).toBe('Organization');
+    // The other side of the branch — without this the assertion above would hold
+    // just as well for a builder that hardcoded 'Organization'.
+    const personal = buildActor({ ...PARAMS, kind: 'personal' });
+    expect(personal.type).toBe('Person');
+    expect(buildActor({ ...PARAMS, kind: 'bot' }).type).toBe('Service');
+
+    // `type` is field 2 of the byte-frozen document: only its VALUE may vary.
+    expect(Object.keys(channel)).toEqual(Object.keys(EXPECTED_ACTOR));
+    expect(Object.keys(channel)[1]).toBe('type');
+    expect(JSON.stringify(channel)).toBe(
+      JSON.stringify({ ...EXPECTED_ACTOR, type: 'Organization' }),
+    );
+  });
+
+  it('leaves an actor with no kind byte-identical to the pre-change document', () => {
+    // The golden vector's PARAMS carries no `kind` — the regression guard that
+    // this change is inert for every ordinary account already federated.
+    expect(buildActor(PARAMS).type).toBe('Person');
+    expect(JSON.stringify(buildActor(PARAMS))).toBe(JSON.stringify(EXPECTED_ACTOR));
   });
 });
 

--- a/packages/federation/src/actorObject.ts
+++ b/packages/federation/src/actorObject.ts
@@ -1,8 +1,8 @@
 /**
- * The single builder of a LOCAL user's ActivityPub `Person` actor document.
+ * The single builder of a LOCAL user's ActivityPub actor document.
  *
  * Shared by the GET actor route (which serves it as a standalone JSON-LD
- * document) and the outbound `Update(Person)` broadcast (which embeds it in an
+ * document) and the outbound `Update` broadcast (which embeds it in an
  * `Update` activity), so a follower's Mastodon renders the same actor whether it
  * was fetched or pushed. Deliberately does NOT include the top-level `@context`:
  * the GET route and the `Update` envelope each own their JSON-LD context, and an
@@ -18,7 +18,122 @@
  * absolute-URL invariant and assembles the AP `Image` object.
  */
 
+import { type AccountKind, isAccountKind } from '@oxyhq/contracts';
 import type { UrlBuilders } from './urls';
+
+/**
+ * The five actor types AS2 defines — the vocabulary for RECOGNIZING any actor,
+ * local or remote, as opposed to {@link LocalActorType} (the subset we emit).
+ *
+ * An inbound `Update` carrying a profile is dispatched on this: gating it on a
+ * hand-written subset is how a receiver silently stops applying profile edits
+ * from a whole class of account (a Lemmy community is a `Group`), with no error
+ * anywhere — the edit simply never lands.
+ */
+export const AP_ACTOR_TYPES = [
+  'Application',
+  'Group',
+  'Organization',
+  'Person',
+  'Service',
+] as const;
+
+/** Any AS2 actor type. */
+export type ApActorType = (typeof AP_ACTOR_TYPES)[number];
+
+/** Whether an untrusted inbound `type` names an AS2 actor. */
+export function isApActorType(value: unknown): value is ApActorType {
+  return typeof value === 'string' && (AP_ACTOR_TYPES as readonly string[]).includes(value);
+}
+
+/**
+ * The AS2 actor types this engine will announce for a LOCAL user actor.
+ *
+ * Narrower than AS2's five actor types, and narrow ON PURPOSE — the union names
+ * what the builder can emit, so the two absences are documented decisions rather
+ * than oversights. Both were checked against real receiving implementations
+ * (mastodon `a3649295`, lemmy `4ce92433`, misskey `b95e4841`, peertube
+ * `fe0da961`), not against the spec:
+ *
+ *  - **`Application`** is the INSTANCE actor's type (see the actor router's
+ *    `/ap/users/instance` branch), reserved by convention for the software
+ *    itself. No account is the software.
+ *  - **`Group`** is refused because in the deployed fediverse it is not read as
+ *    "a collective of actors" but as a FORWARDING actor, and the two failure
+ *    modes are concrete. Lemmy reclassifies a remote `Group` as a COMMUNITY:
+ *    it is followable and the Follow is Accepted, so it looks like it worked,
+ *    and then it never shows a single post — we emit no `Announce`, and our
+ *    Notes do not resolve to a community. PeerTube is worse and louder: it
+ *    REJECTS a `Group` actor outright unless it carries `attributedTo` naming a
+ *    `Person`. An Oxy account authors its own posts and forwards nothing, so
+ *    `Group` would advertise a protocol this engine does not implement.
+ */
+export type LocalActorType = Extract<ApActorType, 'Person' | 'Organization' | 'Service'>;
+
+/**
+ * Oxy account kind → the AS2 actor type the fediverse is told about it.
+ *
+ * `satisfies Record<AccountKind, LocalActorType>` is the load-bearing part: a
+ * kind added to `@oxyhq/contracts` fails THIS build rather than silently
+ * inheriting `Person`, which is how every non-person account came to describe
+ * itself as an individual human in the first place.
+ *
+ * Per kind, and why:
+ *
+ *  - **`personal` → `Person`.** The only kind that is a human login. Unchanged.
+ *  - **`organization` → `Organization`.** AS2 has the exact word.
+ *  - **`project` → `Organization`.** Least-wrong of the three available: a
+ *    project is a collective endeavour, not an individual (`Person`) and not an
+ *    automated one (`Service`).
+ *  - **`bot` → `Service`.** Not merely AS2's word for automation — it is
+ *    literally the value Mastodon writes when a local user ticks "this is an
+ *    automated account" (`account.rb:224`), so it is the same claim its own
+ *    users make about themselves. An Oxy `bot` announcing itself as a `Person`
+ *    is false, and readers specifically want it labelled.
+ *  - **`channel` → `Organization`.** A channel is a CONTENT identity that can
+ *    never be logged into and takes no replies, so `Person` is false about it.
+ *    `Group` would promise forwarding (above). `Service` was the tempting answer
+ *    and is the WRONG one: it is the automation claim, and a channel is curated
+ *    by people. Mastodon's `bot?` is exactly `%w(Application Service)`
+ *    (`account.rb:90`), which paints an **"Automated"** badge with a robot icon
+ *    (`badges.tsx:69`), drops the account from `SimilarProfilesSource`
+ *    (`similar_profiles_source.rb:22-36`), and makes its notifications
+ *    discardable by policy; Lemmy sets `bot_account = true`, hiding it from
+ *    anyone who turned bots off. `Organization` costs NOTHING measurable: it is
+ *    accepted by all four implementations' whitelists and compared in none of
+ *    them — neither `bot?` nor `group?` in Mastodon, `bot_account = false` in
+ *    Lemmy, `isBot` false in Misskey, an ordinary account in PeerTube.
+ *
+ * What this does NOT do: it does not stop a remote instance offering a reply box
+ * under a channel's post. NO actor type gates that in any of the four — Mastodon
+ * has no `canReply` at all (only `canQuote` and `canFeature`) — and AS2 has no
+ * interaction-policy field deployed software honours. A reply to a channel is
+ * still accepted by the sender's own instance and still dropped on arrival here.
+ * This map only stops asserting personhood about things that are not people.
+ */
+export const LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND = {
+  personal: 'Person',
+  organization: 'Organization',
+  project: 'Organization',
+  bot: 'Service',
+  channel: 'Organization',
+} as const satisfies Record<AccountKind, LocalActorType>;
+
+/**
+ * The AS2 actor type for an Oxy account kind, defaulting to `Person`.
+ *
+ * Takes `unknown` rather than `AccountKind` on purpose: the value arrives in an
+ * Oxy API response, so the static type is a claim about the wire that the wire
+ * can break. A deployment whose API knows a kind this package does not would
+ * index a miss and emit `type: undefined` — a MALFORMED actor, which Mastodon
+ * negative-caches for minutes to hours. `isAccountKind` (contracts' own narrowing,
+ * so it cannot drift from the vocabulary) sends an unrecognized or absent kind to
+ * `Person`: a valid actor, and the value every actor carried before this map
+ * existed.
+ */
+export function localActorTypeForAccountKind(kind: unknown): LocalActorType {
+  return isAccountKind(kind) ? LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND[kind] : 'Person';
+}
 
 /** Map common image extensions to a MIME type for an actor image `mediaType`. */
 const IMAGE_MEDIA_TYPE_BY_EXT: Record<string, string> = {
@@ -86,6 +201,13 @@ export interface LocalActorBuilderConfig {
 export interface BuildLocalActorParams {
   username: string;
   /**
+   * The account-graph classification (Oxy `User.kind`), which decides the AS2
+   * actor `type` via {@link LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND}. Absent is read as
+   * `personal` — matching the column's own default, and preserving the `Person`
+   * every actor carried before the map existed.
+   */
+  kind?: AccountKind | null;
+  /**
    * The caller-resolved Oxy `name.displayName` (falling back to the handle). Never
    * recomposed from name parts here.
    */
@@ -102,7 +224,11 @@ export interface BuildLocalActorParams {
   createdAt?: string | null;
 }
 
-/** Assembles a LOCAL user's AP `Person` actor object (WITHOUT the top-level `@context`). */
+/**
+ * Assembles a LOCAL user's AP actor object (WITHOUT the top-level `@context`).
+ * The actor `type` follows the account's kind — see
+ * {@link LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND}.
+ */
 export type LocalActorBuilder = (params: BuildLocalActorParams) => Record<string, unknown>;
 
 /**
@@ -151,11 +277,11 @@ function buildActorImage(
  */
 export function createLocalActorBuilder(config: LocalActorBuilderConfig): LocalActorBuilder {
   return (params: BuildLocalActorParams): Record<string, unknown> => {
-    const { username, displayName, bio, avatar, profileHeaderImage, publicKey, createdAt } = params;
+    const { username, displayName, kind, bio, avatar, profileHeaderImage, publicKey, createdAt } = params;
 
     const actorObject: Record<string, unknown> = {
       id: config.urls.actor(username),
-      type: 'Person',
+      type: localActorTypeForAccountKind(kind),
       preferredUsername: username,
       name: displayName,
       summary: bio || '',

--- a/packages/federation/src/index.ts
+++ b/packages/federation/src/index.ts
@@ -105,11 +105,18 @@ export {
 } from './apUri';
 
 /**
- * The single builder of a LOCAL user's ActivityPub `Person` actor document —
- * byte-identical across apps, with media resolution injected.
+ * The single builder of a LOCAL user's ActivityPub actor document —
+ * byte-identical across apps, with media resolution injected. The actor `type`
+ * follows the Oxy account kind ({@link LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND}).
  */
 export {
   createLocalActorBuilder,
+  localActorTypeForAccountKind,
+  isApActorType,
+  AP_ACTOR_TYPES,
+  LOCAL_ACTOR_TYPE_BY_ACCOUNT_KIND,
+  type ApActorType,
+  type LocalActorType,
   type LocalActorBuilder,
   type LocalActorBuilderConfig,
   type BuildLocalActorParams,

--- a/packages/federation/src/node/actorRouter.ts
+++ b/packages/federation/src/node/actorRouter.ts
@@ -20,6 +20,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
+import type { AccountKind } from '@oxyhq/contracts';
 import type { User } from '@oxyhq/core';
 import { AP_CONTEXT } from '../apContext';
 import { verifyHttpSignature } from '../httpSignature';
@@ -38,6 +39,8 @@ export interface ActorRouteUser {
   bio?: string | null;
   avatar?: string | null;
   createdAt?: string | null;
+  /** Account-graph classification — decides the actor `type`. */
+  kind?: AccountKind | null;
   _count?: { followers?: number; following?: number } | null;
 }
 
@@ -376,6 +379,7 @@ export function createActorRouter(config: ActorRouterConfig): Router {
       const actorObject = config.buildLocalActorObject({
         username,
         displayName,
+        kind: user.kind,
         bio: user.bio,
         avatar: user.avatar,
         profileHeaderImage,

--- a/packages/federation/src/node/delivery.ts
+++ b/packages/federation/src/node/delivery.ts
@@ -24,6 +24,7 @@
  * call `deliverToFollowers` / `deliverActivity` / `queueDelivery` here.
  */
 
+import type { AccountKind } from '@oxyhq/contracts';
 import { AP_CONTEXT } from '../apContext';
 import { signRequest, type HttpSignatureSigner } from '../httpSignature';
 import type { UrlBuilders } from '../urls';
@@ -154,12 +155,21 @@ export interface DeliveryConsent {
   isSharingEnabled(oxyUserId: string): Promise<boolean>;
 }
 
-/** The Oxy profile fields the `Update(Person)` rebroadcast reads. */
+/** The Oxy profile fields the actor `Update` rebroadcast reads. */
 export interface DeliveryActorProfile {
   name?: { displayName?: string | null } | null;
   bio?: string | null;
   avatar?: string | null;
   createdAt?: string | null;
+  /**
+   * Account-graph classification — decides the actor `type`. It MUST travel with
+   * the rebroadcast: an `Update` carrying a different `type` from the one the GET
+   * route serves is exactly the drift the shared builder exists to prevent, and
+   * on a type change it is also the migration vehicle (a follower's instance
+   * adopts the new type from this push rather than waiting out its own actor
+   * staleness window).
+   */
+  kind?: AccountKind | null;
 }
 
 /** Resolve a local username to its Oxy profile (for the `Update(Person)` rebroadcast). */
@@ -672,6 +682,7 @@ export function createDeliveryService<TActor extends DeliveryActorFields>(
       const actorObject = config.buildLocalActorObject({
         username,
         displayName,
+        kind: user.kind,
         bio: user.bio,
         avatar: user.avatar,
         profileHeaderImage,


### PR DESCRIPTION
## Summary

A local ActivityPub actor was hardcoded `type: 'Person'` at `actorObject.ts:158` — the only local-actor type emission in the ecosystem, verified in the shipped `dist` as well as source. Every Oxy account kind (personal, organization, project, bot, channel) was announced to the fediverse as an individual human. The type is now derived from `AccountKind`, which the actor route already resolved and simply never passed to the builder.

**Map** (`as const satisfies Record<AccountKind, LocalActorType>`, so a kind added upstream fails the build instead of silently inheriting `Person`):
- `personal` -> `Person`
- `organization`, `project`, `channel` -> `Organization`
- `bot` -> `Service`

**Why `channel` is `Organization` and not `Service`**: `Service` is literally the value Mastodon writes when a user ticks "this is an automated account" (`account.rb:224`), so a human-curated channel claiming it would be a new falsehood replacing the old one. It also costs the "Automated" badge and one of five follow-suggestion sources. `Organization` is in all four major implementations' whitelists (Mastodon, Lemmy, Misskey, PeerTube) and compared in none of them. `bot` keeps `Service` for exactly the reason `channel` loses it.

**Why `Group` is refused** (checked against real source trees, not the spec): Lemmy reclassifies a `Group` as a *community*, so it's followable, an Accept is sent, it looks like it worked, and it never delivers a post (we never `Announce`, and our Notes can't resolve a community). PeerTube refuses to create the actor at all without an `attributedTo` resolving to a `Person`. Mastodon starts addressing mentions to our followers collection expecting us to relay.

**Does NOT fix**: no actor type suppresses the reply box on any of the four fediverse implementations, and there is no protocol field that does — Mastodon implements `interactionPolicy.canQuote`/`canFeature` only, no `canReply`. Channel replies stay enforced on ingest, which remains the only possible enforcement.

**A pre-existing live bug fixed alongside**, wider than the channel case: the inbound profile-`Update` condition accepted only `Person | Service | Application`, so every Lemmy community's profile edits have been silently discarded — a community is a `Group`. No error, no log; the rename just never landed. This PR adds `isApActorType` as a single AS2-actor-type export so an inbound dispatcher can check against it rather than keep a third inline copy of that vocabulary.

**Migration note**: adoption is ~1 day for actors anyone resolves (`STALE_THRESHOLD`) and 1 week in background; `federateActorUpdate` already rebroadcasts the full actor and now carries the new type, so a one-shot re-broadcast per federated channel only accelerates it and is not required for correctness.

## Not published, no version bump

`@oxyhq/core` and `@oxyhq/services` are currently being published from this same repo by another agent — publishing `@oxyhq/federation` is a deliberately separate step, to run after this merges. `packages/federation/package.json` stays at `0.11.0`; the only manifest change is a new `@oxyhq/contracts: workspace:^` dependency.

**Consumer note**: `Mention/packages/backend/package.json:28` pins `@oxyhq/federation` at `^0.11.0` — a `0.x` caret pins the MINOR, so that range needs an explicit bump once this publishes, or Mention silently keeps the old engine. (Mention's own consumer-side changes are a separate, later piece of work — not part of this PR.)

## Test plan
- [x] `bun run typescript` clean in `packages/federation` (the only type gate; jest runs with `diagnostics: false`)
- [x] `bun run lint` clean
- [x] `bun run build` clean (contracts -> protocol -> core -> federation)
- [x] `packages/federation` jest: 183 passing (was 174)
- [x] 11 mutations, all caught (2 initially survived, since fixed)
- [x] Rebased cleanly onto `origin/main` (`5db3ac60`, unrelated core/services identity-cache fix), re-verified build+tests after rebase
- [x] `bun install` + `git diff --exit-code -- bun.lock` clean (no lockfile drift)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>