### PR TITLE
fix(privacy): refuse block/restrict against an account the caller operates

### DIFF
--- a/packages/api/src/routes/__tests__/privacyOperatedAccount.test.ts
+++ b/packages/api/src/routes/__tests__/privacyOperatedAccount.test.ts
@@ -1,0 +1,473 @@
+/**
+ * `POST /privacy/blocked/:targetId` and `POST /privacy/restricted/:targetId`
+ * must REFUSE a target the caller operates — not merely hide the button.
+ *
+ * The real router over HTTP, against a real Postgres, with a real
+ * `accountService`. Only the auth middleware is mocked, because the caller's
+ * identity is the one input that does not come from a row. Everything the guard
+ * reads — the target's `kind`, the caller's `account_members` row and its
+ * status — is stored, so a test cannot pass by agreeing with a fake.
+ *
+ * ## The two fixtures without which this suite proves nothing
+ *
+ * "Refuses operators" and "refuses everybody" are indistinguishable unless the
+ * suite contains callers who must still SUCCEED, so two are here on purpose:
+ *
+ *  - a STRANGER blocking an ordinary personal account — the baseline, and the
+ *    thing that must not regress;
+ *  - a `billing` member of an organization blocking that organization. They are
+ *    a member, and they may NOT act as it (`account:act_as` is owner/admin/editor
+ *    only), so they keep every affordance a stranger has over it, this one
+ *    included. A suite whose only non-owner fixture is a full member cannot tell
+ *    the implemented guard from `if (isMember) refuse`.
+ *
+ * The refusals then come in the two shapes the rule actually distinguishes: an
+ * active member of a CHANNEL (membership is the whole right there, since a
+ * channel can never be acted as), and a member of an ORGANIZATION who holds
+ * `account:act_as` (bare membership is not enough there).
+ *
+ * Verified by mutation: see `docs` in `accountService.operatesAccount`. Flipping
+ * the final line to `true` reds the billing-member and stranger-adjacent cases;
+ * flipping it to `false` reds the channel and act-as cases; deleting the
+ * `kind !== 'channel'` term reds the channel case alone; removing the route
+ * guard reds all four refusals.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { and, eq } from 'drizzle-orm';
+
+/**
+ * Whose request it is. Mutated per test rather than re-mounting the app: the
+ * router binds `authMiddleware` at import time.
+ */
+let callerId = '';
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (req: { user?: { id: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: callerId };
+    next();
+  },
+}));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import privacyRouter from '../privacy';
+import { errorHandler } from '../../middleware/errorHandler';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { accountMembers } from '../../db/schema/accountMembers';
+import { blocks } from '../../db/schema/blocks';
+import { restrictions } from '../../db/schema/restrictions';
+import { users } from '../../db/schema/users';
+import { accountService } from '../../services/account.service';
+import type { AccountRole } from '../../utils/accountRoles';
+import { permissionsForAccountRole } from '../../utils/accountRoles';
+
+// ===========================================================================
+// Harness
+// ===========================================================================
+
+let server: http.Server;
+
+beforeAll(async () => {
+  await connectPostgres();
+  const app = express();
+  app.use(express.json());
+  app.use('/privacy', privacyRouter);
+  app.use(errorHandler);
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  );
+  await closePostgres();
+});
+
+interface JsonResponse {
+  status: number;
+  body: { message?: string; error?: string };
+}
+
+function post(path: string): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method: 'POST',
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: { 'content-type': 'application/json', 'content-length': 2 },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          try {
+            resolve({ status: res.statusCode ?? 0, body: raw ? JSON.parse(raw) : {} });
+          } catch (error) {
+            reject(
+              new Error(
+                `Non-JSON response (${res.statusCode}): ${raw} — ${(error as Error).message}`
+              )
+            );
+          }
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end('{}');
+  });
+}
+
+// ===========================================================================
+// Fixtures — every one a real row
+// ===========================================================================
+
+let seedCounter = 0;
+
+async function seedAccount(
+  kind: 'personal' | 'organization' | 'project' | 'bot' | 'channel'
+): Promise<string> {
+  seedCounter += 1;
+  const [row] = await getDb()
+    .insert(users)
+    .values({
+      color: 'teal',
+      kind,
+      username: `blockop${seedCounter}z${Date.now().toString(36)}`,
+      accountStatus: 'active',
+    })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function seedMembership(options: {
+  accountId: string;
+  memberUserId: string;
+  role: AccountRole;
+  status?: 'active' | 'invited' | 'removed';
+  inherit?: boolean;
+}): Promise<void> {
+  await getDb()
+    .insert(accountMembers)
+    .values({
+      accountId: options.accountId,
+      memberUserId: options.memberUserId,
+      role: options.role,
+      status: options.status ?? 'active',
+      inherit: options.inherit ?? true,
+      joinedAt: new Date(),
+    });
+}
+
+async function blockRowCount(userId: string, blockedId: string): Promise<number> {
+  const rows = await getDb()
+    .select({ id: blocks.id })
+    .from(blocks)
+    .where(and(eq(blocks.userId, userId), eq(blocks.blockedId, blockedId)));
+  return rows.length;
+}
+
+async function restrictRowCount(userId: string, restrictedId: string): Promise<number> {
+  const rows = await getDb()
+    .select({ id: restrictions.id })
+    .from(restrictions)
+    .where(and(eq(restrictions.userId, userId), eq(restrictions.restrictedId, restrictedId)));
+  return rows.length;
+}
+
+// ===========================================================================
+// The role→permission map this suite depends on
+//
+// The fixtures below are only meaningful if `billing` really lacks
+// `account:act_as` and `editor` really holds it. Asserting it here means a
+// future grant change that invalidates the fixtures fails LOUDLY, instead of
+// silently turning the discriminating test into a second copy of the refusal
+// test.
+// ===========================================================================
+
+describe('the fixtures rest on the real role map', () => {
+  it('billing does NOT carry account:act_as, editor does', () => {
+    expect(permissionsForAccountRole('billing')).not.toContain('account:act_as');
+    expect(permissionsForAccountRole('editor')).toContain('account:act_as');
+  });
+});
+
+// ===========================================================================
+// Callers who must still succeed
+// ===========================================================================
+
+describe('block/restrict still work for callers who do not operate the target', () => {
+  it('a stranger blocks an ordinary personal account', async () => {
+    const caller = await seedAccount('personal');
+    const target = await seedAccount('personal');
+    callerId = caller;
+
+    const response = await post(`/privacy/blocked/${target}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('User blocked successfully');
+    expect(await blockRowCount(caller, target)).toBe(1);
+  });
+
+  it('a stranger restricts an ordinary personal account', async () => {
+    const caller = await seedAccount('personal');
+    const target = await seedAccount('personal');
+    callerId = caller;
+
+    const response = await post(`/privacy/restricted/${target}`);
+
+    expect(response.status).toBe(200);
+    expect(await restrictRowCount(caller, target)).toBe(1);
+  });
+
+  it("a BILLING member of an organization may still block it — they are a member who may not act as it", async () => {
+    const caller = await seedAccount('personal');
+    const org = await seedAccount('organization');
+    await seedMembership({ accountId: org, memberUserId: caller, role: 'billing' });
+    callerId = caller;
+
+    expect(await accountService.operatesAccount(caller, org)).toBe(false);
+
+    const response = await post(`/privacy/blocked/${org}`);
+
+    expect(response.status).toBe(200);
+    expect(await blockRowCount(caller, org)).toBe(1);
+  });
+
+  it('a VIEWER member of an organization may still block it', async () => {
+    const caller = await seedAccount('personal');
+    const org = await seedAccount('organization');
+    await seedMembership({ accountId: org, memberUserId: caller, role: 'viewer' });
+    callerId = caller;
+
+    const response = await post(`/privacy/blocked/${org}`);
+
+    expect(response.status).toBe(200);
+    expect(await blockRowCount(caller, org)).toBe(1);
+  });
+
+  it('an INVITED (not yet active) channel member may still block the channel', async () => {
+    const caller = await seedAccount('personal');
+    const channel = await seedAccount('channel');
+    await seedMembership({
+      accountId: channel,
+      memberUserId: caller,
+      role: 'editor',
+      status: 'invited',
+    });
+    callerId = caller;
+
+    expect(await accountService.operatesAccount(caller, channel)).toBe(false);
+
+    const response = await post(`/privacy/blocked/${channel}`);
+
+    expect(response.status).toBe(200);
+    expect(await blockRowCount(caller, channel)).toBe(1);
+  });
+
+  it('a REMOVED channel member may still block the channel', async () => {
+    const caller = await seedAccount('personal');
+    const channel = await seedAccount('channel');
+    await seedMembership({
+      accountId: channel,
+      memberUserId: caller,
+      role: 'owner',
+      status: 'removed',
+    });
+    callerId = caller;
+
+    const response = await post(`/privacy/blocked/${channel}`);
+
+    expect(response.status).toBe(200);
+    expect(await blockRowCount(caller, channel)).toBe(1);
+  });
+});
+
+// ===========================================================================
+// Callers who must be refused
+// ===========================================================================
+
+describe('block/restrict refuse an account the caller operates', () => {
+  it('an ACTIVE channel member cannot block the channel, and nothing is written', async () => {
+    const caller = await seedAccount('personal');
+    const channel = await seedAccount('channel');
+    // `viewer` deliberately: the WEAKEST role there is. A channel can never be
+    // acted as, so membership is the whole right over it and the permission
+    // gate must not be applied to this family.
+    await seedMembership({ accountId: channel, memberUserId: caller, role: 'viewer' });
+    callerId = caller;
+
+    expect(await accountService.operatesAccount(caller, channel)).toBe(true);
+
+    const response = await post(`/privacy/blocked/${channel}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('You cannot block an account you operate');
+    expect(await blockRowCount(caller, channel)).toBe(0);
+  });
+
+  it('an ACTIVE channel member cannot restrict the channel either', async () => {
+    const caller = await seedAccount('personal');
+    const channel = await seedAccount('channel');
+    await seedMembership({ accountId: channel, memberUserId: caller, role: 'viewer' });
+    callerId = caller;
+
+    const response = await post(`/privacy/restricted/${channel}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('You cannot restrict an account you operate');
+    expect(await restrictRowCount(caller, channel)).toBe(0);
+  });
+
+  it('an organization member holding account:act_as cannot block it', async () => {
+    const caller = await seedAccount('personal');
+    const org = await seedAccount('organization');
+    await seedMembership({ accountId: org, memberUserId: caller, role: 'editor' });
+    callerId = caller;
+
+    expect(await accountService.operatesAccount(caller, org)).toBe(true);
+
+    const response = await post(`/privacy/blocked/${org}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('You cannot block an account you operate');
+    expect(await blockRowCount(caller, org)).toBe(0);
+  });
+
+  it('a bot account the caller owns cannot be blocked', async () => {
+    const caller = await seedAccount('personal');
+    const bot = await seedAccount('bot');
+    await seedMembership({ accountId: bot, memberUserId: caller, role: 'owner' });
+    callerId = caller;
+
+    const response = await post(`/privacy/blocked/${bot}`);
+
+    expect(response.status).toBe(400);
+    expect(await blockRowCount(caller, bot)).toBe(0);
+  });
+
+  it('an INHERITED membership counts — a channel under an org the caller edits', async () => {
+    const caller = await seedAccount('personal');
+    const org = await seedAccount('organization');
+    const channel = await seedAccount('channel');
+    await accountService.moveAccount(channel, org);
+    await seedMembership({ accountId: org, memberUserId: caller, role: 'editor', inherit: true });
+    callerId = caller;
+
+    expect(await accountService.operatesAccount(caller, channel)).toBe(true);
+
+    const response = await post(`/privacy/blocked/${channel}`);
+
+    expect(response.status).toBe(400);
+    expect(await blockRowCount(caller, channel)).toBe(0);
+  });
+
+  it('a NON-INHERITING ancestor membership does not reach the child', async () => {
+    const caller = await seedAccount('personal');
+    const org = await seedAccount('organization');
+    const channel = await seedAccount('channel');
+    await accountService.moveAccount(channel, org);
+    await seedMembership({ accountId: org, memberUserId: caller, role: 'editor', inherit: false });
+    callerId = caller;
+
+    expect(await accountService.operatesAccount(caller, channel)).toBe(false);
+
+    const response = await post(`/privacy/blocked/${channel}`);
+
+    expect(response.status).toBe(200);
+    expect(await blockRowCount(caller, channel)).toBe(1);
+  });
+
+  it('the self-refusal keeps its own message, and never reaches the operator check', async () => {
+    const caller = await seedAccount('personal');
+    callerId = caller;
+
+    const response = await post(`/privacy/blocked/${caller}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe('Invalid block request');
+    expect(await blockRowCount(caller, caller)).toBe(0);
+  });
+});
+
+// ===========================================================================
+// The predicate on its own — the cases the route cannot reach
+// ===========================================================================
+
+describe('accountService.operatesAccount', () => {
+  it('is true for the caller themselves', async () => {
+    const caller = await seedAccount('personal');
+    expect(await accountService.operatesAccount(caller, caller)).toBe(true);
+  });
+
+  it('is false for a personal account the caller happens to be a member of', async () => {
+    // A membership row on a personal account is not a shape any route writes,
+    // but the column accepts it. The kind gate — not the absence of a row — is
+    // what must refuse it, so the row is here deliberately.
+    const caller = await seedAccount('personal');
+    const other = await seedAccount('personal');
+    await seedMembership({ accountId: other, memberUserId: caller, role: 'owner' });
+    expect(await accountService.operatesAccount(caller, other)).toBe(false);
+  });
+
+  it('is false for an account id that does not exist', async () => {
+    const caller = await seedAccount('personal');
+    expect(
+      await accountService.operatesAccount(caller, '00000000-0000-7000-8000-000000000000')
+    ).toBe(false);
+  });
+
+  it('is false for an ARCHIVED account the caller would otherwise operate', async () => {
+    // The unconfirmable direction, stated: `resolveEffectiveAccess` reports no
+    // access over an archived account, and this predicate defers to it rather
+    // than keeping a second opinion. The protective action goes ahead.
+    const caller = await seedAccount('personal');
+    const channel = await seedAccount('channel');
+    await seedMembership({ accountId: channel, memberUserId: caller, role: 'owner' });
+    await getDb().update(users).set({ accountStatus: 'archived' }).where(eq(users.id, channel));
+
+    expect(await accountService.operatesAccount(caller, channel)).toBe(false);
+  });
+
+  it('is false for empty ids', async () => {
+    expect(await accountService.operatesAccount('', '')).toBe(false);
+    const caller = await seedAccount('personal');
+    expect(await accountService.operatesAccount(caller, '')).toBe(false);
+    expect(await accountService.operatesAccount('', caller)).toBe(false);
+  });
+
+  it('PROPAGATES a database fault rather than answering "not an operator"', async () => {
+    // The decided failure direction has one deliberate exclusion. Everything the
+    // predicate can positively read as "not confirmed" answers false and lets
+    // the protective action through; a database fault does NOT, because the
+    // write this guards runs on the same database and is about to fail anyway.
+    // Swallowing it would turn an outage into a silent allow.
+    const caller = await seedAccount('personal');
+    const channel = await seedAccount('channel');
+    await seedMembership({ accountId: channel, memberUserId: caller, role: 'owner' });
+
+    const failure = new Error('connection terminated unexpectedly');
+    const spy = jest
+      .spyOn(accountService, 'resolveEffectiveAccess')
+      .mockRejectedValueOnce(failure);
+    try {
+      await expect(accountService.operatesAccount(caller, channel)).rejects.toThrow(failure);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // And with the fault gone, the same call answers true — so the assertion
+    // above measured the throw, not a fixture that could never have succeeded.
+    expect(await accountService.operatesAccount(caller, channel)).toBe(true);
+  });
+});

--- a/packages/api/src/routes/privacy.ts
+++ b/packages/api/src/routes/privacy.ts
@@ -9,6 +9,7 @@ import { authMiddleware } from '../middleware/auth';
 import { asyncHandler } from '../utils/asyncHandler';
 import { BadRequestError, NotFoundError, ConflictError, UnauthorizedError } from '../utils/error';
 import { resolveUserIdToObjectId } from '../utils/validation';
+import { accountService } from '../services/account.service';
 import { userService } from '../services/user.service';
 import blockCache, { restrictCache } from '../utils/blockCache';
 import graphCache from '../utils/graphCache';
@@ -151,6 +152,32 @@ const createUserListHandler = (relation: UserRelation) =>
     );
   });
 
+/**
+ * Take a relation out on `targetId`.
+ *
+ * ## Neither of these may be pointed at an account the caller operates
+ *
+ * The self-refusal below is the whole truth only for a personal login. A
+ * channel, organization, project or bot is never the caller's own id, so the id
+ * comparison answers "no" for all four and used to let an operator block or
+ * restrict an account they themselves speak with — an act with no coherent
+ * meaning (block is symmetric, so it half-severs the operator from their own
+ * account's audience) and one no client offers. Making it *impossible* rather
+ * than merely hidden is the point: `oxyServices.blockUser` reaches this route
+ * directly, so a guard anywhere else is bypassed by the request the app already
+ * makes.
+ *
+ * `accountService.operatesAccount` is the single authority for "operates" —
+ * shared with `POST /accounts/:id/switch` and with the consuming apps that ask
+ * the same question over the wire — and it answers `false` for everything it
+ * cannot positively confirm, so an unresolvable membership lets the protective
+ * action through rather than stranding somebody who needs it. See that method
+ * for why this direction is the opposite of the one `verifyActingAs` takes.
+ *
+ * BOTH actions, not just block. Restrict is the same shape of decision aimed at
+ * the same target — a self-directed moderation action against your own voice —
+ * and it costs the operator the same nothing to be refused.
+ */
 const createUserActionHandler = (relation: UserRelation, actionName: string) =>
   asyncHandler(async (req: Request, res: Response) => {
     const { targetId } = req.params;
@@ -158,6 +185,15 @@ const createUserActionHandler = (relation: UserRelation, actionName: string) =>
 
     if (!authUser?.id || authUser.id === targetId) {
       throw new BadRequestError(`Invalid ${actionName} request`);
+    }
+
+    // 400 and not 403, matching the self-refusal above: this is a request that
+    // does not mean anything, not a right the caller lacks. 403 would signal the
+    // opposite of the truth — they hold MORE authority over this account than a
+    // stranger does, not less. Naming the reason leaks nothing, since being told
+    // you operate an account you operate tells you what you already knew.
+    if (await accountService.operatesAccount(authUser.id, targetId)) {
+      throw new BadRequestError(`You cannot ${actionName} an account you operate`);
     }
 
     // The compound unique is the arbiter of "already flagged": a concurrent
@@ -368,6 +404,13 @@ router.get("/blocked", getBlockedUsers);
  *     responses:
  *       200:
  *         description: User blocked.
+ *       400:
+ *         description: >
+ *           The target is the caller, or an account the caller operates — an
+ *           active member of a channel, or a member of an organization /
+ *           project / bot holding `account:act_as`.
+ *       409:
+ *         description: Already blocked.
  */
 router.post("/blocked/:targetId", validate({ params: targetIdParams }), blockUser);
 
@@ -423,6 +466,12 @@ router.get("/restricted", getRestrictedUsers);
  *     responses:
  *       200:
  *         description: User restricted.
+ *       400:
+ *         description: >
+ *           The target is the caller, or an account the caller operates — same
+ *           rule as `POST /privacy/blocked/{targetId}`.
+ *       409:
+ *         description: Already restricted.
  */
 router.post("/restricted/:targetId", validate({ params: targetIdParams }), restrictUser);
 

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -49,6 +49,7 @@ import type { AccountKind } from '../db/schema/users';
 import {
   CHILD_ACCOUNT_KINDS,
   RETIRED_ACCOUNT_CATEGORY_IDS,
+  isActAsEligibleKind,
   kindAcceptsAccountCategories,
   newlyAddedRetiredCategories,
   type AccountCategoryId,
@@ -70,6 +71,18 @@ import { DISPLAY_NAME_INVALID_MESSAGE, isValidDisplayName } from '@oxyhq/core';
 import { logger } from '../utils/logger';
 import userCache from '../utils/userCache';
 import type { ApplicationScope } from '../utils/applicationScopes';
+
+/**
+ * The permission that authorises assuming an account's identity — what
+ * `POST /accounts/:id/switch` gates on, and therefore what operating an account
+ * gates on too.
+ *
+ * Typed as an {@link AccountPermission} so renaming or dropping it in
+ * `utils/accountRoles.ts` fails this file's typecheck, rather than leaving a
+ * string literal here that quietly matches nothing and reads as "no operator has
+ * ever held this".
+ */
+const ACT_AS_PERMISSION: AccountPermission = 'account:act_as';
 
 const CREDENTIAL_PUBLIC_KEY_PREFIX = 'oxy_dk_';
 const PUBLIC_KEY_RANDOM_BYTES = 24;
@@ -796,6 +809,102 @@ export class AccountService {
       return null;
     }
     return access.permissions.includes('account:act_as') ? access.role : null;
+  }
+
+  /**
+   * Whether `userId` OPERATES `accountId` — speaks with that account's voice.
+   *
+   * The question every self-directed moderation refusal actually wants to ask.
+   * The one those routes asked was "is this account me?", which is the whole
+   * truth only for a personal login: a channel, organization, project or bot is
+   * never the caller's own id, and yet the caller may act for it. So an id
+   * comparison answers "no" for all four and lets somebody block or restrict an
+   * account they themselves operate. Being the account is ONE CASE of operating
+   * it, which is why the self branch is here rather than a second rule beside
+   * every caller.
+   *
+   * TWO FAMILIES, TWO AUTHORITIES — collapsing them into one membership test is
+   * the easy way to get this wrong, in both directions at once:
+   *
+   *  - a **channel** can never be acted as ({@link isActAsEligibleKind} refuses
+   *    it: it is a content identity, not a seat). No session can be minted whose
+   *    subject is a channel, so there is no stronger right than membership to ask
+   *    for — acting for a channel simply IS being one of its active members;
+   *  - an **act-as-eligible** account (organization / project / bot) CAN be
+   *    switched into, and `account:act_as` is the right that governs that switch.
+   *    Bare membership is NOT enough: an account's `billing`, `developer` and
+   *    `viewer` members are deliberately members who may not act as it, so they
+   *    keep every affordance a stranger has over it, this one included;
+   *  - a **personal** account that is not the caller is never operated, whoever
+   *    asks, and neither is a kind added after this was written — the kinds are
+   *    admitted positively, not by excluding `personal`.
+   *
+   * ONE MEMBERSHIP READER. It resolves through
+   * {@link AccountService.resolveEffectiveAccess}, the same call
+   * {@link AccountService.verifyActingAs} and the account RBAC middleware use, so
+   * this cannot come to a different answer about the same person than the switch
+   * endpoint does. That also means an INHERITED membership counts, exactly as it
+   * does everywhere else here.
+   *
+   * The permission is READ off the resolved access rather than inferred from a
+   * role list: a list of role names at a call site is a second copy of
+   * `ROLE_PERMISSIONS`, and the copy is what goes stale the day a role is added
+   * or its grants change.
+   *
+   * ## It answers `false` for everything it cannot positively confirm
+   *
+   * A missing account row, no membership, an archived account, a member without
+   * the permission, a kind in neither family — all `false`, meaning the caller is
+   * not confirmed as an operator and the protective action goes ahead. The
+   * guarantee is deliberately the narrow one: you cannot act against an account
+   * we can POSITIVELY CONFIRM you operate.
+   *
+   * That is the opposite direction from `verifyActingAs`, which fails closed, and
+   * the two errors are not comparable in the same way. Acting AS an account is a
+   * capability — granting one that cannot be verified puts words in somebody
+   * else's mouth. Block and restrict are PROTECTIVE, and the caller is usually
+   * the person needing protection: wrongly deciding "operates" takes away the
+   * only tool they have for getting away from an account that is abusing them,
+   * with nothing on screen to say why, while wrongly deciding "does not operate"
+   * lets an operator do something pointless to their own account which the UI
+   * never offered them and which they can undo.
+   *
+   * Note what is NOT in that list: a database fault. Unlike a consumer asking
+   * Oxy over HTTP, this reads the same database the write it guards is about to
+   * use, so there is no state where the question is unanswerable but the action
+   * could still succeed. Swallowing that into `false` would convert a real outage
+   * into a silent allow for a write that is itself about to fail; it propagates.
+   */
+  async operatesAccount(userId: string, accountId: string): Promise<boolean> {
+    if (!userId || !accountId) {
+      return false;
+    }
+    if (userId === accountId) {
+      return true;
+    }
+
+    const db = getDb();
+    const [account] = await db
+      .select({ kind: users.kind })
+      .from(users)
+      .where(eq(users.id, accountId))
+      .limit(1);
+    if (!account) {
+      return false;
+    }
+
+    // Ordered so the dominant case — an ordinary personal target — costs this
+    // one indexed lookup and no membership read at all.
+    if (account.kind !== 'channel' && !isActAsEligibleKind(account.kind)) {
+      return false;
+    }
+
+    const access = await this.resolveEffectiveAccess(userId, accountId);
+    if (!access) {
+      return false;
+    }
+
+    return account.kind === 'channel' || access.permissions.includes(ACT_AS_PERMISSION);
   }
 
   /**


### PR DESCRIPTION
## Summary

**Blocking an account you operate was possible.** Mention removed the menu row, but `oxyServices.blockUser` calls oxy-api's `POST /privacy/blocked/:targetId` directly and Mention has no block route of its own to guard — so a direct request still worked. The refusal has to live where the write happens. `createUserActionHandler` in `privacy.ts` refused `authUser.id === targetId` and had no operated-account check.

**"Operates" is Oxy's own definition, implemented from source, not ported from Mention's client of it.** New `accountService.operatesAccount(userId, accountId)` beside `verifyActingAs`, resolving through `resolveEffectiveAccess` — the same reader `verifyActingAs` and the account RBAC middleware use, so there is no second membership reader and the switch endpoint cannot disagree with this guard about the same person. A **channel** takes any active member (it can never be acted as, so membership is the strongest right there); an **organization/project/bot** additionally requires `account:act_as`, read off `access.permissions`, never from a role-name list at the call site.

Because it goes through `resolveEffectiveAccess`, **inherited memberships count here** — closing the gap Mention documents as open on its side, where `GET /accounts/:id/members` returns direct rows only.

**Failure direction, and where Oxy deliberately diverges from Mention in mechanism though not in direction.** Every representable "cannot confirm" answers `false`, so the protective action proceeds: missing account, no membership, `invited`/`removed` status, archived account, a member without `account:act_as`, a kind in neither family, empty ids. Block and restrict are protective and the caller is usually the person needing protection.

But **a database fault propagates rather than failing open.** Mention's fail-open exists because it asks Oxy over HTTP and can get a 503 while its own write would still succeed. Oxy has no such state: this guard reads the same database the `INSERT` it protects is about to use, so a fault that makes the question unanswerable also makes the write fail. Swallowing it into `false` would permit a write that is itself about to fail, and hide the outage. A test pins this with a positive control immediately after, so it measures the throw rather than a fixture that could never have succeeded.

**400, not 403**, matching the self-refusal in the same handler. 403 would signal the opposite of the truth: the caller holds *more* authority over that account than a stranger, not less.

**`restrict` shared the same gap and is fixed too.** There is no `mute` in oxy-api — that is Mention-local. `createUserActionHandler` is the only writer of `blocks` and `restrictions` in the package, so the create surface is fully covered with no path around the guard. Deliberately NOT changed: `services/civic/realLife.service.ts` has the same structural shape, but an attestation is a capability claim and would need to fail CLOSED — the opposite contract — so reusing this predicate there would be wrong and it needs its own decision. `followUser` was left alone as instructed.

## Rebase note

This branch was rebased onto `main` after #801/#802/#803 landed. #802 (`fix(accounts): read account:act_as off permissions, add per-member permission overrides`) touched the same region of `account.service.ts` — it changed `EffectiveAccess.permissions` from `string[]` to `AccountPermission[]` and deleted `roleCanActAs`/`ACTING_AS_ROLES` in favor of reading `account:act_as` off `access.permissions`. The conflict was one import line (`roleCanActAs`, since deleted); the new `operatesAccount` method already read the permission off `access.permissions`, so it composes with #802's change with no further edits needed. Re-verified after resolving: `tsc --noEmit` clean, ESLint clean on the three changed files.

## No migration in this change

No schema/drizzle changes here — `accountService.operatesAccount` reads existing tables (`users`, `account_members`) through the existing `resolveEffectiveAccess` path. **No `Run PostgreSQL migrations` dispatch is needed for this PR.** (Two migration-bearing PRs — #802, #803 — merged in the preceding hour; this one carries none.)

## Verification already done (by the implementing agent, before this rebase — not re-run here)

- contracts → protocol → core → federation built before api
- `tsc --noEmit`: 0 errors
- ESLint clean on the three files
- Full api suite: 312 suites / 4487 tests passing
- Mutation-tested with 8 mutations, each reddening a distinct named set — the discriminating one being "any member is an operator", which reds **only** the `billing` and `viewer` member cases, and a positive control ("everyone is an operator") that reds all 11 must-succeed assertions, which is the vacuity check for the two stranger tests no other mutation touches
- The suite also asserts `permissionsForAccountRole('billing')` really lacks `account:act_as` and `editor` really holds it, so a future grant change breaks loudly instead of quietly turning the discriminating fixture into a second copy of the refusal test

Additionally re-verified after the rebase (see above): `tsc --noEmit` and ESLint, both clean on the post-merge tree.

## Known gaps (as reported by the implementing agent)

- No end-to-end run against a deployed API (verified at the route boundary over real HTTP, not against a deployed instance)
- Mention has no copy for this 400 yet — an operator who somehow reaches the button gets a message the client cannot render meaningfully

## Test plan

- [x] `tsc --noEmit` clean (post-rebase)
- [x] ESLint clean on the three changed files (post-rebase)
- [x] Full api suite passing (pre-rebase, by implementing agent)
- [ ] Watch CI on this PR after auto-merge; report if red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>