### PR TITLE
fix(accounts): read account:act_as off permissions, add per-member permission overrides

### DIFF
--- a/packages/api/drizzle/0014_account_member_permission_overrides.sql
+++ b/packages/api/drizzle/0014_account_member_permission_overrides.sql
@@ -1,0 +1,44 @@
+-- account_members.permission_grants / permission_revokes — the per-member
+-- adjustment to the role's baseline permission set.
+--
+-- SAFE TO APPLY BEFORE THE CODE THAT USES IT DEPLOYS, which is the order this
+-- repo's migrations run in. Both statements are purely additive: nothing is
+-- dropped or renamed, so no column the running image selects by name goes away,
+-- and both columns carry a DEFAULT, so an INSERT issued by the old image (which
+-- does not name them) still succeeds. The old image reads neither column, so a
+-- row written by the new image is fully legible to it.
+--
+-- Neither column carries a `CHECK` restricting it to the permission vocabulary,
+-- and that is a decision rather than an omission. `users_account_categories_
+-- check` in migration 0013 is the shape being deliberately avoided here: with
+-- `check (col <@ array[…])`, later NARROWING that array makes every subsequent
+-- UPDATE of a row holding a now-absent value fail — including an UPDATE naming
+-- only `role`, reported against a column the caller never mentioned. Measured on
+-- Postgres 17.5, and `NOT VALID` does not rescue it: that skips the existing-row
+-- scan at ALTER time and the next update of such a row still fails.
+--
+-- The difference from `account_categories` is that THIS vocabulary is expected
+-- to shrink — six of its twenty-three strings are already read by no code — so
+-- the constraint would be a landmine with a known trigger. It is enforced at the
+-- write boundary instead (the zod schema 400s an unknown permission) and
+-- filtered at the read boundary (`resolveEffectivePermissions` builds its result
+-- by filtering the vocabulary, so a retired string cannot grant anything). A
+-- string that goes out of vocabulary is left in the row rather than scrubbed,
+-- for the same reason 0013 left `organization_category` in place: re-instating
+-- the permission restores the grant instead of having silently lost it.
+--
+-- Adding a column with a non-volatile DEFAULT does not rewrite the table on
+-- Postgres 11+ (the default is recorded in `pg_attribute.attmissingval`), so
+-- neither statement takes a long ACCESS EXCLUSIVE lock on `account_members`.
+--
+-- NOT IN THIS MIGRATION, deliberately: `db:generate` also proposes dropping
+-- `users.organization_category` and its CHECK, because the schema stopped
+-- declaring the column in 0013 while that migration deliberately left it in the
+-- database. Its drop is 0013's deferred second half — gated on a pre-check
+-- written into that file — and carrying it along inside an unrelated migration
+-- would apply someone else's deferred decision without the pre-check having been
+-- run. `meta/0014_snapshot.json` therefore still records the column, so a future
+-- `db:generate` proposes the drop again rather than recording it as applied.
+
+ALTER TABLE "account_members" ADD COLUMN "permission_grants" text[] DEFAULT '{}' NOT NULL;--> statement-breakpoint
+ALTER TABLE "account_members" ADD COLUMN "permission_revokes" text[] DEFAULT '{}' NOT NULL;

