### PR TITLE
fix(accounts): GET /accounts/:id/members discloses inherited holders

### DIFF
--- a/packages/api/src/routes/__tests__/accountsMembersInheritance.test.ts
+++ b/packages/api/src/routes/__tests__/accountsMembersInheritance.test.ts
@@ -1,0 +1,473 @@
+/**
+ * GET /accounts/:id/members — the roster, and the inherited members it used to
+ * leave out.
+ *
+ * ## What broke, and why a one-sided suite cannot see it
+ *
+ * `resolveEffectiveAccess` has always honoured inheritance: an ancestor row with
+ * `inherit: true` confers every account permission on the descendant,
+ * `account:act_as` included. The roster was built from direct rows alone, so it
+ * answered `[]` for an account somebody could act on — and answered it TO that
+ * person, who had just been let through `members:read` by the very row the list
+ * omitted. Consumers that look themselves up in this list to decide whether they
+ * may act (Mention's publish-as gate) therefore read "not a member" for somebody
+ * `POST /accounts/:id/switch` would let in.
+ *
+ * FOUR actors, because fewer cannot tell the rules apart. A suite with only a
+ * direct member and a stranger passes identically whether inheritance counts or
+ * not. A suite with only a direct and an inherited member passes identically
+ * whether inheritance counts or EVERY reachable person counts. So:
+ *
+ *  - `directUser`   — a row on the child. Must stay, must stay editable.
+ *  - `inheritedUser`— an `inherit: true` row on the parent. Must appear, marked
+ *                     `inherited`, carrying the ancestor's row id and account id.
+ *  - `blockedUser`  — an `inherit: false` row on the parent. Must NOT appear, and
+ *                     must be refused the endpoint entirely. This is the fixture
+ *                     that separates "inherited membership counts" from "anybody
+ *                     with a row anywhere up the tree counts"; without it, an
+ *                     implementation that ignored `inherit` passes every case.
+ *  - `strangerUser` — no row anywhere. Must be refused.
+ *
+ * The real router over real Postgres with the real `account.service`, for the
+ * same reason `accountsMemberPermissions.test.ts` gives: the behaviour is spread
+ * across `loadAccountContext` → `requireAccountPermission` → the route body →
+ * the service, and mocking the service would leave most of it unexecuted.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { randomBytes } from 'node:crypto';
+
+let actingUserId = '';
+
+jest.mock('../../middleware/auth', () => ({
+  authMiddleware: (
+    req: { user?: { _id: string; id: string } },
+    _res: unknown,
+    next: () => void
+  ) => {
+    req.user = { _id: actingUserId, id: actingUserId };
+    next();
+  },
+  serviceAuthMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+jest.mock('../../middleware/requireStaff', () => ({ isStaffUser: () => false }));
+
+jest.mock('../../services/session.service', () => ({
+  __esModule: true,
+  default: { createSession: jest.fn(), getSession: jest.fn() },
+}));
+
+jest.mock('../../services/deviceSession.service', () => ({
+  __esModule: true,
+  default: { addAccount: jest.fn() },
+}));
+
+jest.mock('../../utils/socket', () => ({ broadcastDeviceState: jest.fn() }));
+
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import accountsRouter from '../accounts';
+import { errorHandler } from '../../middleware/errorHandler';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { accountMembers } from '../../db/schema/accountMembers';
+import { userAncestors } from '../../db/schema/userAncestors';
+import { users } from '../../db/schema/users';
+import { accountService } from '../../services/account.service';
+import { permissionsForAccountRole, type AccountRole } from '../../utils/accountRoles';
+
+/** The member shape this endpoint serialises, as far as these cases read it. */
+interface MemberBody {
+  _id: string;
+  accountId: string;
+  memberUserId: string;
+  role: AccountRole;
+  permissions: string[];
+  inherit: boolean;
+  status: string;
+  source: 'direct' | 'inherited';
+}
+
+interface ListResponse {
+  status: number;
+  body: { members?: MemberBody[]; message?: string };
+}
+
+let server: http.Server;
+
+function uniqueUsername(prefix: string): string {
+  return `${prefix}-${randomBytes(6).toString('hex')}`;
+}
+
+async function seedAccount(
+  kind: 'personal' | 'organization' | 'project' | 'channel',
+  parentAccountId?: string
+): Promise<string> {
+  const [row] = await getDb()
+    .insert(users)
+    .values({
+      color: 'teal',
+      username: uniqueUsername(kind),
+      kind,
+      parentAccountId,
+      rootAccountId: parentAccountId,
+    })
+    .returning({ id: users.id });
+  if (parentAccountId) {
+    await getDb()
+      .insert(userAncestors)
+      .values({ userId: row.id, ancestorId: parentAccountId, depth: 0 });
+  }
+  return row.id;
+}
+
+async function seedMember(
+  accountId: string,
+  memberUserId: string,
+  role: AccountRole,
+  extra: {
+    inherit?: boolean;
+    status?: 'active' | 'invited' | 'removed';
+    permissionGrants?: string[];
+    permissionRevokes?: string[];
+  } = {}
+): Promise<string> {
+  const [row] = await getDb()
+    .insert(accountMembers)
+    .values({
+      accountId,
+      memberUserId,
+      role,
+      inherit: extra.inherit ?? true,
+      status: extra.status ?? 'active',
+      permissionGrants: extra.permissionGrants ?? [],
+      permissionRevokes: extra.permissionRevokes ?? [],
+    })
+    .returning({ id: accountMembers.id });
+  return row.id;
+}
+
+function listMembers(accountId: string): Promise<ListResponse> {
+  const address = server.address() as AddressInfo;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: address.port,
+        path: `/accounts/${accountId}/members`,
+        method: 'GET',
+        headers: { Authorization: 'Bearer user-token' },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: raw ? (JSON.parse(raw) as ListResponse['body']) : {},
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function entryFor(body: ListResponse['body'], memberUserId: string): MemberBody[] {
+  return (body.members ?? []).filter((member) => member.memberUserId === memberUserId);
+}
+
+/**
+ * A parent organization with a child project under it, and the four actors the
+ * header describes. Returns everything by id so a case can pick who asks.
+ */
+async function seedTree() {
+  const parent = await seedAccount('organization');
+  const child = await seedAccount('project', parent);
+
+  const directUser = await seedAccount('personal');
+  const inheritedUser = await seedAccount('personal');
+  const blockedUser = await seedAccount('personal');
+  const strangerUser = await seedAccount('personal');
+
+  const directRowId = await seedMember(child, directUser, 'editor');
+  const inheritedRowId = await seedMember(parent, inheritedUser, 'editor', { inherit: true });
+  const blockedRowId = await seedMember(parent, blockedUser, 'editor', { inherit: false });
+
+  return {
+    parent,
+    child,
+    directUser,
+    inheritedUser,
+    blockedUser,
+    strangerUser,
+    directRowId,
+    inheritedRowId,
+    blockedRowId,
+  };
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+  const app = express();
+  app.use(express.json());
+  app.use('/accounts', accountsRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, resolve);
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await closePostgres();
+});
+
+describe('the roster and the gate answer the same question', () => {
+  test('an INHERITED member appears in the list they are authorised to read', async () => {
+    const { child, parent, inheritedUser, inheritedRowId } = await seedTree();
+
+    // The premise, measured rather than assumed: the gate that admits this
+    // caller resolves from the ancestor row. Without this the case could pass
+    // for the wrong reason (e.g. the endpoint stopped gating at all).
+    const access = await accountService.resolveEffectiveAccess(inheritedUser, child);
+    expect(access?.source).toBe('inherited');
+    expect(access?.permissions).toContain('members:read');
+
+    actingUserId = inheritedUser;
+    const res = await listMembers(child);
+
+    expect(res.status).toBe(200);
+    const own = entryFor(res.body, inheritedUser);
+    expect(own).toHaveLength(1);
+    expect(own[0].source).toBe('inherited');
+    // The row lives on the PARENT, and the entry says so — a client that
+    // addressed this `_id` through the child would get a 404 from
+    // `requireDirectMember`, which is what `source` exists to prevent.
+    expect(own[0].accountId).toBe(parent);
+    expect(own[0]._id).toBe(inheritedRowId);
+    expect(own[0].status).toBe('active');
+  });
+
+  test("an inherited entry carries the ancestor row's EFFECTIVE permissions, deltas included", async () => {
+    const parent = await seedAccount('organization');
+    const child = await seedAccount('project', parent);
+    const holder = await seedAccount('personal');
+    // `admin` carries both of these in its baseline; the row revokes one. An
+    // implementation that serialised `permissionsForAccountRole(role)` instead
+    // of the row's effective set passes every other case in this file and fails
+    // only here.
+    expect(permissionsForAccountRole('admin')).toContain('account:act_as');
+    expect(permissionsForAccountRole('admin')).toContain('members:invite');
+    await seedMember(parent, holder, 'admin', {
+      inherit: true,
+      permissionRevokes: ['account:act_as'],
+    });
+
+    actingUserId = holder;
+    const res = await listMembers(child);
+
+    expect(res.status).toBe(200);
+    const own = entryFor(res.body, holder);
+    expect(own).toHaveLength(1);
+    expect(own[0].permissions).not.toContain('account:act_as');
+    // Narrowed, not emptied — a serializer that returned `[]` would also satisfy
+    // the assertion above.
+    expect(own[0].permissions).toContain('members:invite');
+  });
+
+  test('a DIRECT member is unchanged: present once, marked direct, on this account', async () => {
+    const { child, directUser, directRowId } = await seedTree();
+
+    actingUserId = directUser;
+    const res = await listMembers(child);
+
+    expect(res.status).toBe(200);
+    const own = entryFor(res.body, directUser);
+    expect(own).toHaveLength(1);
+    expect(own[0].source).toBe('direct');
+    expect(own[0].accountId).toBe(child);
+    expect(own[0]._id).toBe(directRowId);
+  });
+
+  test('an `inherit: false` ancestor row confers nothing: absent from the list, refused the endpoint', async () => {
+    const { child, blockedUser, directUser } = await seedTree();
+
+    // The gate refuses them outright — the list is not even reachable.
+    actingUserId = blockedUser;
+    expect((await listMembers(child)).status).toBe(403);
+
+    // And nobody else sees them in it either. This is the assertion that tells
+    // "inherited membership counts" apart from "any row up the tree counts".
+    actingUserId = directUser;
+    const res = await listMembers(child);
+    expect(res.status).toBe(200);
+    expect(entryFor(res.body, blockedUser)).toHaveLength(0);
+    // Non-vacuity: the SAME actor does see the inherited member, so an empty
+    // result cannot be what makes the line above pass.
+    expect(res.body.members?.length).toBeGreaterThan(0);
+  });
+
+  test('a NON-MEMBER is refused', async () => {
+    const { child, strangerUser } = await seedTree();
+
+    actingUserId = strangerUser;
+    expect((await listMembers(child)).status).toBe(403);
+  });
+
+  test('every active entry is the row the gate would resolve for that person', async () => {
+    // The property that keeps the roster and `resolveEffectiveAccess` from ever
+    // disagreeing about somebody, asserted over the whole list rather than one
+    // fixture: for each person the roster reports as active on this account, the
+    // gate resolves the same row from the same place.
+    const { child, directUser, inheritedUser } = await seedTree();
+
+    actingUserId = directUser;
+    const res = await listMembers(child);
+    expect(res.status).toBe(200);
+
+    const active = (res.body.members ?? []).filter((member) => member.status === 'active');
+    // Vacuity floor: this case is worthless if the list is empty or one-sided.
+    expect(active.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(active.map((member) => member.source))).toEqual(
+      new Set(['direct', 'inherited'])
+    );
+
+    for (const member of active) {
+      const access = await accountService.resolveEffectiveAccess(member.memberUserId, child);
+      expect(access).not.toBeNull();
+      expect(access?.source).toBe(member.source);
+      expect(access?.membership?.id).toBe(member._id);
+      expect(access?.permissions).toEqual(member.permissions);
+    }
+
+    expect(active.map((member) => member.memberUserId).sort()).toEqual(
+      [directUser, inheritedUser].sort()
+    );
+  });
+});
+
+describe('the roster still answers its own question', () => {
+  test('a DIRECT row that is only invited is still listed — it is a pending invitation', async () => {
+    const parent = await seedAccount('organization');
+    const child = await seedAccount('project', parent);
+    const admin = await seedAccount('personal');
+    const invitee = await seedAccount('personal');
+    await seedMember(child, admin, 'admin');
+    await seedMember(child, invitee, 'viewer', { status: 'invited' });
+
+    actingUserId = admin;
+    const res = await listMembers(child);
+
+    expect(res.status).toBe(200);
+    const entries = entryFor(res.body, invitee);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].status).toBe('invited');
+    expect(entries[0].source).toBe('direct');
+  });
+
+  test('a pending direct invitation and live inherited access are BOTH reported', async () => {
+    // The one person who legitimately produces two entries. Keying the inherited
+    // half on "no ACTIVE direct row" rather than "no row at all" is what keeps
+    // both facts: the console renders pending invites as
+    // `members.filter(m => m.status === 'invited')` and the active list from the
+    // rest, and this person belongs in each.
+    const parent = await seedAccount('organization');
+    const child = await seedAccount('project', parent);
+    const admin = await seedAccount('personal');
+    const both = await seedAccount('personal');
+    await seedMember(child, admin, 'admin');
+    await seedMember(child, both, 'viewer', { status: 'invited' });
+    await seedMember(parent, both, 'editor', { inherit: true });
+
+    actingUserId = admin;
+    const res = await listMembers(child);
+
+    expect(res.status).toBe(200);
+    const entries = entryFor(res.body, both);
+    expect(entries).toHaveLength(2);
+    expect(entries.filter((e) => e.status === 'invited' && e.source === 'direct')).toHaveLength(1);
+    expect(entries.filter((e) => e.status === 'active' && e.source === 'inherited')).toHaveLength(1);
+  });
+
+  test('an ACTIVE direct row beats the inherited one — one entry, and it is the direct one', async () => {
+    const parent = await seedAccount('organization');
+    const child = await seedAccount('project', parent);
+    const person = await seedAccount('personal');
+    const childRowId = await seedMember(child, person, 'viewer');
+    await seedMember(parent, person, 'admin', { inherit: true });
+
+    actingUserId = person;
+    const res = await listMembers(child);
+
+    expect(res.status).toBe(200);
+    const entries = entryFor(res.body, person);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]._id).toBe(childRowId);
+    expect(entries[0].source).toBe('direct');
+    // Non-vacuity: the two rows carry different roles, so an implementation that
+    // picked the ancestor's would be visible here rather than merely producing a
+    // different id.
+    expect(entries[0].role).toBe('viewer');
+  });
+
+  test('a REMOVED ancestor row cascades nothing', async () => {
+    const parent = await seedAccount('organization');
+    const child = await seedAccount('project', parent);
+    const admin = await seedAccount('personal');
+    const gone = await seedAccount('personal');
+    await seedMember(child, admin, 'admin');
+    await seedMember(parent, gone, 'editor', { inherit: true, status: 'removed' });
+
+    actingUserId = admin;
+    const res = await listMembers(child);
+
+    expect(res.status).toBe(200);
+    expect(entryFor(res.body, gone)).toHaveLength(0);
+    // Vacuity floor: the list is not empty, so the absence above means something.
+    expect(entryFor(res.body, admin)).toHaveLength(1);
+  });
+
+  test('a ROOT account with no ancestors is unaffected', async () => {
+    const org = await seedAccount('organization');
+    const admin = await seedAccount('personal');
+    await seedMember(org, admin, 'admin');
+
+    actingUserId = admin;
+    const res = await listMembers(org);
+
+    expect(res.status).toBe(200);
+    expect(res.body.members).toHaveLength(1);
+    expect(res.body.members?.[0].source).toBe('direct');
+  });
+
+  test('a CHANNEL inherits from the tree it hangs in, which is what makes it publishable', async () => {
+    // The shape Mention hits: a channel can never be switched into, so membership
+    // IS the whole right over it — and the member whose row lives on the parent
+    // org had been invisible to the only list that answers who those members are.
+    const org = await seedAccount('organization');
+    const channel = await seedAccount('channel', org);
+    const person = await seedAccount('personal');
+    await seedMember(org, person, 'editor', { inherit: true });
+
+    actingUserId = person;
+    const res = await listMembers(channel);
+
+    expect(res.status).toBe(200);
+    const own = entryFor(res.body, person);
+    expect(own).toHaveLength(1);
+    expect(own[0].status).toBe('active');
+    expect(own[0].source).toBe('inherited');
+  });
+});

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -207,7 +207,8 @@ router.post(
 
     res.status(201).json({
       account: formatUserResponse(account),
-      membership: serializeMember(membership),
+      // A row this request just wrote on this account: direct by construction.
+      membership: serializeMember(membership, 'direct'),
     });
   })
 );
