### PR TITLE
fix(deploy): apply migrations as part of the deploy, phased by rollout side

### DIFF
--- a/.github/scripts/deploy-ecs-image.sh
+++ b/.github/scripts/deploy-ecs-image.sh
@@ -512,9 +512,17 @@ if [[ "$RUN_MIGRATIONS" == "true" || -n "$POST_DEPLOY_TASK_COMMAND_JSON" ]]; the
 fi
 
 if [[ "$RUN_MIGRATIONS" == "true" ]]; then
+  # --phase=pre, because at this point the PREVIOUS image is still serving every
+  # request. The migrator applies additive migrations only and stops at the first
+  # one that takes something away; the post-deploy slot below picks those up once
+  # the new image is live. See packages/api/src/db/migrationPhases.ts.
+  #
+  # This runs BEFORE update-service on purpose: a migration that fails leaves the
+  # previous image serving and the deploy red, which is the outcome that costs
+  # nothing. A migration that never runs is the outage this whole path exists for.
   if ! run_one_shot_command \
     "Migration" \
-    '["node","packages/api/dist/db/migrate.js"]'; then
+    '["node","packages/api/dist/db/migrate.js","--phase=pre"]'; then
     exit 1
   fi
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,33 @@ jobs:
       - run: bun scripts/test-check-deploy-secrets-sync.mjs
       - run: bun scripts/check-deploy-secrets-sync.mjs
 
+  # Every migration must declare which side of a deploy it belongs on, and the
+  # deploy must still apply them (see scripts/check-migration-phases.mjs).
+  #
+  # 0013_users_account_categories reached production ahead of the column it adds,
+  # because deploy-aws.yml had no migration step and the ordering lived in a
+  # human's head across two manual dispatches. The deploy now applies migrations
+  # itself; this job is what stops that from being silently disarmed — deleting
+  # one `RUN_MIGRATIONS: 'true'` line reproduces the outage exactly, with a green
+  # deploy and no other symptom.
+  #
+  # Runs on the pull request, before anything is pushed to main, and needs no
+  # install: the gate and the marker reader it imports touch only node builtins,
+  # which `test-check-migration-phases.mjs` asserts with a fixture that has no
+  # node_modules at any level.
+  migration-phases:
+    name: Migration Deploy Phases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      # The gate's own fixture tests — mutated copies of the real journal,
+      # migrations, deploy workflow and deploy script.
+      - run: bun scripts/test-check-migration-phases.mjs
+      - run: bun scripts/check-migration-phases.mjs
+
   # Contracts package tests (Jest — no MongoDB)
   contracts-test:
     name: Contracts Tests

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -167,9 +167,50 @@ jobs:
           echo "digest=$DIGEST" >>"$GITHUB_OUTPUT"
           echo "Built $COMMIT_TAG -> $DIGEST"
 