--- a/packages/api/drizzle/meta/0014_snapshot.json
+++ b/packages/api/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,16042 @@
+{
+  "id": "3eab0113-6eb1-4b3c-aa9f-4b0301fac556",
+  "prevId": "59701d91-f4d5-4277-bb9f-ecbb640d12d0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_credentials": {
+      "name": "account_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'service'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_credential_id": {
+          "name": "rotated_from_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_credentials_account_id_status_idx": {
+          "name": "account_credentials_account_id_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_credentials_account_id_users_id_fk": {
+          "name": "account_credentials_account_id_users_id_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_credentials_created_by_user_id_users_id_fk": {
+          "name": "account_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "account_credentials_rotated_from_fk": {
+          "name": "account_credentials_rotated_from_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "account_credentials",
+          "columnsFrom": [
+            "rotated_from_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_credentials_public_key_key": {
+          "name": "account_credentials_public_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_credentials_type_check": {
+          "name": "account_credentials_type_check",
+          "value": "\"account_credentials\".\"type\" in ('service')"
+        },
+        "account_credentials_environment_check": {
+          "name": "account_credentials_environment_check",
+          "value": "\"account_credentials\".\"environment\" in ('development', 'staging', 'production')"
+        },
+        "account_credentials_status_check": {
+          "name": "account_credentials_status_check",
+          "value": "\"account_credentials\".\"status\" in ('active', 'deprecated', 'revoked')"
+        },
+        "account_credentials_scopes_check": {
+          "name": "account_credentials_scopes_check",
+          "value": "\"account_credentials\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision']::text[]"
+        },
+        "account_credentials_rotated_from_not_self_check": {
+          "name": "account_credentials_rotated_from_not_self_check",
+          "value": "\"account_credentials\".\"rotated_from_credential_id\" <> \"account_credentials\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_members": {
+      "name": "account_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_grants": {
+          "name": "permission_grants",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "permission_revokes": {
+          "name": "permission_revokes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "inherit": {
+          "name": "inherit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_members_member_user_id_status_idx": {
+          "name": "account_members_member_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "member_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_members_account_id_users_id_fk": {
+          "name": "account_members_account_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_members_member_user_id_users_id_fk": {
+          "name": "account_members_member_user_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_members_invited_by_user_id_users_id_fk": {
+          "name": "account_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_members_account_id_member_user_id_key": {
+          "name": "account_members_account_id_member_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_id",
+            "member_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_members_role_check": {
+          "name": "account_members_role_check",
+          "value": "\"account_members\".\"role\" in ('owner', 'admin', 'editor', 'developer', 'billing', 'viewer')"
+        },
+        "account_members_status_check": {
+          "name": "account_members_status_check",
+          "value": "\"account_members\".\"status\" in ('active', 'invited', 'removed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key_usage_events": {
+      "name": "api_key_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_key'"
+        },
+        "service_app": {
+          "name": "service_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_usage_events_application_id_created_at_idx": {
+          "name": "api_key_usage_events_application_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_user_id_created_at_idx": {
+          "name": "api_key_usage_events_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_api_key_id_created_at_idx": {
+          "name": "api_key_usage_events_api_key_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_created_at_idx": {
+          "name": "api_key_usage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_usage_events_api_key_id_developer_api_keys_id_fk": {
+          "name": "api_key_usage_events_api_key_id_developer_api_keys_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "developer_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_usage_events_user_id_users_id_fk": {
+          "name": "api_key_usage_events_user_id_users_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_usage_events_application_id_applications_id_fk": {
+          "name": "api_key_usage_events_application_id_applications_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "api_key_usage_events_method_check": {
+          "name": "api_key_usage_events_method_check",
+          "value": "\"api_key_usage_events\".\"method\" in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')"
+        },
+        "api_key_usage_events_auth_type_check": {
+          "name": "api_key_usage_events_auth_type_check",
+          "value": "\"api_key_usage_events\".\"auth_type\" in ('api_key', 'session', 'internal')"
+        },
+        "api_key_usage_events_status_code_check": {
+          "name": "api_key_usage_events_status_code_check",
+          "value": "\"api_key_usage_events\".\"status_code\" >= 100 and \"api_key_usage_events\".\"status_code\" < 600"
+        },
+        "api_key_usage_events_consumption_check": {
+          "name": "api_key_usage_events_consumption_check",
+          "value": "\"api_key_usage_events\".\"tokens_used\" >= 0 and \"api_key_usage_events\".\"credits_used\" >= 0\n        and (\"api_key_usage_events\".\"response_time\" is null or \"api_key_usage_events\".\"response_time\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_affinity_edges": {
+      "name": "app_affinity_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affinity": {
+          "name": "affinity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_affinity_edges_application_id_from_user_id_affinity_idx": {
+          "name": "app_affinity_edges_application_id_from_user_id_affinity_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affinity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_affinity_edges_application_id_to_user_id_idx": {
+          "name": "app_affinity_edges_application_id_to_user_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_affinity_edges_application_id_applications_id_fk": {
+          "name": "app_affinity_edges_application_id_applications_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_affinity_edges_from_user_id_users_id_fk": {
+          "name": "app_affinity_edges_from_user_id_users_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_affinity_edges_to_user_id_users_id_fk": {
+          "name": "app_affinity_edges_to_user_id_users_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_affinity_edges_directed_edge_key": {
+          "name": "app_affinity_edges_directed_edge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "from_user_id",
+            "to_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_affinity_edges_not_self_check": {
+          "name": "app_affinity_edges_not_self_check",
+          "value": "\"app_affinity_edges\".\"from_user_id\" <> \"app_affinity_edges\".\"to_user_id\""
+        },
+        "app_affinity_edges_affinity_check": {
+          "name": "app_affinity_edges_affinity_check",
+          "value": "\"app_affinity_edges\".\"affinity\" >= 0 and \"app_affinity_edges\".\"event_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_affinity_seen_events": {
+      "name": "app_affinity_seen_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_affinity_seen_events_created_at_idx": {
+          "name": "app_affinity_seen_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_affinity_seen_events_application_id_applications_id_fk": {
+          "name": "app_affinity_seen_events_application_id_applications_id_fk",
+          "tableFrom": "app_affinity_seen_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_affinity_seen_events_application_id_event_id_key": {
+          "name": "app_affinity_seen_events_application_id_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_endorsement_edges": {
+      "name": "app_endorsement_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_endorsement_edges_application_id_member_id_idx": {
+          "name": "app_endorsement_edges_application_id_member_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_endorsement_edges_application_id_applications_id_fk": {
+          "name": "app_endorsement_edges_application_id_applications_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_endorsement_edges_owner_id_users_id_fk": {
+          "name": "app_endorsement_edges_owner_id_users_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_endorsement_edges_member_id_users_id_fk": {
+          "name": "app_endorsement_edges_member_id_users_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_endorsement_edges_idempotency_key": {
+          "name": "app_endorsement_edges_idempotency_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "application_id",
+            "owner_id",
+            "member_id",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_endorsement_edges_not_self_check": {
+          "name": "app_endorsement_edges_not_self_check",
+          "value": "\"app_endorsement_edges\".\"owner_id\" <> \"app_endorsement_edges\".\"member_id\""
+        },
+        "app_endorsement_edges_source_id_check": {
+          "name": "app_endorsement_edges_source_id_check",
+          "value": "\"app_endorsement_edges\".\"source_id\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_grants": {
+      "name": "app_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "first_granted_at": {
+          "name": "first_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_grants_application_id_idx": {
+          "name": "app_grants_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_grants_user_id_users_id_fk": {
+          "name": "app_grants_user_id_users_id_fk",
+          "tableFrom": "app_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_grants_application_id_applications_id_fk": {
+          "name": "app_grants_application_id_applications_id_fk",
+          "tableFrom": "app_grants",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_grants_user_id_application_id_key": {
+          "name": "app_grants_user_id_application_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_update_assets": {
+      "name": "app_update_assets",
+      "schema": "",
+      "columns": {
+        "app_update_id": {
+          "name": "app_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_extension": {
+          "name": "file_extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_update_assets_sha256_idx": {
+          "name": "app_update_assets_sha256_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_update_assets_app_update_id_app_updates_id_fk": {
+          "name": "app_update_assets_app_update_id_app_updates_id_fk",
+          "tableFrom": "app_update_assets",
+          "tableTo": "app_updates",
+          "columnsFrom": [
+            "app_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_update_assets_sha256_update_assets_sha256_fk": {
+          "name": "app_update_assets_sha256_update_assets_sha256_fk",
+          "tableFrom": "app_update_assets",
+          "tableTo": "update_assets",
+          "columnsFrom": [
+            "sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_update_assets_pkey": {
+          "name": "app_update_assets_pkey",
+          "columns": [
+            "app_update_id",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_update_assets_ordinal_check": {
+          "name": "app_update_assets_ordinal_check",
+          "value": "\"app_update_assets\".\"ordinal\" >= 0"
+        },
+        "app_update_assets_sha256_check": {
+          "name": "app_update_assets_sha256_check",
+          "value": "\"app_update_assets\".\"sha256\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_updates": {
+      "name": "app_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "update_id": {
+          "name": "update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "launch_asset_sha256": {
+          "name": "launch_asset_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_key": {
+          "name": "launch_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_content_type": {
+          "name": "launch_asset_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_file_extension": {
+          "name": "launch_asset_file_extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rollout_percent": {
+          "name": "rollout_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "git_commit": {
+          "name": "git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_from_update_id": {
+          "name": "promoted_from_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_updates_head_idx": {
+          "name": "app_updates_head_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_updates_channel_id_idx": {
+          "name": "app_updates_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_updates_application_id_applications_id_fk": {
+          "name": "app_updates_application_id_applications_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_updates_channel_id_update_channels_id_fk": {
+          "name": "app_updates_channel_id_update_channels_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "update_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_updates_launch_asset_sha256_update_assets_sha256_fk": {
+          "name": "app_updates_launch_asset_sha256_update_assets_sha256_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "update_assets",
+          "columnsFrom": [
+            "launch_asset_sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "app_updates_promoted_from_update_id_app_updates_update_id_fk": {
+          "name": "app_updates_promoted_from_update_id_app_updates_update_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "app_updates",
+          "columnsFrom": [
+            "promoted_from_update_id"
+          ],
+          "columnsTo": [
+            "update_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_updates_update_id_key": {
+          "name": "app_updates_update_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "update_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_updates_platform_check": {
+          "name": "app_updates_platform_check",
+          "value": "\"app_updates\".\"platform\" in ('ios', 'android')"
+        },
+        "app_updates_status_check": {
+          "name": "app_updates_status_check",
+          "value": "\"app_updates\".\"status\" in ('published', 'superseded', 'rolled_back')"
+        },
+        "app_updates_update_id_check": {
+          "name": "app_updates_update_id_check",
+          "value": "\"app_updates\".\"update_id\" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'"
+        },
+        "app_updates_launch_asset_sha256_check": {
+          "name": "app_updates_launch_asset_sha256_check",
+          "value": "\"app_updates\".\"launch_asset_sha256\" ~ '^[a-f0-9]{64}$'"
+        },
+        "app_updates_rollout_percent_check": {
+          "name": "app_updates_rollout_percent_check",
+          "value": "\"app_updates\".\"rollout_percent\" >= 0 and \"app_updates\".\"rollout_percent\" <= 100"
+        },
+        "app_updates_extra_expo_client_check": {
+          "name": "app_updates_extra_expo_client_check",
+          "value": "jsonb_typeof(\"app_updates\".\"extra\" -> 'expoClient') is not distinct from 'object'"
+        },
+        "app_updates_metadata_check": {
+          "name": "app_updates_metadata_check",
+          "value": "jsonb_typeof(\"app_updates\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_signals": {
+      "name": "app_user_signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endorsement_score": {
+          "name": "endorsement_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interest_score": {
+          "name": "interest_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_endorsed_at": {
+          "name": "last_endorsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_user_signals_application_id_endorsement_score_idx": {
+          "name": "app_user_signals_application_id_endorsement_score_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endorsement_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_signals_user_id_idx": {
+          "name": "app_user_signals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_signals_application_id_applications_id_fk": {
+          "name": "app_user_signals_application_id_applications_id_fk",
+          "tableFrom": "app_user_signals",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_user_signals_user_id_users_id_fk": {
+          "name": "app_user_signals_user_id_users_id_fk",
+          "tableFrom": "app_user_signals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_user_signals_application_id_user_id_key": {
+          "name": "app_user_signals_application_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_user_signals_interest_score_check": {
+          "name": "app_user_signals_interest_score_check",
+          "value": "\"app_user_signals\".\"interest_score\" >= 0 and \"app_user_signals\".\"interest_score\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_credentials": {
+      "name": "application_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_credential_id": {
+          "name": "rotated_from_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_credentials_application_id_status_idx": {
+          "name": "application_credentials_application_id_status_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_credentials_application_id_applications_id_fk": {
+          "name": "application_credentials_application_id_applications_id_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_credentials_created_by_user_id_users_id_fk": {
+          "name": "application_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_credentials_rotated_from_fk": {
+          "name": "application_credentials_rotated_from_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "rotated_from_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_credentials_public_key_key": {
+          "name": "application_credentials_public_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "application_credentials_type_check": {
+          "name": "application_credentials_type_check",
+          "value": "\"application_credentials\".\"type\" in ('public', 'confidential', 'service')"
+        },
+        "application_credentials_environment_check": {
+          "name": "application_credentials_environment_check",
+          "value": "\"application_credentials\".\"environment\" in ('development', 'staging', 'production')"
+        },
+        "application_credentials_status_check": {
+          "name": "application_credentials_status_check",
+          "value": "\"application_credentials\".\"status\" in ('active', 'deprecated', 'revoked')"
+        },
+        "application_credentials_scopes_check": {
+          "name": "application_credentials_scopes_check",
+          "value": "\"application_credentials\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision']::text[]"
+        },
+        "application_credentials_rotated_from_not_self_check": {
+          "name": "application_credentials_rotated_from_not_self_check",
+          "value": "\"application_credentials\".\"rotated_from_credential_id\" <> \"application_credentials\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_moderation_trust": {
+      "name": "application_moderation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standing": {
+          "name": "standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sandbox'"
+        },
+        "evidence_integrity": {
+          "name": "evidence_integrity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "identity_binding_reliability": {
+          "name": "identity_binding_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "decision_overturn_rate": {
+          "name": "decision_overturn_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "policy_quality": {
+          "name": "policy_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "global_reputation_effects_allowed": {
+          "name": "global_reputation_effects_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_moderation_trust_standing_idx": {
+          "name": "application_moderation_trust_standing_idx",
+          "columns": [
+            {
+              "expression": "standing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_moderation_trust_application_id_applications_id_fk": {
+          "name": "application_moderation_trust_application_id_applications_id_fk",
+          "tableFrom": "application_moderation_trust",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_moderation_trust_reviewed_by_user_id_users_id_fk": {
+          "name": "application_moderation_trust_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "application_moderation_trust",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_moderation_trust_application_id_key": {
+          "name": "application_moderation_trust_application_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "application_moderation_trust_standing_check": {
+          "name": "application_moderation_trust_standing_check",
+          "value": "\"application_moderation_trust\".\"standing\" in ('sandbox', 'trusted', 'restricted')"
+        },
+        "application_moderation_trust_scores_check": {
+          "name": "application_moderation_trust_scores_check",
+          "value": "\"application_moderation_trust\".\"evidence_integrity\" between 0 and 1\n        and \"application_moderation_trust\".\"identity_binding_reliability\" between 0 and 1\n        and \"application_moderation_trust\".\"decision_overturn_rate\" between 0 and 1\n        and \"application_moderation_trust\".\"policy_quality\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'third_party'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_official": {
+          "name": "is_official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_webhook_url": {
+          "name": "dev_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_owner_account_id_created_at_idx": {
+          "name": "applications_owner_account_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_capabilities_idx": {
+          "name": "applications_capabilities_idx",
+          "columns": [
+            {
+              "expression": "capabilities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_owner_account_id_users_id_fk": {
+          "name": "applications_owner_account_id_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_user_id_users_id_fk": {
+          "name": "applications_created_by_user_id_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "applications_type_check": {
+          "name": "applications_type_check",
+          "value": "\"applications\".\"type\" in ('first_party', 'third_party', 'internal', 'system')"
+        },
+        "applications_status_check": {
+          "name": "applications_status_check",
+          "value": "\"applications\".\"status\" in ('active', 'suspended', 'deleted', 'pending_review')"
+        },
+        "applications_scopes_check": {
+          "name": "applications_scopes_check",
+          "value": "\"applications\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision']::text[]"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_challenges": {
+      "name": "auth_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signin'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_challenges_expires_at_idx": {
+          "name": "auth_challenges_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_challenges_challenge_key": {
+          "name": "auth_challenges_challenge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_challenges_purpose_check": {
+          "name": "auth_challenges_purpose_check",
+          "value": "\"auth_challenges\".\"purpose\" in ('signin', 'rotate_key')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_codes": {
+      "name": "auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_codes_user_id_idx": {
+          "name": "auth_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_codes_application_id_idx": {
+          "name": "auth_codes_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_codes_expires_at_idx": {
+          "name": "auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_codes_user_id_users_id_fk": {
+          "name": "auth_codes_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_operated_by_user_id_users_id_fk": {
+          "name": "auth_codes_operated_by_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_application_id_applications_id_fk": {
+          "name": "auth_codes_application_id_applications_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_codes_code_hash_key": {
+          "name": "auth_codes_code_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_codes_code_challenge_method_check": {
+          "name": "auth_codes_code_challenge_method_check",
+          "value": "\"auth_codes\".\"code_challenge_method\" in ('S256')"
+        },
+        "auth_codes_pkce_pair_check": {
+          "name": "auth_codes_pkce_pair_check",
+          "value": "(\"auth_codes\".\"code_challenge\" is null) = (\"auth_codes\".\"code_challenge_method\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorize_code": {
+          "name": "authorize_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_origin": {
+          "name": "bound_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_verified": {
+          "name": "origin_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requester_label": {
+          "name": "requester_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge_nonce": {
+          "name": "challenge_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device_sign_in'"
+        },
+        "oauth_redirect_uri": {
+          "name": "oauth_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_code_challenge": {
+          "name": "oauth_code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_code_challenge_method": {
+          "name": "oauth_code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_subject_account_id": {
+          "name": "oauth_subject_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_auth_code_id": {
+          "name": "finalized_auth_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_by": {
+          "name": "authorized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_user_id": {
+          "name": "authorized_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_sent_at": {
+          "name": "push_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_application_id_idx": {
+          "name": "auth_sessions_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_application_id_applications_id_fk": {
+          "name": "auth_sessions_application_id_applications_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_sessions_oauth_subject_account_id_users_id_fk": {
+          "name": "auth_sessions_oauth_subject_account_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "oauth_subject_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_sessions_authorized_user_id_users_id_fk": {
+          "name": "auth_sessions_authorized_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorized_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_key": {
+          "name": "auth_sessions_session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        },
+        "auth_sessions_authorize_code_key": {
+          "name": "auth_sessions_authorize_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authorize_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_sessions_status_check": {
+          "name": "auth_sessions_status_check",
+          "value": "\"auth_sessions\".\"status\" in ('pending', 'authorized', 'consumed', 'expired', 'cancelled')"
+        },
+        "auth_sessions_purpose_check": {
+          "name": "auth_sessions_purpose_check",
+          "value": "\"auth_sessions\".\"purpose\" in ('device_sign_in', 'oauth_authorization')"
+        },
+        "auth_sessions_denied_reason_check": {
+          "name": "auth_sessions_denied_reason_check",
+          "value": "\"auth_sessions\".\"denied_reason\" in ('declined', 'not_me')"
+        },
+        "auth_sessions_oauth_code_challenge_method_check": {
+          "name": "auth_sessions_oauth_code_challenge_method_check",
+          "value": "\"auth_sessions\".\"oauth_code_challenge_method\" in ('S256')"
+        },
+        "auth_sessions_oauth_binding_check": {
+          "name": "auth_sessions_oauth_binding_check",
+          "value": "(\"auth_sessions\".\"oauth_redirect_uri\" is null and \"auth_sessions\".\"oauth_code_challenge\" is null and \"auth_sessions\".\"oauth_code_challenge_method\" is null and \"auth_sessions\".\"oauth_scopes\" is null)\n        or (\"auth_sessions\".\"oauth_redirect_uri\" is not null and \"auth_sessions\".\"oauth_code_challenge\" is not null and \"auth_sessions\".\"oauth_code_challenge_method\" is not null and \"auth_sessions\".\"oauth_scopes\" is not null)"
+        },
+        "auth_sessions_oauth_purpose_check": {
+          "name": "auth_sessions_oauth_purpose_check",
+          "value": "(\"auth_sessions\".\"purpose\" = 'oauth_authorization') = (\"auth_sessions\".\"oauth_redirect_uri\" is not null)"
+        },
+        "auth_sessions_oauth_subject_requires_binding_check": {
+          "name": "auth_sessions_oauth_subject_requires_binding_check",
+          "value": "\"auth_sessions\".\"oauth_subject_account_id\" is null or \"auth_sessions\".\"oauth_redirect_uri\" is not null"
+        },
+        "auth_sessions_requester_label_length_check": {
+          "name": "auth_sessions_requester_label_length_check",
+          "value": "\"auth_sessions\".\"requester_label\" is null or char_length(\"auth_sessions\".\"requester_label\") <= 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_subscriptions": {
+      "name": "billing_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_credits_per_month": {
+          "name": "plan_credits_per_month",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_price_minor_units": {
+          "name": "plan_price_minor_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_currency": {
+          "name": "plan_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_subscriptions_user_id_status_idx": {
+          "name": "billing_subscriptions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_subscriptions_user_id_users_id_fk": {
+          "name": "billing_subscriptions_user_id_users_id_fk",
+          "tableFrom": "billing_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_subscriptions_stripe_subscription_id_key": {
+          "name": "billing_subscriptions_stripe_subscription_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "billing_subscriptions_status_check": {
+          "name": "billing_subscriptions_status_check",
+          "value": "\"billing_subscriptions\".\"status\" in ('active', 'canceled', 'incomplete', 'incomplete_expired', 'past_due', 'paused', 'trialing', 'unpaid')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_transactions": {
+      "name": "billing_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_period_start": {
+          "name": "stripe_subscription_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor_units": {
+          "name": "amount_minor_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_transactions_subscription_period_key": {
+          "name": "billing_transactions_subscription_period_key",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing_transactions\".\"type\" = 'subscription_payment' and \"billing_transactions\".\"stripe_subscription_id\" is not null and \"billing_transactions\".\"stripe_subscription_period_start\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_transactions_payment_intent_key": {
+          "name": "billing_transactions_payment_intent_key",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing_transactions\".\"type\" = 'credit_purchase' and \"billing_transactions\".\"stripe_payment_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_transactions_user_id_created_at_idx": {
+          "name": "billing_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_transactions_user_id_users_id_fk": {
+          "name": "billing_transactions_user_id_users_id_fk",
+          "tableFrom": "billing_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_transactions_type_check": {
+          "name": "billing_transactions_type_check",
+          "value": "\"billing_transactions\".\"type\" in ('credit_purchase', 'subscription_payment', 'refund')"
+        },
+        "billing_transactions_status_check": {
+          "name": "billing_transactions_status_check",
+          "value": "\"billing_transactions\".\"status\" in ('pending', 'completed', 'failed', 'refunded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_blocked_id_idx": {
+          "name": "blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_user_id_users_id_fk": {
+          "name": "blocks_user_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocks_blocked_id_users_id_fk": {
+          "name": "blocks_blocked_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocks_user_id_blocked_id_key": {
+          "name": "blocks_user_id_blocked_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_id_idx": {
+          "name": "bookmarks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder-outline'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#5F6368'"
+        },
+        "match_labels": {
+          "name": "match_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundles_user_id_lower_name_key": {
+          "name": "bundles_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundles_user_id_users_id_fk": {
+          "name": "bundles_user_id_users_id_fk",
+          "tableFrom": "bundles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.civic_nonces": {
+      "name": "civic_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "civic_nonces_expires_at_idx": {
+          "name": "civic_nonces_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "civic_nonces_subject_user_id_users_id_fk": {
+          "name": "civic_nonces_subject_user_id_users_id_fk",
+          "tableFrom": "civic_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "civic_nonces_nonce_hash_key": {
+          "name": "civic_nonces_nonce_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conduct_strikes": {
+      "name": "conduct_strikes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_points": {
+          "name": "risk_points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conduct_strikes_user_id_status_idx": {
+          "name": "conduct_strikes_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_user_id_family_created_at_idx": {
+          "name": "conduct_strikes_user_id_family_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "family",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_decision_id_decision_revision_idx": {
+          "name": "conduct_strikes_decision_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_expires_at_idx": {
+          "name": "conduct_strikes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conduct_strikes\".\"status\" = 'active' and \"conduct_strikes\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conduct_strikes_user_id_users_id_fk": {
+          "name": "conduct_strikes_user_id_users_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_application_id_applications_id_fk": {
+          "name": "conduct_strikes_application_id_applications_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_transaction_id_reputation_transactions_id_fk": {
+          "name": "conduct_strikes_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_policy_version_fk": {
+          "name": "conduct_strikes_policy_version_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_version"
+          ],
+          "columnsTo": [
+            "policy_version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conduct_strikes_incident_id_user_id_effect_type_revision_key": {
+          "name": "conduct_strikes_incident_id_user_id_effect_type_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "incident_id",
+            "user_id",
+            "effect_type",
+            "decision_revision"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conduct_strikes_effect_type_check": {
+          "name": "conduct_strikes_effect_type_check",
+          "value": "\"conduct_strikes\".\"effect_type\" in ('conduct_penalty', 'report_abuse_penalty', 'review_abuse_penalty')"
+        },
+        "conduct_strikes_severity_check": {
+          "name": "conduct_strikes_severity_check",
+          "value": "\"conduct_strikes\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "conduct_strikes_status_check": {
+          "name": "conduct_strikes_status_check",
+          "value": "\"conduct_strikes\".\"status\" in ('active', 'expired', 'reversed')"
+        },
+        "conduct_strikes_decision_revision_check": {
+          "name": "conduct_strikes_decision_revision_check",
+          "value": "\"conduct_strikes\".\"decision_revision\" >= 0"
+        },
+        "conduct_strikes_resolution_complete_check": {
+          "name": "conduct_strikes_resolution_complete_check",
+          "value": "(\"conduct_strikes\".\"status\" = 'active') = (\"conduct_strikes\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_collected": {
+          "name": "auto_collected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(name, '') || ' ' || coalesce(email, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_user_id_email_key": {
+          "name": "contacts_user_id_email_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_search_vector_idx": {
+          "name": "contacts_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "contacts_starred_idx": {
+          "name": "contacts_starred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"contacts\".\"starred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_user_id_users_id_fk": {
+          "name": "contacts_user_id_users_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.developer_api_keys": {
+      "name": "developer_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"chat:completions\",\"models:read\"}'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_requests_per_minute": {
+          "name": "rate_limit_requests_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_requests_per_day": {
+          "name": "rate_limit_requests_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1000
+        },
+        "rate_limit_tokens_per_minute": {
+          "name": "rate_limit_tokens_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_tokens_per_day": {
+          "name": "rate_limit_tokens_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "developer_api_keys_user_id_is_active_idx": {
+          "name": "developer_api_keys_user_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "developer_api_keys_application_id_is_active_idx": {
+          "name": "developer_api_keys_application_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "developer_api_keys_user_id_users_id_fk": {
+          "name": "developer_api_keys_user_id_users_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "developer_api_keys_application_id_applications_id_fk": {
+          "name": "developer_api_keys_application_id_applications_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "developer_api_keys_key_hash_key": {
+          "name": "developer_api_keys_key_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "developer_api_keys_scopes_check": {
+          "name": "developer_api_keys_scopes_check",
+          "value": "\"developer_api_keys\".\"scopes\" <@ array['chat:completions', 'models:read', 'files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive']::text[]"
+        },
+        "developer_api_keys_rate_limit_check": {
+          "name": "developer_api_keys_rate_limit_check",
+          "value": "(\"developer_api_keys\".\"rate_limit_requests_per_minute\" is null or \"developer_api_keys\".\"rate_limit_requests_per_minute\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_requests_per_day\" is null or \"developer_api_keys\".\"rate_limit_requests_per_day\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_tokens_per_minute\" is null or \"developer_api_keys\".\"rate_limit_tokens_per_minute\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_tokens_per_day\" is null or \"developer_api_keys\".\"rate_limit_tokens_per_day\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_pairing_sessions": {
+      "name": "device_pairing_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pairing_id": {
+          "name": "pairing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_device_ephemeral_public_key": {
+          "name": "new_device_ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_device_label": {
+          "name": "new_device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_device_ephemeral_public_key": {
+          "name": "old_device_ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_pairing_sessions_expires_at_idx": {
+          "name": "device_pairing_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_pairing_sessions_approved_by_user_id_users_id_fk": {
+          "name": "device_pairing_sessions_approved_by_user_id_users_id_fk",
+          "tableFrom": "device_pairing_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_pairing_sessions_pairing_id_key": {
+          "name": "device_pairing_sessions_pairing_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pairing_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_pairing_sessions_status_check": {
+          "name": "device_pairing_sessions_status_check",
+          "value": "\"device_pairing_sessions\".\"status\" in ('pending', 'approved', 'denied', 'expired')"
+        },
+        "device_pairing_sessions_sealed_payload_check": {
+          "name": "device_pairing_sessions_sealed_payload_check",
+          "value": "(\"device_pairing_sessions\".\"old_device_ephemeral_public_key\" is null and \"device_pairing_sessions\".\"ciphertext\" is null and \"device_pairing_sessions\".\"nonce\" is null)\n        or (\"device_pairing_sessions\".\"old_device_ephemeral_public_key\" is not null and \"device_pairing_sessions\".\"ciphertext\" is not null and \"device_pairing_sessions\".\"nonce\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_session_accounts": {
+      "name": "device_session_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_session_id": {
+          "name": "device_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authuser": {
+          "name": "authuser",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_session_accounts_account_id_idx": {
+          "name": "device_session_accounts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_session_accounts_operated_by_user_id_idx": {
+          "name": "device_session_accounts_operated_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "operated_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"device_session_accounts\".\"operated_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_session_accounts_device_session_id_device_sessions_id_fk": {
+          "name": "device_session_accounts_device_session_id_device_sessions_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "device_sessions",
+          "columnsFrom": [
+            "device_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_session_accounts_account_id_users_id_fk": {
+          "name": "device_session_accounts_account_id_users_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_session_accounts_operated_by_user_id_users_id_fk": {
+          "name": "device_session_accounts_operated_by_user_id_users_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_session_accounts_device_session_id_account_id_key": {
+          "name": "device_session_accounts_device_session_id_account_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_session_id",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_session_accounts_authuser_check": {
+          "name": "device_session_accounts_authuser_check",
+          "value": "\"device_session_accounts\".\"authuser\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_sessions": {
+      "name": "device_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_account_id": {
+          "name": "active_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_hash": {
+          "name": "prev_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_expires_at": {
+          "name": "prev_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_hash": {
+          "name": "background_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_account_id": {
+          "name": "background_secret_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_expires_at": {
+          "name": "background_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_sessions_active_account_id_users_id_fk": {
+          "name": "device_sessions_active_account_id_users_id_fk",
+          "tableFrom": "device_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "active_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "device_sessions_background_secret_account_id_users_id_fk": {
+          "name": "device_sessions_background_secret_account_id_users_id_fk",
+          "tableFrom": "device_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "background_secret_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_sessions_device_id_key": {
+          "name": "device_sessions_device_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_id"
+          ]
+        },
+        "device_sessions_secret_hash_key": {
+          "name": "device_sessions_secret_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_verifications": {
+      "name": "domain_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_verifications_user_id_lower_domain_key": {
+          "name": "domain_verifications_user_id_lower_domain_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_verifications_expires_at_idx": {
+          "name": "domain_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_verifications_user_id_users_id_fk": {
+          "name": "domain_verifications_user_id_users_id_fk",
+          "tableFrom": "domain_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_filter_actions": {
+      "name": "email_filter_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filter_id": {
+          "name": "filter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_filter_actions_filter_id_email_filters_id_fk": {
+          "name": "email_filter_actions_filter_id_email_filters_id_fk",
+          "tableFrom": "email_filter_actions",
+          "tableTo": "email_filters",
+          "columnsFrom": [
+            "filter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_filter_actions_filter_id_ord_key": {
+          "name": "email_filter_actions_filter_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filter_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_filter_actions_type_check": {
+          "name": "email_filter_actions_type_check",
+          "value": "\"email_filter_actions\".\"type\" in ('move', 'label', 'star', 'mark-read', 'archive', 'delete', 'forward')"
+        },
+        "email_filter_actions_ord_check": {
+          "name": "email_filter_actions_ord_check",
+          "value": "\"email_filter_actions\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_filter_conditions": {
+      "name": "email_filter_conditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filter_id": {
+          "name": "filter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_filter_conditions_filter_id_email_filters_id_fk": {
+          "name": "email_filter_conditions_filter_id_email_filters_id_fk",
+          "tableFrom": "email_filter_conditions",
+          "tableTo": "email_filters",
+          "columnsFrom": [
+            "filter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_filter_conditions_filter_id_ord_key": {
+          "name": "email_filter_conditions_filter_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filter_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_filter_conditions_field_check": {
+          "name": "email_filter_conditions_field_check",
+          "value": "\"email_filter_conditions\".\"field\" in ('from', 'to', 'subject', 'has-attachment', 'size')"
+        },
+        "email_filter_conditions_operator_check": {
+          "name": "email_filter_conditions_operator_check",
+          "value": "\"email_filter_conditions\".\"operator\" in ('contains', 'equals', 'not-contains', 'starts-with', 'ends-with', 'greater-than', 'less-than')"
+        },
+        "email_filter_conditions_ord_check": {
+          "name": "email_filter_conditions_ord_check",
+          "value": "\"email_filter_conditions\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_filters": {
+      "name": "email_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "match_all": {
+          "name": "match_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_filters_user_id_enabled_order_idx": {
+          "name": "email_filters_user_id_enabled_order_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_filters_user_id_users_id_fk": {
+          "name": "email_filters_user_id_users_id_fk",
+          "tableFrom": "email_filters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_templates_user_id_lower_name_key": {
+          "name": "email_templates_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_user_id_users_id_fk": {
+          "name": "email_templates_user_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_key_pairs": {
+      "name": "federation_key_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_pem": {
+          "name": "private_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_key_pairs_key_id_key": {
+          "name": "federation_key_pairs_key_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_links": {
+      "name": "file_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_links_app_entity_type_entity_id_created_by_idx": {
+          "name": "file_links_app_entity_type_entity_id_created_by_idx",
+          "columns": [
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_links_created_by_idx": {
+          "name": "file_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_links_file_id_files_id_fk": {
+          "name": "file_links_file_id_files_id_fk",
+          "tableFrom": "file_links",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_links_created_by_users_id_fk": {
+          "name": "file_links_created_by_users_id_fk",
+          "tableFrom": "file_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_links_file_id_app_entity_key": {
+          "name": "file_links_file_id_app_entity_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_id",
+            "app",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_variants": {
+      "name": "file_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_variants_file_id_type_idx": {
+          "name": "file_variants_file_id_type_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_variants_file_id_files_id_fk": {
+          "name": "file_variants_file_id_files_id_fk",
+          "tableFrom": "file_variants",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_variants_size_check": {
+          "name": "file_variants_size_check",
+          "value": "\"file_variants\".\"size\" is null or \"file_variants\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_owner": {
+          "name": "system_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "files_sha256_live_key": {
+          "name": "files_sha256_live_key",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"status\" in ('active', 'trash')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_owner_user_id_status_idx": {
+          "name": "files_owner_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_owner_user_id_visibility_status_idx": {
+          "name": "files_owner_user_id_visibility_status_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_visibility_status_idx": {
+          "name": "files_visibility_status_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_sha256_status_idx": {
+          "name": "files_sha256_status_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_purpose_owner_user_id_status_idx": {
+          "name": "files_purpose_owner_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_created_at_idx": {
+          "name": "files_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_owner_user_id_users_id_fk": {
+          "name": "files_owner_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "files_status_check": {
+          "name": "files_status_check",
+          "value": "\"files\".\"status\" in ('active', 'trash', 'deleted')"
+        },
+        "files_visibility_check": {
+          "name": "files_visibility_check",
+          "value": "\"files\".\"visibility\" in ('private', 'public', 'unlisted')"
+        },
+        "files_purpose_check": {
+          "name": "files_purpose_check",
+          "value": "\"files\".\"purpose\" in ('user', 'federation-media-cache', 'link-preview')"
+        },
+        "files_system_owner_check": {
+          "name": "files_system_owner_check",
+          "value": "\"files\".\"system_owner\" is null or \"files\".\"system_owner\" in ('__federation__', '__federation_media_cache__', '__link_preview_cache__')"
+        },
+        "files_owner_exclusive_check": {
+          "name": "files_owner_exclusive_check",
+          "value": "(\"files\".\"owner_user_id\" is null) <> (\"files\".\"system_owner\" is null)"
+        },
+        "files_size_check": {
+          "name": "files_size_check",
+          "value": "\"files\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.identity_backups": {
+      "name": "identity_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_id_hash": {
+          "name": "lookup_id_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_hint": {
+          "name": "public_key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kdf_info": {
+          "name": "kdf_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_created_at": {
+          "name": "client_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "identity_backups_user_id_users_id_fk": {
+          "name": "identity_backups_user_id_users_id_fk",
+          "tableFrom": "identity_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "identity_backups_user_id_key": {
+          "name": "identity_backups_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "identity_backups_lookup_id_hash_key": {
+          "name": "identity_backups_lookup_id_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lookup_id_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_bindings": {
+      "name": "identity_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_principal_id": {
+          "name": "local_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_bindings_application_id_local_principal_id_active_key": {
+          "name": "identity_bindings_application_id_local_principal_id_active_key",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"identity_bindings\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_bindings_application_id_user_id_status_idx": {
+          "name": "identity_bindings_application_id_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_bindings_user_id_idx": {
+          "name": "identity_bindings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_bindings_application_id_applications_id_fk": {
+          "name": "identity_bindings_application_id_applications_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "identity_bindings_user_id_users_id_fk": {
+          "name": "identity_bindings_user_id_users_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "identity_bindings_credential_id_application_credentials_id_fk": {
+          "name": "identity_bindings_credential_id_application_credentials_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "identity_bindings_binding_type_check": {
+          "name": "identity_bindings_binding_type_check",
+          "value": "\"identity_bindings\".\"binding_type\" in ('oauth_grant', 'session_proof', 'commons_signature', 'federated_actor')"
+        },
+        "identity_bindings_status_check": {
+          "name": "identity_bindings_status_check",
+          "value": "\"identity_bindings\".\"status\" in ('active', 'revoked')"
+        },
+        "identity_bindings_revoked_at_check": {
+          "name": "identity_bindings_revoked_at_check",
+          "value": "(\"identity_bindings\".\"status\" = 'revoked') = (\"identity_bindings\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4285f4'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_user_id_lower_name_key": {
+          "name": "labels_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_user_id_users_id_fk": {
+          "name": "labels_user_id_users_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.link_previews": {
+      "name": "link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_url": {
+          "name": "requested_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_image_url": {
+          "name": "origin_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_favicon_url": {
+          "name": "origin_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "link_previews_status_idx": {
+          "name": "link_previews_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "link_previews_updated_at_idx": {
+          "name": "link_previews_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "link_previews_status_check": {
+          "name": "link_previews_status_check",
+          "value": "\"link_previews\".\"status\" in ('resolved', 'pending', 'empty')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mailboxes": {
+      "name": "mailboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "special_use": {
+          "name": "special_use",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mailboxes_user_id_path_key": {
+          "name": "mailboxes_user_id_path_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_user_id_special_use_idx": {
+          "name": "mailboxes_user_id_special_use_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "special_use",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mailboxes_user_id_users_id_fk": {
+          "name": "mailboxes_user_id_users_id_fk",
+          "tableFrom": "mailboxes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_attachments": {
+      "name": "message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_inline": {
+          "name": "is_inline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "message_attachments_file_id_idx": {
+          "name": "message_attachments_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_attachments_message_id_messages_id_fk": {
+          "name": "message_attachments_message_id_messages_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_attachments_file_id_files_id_fk": {
+          "name": "message_attachments_file_id_files_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_attachments_message_id_ord_key": {
+          "name": "message_attachments_message_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "message_attachments_size_check": {
+          "name": "message_attachments_size_check",
+          "value": "\"message_attachments\".\"size\" >= 0"
+        },
+        "message_attachments_ord_check": {
+          "name": "message_attachments_ord_check",
+          "value": "\"message_attachments\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_recipients": {
+      "name": "message_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_recipients_address_idx": {
+          "name": "message_recipients_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_recipients_message_id_messages_id_fk": {
+          "name": "message_recipients_message_id_messages_id_fk",
+          "tableFrom": "message_recipients",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_recipients_message_id_kind_ord_key": {
+          "name": "message_recipients_message_id_kind_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "kind",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "message_recipients_kind_check": {
+          "name": "message_recipients_kind_check",
+          "value": "\"message_recipients\".\"kind\" in ('to', 'cc', 'bcc')"
+        },
+        "message_recipients_ord_check": {
+          "name": "message_recipients_ord_check",
+          "value": "\"message_recipients\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_name": {
+          "name": "reply_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_address": {
+          "name": "reply_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "encrypted_body": {
+          "name": "encrypted_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "answered": {
+          "name": "answered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forwarded": {
+          "name": "forwarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_data": {
+          "name": "card_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_confidence": {
+          "name": "card_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_extracted_at": {
+          "name": "card_extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spam_action": {
+          "name": "spam_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "alias_tag": {
+          "name": "alias_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_from_mailbox": {
+          "name": "snoozed_from_mailbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_receipt_requested": {
+          "name": "read_receipt_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_receipt_sent": {
+          "name": "read_receipt_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(subject, '')), 'A') || setweight(to_tsvector('english', coalesce(\"text\", '')), 'D')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_user_id_mailbox_id_pinned_date_idx": {
+          "name": "messages_user_id_mailbox_id_pinned_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_message_id_idx": {
+          "name": "messages_user_id_message_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_in_reply_to_idx": {
+          "name": "messages_user_id_in_reply_to_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_references_idx": {
+          "name": "messages_references_idx",
+          "columns": [
+            {
+              "expression": "references",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_unseen_idx": {
+          "name": "messages_unseen_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"messages\".\"seen\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_starred_idx": {
+          "name": "messages_starred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"starred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_search_vector_idx": {
+          "name": "messages_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_labels_idx": {
+          "name": "messages_labels_idx",
+          "columns": [
+            {
+              "expression": "labels",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_user_id_alias_tag_idx": {
+          "name": "messages_user_id_alias_tag_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_from_address_date_idx": {
+          "name": "messages_user_id_from_address_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_pinned_date_idx": {
+          "name": "messages_user_id_pinned_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_snoozed_until_idx": {
+          "name": "messages_snoozed_until_idx",
+          "columns": [
+            {
+              "expression": "snoozed_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"snoozed_until\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_scheduled_at_idx": {
+          "name": "messages_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"scheduled_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_mailbox_id_received_at_idx": {
+          "name": "messages_mailbox_id_received_at_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_mailbox_id_mailboxes_id_fk": {
+          "name": "messages_mailbox_id_mailboxes_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "mailboxes",
+          "columnsFrom": [
+            "mailbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_snoozed_from_mailbox_mailboxes_id_fk": {
+          "name": "messages_snoozed_from_mailbox_mailboxes_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "mailboxes",
+          "columnsFrom": [
+            "snoozed_from_mailbox"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_card_type_check": {
+          "name": "messages_card_type_check",
+          "value": "\"messages\".\"card_type\" is null or \"messages\".\"card_type\" in ('trip', 'purchase', 'event', 'bill', 'package')"
+        },
+        "messages_card_complete_check": {
+          "name": "messages_card_complete_check",
+          "value": "\"messages\".\"card_type\" is not null or (\"messages\".\"card_data\" is null and \"messages\".\"card_confidence\" is null and \"messages\".\"card_extracted_at\" is null)"
+        },
+        "messages_size_check": {
+          "name": "messages_size_check",
+          "value": "\"messages\".\"size\" >= 0"
+        },
+        "messages_reply_to_complete_check": {
+          "name": "messages_reply_to_complete_check",
+          "value": "\"messages\".\"reply_to_address\" is not null or \"messages\".\"reply_to_name\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_effects": {
+      "name": "moderation_effects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_risk": {
+          "name": "active_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_multiplier": {
+          "name": "repetition_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_multiplier": {
+          "name": "multi_finding_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strike_id": {
+          "name": "strike_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_transaction_id": {
+          "name": "reversal_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version_universal": {
+          "name": "policy_version_universal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version_application": {
+          "name": "policy_version_application",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version_oxy_conduct": {
+          "name": "policy_version_oxy_conduct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_hash": {
+          "name": "proof_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_reason": {
+          "name": "reversal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "moderation_effects_decision_id_decision_revision_idx": {
+          "name": "moderation_effects_decision_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_effects_incident_id_decision_revision_idx": {
+          "name": "moderation_effects_incident_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_effects_principal_id_applied_at_idx": {
+          "name": "moderation_effects_principal_id_applied_at_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "applied_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_effects_principal_id_users_id_fk": {
+          "name": "moderation_effects_principal_id_users_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_binding_id_identity_bindings_id_fk": {
+          "name": "moderation_effects_binding_id_identity_bindings_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "identity_bindings",
+          "columnsFrom": [
+            "binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_application_id_applications_id_fk": {
+          "name": "moderation_effects_application_id_applications_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_credential_id_application_credentials_id_fk": {
+          "name": "moderation_effects_credential_id_application_credentials_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_transaction_id_reputation_transactions_id_fk": {
+          "name": "moderation_effects_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_strike_id_conduct_strikes_id_fk": {
+          "name": "moderation_effects_strike_id_conduct_strikes_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "conduct_strikes",
+          "columnsFrom": [
+            "strike_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_reversal_transaction_id_reputation_transactions_id_fk": {
+          "name": "moderation_effects_reversal_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "reversal_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_policy_version_oxy_conduct_fk": {
+          "name": "moderation_effects_policy_version_oxy_conduct_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_version_oxy_conduct"
+          ],
+          "columnsTo": [
+            "policy_version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_effects_incident_principal_type_revision_key": {
+          "name": "moderation_effects_incident_principal_type_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "incident_id",
+            "principal_id",
+            "effect_type",
+            "decision_revision"
+          ]
+        },
+        "moderation_effects_event_id_key": {
+          "name": "moderation_effects_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_effects_effect_type_check": {
+          "name": "moderation_effects_effect_type_check",
+          "value": "\"moderation_effects\".\"effect_type\" in ('conduct_penalty', 'report_abuse_penalty', 'review_abuse_penalty')"
+        },
+        "moderation_effects_status_check": {
+          "name": "moderation_effects_status_check",
+          "value": "\"moderation_effects\".\"status\" in ('applied', 'reversed')"
+        },
+        "moderation_effects_severity_check": {
+          "name": "moderation_effects_severity_check",
+          "value": "\"moderation_effects\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "moderation_effects_decision_revision_check": {
+          "name": "moderation_effects_decision_revision_check",
+          "value": "\"moderation_effects\".\"decision_revision\" >= 0"
+        },
+        "moderation_effects_reversal_complete_check": {
+          "name": "moderation_effects_reversal_complete_check",
+          "value": "(\"moderation_effects\".\"status\" = 'reversed') = (\"moderation_effects\".\"reversed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policies": {
+      "name": "moderation_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "conduct_families": {
+          "name": "conduct_families",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_multipliers": {
+          "name": "repetition_multipliers",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_window_days": {
+          "name": "repetition_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_secondary_share": {
+          "name": "multi_finding_secondary_share",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_cap": {
+          "name": "multi_finding_cap",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisional_effects_allowed": {
+          "name": "provisional_effects_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "moderation_policies_status_idx": {
+          "name": "moderation_policies_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policies_policy_version_key": {
+          "name": "moderation_policies_policy_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policies_status_check": {
+          "name": "moderation_policies_status_check",
+          "value": "\"moderation_policies\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policy_severity_rules": {
+      "name": "moderation_policy_severity_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_points": {
+          "name": "risk_points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_expiry_days": {
+          "name": "risk_expiry_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderation_policy_severity_rules_policy_id_fk": {
+          "name": "moderation_policy_severity_rules_policy_id_fk",
+          "tableFrom": "moderation_policy_severity_rules",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policy_severity_rules_policy_id_severity_key": {
+          "name": "moderation_policy_severity_rules_policy_id_severity_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_id",
+            "severity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policy_severity_rules_severity_check": {
+          "name": "moderation_policy_severity_rules_severity_check",
+          "value": "\"moderation_policy_severity_rules\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "moderation_policy_severity_rules_risk_expiry_days_check": {
+          "name": "moderation_policy_severity_rules_risk_expiry_days_check",
+          "value": "\"moderation_policy_severity_rules\".\"risk_expiry_days\" is null or \"moderation_policy_severity_rules\".\"risk_expiry_days\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policy_standing_thresholds": {
+      "name": "moderation_policy_standing_thresholds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standing": {
+          "name": "standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_risk": {
+          "name": "min_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderation_policy_standing_thresholds_policy_id_fk": {
+          "name": "moderation_policy_standing_thresholds_policy_id_fk",
+          "tableFrom": "moderation_policy_standing_thresholds",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policy_standing_thresholds_policy_id_standing_key": {
+          "name": "moderation_policy_standing_thresholds_policy_id_standing_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_id",
+            "standing"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policy_standing_thresholds_standing_check": {
+          "name": "moderation_policy_standing_thresholds_standing_check",
+          "value": "\"moderation_policy_standing_thresholds\".\"standing\" in ('good', 'watch', 'limited', 'restricted')"
+        },
+        "moderation_policy_standing_thresholds_min_risk_check": {
+          "name": "moderation_policy_standing_thresholds_min_risk_check",
+          "value": "\"moderation_policy_standing_thresholds\".\"min_risk\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.node_ingest_witnesses": {
+      "name": "node_ingest_witnesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witness_signature": {
+          "name": "witness_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_ingest_witnesses_user_id_created_at_idx": {
+          "name": "node_ingest_witnesses_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_ingest_witnesses_user_id_users_id_fk": {
+          "name": "node_ingest_witnesses_user_id_users_id_fk",
+          "tableFrom": "node_ingest_witnesses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "node_ingest_witnesses_record_id_signed_records_record_id_fk": {
+          "name": "node_ingest_witnesses_record_id_signed_records_record_id_fk",
+          "tableFrom": "node_ingest_witnesses",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_ingest_witnesses_recordId_unique": {
+          "name": "node_ingest_witnesses_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_id_created_at_idx": {
+          "name": "notifications_recipient_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_recipient_id_actor_id_type_entity_id_key": {
+          "name": "notifications_recipient_id_actor_id_type_entity_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_id",
+            "actor_id",
+            "type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "notifications_type_check": {
+          "name": "notifications_type_check",
+          "value": "\"notifications\".\"type\" in ('like', 'reply', 'mention', 'follow', 'repost', 'quote', 'welcome')"
+        },
+        "notifications_entity_type_check": {
+          "name": "notifications_entity_type_check",
+          "value": "\"notifications\".\"entity_type\" in ('post', 'reply', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personhood_statuses": {
+      "name": "personhood_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_real_person": {
+          "name": "is_real_person",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vouch_count": {
+          "name": "vouch_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "real_life_count": {
+          "name": "real_life_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "biometric_bound": {
+          "name": "biometric_bound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sybil_penalty": {
+          "name": "sybil_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_vouch_signal": {
+          "name": "breakdown_vouch_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_real_life_signal": {
+          "name": "breakdown_real_life_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_biometric_signal": {
+          "name": "breakdown_biometric_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_evidence": {
+          "name": "breakdown_evidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_sybil_penalty": {
+          "name": "breakdown_sybil_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_seed": {
+          "name": "breakdown_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personhood_statuses_score_idx": {
+          "name": "personhood_statuses_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personhood_statuses_is_real_person_idx": {
+          "name": "personhood_statuses_is_real_person_idx",
+          "columns": [
+            {
+              "expression": "is_real_person",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personhood_statuses_user_id_users_id_fk": {
+          "name": "personhood_statuses_user_id_users_id_fk",
+          "tableFrom": "personhood_statuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personhood_statuses_userId_unique": {
+          "name": "personhood_statuses_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personhood_statuses_counts_check": {
+          "name": "personhood_statuses_counts_check",
+          "value": "\"personhood_statuses\".\"vouch_count\" >= 0 and \"personhood_statuses\".\"real_life_count\" >= 0"
+        },
+        "personhood_statuses_signals_check": {
+          "name": "personhood_statuses_signals_check",
+          "value": "\"personhood_statuses\".\"score\" between 0 and 1 and \"personhood_statuses\".\"sybil_penalty\" between 0 and 1 and \"personhood_statuses\".\"breakdown_vouch_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_real_life_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_biometric_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_evidence\" between 0 and 1 and \"personhood_statuses\".\"breakdown_sybil_penalty\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personhood_vouches": {
+      "name": "personhood_vouches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voucher_user_id": {
+          "name": "voucher_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake_amount": {
+          "name": "stake_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personhood_vouches_active_pair_key": {
+          "name": "personhood_vouches_active_pair_key",
+          "columns": [
+            {
+              "expression": "voucher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"personhood_vouches\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personhood_vouches_subject_id_status_idx": {
+          "name": "personhood_vouches_subject_id_status_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personhood_vouches_voucher_user_id_users_id_fk": {
+          "name": "personhood_vouches_voucher_user_id_users_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voucher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personhood_vouches_subject_user_id_users_id_fk": {
+          "name": "personhood_vouches_subject_user_id_users_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personhood_vouches_record_id_signed_records_record_id_fk": {
+          "name": "personhood_vouches_record_id_signed_records_record_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "personhood_vouches_status_check": {
+          "name": "personhood_vouches_status_check",
+          "value": "\"personhood_vouches\".\"status\" in ('active', 'slashed', 'withdrawn')"
+        },
+        "personhood_vouches_stake_check": {
+          "name": "personhood_vouches_stake_check",
+          "value": "\"personhood_vouches\".\"stake_amount\" >= 0"
+        },
+        "personhood_vouches_not_self_check": {
+          "name": "personhood_vouches_not_self_check",
+          "value": "\"personhood_vouches\".\"voucher_user_id\" <> \"personhood_vouches\".\"subject_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_tokens_user_id_application_id_idx": {
+          "name": "push_tokens_user_id_application_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_tokens_user_id_users_id_fk": {
+          "name": "push_tokens_user_id_users_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "push_tokens_application_id_applications_id_fk": {
+          "name": "push_tokens_application_id_applications_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_user_id_token_key": {
+          "name": "push_tokens_user_id_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('ios', 'android', 'web')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_message_id": {
+          "name": "related_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reminders_user_id_completed_remind_at_idx": {
+          "name": "reminders_user_id_completed_remind_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remind_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reminders_due_idx": {
+          "name": "reminders_due_idx",
+          "columns": [
+            {
+              "expression": "remind_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"reminders\".\"completed\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_user_id_users_id_fk": {
+          "name": "reminders_user_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_related_message_id_messages_id_fk": {
+          "name": "reminders_related_message_id_messages_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "related_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_heads": {
+      "name": "repo_heads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "repo_heads_user_id_users_id_fk": {
+          "name": "repo_heads_user_id_users_id_fk",
+          "tableFrom": "repo_heads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_heads_head_record_id_signed_records_record_id_fk": {
+          "name": "repo_heads_head_record_id_signed_records_record_id_fk",
+          "tableFrom": "repo_heads",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "head_record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repo_heads_userId_unique": {
+          "name": "repo_heads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repo_heads_seq_check": {
+          "name": "repo_heads_seq_check",
+          "value": "\"repo_heads\".\"seq\" >= 0"
+        },
+        "repo_heads_record_count_check": {
+          "name": "repo_heads_record_count_check",
+          "value": "\"repo_heads\".\"record_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reporter_reputation_profiles": {
+      "name": "reporter_reputation_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed": {
+          "name": "confirmed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected": {
+          "name": "rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate": {
+          "name": "duplicate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "malicious": {
+          "name": "malicious",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_by_family": {
+          "name": "confirmed_by_family",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rejected_by_family": {
+          "name": "rejected_by_family",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reliability": {
+          "name": "reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_outcome_at": {
+          "name": "last_outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reporter_reputation_profiles_user_id_users_id_fk": {
+          "name": "reporter_reputation_profiles_user_id_users_id_fk",
+          "tableFrom": "reporter_reputation_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reporter_reputation_profiles_user_id_key": {
+          "name": "reporter_reputation_profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reporter_reputation_profiles_confirmed_by_family_object_check": {
+          "name": "reporter_reputation_profiles_confirmed_by_family_object_check",
+          "value": "jsonb_typeof(\"reporter_reputation_profiles\".\"confirmed_by_family\") = 'object'"
+        },
+        "reporter_reputation_profiles_rejected_by_family_object_check": {
+          "name": "reporter_reputation_profiles_rejected_by_family_object_check",
+          "value": "jsonb_typeof(\"reporter_reputation_profiles\".\"rejected_by_family\") = 'object'"
+        },
+        "reporter_reputation_profiles_counts_check": {
+          "name": "reporter_reputation_profiles_counts_check",
+          "value": "\"reporter_reputation_profiles\".\"confirmed\" >= 0 and \"reporter_reputation_profiles\".\"rejected\" >= 0 and \"reporter_reputation_profiles\".\"duplicate\" >= 0 and \"reporter_reputation_profiles\".\"malicious\" >= 0"
+        },
+        "reporter_reputation_profiles_reliability_check": {
+          "name": "reporter_reputation_profiles_reliability_check",
+          "value": "\"reporter_reputation_profiles\".\"reliability\" >= 0 and \"reporter_reputation_profiles\".\"reliability\" <= 1"
+        },
+        "reporter_reputation_profiles_confidence_check": {
+          "name": "reporter_reputation_profiles_confidence_check",
+          "value": "\"reporter_reputation_profiles\".\"confidence\" >= 0 and \"reporter_reputation_profiles\".\"confidence\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_balances": {
+      "name": "reputation_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "positive": {
+          "name": "positive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "negative": {
+          "name": "negative",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_content": {
+          "name": "breakdown_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_social": {
+          "name": "breakdown_social",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_trust": {
+          "name": "breakdown_trust",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_moderation": {
+          "name": "breakdown_moderation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_physical": {
+          "name": "breakdown_physical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_penalties": {
+          "name": "breakdown_penalties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trust_tier": {
+          "name": "trust_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "influence_default_weight": {
+          "name": "influence_default_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_report_weight": {
+          "name": "influence_report_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_moderation_weight": {
+          "name": "influence_moderation_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_ranking_feedback_weight": {
+          "name": "influence_ranking_feedback_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_accurate_reports": {
+          "name": "reliability_accurate_reports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_rejected_reports": {
+          "name": "reliability_rejected_reports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_report_accuracy_score": {
+          "name": "reliability_report_accuracy_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_abuse_score": {
+          "name": "reliability_abuse_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "personhood_status": {
+          "name": "personhood_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "personhood_score": {
+          "name": "personhood_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contribution_points": {
+          "name": "contribution_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contribution_tier": {
+          "name": "contribution_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "conduct_standing": {
+          "name": "conduct_standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'good'"
+        },
+        "conduct_active_risk": {
+          "name": "conduct_active_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conduct_active_strikes": {
+          "name": "conduct_active_strikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conduct_next_expiry_at": {
+          "name": "conduct_next_expiry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporting_reliability": {
+          "name": "reporting_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "reporting_confidence": {
+          "name": "reporting_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_confirmed": {
+          "name": "reporting_confirmed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_rejected": {
+          "name": "reporting_rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_malicious": {
+          "name": "reporting_malicious",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviewing_global_reliability": {
+          "name": "reviewing_global_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "contextual_report_priority_weight": {
+          "name": "contextual_report_priority_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contextual_review_selection_weight": {
+          "name": "contextual_review_selection_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contextual_ranking_weight": {
+          "name": "contextual_ranking_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_transaction_id": {
+          "name": "last_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recalculated_at": {
+          "name": "recalculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reputation_balances_total_idx": {
+          "name": "reputation_balances_total_idx",
+          "columns": [
+            {
+              "expression": "total",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_balances_trust_tier_idx": {
+          "name": "reputation_balances_trust_tier_idx",
+          "columns": [
+            {
+              "expression": "trust_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_balances_conduct_standing_idx": {
+          "name": "reputation_balances_conduct_standing_idx",
+          "columns": [
+            {
+              "expression": "conduct_standing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_balances_user_id_users_id_fk": {
+          "name": "reputation_balances_user_id_users_id_fk",
+          "tableFrom": "reputation_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_balances_last_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_balances_last_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_balances",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "last_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reputation_balances_userId_unique": {
+          "name": "reputation_balances_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reputation_balances_trust_tier_check": {
+          "name": "reputation_balances_trust_tier_check",
+          "value": "\"reputation_balances\".\"trust_tier\" in ('restricted', 'new', 'trusted', 'high_trust', 'verified')"
+        },
+        "reputation_balances_personhood_status_check": {
+          "name": "reputation_balances_personhood_status_check",
+          "value": "\"reputation_balances\".\"personhood_status\" in ('unknown', 'probable', 'verified')"
+        },
+        "reputation_balances_contribution_tier_check": {
+          "name": "reputation_balances_contribution_tier_check",
+          "value": "\"reputation_balances\".\"contribution_tier\" in ('new', 'trusted', 'high_trust')"
+        },
+        "reputation_balances_conduct_standing_check": {
+          "name": "reputation_balances_conduct_standing_check",
+          "value": "\"reputation_balances\".\"conduct_standing\" in ('good', 'watch', 'limited', 'restricted')"
+        },
+        "reputation_balances_positive_check": {
+          "name": "reputation_balances_positive_check",
+          "value": "\"reputation_balances\".\"positive\" >= 0"
+        },
+        "reputation_balances_negative_check": {
+          "name": "reputation_balances_negative_check",
+          "value": "\"reputation_balances\".\"negative\" <= 0"
+        },
+        "reputation_balances_penalties_check": {
+          "name": "reputation_balances_penalties_check",
+          "value": "\"reputation_balances\".\"breakdown_penalties\" >= 0"
+        },
+        "reputation_balances_contribution_points_check": {
+          "name": "reputation_balances_contribution_points_check",
+          "value": "\"reputation_balances\".\"contribution_points\" >= 0"
+        },
+        "reputation_balances_reliability_counts_check": {
+          "name": "reputation_balances_reliability_counts_check",
+          "value": "\"reputation_balances\".\"reliability_accurate_reports\" >= 0 and \"reputation_balances\".\"reliability_rejected_reports\" >= 0"
+        },
+        "reputation_balances_reporting_counts_check": {
+          "name": "reputation_balances_reporting_counts_check",
+          "value": "\"reputation_balances\".\"reporting_confirmed\" >= 0 and \"reputation_balances\".\"reporting_rejected\" >= 0 and \"reputation_balances\".\"reporting_malicious\" >= 0"
+        },
+        "reputation_balances_conduct_check": {
+          "name": "reputation_balances_conduct_check",
+          "value": "\"reputation_balances\".\"conduct_active_risk\" >= 0 and \"reputation_balances\".\"conduct_active_strikes\" >= 0"
+        },
+        "reputation_balances_scores_check": {
+          "name": "reputation_balances_scores_check",
+          "value": "\"reputation_balances\".\"reliability_report_accuracy_score\" between 0 and 1 and \"reputation_balances\".\"reliability_abuse_score\" between 0 and 1 and \"reputation_balances\".\"personhood_score\" between 0 and 1 and \"reputation_balances\".\"reporting_reliability\" between 0 and 1 and \"reputation_balances\".\"reporting_confidence\" between 0 and 1 and \"reputation_balances\".\"reviewing_global_reliability\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_reviewing_reliability": {
+      "name": "reputation_reviewing_reliability",
+      "schema": "",
+      "columns": {
+        "balance_id": {
+          "name": "balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reliability": {
+          "name": "reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reputation_reviewing_reliability_balance_id_reputation_balances_id_fk": {
+          "name": "reputation_reviewing_reliability_balance_id_reputation_balances_id_fk",
+          "tableFrom": "reputation_reviewing_reliability",
+          "tableTo": "reputation_balances",
+          "columnsFrom": [
+            "balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reputation_reviewing_reliability_pkey": {
+          "name": "reputation_reviewing_reliability_pkey",
+          "columns": [
+            "balance_id",
+            "scope",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_reviewing_reliability_scope_check": {
+          "name": "reputation_reviewing_reliability_scope_check",
+          "value": "\"reputation_reviewing_reliability\".\"scope\" in ('category', 'language')"
+        },
+        "reputation_reviewing_reliability_value_check": {
+          "name": "reputation_reviewing_reliability_value_check",
+          "value": "\"reputation_reviewing_reliability\".\"reliability\" between 0 and 1"
+        },
+        "reputation_reviewing_reliability_key_check": {
+          "name": "reputation_reviewing_reliability_key_check",
+          "value": "length(\"reputation_reviewing_reliability\".\"key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_disputes": {
+      "name": "reputation_disputes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reputation_disputes_user_id_status_idx": {
+          "name": "reputation_disputes_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_disputes_status_idx": {
+          "name": "reputation_disputes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_disputes_transaction_id_idx": {
+          "name": "reputation_disputes_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_disputes_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_disputes_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_disputes_user_id_users_id_fk": {
+          "name": "reputation_disputes_user_id_users_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_disputes_resolved_by_user_id_users_id_fk": {
+          "name": "reputation_disputes_resolved_by_user_id_users_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_disputes_status_check": {
+          "name": "reputation_disputes_status_check",
+          "value": "\"reputation_disputes\".\"status\" in ('open', 'accepted', 'rejected', 'needs_review')"
+        },
+        "reputation_disputes_resolution_check": {
+          "name": "reputation_disputes_resolution_check",
+          "value": "(\"reputation_disputes\".\"status\" in ('open', 'needs_review') and \"reputation_disputes\".\"resolved_at\" is null) or (\"reputation_disputes\".\"status\" in ('accepted', 'rejected') and \"reputation_disputes\".\"resolved_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_rules": {
+      "name": "reputation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooldown_in_minutes": {
+          "name": "cooldown_in_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reputation_rules_actionType_unique": {
+          "name": "reputation_rules_actionType_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "action_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reputation_rules_category_check": {
+          "name": "reputation_rules_category_check",
+          "value": "\"reputation_rules\".\"category\" in ('content', 'social', 'trust', 'moderation', 'physical', 'penalty', 'other')"
+        },
+        "reputation_rules_cooldown_check": {
+          "name": "reputation_rules_cooldown_check",
+          "value": "\"reputation_rules\".\"cooldown_in_minutes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_transactions": {
+      "name": "reputation_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_id": {
+          "name": "source_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_type": {
+          "name": "source_action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_entity_id": {
+          "name": "target_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_entity_type": {
+          "name": "target_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reversed_transaction_id": {
+          "name": "reversed_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reputation_transactions_user_id_status_idx": {
+          "name": "reputation_transactions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_user_id_created_at_idx": {
+          "name": "reputation_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_application_id_idx": {
+          "name": "reputation_transactions_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reputation_transactions\".\"application_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_source_action_key": {
+          "name": "reputation_transactions_source_action_key",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_status_idx": {
+          "name": "reputation_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_transactions_user_id_users_id_fk": {
+          "name": "reputation_transactions_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_application_id_applications_id_fk": {
+          "name": "reputation_transactions_application_id_applications_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_credential_id_application_credentials_id_fk": {
+          "name": "reputation_transactions_credential_id_application_credentials_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_reversed_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_transactions_reversed_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "reversed_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_created_by_user_id_users_id_fk": {
+          "name": "reputation_transactions_created_by_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_reviewed_by_user_id_users_id_fk": {
+          "name": "reputation_transactions_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_transactions_category_check": {
+          "name": "reputation_transactions_category_check",
+          "value": "\"reputation_transactions\".\"category\" in ('content', 'social', 'trust', 'moderation', 'physical', 'penalty', 'other')"
+        },
+        "reputation_transactions_status_check": {
+          "name": "reputation_transactions_status_check",
+          "value": "\"reputation_transactions\".\"status\" in ('active', 'disputed', 'reversed', 'voided')"
+        },
+        "reputation_transactions_target_entity_type_check": {
+          "name": "reputation_transactions_target_entity_type_check",
+          "value": "\"reputation_transactions\".\"target_entity_type\" is null or \"reputation_transactions\".\"target_entity_type\" in ('post', 'comment', 'report', 'purchase', 'event', 'check_in', 'manual_review', 'user', 'other')"
+        },
+        "reputation_transactions_reversal_not_self_check": {
+          "name": "reputation_transactions_reversal_not_self_check",
+          "value": "\"reputation_transactions\".\"reversed_transaction_id\" is null or \"reputation_transactions\".\"reversed_transaction_id\" <> \"reputation_transactions\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.restrictions": {
+      "name": "restrictions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted_id": {
+          "name": "restricted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "restrictions_user_id_users_id_fk": {
+          "name": "restrictions_user_id_users_id_fk",
+          "tableFrom": "restrictions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "restrictions_restricted_id_users_id_fk": {
+          "name": "restrictions_restricted_id_users_id_fk",
+          "tableFrom": "restrictions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "restricted_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "restrictions_user_id_restricted_id_key": {
+          "name": "restrictions_user_id_restricted_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "restricted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviewer_reputation_profiles": {
+      "name": "reviewer_reputation_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "agreements": {
+          "name": "agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disagreements": {
+          "name": "disagreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gold_passed": {
+          "name": "gold_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gold_failed": {
+          "name": "gold_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overturned": {
+          "name": "overturned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "global_reliability": {
+          "name": "global_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "category_reliability": {
+          "name": "category_reliability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "language_reliability": {
+          "name": "language_reliability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "unlocked_categories": {
+          "name": "unlocked_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seed_weight": {
+          "name": "seed_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviewer_reputation_profiles_status_idx": {
+          "name": "reviewer_reputation_profiles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviewer_reputation_profiles_user_id_users_id_fk": {
+          "name": "reviewer_reputation_profiles_user_id_users_id_fk",
+          "tableFrom": "reviewer_reputation_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviewer_reputation_profiles_user_id_key": {
+          "name": "reviewer_reputation_profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviewer_reputation_profiles_status_check": {
+          "name": "reviewer_reputation_profiles_status_check",
+          "value": "\"reviewer_reputation_profiles\".\"status\" in ('active', 'probation', 'suspended')"
+        },
+        "reviewer_reputation_profiles_category_reliability_object_check": {
+          "name": "reviewer_reputation_profiles_category_reliability_object_check",
+          "value": "jsonb_typeof(\"reviewer_reputation_profiles\".\"category_reliability\") = 'object'"
+        },
+        "reviewer_reputation_profiles_language_reliability_object_check": {
+          "name": "reviewer_reputation_profiles_language_reliability_object_check",
+          "value": "jsonb_typeof(\"reviewer_reputation_profiles\".\"language_reliability\") = 'object'"
+        },
+        "reviewer_reputation_profiles_counts_check": {
+          "name": "reviewer_reputation_profiles_counts_check",
+          "value": "\"reviewer_reputation_profiles\".\"agreements\" >= 0 and \"reviewer_reputation_profiles\".\"disagreements\" >= 0 and \"reviewer_reputation_profiles\".\"gold_passed\" >= 0 and \"reviewer_reputation_profiles\".\"gold_failed\" >= 0 and \"reviewer_reputation_profiles\".\"overturned\" >= 0"
+        },
+        "reviewer_reputation_profiles_global_reliability_check": {
+          "name": "reviewer_reputation_profiles_global_reliability_check",
+          "value": "\"reviewer_reputation_profiles\".\"global_reliability\" >= 0 and \"reviewer_reputation_profiles\".\"global_reliability\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_activities": {
+      "name": "security_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "security_activities_user_id_occurred_at_idx": {
+          "name": "security_activities_user_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_user_id_event_type_occurred_at_idx": {
+          "name": "security_activities_user_id_event_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_user_id_device_id_occurred_at_idx": {
+          "name": "security_activities_user_id_device_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_occurred_at_idx": {
+          "name": "security_activities_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_activities_user_id_users_id_fk": {
+          "name": "security_activities_user_id_users_id_fk",
+          "tableFrom": "security_activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_activities_event_type_check": {
+          "name": "security_activities_event_type_check",
+          "value": "\"security_activities\".\"event_type\" in ('sign_in', 'sign_out', 'email_changed', 'profile_updated', 'device_added', 'device_removed', 'account_recovery', 'security_settings_changed', 'private_key_exported', 'backup_created', 'suspicious_activity')"
+        },
+        "security_activities_severity_check": {
+          "name": "security_activities_severity_check",
+          "value": "\"security_activities\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sender_avatars": {
+      "name": "sender_avatars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sender_avatars_email_key": {
+          "name": "sender_avatars_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sender_avatars_expires_at_idx": {
+          "name": "sender_avatars_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sender_avatars_source_check": {
+          "name": "sender_avatars_source_check",
+          "value": "\"sender_avatars\".\"source\" in ('oxy', 'bimi', 'gravatar', 'favicon', 'none')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_fingerprint": {
+          "name": "device_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_refresh_token": {
+          "name": "previous_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_rotated_at": {
+          "name": "token_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh": {
+          "name": "last_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_device_id_idx": {
+          "name": "sessions_user_id_device_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_is_active_expires_at_idx": {
+          "name": "sessions_user_id_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_device_id_is_active_expires_at_idx": {
+          "name": "sessions_device_id_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_previous_refresh_token_rotated_at_idx": {
+          "name": "sessions_previous_refresh_token_rotated_at_idx",
+          "columns": [
+            {
+              "expression": "previous_refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_rotated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"previous_refresh_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_device_fingerprint_is_active_expires_at_idx": {
+          "name": "sessions_device_fingerprint_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "device_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"device_fingerprint\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_operated_by_user_id_users_id_fk": {
+          "name": "sessions_operated_by_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_id_key": {
+          "name": "sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        },
+        "sessions_access_token_key": {
+          "name": "sessions_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "sessions_refresh_token_key": {
+          "name": "sessions_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signed_records": {
+      "name": "signed_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nsid": {
+          "name": "nsid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "signed_records_subject_did_idx": {
+          "name": "signed_records_subject_did_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_type_created_at_idx": {
+          "name": "signed_records_user_id_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_seq_key": {
+          "name": "signed_records_user_id_seq_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_nsid_rkey_created_at_idx": {
+          "name": "signed_records_user_id_nsid_rkey_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nsid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"signed_records\".\"nsid\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signed_records_user_id_users_id_fk": {
+          "name": "signed_records_user_id_users_id_fk",
+          "tableFrom": "signed_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signed_records_prev_signed_records_record_id_fk": {
+          "name": "signed_records_prev_signed_records_record_id_fk",
+          "tableFrom": "signed_records",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "prev"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signed_records_recordId_unique": {
+          "name": "signed_records_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "signed_records_type_check": {
+          "name": "signed_records_type_check",
+          "value": "\"signed_records\".\"type\" in ('identity', 'profile', 'reputation_attestation', 'real_life_attestation', 'validation_verdict', 'personhood_vouch', 'credential', 'node')"
+        },
+        "signed_records_seq_check": {
+          "name": "signed_records_seq_check",
+          "value": "\"signed_records\".\"seq\" is null or \"signed_records\".\"seq\" >= 0"
+        },
+        "signed_records_chain_completeness_check": {
+          "name": "signed_records_chain_completeness_check",
+          "value": "(\"signed_records\".\"seq\" is null and \"signed_records\".\"record_id\" is null and \"signed_records\".\"nsid\" is null and \"signed_records\".\"rkey\" is null) or (\"signed_records\".\"record_id\" is not null and \"signed_records\".\"nsid\" is not null and \"signed_records\".\"rkey\" is not null)"
+        },
+        "signed_records_prev_not_self_check": {
+          "name": "signed_records_prev_not_self_check",
+          "value": "\"signed_records\".\"prev\" is null or \"signed_records\".\"prev\" <> \"signed_records\".\"record_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_renew": {
+          "name": "auto_renew",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_invoice": {
+          "name": "latest_invoice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_analytics": {
+          "name": "feature_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_premium_badge": {
+          "name": "feature_premium_badge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_unlimited_following": {
+          "name": "feature_unlimited_following",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_higher_upload_limits": {
+          "name": "feature_higher_upload_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_promoted_posts": {
+          "name": "feature_promoted_posts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_business_tools": {
+          "name": "feature_business_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_status_idx": {
+          "name": "subscriptions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_active_end_date_idx": {
+          "name": "subscriptions_active_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"subscriptions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "subscriptions_plan_check": {
+          "name": "subscriptions_plan_check",
+          "value": "\"subscriptions\".\"plan\" in ('basic', 'pro', 'business')"
+        },
+        "subscriptions_status_check": {
+          "name": "subscriptions_status_check",
+          "value": "\"subscriptions\".\"status\" in ('active', 'canceled', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "parent_topic_id": {
+          "name": "parent_topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "translations": {
+          "name": "translations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(display_name, '')), 'B') || setweight(to_tsvector('english', replace(array_to_tsvector(coalesce(aliases, '{}'::text[]))::text, '''', ' ')), 'C') || setweight(to_tsvector('english', coalesce(description, '')), 'D')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_is_active_type_idx": {
+          "name": "topics_is_active_type_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_parent_topic_id_idx": {
+          "name": "topics_parent_topic_id_idx",
+          "columns": [
+            {
+              "expression": "parent_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"topics\".\"parent_topic_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_search_vector_idx": {
+          "name": "topics_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_parent_topic_id_topics_id_fk": {
+          "name": "topics_parent_topic_id_topics_id_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "parent_topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topics_name_key": {
+          "name": "topics_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topics_slug_key": {
+          "name": "topics_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "topics_type_check": {
+          "name": "topics_type_check",
+          "value": "\"topics\".\"type\" in ('category', 'topic', 'entity')"
+        },
+        "topics_source_check": {
+          "name": "topics_source_check",
+          "value": "\"topics\".\"source\" in ('seed', 'ai', 'manual', 'system')"
+        },
+        "topics_translations_object_check": {
+          "name": "topics_translations_object_check",
+          "value": "\"topics\".\"translations\" is null or jsonb_typeof(\"topics\".\"translations\") = 'object'"
+        },
+        "topics_parent_topic_id_not_self_check": {
+          "name": "topics_parent_topic_id_not_self_check",
+          "value": "\"topics\".\"parent_topic_id\" <> \"topics\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference": {
+          "name": "external_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_id_created_at_idx": {
+          "name": "transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recipient_id_created_at_idx": {
+          "name": "transactions_recipient_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"recipient_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_recipient_id_users_id_fk": {
+          "name": "transactions_recipient_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transactions_type_check": {
+          "name": "transactions_type_check",
+          "value": "\"transactions\".\"type\" in ('deposit', 'withdrawal', 'transfer', 'purchase')"
+        },
+        "transactions_status_check": {
+          "name": "transactions_status_check",
+          "value": "\"transactions\".\"status\" in ('pending', 'completed', 'failed', 'cancelled')"
+        },
+        "transactions_amount_check": {
+          "name": "transactions_amount_check",
+          "value": "\"transactions\".\"amount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_anchors": {
+      "name": "transparency_checkpoint_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txid": {
+          "name": "txid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmations": {
+          "name": "confirmations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anchored_at": {
+          "name": "anchored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_anchors_txid_key": {
+          "name": "transparency_checkpoint_anchors_txid_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "txid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_anchors_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_anchors_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_anchors",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_anchors_confirmations_check": {
+          "name": "transparency_checkpoint_anchors_confirmations_check",
+          "value": "\"transparency_checkpoint_anchors\".\"confirmations\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_signatures": {
+      "name": "transparency_checkpoint_signatures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_signatures_position_key": {
+          "name": "transparency_checkpoint_signatures_position_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transparency_checkpoint_signatures_signer_key": {
+          "name": "transparency_checkpoint_signatures_signer_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_signatures_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_signatures_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_signatures",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_signatures_alg_check": {
+          "name": "transparency_checkpoint_signatures_alg_check",
+          "value": "\"transparency_checkpoint_signatures\".\"alg\" in ('ES256K-DER-SHA256')"
+        },
+        "transparency_checkpoint_signatures_position_check": {
+          "name": "transparency_checkpoint_signatures_position_check",
+          "value": "\"transparency_checkpoint_signatures\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_snapshot_entries": {
+      "name": "transparency_checkpoint_snapshot_entries",
+      "schema": "",
+      "columns": {
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_index": {
+          "name": "leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_snapshot_entries_subject_key": {
+          "name": "transparency_checkpoint_snapshot_entries_subject_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_snapshot_entries_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_snapshot_entries_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_snapshot_entries",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transparency_checkpoint_snapshot_entries_pkey": {
+          "name": "transparency_checkpoint_snapshot_entries_pkey",
+          "columns": [
+            "checkpoint_id",
+            "leaf_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_snapshot_entries_leaf_index_check": {
+          "name": "transparency_checkpoint_snapshot_entries_leaf_index_check",
+          "value": "\"transparency_checkpoint_snapshot_entries\".\"leaf_index\" >= 0"
+        },
+        "transparency_checkpoint_snapshot_entries_seq_check": {
+          "name": "transparency_checkpoint_snapshot_entries_seq_check",
+          "value": "\"transparency_checkpoint_snapshot_entries\".\"seq\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoints": {
+      "name": "transparency_checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_size": {
+          "name": "tree_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_checkpoint_hash": {
+          "name": "prev_checkpoint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transparency_checkpoints_index_unique": {
+          "name": "transparency_checkpoints_index_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoints_index_check": {
+          "name": "transparency_checkpoints_index_check",
+          "value": "\"transparency_checkpoints\".\"index\" >= 0"
+        },
+        "transparency_checkpoints_tree_size_check": {
+          "name": "transparency_checkpoints_tree_size_check",
+          "value": "\"transparency_checkpoints\".\"tree_size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_assets": {
+      "name": "update_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "'public/updates/assets/' || sha256",
+            "type": "stored"
+          }
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "update_assets_sha256_key": {
+          "name": "update_assets_sha256_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "update_assets_status_check": {
+          "name": "update_assets_status_check",
+          "value": "\"update_assets\".\"status\" in ('pending', 'uploaded')"
+        },
+        "update_assets_sha256_check": {
+          "name": "update_assets_sha256_check",
+          "value": "\"update_assets\".\"sha256\" ~ '^[a-f0-9]{64}$'"
+        },
+        "update_assets_size_check": {
+          "name": "update_assets_size_check",
+          "value": "\"update_assets\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_channel_rollbacks": {
+      "name": "update_channel_rollbacks",
+      "schema": "",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_time": {
+          "name": "commit_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "update_channel_rollbacks_channel_id_update_channels_id_fk": {
+          "name": "update_channel_rollbacks_channel_id_update_channels_id_fk",
+          "tableFrom": "update_channel_rollbacks",
+          "tableTo": "update_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "update_channel_rollbacks_pkey": {
+          "name": "update_channel_rollbacks_pkey",
+          "columns": [
+            "channel_id",
+            "runtime_version",
+            "platform"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "update_channel_rollbacks_platform_check": {
+          "name": "update_channel_rollbacks_platform_check",
+          "value": "\"update_channel_rollbacks\".\"platform\" in ('ios', 'android')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_channels": {
+      "name": "update_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "update_channels_application_id_applications_id_fk": {
+          "name": "update_channels_application_id_applications_id_fk",
+          "tableFrom": "update_channels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "update_channels_application_id_name_key": {
+          "name": "update_channels_application_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_analytics": {
+      "name": "user_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_views": {
+          "name": "post_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "profile_views": {
+          "name": "profile_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_likes": {
+          "name": "engagement_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_replies": {
+          "name": "engagement_replies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_reposts": {
+          "name": "engagement_reposts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_quotes": {
+          "name": "engagement_quotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_bookmarks": {
+          "name": "engagement_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reach_impressions": {
+          "name": "reach_impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reach_unique_viewers": {
+          "name": "reach_unique_viewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "demographics_countries": {
+          "name": "demographics_countries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "demographics_languages": {
+          "name": "demographics_languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "peak_activity_hour": {
+          "name": "peak_activity_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "peak_activity_count": {
+          "name": "peak_activity_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_analytics_user_id_users_id_fk": {
+          "name": "user_analytics_user_id_users_id_fk",
+          "tableFrom": "user_analytics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_analytics_user_id_period_date_key": {
+          "name": "user_analytics_user_id_period_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "period",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_analytics_period_check": {
+          "name": "user_analytics_period_check",
+          "value": "\"user_analytics\".\"period\" in ('daily', 'weekly', 'monthly', 'yearly')"
+        },
+        "user_analytics_peak_activity_hour_check": {
+          "name": "user_analytics_peak_activity_hour_check",
+          "value": "\"user_analytics\".\"peak_activity_hour\" >= 0 and \"user_analytics\".\"peak_activity_hour\" < 24"
+        },
+        "user_analytics_demographics_countries_object_check": {
+          "name": "user_analytics_demographics_countries_object_check",
+          "value": "jsonb_typeof(\"user_analytics\".\"demographics_countries\") = 'object'"
+        },
+        "user_analytics_demographics_languages_object_check": {
+          "name": "user_analytics_demographics_languages_object_check",
+          "value": "jsonb_typeof(\"user_analytics\".\"demographics_languages\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_ancestors": {
+      "name": "user_ancestors",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_id": {
+          "name": "ancestor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_ancestors_ancestor_id_idx": {
+          "name": "user_ancestors_ancestor_id_idx",
+          "columns": [
+            {
+              "expression": "ancestor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ancestors_user_id_users_id_fk": {
+          "name": "user_ancestors_user_id_users_id_fk",
+          "tableFrom": "user_ancestors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_ancestors_ancestor_id_users_id_fk": {
+          "name": "user_ancestors_ancestor_id_users_id_fk",
+          "tableFrom": "user_ancestors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ancestor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_ancestors_pkey": {
+          "name": "user_ancestors_pkey",
+          "columns": [
+            "user_id",
+            "depth"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_ancestors_depth_check": {
+          "name": "user_ancestors_depth_check",
+          "value": "\"user_ancestors\".\"depth\" >= 0 and \"user_ancestors\".\"depth\" < 8"
+        },
+        "user_ancestors_not_self_check": {
+          "name": "user_ancestors_not_self_check",
+          "value": "\"user_ancestors\".\"ancestor_id\" <> \"user_ancestors\".\"user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_app_data": {
+      "name": "user_app_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_app_data_user_id_users_id_fk": {
+          "name": "user_app_data_user_id_users_id_fk",
+          "tableFrom": "user_app_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_app_data_user_id_namespace_key_key": {
+          "name": "user_app_data_user_id_namespace_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "namespace",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_app_data_namespace_check": {
+          "name": "user_app_data_namespace_check",
+          "value": "\"user_app_data\".\"namespace\" ~ '^[a-z0-9_-]{1,64}$'"
+        },
+        "user_app_data_key_check": {
+          "name": "user_app_data_key_check",
+          "value": "\"user_app_data\".\"key\" ~ '^[a-z0-9_-]{1,64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_auth_methods": {
+      "name": "user_auth_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "method_public_key": {
+          "name": "method_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_email": {
+          "name": "method_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_credential_id": {
+          "name": "method_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_name": {
+          "name": "method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_auth_methods_user_id_idx": {
+          "name": "user_auth_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_auth_methods_lower_method_public_key_key": {
+          "name": "user_auth_methods_lower_method_public_key_key",
+          "columns": [
+            {
+              "expression": "lower(\"method_public_key\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_auth_methods\".\"method_public_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_auth_methods_method_credential_id_key": {
+          "name": "user_auth_methods_method_credential_id_key",
+          "columns": [
+            {
+              "expression": "method_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_auth_methods\".\"method_credential_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_auth_methods_user_id_users_id_fk": {
+          "name": "user_auth_methods_user_id_users_id_fk",
+          "tableFrom": "user_auth_methods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_auth_methods_type_check": {
+          "name": "user_auth_methods_type_check",
+          "value": "\"user_auth_methods\".\"type\" in ('identity', 'webauthn')"
+        },
+        "user_auth_methods_identifier_check": {
+          "name": "user_auth_methods_identifier_check",
+          "value": "(\"user_auth_methods\".\"type\" = 'identity' and \"user_auth_methods\".\"method_public_key\" is not null) or (\"user_auth_methods\".\"type\" = 'webauthn' and \"user_auth_methods\".\"method_credential_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_credits": {
+      "name": "user_credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits_free": {
+          "name": "credits_free",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "credits_free_limit": {
+          "name": "credits_free_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "credits_daily_refresh": {
+          "name": "credits_daily_refresh",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "credits_last_refresh": {
+          "name": "credits_last_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "credits_paid": {
+          "name": "credits_paid",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_credits_stripe_customer_id_key": {
+          "name": "user_credits_stripe_customer_id_key",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_credits\".\"stripe_customer_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_credits_user_id_users_id_fk": {
+          "name": "user_credits_user_id_users_id_fk",
+          "tableFrom": "user_credits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_credits_credits_free_check": {
+          "name": "user_credits_credits_free_check",
+          "value": "\"user_credits\".\"credits_free\" >= 0"
+        },
+        "user_credits_credits_paid_check": {
+          "name": "user_credits_credits_paid_check",
+          "value": "\"user_credits\".\"credits_paid\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followed_id": {
+          "name": "followed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_followed_id_created_at_id_idx": {
+          "name": "user_follows_followed_id_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "followed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_created_at_id_idx": {
+          "name": "user_follows_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_followed_id_users_id_fk": {
+          "name": "user_follows_followed_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follows_follower_id_followed_id_key": {
+          "name": "user_follows_follower_id_followed_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "followed_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_follows_not_self_check": {
+          "name": "user_follows_not_self_check",
+          "value": "\"user_follows\".\"follower_id\" <> \"user_follows\".\"followed_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_link_metadata": {
+      "name": "user_link_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_link_metadata_user_id_position_key": {
+          "name": "user_link_metadata_user_id_position_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_link_metadata_user_id_users_id_fk": {
+          "name": "user_link_metadata_user_id_users_id_fk",
+          "tableFrom": "user_link_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_locations": {
+      "name": "user_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_key": {
+          "name": "location_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street_number": {
+          "name": "street_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street_details": {
+          "name": "street_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(longitude, latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_id": {
+          "name": "osm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_type": {
+          "name": "osm_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(name, '') || ' ' || coalesce(formatted_address, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_locations_user_id_location_key_key": {
+          "name": "user_locations_user_id_location_key_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_city_country_idx": {
+          "name": "user_locations_city_country_idx",
+          "columns": [
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_country_idx": {
+          "name": "user_locations_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_type_city_idx": {
+          "name": "user_locations_type_city_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_country_code_city_idx": {
+          "name": "user_locations_country_code_city_idx",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_search_vector_idx": {
+          "name": "user_locations_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_locations_geo_idx": {
+          "name": "user_locations_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_locations_user_id_users_id_fk": {
+          "name": "user_locations_user_id_users_id_fk",
+          "tableFrom": "user_locations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_locations_type_check": {
+          "name": "user_locations_type_check",
+          "value": "\"user_locations\".\"type\" in ('home', 'work', 'school', 'other')"
+        },
+        "user_locations_latitude_check": {
+          "name": "user_locations_latitude_check",
+          "value": "\"user_locations\".\"latitude\" is null or (\"user_locations\".\"latitude\" >= -90 and \"user_locations\".\"latitude\" <= 90)"
+        },
+        "user_locations_longitude_check": {
+          "name": "user_locations_longitude_check",
+          "value": "\"user_locations\".\"longitude\" is null or (\"user_locations\".\"longitude\" >= -180 and \"user_locations\".\"longitude\" <= 180)"
+        },
+        "user_locations_coordinates_complete_check": {
+          "name": "user_locations_coordinates_complete_check",
+          "value": "(\"user_locations\".\"latitude\" is null) = (\"user_locations\".\"longitude\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_nodes": {
+      "name": "user_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_did": {
+          "name": "node_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_public_key": {
+          "name": "node_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pull'"
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_at": {
+          "name": "last_probe_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_nodes_status_idx": {
+          "name": "user_nodes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nodes_user_id_users_id_fk": {
+          "name": "user_nodes_user_id_users_id_fk",
+          "tableFrom": "user_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nodes_userId_unique": {
+          "name": "user_nodes_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_nodes_mode_check": {
+          "name": "user_nodes_mode_check",
+          "value": "\"user_nodes\".\"mode\" in ('pull', 'push')"
+        },
+        "user_nodes_controller_check": {
+          "name": "user_nodes_controller_check",
+          "value": "\"user_nodes\".\"controller\" in ('self', 'oxy')"
+        },
+        "user_nodes_status_check": {
+          "name": "user_nodes_status_check",
+          "value": "\"user_nodes\".\"status\" in ('active', 'unreachable', 'revoked')"
+        },
+        "user_nodes_cursor_check": {
+          "name": "user_nodes_cursor_check",
+          "value": "\"user_nodes\".\"cursor\" is null or \"user_nodes\".\"cursor\" >= 0"
+        },
+        "user_nodes_managed_controller_check": {
+          "name": "user_nodes_managed_controller_check",
+          "value": "(\"user_nodes\".\"managed\" = true and \"user_nodes\".\"controller\" = 'oxy') or (\"user_nodes\".\"managed\" = false and \"user_nodes\".\"controller\" = 'self')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_verified_domains": {
+      "name": "user_verified_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_verified_domains_user_id_lower_domain_key": {
+          "name": "user_verified_domains_user_id_lower_domain_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_verified_domains_lower_domain_idx": {
+          "name": "user_verified_domains_lower_domain_idx",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_verified_domains_user_id_users_id_fk": {
+          "name": "user_verified_domains_user_id_users_id_fk",
+          "tableFrom": "user_verified_domains",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_verified_domains_method_check": {
+          "name": "user_verified_domains_method_check",
+          "value": "\"user_verified_domains\".\"method\" in ('dns-txt', 'well-known')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_email": {
+          "name": "hashed_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when btrim(coalesce(email, '')) = '' then null else encode(sha256(decode(replace(lower(btrim(email)), '\\', '\\\\'), 'escape')), 'hex') end",
+            "type": "stored"
+          }
+        },
+        "hashed_phone": {
+          "name": "hashed_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when regexp_replace(coalesce(phone, ''), '[^0-9]', '', 'g') = '' then null else encode(sha256(decode(replace('+' || regexp_replace(phone, '[^0-9]', '', 'g'), '\\', '\\\\'), 'escape')), 'hex') end",
+            "type": "stored"
+          }
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_first": {
+          "name": "name_first",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_last": {
+          "name": "name_last",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_display": {
+          "name": "name_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "organization_category": {
+          "name": "organization_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_categories": {
+          "name": "account_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "parent_account_id": {
+          "name": "parent_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_account_id": {
+          "name": "root_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "federation_actor_uri": {
+          "name": "federation_actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_domain": {
+          "name": "federation_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_actor_id": {
+          "name": "federation_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_last_avatar_fetched_at": {
+          "name": "federation_last_avatar_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_avatar_e_tag": {
+          "name": "federation_avatar_e_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_avatar_last_modified": {
+          "name": "federation_avatar_last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_last_resolved_at": {
+          "name": "federation_last_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_unavailable_at": {
+          "name": "federation_unavailable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_unavailable_reason": {
+          "name": "federation_unavailable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_owner_id": {
+          "name": "automation_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reputation_rank_weight": {
+          "name": "reputation_rank_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.1
+        },
+        "reputation_tier": {
+          "name": "reputation_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "is_staff": {
+          "name": "is_staff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_seed_verifier": {
+          "name": "is_seed_verifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"en-US\"}'"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_expires_after_inactivity_days": {
+          "name": "account_expires_after_inactivity_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_is_private_account": {
+          "name": "privacy_is_private_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_online_status": {
+          "name": "privacy_hide_online_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_last_seen": {
+          "name": "privacy_hide_last_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_profile_visibility": {
+          "name": "privacy_profile_visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_login_alerts": {
+          "name": "privacy_login_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_block_screenshots": {
+          "name": "privacy_block_screenshots",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_login": {
+          "name": "privacy_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_biometric_login": {
+          "name": "privacy_biometric_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_show_activity": {
+          "name": "privacy_show_activity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_tagging": {
+          "name": "privacy_allow_tagging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_mentions": {
+          "name": "privacy_allow_mentions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_hide_read_receipts": {
+          "name": "privacy_hide_read_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_allow_direct_messages": {
+          "name": "privacy_allow_direct_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_data_sharing": {
+          "name": "privacy_data_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_location_sharing": {
+          "name": "privacy_location_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_analytics_sharing": {
+          "name": "privacy_analytics_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_sensitive_content": {
+          "name": "privacy_sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_auto_filter": {
+          "name": "privacy_auto_filter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_mute_keywords": {
+          "name": "privacy_mute_keywords",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_discoverable_by_email": {
+          "name": "privacy_discoverable_by_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_discoverable_by_phone": {
+          "name": "privacy_discoverable_by_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_fediverse_sharing": {
+          "name": "privacy_fediverse_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_signature": {
+          "name": "email_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_enabled": {
+          "name": "auto_reply_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reply_subject": {
+          "name": "auto_reply_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_body": {
+          "name": "auto_reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_start_date": {
+          "name": "auto_reply_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_end_date": {
+          "name": "auto_reply_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_forward_to": {
+          "name": "auto_forward_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_forward_keep_copy": {
+          "name": "auto_forward_keep_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_push_enabled": {
+          "name": "notification_push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email_digest": {
+          "name": "notification_email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_security_alerts": {
+          "name": "notification_security_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_marketing_emails": {
+          "name": "notification_marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preference_language": {
+          "name": "preference_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_theme": {
+          "name": "preference_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "preference_reduce_motion": {
+          "name": "preference_reduce_motion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preference_timezone": {
+          "name": "preference_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference_mode": {
+          "name": "theme_preference_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference_color_preset": {
+          "name": "theme_preference_color_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_lower_username_key": {
+          "name": "users_lower_username_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"username\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_lower_email_key": {
+          "name": "users_lower_email_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"email\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_lower_public_key_key": {
+          "name": "users_lower_public_key_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"public_key\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_actor_uri_key": {
+          "name": "users_federation_actor_uri_key",
+          "columns": [
+            {
+              "expression": "federation_actor_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_hashed_email_idx": {
+          "name": "users_hashed_email_idx",
+          "columns": [
+            {
+              "expression": "hashed_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"hashed_email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_hashed_phone_idx": {
+          "name": "users_hashed_phone_idx",
+          "columns": [
+            {
+              "expression": "hashed_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"hashed_phone\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_kind_parent_account_id_idx": {
+          "name": "users_kind_parent_account_id_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_parent_account_id_idx": {
+          "name": "users_parent_account_id_idx",
+          "columns": [
+            {
+              "expression": "parent_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"parent_account_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_root_account_id_idx": {
+          "name": "users_root_account_id_idx",
+          "columns": [
+            {
+              "expression": "root_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"root_account_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_type_idx": {
+          "name": "users_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_domain_idx": {
+          "name": "users_federation_domain_idx",
+          "columns": [
+            {
+              "expression": "federation_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_domain\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_last_resolved_at_idx": {
+          "name": "users_federation_last_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "federation_last_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_last_resolved_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_unavailable_at_idx": {
+          "name": "users_federation_unavailable_at_idx",
+          "columns": [
+            {
+              "expression": "federation_unavailable_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_unavailable_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_automation_owner_id_idx": {
+          "name": "users_automation_owner_id_idx",
+          "columns": [
+            {
+              "expression": "automation_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"automation_owner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_reputation_rank_weight_idx": {
+          "name": "users_reputation_rank_weight_idx",
+          "columns": [
+            {
+              "expression": "reputation_rank_weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_reputation_tier_idx": {
+          "name": "users_reputation_tier_idx",
+          "columns": [
+            {
+              "expression": "reputation_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_is_sensitive_idx": {
+          "name": "users_is_sensitive_idx",
+          "columns": [
+            {
+              "expression": "is_sensitive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_parent_account_id_users_id_fk": {
+          "name": "users_parent_account_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "parent_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_root_account_id_users_id_fk": {
+          "name": "users_root_account_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "root_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_automation_owner_id_users_id_fk": {
+          "name": "users_automation_owner_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "automation_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "users_kind_check": {
+          "name": "users_kind_check",
+          "value": "\"users\".\"kind\" in ('personal', 'organization', 'project', 'bot', 'channel')"
+        },
+        "users_organization_category_check": {
+          "name": "users_organization_category_check",
+          "value": "\"users\".\"organization_category\" is null or \"users\".\"organization_category\" in ('agency', 'cooperative', 'landlord', 'other')"
+        },
+        "users_account_categories_check": {
+          "name": "users_account_categories_check",
+          "value": "\"users\".\"account_categories\" <@ array['news', 'politics', 'business', 'startup', 'finance', 'crypto', 'marketplace', 'retail', 'real_estate', 'agency', 'landlord', 'cooperative', 'architecture', 'technology', 'software', 'ai', 'security', 'automation', 'science', 'education', 'books', 'health', 'fitness', 'sports', 'gaming', 'music', 'film', 'podcast', 'art', 'photography', 'comedy', 'food', 'travel', 'fashion', 'home_garden', 'diy', 'automotive', 'animals', 'family', 'nonprofit', 'government', 'community', 'activism', 'environment', 'religion', 'other']::text[]"
+        },
+        "users_account_categories_max_check": {
+          "name": "users_account_categories_max_check",
+          "value": "cardinality(\"users\".\"account_categories\") <= 4"
+        },
+        "users_account_categories_kind_check": {
+          "name": "users_account_categories_kind_check",
+          "value": "\"users\".\"kind\" in ('organization', 'project', 'bot', 'channel') or cardinality(\"users\".\"account_categories\") = 0"
+        },
+        "users_account_status_check": {
+          "name": "users_account_status_check",
+          "value": "\"users\".\"account_status\" in ('active', 'archived')"
+        },
+        "users_type_check": {
+          "name": "users_type_check",
+          "value": "\"users\".\"type\" in ('local', 'federated', 'agent', 'automated')"
+        },
+        "users_reputation_tier_check": {
+          "name": "users_reputation_tier_check",
+          "value": "\"users\".\"reputation_tier\" in ('restricted', 'new', 'trusted', 'high_trust', 'verified')"
+        },
+        "users_preference_theme_check": {
+          "name": "users_preference_theme_check",
+          "value": "\"users\".\"preference_theme\" in ('light', 'dark', 'system')"
+        },
+        "users_color_check": {
+          "name": "users_color_check",
+          "value": "\"users\".\"color\" in ('teal', 'blue', 'green', 'amber', 'red', 'purple', 'pink', 'sky', 'orange', 'mint', 'oxy') or \"users\".\"color\" ~* '^#([0-9a-f]{3}|[0-9a-f]{6})$'"
+        },
+        "users_account_expires_after_inactivity_days_check": {
+          "name": "users_account_expires_after_inactivity_days_check",
+          "value": "\"users\".\"account_expires_after_inactivity_days\" is null or \"users\".\"account_expires_after_inactivity_days\" in (30, 90, 180, 365)"
+        },
+        "users_theme_preference_check": {
+          "name": "users_theme_preference_check",
+          "value": "(\"users\".\"theme_preference_mode\" is null and \"users\".\"theme_preference_color_preset\" is null) or (\"users\".\"theme_preference_mode\" is not null and \"users\".\"theme_preference_color_preset\" is not null and length(\"users\".\"theme_preference_color_preset\") > 0)"
+        },
+        "users_parent_account_id_not_self_check": {
+          "name": "users_parent_account_id_not_self_check",
+          "value": "\"users\".\"parent_account_id\" <> \"users\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_request_validators": {
+      "name": "validation_request_validators",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "validation_request_validators_user_id_idx": {
+          "name": "validation_request_validators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_request_validators_position_key": {
+          "name": "validation_request_validators_position_key",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_request_validators_request_id_validation_requests_id_fk": {
+          "name": "validation_request_validators_request_id_validation_requests_id_fk",
+          "tableFrom": "validation_request_validators",
+          "tableTo": "validation_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_request_validators_user_id_users_id_fk": {
+          "name": "validation_request_validators_user_id_users_id_fk",
+          "tableFrom": "validation_request_validators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "validation_request_validators_pkey": {
+          "name": "validation_request_validators_pkey",
+          "columns": [
+            "request_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_request_validators_position_check": {
+          "name": "validation_request_validators_position_check",
+          "value": "\"validation_request_validators\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_requests": {
+      "name": "validation_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_id": {
+          "name": "source_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_value": {
+          "name": "high_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rng_seed": {
+          "name": "rng_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "validation_requests_subject_user_id_idx": {
+          "name": "validation_requests_subject_user_id_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_requests_status_expires_at_idx": {
+          "name": "validation_requests_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_requests_open_source_action_key": {
+          "name": "validation_requests_open_source_action_key",
+          "columns": [
+            {
+              "expression": "source_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"validation_requests\".\"status\" in ('pending', 'quorum_met')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_requests_subject_user_id_users_id_fk": {
+          "name": "validation_requests_subject_user_id_users_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_requests_application_id_applications_id_fk": {
+          "name": "validation_requests_application_id_applications_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "validation_requests_resolved_txn_id_reputation_transactions_id_fk": {
+          "name": "validation_requests_resolved_txn_id_reputation_transactions_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_requests_status_check": {
+          "name": "validation_requests_status_check",
+          "value": "\"validation_requests\".\"status\" in ('pending', 'quorum_met', 'validated', 'rejected', 'expired')"
+        },
+        "validation_requests_outcome_check": {
+          "name": "validation_requests_outcome_check",
+          "value": "\"validation_requests\".\"outcome\" is null or \"validation_requests\".\"outcome\" in ('validated', 'rejected')"
+        },
+        "validation_requests_quorum_check": {
+          "name": "validation_requests_quorum_check",
+          "value": "\"validation_requests\".\"quorum\" > 0"
+        },
+        "validation_requests_threshold_check": {
+          "name": "validation_requests_threshold_check",
+          "value": "\"validation_requests\".\"threshold\" >= \"validation_requests\".\"quorum\""
+        },
+        "validation_requests_terminal_check": {
+          "name": "validation_requests_terminal_check",
+          "value": "(\"validation_requests\".\"status\" in ('validated', 'rejected') and \"validation_requests\".\"outcome\" is not null and \"validation_requests\".\"status\" = \"validation_requests\".\"outcome\") or (\"validation_requests\".\"status\" in ('pending', 'quorum_met', 'expired') and \"validation_requests\".\"outcome\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_votes": {
+      "name": "validation_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_user_id": {
+          "name": "validator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake_weight": {
+          "name": "stake_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "validation_votes_request_validator_key": {
+          "name": "validation_votes_request_validator_key",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "validator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_votes_validator_user_id_idx": {
+          "name": "validation_votes_validator_user_id_idx",
+          "columns": [
+            {
+              "expression": "validator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_votes_request_id_validation_requests_id_fk": {
+          "name": "validation_votes_request_id_validation_requests_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "validation_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_votes_validator_user_id_users_id_fk": {
+          "name": "validation_votes_validator_user_id_users_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_votes_record_id_signed_records_record_id_fk": {
+          "name": "validation_votes_record_id_signed_records_record_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_votes_verdict_check": {
+          "name": "validation_votes_verdict_check",
+          "value": "\"validation_votes\".\"verdict\" in ('valid', 'invalid', 'abstain')"
+        },
+        "validation_votes_stake_weight_check": {
+          "name": "validation_votes_stake_weight_check",
+          "value": "\"validation_votes\".\"stake_weight\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validator_affinities": {
+      "name": "validator_affinities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "validator_a": {
+          "name": "validator_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_b": {
+          "name": "validator_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_vote_count": {
+          "name": "co_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_co_vote_at": {
+          "name": "last_co_vote_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "validator_affinities_pair_key": {
+          "name": "validator_affinities_pair_key",
+          "columns": [
+            {
+              "expression": "validator_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "validator_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validator_affinities_validator_a_users_id_fk": {
+          "name": "validator_affinities_validator_a_users_id_fk",
+          "tableFrom": "validator_affinities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validator_affinities_validator_b_users_id_fk": {
+          "name": "validator_affinities_validator_b_users_id_fk",
+          "tableFrom": "validator_affinities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validator_affinities_co_vote_count_check": {
+          "name": "validator_affinities_co_vote_count_check",
+          "value": "\"validator_affinities\".\"co_vote_count\" >= 0"
+        },
+        "validator_affinities_canonical_pair_check": {
+          "name": "validator_affinities_canonical_pair_check",
+          "value": "\"validator_affinities\".\"validator_a\" < \"validator_affinities\".\"validator_b\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifiable_credentials": {
+      "name": "verifiable_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_user_id": {
+          "name": "holder_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_did": {
+          "name": "holder_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_user_id": {
+          "name": "issuer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer_did": {
+          "name": "issuer_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claims": {
+          "name": "claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifiable_credentials_holder_status_idx": {
+          "name": "verifiable_credentials_holder_status_idx",
+          "columns": [
+            {
+              "expression": "holder_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifiable_credentials_issuer_did_idx": {
+          "name": "verifiable_credentials_issuer_did_idx",
+          "columns": [
+            {
+              "expression": "issuer_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verifiable_credentials_holder_user_id_users_id_fk": {
+          "name": "verifiable_credentials_holder_user_id_users_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "holder_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "verifiable_credentials_issuer_user_id_users_id_fk": {
+          "name": "verifiable_credentials_issuer_user_id_users_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issuer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "verifiable_credentials_record_id_signed_records_record_id_fk": {
+          "name": "verifiable_credentials_record_id_signed_records_record_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verifiable_credentials_recordId_unique": {
+          "name": "verifiable_credentials_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "verifiable_credentials_status_check": {
+          "name": "verifiable_credentials_status_check",
+          "value": "\"verifiable_credentials\".\"status\" in ('active', 'revoked', 'expired')"
+        },
+        "verifiable_credentials_revocation_check": {
+          "name": "verifiable_credentials_revocation_check",
+          "value": "(\"verifiable_credentials\".\"status\" = 'revoked' and \"verifiable_credentials\".\"revoked_at\" is not null) or (\"verifiable_credentials\".\"status\" <> 'revoked' and \"verifiable_credentials\".\"revoked_at\" is null)"
+        },
+        "verifiable_credentials_expiry_check": {
+          "name": "verifiable_credentials_expiry_check",
+          "value": "\"verifiable_credentials\".\"expires_at\" is null or \"verifiable_credentials\".\"expires_at\" > \"verifiable_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(38, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_user_id_key": {
+          "name": "wallets_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "wallets_balance_check": {
+          "name": "wallets_balance_check",
+          "value": "\"wallets\".\"balance\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webauthn_challenges_expires_at_idx": {
+          "name": "webauthn_challenges_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webauthn_challenges_challenge_key": {
+          "name": "webauthn_challenges_challenge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webauthn_challenges_type_check": {
+          "name": "webauthn_challenges_type_check",
+          "value": "\"webauthn_challenges\".\"type\" in ('registration', 'authentication')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webauthn_credentials": {
+      "name": "webauthn_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_verified": {
+          "name": "user_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webauthn_credentials_user_id_idx": {
+          "name": "webauthn_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webauthn_credentials_user_id_users_id_fk": {
+          "name": "webauthn_credentials_user_id_users_id_fk",
+          "tableFrom": "webauthn_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webauthn_credentials_credential_id_key": {
+          "name": "webauthn_credentials_credential_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webauthn_credentials_device_type_check": {
+          "name": "webauthn_credentials_device_type_check",
+          "value": "\"webauthn_credentials\".\"device_type\" in ('singleDevice', 'multiDevice')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1785760203479,
       "tag": "0013_users_account_categories",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1785763616556,
+      "tag": "0014_account_member_permission_overrides",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema/accountMembers.ts
+++ b/packages/api/src/db/schema/accountMembers.ts
@@ -7,20 +7,37 @@
  * `routes/applications.ts` resolves through: the NEAREST row over
  * `[accountId, ...account.ancestors]` wins, unless `inherit` is false.
  *
- * ## `permissions` does NOT travel
+ * ## `permissions` is DERIVED; the two delta columns are the stored part
  *
- * Mongo stored a `permissions[]` array beside `role`, and every write site sets
- * it to exactly `permissionsForAccountRole(role)` — `account.service.ts:283`,
- * `:726`, `:733`, `:766`, `:840`, `:850`. It is a derivation of `role`, not
- * data, and `resolveEffectiveRole` (`account.service.ts:549`) already falls back
- * to deriving it when the array is empty, a branch that exists only for rows
- * written before the field.
+ * Mongo stored a `permissions[]` array beside `role` that every write site set to
+ * exactly `permissionsForAccountRole(role)` — a derivation of `role`, not data,
+ * so it did not travel. `serializeMember` (`routes/accounts.ts`) keeps emitting
+ * `permissions` on the wire, computed rather than read.
  *
- * The wire contract is unchanged: `serializeMember` (`routes/accounts.ts:167`)
- * keeps emitting `permissions`, computed with the same
- * `permissionsForAccountRole(role)` the writes used. Same treatment as
- * `name.displayName` and `did` on `users` — derived at the serializer, and the
- * legacy empty-array branch does not travel with it.
+ * What IS data is the per-member ADJUSTMENT: `permission_grants` and
+ * `permission_revokes`. The role still picks the baseline; these two say what
+ * this one member holds beyond it or is denied out of it, which is the thing a
+ * role name cannot express. `resolveEffectivePermissions` (`utils/accountRoles.ts`)
+ * combines all three and is the only place that does.
+ *
+ * ## Neither delta column carries a vocabulary CHECK, deliberately
+ *
+ * The obvious shape — `check (permission_grants <@ array[…ACCOUNT_PERMISSIONS…])`,
+ * exactly like `users_account_categories_check` — is a trap here, because this
+ * vocabulary is expected to lose entries: six of its strings are already read by
+ * no code at all. Measured on Postgres 17.5: narrowing such an array makes every
+ * later `UPDATE` of a row holding a now-absent value fail, INCLUDING an update
+ * that names only `role`, and the error names a column the caller never
+ * mentioned. `NOT VALID` does not rescue it — that only skips the existing-row
+ * scan at `ALTER` time; the next update of such a row still fails.
+ *
+ * The vocabulary is enforced where it can be enforced without that hazard: the
+ * zod schema 400s an unknown permission on the way in, and
+ * `resolveEffectivePermissions` builds its result by filtering the vocabulary, so
+ * a retired string is structurally incapable of granting anything on the way out.
+ * The stored string is left in place rather than scrubbed — same reasoning as
+ * `users.organization_category` in migration 0013 — so re-instating a permission
+ * restores it rather than losing it.
  */
 
 import { sql } from 'drizzle-orm';
@@ -58,6 +75,21 @@ export const accountMembers = pgTable(
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
     role: text({ enum: ACCOUNT_ROLES }).notNull(),
+    /**
+     * Permissions this member holds IN ADDITION to their role's baseline.
+     *
+     * `text[]` rather than a join table: the value is a small unordered set read
+     * on every authorization decision alongside the row it belongs to, so a
+     * second table would add a join to the hottest path in the account graph to
+     * buy referential integrity against a vocabulary that lives in TypeScript
+     * and not in the database.
+     */
+    permissionGrants: text().array().notNull().default([]),
+    /**
+     * Permissions this member is denied even though their role's baseline
+     * carries them. Beats a grant naming the same permission.
+     */
+    permissionRevokes: text().array().notNull().default([]),
     /**
      * Whether the membership cascades to descendant accounts. `false` scopes it
      * to `account_id` alone — the member is NOT a member of its children.

--- a/packages/api/src/routes/__tests__/accountsCreate.test.ts
+++ b/packages/api/src/routes/__tests__/accountsCreate.test.ts
@@ -121,6 +121,11 @@ describe('POST /accounts', () => {
     // The route destructures `{ account, membership }` and builds an AccountNode
     // from it, so a bare `jest.fn()` returning undefined would throw before any
     // status could be asserted — a 500 that reads like a refusal.
+    //
+    // `membership` is serialised, so it has to carry the columns the serializer
+    // reads. It does NOT carry `permissions`: that is derived from the role plus
+    // the two delta columns (`effectivePermissionsForMember`), and a fixture
+    // supplying it would be asserting a field the service never returns.
     mockCreateChildAccount.mockImplementation(
       async (_parentId: string, _actorId: string, input: { kind: string; username: string }) => ({
         account: {
@@ -130,7 +135,11 @@ describe('POST /accounts', () => {
           parentAccountId: OPERATOR_ID,
           rootAccountId: OPERATOR_ID,
         },
-        membership: { role: 'owner', permissions: ['children:create'] },
+        membership: {
+          role: 'owner',
+          permissionGrants: [],
+          permissionRevokes: [],
+        },
       })
     );
   });

--- a/packages/api/src/routes/__tests__/accountsMemberPermissions.test.ts
+++ b/packages/api/src/routes/__tests__/accountsMemberPermissions.test.ts
@@ -1,0 +1,477 @@
+/**
+ * PATCH /accounts/:id/members/:memberId — per-member permission editing and the
+ * guards that stop it becoming a privilege-escalation endpoint.
+ *
+ * The real router over real Postgres with the real `account.service`: the guards
+ * are distributed across `loadAccountContext` → `requireAccountPermission` →
+ * the route body → `accountService.updateMember`, so mocking the service would
+ * leave most of the thing under test unexecuted. Only auth, the rate limiter,
+ * the logger and the session/device collaborators (which this route never
+ * touches, but the router imports) are stubbed.
+ *
+ * ## Why the ACTOR in most cases is an admin and not an owner
+ *
+ * `members:update` is held by owner and admin, and admin's baseline is a proper
+ * subset of owner's. A suite whose actor is always an owner cannot tell "an
+ * actor may grant what they hold" from "anyone may grant anything" — every
+ * request would be permitted under both rules. Each refusal below therefore has
+ * a matching PERMITTED case that differs only in who is asking or what is being
+ * asked for, so a blanket-deny implementation fails just as loudly as a
+ * blanket-allow one.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { randomBytes } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+
+let actingUserId = '';
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (
+    req: { user?: { _id: string; id: string } },
+    _res: unknown,
+    next: () => void
+  ) => {
+    req.user = { _id: actingUserId, id: actingUserId };
+    next();
+  },
+  serviceAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/requireStaff', () => ({ isStaffUser: () => false }));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: jest.fn(), getSession: jest.fn() },
+}));
+
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: { addAccount: jest.fn() },
+}));
+
+jest.mock('../../utils/socket', () => ({ broadcastDeviceState: jest.fn() }));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import accountsRouter from '../accounts';
+import { errorHandler } from '../../middleware/errorHandler';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { accountMembers } from '../../db/schema/accountMembers';
+import { userAncestors } from '../../db/schema/userAncestors';
+import { users } from '../../db/schema/users';
+import { permissionsForAccountRole, type AccountRole } from '../../utils/accountRoles';
+
+interface MemberBody {
+  permissions?: string[];
+  permissionGrants?: string[];
+  permissionRevokes?: string[];
+  role?: string;
+  inherit?: boolean;
+}
+
+interface JsonResponse {
+  status: number;
+  body: { message?: string; member?: MemberBody };
+}
+
+let server: http.Server;
+
+function uniqueUsername(prefix: string): string {
+  return `${prefix}-${randomBytes(6).toString('hex')}`;
+}
+
+async function seedUser(kind: 'personal' | 'organization' | 'project'): Promise<string> {
+  const [row] = await getDb()
+    .insert(users)
+    .values({ color: 'teal', username: uniqueUsername(kind), kind })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function seedMember(
+  accountId: string,
+  memberUserId: string,
+  role: AccountRole,
+  extra: { permissionGrants?: string[]; permissionRevokes?: string[] } = {}
+): Promise<string> {
+  const [row] = await getDb()
+    .insert(accountMembers)
+    .values({
+      accountId,
+      memberUserId,
+      role,
+      inherit: true,
+      status: 'active',
+      permissionGrants: extra.permissionGrants ?? [],
+      permissionRevokes: extra.permissionRevokes ?? [],
+    })
+    .returning({ id: accountMembers.id });
+  return row.id;
+}
+
+function patchMember(
+  accountId: string,
+  memberId: string,
+  payload: Record<string, unknown>
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: address.port,
+        path: `/accounts/${accountId}/members/${memberId}`,
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          Authorization: 'Bearer user-token',
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: raw ? (JSON.parse(raw) as JsonResponse['body']) : {},
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+async function rowById(memberId: string) {
+  const [row] = await getDb()
+    .select()
+    .from(accountMembers)
+    .where(eq(accountMembers.id, memberId));
+  return row;
+}
+
+/**
+ * One organization with an owner, an admin (the usual actor) and a viewer (the
+ * usual target). Returns everything by id so a case can pick who asks.
+ */
+async function seedOrg() {
+  const org = await seedUser('organization');
+  const ownerUserId = await seedUser('personal');
+  const adminUserId = await seedUser('personal');
+  const targetUserId = await seedUser('personal');
+
+  const ownerMemberId = await seedMember(org, ownerUserId, 'owner');
+  const adminMemberId = await seedMember(org, adminUserId, 'admin');
+  const targetMemberId = await seedMember(org, targetUserId, 'viewer');
+
+  return { org, ownerUserId, adminUserId, targetUserId, ownerMemberId, adminMemberId, targetMemberId };
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+  const app = express();
+  app.use(express.json());
+  app.use('/accounts', accountsRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, resolve);
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await closePostgres();
+});
+
+describe('per-member permission editing', () => {
+  test('an admin may grant a permission the admin holds', async () => {
+    const { org, adminUserId, targetMemberId } = await seedOrg();
+    // Non-vacuity: the grant has to be something the TARGET does not already
+    // have, or a no-op write would pass this case.
+    expect(permissionsForAccountRole('viewer')).not.toContain('credentials:read');
+    expect(permissionsForAccountRole('admin')).toContain('credentials:read');
+    actingUserId = adminUserId;
+
+    const res = await patchMember(org, targetMemberId, {
+      permissionGrants: ['credentials:read'],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.member?.permissionGrants).toEqual(['credentials:read']);
+    // The serialized `permissions` is the EFFECTIVE set, which is what every
+    // consumer gates on.
+    expect(res.body.member?.permissions).toContain('credentials:read');
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual(['credentials:read']);
+  });
+
+  test('an admin may NOT grant a permission the admin does not hold', async () => {
+    const { org, adminUserId, targetMemberId } = await seedOrg();
+    // The whole case rests on this being absent from the admin baseline.
+    expect(permissionsForAccountRole('admin')).not.toContain('ownership:transfer');
+    actingUserId = adminUserId;
+
+    const res = await patchMember(org, targetMemberId, {
+      permissionGrants: ['ownership:transfer'],
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/cannot grant permissions you do not hold/i);
+    // A refusal that still wrote would be the worst possible outcome here.
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual([]);
+  });
+
+  test('an OWNER may grant that same permission — the refusal is about the actor', async () => {
+    // The control for the case above. Without it, a blanket "nobody may grant
+    // ownership:transfer" would be indistinguishable from the actual rule.
+    const { org, ownerUserId, targetMemberId } = await seedOrg();
+    expect(permissionsForAccountRole('owner')).toContain('ownership:transfer');
+    actingUserId = ownerUserId;
+
+    const res = await patchMember(org, targetMemberId, {
+      permissionGrants: ['ownership:transfer'],
+    });
+
+    expect(res.status).toBe(200);
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual(['ownership:transfer']);
+  });
+
+  test('the bound is the actor EFFECTIVE set, not their role baseline', async () => {
+    // An admin whose own `credentials:create` was revoked cannot re-mint it
+    // through somebody else's row. A guard written against
+    // `permissionsForAccountRole(access.role)` would permit this.
+    const { org, adminUserId, adminMemberId, targetMemberId } = await seedOrg();
+    expect(permissionsForAccountRole('admin')).toContain('credentials:create');
+    await getDb()
+      .update(accountMembers)
+      .set({ permissionRevokes: ['credentials:create'] })
+      .where(eq(accountMembers.id, adminMemberId));
+    actingUserId = adminUserId;
+
+    const res = await patchMember(org, targetMemberId, {
+      permissionGrants: ['credentials:create'],
+    });
+
+    expect(res.status).toBe(403);
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual([]);
+  });
+
+  test('a grant BEYOND the actor is refused even when bundled with a legal one', async () => {
+    // Partial application would be the subtle failure: the legal half landing
+    // while the response says 403.
+    const { org, adminUserId, targetMemberId } = await seedOrg();
+    actingUserId = adminUserId;
+
+    const res = await patchMember(org, targetMemberId, {
+      permissionGrants: ['credentials:read', 'ownership:transfer'],
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('ownership:transfer');
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual([]);
+  });
+
+  test('an actor may REVOKE a permission they do not themselves hold', async () => {
+    // Revokes are deliberately outside rule 1: taking something away is not a
+    // conferral, and a grant left by a departed owner must remain withdrawable.
+    const { org, adminUserId } = await seedOrg();
+    const richMemberId = await seedMember(org, await seedUser('personal'), 'editor', {
+      permissionGrants: ['ownership:transfer'],
+    });
+    expect(permissionsForAccountRole('admin')).not.toContain('ownership:transfer');
+    actingUserId = adminUserId;
+
+    const res = await patchMember(org, richMemberId, {
+      permissionRevokes: ['ownership:transfer'],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.member?.permissions).not.toContain('ownership:transfer');
+  });
+
+  test('an actor may not edit their OWN membership row', async () => {
+    const { org, adminUserId, adminMemberId } = await seedOrg();
+    actingUserId = adminUserId;
+
+    const res = await patchMember(org, adminMemberId, { permissionRevokes: ['members:invite'] });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/your own membership/i);
+    expect((await rowById(adminMemberId)).permissionRevokes).toEqual([]);
+  });
+
+  test("an OWNER row's permissions cannot be edited by anyone", async () => {
+    // Asked by another owner-equivalent authority (the second owner below), so
+    // the refusal is about the TARGET being an owner rather than about the actor
+    // lacking `members:update`.
+    const { org, ownerMemberId } = await seedOrg();
+    const secondOwnerUserId = await seedUser('personal');
+    await seedMember(org, secondOwnerUserId, 'owner');
+    actingUserId = secondOwnerUserId;
+
+    const res = await patchMember(org, ownerMemberId, {
+      permissionRevokes: ['account:delete'],
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/transfer-ownership/i);
+    expect((await rowById(ownerMemberId)).permissionRevokes).toEqual([]);
+  });
+
+  test('an unknown permission string is a 400, not a stored value', async () => {
+    const { org, ownerUserId, targetMemberId } = await seedOrg();
+    actingUserId = ownerUserId;
+
+    const res = await patchMember(org, targetMemberId, {
+      permissionGrants: ['account:moderate'],
+    });
+
+    expect(res.status).toBe(400);
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual([]);
+  });
+
+  test('an empty body is a 400', async () => {
+    const { org, ownerUserId, targetMemberId } = await seedOrg();
+    actingUserId = ownerUserId;
+
+    expect((await patchMember(org, targetMemberId, {})).status).toBe(400);
+  });
+
+  test('an empty array CLEARS a delta list', async () => {
+    const { org, ownerUserId, targetMemberId } = await seedOrg();
+    await getDb()
+      .update(accountMembers)
+      .set({ permissionGrants: ['credentials:read'] })
+      .where(eq(accountMembers.id, targetMemberId));
+    actingUserId = ownerUserId;
+
+    const res = await patchMember(org, targetMemberId, { permissionGrants: [] });
+
+    expect(res.status).toBe(200);
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual([]);
+  });
+
+  test('a role-only patch still works and leaves the deltas alone', async () => {
+    const { org, ownerUserId, targetMemberId } = await seedOrg();
+    await getDb()
+      .update(accountMembers)
+      .set({ permissionGrants: ['credentials:read'] })
+      .where(eq(accountMembers.id, targetMemberId));
+    actingUserId = ownerUserId;
+
+    const res = await patchMember(org, targetMemberId, { role: 'developer' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.member?.role).toBe('developer');
+    // Absent means UNCHANGED — only `[]` clears.
+    expect((await rowById(targetMemberId)).permissionGrants).toEqual(['credentials:read']);
+  });
+
+  test('a member of ANOTHER account is a 404, not an edit', async () => {
+    const first = await seedOrg();
+    const second = await seedOrg();
+    actingUserId = first.ownerUserId;
+
+    const res = await patchMember(first.org, second.targetMemberId, {
+      permissionGrants: ['credentials:read'],
+    });
+
+    expect(res.status).toBe(404);
+    expect((await rowById(second.targetMemberId)).permissionGrants).toEqual([]);
+  });
+
+  test('an actor without members:update cannot reach the editor at all', async () => {
+    // `viewer` holds `members:read` but not `members:update`, so the RBAC
+    // middleware refuses before any of the rules above are consulted.
+    const { org, targetUserId, ownerMemberId } = await seedOrg();
+    expect(permissionsForAccountRole('viewer')).not.toContain('members:update');
+    actingUserId = targetUserId;
+
+    const res = await patchMember(org, ownerMemberId, { role: 'developer' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/members:update/);
+  });
+
+  test('a member with a GRANTED members:update can reach the editor', async () => {
+    // The control for the case above, and the end-to-end proof that a per-member
+    // grant is honoured by `requireAccountPermission` and not only by the
+    // serializer: `developer` has no `members:read` either, so this member is
+    // reaching a route their role cannot.
+    const { org, targetMemberId, targetUserId } = await seedOrg();
+    const victimMemberId = await seedMember(org, await seedUser('personal'), 'viewer');
+    await getDb()
+      .update(accountMembers)
+      .set({ role: 'developer', permissionGrants: ['members:update'] })
+      .where(eq(accountMembers.id, targetMemberId));
+    expect(permissionsForAccountRole('developer')).not.toContain('members:update');
+    actingUserId = targetUserId;
+
+    const res = await patchMember(org, victimMemberId, { role: 'billing' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.member?.role).toBe('billing');
+  });
+
+  test('an INHERITED actor is bound by the same rules as a direct one', async () => {
+    // Access resolved from an ancestor row carries that row's deltas, so an
+    // admin narrowed at the org level cannot widen someone on the project.
+    const org = await seedUser('organization');
+    const project = await seedUser('project');
+    await getDb()
+      .update(users)
+      .set({ parentAccountId: org, rootAccountId: org })
+      .where(eq(users.id, project));
+    // `depth = 0` is the tree root and the highest depth is the immediate
+    // parent, so a direct child of a root carries exactly one edge at 0.
+    await getDb()
+      .insert(userAncestors)
+      .values({ userId: project, ancestorId: org, depth: 0 });
+
+    const adminUserId = await seedUser('personal');
+    await seedMember(org, adminUserId, 'admin', {
+      permissionRevokes: ['credentials:create'],
+    });
+    const victimMemberId = await seedMember(project, await seedUser('personal'), 'viewer');
+    actingUserId = adminUserId;
+
+    const refused = await patchMember(project, victimMemberId, {
+      permissionGrants: ['credentials:create'],
+    });
+    expect(refused.status).toBe(403);
+
+    // …and is still able to grant what it does hold, so the case is not just
+    // "an inherited actor can do nothing".
+    const allowed = await patchMember(project, victimMemberId, {
+      permissionGrants: ['credentials:read'],
+    });
+    expect(allowed.status).toBe(200);
+  });
+});
+
+describe('a member of another account entirely', () => {
+  test('is refused with no access to the account', async () => {
+    const { org, targetMemberId } = await seedOrg();
+    const outsider = await seedUser('personal');
+    actingUserId = outsider;
+
+    const res = await patchMember(org, targetMemberId, { role: 'developer' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/do not have access/i);
+    expect((await rowById(targetMemberId)).role).toBe('viewer');
+  });
+});

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -41,7 +41,7 @@ import { accountMembers } from '../db/schema/accountMembers';
 import { stripSensitiveUrlQueryParams } from '../utils/sanitizeUrl';
 import { formatUserResponse } from '../utils/userTransform';
 import {
-  permissionsForAccountRole,
+  effectivePermissionsForMember,
   type AccountPermission,
   type AccountRole,
 } from '../utils/accountRoles';
@@ -422,10 +422,18 @@ function serializeMember(member: AccountMemberRow, source: 'direct' | 'inherited
     accountId: member.accountId,
     memberUserId: member.memberUserId,
     role: member.role,
-    // `account_members.permissions` does not travel to Postgres: every write
-    // site set it to exactly `permissionsForAccountRole(role)`, making it a
-    // derivation rather than data. The wire keeps the field, computed here.
-    permissions: permissionsForAccountRole(member.role),
+    // `account_members.permissions` does not travel to Postgres — it was always
+    // a derivation rather than data. The wire keeps the field, computed here,
+    // and it is the EFFECTIVE set: the role's baseline with this member's own
+    // grants and revokes applied. Consumers gate on this array (Mention reads
+    // `account:act_as` out of it to decide who may publish as an account), so it
+    // has to be the same answer this API's own gates give.
+    permissions: effectivePermissionsForMember(member),
+    // The deltas themselves, so an editor UI can show what was adjusted rather
+    // than diffing the effective set against a role map it would have to keep a
+    // second copy of.
+    permissionGrants: member.permissionGrants,
+    permissionRevokes: member.permissionRevokes,
     inherit: member.inherit,
     status: member.status,
     source,
@@ -994,7 +1002,40 @@ router.post(
   })
 );
 
-/** Change a member's role/inheritance (`members:update`). */
+/**
+ * Change a member's role, inheritance and/or per-member permissions
+ * (`members:update`).
+ *
+ * ## The escalation guards
+ *
+ * `members:update` is held by owner and admin, and an admin's baseline is a
+ * PROPER SUBSET of an owner's — it carries neither `account:delete` nor
+ * `ownership:transfer`. Without a bound on what may be conferred, this endpoint
+ * would hand an admin both of those (via a confederate's row, or their own) and
+ * with them the account. The two rules below are what stop that, and the
+ * FIRST is the load-bearing one:
+ *
+ *  1. **An actor may only grant what they themselves effectively hold.** This is
+ *     transitive-closure-safe on its own: whatever chain of members grant each
+ *     other, no permission enters the account that was not already inside it.
+ *     Compared against the actor's EFFECTIVE set, so an actor whose own
+ *     `credentials:create` was revoked cannot re-mint it through somebody else.
+ *  2. **An actor may not edit their OWN membership row.** Rule 1 already refuses
+ *     the dangerous half of a self-edit, so this is not what closes the hole; it
+ *     is here because rule 1 evaluated against the very row being rewritten is a
+ *     read-modify-write racing itself, and because "you cannot rewrite your own
+ *     permissions" is the property an operator will assume holds.
+ *
+ * Escalation to OWNER is refused structurally rather than by a rule: `role` is
+ * typed to the assignable roles (owner is not among them), and `updateMember`
+ * refuses an owner ROW outright, so neither the actor nor their target can reach
+ * ownership through this endpoint at all.
+ *
+ * REVOKES are deliberately NOT subject to rule 1. An admin may revoke a
+ * permission they do not hold themselves — taking something away is not a
+ * conferral, and the alternative would leave a permission granted by a
+ * since-departed owner with nobody able to withdraw it.
+ */
 router.patch(
   '/:id/members/:memberId',
   membersLimiter,
@@ -1002,20 +1043,48 @@ router.patch(
   requireAccountPermission('members:update'),
   asyncHandler(async (req: AccountContextRequest, res) => {
     const account = req.account;
-    if (!account) {
+    const access = req.access;
+    if (!account || !access) {
       throw new NotFoundError('Account not found');
     }
-    const { role, inherit } = req.body as {
-      role: Exclude<AccountRole, 'owner'>;
+    const { role, inherit, permissionGrants, permissionRevokes } = req.body as {
+      role?: Exclude<AccountRole, 'owner'>;
       inherit?: boolean;
+      permissionGrants?: AccountPermission[];
+      permissionRevokes?: AccountPermission[];
     };
 
-    const member = await accountService.updateMemberRole(
+    const target = await accountService.requireDirectMember(
       account.id,
-      req.params.memberId,
-      role,
-      inherit
+      req.params.memberId
     );
+
+    // Rule 2. Compared on `memberUserId`, not on the membership id: an actor
+    // whose access is INHERITED from an ancestor has no row on this account, and
+    // the row they would be editing here is a different one that nonetheless
+    // decides what they may do on this account.
+    if (target.memberUserId === requireUserId(req)) {
+      throw new ForbiddenError('You cannot change your own membership');
+    }
+
+    // Rule 1.
+    if (permissionGrants && permissionGrants.length > 0) {
+      const beyondActor = permissionGrants.filter(
+        (permission) => !access.permissions.includes(permission)
+      );
+      if (beyondActor.length > 0) {
+        throw new ForbiddenError(
+          `You cannot grant permissions you do not hold: ${beyondActor.join(', ')}`
+        );
+      }
+    }
+
+    const member = await accountService.updateMember(account.id, req.params.memberId, {
+      ...(role !== undefined ? { role } : {}),
+      ...(inherit !== undefined ? { inherit } : {}),
+      ...(permissionGrants !== undefined ? { permissionGrants } : {}),
+      ...(permissionRevokes !== undefined ? { permissionRevokes } : {}),
+    });
     res.json({ member: serializeMember(member) });
   })
 );

--- a/packages/api/src/schemas/account.schemas.ts
+++ b/packages/api/src/schemas/account.schemas.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { accountCategoriesSchema, createAccountRequestSchema } from '@oxyhq/contracts';
-import { ACCOUNT_ROLES } from '../utils/accountRoles';
+import { ACCOUNT_PERMISSIONS, ACCOUNT_ROLES } from '../utils/accountRoles';
 import { ACCOUNT_CREDENTIAL_ENVIRONMENTS } from '../db/schema/accountCredentials';
 import { APPLICATION_SCOPES } from '../utils/applicationScopes';
 
@@ -107,13 +107,51 @@ export const inviteAccountMemberSchema = z.object({
   inherit: z.boolean().optional(),
 });
 
-/** PATCH /accounts/:id/members/:memberId — change a member role / inheritance. */
+/**
+ * A per-member permission delta list.
+ *
+ * The vocabulary is enforced HERE, at the write boundary, and nowhere else — no
+ * SQL `CHECK` lists it (see `db/schema/accountMembers.ts` for the measurement
+ * that rules that out), and the read path filters rather than validates. So a
+ * string outside `ACCOUNT_PERMISSIONS` is a 400 naming the offending value,
+ * while a string that WAS valid when it was stored and has since been retired
+ * simply stops counting.
+ *
+ * Capped at the size of the vocabulary itself: a longer list can only be
+ * duplicates or padding, and an unbounded array on a write endpoint is a free
+ * row-size amplifier.
+ */
+const permissionListSchema = z
+  .array(z.enum(ACCOUNT_PERMISSIONS))
+  .max(ACCOUNT_PERMISSIONS.length);
+
+/**
+ * PATCH /accounts/:id/members/:memberId — change a member's role, inheritance
+ * and/or per-member permission deltas.
+ *
+ * Every field is optional and the body must name at least one: permissions are
+ * editable WITHOUT restating the role, which is the whole point of the endpoint,
+ * and a caller forced to re-send `role` to adjust a permission would be
+ * re-asserting a value it may have read before someone else changed it.
+ *
+ * An empty array is a meaningful value — it CLEARS that delta list — so the
+ * "at least one field" check counts keys present in the parsed object rather
+ * than truthy ones.
+ */
 export const updateAccountMemberSchema = z
   .object({
-    role: z.enum(assignableRoles as [typeof assignableRoles[number], ...typeof assignableRoles]),
+    role: z
+      .enum(assignableRoles as [typeof assignableRoles[number], ...typeof assignableRoles])
+      .optional(),
     inherit: z.boolean().optional(),
+    permissionGrants: permissionListSchema.optional(),
+    permissionRevokes: permissionListSchema.optional(),
   })
-  .strict();
+  .strict()
+  .refine((body) => Object.keys(body).length > 0, {
+    message:
+      'Provide at least one of: role, inherit, permissionGrants, permissionRevokes',
+  });
 
 /** POST /accounts/:id/transfer-ownership. */
 export const transferAccountOwnershipSchema = z.object({

--- a/packages/api/src/services/__tests__/account.service.test.ts
+++ b/packages/api/src/services/__tests__/account.service.test.ts
@@ -98,7 +98,12 @@ async function seedMember(
   accountId: string,
   memberUserId: string,
   role: AccountMemberRow['role'],
-  extra: { inherit?: boolean; status?: AccountMemberRow['status'] } = {}
+  extra: {
+    inherit?: boolean;
+    status?: AccountMemberRow['status'];
+    permissionGrants?: string[];
+    permissionRevokes?: string[];
+  } = {}
 ): Promise<AccountMemberRow> {
   const [row] = await getDb()
     .insert(accountMembers)
@@ -108,6 +113,8 @@ async function seedMember(
       role,
       inherit: extra.inherit ?? true,
       status: extra.status ?? 'active',
+      permissionGrants: extra.permissionGrants ?? [],
+      permissionRevokes: extra.permissionRevokes ?? [],
     })
     .returning();
   return row;
@@ -687,6 +694,73 @@ describe('membership inheritance + verifyActingAs', () => {
     expect(access?.source).toBe('self');
     expect(access?.membership).toBeNull();
   });
+
+  test('a per-member GRANT reaches resolveEffectiveAccess', async () => {
+    const org = await seedAccount({ kind: 'organization' });
+    const bob = await seedAccount();
+    await seedMember(org.id, bob.id, 'developer', { permissionGrants: ['members:read'] });
+
+    const access = await accountService.resolveEffectiveAccess(bob.id, org.id);
+    expect(access?.role).toBe('developer');
+    expect(access?.permissions).toContain('members:read');
+  });
+
+  test('a per-member REVOKE reaches resolveEffectiveAccess', async () => {
+    const org = await seedAccount({ kind: 'organization' });
+    const bob = await seedAccount();
+    await seedMember(org.id, bob.id, 'admin', { permissionRevokes: ['members:remove'] });
+
+    const access = await accountService.resolveEffectiveAccess(bob.id, org.id);
+    expect(access?.role).toBe('admin');
+    expect(access?.permissions).not.toContain('members:remove');
+    // Narrowed, not emptied.
+    expect(access?.permissions).toContain('members:invite');
+  });
+
+  test('deltas travel through INHERITANCE with the row that carries them', async () => {
+    // Inheritance resolves to a ROW, and the row's adjustments are part of what
+    // it grants — an implementation that carried only the role down the tree
+    // would widen an intentionally-narrowed member on every descendant account.
+    const { org, project } = await seedOrgTree();
+    const bob = await seedAccount();
+    await seedMember(org.id, bob.id, 'admin', {
+      inherit: true,
+      permissionRevokes: ['account:act_as'],
+    });
+
+    const access = await accountService.resolveEffectiveAccess(bob.id, project.id);
+    expect(access?.source).toBe('inherited');
+    expect(access?.permissions).not.toContain('account:act_as');
+  });
+
+  test('verifyActingAs honours a revoke of account:act_as', async () => {
+    // The measurement that makes this endpoint's guarantee real: `admin` carries
+    // `account:act_as` in its baseline, so a role-driven check returns 'admin'
+    // here and only a permission-driven one returns null.
+    const org = await seedAccount({ kind: 'organization' });
+    const bob = await seedAccount();
+    await seedMember(org.id, bob.id, 'admin', { permissionRevokes: ['account:act_as'] });
+
+    expect(await accountService.verifyActingAs(bob.id, org.id)).toBeNull();
+  });
+
+  test('verifyActingAs honours a grant of account:act_as to a role without it', async () => {
+    const org = await seedAccount({ kind: 'organization' });
+    const bob = await seedAccount();
+    // `developer` has no `account:act_as` baseline — asserted, so the case
+    // cannot quietly become vacuous if the role map changes.
+    await seedMember(org.id, bob.id, 'developer');
+    expect(await accountService.verifyActingAs(bob.id, org.id)).toBeNull();
+
+    await getDb()
+      .update(accountMembers)
+      .set({ permissionGrants: ['account:act_as'] })
+      .where(
+        and(eq(accountMembers.accountId, org.id), eq(accountMembers.memberUserId, bob.id))
+      );
+
+    expect(await accountService.verifyActingAs(bob.id, org.id)).toBe('developer');
+  });
 });
 
 // ===========================================================================
@@ -759,14 +833,76 @@ describe('members CRUD', () => {
     expect(await memberRowsFor(org.id, charlie.id)).toHaveLength(1);
   });
 
-  test('updateMemberRole rejects changing an owner row', async () => {
+  test('updateMember rejects changing an owner row', async () => {
     const org = await seedAccount({ kind: 'organization' });
     const owner = await seedAccount();
     const ownerMember = await seedMember(org.id, owner.id, 'owner');
 
     await expect(
-      accountService.updateMemberRole(org.id, ownerMember.id, 'admin')
+      accountService.updateMember(org.id, ownerMember.id, { role: 'admin' })
     ).rejects.toThrow(/transfer-ownership/i);
+  });
+
+  test('updateMember refuses a PERMISSION edit on an owner row, not just a role edit', async () => {
+    // An owner row is uneditable through this endpoint, so a revoke landing on
+    // one would be irreversible: there is no way back short of transferring the
+    // account away and back again.
+    const org = await seedAccount({ kind: 'organization' });
+    const owner = await seedAccount();
+    const ownerMember = await seedMember(org.id, owner.id, 'owner');
+
+    await expect(
+      accountService.updateMember(org.id, ownerMember.id, {
+        permissionRevokes: ['account:delete'],
+      })
+    ).rejects.toThrow(/transfer-ownership/i);
+    expect((await memberRowById(ownerMember.id)).permissionRevokes).toEqual([]);
+  });
+
+  test('addMember RESETS the delta columns when it reactivates a removed row', async () => {
+    // A removed member carrying a grant must not carry it back in silently on
+    // re-invitation: the invite names a role, and the row has to mean what the
+    // invite said.
+    const org = await seedAccount({ kind: 'organization' });
+    const owner = await seedAccount();
+    const charlie = await seedAccount();
+    await seedMember(org.id, charlie.id, 'admin', {
+      status: 'removed',
+      permissionGrants: ['ownership:transfer'],
+      permissionRevokes: ['account:read'],
+    });
+
+    const member = await accountService.addMember(org.id, owner.id, charlie.id, 'viewer');
+
+    expect(member.permissionGrants).toEqual([]);
+    expect(member.permissionRevokes).toEqual([]);
+    expect(
+      (await accountService.resolveEffectiveAccess(charlie.id, org.id))?.permissions
+    ).not.toContain('ownership:transfer');
+  });
+
+  test('transferOwnership clears the promoted row deltas', async () => {
+    // An owner row can never be edited again, so an admin-era revoke carried
+    // into ownership would be a permanent, unfixable hole in that owner's
+    // authority.
+    const org = await seedAccount({ kind: 'organization' });
+    const alice = await seedAccount();
+    const bob = await seedAccount();
+    await seedMember(org.id, alice.id, 'owner');
+    const bobMember = await seedMember(org.id, bob.id, 'admin', {
+      permissionRevokes: ['account:update'],
+      permissionGrants: ['ownership:transfer'],
+    });
+
+    await accountService.transferOwnership(org.id, alice.id, bob.id);
+
+    const promoted = await memberRowById(bobMember.id);
+    expect(promoted.role).toBe('owner');
+    expect(promoted.permissionRevokes).toEqual([]);
+    expect(promoted.permissionGrants).toEqual([]);
+    expect(
+      (await accountService.resolveEffectiveAccess(bob.id, org.id))?.permissions
+    ).toContain('account:update');
   });
 
   test('removeMember refuses to remove the last owner', async () => {

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -20,7 +20,10 @@
  *   the Mongo array carried implicitly is now stated (`db/schema/userAncestors.ts`).
  * - **`account_members.permissions` does not travel.** Every write site set it
  *   to exactly `permissionsForAccountRole(role)`; it is a derivation of `role`,
- *   not data, and the serializer keeps emitting it from the role.
+ *   not data, and the serializer keeps emitting it. What the table stores
+ *   instead is the per-member ADJUSTMENT — `permission_grants` /
+ *   `permission_revokes` — which a role name genuinely cannot express;
+ *   `effectivePermissionsForMember` combines the three.
  * - **The session-less transaction fallback is DELETED, not translated.** The
  *   Mongoose helper string-matched a "no replica set" error and re-ran the work
  *   WITHOUT a transaction, so a subtree move on a standalone deployment ran
@@ -51,8 +54,9 @@ import {
   type AccountCategoryId,
 } from '@oxyhq/contracts';
 import {
+  effectivePermissionsForMember,
   permissionsForAccountRole,
-  roleCanActAs,
+  type AccountPermission,
   type AccountRole,
 } from '../utils/accountRoles';
 import { isCredentialUsable } from '../utils/credentialUsability';
@@ -149,7 +153,14 @@ export interface MembershipLike {
 /** Resolved effective access of a caller over an account. */
 export interface EffectiveAccess {
   role: AccountRole;
-  permissions: string[];
+  /**
+   * What the caller may actually do: the role's baseline adjusted by the
+   * membership row's own grants and revokes. Typed as the permission union
+   * rather than `string[]` so a gate cannot be written against a string that is
+   * not in the vocabulary — a typo in `requireAccountPermission('acount:read')`
+   * would otherwise be a permanently-false check that reads as a working gate.
+   */
+  permissions: AccountPermission[];
   /** `self` = implicit ownership of one's own personal account. */
   source: 'self' | 'direct' | 'inherited';
   /** The concrete membership row, when the access came from one. */
@@ -756,9 +767,7 @@ export class AccountService {
 
     return {
       role: resolved.row.role,
-      // Derived from the role, always. Mongo stored an array beside it that
-      // every write site set to exactly this; it is not data and does not travel.
-      permissions: permissionsForAccountRole(resolved.row.role),
+      permissions: effectivePermissionsForMember(resolved.row),
       source: resolved.source,
       membership: resolved.row,
     };
@@ -766,16 +775,27 @@ export class AccountService {
 
   /**
    * Authorise `userId` to switch INTO `accountId` (`POST /accounts/:id/switch`).
-   * Authorised iff the caller's effective role carries `account:act_as`. Returns
-   * the role on success, null otherwise. Also re-run to keep a managed-account
-   * session bound to its operator's membership (revocation kills the session).
+   * Authorised iff the caller's EFFECTIVE permissions carry `account:act_as`.
+   * Returns the role on success, null otherwise. Also re-run to keep a
+   * managed-account session bound to its operator's membership (revocation kills
+   * the session).
+   *
+   * Read off the permission set, never off the role. The two agreed for as long
+   * as permissions were a pure function of the role, but a per-member revoke of
+   * `account:act_as` is precisely the grant an operator most wants to be able to
+   * withdraw — a ghostwriter who may edit a channel but may not become it — and a
+   * role check would silently ignore it. It would ALSO disagree with the copy of
+   * this decision consumers already make: they read `account:act_as` out of the
+   * `permissions` array this service serialises, so gating the session mint on
+   * the role would let an app publish under an identity Oxy refuses to mint a
+   * session for, and vice versa.
    */
   async verifyActingAs(userId: string, accountId: string): Promise<AccountRole | null> {
     const access = await this.resolveEffectiveAccess(userId, accountId);
     if (!access) {
       return null;
     }
-    return roleCanActAs(access.role) ? access.role : null;
+    return access.permissions.includes('account:act_as') ? access.role : null;
   }
 
   /**
@@ -973,12 +993,21 @@ export class AccountService {
       throw new BadRequestError('User is already a member of this account');
     }
 
+    // Both delta columns are RESET on the conflict path, not just left to their
+    // insert default. A `removed` row is reactivated rather than replaced, so
+    // without this a member removed while holding a grant of `credentials:create`
+    // would silently carry it back in on re-invitation as a `viewer` — the
+    // permissions the invite is nominally handing out being a strict subset of
+    // what the row actually confers, with nothing in the request to hint at it.
+    // A re-invitation is a fresh grant.
     const [member] = await db
       .insert(accountMembers)
       .values({
         accountId,
         memberUserId: targetUserId,
         role,
+        permissionGrants: [],
+        permissionRevokes: [],
         inherit,
         status: 'active',
         invitedByUserId: callerUserId,
@@ -988,6 +1017,8 @@ export class AccountService {
         target: [accountMembers.accountId, accountMembers.memberUserId],
         set: {
           role,
+          permissionGrants: [],
+          permissionRevokes: [],
           inherit,
           status: 'active',
           invitedByUserId: callerUserId,
@@ -1007,27 +1038,63 @@ export class AccountService {
   }
 
   /**
-   * Change a member's role and/or inheritance. An owner's role can only be
-   * changed via {@link transferOwnership}.
+   * Change a member's role, inheritance and/or per-member permission deltas.
+   *
+   * An OWNER row is refused outright — not just its `role`, but its permissions
+   * too. Ownership is absolute and is granted only through
+   * {@link transferOwnership}; an editable owner row would let anyone holding
+   * `members:update` revoke `account:delete` from the account's owner, and there
+   * would then be no endpoint able to give it back.
+   *
+   * The caller is responsible for the escalation guard (an actor may not confer
+   * a permission they do not themselves hold). It lives at the route, where the
+   * actor's own effective access has already been resolved, rather than here,
+   * where it would need to resolve that access a second time — the route is the
+   * only caller and the guard is exercised through it.
    */
-  async updateMemberRole(
+  async updateMember(
     accountId: string,
     memberId: string,
-    role: Exclude<AccountRole, 'owner'>,
-    inherit?: boolean
+    patch: {
+      role?: Exclude<AccountRole, 'owner'>;
+      inherit?: boolean;
+      permissionGrants?: AccountPermission[];
+      permissionRevokes?: AccountPermission[];
+    }
   ): Promise<AccountMemberRow> {
     const member = await this.requireDirectMember(accountId, memberId);
     if (member.role === 'owner') {
-      throw new ForbiddenError("An owner's role can only be changed via transfer-ownership");
+      throw new ForbiddenError(
+        "An owner's membership can only be changed via transfer-ownership"
+      );
+    }
+
+    const set: Partial<typeof accountMembers.$inferInsert> = {};
+    if (patch.role !== undefined) set.role = patch.role;
+    if (patch.inherit !== undefined) set.inherit = patch.inherit;
+    // Each delta list is assigned WHOLE, so sending `[]` is how a caller clears
+    // one. That is why the route's schema treats "absent" and "empty" as
+    // different requests rather than normalising them together.
+    if (patch.permissionGrants !== undefined) set.permissionGrants = patch.permissionGrants;
+    if (patch.permissionRevokes !== undefined) set.permissionRevokes = patch.permissionRevokes;
+
+    if (Object.keys(set).length === 0) {
+      return member;
     }
 
     const [updated] = await getDb()
       .update(accountMembers)
-      .set(inherit === undefined ? { role } : { role, inherit })
+      .set(set)
       .where(eq(accountMembers.id, memberId))
       .returning();
 
-    logger.info('Account member role updated', { accountId, memberId, role });
+    logger.info('Account member updated', {
+      accountId,
+      memberId,
+      role: updated.role,
+      grants: updated.permissionGrants.length,
+      revokes: updated.permissionRevokes.length,
+    });
     return updated;
   }
 
@@ -1101,9 +1168,14 @@ export class AccountService {
     }
 
     await db.transaction(async (tx) => {
+      // The promoted row's per-member deltas are CLEARED, because an owner row
+      // can never be edited again (`updateMember` refuses one). Carrying an
+      // admin-era revoke of `account:delete` into ownership would mint an owner
+      // permanently missing a permission with no endpoint able to restore it —
+      // the one shape of lockout this graph has no answer for.
       const promoted = await tx
         .update(accountMembers)
-        .set({ role: 'owner' })
+        .set({ role: 'owner', permissionGrants: [], permissionRevokes: [] })
         .where(
           and(
             eq(accountMembers.accountId, accountId),
@@ -1311,8 +1383,15 @@ export class AccountService {
   // Internal helpers
   // -------------------------------------------------------------------------
 
-  /** Fetch a direct, non-removed membership row or throw 404. */
-  private async requireDirectMember(
+  /**
+   * Fetch a direct, non-removed membership row or throw 404.
+   *
+   * Public because the member-permission editor's escalation guards run at the
+   * route (where the ACTOR's effective access is already resolved) and need the
+   * target row to compare against — with the same 404 for a member of another
+   * account that every other member operation gives.
+   */
+  async requireDirectMember(
     accountId: string,
     memberId: string
   ): Promise<AccountMemberRow> {

--- a/packages/api/src/utils/__tests__/accountRoles.test.ts
+++ b/packages/api/src/utils/__tests__/accountRoles.test.ts
@@ -1,0 +1,107 @@
+/**
+ * `resolveEffectivePermissions` — the ONE place a role baseline and a member's
+ * own grants/revokes become a permission set.
+ *
+ * Every account authorization decision reads its output, so the cases below are
+ * chosen to distinguish it from the implementations it could plausibly be
+ * mistaken for: a role-only lookup, a union that forgets revokes, a revoke that
+ * loses to a grant, and a pass-through that would let a retired vocabulary entry
+ * keep granting.
+ */
+
+import {
+  ACCOUNT_PERMISSIONS,
+  ROLE_PERMISSIONS,
+  isAccountPermission,
+  permissionsForAccountRole,
+  resolveEffectivePermissions,
+} from '../accountRoles';
+
+describe('resolveEffectivePermissions', () => {
+  test('with no deltas it is exactly the role baseline', () => {
+    for (const role of Object.keys(ROLE_PERMISSIONS) as (keyof typeof ROLE_PERMISSIONS)[]) {
+      expect(resolveEffectivePermissions(role, [], []).sort()).toEqual(
+        permissionsForAccountRole(role).sort()
+      );
+    }
+  });
+
+  test('a grant adds a permission the role does not carry', () => {
+    // `developer` genuinely lacks `members:read` — asserted rather than assumed,
+    // because if the baseline ever gained it this test would pass while testing
+    // nothing.
+    expect(permissionsForAccountRole('developer')).not.toContain('members:read');
+
+    const effective = resolveEffectivePermissions('developer', ['members:read'], []);
+    expect(effective).toContain('members:read');
+    // Everything the role already carried survives the addition.
+    for (const permission of permissionsForAccountRole('developer')) {
+      expect(effective).toContain(permission);
+    }
+  });
+
+  test('a revoke removes a permission the role does carry', () => {
+    expect(permissionsForAccountRole('editor')).toContain('account:act_as');
+
+    expect(resolveEffectivePermissions('editor', [], ['account:act_as'])).not.toContain(
+      'account:act_as'
+    );
+  });
+
+  test('a revoke beats a grant naming the same permission', () => {
+    // The safe reading of a contradiction is the narrower one. A union-then-add
+    // implementation would return it.
+    expect(
+      resolveEffectivePermissions('viewer', ['account:delete'], ['account:delete'])
+    ).not.toContain('account:delete');
+  });
+
+  test('a grant outside the current vocabulary is inert', () => {
+    // The failure this guards is a permission RETIRED from ACCOUNT_PERMISSIONS
+    // while rows still name it. Stored strings are never scrubbed, so the read
+    // path is the only thing standing between a retired string and a live grant.
+    const effective = resolveEffectivePermissions('viewer', ['account:retired_capability'], []);
+    expect(effective).not.toContain('account:retired_capability');
+    expect(effective).toEqual(permissionsForAccountRole('viewer'));
+  });
+
+  test('a revoke outside the current vocabulary removes nothing', () => {
+    expect(resolveEffectivePermissions('admin', [], ['account:retired_capability'])).toEqual(
+      resolveEffectivePermissions('admin', [], [])
+    );
+  });
+
+  test('every returned permission is in the vocabulary, in declaration order', () => {
+    const effective = resolveEffectivePermissions(
+      'viewer',
+      ['ownership:transfer', 'account:act_as', 'not-a-permission'],
+      []
+    );
+    for (const permission of effective) {
+      expect(isAccountPermission(permission)).toBe(true);
+    }
+    // Ordering is the vocabulary's, not the caller's — so the wire value is
+    // deterministic for a given input regardless of what order a client sent.
+    const indices = effective.map((permission) => ACCOUNT_PERMISSIONS.indexOf(permission));
+    expect(indices).toEqual([...indices].sort((a, b) => a - b));
+  });
+
+  test('duplicates in a delta list collapse', () => {
+    expect(
+      resolveEffectivePermissions('viewer', ['account:act_as', 'account:act_as'], [])
+    ).toEqual(resolveEffectivePermissions('viewer', ['account:act_as'], []));
+  });
+});
+
+describe('isAccountPermission', () => {
+  test('accepts every declared permission and nothing else', () => {
+    for (const permission of ACCOUNT_PERMISSIONS) {
+      expect(isAccountPermission(permission)).toBe(true);
+    }
+    expect(isAccountPermission('account:moderate')).toBe(false);
+    expect(isAccountPermission('')).toBe(false);
+    // Neither a prefix nor a superstring of a real permission passes.
+    expect(isAccountPermission('account')).toBe(false);
+    expect(isAccountPermission('account:read:all')).toBe(false);
+  });
+});

--- a/packages/api/src/utils/accountRoles.ts
+++ b/packages/api/src/utils/accountRoles.ts
@@ -3,18 +3,20 @@
  *
  * The unified Account system collapses the three legacy role vocabularies
  * (`workspaceRoles`, `applicationRoles`, and `ManagedAccount.managers[].role`)
- * into ONE set of roles + capabilities keyed off an {@link AccountMember} row.
+ * into ONE set of roles + capabilities keyed off an `account_members` row.
  *
- * Each AccountMember has a `role`; the concrete `permissions` array stored on
- * the member document is derived from this map at write time via
- * `permissionsForAccountRole`. Routes gate actions on individual permission
- * strings (see `requireAccountPermission`) rather than on the role directly, so
- * the role map is the single source of truth for what each role may do.
+ * A member's role picks a BASELINE permission set out of {@link ROLE_PERMISSIONS};
+ * the row's `permission_grants` / `permission_revokes` then adjust it per member.
+ * {@link resolveEffectivePermissions} is the ONE place those three inputs are
+ * combined, and every gate reads its output — routes check individual permission
+ * strings (see `requireAccountPermission`), never a role name.
  *
  * `account:act_as` (the right to switch INTO the account via
- * `POST /accounts/:id/switch`, minting a real session AS it) is deliberately
- * granted ONLY to owner/admin/editor — billing/developer/viewer may manage
- * facets of the account but never post/act as it.
+ * `POST /accounts/:id/switch`, minting a real session AS it) is baseline for
+ * owner/admin/editor only — billing/developer/viewer may manage facets of the
+ * account but never post/act as it. It is read like every other permission, so a
+ * per-member revoke genuinely takes it away and a per-member grant genuinely
+ * confers it; there is deliberately no role-shaped shortcut for it.
  *
  * Legacy role mapping (used by the migration scripts):
  *  - ManagedAccount owner/admin/editor → owner/admin/editor (unchanged)
@@ -161,12 +163,13 @@ export const ROLE_PERMISSIONS: Readonly<Record<AccountRole, readonly AccountPerm
   viewer: VIEWER_PERMISSIONS,
 };
 
-/** Roles whose holders may switch INTO the account (mint a session AS it). */
-export const ACTING_AS_ROLES: readonly AccountRole[] = ['owner', 'admin', 'editor'];
-
 /**
- * Resolve the concrete permission list for a role. Returns a fresh array so the
- * caller can persist it without aliasing the shared constant.
+ * Resolve the BASELINE permission list for a role, before any per-member
+ * adjustment. Returns a fresh array so the caller can persist it without
+ * aliasing the shared constant.
+ *
+ * Callers gating an action want {@link resolveEffectivePermissions}, which
+ * layers the member's own grants and revokes over this.
  */
 export function permissionsForAccountRole(role: AccountRole): AccountPermission[] {
   return [...ROLE_PERMISSIONS[role]];
@@ -177,9 +180,76 @@ export function isAccountRole(value: string): value is AccountRole {
   return (ACCOUNT_ROLES as readonly string[]).includes(value);
 }
 
-/** Whether a role carries the `account:act_as` capability. */
-export function roleCanActAs(role: AccountRole): boolean {
-  return ROLE_PERMISSIONS[role].includes('account:act_as');
+/** Type guard for an arbitrary string being a permission in the CURRENT vocabulary. */
+export function isAccountPermission(value: string): value is AccountPermission {
+  return (ACCOUNT_PERMISSIONS as readonly string[]).includes(value);
+}
+
+/**
+ * The permissions a member actually holds: the role's baseline, plus the row's
+ * `permission_grants`, minus its `permission_revokes`.
+ *
+ * A REVOKE beats a GRANT naming the same permission, because the two disagreeing
+ * can only be a mistake and the safe reading of a mistake is the narrower one.
+ *
+ * ## Why this is a filter over the vocabulary rather than a set built from the row
+ *
+ * The result is produced by filtering {@link ACCOUNT_PERMISSIONS} itself, so a
+ * stored string that is no longer in the vocabulary CANNOT appear in the output —
+ * it goes inert the moment the permission is retired, with no write, no
+ * backfill and no failure. That is deliberate, and it is why neither delta column
+ * carries a SQL `CHECK` listing the vocabulary: measured on Postgres 17.5, adding
+ * `check (col <@ array[…])` and later NARROWING that array makes every subsequent
+ * `UPDATE` of a row holding a retired value fail — including an `UPDATE` that
+ * names only `role`, reported against a column the caller never mentioned. Adding
+ * the constraint `NOT VALID` does not help: it skips validating the existing rows
+ * at `ALTER` time, and the next update of one still fails. The vocabulary is
+ * therefore enforced at the WRITE boundary (the zod schema, which 400s an unknown
+ * string) and dropped again at the READ boundary (here).
+ *
+ * Output order follows the {@link ACCOUNT_PERMISSIONS} declaration order, so the
+ * wire value is deterministic for a given input and two members' sets diff
+ * meaningfully.
+ */
+export function resolveEffectivePermissions(
+  role: AccountRole,
+  grants: readonly string[],
+  revokes: readonly string[]
+): AccountPermission[] {
+  const held = new Set<string>(ROLE_PERMISSIONS[role]);
+  for (const permission of grants) held.add(permission);
+  for (const permission of revokes) held.delete(permission);
+  return ACCOUNT_PERMISSIONS.filter((permission) => held.has(permission));
+}
+
+/**
+ * The row-shaped form of {@link resolveEffectivePermissions}: what a membership
+ * row actually grants. The ONE place a stored row becomes a permission set, so
+ * a caller cannot read `role` and forget the deltas — `requireAccountPermission`,
+ * `verifyActingAs`, `serializeMember` and the permission editor's own escalation
+ * guard all resolve through it.
+ *
+ * It lives HERE rather than beside the row's other operations in
+ * `account.service.ts`, and that placement is load-bearing rather than
+ * aesthetic. Route suites whole-mock `services/account.service` (a `jest.mock`
+ * factory naming only `accountService`), so a serializer reaching into that
+ * module for a pure function gets `undefined is not a function` at request time
+ * — a 500 that reads like a route bug and is nowhere near the mock that caused
+ * it. This module is dependency-free and nothing mocks it. The parameter is
+ * structural for the same reason: naming the drizzle row type would make this
+ * file import `db/schema/accountMembers.ts`, which imports `ACCOUNT_ROLES` back
+ * out of it.
+ */
+export function effectivePermissionsForMember(member: {
+  role: AccountRole;
+  permissionGrants: readonly string[];
+  permissionRevokes: readonly string[];
+}): AccountPermission[] {
+  return resolveEffectivePermissions(
+    member.role,
+    member.permissionGrants,
+    member.permissionRevokes
+  );
 }
 
 /**


### PR DESCRIPTION
## ⚠️ Operational hazard — dispatch the migration BEFORE this deploys

This PR adds Drizzle migration `0014_account_member_permission_overrides.sql`. **`deploy-aws.yml` has no migration step.** Earlier today a migration-bearing PR merged, deployed, and took `POST /users/by-ids` down ecosystem-wide until the migration was dispatched by hand.

This migration is additive (two `text[] DEFAULT '{}' NOT NULL` columns, no CHECK) and verified:
- Does not rewrite the ~200k-row `account_members` table (non-volatile default, Postgres 11+ `attmissingval` path).
- A pre-deploy-shaped `INSERT` naming only the old columns still succeeds.

So it is safe to apply **before** the code, and it must be applied that way — via `Run PostgreSQL migrations` (`dry_run=true` first, then for real) — before this PR's image reaches ECS. **Whoever merges this: dispatch the migration workflow first.**

## Summary

- **The brief's premise was wrong, and the measurement is the finding.** `AccountMember.permissions` is not a stored field on `origin/main` — the Postgres port deliberately dropped it (the schema docblock already said so). Permissions were 100% a function of `role`, computed at read time in two places: `effectiveAccessForAccount` and `serializeMember`.
- **`account:act_as` was not read off permissions either.** `verifyActingAs` called `roleCanActAs(access.role)` — a role lookup — while Mention's `publishAsAccount.ts` reads it out of the DTO's `permissions` array. The two agreed only because both derived from the role; they were one delta away from disagreeing. `verifyActingAs` now reads `access.permissions`, making the ecosystem's written rule ("read off `AccountMember.permissions`, never inferred from `membership.role`") true rather than aspirational. `roleCanActAs` and `ACTING_AS_ROLES` are deleted (the latter was exported and referenced by nothing).
- **Design: per-member deltas over the role baseline**, not an absolute override list — a member keeps tracking vocabulary changes for anything not explicitly adjusted. `resolveEffectivePermissions` filters through `ACCOUNT_PERMISSIONS`, which does the vocabulary filter and the deterministic ordering in one line — a retired permission string is structurally incapable of appearing in the output. Revoke beats grant.
- **No vocabulary CHECK constraint, deliberately — measured on real Postgres 17.5.** With `check (perms <@ array[...])`, narrowing the array later makes an `UPDATE ... SET role='editor'` that never mentions `perms` fail with `violates check constraint`. `NOT VALID` does not rescue it: it skips the existing-row scan at ALTER time, but the next update of such a row still fails. Six of the 23 permission strings are already dead, so that constraint would be a landmine with a known trigger.
- **Enforcement census, 23 permissions:** 15 middleware sites covering 14 distinct strings, 3 inline `includes(...)` checks, 1 role-shaped site (now fixed), and 6 strings read by nothing outside the role map — `children:delete`, `apps:read`, `apps:update`, `apps:delete`, `billing:read`, `billing:manage`. The apps ones are decoration because `applications.ts` gates on a separate `ApplicationPermission` vocabulary.
- **Escalation guards on `PATCH /accounts/:id/members/:memberId`:** an actor may only grant what they effectively hold (transitive-closure-safe on its own); no self-edit; owner-row edits refused entirely; promotion to owner is structurally impossible since `owner` is not in the assignable enum. Revokes are deliberately exempt from the grant guard. `addMember` resets both delta columns on the reactivate path so a removed member cannot carry a grant back in, and `transferOwnership` clears them on the promoted row since an owner row is uneditable and an inherited revoke would otherwise be permanent.
- **`account:moderate` deliberately NOT added** — six strings are already read by nothing, and a seventh would let an owner store a moderation grant and reasonably believe they had conferred something. It should land in the same commit as the endpoint that reads it.
- **Migration hygiene:** `db:generate` also proposed dropping `users.organization_category` — that's 0013's *deferred* second half, gated on a pre-check written into that file. Stripped from 0014 and the column spliced back into the snapshot, so a later `generate` re-proposes exactly that drop rather than silently recording the deferred decision as applied.

## Not published, not version-bumped

This change does not touch `package.json` or any workspace version — publishing/bumping is owned by another agent's chain.

## Follow-ups (not in this PR)

- `@oxyhq/core`'s `AccountMember` and `UpdateAccountMemberInput` need `permissionGrants`/`permissionRevokes` and an optional `role` before an SDK-driven editor is possible (extra wire fields are ignored today, so nothing breaks meanwhile).
- `AccountMembersScreen` edits roles only and inherits the per-member effect for free.
- `loadApplicationContext` still derives app permissions from role alone, so revoking an account permission does not reach inside an existing app.
- Invite remains role-only.
- The console keeps its own copy of the `AccountPermission` union, free to drift.

## Test plan

Already run by the implementing agent (not re-run here):
- [x] Baseline measured at 311 suites / 4466 tests green (brief's stated 4460 was stale); after: 313 suites / 4500 tests green.
- [x] `tsc --noEmit` and `tsc -p tsconfig.scripts.json` clean.
- [x] Lint: 0 errors, 92 pre-existing warnings, none new.
- [x] Mutation harness: 14 mutations, 0 survivors, control green first; every refusal case has a matching permitted control differing only in who asks (so blanket-deny fails as loudly as blanket-allow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)