@@ -257,7 +258,8 @@ router.post(
       appId: req.serviceApp?.appId,
     });
 
-    res.status(201).json({ member: serializeMember(membership) });
+    // A row this request just wrote on this channel: direct by construction.
+    res.status(201).json({ member: serializeMember(membership, 'direct') });
   })
 );
 
@@ -412,11 +414,18 @@ const credentialsLimiter = rateLimit({
 /** Serialise an account (a User doc) for client responses. */
 /**
  * Serialise a membership row for client responses. `source` is the contextual
- * resolution origin — `'direct'` for a real row on the account (the default for
- * the members list), `'inherited'` when surfaced as a node's `callerMembership`
- * resolved from an ancestor.
+ * resolution origin — `'direct'` for a row that lives on the account being
+ * reported, `'inherited'` for one resolved from an ancestor of it.
+ *
+ * REQUIRED, with no default. It used to default to `'direct'`, which was
+ * correct at every call site that returns a row it just wrote and quietly wrong
+ * at the one that returns a roster: an inherited entry serialised as `direct`
+ * tells a client it may edit a row belonging to another account, and
+ * `requireDirectMember` scopes by `accountId`, so the edit 404s. A parameter
+ * every caller has to answer is the only version of this that a new call site
+ * cannot get wrong by saying nothing.
  */
-function serializeMember(member: AccountMemberRow, source: 'direct' | 'inherited' = 'direct') {
+function serializeMember(member: AccountMemberRow, source: 'direct' | 'inherited') {
   return {
     _id: member.id,
     accountId: member.accountId,
@@ -952,7 +961,13 @@ router.post(
 // Members
 // ============================================================================
 
-/** List direct members of an account (`members:read`). */
+/**
+ * List the members of an account (`members:read`) — its own rows plus the
+ * ancestor rows that cascade into it, each carrying the `source` that says
+ * which. See {@link AccountService.listMembers} for why an inherited holder
+ * belongs in this list and what changes by including them (disclosure, not
+ * permission).
+ */
 router.get(
   '/:id/members',
   membersLimiter,
@@ -964,7 +979,7 @@ router.get(
       throw new NotFoundError('Account not found');
     }
     const members = await accountService.listMembers(account.id);
-    res.json({ members: members.map((member) => serializeMember(member)) });
+    res.json({ members: members.map(({ row, source }) => serializeMember(row, source)) });
   })
 );
 
@@ -998,7 +1013,9 @@ router.post(
       inherit
     );
 
-    res.status(201).json({ member: serializeMember(member) });
+    // `addMember` writes on `account.id`, so the row is direct by construction —
+    // `inherit` governs whether it cascades to CHILDREN, not where it lives.
+    res.status(201).json({ member: serializeMember(member, 'direct') });
   })
 );
 
@@ -1085,7 +1102,9 @@ router.patch(
       ...(permissionGrants !== undefined ? { permissionGrants } : {}),
       ...(permissionRevokes !== undefined ? { permissionRevokes } : {}),
     });
