### PR TITLE
fix: exclude channel accounts from every switcher surface

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -143,7 +143,7 @@ Carried forward from [`CONTINUATION.md`](../CONTINUATION.md) §8 and the roadmap
   "Create your vault" surface in Commons Settings. (If `OxyServices.nodes.ts`
   is present, the SDK side has landed; the Commons UI is the remaining piece —
   see [nodes/README.md](nodes/README.md).)
-- **Publish `@oxyhq/contracts` 0.4.0 → core → auth → services** — only when an
+- **Publish `@oxyhq/contracts` 0.4.0 → core → services → auth** — only when an
   external app needs the new civic types. Commons consumes them as `workspace:*`
   and the API Docker build builds contracts from source, so no publish is needed
   for current deploys.

--- a/packages/accounts/app/(tabs)/managed-accounts.tsx
+++ b/packages/accounts/app/(tabs)/managed-accounts.tsx
@@ -12,7 +12,7 @@ import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useHapticPress } from '@/hooks/use-haptic-press';
 import { useTranslation } from '@/lib/i18n';
 import type { AccountNode } from '@oxyhq/core';
-import { getAccountDisplayName, getNormalizedUserHandle } from '@oxyhq/core';
+import { getAccountDisplayName, getNormalizedUserHandle, isSwitchTargetAccount } from '@oxyhq/core';
 import { useAccountRowBuilder } from '@/components/managed-accounts/account-row';
 import { useManagedAccountGroups } from '@/hooks/managed-accounts/useManagedAccountGroups';
 