+      # Whether this release contains a migration that must run AFTER the rollout.
+      #
+      # Answerable from the repository alone, which is the only reason it can be
+      # answered here at all: pendingness needs the ledger, and the database is on
+      # a private VPC address this runner cannot reach. But a `post` migration can
+      # only be PENDING if it EXISTS, so "no post-phase marker anywhere in
+      # drizzle/" is a sound reason to skip the second one-shot task, and today
+      # that is every release — the common case pays nothing for this.
+      #
+      # The grep is exact rather than approximate because
+      # `scripts/check-migration-phases.mjs` separately proves every migration
+      # carries exactly one marker line in exactly this spelling, and asserts this
+      # workflow greps for the pattern that module exports. Without that gate a
+      # typo'd marker would read as "no post migration in this release" and the
+      # drop would never be applied by anything.
+      - name: Decide whether a post-rollout migration task is needed
+        id: post_migrations
+        run: |
+          set -euo pipefail
+          if grep -lE '^-- oxy:deploy-phase=post$' packages/api/drizzle/*.sql; then
+            echo 'command=["node","packages/api/dist/db/migrate.js","--phase=post"]' >>"$GITHUB_OUTPUT"
+            echo "This release carries post-rollout migrations."
+          else
+            echo 'command=' >>"$GITHUB_OUTPUT"
+            echo "No post-rollout migrations in this release; skipping that task."
+          fi
+
       - name: Register immutable task definition and deploy
         env:
           IMAGE_URI: ${{ env.ECR_REGISTRY }}/oxy/${{ env.APP }}@${{ steps.build.outputs.digest }}
+          # Applies pending additive migrations on the NEW image, inside the VPC,
+          # BEFORE the service update — so the schema a rollout needs is never
+          # behind the image that reads it. This is the whole fix for the
+          # 2026-08-02 outage: 0013_users_account_categories reached production
+          # minutes after the code that selects the column it adds, because the
+          # ordering lived in a human's head across two manual dispatches.
+          #
+          # Every deploy pays one one-shot task for this, whether anything is
+          # pending or not. There is no sound way to skip it: pendingness needs the
+          # ledger, and every cheaper proxy is a silent-skip machine. Concretely,
+          # "skip when this push changed no migration file" would have skipped the
+          # deploy AFTER the one that stranded 0013 and left production broken.
+          RUN_MIGRATIONS: 'true'
+          POST_DEPLOY_TASK_COMMAND_JSON: ${{ steps.post_migrations.outputs.command }}
         run: |
           STATUS=$(aws ecs describe-services --cluster "$CLUSTER" --services "$APP" --query 'services[0].status' --output text 2>/dev/null || echo NONE)
           if [ "$STATUS" != "ACTIVE" ]; then

--- a/.github/workflows/run-postgres-migrations.yml
+++ b/.github/workflows/run-postgres-migrations.yml
@@ -1,7 +1,20 @@
 name: Run PostgreSQL migrations
 
 # Applies the SQL migrations in `packages/api/drizzle/` to the production
-# PostgreSQL database. Manual only.
+# PostgreSQL database.
+#
+# THIS IS NO LONGER THE NORMAL PATH, AND MUST NOT BECOME ONE AGAIN. Every deploy
+# now applies its own pending additive migrations before the rollout, and its own
+# post-rollout ones after (`.github/workflows/deploy-aws.yml` ->
+# `.github/scripts/deploy-ecs-image.sh`). This workflow is the escape hatch: a
+# migration stranded by a failed deploy, a schema change with no code behind it,
+# a dry run to read the plan before a release.
+#
+# It exists because on 2026-08-02 it was the ONLY path, and 0013 reached
+# production behind the image that reads the column it adds — a 500 on
+# `POST /users/by-ids` ecosystem-wide until this workflow was dispatched by hand.
+# Nothing about that migration was wrong; the ordering just depended on somebody
+# remembering to run two workflows in the right order while a deploy raced them.
 #
 # WHY IT IS SHAPED LIKE THIS:
 #
@@ -31,6 +44,11 @@ name: Run PostgreSQL migrations
 # the list, then re-run with dry_run=false.
 #
 # Applying twice is safe: the second run finds nothing pending and exits 0.
+# Applying twice AT ONCE is not, and the migrator now refuses to — it holds a
+# Postgres advisory lock for the whole run, because drizzle's own migrator takes
+# no lock and two of them replay the same DDL. That lock is the only interlock
+# this workflow and a running deploy share: they sit in different `concurrency`
+# groups (`postgres-migrations` and `deploy-oxy-api`) and cannot see each other.
 
 on:
   workflow_dispatch:
@@ -45,6 +63,16 @@ on:
         required: true
         type: boolean
         default: true
+      phase:
+        description: >-
+          all = everything pending (the usual answer here; this workflow is
+          dispatched when nothing needs protecting from a half-migrated schema).
+          pre = additive only, stopping at the first destructive migration.
+          post = what a pre run deferred, once the new image is live.
+        required: true
+        type: choice
+        options: [all, pre, post]
+        default: all
 
 concurrency:
   # Two migrators against one database would race on the ledger.
@@ -111,11 +139,23 @@ jobs:
             ls packages/api/drizzle/*.sql >/dev/null
             echo "migrator + $(ls packages/api/drizzle/*.sql | wc -l) migration file(s) present"
           '
+          # And that it is a migrator that understands phases. An older image
+          # ignores the flag entirely and applies EVERYTHING, destructive
+          # migrations included, which is the failure this whole mechanism exists
+          # to prevent — and it would look like an ordinary successful run. The
+          # flag is parsed before DATABASE_URL is read, so this needs no database.
+          docker run --rm --entrypoint sh "$IMAGE" -c '
+            node packages/api/dist/db/migrate.js --phase=nonsense 2>&1 \
+              | grep -q "Unrecognised --phase" \
+              || { echo "This image does not validate --phase; it predates phased migrations."; exit 1; }
+            echo "migrator understands --phase"
+          '
 
       - name: Run the migration as an ECS one-shot task
         env:
           IMAGE: ${{ steps.image.outputs.image }}
           DRY_RUN: ${{ inputs.dry_run }}
+          PHASE: ${{ inputs.phase }}
         run: |
           set -euo pipefail
 
@@ -159,9 +199,10 @@ jobs:
           OVERRIDES=$(jq -nc \
             --arg name "$CONTAINER" \
             --arg dry "$DRY_RUN" \
+            --arg phase "$PHASE" \
             '{containerOverrides:[{
                name: $name,
-               command: ["node","packages/api/dist/db/migrate.js"],
+               command: ["node","packages/api/dist/db/migrate.js", "--phase=" + $phase],
                environment: [
                  {name:"DRY_RUN", value:$dry}
                ]

--- a/packages/api/drizzle/0000_groovy_colossus.sql
+++ b/packages/api/drizzle/0000_groovy_colossus.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 CREATE TABLE "app_affinity_seen_events" (
 	"id" text PRIMARY KEY NOT NULL,
 	"application_id" text NOT NULL,

--- a/packages/api/drizzle/0001_worthless_zarda.sql
+++ b/packages/api/drizzle/0001_worthless_zarda.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 CREATE TABLE "user_ancestors" (
 	"user_id" text NOT NULL,
 	"depth" integer NOT NULL,

--- a/packages/api/drizzle/0002_messy_karnak.sql
+++ b/packages/api/drizzle/0002_messy_karnak.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 CREATE TABLE "auth_codes" (
 	"id" text PRIMARY KEY NOT NULL,
 	"code_hash" text NOT NULL,

--- a/packages/api/drizzle/0003_eminent_luke_cage.sql
+++ b/packages/api/drizzle/0003_eminent_luke_cage.sql
@@ -1,2 +1,5 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 ALTER TABLE "user_locations" ADD COLUMN "geo" "geography" GENERATED ALWAYS AS (ST_MakePoint(longitude, latitude)::geography) STORED;--> statement-breakpoint
 CREATE INDEX "user_locations_geo_idx" ON "user_locations" USING gist ("geo");

--- a/packages/api/drizzle/0004_nebulous_warbound.sql
+++ b/packages/api/drizzle/0004_nebulous_warbound.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 CREATE TABLE "bundles" (
 	"id" text PRIMARY KEY NOT NULL,
 	"user_id" text NOT NULL,

--- a/packages/api/drizzle/0005_transparency_immutability.sql
+++ b/packages/api/drizzle/0005_transparency_immutability.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 -- Transparency-checkpoint immutability.
 --
 -- HAND-WRITTEN, not generated. drizzle-kit emits tables, constraints and

--- a/packages/api/drizzle/0006_workable_blonde_phantom.sql
+++ b/packages/api/drizzle/0006_workable_blonde_phantom.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 CREATE TABLE "account_credentials" (
 	"id" text PRIMARY KEY NOT NULL,
 	"account_id" text NOT NULL,

--- a/packages/api/drizzle/0007_billing_payment_intent_idempotency.sql
+++ b/packages/api/drizzle/0007_billing_payment_intent_idempotency.sql
@@ -1,1 +1,4 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 CREATE UNIQUE INDEX "billing_transactions_payment_intent_key" ON "billing_transactions" USING btree ("stripe_payment_intent_id","type") WHERE "billing_transactions"."type" = 'credit_purchase' and "billing_transactions"."stripe_payment_intent_id" is not null;

--- a/packages/api/drizzle/0008_billing_subscription_all_stripe_statuses.sql
+++ b/packages/api/drizzle/0008_billing_subscription_all_stripe_statuses.sql
@@ -1,2 +1,5 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 ALTER TABLE "billing_subscriptions" DROP CONSTRAINT "billing_subscriptions_status_check";--> statement-breakpoint
 ALTER TABLE "billing_subscriptions" ADD CONSTRAINT "billing_subscriptions_status_check" CHECK ("billing_subscriptions"."status" in ('active', 'canceled', 'incomplete', 'incomplete_expired', 'past_due', 'paused', 'trialing', 'unpaid'));

--- a/packages/api/drizzle/0009_signed_records_fork_mirror.sql
+++ b/packages/api/drizzle/0009_signed_records_fork_mirror.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 -- Relax `signed_records_chain_completeness_check` so a v2 record can be stored
 -- OFF the linear chain.
 --

--- a/packages/api/drizzle/0010_icy_madame_hydra.sql
+++ b/packages/api/drizzle/0010_icy_madame_hydra.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 CREATE TABLE "federation_key_pairs" (
 	"id" text PRIMARY KEY NOT NULL,
 	"key_id" text NOT NULL,

--- a/packages/api/drizzle/0011_account_kind_channel.sql
+++ b/packages/api/drizzle/0011_account_kind_channel.sql
@@ -1,2 +1,5 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 ALTER TABLE "users" DROP CONSTRAINT "users_kind_check";--> statement-breakpoint
 ALTER TABLE "users" ADD CONSTRAINT "users_kind_check" CHECK ("users"."kind" in ('personal', 'organization', 'project', 'bot', 'channel'));

--- a/packages/api/drizzle/0012_users_name_display.sql
+++ b/packages/api/drizzle/0012_users_name_display.sql
@@ -1,1 +1,4 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 ALTER TABLE "users" ADD COLUMN "name_display" text;

--- a/packages/api/drizzle/0013_users_account_categories.sql
+++ b/packages/api/drizzle/0013_users_account_categories.sql
@@ -1,3 +1,6 @@
+-- oxy:deploy-phase=pre
+-- Additive; safe while the previous image serves. See src/db/migrationPhases.ts.
+
 -- users.account_categories — the ordered, multi-valued replacement for the
 -- single-valued users.organization_category.
 --

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,7 @@
     "prepublishOnly": "node ../../scripts/assert-bun-publish.mjs && bun run clean && bun run build",
     "release": "rm -rf dist && bun run build && release-it",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "bun run src/db/migrate.ts"
+    "db:migrate": "bun run src/db/migrate.ts --phase=all"
   },
   "release-it": {
     "git": {

--- a/packages/api/src/db/MIGRATION-CONTRACT.md
+++ b/packages/api/src/db/MIGRATION-CONTRACT.md
@@ -92,6 +92,36 @@ Production MongoDB is NOT touched by any code-porting task. It stays live servin
 six backends with its S3 backups running until a separately-approved cutover. Local
 data is disposable. No agent runs a backfill against production.
 
+### Every migration declares which side of a deploy it runs on
+
+One line, in the `.sql` file, no default:
+
+```sql
+-- oxy:deploy-phase=pre    additive; correct against BOTH the image serving and the one arriving
+-- oxy:deploy-phase=post   drops/renames/narrows; only correct once the new image is live
+```
+
+The deploy applies them itself — `pre` before the rollout, `post` after — so the
+ordering is not something anyone has to remember. `scripts/check-migration-phases.mjs`
+fails the pull request when a migration omits the marker or when the deploy stops
+applying migrations; `src/db/migrationPhases.ts` carries the full reasoning.
+
+Two rules follow, and both bite:
+
+- **Split expand and contract into separate migrations.** A file that adds a column
+  and drops another has no single correct side. `0013_users_account_categories` is
+  the model: it adds and carries the data, and leaves the drop of
+  `organization_category` to its own later migration.
+- **A `pre` migration must never land behind an unapplied `post` one.** The ledger
+  records progress as a high-water mark and cannot skip an entry, so the migrator
+  REFUSES that pending list rather than picking a half that breaks one of the two
+  images. Land such a pair in separate releases.
+
+Do NOT edit an already-applied migration to change its SQL. Adding the phase marker
+to the fourteen that predate it was safe only because drizzle stores the file hash
+but never compares it — pendingness is `created_at` versus the journal's `when`
+(verified in `drizzle-orm@0.45.2`, `pg-core/dialect.cjs`).
+
 ## Verification — evidence, not assertion
 
 Run each package's OWN `bun run test`; `bun run build` must be run from

--- a/packages/api/src/db/__tests__/migrationPhases.test.ts
+++ b/packages/api/src/db/__tests__/migrationPhases.test.ts
@@ -1,0 +1,248 @@
+/**
+ * The deploy-phase marker reader and the run planner.
+ *
+ * Two properties carry the weight here. First, a migration that does not
+ * legibly declare its side of a deploy must produce a PROBLEM rather than a
+ * default — a default is how `0013_users_account_categories` reached production
+ * ahead of its column, just relocated one layer down. Second, the planner must
+ * never return a set that skips a migration: the ledger records progress as a
+ * high-water mark (`pendingEntries`), so an apply set with a hole in it cannot
+ * be represented, and a planner that produced one would silently record a
+ * migration as applied that never ran.
+ *
+ * The end-to-end behaviour — that `--phase=pre` really does leave a DROP alone
+ * against a live Postgres — is exercised by the real migrator; these are the
+ * pure pieces underneath it.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readJournal, MIGRATIONS_FOLDER } from '../migrationLedger';
+import {
+  DEPLOY_PHASES,
+  MIGRATION_RUNS,
+  POST_PHASE_GREP_PATTERN,
+  phaseMarkerLine,
+  planMigrationRun,
+  readMigrationPhases,
+} from '../migrationPhases';
+
+const throwawayFolders: string[] = [];
+
+afterAll(() => {
+  for (const folder of throwawayFolders) rmSync(folder, { recursive: true, force: true });
+});
+
+/** A throwaway drizzle folder holding `<tag>.sql` for each entry given. */
+function migrationFolder(files: Record<string, string>): string {
+  const folder = mkdtempSync(join(tmpdir(), 'oxy-phases-'));
+  throwawayFolders.push(folder);
+  mkdirSync(folder, { recursive: true });
+  for (const [tag, body] of Object.entries(files)) {
+    writeFileSync(join(folder, `${tag}.sql`), body);
+  }
+  return folder;
+}
+
+describe('readMigrationPhases', () => {
+  it('reads every migration that actually ships with the package', () => {
+    const tags = readJournal(MIGRATIONS_FOLDER).map((entry) => entry.tag);
+    const { phases, problems } = readMigrationPhases(tags, MIGRATIONS_FOLDER);
+
+    expect(problems).toEqual([]);
+    expect(phases.size).toBe(tags.length);
+    for (const tag of tags) {
+      expect(DEPLOY_PHASES).toContain(phases.get(tag));
+    }
+  });
+
+  it('accepts a marker anywhere in the file, not only the first line', () => {
+    const folder = migrationFolder({
+      '0000_x': `-- a header comment\n\n${phaseMarkerLine('post')}\n\nDROP TABLE "x";\n`,
+    });
+    const { phases, problems } = readMigrationPhases(['0000_x'], folder);
+
+    expect(problems).toEqual([]);
+    expect(phases.get('0000_x')).toBe('post');
+  });
+
+  it('tolerates CRLF, which is how a marker arrives from a Windows editor', () => {
+    const folder = migrationFolder({ '0000_x': `${phaseMarkerLine('pre')}\r\nSELECT 1;\r\n` });
+    const { phases, problems } = readMigrationPhases(['0000_x'], folder);
+
+    expect(problems).toEqual([]);
+    expect(phases.get('0000_x')).toBe('pre');
+  });
+
+  it('reports a missing marker and names the migration', () => {
+    const folder = migrationFolder({ '0000_x': 'ALTER TABLE "users" ADD COLUMN "a" text;\n' });
+    const { phases, problems } = readMigrationPhases(['0000_x'], folder);
+
+    expect(phases.size).toBe(0);
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('0000_x: no deploy-phase marker');
+  });
+
+  it('reports two markers rather than picking one', () => {
+    const folder = migrationFolder({
+      '0000_x': `${phaseMarkerLine('pre')}\n${phaseMarkerLine('post')}\nSELECT 1;\n`,
+    });
+    const { phases, problems } = readMigrationPhases(['0000_x'], folder);
+
+    expect(phases.size).toBe(0);
+    expect(problems[0]).toContain('2 deploy-phase markers');
+  });
+
+  it('reports a misspelled phase AS a misspelling, not as an absent marker', () => {
+    // Matching only `(pre|post)` would make this indistinguishable from a file
+    // with no marker at all, and "you wrote no phase" sends the reader looking
+    // at the wrong line.
+    const folder = migrationFolder({ '0000_x': '-- oxy:deploy-phase=after\nSELECT 1;\n' });
+    const { problems } = readMigrationPhases(['0000_x'], folder);
+
+    expect(problems[0]).toContain('unrecognised deploy phase "after"');
+  });
+
+  it('reports an unreadable file rather than treating it as undeclared', () => {
+    const { phases, problems } = readMigrationPhases(['0000_absent'], migrationFolder({}));
+
+    expect(phases.size).toBe(0);
+    expect(problems[0]).toContain('0000_absent: cannot read');
+  });
+
+  it('does not treat a marker-shaped string inside a statement as a marker', () => {
+    // Line-anchored: an indented or mid-line occurrence is SQL, not a
+    // declaration, and honouring it would let a comment inside a DO block decide
+    // when a production migration runs.
+    const folder = migrationFolder({
+      '0000_x': `  ${phaseMarkerLine('post')}\nINSERT INTO t VALUES ('-- oxy:deploy-phase=post');\n`,
+    });
+    const { problems } = readMigrationPhases(['0000_x'], folder);
+
+    expect(problems[0]).toContain('no deploy-phase marker');
+  });
+
+  it('exports the grep pattern the deploy workflow uses, matching its own marker', () => {
+    // deploy-aws.yml greps with this to decide whether a release needs a
+    // post-rollout task at all; if it stopped matching what `phaseMarkerLine`
+    // writes, that task would be skipped and the drop applied by nothing.
+    expect(new RegExp(POST_PHASE_GREP_PATTERN).test(phaseMarkerLine('post'))).toBe(true);
+    expect(new RegExp(POST_PHASE_GREP_PATTERN).test(phaseMarkerLine('pre'))).toBe(false);
+  });
+});
+
+describe('planMigrationRun', () => {
+  const pending = [
+    { tag: 'a_pre' },
+    { tag: 'b_pre' },
+    { tag: 'c_post' },
+    { tag: 'd_post' },
+  ];
+  const phases = new Map<string, 'pre' | 'post'>([
+    ['a_pre', 'pre'],
+    ['b_pre', 'pre'],
+    ['c_post', 'post'],
+    ['d_post', 'post'],
+  ]);
+
+  it('applies nothing and defers nothing when nothing is pending', () => {
+    for (const run of MIGRATION_RUNS) {
+      expect(planMigrationRun([], phases, run)).toEqual({ apply: [], deferred: [], blocked: null });
+    }
+  });
+
+  it('pre stops at the first post migration', () => {
+    const plan = planMigrationRun(pending, phases, 'pre');
+
+    expect(plan.blocked).toBeNull();
+    expect(plan.apply.map((entry) => entry.tag)).toEqual(['a_pre', 'b_pre']);
+    expect(plan.deferred.map((entry) => entry.tag)).toEqual(['c_post', 'd_post']);
+  });
+
+  it('pre applies everything when no post migration is pending', () => {
+    const additive = pending.slice(0, 2);
+    const plan = planMigrationRun(additive, phases, 'pre');
+
+    expect(plan.apply.map((entry) => entry.tag)).toEqual(['a_pre', 'b_pre']);
+    expect(plan.deferred).toEqual([]);
+  });
+
+  it('pre applies NOTHING when the first pending migration is destructive', () => {
+    const plan = planMigrationRun(pending.slice(2), phases, 'pre');
+
+    expect(plan.apply).toEqual([]);
+    expect(plan.deferred.map((entry) => entry.tag)).toEqual(['c_post', 'd_post']);
+    expect(plan.blocked).toBeNull();
+  });
+
+  it('post applies what pre deferred', () => {
+    const plan = planMigrationRun(pending.slice(2), phases, 'post');
+
+    expect(plan.apply.map((entry) => entry.tag)).toEqual(['c_post', 'd_post']);
+    expect(plan.blocked).toBeNull();
+  });
+
+  it('all ignores phases entirely', () => {
+    const plan = planMigrationRun(pending, phases, 'all');
+
+    expect(plan.apply.map((entry) => entry.tag)).toEqual(['a_pre', 'b_pre', 'c_post', 'd_post']);
+    expect(plan.deferred).toEqual([]);
+  });
+
+  it('BLOCKS pre when a pre migration is stranded behind an unapplied post one', () => {
+    // The ledger cannot express a hole, so there is no ordering here that is
+    // safe for both the image serving and the image arriving. Refusing names
+    // both; picking either one silently breaks one of the two.
+    const stranded = [{ tag: 'c_post' }, { tag: 'e_pre' }];
+    const plan = planMigrationRun(
+      stranded,
+      new Map<string, 'pre' | 'post'>([['c_post', 'post'], ['e_pre', 'pre']]),
+      'pre'
+    );
+
+    expect(plan.apply).toEqual([]);
+    expect(plan.deferred).toEqual([]);
+    expect(plan.blocked).toContain('e_pre');
+    expect(plan.blocked).toContain('c_post');
+  });
+
+  it('BLOCKS post when a pre migration is still pending after the rollout', () => {
+    // Reached only when the pre step did not run. The live image is already
+    // reading a column that does not exist, so failing here is what rolls the
+    // service back to the image that matches the schema.
+    const plan = planMigrationRun(pending, phases, 'post');
+
+    expect(plan.apply).toEqual([]);
+    expect(plan.blocked).toContain('a_pre');
+  });
+
+  it('BLOCKS every run when a pending migration declares no phase', () => {
+    for (const run of MIGRATION_RUNS) {
+      const plan = planMigrationRun([{ tag: 'z_unknown' }], phases, run);
+
+      expect(plan.apply).toEqual([]);
+      expect(plan.blocked).toContain('z_unknown');
+      expect(plan.blocked).toContain('do not declare a deploy phase');
+    }
+  });
+
+  it('never returns an apply set with a hole in it', () => {
+    // The ledger records "everything up to the newest applied", so a set that
+    // skips a pending migration would mark that migration applied without
+    // running it. Assert the apply set is a PREFIX of pending for every run.
+    for (const run of MIGRATION_RUNS) {
+      const plan = planMigrationRun(pending, phases, run);
+      const applied = plan.apply.map((entry) => entry.tag);
+
+      expect(applied).toEqual(pending.slice(0, applied.length).map((entry) => entry.tag));
+    }
+  });
+
+  it('does not mutate the pending list it was handed', () => {
+    const original = [...pending];
+    planMigrationRun(pending, phases, 'all').apply.pop();
+
+    expect(pending).toEqual(original);
+  });
+});

