### PR TITLE
ci: add one aggregate CI complete status check for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,3 +544,57 @@ jobs:
 
       - name: Run npm audit
         run: npm audit --audit-level=high || true
+
+  # THE one status check `main` requires. Everything above it reports here.
+  #
+  # Requiring the test jobs by name cannot work: a required check that never
+  # reports blocks the pull request forever, so every required name has to be a
+  # job that runs on every pull request for all time — and the list would live in
+  # a repository setting nothing in this tree can see, so a job added later would
+  # be required by nothing with no signal in the diff.
+  #
+  # `if: always()` is what makes this reachable when something above it failed,
+  # was cancelled, or skipped. Without it this job inherits their skip and — as a
+  # required check reporting `skipped` — never becomes satisfied.
+  #
+  # The verdict logic, the coverage check that catches a job added later, and
+  # every guard against this passing vacuously live in scripts/check-ci-complete.mjs.
+  ci-complete:
+    name: CI complete
+    needs:
+      - deploy-script-test
+      - api-test
+      - api-backfill-test
+      - api-build
+      - lockfile-sync
+      - deploy-secrets-sync
+      - migration-phases
+      - contracts-test
+      - protocol-test
+      - federation-test
+      - core-test
+      - ship-test
+      - node-test
+      - services-test
+      - auth-test
+      - commons-test
+      - inbox-test
+      - accounts-test
+      - security-audit
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      # The gate's own fixture tests, run before the gate itself — same shape as
+      # lockfile-sync, deploy-secrets-sync and migration-phases beside it. No
+      # install: both files read YAML through Bun's built-in parser and shell out
+      # to nothing.
+      - run: bun scripts/test-check-ci-complete.mjs
+      - name: Require every CI job to have passed
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: bun scripts/check-ci-complete.mjs