@@ -69,9 +69,12 @@ export default function ManagedAccountsScreen() {
 
   const handleEditProfile = useCallback((accountId: string) => {
     const node = accounts.find((entry) => entry.accountId === accountId);
-    // Channels are content identities — nobody switches into them. Edit via the
-    // per-account settings sheet, which PATCHes by id without a session switch.
-    if (node?.kind === 'channel') {
+    // An account nobody can become — a channel, a content identity — cannot be
+    // edited by switching into it first. Edit via the per-account settings
+    // sheet, which PATCHes by id without a session switch. Asking
+    // `isSwitchTargetAccount` rather than testing the kind keeps this branch
+    // correct for the next kind that is manageable but not occupiable.
+    if (!node || !isSwitchTargetAccount(node)) {
       showBottomSheet?.({ screen: 'AccountSettings', props: { accountId } });
       return;
     }

--- a/packages/accounts/components/managed-accounts/account-row.tsx
+++ b/packages/accounts/components/managed-accounts/account-row.tsx
@@ -3,7 +3,12 @@ import { View, StyleSheet, Text, TouchableOpacity, ActivityIndicator } from 'rea
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { Avatar } from '@oxyhq/bloom/avatar';
 import type { AccountNode, AccountRole, OxyServices } from '@oxyhq/core';
-import { getAccountFallbackHandle, getAccountDisplayName, getNormalizedUserHandle } from '@oxyhq/core';
+import {
+  getAccountFallbackHandle,
+  getAccountDisplayName,
+  getNormalizedUserHandle,
+  isSwitchTargetAccount,
+} from '@oxyhq/core';
 import { useColors, type AppColors } from '@/hooks/useColors';
 import { useHapticPress } from '@/hooks/use-haptic-press';
 import { useTranslation } from '@/lib/i18n';
@@ -78,7 +83,12 @@ function AccountRowContent({
 
   const role = getNodeRole(node);
   const badgeColor = getRoleBadgeColor(role, colors);
-  const canSwitchInto = SWITCHABLE_ROLES.includes(role) && node.kind !== 'channel';
+  // Two independent conditions, both required: the caller's ROLE must carry
+  // `account:act_as`, and the ACCOUNT must be something anybody can become at
+  // all. `isSwitchTargetAccount` answers the second — the same rule the account
+  // switcher uses — rather than a `kind !== 'channel'` literal, which would
+  // silently admit the next kind nobody may act as.
+  const canSwitchInto = SWITCHABLE_ROLES.includes(role) && isSwitchTargetAccount(node);
   const canManageMembers = MANAGE_MEMBER_ROLES.includes(role);
   const canEdit = EDIT_ROLES.includes(role);
   const canArchive = role === 'owner';
@@ -209,7 +219,9 @@ export function useAccountRowBuilder({
     const avatarUri = node.account?.avatar
       ? oxyServices.getFileDownloadUrl(node.account.avatar, 'thumb')
       : undefined;
-    const canSwitchInto = SWITCHABLE_ROLES.includes(role) && node.kind !== 'channel';
+    // Same two conditions as `AccountRowContent`'s switch button above — the
+    // whole row is that button's larger tap target, so the two must agree.
+    const canSwitchInto = SWITCHABLE_ROLES.includes(role) && isSwitchTargetAccount(node);
     const canManageMembers = MANAGE_MEMBER_ROLES.includes(role);
 
     return {

--- a/packages/console/src/components/layout/__tests__/workspace-tree.test.ts
+++ b/packages/console/src/components/layout/__tests__/workspace-tree.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { ACCOUNT_KINDS } from '@oxyhq/contracts';
+import type { AccountKind, AccountNode, AccountRelationship } from '@oxyhq/core';
+import { buildWorkspaceTree } from '../workspace-tree';
+
+function node(
+  accountId: string,
+  kind: AccountKind,
+  relationship: AccountRelationship,
+  parentAccountId: string | null = null
+): AccountNode {
+  return {
+    accountId,
+    kind,
+    parentAccountId,
+    account: {
+      id: accountId,
+      publicKey: `pk_${accountId}`,
+      username: accountId,
+      name: { displayName: accountId },
+    } as AccountNode['account'],
+    relationship,
+    callerMembership: null,
+  };
+}
+
+/**
+ * The workspace switcher's rows each perform a REAL session switch, so what it
+ * lists is a security-adjacent question and not a cosmetic one: a channel row
+ * here is an affordance for something `POST /accounts/:id/switch` answers 403
+ * to, every time.
+ *
+ * The Console reaches this list through its own `listAccounts()` React Query
+ * rather than through `projectSwitchableAccounts`, which is exactly how it kept
+ * rendering channels after the SDK's projection learned to drop them — so this
+ * suite exists to keep the two answers together.
+ */
+describe('buildWorkspaceTree', () => {
+  /**
+   * EXHAUSTIVE over `ACCOUNT_KINDS`, and asserted as one object equality so it
+   * cannot pass vacuously.
+   *
+   * Three kinds must SURVIVE. A fixture list of channels alone could not tell
+   * "drops channels" from "drops everything" — and dropping everything is the
+   * worse failure, because it would empty an operator's switcher of the orgs
+   * they actually work in. Adding a sixth kind fails this with a missing key.
+   */
+  it('lists every switchable kind and no channel', () => {
+    const accounts = ACCOUNT_KINDS.map((kind) =>
+      node(kind, kind, kind === 'personal' ? 'self' : 'owner')
+    );
+
+    const { yourAccounts } = buildWorkspaceTree(accounts);
+
+    expect(Object.fromEntries(
+      ACCOUNT_KINDS.map((kind) => [kind, yourAccounts.some((a) => a.kind === kind)])
+    )).toEqual({
+      personal: true,
+      organization: true,
+      project: true,
+      bot: true,
+      channel: false,
+    });
+  });
+
+  /**
+   * The caller's own personal account is act-as INELIGIBLE, so a switcher
+   * narrowed with `isActAsEligibleKind` instead of `isSwitchTargetAccount`
+   * would drop the row that returns you to yourself — the one row that must
+   * never disappear. Pinned separately from the matrix above so the reason is
+   * legible when it breaks.
+   */
+  it('keeps the caller’s own personal account', () => {
+    const { yourAccounts } = buildWorkspaceTree([node('me', 'personal', 'self')]);
+    expect(yourAccounts.map((a) => a.accountId)).toEqual(['me']);
+  });
+
+  /**
+   * The fixture that tells `isSwitchTargetAccount` from a `kind !== 'channel'`
+   * literal, and the ONLY input shape that does.
+   *
+   * Every other case in this file has exactly one personal account and it is
+   * the caller's own, so both readings agree on all of them — a suite made
+   * entirely of those cannot see the difference, and a mutation to the literal
+   * passed all seven before this was added. Somebody else's personal account is
+   * a human login: `POST /accounts/:id/switch` refuses it as impersonation, so
+   * offering the row is a 403 with a friendly avatar on it.
+   */
+  it('drops a personal account that is not the caller’s own', () => {
+    const { yourAccounts, sharedAccounts } = buildWorkspaceTree([
+      node('me', 'personal', 'self'),
+      node('someoneElse', 'personal', 'member'),
+      node('alsoNotMe', 'personal', 'owner'),
+    ]);
+
+    expect(yourAccounts.map((a) => a.accountId)).toEqual(['me']);
+    expect(sharedAccounts).toEqual([]);
+  });
+
+  it('separates accounts shared via membership from owned roots', () => {
+    const { yourAccounts, sharedAccounts } = buildWorkspaceTree([
+      node('me', 'personal', 'self'),
+      node('mine', 'organization', 'owner'),
+      node('theirs', 'organization', 'member'),
+      node('theirChannel', 'channel', 'member'),
+    ]);
+
+    expect(yourAccounts.map((a) => a.accountId)).toEqual(['me', 'mine']);
+    expect(sharedAccounts.map((a) => a.accountId)).toEqual(['theirs']);
+  });
+
+  it('nests direct children one level under their root, channels excluded', () => {
+    const { yourAccounts, childrenOf } = buildWorkspaceTree([
+      node('me', 'personal', 'self'),
+      node('org', 'organization', 'owner', 'me'),
+      node('proj', 'project', 'owner', 'org'),
+      node('chan', 'channel', 'owner', 'org'),
+    ]);
+
+    expect(yourAccounts.map((a) => a.accountId)).toEqual(['me']);
+    expect(childrenOf('me').map((a) => a.accountId)).toEqual(['org']);
+    expect(childrenOf('org').map((a) => a.accountId)).toEqual(['proj']);
+  });
+
+  /**
+   * Dropping a channel must not strand what hangs off it. `underChan` is
+   * parented to a channel that no longer renders, so its parent is absent from
+   * the switchable set and it has to promote to a root — otherwise it would be
+   * reachable only as a child of a row nobody can see, i.e. not at all.
+   *
+   * And having promoted, it must not ALSO come back from `childrenOf('chan')`,
+   * or the same account is offered twice.
+   */
+  it('promotes a descendant of a dropped channel to a root, exactly once', () => {
+    const { yourAccounts, childrenOf } = buildWorkspaceTree([
+      node('me', 'personal', 'self'),
+      node('chan', 'channel', 'owner', 'me'),
+      node('underChan', 'project', 'owner', 'chan'),
+    ]);
+
+    expect(yourAccounts.map((a) => a.accountId)).toEqual(['me', 'underChan']);
+    expect(childrenOf('chan')).toEqual([]);
+  });
+
+  /**
+   * The roots and the nested rows must PARTITION the switchable set: every
+   * switchable account appears exactly once across the whole rendered tree, and
+   * no unswitchable one appears at all.
+   *
+   * Asserted over a fixture that exercises every branch at once — a shared
+   * root, two nested children, a channel to drop, and a child orphaned by that
+   * drop — because each of the earlier tests pins one group in isolation and
+   * none of them would notice an account counted twice across two groups.
+   *
+   * The fixture is at most two levels deep because the switcher itself renders
+   * two: `renderAccountTree` draws a root and `childrenOf(root)` and stops. A
+   * grandchild is therefore unreachable here — a pre-existing limit of this
+   * component, untouched by the switch-target filter, and deliberately not
+   * papered over by a fixture that pretends otherwise.
+   */
+  it('renders each switchable account exactly once across the whole tree', () => {
+    const accounts = [
+      node('me', 'personal', 'self'),
+      node('org', 'organization', 'owner', 'me'),
+      node('bot', 'bot', 'owner', 'me'),
+      node('chan', 'channel', 'owner', 'me'),
+      node('underChan', 'project', 'owner', 'chan'),
+      node('shared', 'organization', 'member'),
+    ];
+    const { yourAccounts, sharedAccounts, childrenOf } = buildWorkspaceTree(accounts);
+
+    const rendered = [...yourAccounts, ...sharedAccounts].flatMap((root) => [
+      root.accountId,
+      ...childrenOf(root.accountId).map((child) => child.accountId),
+    ]);
+
+    expect(rendered.slice().sort()).toEqual(['bot', 'me', 'org', 'shared', 'underChan']);
+    // Exactly once each — a set comparison alone cannot see a duplicate.
+    expect(rendered).toHaveLength(new Set(rendered).size);
+    expect(rendered).not.toContain('chan');
+  });
+
+  it('returns empty groups for an empty account list', () => {
+    const { yourAccounts, sharedAccounts, childrenOf } = buildWorkspaceTree([]);
+    expect(yourAccounts).toEqual([]);
+    expect(sharedAccounts).toEqual([]);
+    expect(childrenOf('anything')).toEqual([]);
+  });
+});

--- a/packages/console/src/components/layout/sidebar-header.tsx
+++ b/packages/console/src/components/layout/sidebar-header.tsx
@@ -41,6 +41,7 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar';
 import { useAccount } from '@/hooks/use-account';
+import { buildWorkspaceTree } from './workspace-tree';
 
 const roleLabels: Record<AccountRole, string> = {
   owner: 'Owner',
@@ -107,24 +108,10 @@ export function SidebarHeaderBrand() {
   const [newAccountHandle, setNewAccountHandle] = React.useState('');
   const [isCreating, setIsCreating] = React.useState(false);
 
-  // Build a relationship-grouped, two-level tree from the flat account list. A
-  // node is top-level when its parent is not in the accessible set; its direct
-  // children nest one level beneath it. "Your accounts" holds `self`/`owner`
-  // roots; "Shared with you" holds accounts shared via membership.
-  const { yourAccounts, sharedAccounts, childrenOf } = React.useMemo(() => {
-    const present = new Set(accounts.map((a) => a.accountId));
-    const isTopLevel = (a: AccountNode) =>
-      !a.parentAccountId || !present.has(a.parentAccountId);
-    const topLevel = accounts.filter(isTopLevel);
-    return {
-      yourAccounts: topLevel.filter(
-        (a) => a.relationship === 'self' || a.relationship === 'owner'
-      ),
-      sharedAccounts: topLevel.filter((a) => a.relationship === 'member'),
-      childrenOf: (accountId: string) =>
-        accounts.filter((a) => a.parentAccountId === accountId),
-    };
-  }, [accounts]);
+  const { yourAccounts, sharedAccounts, childrenOf } = React.useMemo(
+    () => buildWorkspaceTree(accounts),
+    [accounts]
+  );
 
   const handleCreateAccount = async () => {
     const name = newAccountName.trim();

--- a/packages/console/src/components/layout/workspace-tree.ts
+++ b/packages/console/src/components/layout/workspace-tree.ts
@@ -1,0 +1,63 @@
+import { isSwitchTargetAccount } from '@oxyhq/core';
+import type { AccountNode } from '@/hooks/use-account';
+
+/** The workspace switcher's rendered shape — see {@link buildWorkspaceTree}. */
+export interface WorkspaceTree {
+  /** `self` / owned roots, in graph order. */
+  yourAccounts: AccountNode[];
+  /** Roots shared with the caller via membership. */
+  sharedAccounts: AccountNode[];
+  /**
+   * Direct children of a root, one level deep. DISJOINT from the two root
+   * lists: an account promoted to a root because its own parent was dropped is
+   * not also returned here, so nothing renders twice.
+   */
+  childrenOf: (accountId: string) => AccountNode[];
+}
+
+/**
+ * Build the relationship-grouped, two-level tree the workspace switcher renders:
+ * a node is a root when its parent is not in the switchable set, and its direct
+ * children nest one level beneath it.
+ *
+ * Every row it produces SWITCHES the session, so the tree is built from the
+ * SWITCH TARGETS, not from the whole accessible forest. `useAccount().accounts`
+ * is deliberately unfiltered — the Console manages accounts it can never become
+ * (a channel's members, its profile, its applications) — so the narrowing
+ * belongs here, at the one place that asks "which identity can I become?".
+ *
+ * It asks {@link isSwitchTargetAccount} so the answer is the SAME one
+ * `projectSwitchableAccounts` gives the SDK's own switcher. The Console reaches
+ * its list through its own `listAccounts()` query rather than through that
+ * projection, which is precisely how it went on offering channel rows after the
+ * projection learned to drop them: a second enumeration of switch targets is a
+ * second place for the rule to be missing.
+ *
+ * Filtering BEFORE the top-level pass is what keeps a descendant reachable — an
+ * account parented to a channel finds its parent absent and promotes to a root,
+ * rather than nesting under a row that no longer renders.
+ *
+ * Lives apart from `sidebar-header.tsx` because the component drags in the whole
+ * UI tree, which no unit test can transform; an untested exclusion here is one
+ * refactor away from being dropped again.
+ */
+export function buildWorkspaceTree(accounts: AccountNode[]): WorkspaceTree {
+  const switchable = accounts.filter(isSwitchTargetAccount);
+  const present = new Set(switchable.map((a) => a.accountId));
+  const isTopLevel = (a: AccountNode) => !a.parentAccountId || !present.has(a.parentAccountId);
+  // A strict partition of `switchable`. `nested` excludes promoted roots on
+  // purpose: without that, an account whose parent was dropped would be listed
+  // BOTH as a root and as a child of the dropped parent — harmless only for as
+  // long as nobody calls `childrenOf` with a non-root id, which is not an
+  // invariant worth resting on.
+  const topLevel = switchable.filter(isTopLevel);
+  const nested = switchable.filter((a) => !isTopLevel(a));
+  return {
+    yourAccounts: topLevel.filter(
+      (a) => a.relationship === 'self' || a.relationship === 'owner'
+    ),
+    sharedAccounts: topLevel.filter((a) => a.relationship === 'member'),
+    childrenOf: (accountId: string) =>
+      nested.filter((a) => a.parentAccountId === accountId),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -647,7 +647,14 @@ export {
 // chooser: device sign-ins ∪ account graph, deduped by accountId). Pure +
 // I/O-free — the caller hydrates profiles via `getUsersByIds`. Shared by
 // `@oxyhq/services` and auth.oxy.so so the list can't diverge.
+// `isSwitchTargetAccount` is the switcher's own question ("can I become this
+// account?"), exported so a surface that renders `AccountNode`s rather than the
+// projection — the Console's workspace switcher, the accounts app's
+// managed-accounts rows — asks the SAME question instead of testing a kind
+// literal. It is NOT `isActAsEligibleKind`: that one is false for `personal`
+// too, so gating a switcher on it alone empties the list.
 export {
+    isSwitchTargetAccount,
     projectSwitchableAccounts,
     switchableAccountIds,
 } from './session/accountProjection';

--- a/packages/core/src/session/__tests__/accountProjection.test.ts
+++ b/packages/core/src/session/__tests__/accountProjection.test.ts
@@ -1,7 +1,9 @@
 import type { DeviceSessionState } from '@oxyhq/contracts';
+import { ACCOUNT_KINDS } from '@oxyhq/contracts';
 import type { User } from '../../models/interfaces';
 import type { AccountNode } from '../../mixins/OxyServices.accounts';
 import {
+  isSwitchTargetAccount,
   projectSwitchableAccounts,
   switchableAccountIds,
 } from '../accountProjection';
@@ -48,6 +50,57 @@ const mapOf = (...users: User[]): Map<string, User> => {
 };
 
 const noAvatar = (): undefined => undefined;
+
+describe('isSwitchTargetAccount', () => {
+  /**
+   * EXHAUSTIVE over `ACCOUNT_KINDS`, as one object equality rather than a
+   * per-kind assertion, for two reasons that a `channel → false` spot-check
+   * cannot give:
+   *
+   *  - It distinguishes "excludes channels" from "excludes everything". Three
+   *    kinds must come back `true` here, so a predicate that answered `false`
+   *    unconditionally — the shape that empties a switcher instead of filtering
+   *    it — fails on those three, not on the channel.
+   *  - Adding a sixth kind fails this test with a missing key, forcing the
+   *    decision to be made HERE rather than inherited silently from whichever
+   *    literal comparison happened to be written first.
+   */
+  it('answers by kind for an account the caller merely owns or is a member of', () => {
+    expect(
+      Object.fromEntries(
+        ACCOUNT_KINDS.map((kind) => [kind, isSwitchTargetAccount({ kind, relationship: 'owner' })]),
+      ),
+    ).toEqual({
+      personal: false,
+      organization: true,
+      project: true,
+      bot: true,
+      channel: false,
+    });
+  });
+
+  /**
+   * The `self` ground, and the reason this predicate is not `isActAsEligibleKind`.
+   *
+   * `personal` is act-as INELIGIBLE — assuming somebody's human login would be
+   * impersonation — so a switcher gated on that predicate alone would drop the
+   * caller's OWN account and render an empty list. `GET /accounts` resolves its
+   * caller through `resolveOperatorId`, so a `self` node is always the human
+   * operator's own personal account, even while they operate an org.
+   */
+  it('admits the caller’s own personal account, which is act-as ineligible', () => {
+    expect(isSwitchTargetAccount({ kind: 'personal', relationship: 'self' })).toBe(true);
+    // Same kind, not the caller's own → refused. The `relationship` is doing the
+    // work, so neither half of the predicate can be deleted without a failure.
+    expect(isSwitchTargetAccount({ kind: 'personal', relationship: 'member' })).toBe(false);
+  });
+
+  it('refuses an account with no kind information rather than assuming', () => {
+    expect(isSwitchTargetAccount({})).toBe(false);
+    expect(isSwitchTargetAccount({ kind: null })).toBe(false);
+    expect(isSwitchTargetAccount({ kind: undefined, relationship: 'owner' })).toBe(false);
+  });
+});
 
 describe('projectSwitchableAccounts', () => {
   it('returns [] for null state and empty graph', () => {
@@ -136,6 +189,50 @@ describe('projectSwitchableAccounts', () => {
 
     expect(rows.map((r) => r.accountId)).toEqual(['a1', 'org1']);
     expect(rows.some((r) => r.kind === 'channel')).toBe(false);
+  });
+
+  /**
+   * The same rule as the `isSwitchTargetAccount` matrix above, asserted through
+   * the projection so the WIRING is covered and not just the predicate.
+   *
+   * The fixture deliberately carries one graph-only node of every kind, and
+   * FOUR of the five must survive: a fixture list of channels alone could not
+   * tell "omits channels" from "omits every graph-only row", which is the
+   * failure mode that would silently empty an operator's switcher of the orgs
+   * they actually work in. `a1` is a device row and is asserted separately, so
+   * the graph lane's output is never confused with the device lane's.
+   */
+  it('keeps every switchable kind while dropping the channel (graph lane)', () => {
+    const rows = projectSwitchableAccounts({
+      state: state([{ accountId: 'a1', sessionId: 's1' }], 'a1'),
+      graph: [
+        graphNode('self1', { kind: 'personal', relationship: 'self' }),
+        graphNode('org1', { kind: 'organization' }),
+        graphNode('proj1', { kind: 'project' }),
+        graphNode('bot1', { kind: 'bot' }),
+        graphNode('chan1', { kind: 'channel' }),
+      ],
+      profilesById: mapOf(
+        user('a1'),
+        user('self1'),
+        user('org1'),
+        user('proj1'),
+        user('bot1'),
+        user('chan1'),
+      ),
+      resolveAvatarUrl: noAvatar,
+    });
+
+    expect(rows.map((r) => r.accountId)).toEqual(['a1', 'self1', 'org1', 'proj1', 'bot1']);
+    // Stated the other way round too, so a fixture that stopped reaching the
+    // graph lane at all could not pass this as a vacuous "no channels found".
+    expect(rows.map((r) => r.kind)).toEqual([
+      undefined,
+      'personal',
+      'organization',
+      'project',
+      'bot',
+    ]);
   });
 
   it('dedups an account present as BOTH device session and graph node into ONE enriched row', () => {
@@ -232,11 +329,21 @@ describe('switchableAccountIds', () => {
     expect(switchableAccountIds(null, [])).toEqual([]);
   });
 
-  it('omits a graph-only channel, so no profile is fetched for a dropped row', () => {
+  /**
+   * Must stay in lockstep with the projection's own filter in BOTH directions:
+   * an id fetched for a dropped row is wasted work, but an id NOT fetched for a
+   * row the projection keeps is worse — that row has no profile, so the
+   * projection's device lane skips it and it silently never renders.
+   */
+  it('applies the same switch-target filter as the projection', () => {
     const ids = switchableAccountIds(null, [
+      graphNode('self1', { kind: 'personal', relationship: 'self' }),
       graphNode('org1', { kind: 'organization' }),
+      graphNode('proj1', { kind: 'project' }),
+      graphNode('bot1', { kind: 'bot' }),
       graphNode('chan1', { kind: 'channel' }),
+      graphNode('other1', { kind: 'personal', relationship: 'member' }),
     ]);
-    expect(ids).toEqual(['org1']);
+    expect(ids).toEqual(['bot1', 'org1', 'proj1', 'self1']);
   });
 });

--- a/packages/core/src/session/accountProjection.ts
+++ b/packages/core/src/session/accountProjection.ts
@@ -103,6 +103,38 @@ export interface SwitchableAccount {
   user: SwitchableAccountUser;
 }
 
+/**
+ * Whether the caller can BECOME this account — the one question every account
+ * switcher asks, answered here so no surface has to re-derive it.
+ *
+ * Two independent grounds, either of which suffices:
+ *
+ *  - **It is already the caller's own identity** (`relationship: 'self'`).
+ *    `GET /accounts` resolves its caller through `resolveOperatorId`, so `self`
+ *    is the HUMAN operator's personal account even while they are operating an
+ *    org — never the operated account. Kind is irrelevant on this ground: the
+ *    caller IS that account, so returning to it asks the server for nothing.
+ *  - **The server will mint a session for it** — `isActAsEligibleKind(kind)` is
+ *    the exact predicate `POST /accounts/:id/switch` enforces, so a row offered
+ *    on this ground is never a dead button.
+ *
+ * `isActAsEligibleKind` ALONE is not this question, and reaching for it
+ * directly is the mistake this function exists to prevent: it is false for
+ * `personal` as well as `channel`, so a switcher gated on it alone renders an
+ * empty list rather than a filtered one. Equally, `kind !== 'channel'` is not
+ * this question either — it silently admits every kind invented after it was
+ * written, which is the same trap `isActAsEligibleKind` was introduced to close
+ * on the server.
+ *
+ * Takes a structural subset rather than a whole {@link AccountNode} so a caller
+ * holding a projected {@link SwitchableAccount} can ask it too.
+ */
+export function isSwitchTargetAccount(
+  node: { kind?: AccountKind | null; relationship?: AccountRelationship },
+): boolean {
+  return node.relationship === 'self' || isActAsEligibleKind(node.kind);
+}
+
 /** Input to {@link projectSwitchableAccounts}. */
 export interface ProjectSwitchableAccountsInput {
   /**
@@ -144,8 +176,9 @@ export interface ProjectSwitchableAccountsInput {
  * and a graph node is deduped into ONE device row enriched with the graph
  * metadata (relationship / kind / parent / membership).
  *
- * Graph nodes of a kind nobody may act as (`channel`) are omitted — see the
- * filter below.
+ * Graph nodes that are not switch targets — a `channel`, which nobody may act
+ * as — are omitted. {@link isSwitchTargetAccount} is the rule; see the filter
+ * below.
  */
 export function projectSwitchableAccounts(input: ProjectSwitchableAccountsInput): SwitchableAccount[] {
   const { state, graph, profilesById, activeUser, locale, resolveAvatarUrl } = input;
@@ -236,10 +269,12 @@ export function projectSwitchableAccounts(input: ProjectSwitchableAccountsInput)
     // construction": the graph contributes accounts that have no device session
     // and no credentials at all, which is exactly how an org first becomes
     // switchable. So a kind that must never be switched into has to be filtered
-    // HERE, and `isActAsEligibleKind` is the same predicate the server enforces
-    // on `POST /accounts/:id/switch` — offering a row the server would 403 is a
-    // dead button.
-    if (!isActAsEligibleKind(node.kind)) {
+    // HERE — offering a row the server would 403 is a dead button.
+    //
+    // An account already on the device skipped this check via the branch above,
+    // and correctly: whatever its kind, the caller is signed into it, so
+    // switching is a local activation that asks the server for nothing.
+    if (!isSwitchTargetAccount(node)) {
       continue;
     }
     remember(toRow(node.account, {
@@ -263,8 +298,11 @@ export function projectSwitchableAccounts(input: ProjectSwitchableAccountsInput)
  * document, but including their ids lets the caller pass one id set and lets the
  * projection prefer freshly-fetched profiles uniformly.
  *
- * Applies the SAME act-as filter as {@link projectSwitchableAccounts} to graph
- * nodes, so this never fetches a profile for a row the projection will drop.
+ * Applies the SAME {@link isSwitchTargetAccount} filter as
+ * {@link projectSwitchableAccounts} to graph nodes, so this never fetches a
+ * profile for a row the projection will drop — and, just as importantly, never
+ * SKIPS one the projection will keep, which would leave that row unrendered
+ * until some later fetch happened to resolve it.
  */
 export function switchableAccountIds(
   state: DeviceSessionState | null,
@@ -277,7 +315,7 @@ export function switchableAccountIds(
     }
   }
   for (const node of graph) {
-    if (node.accountId && isActAsEligibleKind(node.kind)) {
+    if (node.accountId && isSwitchTargetAccount(node)) {
       ids.add(node.accountId);
     }
   }


### PR DESCRIPTION
## Summary

**The Oxy account switcher was offering `channel` accounts.** The cause was not a missing filter in the shared projection — it was a surface that never consulted it. The Console's workspace switcher ran its own `oxyServices.listAccounts()` and rendered the raw `AccountNode[]` forest, so every kind the API returns became a clickable row.

The smoking gun is inside commit `cb4f06f1` itself: the same commit that added the channel filter to `projectSwitchableAccounts` also added `channel: 'Channel'` to the Console's `kindSubtitles` map. The Console was taught to LABEL channel rows in the very change that taught the SDK to DROP them.

So the ecosystem's "channels cannot appear in the switcher structurally, not by a UI filter" claim is half true, and the failing half is the one users see: it is structural for **session minting** — `accounts.ts:655-661` throws `Cannot switch into a channel account`, `authSession.service.ts:197` does the same for OAuth delegated subjects, and both are tested — but it was never structural for **list rendering**, because the account graph deliberately contributes credential-less accounts. So the Console row was a **dead button, not an escalation**. Every enumerating surface needs the rule explicitly.

**The predicate is not `isActAsEligibleKind`**, which returns false for `personal` too and would have hidden the row that returns you to yourself. New `isSwitchTargetAccount` in `@oxyhq/core` admits `relationship === 'self'` OR an act-as-eligible kind. The `self` ground is verifiable rather than assumed: `GET /accounts` resolves its caller through `resolveOperatorId`, so a `self` node is the human operator's personal account even while they operate an org.

**Six surfaces enumerate switchable accounts.** Four were already correct through the one projection — including **both** IdP screens, which share the path via `useSwitchableAccounts` and inherit the fix with zero config. Two maintained their own enumeration and now use the shared predicate: the Console workspace tree (extracted to a leaf module so a unit test can reach it without dragging in the whole UI tree), and the accounts app's managed-accounts rows, which carried three hand-rolled `kind === 'channel'` literals — correct today, wrong for the next kind Oxy adds.

**A second bug found by a failing assertion:** a node promoted to a root because its parent was dropped was ALSO still returned by `childrenOf(droppedParent)` — a duplicate render waiting for any caller passing a non-root id. `buildWorkspaceTree` now returns a strict partition.

**Mutation testing caught a dead assertion:** the Console's `kind !== 'channel'` check initially SURVIVED all 7 tests, because every fixture had exactly one personal account and it was `self`, so both readings agreed on all of them. The distinguishing fixture is somebody ELSE's personal account. Added; the mutant now dies. Every fixture set carries personal + organization + project + bot that must survive alongside the channel that must not.

Also includes a small documentation correction to `docs/CHANGELOG.md`, found by this work: the pending publish order was listed as `core → auth → services`, but `packages/auth` resolves `@oxyhq/services/lib`, so building auth before services fails. Corrected to `core → services → auth`.

## Test plan

Gates already run by the implementing agent (not re-run here):
- [x] core 104 suites / 1439 tests
- [x] services 67/595
- [x] auth 127
- [x] accounts 15/137
- [x] contracts 16/238
- [x] console 1/8 (new — that package had zero test files before)
- [x] Builds green across contracts, protocol, core, auth, services, console
- [x] Biome delta 0 on the touched core files (5 pre-existing errors before and after)

Known gaps, reported as-is:
- [ ] No browser verification of the Console UI
- [ ] The Console switcher renders only two levels; a grandchild has never been rendered (pre-existing, documented in the new test rather than papered over)

No npm package was published and no package version was bumped as part of this PR.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>