--- a/packages/api/src/db/migrate.ts
+++ b/packages/api/src/db/migrate.ts
@@ -4,9 +4,24 @@
  * This is the ONE migration mechanism in this package. `bun run db:migrate`
  * runs it, the jest harness (`src/db/testDatabase.ts`) shells out to that same
  * script, CI runs the same script, and production runs its COMPILED form
- * (`dist/db/migrate.js`) as a one-shot ECS task
- * (`.github/workflows/run-postgres-migrations.yml`). Nothing applies a
- * migration by any other route.
+ * (`dist/db/migrate.js`) as a one-shot ECS task — twice per deploy at most, on
+ * either side of the rollout (`.github/scripts/deploy-ecs-image.sh`), plus the
+ * manual escape hatch (`.github/workflows/run-postgres-migrations.yml`).
+ * Nothing applies a migration by any other route.
+ *
+ * `--phase` IS REQUIRED, and says which side of a deployment this run stands
+ * on. `src/db/migrationPhases.ts` explains the marker each migration carries
+ * and the incident that put it there; the short version:
+ *
+ *   --phase=pre    the PREVIOUS image is still serving. Applies additive
+ *                  migrations only, and stops at the first destructive one.
+ *   --phase=post   the NEW image is live. Applies what `pre` deferred.
+ *   --phase=all    nothing to protect — a developer's database, the jest
+ *                  harness, the manual dispatch. Applies everything pending.
+ *
+ * There is no default. A run that does not say which side it is on would have
+ * to guess, and guessing "pre" silently strands a drop while guessing "all"
+ * silently runs one against a live previous image.
  *
  * WHY NOT `drizzle-kit migrate`
  *
@@ -35,10 +50,23 @@
  * than the newest recorded `created_at`" rule — so a database migrated by
  * either is understood by the other.
  *
