### PR TITLE
fix(core): unbreak main — give the account-forest cache keys one owner both mixins can reach

### DIFF
--- a/packages/core/src/mixins/OxyServices.accounts.ts
+++ b/packages/core/src/mixins/OxyServices.accounts.ts
@@ -38,6 +38,7 @@ import type { SessionLoginResponse } from '../models/session';
 import type { OxyServicesBase } from '../OxyServices.base';
 import { normalizeUserIdentity } from '../utils/userIdentity';
 import { evictOxyIdentityCache } from '../utils/identityCacheSweep';
+import { evictOxyAccountForestCache, oxyAccountDetailCacheKey } from '../utils/accountCacheSweep';
 import { CACHE_TIMES } from './mixinHelpers';
 
 // ---------------------------------------------------------------------------
@@ -709,7 +710,7 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
         );
         // A new account changes the accessible forest — bust every cached list
         // (flat + tree) so it appears on the next `listAccounts()` read.
-        this._invalidateAccountLists();
+        evictOxyAccountForestCache(this);
         return res.account;
       } catch (error) {
         throw this.handleError(error);
@@ -800,8 +801,7 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
         );
         // Bust the cached detail and every list (which embeds account profile
         // data) so neither serves the pre-update snapshot.
-        this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(accountId)}`);
-        this._invalidateAccountLists();
+        evictOxyAccountForestCache(this, accountId);
         // The parent's children list embeds this account's profile and is keyed
         // by the PARENT id, so it is reachable only from the response node.
         const parentAccountId = res.account?.parentAccountId;
@@ -833,10 +833,9 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
           { cache: false },
         );
         // Bust every cached representation of the archived account.
-        this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(accountId)}`);
         this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(accountId)}/members`);
         this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(accountId)}/credentials`);
-        this._invalidateAccountLists();
+        evictOxyAccountForestCache(this, accountId);
         return result;
       } catch (error) {
         throw this.handleError(error);
@@ -975,7 +974,7 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
         // Ownership change alters roles in the member list AND the detail, and
         // can change which accounts the caller "owns" in the list view.
         this._invalidateAccountMembership(accountId);
-        this._invalidateAccountLists();
+        evictOxyAccountForestCache(this);
         return result;
       } catch (error) {
         throw this.handleError(error);
@@ -1317,36 +1316,22 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
     // =========================================================================
 
     /**
-     * Bust every cached account list. `listAccounts({tree?})` keys the flat list
-     * as `GET:/accounts` and the tree variant as `GET:/accounts?tree=true` (the
-     * query string is part of the URL path). A change to the accessible forest
-     * (create/archive/ownership transfer) invalidates both, so we clear the
-     * unscoped entry plus every `?`-query variant via a prefix sweep. The prefix
-     * `GET:/accounts?` matches only the query-string list variants, never the
-     * `GET:/accounts/<id>…` detail/sub-resource keys.
-     *
-     * Internal helper (leading underscore); not part of the supported public
-     * surface. Public rather than `private` because mixins compose into an
-     * exported anonymous class, where TypeScript cannot represent a private
-     * member in the emitted declaration file (TS4094).
-     */
-    _invalidateAccountLists(): void {
-      this.clearCacheEntry('GET:/accounts');
-      this.clearCacheByPrefix('GET:/accounts?');
-    }
-
-    /**
      * Bust the cached member list and detail for an account after a membership
      * mutation. The member list (`listAccountMembers`) and the detail
      * (`getAccount`, which can embed the caller's membership) both go stale when
      * the member set or a member's role changes.
      *
-     * Internal helper (leading underscore); see `_invalidateAccountLists` for why
-     * this is public rather than `private`.
+     * Internal helper (leading underscore); not part of the supported public
+     * surface. Public rather than `private` because mixins compose into an
+     * exported anonymous class, where TypeScript cannot represent a private
+     * member in the emitted declaration file (TS4094).
+     *
+     * The forest keys themselves are NOT owned here — see
+     * `utils/accountCacheSweep`, which the user mixin has to reach as well.
      */
     _invalidateAccountMembership(accountId: string): void {
       this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(accountId)}/members`);
-      this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(accountId)}`);
+      this.clearCacheEntry(oxyAccountDetailCacheKey(accountId));
     }
 
     /**
@@ -1358,8 +1343,8 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
      * query-string list variants, never the `GET:/applications/<id>…`
      * detail/sub-resource keys.
      *
-     * Internal helper (leading underscore); see `_invalidateAccountLists` for why
-     * this is public rather than `private`.
+     * Internal helper (leading underscore); see `_invalidateAccountMembership`
+     * for why this is public rather than `private`.
      */
     _invalidateAppLists(): void {
       this.clearCacheEntry('GET:/applications');

--- a/packages/core/src/mixins/OxyServices.user.ts
+++ b/packages/core/src/mixins/OxyServices.user.ts
@@ -29,6 +29,7 @@ import { KeyManager } from '../crypto/keyManager';
 import { SignatureService } from '../crypto/signatureService';
 import { normalizeUserIdentity, normalizeUserIdentityOrNull } from '../utils/userIdentity';
 import { evictOxyIdentityCache } from '../utils/identityCacheSweep';
+import { evictOxyAccountForestCache } from '../utils/accountCacheSweep';
 import { logger } from '../logger';
 import { extractErrorStatus } from '../utils/errorUtils';
 
@@ -540,8 +541,11 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
      * a new identity read is added in one place instead of to each writer
      * separately (this method's own hand-written copy had already drifted from
      * the server-side one, missing `GET /auth/lookup/*` and
-     * `GET /profiles/resolve`). The account forest (`GET /accounts`, detail) is
-     * swept too — a personal account embeds the same profile on those reads.
+     * `GET /profiles/resolve`). The account forest (`GET /accounts` and the
+     * caller's own detail row) is swept too — a personal account IS this user,
+     * and `AccountNode.account` embeds the whole profile — from the list that
+     * {@link evictOxyAccountForestCache} owns, for the same reason: the accounts
+     * mixin writes those keys as well, and two hand-written copies drift.
      *
      * TanStack Query handles offline queuing automatically.
      */
@@ -552,12 +556,7 @@ export function OxyServicesUserMixin<T extends typeof OxyServicesBase>(Base: T) 
         );
 
         evictOxyIdentityCache(this, result?.id);
