### PR TITLE
fix(services): a member with no resolvable handle is skipped, not stored as null

### DIFF
--- a/packages/services/src/ui/screens/AccountMembersScreen.tsx
+++ b/packages/services/src/ui/screens/AccountMembersScreen.tsx
@@ -99,7 +99,11 @@ const AccountMembersScreen: React.FC<BaseScreenProps> = ({ onClose, goBack, acco
   const memberLabelByUserId = useMemo(() => {
     const labels = new Map<string, string>();
     for (const profile of memberProfilesQuery.data ?? []) {
-      labels.set(profile.id, getNormalizedUserHandle(profile));
+      // `getNormalizedUserHandle` answers null for an actor with no resolvable
+      // handle. Leaving that entry out is what lets `memberDisplayLabel`'s own
+      // fallback run, rather than storing a null the map is not typed to hold.
+      const handle = getNormalizedUserHandle(profile);
+      if (handle) labels.set(profile.id, handle);
     }
     return labels;
   }, [memberProfilesQuery.data]);


### PR DESCRIPTION
`3f145f20` turned `main` red: `getNormalizedUserHandle` answers `string | null` and the label map is `Map<string, string>`, so `AccountMembersScreen.tsx:102` failed with TS2345. That takes the SDK's **definition-file build** down, and Auth, Commons, Inbox and Accounts all build the SDK first — four suites red from one line.

Skipping a null entry rather than widening the map is what lets `memberDisplayLabel`'s existing `?? memberUserId` fallback run, which is already what happens for a member whose profile never loaded.

**Why it got through:** `tsc --noEmit` on the package passes. The definition-file build is a separate and stricter pass, and it is the one CI runs. A green `--noEmit` is not evidence the package builds.

Verified with a control, not just a green run: with dependencies built, reverting this one change reproduces `Found 1 error` and exit 1; restoring it gives exit 0.