- * DRY RUN. `DRY_RUN=true` reports which migrations WOULD be applied and writes
- * nothing — not even the ledger table. The deployment workflow defaults to it.
+ * ONE MIGRATOR AT A TIME. drizzle's migrator takes no lock of any kind: it
+ * reads the newest ledger row OUTSIDE its transaction, then opens one and
+ * replays everything newer. Two of them against one database both read the same
+ * high-water mark and both replay the same DDL, so the loser fails on an
+ * already-applied statement — after the winner has committed, and with a
+ * duplicate ledger row left behind. Verified against a real Postgres 17. This
+ * matters more now than it used to: a deploy runs the migrator on its own, so a
+ * deploy and a manual dispatch can overlap, and their two workflows sit in
+ * different GitHub concurrency groups and cannot see each other. Hence the
+ * session advisory lock below, which is the only interlock both paths share.
+ *
+ * DRY RUN. `DRY_RUN=true` reports what this phase WOULD apply and writes
+ * nothing — not even the ledger table.
  */
 
+import { createHash } from 'node:crypto';
+import { rmSync } from 'node:fs';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
 import postgres from 'postgres';
@@ -49,13 +77,38 @@ import {
   MIGRATIONS_FOLDER,
   MIGRATIONS_SCHEMA,
   MIGRATIONS_TABLE,
+  materializeJournalPrefix,
   pendingEntries,
   readJournal,
   readLastAppliedMillis,
 } from './migrationLedger';
+import {
+  MIGRATION_RUNS,
+  type MigrationRun,
+  planMigrationRun,
+  readMigrationPhases,
+} from './migrationPhases';
 
 /** Seconds to wait for in-flight queries before forcing the socket shut. */
 const CLOSE_TIMEOUT_SECONDS = 5;