-        // A personal account is a row in the account forest; profile edits change
-        // the embedded profile on list/detail reads, not only identity endpoints.
-        this._invalidateAccountLists();
-        if (result?.id) {
-          this.clearCacheEntry(`GET:/accounts/${encodeURIComponent(result.id)}`);
-        }
+        evictOxyAccountForestCache(this, result?.id);
 
         return result;
       } catch (error) {

--- a/packages/core/src/utils/accountCacheSweep.ts
+++ b/packages/core/src/utils/accountCacheSweep.ts
@@ -1,0 +1,82 @@
+/**
+ * THE enumeration of `OxyServices` GET-cache keys that serve the ACCOUNT FOREST
+ * — the caller's accessible accounts, as lists and as individual detail rows —
+ * and the one sweep that clears them.
+ *
+ * WHY THIS IS NOT A METHOD ON THE ACCOUNTS MIXIN
+ * ---------------------------------------------
+ * `AccountNode.account` is a whole `User`, so a forest read embeds the very
+ * profile the identity reads serve. That makes an IDENTITY write a writer of
+ * these keys too: `updateProfile` edits the caller's own personal account,
+ * which is a row in `GET /accounts` and is its own `GET /accounts/<id>`. Leave
+ * those cached and the account switcher keeps drawing the pre-edit name and
+ * picture for the full TTL, against a perfectly healthy server.
+ *
+ * The mixins compose into one class at runtime but are typed one at a time, so
+ * the user mixin cannot call a method the accounts mixin owns. The key list
+ * therefore lives here, once, and every writer calls {@link
+ * evictOxyAccountForestCache} — exactly like the identity key list in
+ * `identityCacheSweep`, which the accounts mixin already calls for the
+ * mirror-image case (an account write staling the identity reads). The
+ * alternative — a second hand-written copy of these keys in the other mixin —
+ * is the drift that shipped the two stale-profile bugs `identityCacheSweep`
+ * documents.
+ *
+ * WHY THE LIST NEEDS A PREFIX AND THE DETAIL DOES NOT
+ * --------------------------------------------------
+ * `listAccounts({tree?})` keys the flat list as `GET:/accounts` and every
+ * option variant as `GET:/accounts?<query>` (the query string is part of the
+ * URL, hence of the key), and a writer cannot enumerate which variants a caller
+ * has read. The detail key, by contrast, is derivable from the account id the
+ * writer already holds.
+ *
+ * The `GET:/accounts?` prefix matches ONLY the query-string list variants —
+ * never `GET:/accounts/<id>` or its `…/members`, `…/credentials`, `…/children`
+ * sub-resources, which are the accounts mixin's own business and stay there.
+ */
+
+import type { OxyIdentityCacheEvictor } from './identityCacheSweep';
+
+/**
+ * The cache-eviction surface of an `OxyServices` instance. Reused from
+ * `identityCacheSweep` rather than re-declared: it is the SDK's one published
+ * name for these two methods, and a second identical interface would be one
+ * more shape to keep in step.
+ */
+export type OxyAccountCacheEvictor = OxyIdentityCacheEvictor;
+
+/** The cache key `listAccounts()` reads under with no options. */
+export const OXY_ACCOUNT_LIST_CACHE_KEY = 'GET:/accounts';
+
+/**
+ * The prefix covering every option-carrying `listAccounts(opts)` variant
+ * (`?tree=true`, …), none of which a writer can enumerate.
+ */
+export const OXY_ACCOUNT_LIST_CACHE_QUERY_PREFIX = 'GET:/accounts?';
+
+/**
+ * Build the exact cache key `getAccount(accountId)` reads under.
+ */
+export function oxyAccountDetailCacheKey(accountId: string): string {
+  return `GET:/accounts/${encodeURIComponent(accountId)}`;
+}
+
+/**
+ * Sweep an `OxyServices` GET response cache of the account forest.
+ *
+ * @param oxy       - Anything exposing the SDK's two eviction methods.
+ * @param accountId - The account whose detail row to drop as well. Optional: a
+ *                    writer that changed the SHAPE of the forest rather than one
+ *                    account in it (create, archive, ownership transfer) has no
+ *                    detail row to name, and clears only the lists.
+ */
+export function evictOxyAccountForestCache(
+  oxy: OxyAccountCacheEvictor,
+  accountId?: string,
+): void {
+  oxy.clearCacheEntry(OXY_ACCOUNT_LIST_CACHE_KEY);
+  oxy.clearCacheByPrefix(OXY_ACCOUNT_LIST_CACHE_QUERY_PREFIX);
+  if (accountId) {
+    oxy.clearCacheEntry(oxyAccountDetailCacheKey(accountId));
+  }
+}


### PR DESCRIPTION
## The break

`3251030f` made `updateProfile` bust the account forest. That is the right call — `AccountNode.account` is a whole `User`, so a self-profile edit stales `GET /accounts` and the caller's own `GET /accounts/<id>` exactly as it stales the identity reads, and the account switcher otherwise keeps drawing the pre-edit name and picture for the full TTL.

It reached for `this._invalidateAccountLists()`, a method the **accounts** mixin owns. The mixins compose into one class at runtime but are each typed against `OxyServicesBase` alone, so the user mixin cannot see it:

```
packages/core/src/mixins/OxyServices.user.ts(557,14): error TS2339:
  Property '_invalidateAccountLists' does not exist on type '(Anonymous class)'.
```

`tsc` emits before it exits non-zero, and `build` is `build:cjs && build:esm && build:types`, so `packages/core/dist` was left with **`cjs` only — no `esm`, no types**, and every downstream package failed to resolve `@oxyhq/core` at all. 11 jobs down across **CI/CD Pipeline**, **Deploy to AWS** and **Deploy Frontend to Cloudflare Pages**.

## The fix

The repo already answers this exact question for the mirror-image case: the accounts mixin busts the identity reads by calling `evictOxyIdentityCache`, a free function over a structural evictor in `utils/identityCacheSweep`, shared by both mixins **and** the server-side invalidation subscriber. The account-forest keys now live the same way, in a new `utils/accountCacheSweep`, and `_invalidateAccountLists` is deleted — it was core-internal (nothing outside the package referenced it) and a second name for one sweep is drift bait.

Five writers, same key set at each, behaviour unchanged:

| writer | before | after |
|---|---|---|
| `createAccount` | `_invalidateAccountLists()` | `evictOxyAccountForestCache(this)` |
| `updateAccount` | detail clear + `_invalidateAccountLists()` | `evictOxyAccountForestCache(this, accountId)` |
| `archiveAccount` | detail clear + `_invalidateAccountLists()` | `evictOxyAccountForestCache(this, accountId)` |
| `transferAccountOwnership` | `_invalidateAccountLists()` | `evictOxyAccountForestCache(this)` |
| `updateProfile` (user mixin) | **did not compile** | `evictOxyAccountForestCache(this, result?.id)` |

### Why not `declare`

`user.ts` already carries `declare makeServiceRequest` for the auth mixin's method, so a `declare _invalidateAccountLists(): void` would have matched an in-file precedent and been a one-line change. It is the wrong tool here: a `declare` is an unchecked assertion that nothing verifies against the accounts mixin, so a later rename compiles fine and fails at runtime the moment somebody edits their profile — and it leaves `user.ts` still hand-writing `GET:/accounts/<id>`, a second copy of a key format. That is precisely the drift `identityCacheSweep`'s own docblock records as having already shipped two stale-profile bugs. No cast, no `as any`, no `@ts-ignore`, no `!`.

## Measured

Baseline taken on `3251030f` before touching anything, so every number is a delta.

- **core `tsc --noEmit`**: 1 error → **0**
- **`dist` completeness**: `cjs` only → **`cjs` + `esm` + `types`** (126 / 126 / 104 files, both entry trees and `i18n/locales` present)
- **core jest**: 104 suites / 1440 tests pass (unchanged)
- **services**: build clean, 67 suites / 595 tests pass
- **auth**: 127 tests pass, `tsc --noEmit` clean
- **biome**: 212 → 212, with a byte-identical per-file × rule distribution. Both runs used `--max-diagnostics=1000` (the default run truncates and reports 210 on the same tree, so the flags have to match).
- **Mutation test**: reverting all three files reproduces the exact `TS2339` and the cjs-only `dist`.

Build order used throughout: contracts → protocol → core → services → auth, matching `ci.yml`.

## Not done deliberately

No version bump, no publish — a separate publish chain is waiting on main going green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)