-    res.json({ member: serializeMember(member) });
+    // `requireDirectMember` above already refused anything but a row on this
+    // account, so the edited row is direct by construction.
+    res.json({ member: serializeMember(member, 'direct') });
   })
 );
 

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -163,6 +163,20 @@ export interface MembershipLike {
   status: string;
 }
 
+/**
+ * One person's membership AS IT APPLIES TO a given account: the row that grants
+ * it, and whether that row lives on the account or on an ancestor of it.
+ *
+ * The pair is the unit rather than the row alone because the row cannot say
+ * which account it is being reported for — an inherited entry's `accountId` is
+ * the ANCESTOR's, and a caller that reads only the row has no way to tell that
+ * it may not edit it through the account it asked about.
+ */
+export interface EffectiveMember {
+  row: AccountMemberRow;
+  source: 'direct' | 'inherited';
+}
+
 /** Resolved effective access of a caller over an account. */
 export interface EffectiveAccess {
   role: AccountRole;
@@ -1060,15 +1074,121 @@ export class AccountService {
   // Members CRUD
   // -------------------------------------------------------------------------
 
-  /** Direct (non-removed) membership rows on an account. */
-  async listMembers(accountId: string): Promise<AccountMemberRow[]> {
-    return getDb()
+  /**
+   * The people who hold membership OVER an account — its direct rows plus the
+   * ancestor rows that cascade into it.
+   *
+   * ## Why this is not the direct rows alone
+   *
+   * It was, and the omission was silent. `resolveEffectiveAccess` has always
+   * honoured inheritance, so an ancestor row with `inherit: true` confers every
+   * account permission on the descendant, `account:act_as` included — the switch
+   * endpoint says so in as many words. A roster built from direct rows therefore
+   * answered `[]` for an account five people could act on, and it answered it to
+   * a reader those five included: measured on a real database, an inherited
+   * `editor` of a child account got `200 {"members":[]}` from
+   * `GET /accounts/:id/members`, having just been authorised to read it by
+   * `members:read` resolved from the very row the list omitted.
+   *
+   * That is not a stricter answer, it is a WRONG one, and it is wrong in the
+   * direction that is hardest to notice: a consumer looking itself up in this
+   * list to decide whether it may act (Mention's publish-as gate does exactly
+   * that) reads "not a member" for somebody Oxy would let switch INTO the
+   * account. Two doors, opposite answers, no error anywhere.
+   *
+   * ## What each entry is
+   *
+   * Every direct non-removed row is present, unchanged — including `invited`
+   * ones, because a pending invitation IS a member row here and the consoles
+   * render the pending list as `members.filter(m => m.status === 'invited')`.
+   *
+   * On top of that, each person with no ACTIVE direct row contributes their
+   * nearest cascading ancestor row, marked `inherited`. Keying the addition on
+   * the ACTIVE direct row rather than on any row is what keeps somebody who has
+   * both a pending invitation here and live inherited access from losing one of
+   * those two facts: they appear in the pending list AND in the active list,
+   * which is what is true of them.
+   *
+   * Resolution runs through {@link resolveEffectiveMembership}, once per person,
+   * rather than a rule of its own — the same function
+   * {@link AccountService.effectiveAccessForAccount} and
+   * {@link AccountService.annotateAccounts} resolve through. So this roster
+   * cannot come to a different conclusion about a person than the gate that
+   * admits them: an entry marked `active` here is exactly the row
+   * `resolveEffectiveAccess` would resolve for that person over this account.
+   *
+   * ## What it does NOT do
+   *
+   * It confers nothing. No access decision in this service reads it — the
+   * last-owner guard queries `account_members` directly, and every gate goes
+   * through `resolveEffectiveAccess` — so widening the roster changes what is
+   * DISCLOSED, not what is permitted. The disclosure it adds is the identity of
+   * people who can already act on the account, to readers who already hold
+   * `members:read` over it, which is the question a roster exists to answer.
+   *
+   * An entry's `accountId` is the account its ROW lives on, so an inherited
+   * entry names the ancestor — and `source` is what a caller must branch on
+   * before offering to edit it, since `requireDirectMember` scopes by
+   * `accountId` and will 404 an ancestor's row addressed through this account.
+   */
+  async listMembers(accountId: string): Promise<EffectiveMember[]> {
+    const db = getDb();
+    const ancestors = await loadAncestors(db, accountId);
+
+    const direct = await db
       .select()
       .from(accountMembers)
       .where(
         and(eq(accountMembers.accountId, accountId), ne(accountMembers.status, 'removed'))
       )
       .orderBy(asc(accountMembers.createdAt));
+
+    const entries: EffectiveMember[] = direct.map((row) => ({ row, source: 'direct' }));
+    if (ancestors.length === 0) {
+      return entries;
+    }
+
+    // Only rows that can actually cascade are worth loading: an ancestor row
+    // that is inactive or opted out of inheritance confers nothing here, and
+    // reading it would put a person in the roster the gate would refuse.
+    const cascading = await db
+      .select()
+      .from(accountMembers)
+      .where(
+        and(
+          inArray(accountMembers.accountId, ancestors),
+          eq(accountMembers.status, 'active'),
+          eq(accountMembers.inherit, true)
+        )
+      )
+      .orderBy(asc(accountMembers.createdAt));
+    if (cascading.length === 0) {
+      return entries;
+    }
+
+    const withActiveDirectRow = new Set(
+      direct.filter((row) => row.status === 'active').map((row) => row.memberUserId)
+    );
+
+    const byMember = new Map<string, AccountMemberRow[]>();
+    for (const row of cascading) {
+      if (withActiveDirectRow.has(row.memberUserId)) continue;
+      const rows = byMember.get(row.memberUserId) ?? [];
+      rows.push(row);
+      byMember.set(row.memberUserId, rows);
+    }
+
+    for (const rows of byMember.values()) {
+      // No direct row is passed, so this can only resolve to an ancestor — but
+      // it is the shared resolver that decides WHICH ancestor, so nearest-first
+      // precedence is the one rule rather than a second copy of it.
+      const resolved = resolveEffectiveMembership(rows, accountId, ancestors);
+      if (resolved) {
+        entries.push({ row: resolved.row, source: resolved.source });
+      }
+    }
+
+    return entries;
   }
 
   /**

--- a/packages/console/src/routes/_layout/settings/account.tsx
+++ b/packages/console/src/routes/_layout/settings/account.tsx
@@ -145,7 +145,14 @@ function AccountSettingsPage() {
   const members = membersQuery.data ?? [];
   const activeMembers = members.filter((m) => m.status === 'active');
   const pendingInvites = members.filter((m) => m.status === 'invited');
-  const ownerCount = activeMembers.filter((m) => m.role === 'owner').length;
+  // DIRECT owners only. The list also carries members whose row lives on an
+  // ancestor account, and the last-owner rule this count feeds is about the rows
+  // on THIS account — which is what the server's own guard counts. Including an
+  // inherited owner would make a child with no owner of its own look like it has
+  // exactly one, and silently disable removing anybody.
+  const ownerCount = activeMembers.filter(
+    (m) => m.role === 'owner' && m.source !== 'inherited',
+  ).length;
 
   const inviteMemberMutation = useInviteAccountMember();
   const updateMemberMutation = useUpdateAccountMember();
@@ -481,9 +488,16 @@ function AccountSettingsPage() {
               {activeMembers.map((member) => {
                 const isOwner = member.role === 'owner';
                 const isLastOwner = isOwner && ownerCount <= 1;
-                const canEditThisRole = canManage && !isOwner;
-                const canRemoveThisMember = canManage && !isOwner && !isLastOwner;
-                const canTransferToThis = canTransfer && !isOwner;
+                // An INHERITED entry's row lives on an ancestor account, and every
+                // member mutation is scoped to rows on the account in the path — so
+                // offering to edit, remove or promote one would be offering a
+                // request the server answers 404. It is changed where it lives, on
+                // that ancestor's own members screen.
+                const isEditableHere = member.source !== 'inherited';
+                const canEditThisRole = canManage && isEditableHere && !isOwner;
+                const canRemoveThisMember =
+                  canManage && isEditableHere && !isOwner && !isLastOwner;
+                const canTransferToThis = canTransfer && isEditableHere && !isOwner;
 
                 return (
                   <div
@@ -504,6 +518,11 @@ function AccountSettingsPage() {
                       </div>
                     </div>
                     <div className="flex items-center gap-2">
+                      {!isEditableHere ? (
+                        <Badge variant="outline" title="Granted on a parent account">
+                          Inherited
+                        </Badge>
+                      ) : null}
                       {isOwner ? (
                         <Badge variant="secondary" className="gap-1">
                           <HugeiconsIcon icon={CrownIcon} size={12} />

--- a/packages/core/src/i18n/locales/en-US.json
+++ b/packages/core/src/i18n/locales/en-US.json
@@ -1839,6 +1839,7 @@
       "title": "Members",
       "subtitle": "People with access to this account.",
       "empty": "No members yet.",
+      "inherited": "Inherited",
       "actions": {
         "remove": "Remove member",
         "transfer": "Transfer ownership"

--- a/packages/core/src/i18n/locales/es-ES.json
+++ b/packages/core/src/i18n/locales/es-ES.json
@@ -1839,6 +1839,7 @@
       "title": "Miembros",
       "subtitle": "Personas con acceso a esta cuenta.",
       "empty": "Aún no hay miembros.",
+      "inherited": "Heredado",
       "actions": {
         "remove": "Eliminar miembro",
         "transfer": "Transferir propiedad"

--- a/packages/core/src/mixins/OxyServices.accounts.ts
+++ b/packages/core/src/mixins/OxyServices.accounts.ts
@@ -111,10 +111,18 @@ export interface AccountMember {
   inherit: boolean;
   status: AccountMemberStatus;
   /**
-   * Origin of the membership when the API resolves an effective role. Present on
-   * a resolved `callerMembership` to indicate whether the caller's access is
-   * `direct` on the account or `inherited` from an ancestor. Absent on plain
-   * member-list rows (which are always direct rows on the account).
+   * Where this membership COMES FROM relative to the account it is being
+   * reported for: `direct` when the row lives on that account, `inherited` when
+   * it lives on an ancestor whose `inherit` flag cascades it down.
+   *
+   * Present on every membership the API serialises — a resolved
+   * `callerMembership` and every entry of a member list alike. It is not
+   * decoration: an `inherited` entry's `accountId` is the ANCESTOR's, and the
+   * member-mutation endpoints are scoped to rows on the account named in the
+   * path, so `PATCH`/`DELETE .../members/<that row's _id>` against the
+   * descendant 404s. **Branch on `source === 'direct'` before offering to edit,
+   * remove or transfer to a member**, and count owners for a last-owner check
+   * over direct entries only.
    */
   source?: AccountMemberSource;
   invitedByUserId?: string | null;
@@ -865,7 +873,27 @@ export function OxyServicesAccountsMixin<T extends typeof OxyServicesBase>(Base:
     // =========================================================================
 
     /**
-     * List members of an account (direct membership rows on the account).
+     * List the members of an account: the membership rows ON it, plus the rows
+     * on its ancestors that cascade into it. Each entry carries `source`
+     * (`direct` | `inherited`) saying which it is.
+     *
+     * Inherited entries are members in every sense the server enforces — an
+     * ancestor row with `inherit: true` resolves through
+     * `resolveEffectiveAccess` and confers every account permission on the
+     * descendant, `account:act_as` included — so a roster that omitted them
+     * answered `[]` for accounts several people could act on.
+     *
+     * Two things follow for a caller. An entry's `accountId` is the account its
+     * ROW lives on, so an inherited entry names an ancestor rather than the
+     * account you asked about; and the member-mutation endpoints only accept
+     * rows on the account in the path, so gate any edit/remove/transfer
+     * affordance on `source === 'direct'`.
+     *
+     * Asking what the CALLER holds over an account is a different question, and
+     * scanning this list for yourself is the wrong way to answer it — use
+     * {@link OxyServicesAccountsMixin.getAccount}, whose `callerMembership` is
+     * the server's own resolution.
+     *
      * @param accountId - The account's Mongo `_id`.
      */
     async listAccountMembers(accountId: string): Promise<AccountMember[]> {

--- a/packages/services/src/ui/screens/AccountMembersScreen.tsx
+++ b/packages/services/src/ui/screens/AccountMembersScreen.tsx
@@ -86,7 +86,15 @@ const AccountMembersScreen: React.FC<BaseScreenProps> = ({ onClose, goBack, acco
     enabled: canUsePrivateApi && id.length > 0 && canRead,
   });
   const members = useMemo<AccountMember[]>(() => membersQuery.data ?? [], [membersQuery.data]);
-  const ownerCount = useMemo(() => members.filter((m) => m.role === 'owner').length, [members]);
+  // DIRECT owners only. The list also carries members whose row lives on an
+  // ancestor, and the last-owner rule this count feeds is about the rows on THIS
+  // account — the server's guard counts those. Including an inherited owner
+  // would make a child that has no owner of its own look like it has exactly
+  // one, and silently disable removing anybody.
+  const ownerCount = useMemo(
+    () => members.filter((m) => m.role === 'owner' && m.source !== 'inherited').length,
+    [members],
+  );
 
   const invalidateMembers = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ['accounts', 'members', id] });
@@ -308,9 +316,18 @@ const AccountMembersScreen: React.FC<BaseScreenProps> = ({ onClose, goBack, acco
                   {members.map((member, index) => {
                     const isOwner = member.role === 'owner';
                     const isLastOwner = isOwner && ownerCount <= 1;
-                    const canEditThisRole = canUpdate && !isOwner;
-                    const canRemoveThisMember = canRemove && !isLastOwner && (!isOwner || canTransfer);
-                    const canTransferToThis = canTransfer && !isOwner && member.status === 'active';
+                    // An INHERITED entry's row lives on an ancestor account, and
+                    // every member mutation is scoped to rows on the account in
+                    // the path — so offering to edit, remove or promote one would
+                    // be offering a request the server answers 404. The row is
+                    // changed where it lives, on that ancestor's own member
+                    // screen.
+                    const isEditableHere = member.source !== 'inherited';
+                    const canEditThisRole = canUpdate && isEditableHere && !isOwner;
+                    const canRemoveThisMember =
+                      canRemove && isEditableHere && !isLastOwner && (!isOwner || canTransfer);
+                    const canTransferToThis =
+                      canTransfer && isEditableHere && !isOwner && member.status === 'active';
                     return (
                       <View key={member._id}>
                         {index > 0 ? <Divider color={colors.border} spacing={0} /> : null}
@@ -323,6 +340,13 @@ const AccountMembersScreen: React.FC<BaseScreenProps> = ({ onClose, goBack, acco
                               <View className="px-space-8 py-space-4 rounded-radius-full" style={{ backgroundColor: colors.primarySubtle }}>
                                 <Text className="text-caption font-bodyBold" style={{ color: colors.primary }}>
                                   {roleLabel('owner')}
+                                </Text>
+                              </View>
+                            ) : null}
+                            {!isEditableHere ? (
+                              <View className="px-space-8 py-space-4 rounded-radius-full" style={{ backgroundColor: colors.card }}>
+                                <Text className="text-caption font-caption text-text-secondary">
+                                  {t('accounts.members.inherited') || 'Inherited'}
                                 </Text>
                               </View>
                             ) : null}


### PR DESCRIPTION
## Summary

`GET /accounts/:id/members` authorised a read using the very row it then omitted. Measured against a real Postgres: for an inherited `editor` on a child account, the effective-access reader answered `{"role":"editor","source":"inherited","hasMembersRead":true,"hasActAs":true}` while the same request over HTTP returned **`200 {"members":[]}`**. Mention's `assertCanPublishAsAccount` scans that response for the caller's own id, so an inherited member read as "not a member" — while `POST /accounts/:id/switch` admitted the same person, as its own comment says it should ("directly or inherited").

Five readers of `account_members` exist, and they split by which QUESTION they answer — that split, not a policy disagreement, was the bug. Two answer "what does caller X hold over account Y?" and both already inherit (`resolveEffectiveAccess`, serving every `/accounts/:id/*` gate, `verifyActingAs`, `operatesAccount`; and `annotateAccounts`, serving the listings). One answers "who are the members of Y?" and did not inherit. Two answer "which ROW records this person" and correctly do not — those govern edits, and an inherited row belongs to the ancestor's authority.

The per-permission review concluded nothing should change. Every one of the 23 permissions is already inherited and has been. Arguing the hardest case rather than waving at it: `account:act_as` is the one that differs in kind, but narrowing it would revoke live capability from every inherited admin, and there is no coherent policy under which you may `account:delete` an account but not speak as it — which that same inherited admin can already do. For a `channel`, which can never be switched into, membership IS the whole right, and Mention already routes an inherited member's channel notifications off the inheriting reader. The policy was right; the roster was wrong.

This is a disclosure change, not a permission change. `listMembers` has exactly one caller and no access decision in oxy-api reads it. It now returns every direct non-removed row (byte-identical to before, `invited` included) plus the nearest cascading ancestor row for each person with no active direct row, resolved through the same shared helper the gates use — so the roster cannot reach a different conclusion about someone than the gate that admits them. Only `inherit: true`, active, on-path rows qualify.

The client half is not optional. Without it the fix would introduce a NEW affordance violation: edit controls would render on rows that `requireDirectMember` 404s, and a child with no owner of its own would read as "has exactly one", silently disabling removal. So edit/remove/transfer now require `source !== 'inherited'` and `ownerCount` counts direct owners only. `serializeMember`'s `source` parameter also lost its `= 'direct'` default, which was right at four call sites and silently wrong at the fifth.

**Who gains and loses:** in oxy-api, nobody gains — no gate reads this reader. In Mention, an inherited member of a channel or organization gains publish-as, insights, post-management and the moderation refusals that funnel through `assertCanPublishAsAccount` — exactly what `/switch` already gave the same person. Nobody loses; no permission was narrowed. Newly disclosed: a holder of `members:read` now sees ancestor members who cascade in — people who can already act on that account.

**A second instance of the same invariant, reported and deliberately NOT fixed:** `listAccessibleAccounts` treats an account as reachable if any ancestor is a direct membership, but the resolver then requires `inherit: true`, so an `inherit: false` grant yields nodes labelled `relationship: 'member'` with a null membership — offered in the caller's own forest and 403 on every route. Fixing it needs `AccountRelationship` to gain a fourth value, and `AccountMembersScreen.tsx` currently reads `relationship !== 'member'` as "implicit owner", so widening that enum without auditing every consumer turns a listing bug into a UI privilege escalation. Unreachable from Mention today.

## Test plan

Already run by the implementing agent (not re-run here):
- [x] Baseline 315 suites / 4541 tests green → 316 / 4553 green after, delta exactly the 12 new tests, zero regressions
- [x] `api` `tsc` clean
- [x] `services` typecheck clean
- [x] `api` eslint 0 errors
- [x] `core` biome 5 diagnostics before and after (unchanged baseline)
- [x] Seven mutations, each caught by the right test, with four-sided fixtures (direct / inherited / `inherit:false` / stranger) so "inherited counts" cannot pass as "any row up the tree counts"

Done in this session:
- [x] Dropped the stale `_invalidateAccountLists` declare workaround (superseded by `f478bd30`'s shared `accountCacheSweep` util)
- [x] Rebased cleanly onto `origin/main` (no conflicts)
- [x] `@oxyhq/core` build green on the rebased tree, confirmed built output wires through `accountCacheSweep`, not the dropped declare

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>