+
+/**
+ * The advisory-lock namespace. Hashed into a key rather than written as a magic
+ * number so the value cannot be mistyped and the string says what it protects.
+ */
+const MIGRATION_LOCK_NAMESPACE = 'oxy-api:drizzle-migrations';
+
+/**
+ * How long to wait for another migrator to finish before giving up. A deploy's
+ * pre-rollout task and a manual dispatch legitimately overlap; a real migration
+ * against this database takes seconds, so a wait this long means the other
+ * holder is stuck rather than busy, and failing is better than a one-shot task
+ * that never stops.
+ */
+const LOCK_WAIT_MS = 10 * 60 * 1000;
+
+/** How often to retry the lock while waiting. */
+const LOCK_POLL_MS = 2_000;
 
 /** Whether `DRY_RUN` asks for a report instead of an apply. */
 function isDryRun(): boolean {
@@ -63,7 +116,84 @@ function isDryRun(): boolean {
   return value === '1' || value === 'true' || value === 'yes';
 }
 
+/** The `--phase=<run>` argument. */
+function readRun(argv: readonly string[]): MigrationRun {
+  const flags = argv.filter((argument) => argument.startsWith('--phase='));
+
+  if (flags.length === 0) {
+    throw new ConfigurationError(
+      `--phase is required. Use one of: ${MIGRATION_RUNS.map((run) => `--phase=${run}`).join(', ')}. ` +
+      'See the header of src/db/migrate.ts for which one a given caller wants; ' +
+      '`--phase=all` is the right answer for a developer database or a manual dispatch.'
+    );
+  }
+  if (flags.length > 1) {
+    throw new ConfigurationError(`--phase was given ${flags.length} times: ${flags.join(' ')}.`);
+  }
+
+  const value = flags[0].slice('--phase='.length);
+  if (!(MIGRATION_RUNS as readonly string[]).includes(value)) {
+    throw new ConfigurationError(
+      `Unrecognised --phase=${value}. Use one of: ${MIGRATION_RUNS.join(', ')}.`
+    );
+  }
+  return value as MigrationRun;
+}
+
+/** A stable signed 64-bit advisory-lock key for `name`. */
+function advisoryLockKey(name: string): bigint {
+  return createHash('sha256').update(name).digest().readBigInt64BE(0);
+}
+
+/**
+ * Hold the migration advisory lock for the life of `client`'s session.
+ *
+ * The lock lives on its OWN connection, not on the pool drizzle migrates
+ * through: a session-level advisory lock belongs to the connection that took
+ * it, so sharing one with the migrator would silently drop the lock if
+ * postgres.js ever reconnected mid-run. Released when the session ends, which
+ * `main`'s `finally` guarantees even when the process is killed.
+ */
+async function acquireMigrationLock(client: postgres.Sql): Promise<void> {
+  const key = advisoryLockKey(MIGRATION_LOCK_NAMESPACE).toString();
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  let waited = false;
+
+  for (;;) {
+    const [row] = await client<{ locked: boolean }[]>`
+      select pg_try_advisory_lock(${key}::bigint) as locked
+    `;
+    if (row?.locked) {
+      if (waited) logger.info('Acquired the migration lock');
+      return;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Another migration has held the ${MIGRATION_LOCK_NAMESPACE} advisory lock for ` +
+        `${Math.round(LOCK_WAIT_MS / 1000)}s. Refusing to migrate alongside it: drizzle's ` +
+        'migrator takes no lock of its own, so two concurrent runs replay the same DDL. ' +
+        'Find the other run before retrying.'
+      );
+    }
+
+    if (!waited) {
+      waited = true;
+      logger.warn('Another migration holds the migration lock; waiting', {
+        waitSeconds: Math.round(LOCK_WAIT_MS / 1000),
+      });
+    }
+    await new Promise((resolve) => setTimeout(resolve, LOCK_POLL_MS));
+  }
+}
+
 async function main(): Promise<void> {
+  // Argument validation first, and before DATABASE_URL: it is the cheapest and
+  // most local failure, and it lets the deploy workflow prove an image
+  // understands `--phase` without handing it a database
+  // (`run-postgres-migrations.yml`, "Assert the image can actually migrate").
+  const run = readRun(process.argv.slice(2));
+
   const url = process.env.DATABASE_URL;
   if (!url) {
     throw new ConfigurationError(
@@ -75,27 +205,61 @@ async function main(): Promise<void> {
   const entries = readJournal();
   const dryRun = isDryRun();
 
+  const { phases, problems } = readMigrationPhases(
+    entries.map((entry) => entry.tag),
+    MIGRATIONS_FOLDER
+  );
+  if (problems.length > 0) {
+    throw new ConfigurationError(
+      `${problems.length} migration(s) do not declare which side of a deploy they belong on:\n` +
+      problems.map((problem) => `  - ${problem}`).join('\n')
+    );
+  }
+
+  // The lock's own connection. Taken before anything is read, so the pending
+  // calculation below cannot be invalidated by another migrator between the
+  // read and the apply.
+  const lockClient = postgres(url, { max: 1 });
   // `max: 1` — migrations are one serial stream of DDL; a pool would buy
   // nothing and would let statements interleave across connections.
   const client = postgres(url, {
     max: 1,
     onnotice: (notice) => logger.debug('Postgres notice', { notice: notice.message }),
   });
+  let prefixFolder: string | null = null;
 
   try {
-    const pending = pendingEntries(entries, await readLastAppliedMillis(client));
+    await acquireMigrationLock(lockClient);
 
-    if (pending.length === 0) {
-      logger.info('No pending migrations', { journalEntries: entries.length });
+    const pending = pendingEntries(entries, await readLastAppliedMillis(client));
+    const plan = planMigrationRun(pending, phases, run);
+
+    if (plan.blocked) {
+      throw new Error(plan.blocked);
+    }
+
+    if (plan.deferred.length > 0) {
+      logger.info(
+        `Leaving ${plan.deferred.length} migration(s) for a later phase`,
+        { phase: run, deferred: plan.deferred.map((entry) => entry.tag) }
+      );
+    }
+
+    if (plan.apply.length === 0) {
+      logger.info('No migrations to apply', {
+        phase: run,
+        journalEntries: entries.length,
+        pending: pending.map((entry) => entry.tag),
+      });
       return;
     }
 
-    const tags = pending.map((entry) => entry.tag);
+    const tags = plan.apply.map((entry) => entry.tag);
 
     if (dryRun) {
       logger.info(
-        `DRY RUN — ${pending.length} migration(s) would be applied; nothing was written`,
-        { pending: tags, journalEntries: entries.length }
+        `DRY RUN — ${plan.apply.length} migration(s) would be applied; nothing was written`,
+        { phase: run, pending: tags, journalEntries: entries.length }
       );
       return;
     }
@@ -107,20 +271,38 @@ async function main(): Promise<void> {
     // creates a `geography` column fails at table 39 of 45 without it.
     await ensureExtensions(url);
 
-    logger.info(`Applying ${pending.length} migration(s)`, { pending: tags });
+    logger.info(`Applying ${plan.apply.length} migration(s)`, { phase: run, pending: tags });
+
+    // A phase that stops short points the migrator at a folder ending where it
+    // stops; a phase applying everything pending uses the real one, so the
+    // common path is byte for byte what it always was.
+    let migrationsFolder = MIGRATIONS_FOLDER;
+    if (plan.deferred.length > 0) {
+      const last = plan.apply[plan.apply.length - 1];
+      prefixFolder = materializeJournalPrefix(
+        entries.findIndex((entry) => entry.tag === last.tag) + 1,
+        MIGRATIONS_FOLDER
+      );
+      migrationsFolder = prefixFolder;
+    }
 
     // No `schema`/`casing` here on purpose: `migrate()` only executes the raw
     // SQL text of the migration files, so it never builds a query from the
     // schema definitions and the compiled migrator stays independent of them.
     await migrate(drizzle(client), {
-      migrationsFolder: MIGRATIONS_FOLDER,
+      migrationsFolder,
       migrationsSchema: MIGRATIONS_SCHEMA,
       migrationsTable: MIGRATIONS_TABLE,
     });
 
     // A migrator that reports success while leaving work pending is worse than
     // one that fails, so re-read the ledger rather than trusting the call.
-    const remaining = pendingEntries(entries, await readLastAppliedMillis(client));
+    // Measured against what this PHASE undertook — anything it deliberately
+    // deferred is still pending on purpose.
+    const stillPending = pendingEntries(entries, await readLastAppliedMillis(client));
+    const remaining = plan.apply.filter((entry) =>
+      stillPending.some((pendingEntry) => pendingEntry.tag === entry.tag)
+    );
     if (remaining.length > 0) {
       throw new Error(
         `Migration reported success but ${remaining.length} migration(s) are still ` +
@@ -128,9 +310,12 @@ async function main(): Promise<void> {
       );
     }
 
-    logger.info(`Applied ${pending.length} migration(s)`, { applied: tags });
+    logger.info(`Applied ${plan.apply.length} migration(s)`, { phase: run, applied: tags });
   } finally {
+    if (prefixFolder) rmSync(prefixFolder, { recursive: true, force: true });
     await client.end({ timeout: CLOSE_TIMEOUT_SECONDS });
+    // Ends the lock's session, which is what releases the advisory lock.
+    await lockClient.end({ timeout: CLOSE_TIMEOUT_SECONDS });
   }
 }
 

--- a/packages/api/src/db/migrationLedger.ts
+++ b/packages/api/src/db/migrationLedger.ts
@@ -6,7 +6,8 @@
  * module whose top level connects to a database and exits the process.
  */
 
-import { readFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type postgres from 'postgres';
 import { ConfigurationError } from '../config/env';
@@ -94,6 +95,52 @@ export function pendingEntries(
 ): JournalEntry[] {
   if (lastAppliedMillis === null) return [...entries];
   return entries.filter((entry) => lastAppliedMillis < entry.when);
+}
+
+/**
+ * A throwaway migrations folder holding only the first `count` journal entries
+ * and their `.sql` files.
+ *
+ * WHY THIS EXISTS. drizzle's migrator reads its own folder
+ * (`readMigrationFiles`) and applies every entry newer than the newest one the
+ * ledger records; there is no public way to hand it a subset. A pre-deploy run
+ * that must stop before a `post` migration therefore points the migrator at a
+ * folder that ends there. The `.sql` files are copied byte for byte, so the
+ * `hash` drizzle records is identical to the one a full-folder run would have
+ * recorded — a later full run cannot tell the difference.
+ *
+ * Deliberately NOT `db.dialect.migrate(subset, ...)`, which would reach past
+ * the public `migrate()` helper: drizzle marks `dialect` and `session`
+ * `@internal` and does not declare them on `PgDatabase`, so reaching them needs
+ * a cast this repository does not permit.
+ *
+ * @returns The temporary folder. The caller owns it and must remove it.
+ */
+export function materializeJournalPrefix(
+  count: number,
+  sourceFolder: string = MIGRATIONS_FOLDER
+): string {
+  const journalPath = join(sourceFolder, 'meta', '_journal.json');
+  const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as { entries: JournalEntry[] };
+  const retained = journal.entries.slice(0, count);
+
+  if (retained.length !== count) {
+    throw new ConfigurationError(
+      `Cannot take the first ${count} entries of a journal holding ${journal.entries.length}.`
+    );
+  }
+
+  const folder = mkdtempSync(join(tmpdir(), 'oxy-migrate-prefix-'));
+  mkdirSync(join(folder, 'meta'), { recursive: true });
+  writeFileSync(
+    join(folder, 'meta', '_journal.json'),
+    JSON.stringify({ ...journal, entries: retained })
+  );
+  for (const entry of retained) {
+    copyFileSync(join(sourceFolder, `${entry.tag}.sql`), join(folder, `${entry.tag}.sql`));
+  }
+
+  return folder;
 }
 
 /**

--- a/packages/api/src/db/migrationPhases.ts
+++ b/packages/api/src/db/migrationPhases.ts
@@ -1,0 +1,271 @@
+/**
+ * Which side of a deployment each migration belongs on.
+ *
+ * THE BUG THIS EXISTS FOR
+ *
+ * `0013_users_account_categories` added `users.account_categories`, and the same
+ * pull request added code that selects that column by name. The image reached
+ * production; the column did not. `POST /users/by-ids` returned 500
+ * ecosystem-wide until `Run PostgreSQL migrations` was dispatched by hand.
+ *
+ * The migration itself was additive, defaulted, dropped nothing and documented
+ * its own ordering requirement. None of that helped, because the ordering
+ * depended on a human performing two dispatches in the right order while a
+ * deploy raced them.
+ *
+ * So a migration now DECLARES its side, in its own file, on one line:
+ *
+ *     -- oxy:deploy-phase=pre      applied BEFORE the new image rolls out
+ *     -- oxy:deploy-phase=post     applied AFTER the new image is live
+ *
+ * `pre` is every additive change — a new column carrying a DEFAULT, a new
+ * table, a widened CHECK. Correct against the image still serving AND the one
+ * arriving, so it can be applied while the old image runs.
+ *
+ * `post` is every change that takes something away — a DROP, a RENAME, a
+ * narrowed constraint. Applied early it is an outage on the image still
+ * serving: drizzle selects columns by name, so dropping one 500s every read the
+ * previous image performs. That is the second half of the same pull request,
+ * and it is exactly why "always migrate first" is wrong as a blanket rule.
+ *
+ * THERE IS NO DEFAULT, and that is the point. A migration with no marker, with
+ * two, or with an unrecognised value is a hard failure both in CI
+ * (`scripts/check-migration-phases.mjs`) and at migration time. A default would
+ * quietly pick a side for a migration whose author never considered the
+ * question — the same class of failure as the incident above, moved one step
+ * later and made harder to see.
+ *
+ * WHY THIS MODULE IMPORTS NOTHING BUT NODE BUILTINS
+ *
+ * The CI gate runs under `bun` with no `node_modules` installed, exactly like
+ * the two gates beside it (`check-lockfile-sync.mjs`,
+ * `check-deploy-secrets-sync.mjs`). Keeping this module dependency-free is what
+ * lets the gate import the REAL marker reader instead of carrying a second copy
+ * of the regex — so the gate and the migrator can never disagree about what a
+ * marker says.
+ *
+ * Nothing here throws. Problems are RETURNED, because the same list has to
+ * become a CI failure message in one caller and a migration-time
+ * `ConfigurationError` in the other.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** The side of a deployment a migration is safe to run on. */
+export type DeployPhase = 'pre' | 'post';
+
+/** Every accepted marker value, in the order the docs list them. */
+export const DEPLOY_PHASES: readonly DeployPhase[] = ['pre', 'post'];
+
+/** What a migration run is allowed to apply. */
+export type MigrationRun = 'pre' | 'post' | 'all';
+
+/** Every accepted `--phase` value. */
+export const MIGRATION_RUNS: readonly MigrationRun[] = ['pre', 'post', 'all'];
+
+/** The one accepted spelling of a phase marker. */
+export function phaseMarkerLine(phase: DeployPhase): string {
+  return `-- oxy:deploy-phase=${phase}`;
+}
+
+/**
+ * The POSIX ERE `.github/workflows/deploy-aws.yml` greps the migration files
+ * with, to decide whether this release needs a post-rollout migration task at
+ * all. Exported so the workflow cannot drift from the marker syntax this module
+ * accepts: the CI gate asserts the workflow contains this exact string.
+ *
+ * A grep is sound here ONLY because the gate separately proves every migration
+ * carries exactly one well-formed marker line. Without that, a typo'd marker
+ * would read as "no post migration in this release" and the drop would never be
+ * applied by anything.
+ */
+export const POST_PHASE_GREP_PATTERN = '^-- oxy:deploy-phase=post$';
+
+/**
+ * A marker line with the value left unconstrained on purpose. Matching
+ * `(pre|post)` instead would make `-- oxy:deploy-phase=later` indistinguishable
+ * from a file with no marker at all, and "you wrote a phase I do not recognise"
+ * is a far more useful thing to be told than "you wrote no phase".
+ */
+const MARKER_LINE = /^-- oxy:deploy-phase=(.*)$/;
+
+/** What `readMigrationPhases` found, and everything it could not make sense of. */
+export interface MigrationPhaseReadResult {
+  /** Tag -> declared phase, for every migration that declared one legibly. */
+  phases: Map<string, DeployPhase>;
+  /** Human-readable problems. Empty means every tag is in `phases`. */
+  problems: string[];
+}
+
+/**
+ * Read the phase marker out of each migration file.
+ *
+ * @param tags Journal tags, in journal order. A tag with no `<tag>.sql` beside
+ *   it is a problem rather than a silent omission — an image shipped without
+ *   its migrations must never read as "nothing declared, nothing to do".
+ * @param folder The `drizzle/` directory holding `<tag>.sql`.
+ */
+export function readMigrationPhases(
+  tags: readonly string[],
+  folder: string
+): MigrationPhaseReadResult {
+  const phases = new Map<string, DeployPhase>();
+  const problems: string[] = [];
+
+  for (const tag of tags) {
+    const path = join(folder, `${tag}.sql`);
+
+    let contents: string;
+    try {
+      contents = readFileSync(path, 'utf8');
+    } catch (error) {
+      problems.push(
+        `${tag}: cannot read ${path} (${error instanceof Error ? error.message : String(error)}).`
+      );
+      continue;
+    }
+
+    const values: string[] = [];
+    for (const line of contents.split('\n')) {
+      const match = MARKER_LINE.exec(line.replace(/\r$/, ''));
+      if (match) values.push(match[1]);
+    }
+
+    if (values.length === 0) {
+      problems.push(
+        `${tag}: no deploy-phase marker. Add exactly one line reading ` +
+        `\`${phaseMarkerLine('pre')}\` (additive — safe while the previous image serves) or ` +
+        `\`${phaseMarkerLine('post')}\` (drops/renames/narrows — only safe once the new image is live) ` +
+        `to ${tag}.sql.`
+      );
+      continue;
+    }
+
+    if (values.length > 1) {
+      problems.push(
+        `${tag}: ${values.length} deploy-phase markers (${values.join(', ')}). ` +
+        'Exactly one, or the file does not say which side of the deploy it belongs on.'
+      );
+      continue;
+    }
+
+    const value = values[0];
+    if (!isDeployPhase(value)) {
+      problems.push(
+        `${tag}: unrecognised deploy phase "${value}". Use one of: ${DEPLOY_PHASES.join(', ')}.`
+      );
+      continue;
+    }
+
+    phases.set(tag, value);
+  }
+
+  return { phases, problems };
+}
+
+function isDeployPhase(value: string): value is DeployPhase {
+  return (DEPLOY_PHASES as readonly string[]).includes(value);
+}
+
+/** What a run may apply, what it must leave alone, and why it may do neither. */
+export interface MigrationRunPlan<T> {
+  /** Migrations this run applies, in journal order. */
+  apply: T[];
+  /** Pending migrations this run deliberately leaves for a later phase. */
+  deferred: T[];
+  /**
+   * Non-null when there is no ordering this run can take that is safe. The
+   * caller must fail, and this string names the migrations responsible.
+   */
+  blocked: string | null;
+}
+
+/**
+ * Decide what a run applies.
+ *
+ * `all` applies everything pending. This is a developer's database, the jest
+ * harness, and the manual `Run PostgreSQL migrations` escape hatch — none of
+ * which has a previous image to protect.
+ *
+ * `pre` runs while the PREVIOUS image is still serving, so it applies the
+ * longest run of `pre` migrations at the front of the pending list and stops at
+ * the first `post` one.
+ *
+ * The stop has to be a PREFIX, because the ledger records progress as "the
+ * newest `created_at` applied" (see `pendingEntries`) — there is no way to
+ * express a hole. So a `pre` migration sitting BEHIND an unapplied `post` one
+ * cannot be applied without also applying the `post` one, and applying that
+ * breaks the image currently serving. Neither half is acceptable, so the run is
+ * BLOCKED and names both. It is the one case a human must resolve, and it is
+ * loud rather than silent, which is the whole point.
+ *
+ * `post` runs once the new image is live and applies everything still pending.
+ * It BLOCKS if a `pre` migration is pending, because at that point the pre
+ * phase either never ran or did not do its job: the live image is already
+ * reading a column that does not exist. Blocking fails the post-deploy task,
+ * which rolls the service back to the image that matches the schema on disk —
+ * the correct repair, and one that says out loud what went wrong.
+ */
+export function planMigrationRun<T extends { tag: string }>(
+  pending: readonly T[],
+  phases: ReadonlyMap<string, DeployPhase>,
+  run: MigrationRun
+): MigrationRunPlan<T> {
+  const undeclared = pending.filter((entry) => !phases.has(entry.tag));
+  if (undeclared.length > 0) {
+    return {
+      apply: [],
+      deferred: [],
+      blocked:
+        `${undeclared.length} pending migration(s) do not declare a deploy phase: ` +
+        `${undeclared.map((entry) => entry.tag).join(', ')}. ` +
+        'Refusing to guess which side of a deploy they belong on.',
+    };
+  }
+
+  if (run === 'all') {
+    return { apply: [...pending], deferred: [], blocked: null };
+  }
+
+  if (run === 'post') {
+    const stranded = pending.filter((entry) => phases.get(entry.tag) === 'pre');
+    if (stranded.length > 0) {
+      return {
+        apply: [],
+        deferred: [],
+        blocked:
+          `${stranded.map((entry) => entry.tag).join(', ')} ` +
+          `${stranded.length === 1 ? 'is a pre-deploy migration that is' : 'are pre-deploy migrations that are'} ` +
+          'still pending after the rollout. The pre-deploy migration step did not apply ' +
+          'it, so the image now serving is reading a schema this database does not have. ' +
+          'Failing so the deployment rolls back to the image that matches.',
+      };
+    }
+    return { apply: [...pending], deferred: [], blocked: null };
+  }
+
+  const firstPost = pending.findIndex((entry) => phases.get(entry.tag) === 'post');
+  if (firstPost === -1) {
+    return { apply: [...pending], deferred: [], blocked: null };
+  }
+
+  const deferred = pending.slice(firstPost);
+  const stranded = deferred.find((entry) => phases.get(entry.tag) === 'pre');
+  if (stranded) {
+    return {
+      apply: [],
+      deferred: [],
+      blocked:
+        `${stranded.tag} is a pre-deploy migration queued behind the post-deploy migration ` +
+        `${pending[firstPost].tag}, which is not applied yet. Applying ${stranded.tag} would ` +
+        `require applying ${pending[firstPost].tag} first — the ledger records progress as a ` +
+        'high-water mark and cannot skip one — and that would break the image currently ' +
+        `serving. Leaving ${stranded.tag} unapplied would break the image about to serve. ` +
+        'Deploy them in separate releases, or dispatch `Run PostgreSQL migrations` with ' +
+        'phase=all and accept that the previous image 500s until this rollout completes.',
+    };
+  }
+
+  return { apply: pending.slice(0, firstPost), deferred, blocked: null };
+}

--- a/scripts/check-migration-phases.mjs
+++ b/scripts/check-migration-phases.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+/**
+ * Fail the build when a schema change could reach production out of order.
+ *
+ * THE OUTAGE THIS EXISTS FOR
+ *
+ * `0013_users_account_categories` added `users.account_categories`, and the same
+ * pull request added code selecting that column by name. The pull request merged
+ * (this repository has no required status checks, so `--auto` merged it at once),
+ * `Deploy to AWS` built and rolled out the image, and `deploy-aws.yml` contained
+ * no migration step. The image reached production; the column did not.
+ * `POST /users/by-ids` returned 500 ecosystem-wide until `Run PostgreSQL
+ * migrations` was dispatched by hand.
+ *
+ * The migration was additive, defaulted, dropped nothing, and its pull request
+ * documented the ordering it needed. None of that helped, because the ordering
+ * depended on a human performing two dispatches in the right order while a
+ * deploy raced them.
+ *
+ * The fix is that the deploy applies migrations itself. This gate is what stops
+ * that mechanism from being silently disarmed or silently misfed.
+ *
+ * WHAT IS CHECKED
+ *
+ *   1. Every migration in the journal declares its deploy phase — exactly one
+ *      `-- oxy:deploy-phase=pre|post` line — using the SAME reader the migrator
+ *      uses at runtime. No default exists, so a migration whose author never
+ *      considered the question fails here rather than in production.
+ *   2. `.github/workflows/deploy-aws.yml` still sets `RUN_MIGRATIONS: 'true'`.
+ *      Deleting it is a one-line change that reproduces the outage exactly, with
+ *      a green deploy and no other symptom.
+ *   3. `.github/scripts/deploy-ecs-image.sh` still runs the pre-deploy migrator
+ *      with `--phase=pre`. Without the flag the migrator refuses to run at all,
+ *      but the failure would arrive as a red deploy nobody can place; with the
+ *      WRONG phase it would apply destructive migrations against the image still
+ *      serving, which is worse than the outage it replaced.
+ *   4. `deploy-aws.yml` decides whether it needs a post-rollout migration task by
+ *      grepping for the pattern `migrationPhases.ts` exports. That grep is only
+ *      sound because of (1); this pins the two together so the workflow cannot
+ *      drift to a pattern the marker syntax no longer matches.
+ *
+ * WHAT IS NOT CHECKED, DELIBERATELY
+ *
+ * Whether anything is PENDING. That needs the ledger, and the database is on a
+ * private VPC address a pull-request check must never be given credentials for.
+ * The pending question is answered at migration time, inside the VPC, by the
+ * migrator itself — which names every migration it applies, defers, or refuses.
+ * This gate covers the half that lives in the repository.
+ *
+ * Paths are resolved from the working directory, so the fixture tests in
+ * `scripts/test-check-migration-phases.mjs` can run it against a mutated copy of
+ * the real files.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  POST_PHASE_GREP_PATTERN,
+  readMigrationPhases,
+} from '../packages/api/src/db/migrationPhases.ts';
+
+const DRIZZLE_FOLDER = join('packages', 'api', 'drizzle');
+const JOURNAL_PATH = join(DRIZZLE_FOLDER, 'meta', '_journal.json');
+const DEPLOY_WORKFLOW_PATH = join('.github', 'workflows', 'deploy-aws.yml');
+const DEPLOY_SCRIPT_PATH = join('.github', 'scripts', 'deploy-ecs-image.sh');
+
+/**
+ * Vacuity guards. A journal this gate cannot read would otherwise check zero
+ * migrations and report zero problems — the shape that lets a broken traversal
+ * pass as a clean run. The sentinel is the first migration ever written, which
+ * is the one tag that can never legitimately leave the journal.
+ */
+const MINIMUM_JOURNAL_ENTRIES = 10;
+const JOURNAL_SENTINEL = '0000_groovy_colossus';
+
+/** What the pre-deploy one-shot must invoke, verbatim. */
+const PRE_PHASE_COMMAND = '"--phase=pre"';
+
+const problems = [];
+
+function fail(message) {
+  problems.push(message);
+}
+
+function read(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch (error) {
+    console.error(`Cannot read ${path}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+/** Journal tags, in journal order. */
+function parseJournalTags() {
+  let parsed;
+  try {
+    parsed = JSON.parse(read(JOURNAL_PATH));
+  } catch (error) {
+    fail(`${JOURNAL_PATH} is not readable JSON (${error.message}); the gate cannot see any migration.`);
+    return [];
+  }
+
+  const entries = parsed?.entries;
+  if (!Array.isArray(entries)) {
+    fail(`${JOURNAL_PATH} has no \`entries\` array; the gate cannot see any migration.`);
+    return [];
+  }
+
+  return entries.map((entry) => entry?.tag).filter((tag) => typeof tag === 'string');
+}
+
+const tags = parseJournalTags();
+
+// ── Vacuity guards ─────────────────────────────────────────────────────────
+if (tags.length > 0 && tags.length < MINIMUM_JOURNAL_ENTRIES) {
+  fail(
+    `Only ${tags.length} migration tag(s) parsed out of ${JOURNAL_PATH} (expected at least ` +
+    `${MINIMUM_JOURNAL_ENTRIES}). The parse is broken, not the source.`
+  );
+}
+if (tags.length > 0 && !tags.includes(JOURNAL_SENTINEL)) {
+  fail(
+    `${JOURNAL_SENTINEL} was not among the parsed journal tags — the gate is reading the wrong ` +
+    `array in ${JOURNAL_PATH}.`
+  );
+}
+
+// ── 1. Every migration declares its side of the deploy ─────────────────────
+const { phases, problems: phaseProblems } = readMigrationPhases(tags, DRIZZLE_FOLDER);
+for (const problem of phaseProblems) fail(problem);
+
+// ── 2/3. The deploy still applies migrations, on the right side ────────────
+const deployWorkflow = read(DEPLOY_WORKFLOW_PATH);
+const deployScript = read(DEPLOY_SCRIPT_PATH);
+
+if (!/^\s+RUN_MIGRATIONS:\s*'true'\s*$/m.test(deployWorkflow)) {
+  fail(
+    `${DEPLOY_WORKFLOW_PATH} no longer sets \`RUN_MIGRATIONS: 'true'\` on the deploy step, so no ` +
+    'deploy applies migrations before its rollout. That is exactly the 2026-08-02 outage: the ' +
+    'image ships, the column does not, and every read of it 500s until somebody dispatches ' +
+    '`Run PostgreSQL migrations` by hand.'
+  );
+}
+
+if (!deployScript.includes(PRE_PHASE_COMMAND)) {
+  fail(
+    `${DEPLOY_SCRIPT_PATH} no longer passes ${PRE_PHASE_COMMAND} to the pre-deploy migrator. ` +
+    'Without a phase the migrator refuses to run and the deploy fails for a reason nobody can ' +
+    'place; with the wrong phase it applies destructive migrations while the previous image is ' +
+    'still serving.'
+  );
+}
+
+// ── 4. The workflow's post-phase grep matches the real marker syntax ───────
+if (!deployWorkflow.includes(POST_PHASE_GREP_PATTERN)) {
+  fail(
+    `${DEPLOY_WORKFLOW_PATH} does not grep for ${POST_PHASE_GREP_PATTERN}, the pattern ` +
+    'packages/api/src/db/migrationPhases.ts exports. The workflow decides whether a release needs ' +
+    'a post-rollout migration task from that grep, so a pattern that no longer matches the marker ' +
+    'syntax silently skips the task and the destructive migration is never applied by anything.'
+  );
+}
+
+if (problems.length > 0) {
+  console.error('Migration deploy phases are BROKEN:\n');
+  for (const problem of problems) console.error(`- ${problem}`);
+  console.error(
+    '\nA migration that does not declare its side of the deploy, or a deploy that has stopped' +
+    '\napplying migrations, ships an image against a schema that does not match it. Nothing' +
+    '\nerrors at deploy time; the API just starts returning 500 on every read of the new column.'
+  );
+  process.exit(1);
+}
+
+const postCount = [...phases.values()].filter((phase) => phase === 'post').length;
+console.log(
+  `Migration deploy phases are sound: all ${tags.length} migration(s) declare a phase ` +
+  `(${tags.length - postCount} pre, ${postCount} post), deploy-aws.yml applies them before its ` +
+  'rollout, and its post-rollout grep matches the marker syntax the migrator reads.'
+);

--- a/scripts/test-check-migration-phases.mjs
+++ b/scripts/test-check-migration-phases.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env bun
+
+/**
+ * Exercises check-migration-phases.mjs against mutated copies of the REAL files
+ * it guards.
+ *
+ * Fixtures are copies, not hand-written miniatures: a synthetic journal would
+ * drift away from `packages/api/drizzle/` and start proving something about the
+ * fixture instead of about the migrations. Each case copies the real files into
+ * a temp root, breaks exactly one thing, and asserts the gate goes red AND names
+ * the offending migration or step — a gate that fails without naming what to fix
+ * is a gate nobody can act on, which is the failure mode this whole mechanism is
+ * an instance of.
+ *
+ * The `undeclared-new-migration` case is the one that matters most: it is the
+ * 2026-08-02 shape, a migration landing with the deploy having no idea which
+ * side of the rollout it belongs on.
+ *
+ * The last three cases keep the gate's own guards honest: each passes (exit 0)
+ * if the guard it targets is deleted, so none can rot into decoration.
+ *
+ * `no-node-modules` is not a mutation but a property test: the CI job runs this
+ * gate WITHOUT `bun install`, exactly like the two gates beside it, so the gate
+ * and the parser it imports must resolve with an empty dependency tree.
+ *
+ * Offline. Fixtures are created under the OS temp dir.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const checkScript = join(repoRoot, 'scripts', 'check-migration-phases.mjs');
+
+const DRIZZLE = join('packages', 'api', 'drizzle');
+const JOURNAL = join(DRIZZLE, 'meta', '_journal.json');
+const WORKFLOW = join('.github', 'workflows', 'deploy-aws.yml');
+const DEPLOY_SCRIPT = join('.github', 'scripts', 'deploy-ecs-image.sh');
+const PARSER = join('packages', 'api', 'src', 'db', 'migrationPhases.ts');
+const GATE = join('scripts', 'check-migration-phases.mjs');
+
+const fixturePrefix = join(tmpdir(), 'oxy-migration-phases-');
+const createdFixtures = [];
+const failures = [];
+
+function createFixture() {
+  const root = mkdtempSync(fixturePrefix);
+  createdFixtures.push(root);
+  cpSync(join(repoRoot, DRIZZLE), join(root, DRIZZLE), { recursive: true });
+  for (const relative of [WORKFLOW, DEPLOY_SCRIPT]) {
+    mkdirSync(join(root, dirname(relative)), { recursive: true });
+    cpSync(join(repoRoot, relative), join(root, relative));
+  }
+  return root;
+}
+
+/** Rewrite a fixture file, failing loudly if the edit matched nothing. */
+function edit(root, relative, caseName, replacer) {
+  const path = join(root, relative);
+  const before = readFileSync(path, 'utf8');
+  const after = replacer(before);
+  if (after === before) {
+    failures.push(
+      `${caseName}: the fixture edit changed nothing — the mutation never happened, so the case proves nothing.`
+    );
+    return;
+  }
+  writeFileSync(path, after);
+}
+
+function expectVerdict(caseName, root, expectedCode, expectedFragment, script = checkScript) {
+  let code = 0;
+  let output = '';
+  try {
+    output = execFileSync('bun', [script], { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch (error) {
+    code = error.status ?? 1;
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+  if (code !== expectedCode) {
+    failures.push(`${caseName}: expected exit ${expectedCode}, got ${code}.\n${output}`);
+    return;
+  }
+  if (!output.includes(expectedFragment)) {
+    failures.push(`${caseName}: output does not contain ${JSON.stringify(expectedFragment)}.\n${output}`);
+  }
+}
+
+/** Append a journal entry plus its `.sql` file to a fixture. */
+function addMigration(root, tag, body) {
+  const journalPath = join(root, JOURNAL);
+  const journal = JSON.parse(readFileSync(journalPath, 'utf8'));
+  const last = journal.entries[journal.entries.length - 1];
+  journal.entries.push({ idx: last.idx + 1, version: last.version, when: last.when + 1000, tag, breakpoints: true });
+  writeFileSync(journalPath, JSON.stringify(journal, null, 2));
+  writeFileSync(join(root, DRIZZLE, `${tag}.sql`), body);
+}
+
+// The real files must pass, or nothing below means anything.
+expectVerdict('unchanged', createFixture(), 0, 'Migration deploy phases are sound');
+
+// ── The 2026-08-02 shape: a migration lands, nothing says when to apply it ──
+const undeclared = createFixture();
+addMigration(
+  undeclared,
+  '0014_users_drop_organization_category',
+  'ALTER TABLE "users" DROP COLUMN "organization_category";\n'
+);
+expectVerdict(
+  'undeclared-new-migration',
+  undeclared,
+  1,
+  '0014_users_drop_organization_category: no deploy-phase marker',
+);
+
+// A marker stripped from an existing migration is the same hole, arriving by
+// edit rather than by addition.
+const markerRemoved = createFixture();
+edit(markerRemoved, join(DRIZZLE, '0013_users_account_categories.sql'), 'marker-removed', (text) =>
+  text.replace('-- oxy:deploy-phase=pre\n', ''));
+expectVerdict(
+  'marker-removed',
+  markerRemoved,
+  1,
+  '0013_users_account_categories: no deploy-phase marker',
+);
+
+// Two markers do not average out — the file does not say which side it is on.
+const twoMarkers = createFixture();
+edit(twoMarkers, join(DRIZZLE, '0012_users_name_display.sql'), 'two-markers', (text) =>
+  `${text}\n-- oxy:deploy-phase=post\n`);
+expectVerdict('two-markers', twoMarkers, 1, '0012_users_name_display: 2 deploy-phase markers');
+
+// A misspelled phase must be reported as a misspelling. Matching only
+// `(pre|post)` would make this indistinguishable from a file with no marker,
+// and "you wrote no phase" sends the reader looking in the wrong place.
+const unknownPhase = createFixture();
+edit(unknownPhase, join(DRIZZLE, '0011_account_kind_channel.sql'), 'unknown-phase', (text) =>
+  text.replace('-- oxy:deploy-phase=pre', '-- oxy:deploy-phase=after'));
+expectVerdict('unknown-phase', unknownPhase, 1, '0011_account_kind_channel: unrecognised deploy phase "after"');
+
+// A journal tag whose file is gone must be a problem, never "nothing declared,
+// nothing to do" — that is how an image shipped without its migrations reads.
+const missingFile = createFixture();
+rmSync(join(missingFile, DRIZZLE, '0010_icy_madame_hydra.sql'));
+expectVerdict('missing-migration-file', missingFile, 1, '0010_icy_madame_hydra: cannot read');
+
+// ── The deploy step itself ─────────────────────────────────────────────────
+//
+// Deleting one line from the workflow reproduces the outage exactly, with a
+// green deploy and no other symptom anywhere.
+const noRunMigrations = createFixture();
+edit(noRunMigrations, WORKFLOW, 'run-migrations-removed', (text) =>
+  text.replace(/^\s+RUN_MIGRATIONS: 'true'\n/m, ''));
+expectVerdict(
+  'run-migrations-removed',
+  noRunMigrations,
+  1,
+  "no longer sets `RUN_MIGRATIONS: 'true'` on the deploy step",
+);
+
+// A pre-deploy migrator without `--phase=pre` either refuses to run (red deploy,
+// no explanation) or, with the wrong phase, applies a DROP against the image
+// still serving.
+const noPhaseFlag = createFixture();
+edit(noPhaseFlag, DEPLOY_SCRIPT, 'pre-phase-flag-removed', (text) =>
+  text.replace(',"--phase=pre"', ''));
+expectVerdict('pre-phase-flag-removed', noPhaseFlag, 1, 'no longer passes "--phase=pre"');
+
+// The workflow decides whether to run a post-rollout migration task from a grep.
+// A pattern that no longer matches the marker syntax skips that task silently,
+// and the destructive migration is then applied by nothing at all.
+const driftedGrep = createFixture();
+edit(driftedGrep, WORKFLOW, 'post-grep-drifted', (text) =>
+  text.replace(/\^-- oxy:deploy-phase=post\$/g, '^-- oxy:migration-phase=post$'));
+expectVerdict('post-grep-drifted', driftedGrep, 1, 'does not grep for ^-- oxy:deploy-phase=post$');
+
+// ── The gate's own guards, each with a case that goes GREEN without it ──────
+//
+// A journal parse landing on a SHORTER array checks a handful of migrations,
+// finds nothing wrong with them, and reports success. Delete
+// MINIMUM_JOURNAL_ENTRIES and this case exits 0.
+const truncatedJournal = createFixture();
+edit(truncatedJournal, JOURNAL, 'truncated-journal', (text) => {
+  const journal = JSON.parse(text);
+  return JSON.stringify({ ...journal, entries: journal.entries.slice(0, 2) }, null, 2);
+});
+expectVerdict('truncated-journal', truncatedJournal, 1, 'migration tag(s) parsed out of');
+
+// And a parse landing on a DIFFERENT array of acceptable size is invisible to a
+// count floor: every tag below is a real, correctly marked migration, so every
+// other check passes. Only the sentinel notices the first migration vanished.
+// Delete JOURNAL_SENTINEL and this case exits 0.
+const wrongJournalArray = createFixture();
+edit(wrongJournalArray, JOURNAL, 'sentinel-absent', (text) => {
+  const journal = JSON.parse(text);
+  return JSON.stringify({ ...journal, entries: journal.entries.slice(1) }, null, 2);
+});
+expectVerdict('sentinel-absent', wrongJournalArray, 1, 'was not among the parsed journal tags');
+
+// ── Property: the gate resolves with no dependency tree ────────────────────
+//
+// The CI job runs this gate without `bun install`, like the two beside it. Copy
+// the gate AND the parser it imports into a fixture that has no `node_modules`
+// at any level, and run the COPY — running the real script would resolve against
+// the real repository's tree and prove nothing.
+const isolated = createFixture();
+for (const relative of [PARSER, GATE]) {
+  mkdirSync(join(isolated, dirname(relative)), { recursive: true });
+  cpSync(join(repoRoot, relative), join(isolated, relative));
+}
+expectVerdict(
+  'no-node-modules',
+  isolated,
+  0,
+  'Migration deploy phases are sound',
+  join(isolated, GATE),
+);
+
+for (const fixture of createdFixtures) {
+  if (fixture.startsWith(fixturePrefix)) rmSync(fixture, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error('Migration phase check tests failed:\n');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(`Migration phase check discriminated ${createdFixtures.length} fixture case(s).`);


### PR DESCRIPTION
## Summary

Today an image reached production selecting a column that did not exist yet, and `POST /users/by-ids` returned 500 ecosystem-wide until the migration was dispatched by hand. The migration was additive, defensive and documented its own required ordering — none of which helped, because the ordering depended on a human doing two dispatches in the right order while a deploy raced them.

**The reframing finding: `.github/scripts/deploy-ecs-image.sh` already implemented this.** `RUN_MIGRATIONS=true` runs the migrator as an ECS one-shot on the new task definition before `update-service`, aborting the deploy if it fails, and it is tested. `deploy-aws.yml` simply never set the variable. **Mention already sets it**; oxy-api was the outlier. Capability existed, nothing invoked it.

**Each migration now declares its side, in its own file, with no default:** `-- oxy:deploy-phase=pre` (additive; correct against the image serving AND the one arriving) or `post` (drops/renames/narrows; only correct once the new image is live). The deploy straddles the rollout — `--phase=pre` before `update-service`, `--phase=post` after a verified-healthy rollout. No default is load-bearing: a default silently picks a side for an author who never considered the question, which is this incident relocated one layer down. The marker lives in the `.sql` rather than a sidecar manifest so it is the source's own declaration, next to the DDL in review, with no second list to drift.

**The migrator was not safe to invoke twice at once — measured, not reasoned.** drizzle-orm 0.45.2 reads the newest ledger row OUTSIDE its transaction and takes no lock. Against real Postgres 17: two concurrent migrators on a fresh DB → one dies on `CREATE SCHEMA IF NOT EXISTS "drizzle"`; with one pending migration (the realistic deploy-vs-dispatch race) → `FAILED code=42701 column "account_categories" of relation "users" already exists`. This gets WORSE with this change, since the deploy now runs the migrator itself and `deploy-aws.yml` (`concurrency: deploy-oxy-api`) and `run-postgres-migrations.yml` (`concurrency: postgres-migrations`) are different groups that cannot see each other. So the migrator now takes a session advisory lock on its own connection. Also measured: advisory locks are per-database, not cluster-wide, which is why the jest harness (one throwaway DB per file) is unaffected.

**The phase stop must be a PREFIX**, because the ledger records progress as a high-water mark and cannot express a hole. A `pre` migration queued behind an unapplied `post` one therefore has no safe ordering: applying it needs the drop applied against the live image, not applying it breaks the incoming one. The migrator **refuses, applies nothing, and names both**. `--phase=post` likewise refuses if a `pre` is still pending, which fails the post-deploy task and rolls the service back to the image matching the schema. Verified end-to-end against real Postgres using the actual deferred second half of #789.

**The common case stays cheap, and one optimisation was deliberately rejected:** the post-rollout task is skipped entirely when no `post`-marked migration exists. The pre-rollout task runs on every deploy (~45–90s, estimated, not measured) and was NOT optimised, because pendingness needs the ledger on a private VPC address the runner cannot reach, and every repo-only proxy is a silent-skip machine — specifically, "skip when this push changed no migration file" would have skipped the deploy after the one that stranded 0013 and left production broken.

**All 14 existing migrations were marked `pre`** after grepping to confirm every one is genuinely additive (zero `DROP COLUMN`/`DROP TABLE`/`RENAME`). Safe to edit: drizzle stores each file's hash but never compares it — pendingness is `created_at` versus the journal's `when`.

## Test plan

Gates already run by the implementing agent (not re-run in this PR):
- [x] New CI gate mutation-tested with 7 mutations and 0 survivors against a green control, each guard killed by exactly its own case including both vacuity guards
- [x] 12-case fixture suite covering the 2026-08-02 shape and a no-`node_modules` property test
- [x] 20 new jest tests including "the apply set never has a hole"
- [x] Deploy path exercised against a stub `aws` (failed pre-migration → 1 run-task, 0 update-service, previous image keeps serving)
- [x] Image assertion positive- and negative-controlled under POSIX sh
- [x] `src/db/__tests__/` 7 suites / 80 tests
- [x] `bun.lock` untouched
- [x] eslint 0 errors and 0 new warnings

Also noted, as reported:
- The one-shot's real duration is an estimate
- `logs:GetLogEvents` could not be settled because `simulate-principal-policy` returns implicitDeny even against the policy's own literal resource string, so the simulator is not an oracle for CloudWatch Logs compound ARNs (real-world evidence says it works — `run-postgres-migrations.yml` already calls it, and that is the workflow that ended today's outage)
- The full api suite was not run
- **`oxy-api` has no `require-current-main.sh`**, which Mention has and its deploy uses to re-verify `origin/main` immediately before `update-service` — `deploy-ecs-image.sh` here already supports it and it is simply never wired. That is a separate race, left out of scope.

Publishes nothing, bumps no version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)