--- a/scripts/check-ci-complete.mjs
+++ b/scripts/check-ci-complete.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env bun
+/**
+ * The body of the `CI complete` job — the single check name `main` requires.
+ *
+ * THE OUTAGE THIS EXISTS FOR
+ *
+ * This repository's branch protection carried `required_status_checks: null`.
+ * Nothing was required, so `gh pr merge --auto` did not wait for anything: it
+ * merged the moment the mergeability check cleared. Measured on the last six
+ * merged pull requests, #803 merged at 14:09:46Z with `Core Tests`, `API Build`
+ * and `Lockfile Sync` all still `queued`, having started at 14:09:45Z — one
+ * second of CI, then main. `--auto` in the pull request title reads as "merged
+ * after CI passed" and meant nothing of the kind. One of those merges took
+ * production down (see scripts/check-migration-phases.mjs for that half).
+ *
+ * Requiring the test jobs BY NAME is not the fix, and the reason is the whole
+ * design of this file:
+ *
+ *   - A required check that never reports blocks the pull request FOREVER, with
+ *     no way to merge short of an admin override. So every name required must be
+ *     a job that runs on every pull request, forever, including after edits
+ *     nobody has made yet.
+ *   - Naming today's nineteen jobs freezes that list into a repository setting
+ *     nothing in this tree can see. A job added next month is required by
+ *     nothing, and no reviewer looking at the diff has any signal that it is not.
+ *
+ * One aggregate job avoids both: it always runs, it reports the verdict of every
+ * other job, and — because it reads this workflow back and compares — it fails
+ * when a job exists that it was not wired to.
+ *
+ * WHAT IS CHECKED
+ *
+ *   1. `on.pull_request` still fires this workflow for every pull request into
+ *      `main`. A `paths:` filter here, or a `branches:` list that drops `main`,
+ *      stops the workflow running at all — and a required check that does not
+ *      report is not a lenient gate, it is an unmergeable repository. Branch
+ *      protection already fails closed on this; the point of checking is to make
+ *      the pull request that would cause it red and legible, instead of every
+ *      unrelated pull request afterwards mysteriously unmergeable.
+ *   2. Coverage: every job in this workflow is a dependency of this one. This is
+ *      the defence against the classic aggregate-gate rot, where the `needs:`
+ *      list silently stops covering the repository months after anyone looked.
+ *   3. The verdict, per dependency, treating each `needs.*.result` explicitly:
+ *        success   pass.
+ *        skipped   pass ONLY if that job could legitimately skip — it declares a
+ *                  job-level `if:`, or something it `needs` skipped. Reading an
+ *                  unexplained `skipped` as "fine" is how a required check stops
+ *                  checking: one accidental `if: false` and the gate is green
+ *                  over a suite that never ran.
+ *        failure   fail.
+ *        cancelled fail. A cancelled job verified nothing. Collapsing it into
+ *                  success makes this a rubber stamp, and cancellation is common
+ *                  precisely when several pushes race — the moment the gate
+ *                  matters most.
+ *        anything else, including a missing result, fails. Unknown is not good
+ *                  news.
+ *
+ * WHAT IS NOT CHECKED, AND CANNOT BE
+ *
+ * Jobs in OTHER workflow files. `needs:` cannot cross a workflow, so CodeQL,
+ * Socket Security and the scaffold smoke test are invisible here and this gate
+ * makes no claim about them. Requiring those separately is a branch-protection
+ * decision, not something this file can enforce.
+ *
+ * Paths resolve from the working directory, so the fixture tests in
+ * scripts/test-check-ci-complete.mjs can run this against mutated copies of the
+ * real workflow.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW_PATH = join('.github', 'workflows', 'ci.yml');
+
+/** This job's own id. It is excluded from the coverage set — it cannot need itself. */
+const GATE_JOB_ID = 'ci-complete';
+
+/**
+ * Vacuity floor. A parse that yields nothing would check nothing and report no
+ * problems, which is the shape that lets a broken traversal pass as a clean run.
+ * The exact number is not the guard — finding this gate's OWN job id is, because
+ * that one cannot legitimately leave the file while this code is running.
+ */
+const MINIMUM_JOBS = 5;
+
+const problems = [];
+
+function fail(message) {
+  problems.push(message);
+}
+
+function read(path) {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch (error) {
+    console.error(`Cannot read ${path}: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+// ── The workflow, as GitHub sees it ────────────────────────────────────────
+let workflow;
+try {
+  workflow = Bun.YAML.parse(read(WORKFLOW_PATH));
+} catch (error) {
+  console.error(`${WORKFLOW_PATH} is not parseable YAML (${error.message}); the gate cannot see any job.`);
+  process.exit(1);
+}
+
+const jobs = workflow?.jobs;
+if (jobs === null || typeof jobs !== 'object' || Array.isArray(jobs)) {
+  console.error(`${WORKFLOW_PATH} has no \`jobs\` mapping; the gate cannot see any job.`);
+  process.exit(1);
+}
+
+const jobIds = Object.keys(jobs);
+
+// ── Vacuity guards ─────────────────────────────────────────────────────────
+if (!jobIds.includes(GATE_JOB_ID)) {
+  fail(
+    `\`${GATE_JOB_ID}\` is not among the jobs parsed out of ${WORKFLOW_PATH} (found: ` +
+    `${jobIds.join(', ') || 'none'}). This gate is running, so it is in the file — the parse is ` +
+    'broken, and every check below it is reading an empty set.'
+  );
+}
+if (jobIds.length < MINIMUM_JOBS) {
+  fail(
+    `Only ${jobIds.length} job(s) parsed out of ${WORKFLOW_PATH} (expected at least ` +
+    `${MINIMUM_JOBS}). The parse is broken, not the workflow.`
+  );
+}
+
+// ── 1. This workflow still runs on every pull request into main ────────────
+// YAML 1.1 folds a bare `on` key to boolean true; Bun.YAML follows 1.2 and keeps
+// the string. Read both rather than let a parser change silently skip this.
+const triggers = workflow?.on ?? workflow?.[true];
+const pullRequest = triggers?.pull_request;
+
+if (pullRequest === undefined) {
+  fail(
+    `${WORKFLOW_PATH} no longer declares an \`on.pull_request\` trigger, so it does not run on ` +
+    'pull requests at all. The one required check would never report and every pull request ' +
+    'would be permanently unmergeable.'
+  );
+} else if (pullRequest !== null && typeof pullRequest === 'object') {
+  for (const key of ['paths', 'paths-ignore']) {
+    if (key in pullRequest) {
+      fail(
+        `${WORKFLOW_PATH} filters \`on.pull_request\` by \`${key}\`. A path-filtered workflow does ` +
+        'not run when nothing matches, so the required `CI complete` check never reports and the ' +
+        'pull request can never be merged. Path-filter individual JOBS with `if:` instead — a ' +
+        'skipped job satisfies this gate, a missing workflow run does not.'
+      );
+    }
+  }
+
+  const branches = pullRequest.branches;
+  if (Array.isArray(branches) && !branches.includes('main')) {
+    fail(
+      `${WORKFLOW_PATH} restricts \`on.pull_request.branches\` to ${branches.join(', ')}, which ` +
+      'excludes `main`. The required check would never report on the branch that requires it.'
+    );
+  }
+}
+
+// ── The verdicts this run produced ─────────────────────────────────────────
+const rawNeeds = process.env.NEEDS_JSON;
+if (!rawNeeds) {
+  console.error(
+    'NEEDS_JSON is empty or unset. The job must pass `NEEDS_JSON: ${{ toJSON(needs) }}` — without ' +
+    'it this gate has no verdicts to read and would pass over a completely red run.'
+  );
+  process.exit(1);
+}
+
+let needs;
+try {
+  needs = JSON.parse(rawNeeds);
+} catch (error) {
+  console.error(`NEEDS_JSON is not parseable JSON (${error.message}).`);
+  process.exit(1);
+}
+
+if (needs === null || typeof needs !== 'object' || Array.isArray(needs)) {
+  console.error('NEEDS_JSON did not decode to an object of job results.');
+  process.exit(1);
+}
+
+const needIds = Object.keys(needs);
+if (needIds.length === 0) {
+  fail(
+    'This job depends on nothing (`needs:` is empty), so it reports the verdict of zero jobs while ' +
+    'presenting as the gate for all of them.'
+  );
+}
+
+// ── 2. Coverage: every job in the workflow is a dependency of this one ─────
+const expected = jobIds.filter((id) => id !== GATE_JOB_ID);
+const uncovered = expected.filter((id) => !needIds.includes(id));
+if (uncovered.length > 0) {
+  fail(
+    `${uncovered.length} job(s) in ${WORKFLOW_PATH} are not dependencies of \`${GATE_JOB_ID}\`: ` +
+    `${uncovered.join(', ')}. \`${GATE_JOB_ID}\` is the only check \`main\` requires, so a job it ` +
+    'does not need can fail without blocking anything. Add each one to its `needs:` list.'
+  );
+}
+
+const unknown = needIds.filter((id) => !jobIds.includes(id));
+if (unknown.length > 0) {
+  fail(
+    `\`${GATE_JOB_ID}\` needs ${unknown.join(', ')}, which the parse of ${WORKFLOW_PATH} did not ` +
+    'find. GitHub rejects a `needs:` naming a job that does not exist, so this means the gate is ' +
+    'reading a different file than the one that ran.'
+  );
+}
+
+// ── 3. The verdict, per dependency ─────────────────────────────────────────
+
+/** A `needs:` value is a string or a list of strings. */
+function dependenciesOf(jobId) {
+  const declared = jobs?.[jobId]?.needs;
+  if (typeof declared === 'string') return [declared];
+  if (Array.isArray(declared)) return declared.filter((id) => typeof id === 'string');
+  return [];
+}
+
+/**
+ * Whether `skipped` is explicable for this job. Either it declares a job-level
+ * `if:` — the supported way to make a job conditional, and the one that keeps
+ * this gate satisfiable on a pull request the job does not apply to — or one of
+ * its own dependencies skipped, which skips it in turn through no choice of its
+ * own. The dependency case needs no recursion: if THAT job skipped without
+ * cause, it is already failing this gate on its own line, which names the root
+ * of the chain instead of every job downstream of it.
+ */
+function maySkip(jobId) {
+  if (jobs?.[jobId] !== null && typeof jobs?.[jobId] === 'object' && 'if' in jobs[jobId]) return true;
+  return dependenciesOf(jobId).some((id) => needs?.[id]?.result === 'skipped');
+}
+
+const counts = { success: 0, skipped: 0 };
+
+for (const id of needIds.sort()) {
+  const result = needs[id]?.result;
+
+  if (result === 'success') {
+    counts.success += 1;
+    continue;
+  }
+
+  if (result === 'skipped') {
+    if (maySkip(id)) {
+      counts.skipped += 1;
+      continue;
+    }
+    fail(
+      `\`${id}\` was skipped, but it declares no \`if:\` and nothing it needs skipped — so nothing ` +
+      'explains why it did not run. Treating that as a pass is how a required check stops ' +
+      'checking: one `if: false` and this gate is green over a suite that never executed.'
+    );
+    continue;
+  }
+
+  if (result === 'failure') {
+    fail(`\`${id}\` failed.`);
+    continue;
+  }
+
+  if (result === 'cancelled') {
+    fail(
+      `\`${id}\` was cancelled, so it verified nothing. Cancellation is most common when pushes ` +
+      'race, which is exactly when merging on an unverified tree is most likely.'
+    );
+    continue;
+  }
+
+  fail(
+    `\`${id}\` reported ${JSON.stringify(result)}, which this gate does not recognise as a pass. ` +
+    'An unrecognised result is not good news.'
+  );
+}
+
+if (problems.length > 0) {
+  console.error('CI is NOT complete:\n');
+  for (const problem of problems) console.error(`- ${problem}`);
+  console.error(
+    '\n`CI complete` is the only status check `main` requires. It is red, so this pull request' +
+    '\ncannot merge — which is the mechanism working, not a flake to re-run around.'
+  );
+  process.exit(1);
+}
+
+console.log(
+  `CI is complete: ${counts.success} job(s) passed, ${counts.skipped} skipped for a declared ` +
+  `reason, across all ${expected.length} job(s) in ${WORKFLOW_PATH}.`
+);

--- a/scripts/test-check-ci-complete.mjs
+++ b/scripts/test-check-ci-complete.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env bun
+
+/**
+ * Exercises check-ci-complete.mjs against mutated copies of the REAL workflow it
+ * guards.
+ *
+ * This gate needs its own tests more than most, because of what it is: once
+ * `CI complete` is the single required status check, it is the only thing
+ * between a merge and `main`. A gate that returns success no matter what it is
+ * shown is strictly worse than no gate, since it is trusted. Every case below
+ * therefore asserts a VERDICT and the REASON given for it — an aggregate that
+ * goes red without naming which job failed is one nobody can act on.
+ *
+ * The four cases that matter are the four results GitHub can put in
+ * `needs.*.result`, since collapsing any of them into the wrong bucket is a
+ * real, shipped failure mode of this pattern:
+ *
+ *   success    → passes
+ *   skipped    → passes when the job declares `if:`, fails when nothing explains
+ *                it (collapse it into failure and every path-filtered pull
+ *                request is blocked; collapse it into success and one `if: false`
+ *                silently retires a suite)
+ *   failure    → fails
+ *   cancelled  → fails
+ *
+ * Fixtures are copies of `.github/workflows/ci.yml`, not hand-written
+ * miniatures: a synthetic workflow would drift and start proving something about
+ * the fixture rather than about CI. `NEEDS_JSON` is DERIVED from each fixture —
+ * every job except the gate itself, reported `success` — so the coverage case is
+ * the only one where a job is missing from it, and it is missing on purpose.
+ *
+ * Offline, and deliberately run with no `node_modules` anywhere in the fixture
+ * root: the CI job runs this gate without `bun install`, exactly like the three
+ * gates beside it, so both files must work with an empty dependency tree.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const checkScript = join(repoRoot, 'scripts', 'check-ci-complete.mjs');
+
+const WORKFLOW = join('.github', 'workflows', 'ci.yml');
+const GATE_JOB_ID = 'ci-complete';
+
+const fixturePrefix = join(tmpdir(), 'oxy-ci-complete-');
+const createdFixtures = [];
+const failures = [];
+
+function createFixture() {
+  const root = mkdtempSync(fixturePrefix);
+  createdFixtures.push(root);
+  mkdirSync(join(root, dirname(WORKFLOW)), { recursive: true });
+  cpSync(join(repoRoot, WORKFLOW), join(root, WORKFLOW));
+  return root;
+}
+
+/** Rewrite a fixture file, failing loudly if the edit matched nothing. */
+function edit(root, caseName, replacer) {
+  const path = join(root, WORKFLOW);
+  const before = readFileSync(path, 'utf8');
+  const after = replacer(before);
+  if (after === before) {
+    failures.push(
+      `${caseName}: the fixture edit changed nothing — the mutation never happened, so the case proves nothing.`
+    );
+    return;
+  }
+  writeFileSync(path, after);
+}
+
+/**
+ * Every job in the fixture except the gate, reported `success`, with overrides
+ * applied. Derived rather than hard-coded so a job added to ci.yml is covered by
+ * these tests the day it lands.
+ */
+function needsFor(root, overrides = {}) {
+  const parsed = Bun.YAML.parse(readFileSync(join(root, WORKFLOW), 'utf8'));
+  const needs = {};
+  for (const id of Object.keys(parsed?.jobs ?? {})) {
+    if (id === GATE_JOB_ID) continue;
+    needs[id] = { result: 'success', outputs: {} };
+  }
+  for (const [id, result] of Object.entries(overrides)) {
+    if (result === undefined) delete needs[id];
+    else needs[id] = { result, outputs: {} };
+  }
+  return needs;
+}
+
+function expectVerdict(caseName, root, needs, expectedCode, expectedFragment) {
+  let code = 0;
+  let output = '';
+  const env = { ...process.env };
+  if (needs === null) delete env.NEEDS_JSON;
+  else env.NEEDS_JSON = JSON.stringify(needs);
+
+  try {
+    output = execFileSync('bun', [checkScript], {
+      cwd: root,
+      env,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    code = error.status ?? 1;
+    output = `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+
+  if (code !== expectedCode) {
+    failures.push(`${caseName}: expected exit ${expectedCode}, got ${code}.\n${output}`);
+    return;
+  }
+  if (!output.includes(expectedFragment)) {
+    failures.push(`${caseName}: output does not contain ${JSON.stringify(expectedFragment)}.\n${output}`);
+  }
+}
+
+// ── Positive control ───────────────────────────────────────────────────────
+// Runs first and on the unmutated workflow. If this is red every case below is
+// measuring the harness, not the gate.
+{
+  const root = createFixture();
+  expectVerdict('unmutated-workflow-passes', root, needsFor(root), 0, 'CI is complete');
+}
+
+// ── The four results, which is what this gate is for ───────────────────────
+{
+  const root = createFixture();
+  expectVerdict(
+    'a-failed-job-fails-the-gate',
+    root,
+    needsFor(root, { 'core-test': 'failure' }),
+    1,
+    '`core-test` failed.'
+  );
+}
+
+{
+  const root = createFixture();
+  expectVerdict(
+    'a-cancelled-job-fails-the-gate',
+    root,
+    needsFor(root, { 'api-build': 'cancelled' }),
+    1,
+    '`api-build` was cancelled'
+  );
+}
+
+{
+  // A job that declares `if:` is one somebody deliberately made conditional, so
+  // `skipped` is the designed outcome and must NOT block. This is the case that
+  // makes the gate satisfiable if a path-filtered job is ever added.
+  const root = createFixture();
+  edit(root, 'a-conditional-job-may-skip', (yaml) =>
+    yaml.replace(
+      '  ship-test:\n    name: Ship Tests\n',
+      "  ship-test:\n    name: Ship Tests\n    if: \"github.event_name == 'pull_request'\"\n"
+    )
+  );
+  expectVerdict(
+    'a-conditional-job-may-skip',
+    root,
+    needsFor(root, { 'ship-test': 'skipped' }),
+    0,
+    '1 skipped for a declared reason'
+  );
+}
+
+{
+  // The other half of the same rule: no `if:`, nothing upstream skipped, so
+  // nothing explains the skip. Reading this as a pass is how the gate rots.
+  const root = createFixture();
+  expectVerdict(
+    'an-unexplained-skip-fails-the-gate',
+    root,
+    needsFor(root, { 'ship-test': 'skipped' }),
+    1,
+    '`ship-test` was skipped, but it declares no `if:`'
+  );
+}
+
+{
+  // Skipped because a dependency skipped — the job made no choice, so it is not
+  // the thing to report. The gate names the root of the chain instead.
+  const root = createFixture();
+  edit(root, 'a-skip-inherited-from-a-dependency', (yaml) =>
+    yaml
+      .replace(
+        '  ship-test:\n    name: Ship Tests\n',
+        "  ship-test:\n    name: Ship Tests\n    if: \"github.event_name == 'push'\"\n"
+      )
+      .replace('  node-test:\n    name: Node Tests\n', '  node-test:\n    name: Node Tests\n    needs: [ship-test]\n')
+  );
+  expectVerdict(
+    'a-skip-inherited-from-a-dependency',
+    root,
+    needsFor(root, { 'ship-test': 'skipped', 'node-test': 'skipped' }),
+    0,
+    '2 skipped for a declared reason'
+  );
+}
+
+{
+  const root = createFixture();
+  expectVerdict(
+    'an-unrecognised-result-fails-the-gate',
+    root,
+    needsFor(root, { 'auth-test': 'neutral' }),
+    1,
+    'reported "neutral", which this gate does not recognise as a pass'
+  );
+}
+
+// ── Coverage: the defence against silent rot ───────────────────────────────
+{
+  // The failure this gate exists to prevent: somebody adds a job and does not
+  // add it to `needs:`, so it can fail without blocking anything.
+  const root = createFixture();
+  edit(root, 'a-job-missing-from-needs-fails-the-gate', (yaml) =>
+    yaml.replace(
+      '  security-audit:\n',
+      '  brand-new-suite:\n    name: Brand New Suite\n    runs-on: ubuntu-latest\n    steps:\n      - run: exit 0\n\n  security-audit:\n'
+    )
+  );
+  expectVerdict(
+    'a-job-missing-from-needs-fails-the-gate',
+    root,
+    needsFor(root, { 'brand-new-suite': undefined }),
+    1,
+    'are not dependencies of `ci-complete`: brand-new-suite'
+  );
+}
+
+// ── The workflow must keep reporting at all ────────────────────────────────
+{
+  // Path-filtering the WORKFLOW is the one edit that makes a required check
+  // unsatisfiable rather than lenient.
+  const root = createFixture();
+  edit(root, 'a-path-filtered-workflow-fails-the-gate', (yaml) =>
+    yaml.replace(
+      '  pull_request:\n    branches: [main, develop]\n',
+      "  pull_request:\n    branches: [main, develop]\n    paths: ['packages/**']\n"
+    )
+  );
+  expectVerdict(
+    'a-path-filtered-workflow-fails-the-gate',
+    root,
+    needsFor(root),
+    1,
+    'filters `on.pull_request` by `paths`'
+  );
+}
+
+{
+  const root = createFixture();
+  edit(root, 'a-workflow-that-skips-main-fails-the-gate', (yaml) =>
+    yaml.replace('  pull_request:\n    branches: [main, develop]\n', '  pull_request:\n    branches: [develop]\n')
+  );
+  expectVerdict(
+    'a-workflow-that-skips-main-fails-the-gate',
+    root,
+    needsFor(root),
+    1,
+    'which excludes `main`'
+  );
+}
+
+// ── The gate's own guards, so none can rot into decoration ─────────────────
+{
+  // No verdicts to read. Passing here would mean the job reports success having
+  // measured nothing at all.
+  const root = createFixture();
+  expectVerdict('a-missing-NEEDS_JSON-fails-the-gate', root, null, 1, 'NEEDS_JSON is empty or unset');
+}
+
+{
+  const root = createFixture();
+  expectVerdict('an-empty-needs-fails-the-gate', root, {}, 1, 'This job depends on nothing');
+}
+
+{
+  // The vacuity floor. If the gate cannot find its own job in the file it is
+  // parsing, every set it computes below is empty and every check is vacuous.
+  const root = createFixture();
+  const yaml = readFileSync(join(root, WORKFLOW), 'utf8');
+  writeFileSync(join(root, WORKFLOW), `${yaml.split('\njobs:\n')[0]}\njobs:\n  only-one:\n    runs-on: ubuntu-latest\n    steps:\n      - run: exit 0\n`);
+  expectVerdict(
+    'a-workflow-without-the-gate-job-fails-the-gate',
+    root,
+    { 'only-one': { result: 'success' } },
+    1,
+    'is not among the jobs parsed out of'
+  );
+}
+
+// ── Report ─────────────────────────────────────────────────────────────────
+for (const root of createdFixtures) rmSync(root, { recursive: true, force: true });
+
+if (failures.length > 0) {
+  console.error(`check-ci-complete.mjs is BROKEN (${failures.length} case(s)):\n`);
+  for (const failure of failures) console.error(`- ${failure}\n`);
+  process.exit(1);
+}
+
+console.log(
+  `check-ci-complete.mjs behaves: ${createdFixtures.length} fixtures, covering every ` +
+  '`needs.*.result` value, the coverage guard, both workflow-trigger guards, and the gate\'s own ' +
+  'vacuity floors.'
+);


### PR DESCRIPTION
## Summary

**Every PR in this repository is merged before its CI has run.** Measured across the last six: lifetimes of 7 to 11 seconds from creation to merge, and **zero of six had a single green Actions check at merge time**. #803 merged at 14:09:46Z while `Core Tests`, `API Build` and `Lockfile Sync` started at 14:09:45Z; #788 merged three seconds before its CI run started. A full green run takes 15–24 minutes. `main` has branch protection with `required_status_checks: null`, so `gh pr merge --auto` is unconditional — and several agents have been merging today believing `--auto` waited.

**Why one aggregate check rather than requiring the existing ones:** `needs:` cannot cross workflows, and 19 jobs is 19 names to keep in a repository setting that no one will update. One job, `CI complete`, `needs:` all 19, `if: always()`.

**The verdict rules, and one deliberate deviation worth reviewing:** `success` passes; `failure` and `cancelled` each fail with their own message; anything unrecognised, including a missing result, fails. `skipped` passes **only if that job declares a job-level `if:`, or something it needs skipped**. Unconditional skip-passes is the general-purpose rule, but it would be a hole here: no job in this workflow can legitimately skip today, so any skip means somebody gated a suite, and one accidental `if: false` would leave the gate green over a suite that never ran. The rule reads the condition out of the file rather than a hand-kept list, so the day a genuinely path-filtered job is added, it carries an `if:` and its skip passes.

**The new-job problem is defended mechanically, not by a reviewer remembering.** The gate parses `ci.yml` back and asserts every job in it appears in its own `needs:` — add a job, forget the line, and `CI complete` goes red naming it. It also refuses to pass vacuously: if the parse cannot find `ci-complete` in the file it just read, that is a broken parse, not a clean run. Two further guards make the "required check that never reports" failure legible on the PR that causes it rather than on every PR afterwards: a `paths:`/`paths-ignore:` filter on `on.pull_request` is rejected, as is a `branches:` list that drops `main`.

**`strict` (require branches up to date) is deliberately NOT recommended**, on the measured numbers: CI is 15–24 minutes and consecutive merges have landed 72 seconds apart, so requiring an up-to-date branch is a livelock rather than a slowdown. A merge queue is the right tool if the combined-result problem ever needs solving.

Branch protection itself is NOT changed by this PR — that's a separate, deliberate follow-up once `CI complete` has been observed reporting on a real run.

## What was verified (by the implementing agent, not re-run here)

- 13/13 fixture cases green against a positive control
- The gate itself mutation-tested with 12 mutations, all killed, each by its designed case, gate restored byte-identical
- All four requested scenarios run end-to-end against the real 19-job workflow (all-success → exit 0; one `failure`, one `cancelled`, one undeclared `skipped` → exit 1 each with a distinct message; one declared `skipped` → exit 0)
- Strict YAML parse with `uniqueKeys: true` clean
- Job graph asserted at 20 jobs with 19 `needs`, non-self-referential

## Known gaps, stated honestly

- `actionlint` is not installed so nothing was linted, only parsed and graph-asserted
- Nothing has executed on GitHub, so `toJSON(needs)` serialising as expected is the one thing only a real run can confirm
- The gate makes **no claim** about CodeQL, Socket Security, Cursor Security Agent or `scaffold-smoke.yml`, since `needs:` cannot cross workflows — note `CodeQL` reported `neutral` on five of six PRs and how branch protection treats `neutral` was not verified

## Test plan

- [ ] Confirm a `CI complete` check-run appears on the `main` CI run triggered by this merge
- [ ] Confirm its conclusion (success/failure) matches the state of the 19 jobs it depends on