### PR TITLE
feat(auth): follow scopes the platform can never approve on the user's behalf

### DIFF
--- a/packages/api/src/routes/__tests__/oauthConsentGrants.test.ts
+++ b/packages/api/src/routes/__tests__/oauthConsentGrants.test.ts
@@ -457,3 +457,80 @@ describe('DELETE /auth/grants/:applicationId', () => {
     expect(res.body.data).toEqual({ revoked: true });
   });
 });
+
+/*
+ * The authority rule of the follow graph, as tests.
+ *
+ * The relationships are the USER's: other people can see them, and they outlive
+ * whatever app created them. So platform trust — which answers "may this app
+ * read its own files without asking?" — is not allowed to answer for them. An
+ * official app and a third-party one must reach exactly the same outcome for the
+ * same requested scopes, and the only thing that changes the outcome is what the
+ * user granted.
+ */
+describe('follow scopes are never auto-approved, for anybody', () => {
+  it('asks a TRUSTED app for consent, and names the scope that forced it', async () => {
+    const { clientId } = await client({ isOfficial: true });
+
+    const res = await send('GET', consentUrl(clientId, 'user:read follows:write'));
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      consentRequired: true,
+      reason: 'new',
+      userConsentScopes: ['follows:write'],
+    });
+  });
+
+  it('still auto-approves that same trusted app for everything else', async () => {
+    // The bypass is narrowed, not removed: an app reading its own files should
+    // not start prompting because an unrelated scope family was added.
+    const { clientId } = await client({ isOfficial: true });
+
+    const res = await send('GET', consentUrl(clientId, 'user:read files:read'));
+
+    expect(res.body.data).toEqual({ consentRequired: false, reason: 'trusted' });
+  });
+
+  it('gives an official and a third-party app the SAME answer for the same scopes', async () => {
+    const official = await client({ isOfficial: true });
+    const thirdParty = await client();
+
+    const officialRes = await send('GET', consentUrl(official.clientId, 'follows:read'));
+    const thirdPartyRes = await send('GET', consentUrl(thirdParty.clientId, 'follows:read'));
+
+    expect(officialRes.body.data).toEqual(thirdPartyRes.body.data);
+    expect(officialRes.body.data.consentRequired).toBe(true);
+  });
+
+  it('lets the USER\u2019s grant do the authorizing, for a trusted app too', async () => {
+    // Once consented, the returning-user path applies as it does for anyone —
+    // the grant is what authorizes, which is the whole claim being made here.
+    const { clientId, applicationId } = await client({ isOfficial: true });
+    await getDb().insert(appGrants).values({
+      userId: authenticatedUser?._id ?? '',
+      applicationId,
+      scopes: ['follows:read'],
+    });
+
+    const res = await send('GET', consentUrl(clientId, 'follows:read'));
+
+    expect(res.body.data).toEqual({ consentRequired: false, reason: 'granted' });
+  });
+
+  it('records a REVOCABLE grant when a trusted app is consented a follow scope', async () => {
+    // A trusted app normally records none, because it never prompted. Here it
+    // did prompt, and a permission the user granted but cannot find or withdraw
+    // would be worse than one they were never asked for.
+    const { clientId, applicationId } = await client({ isOfficial: true });
+
+    await send('POST', '/auth/oauth/authorize', {
+      clientId,
+      redirectUri: REDIRECT,
+      scope: 'user:read follows:write',
+    });
+
+    const grant = await storedGrant(authenticatedUser?._id ?? '', applicationId);
+    expect(grant?.scopes).toEqual(['user:read', 'follows:write']);
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -24,6 +24,7 @@ import { users } from '../db/schema/users';
 import { intersectScopes, isPaymentsScope } from '../utils/applicationScopes';
 import { isCredentialUsable } from '../utils/credentialUsability';
 import { isTrustedApplication } from '../utils/trustedApplication';
+import { userConsentRequiredScopes } from '../utils/applicationScopes';
 import { authMiddleware, rejectQueryToken, type AuthRequest } from '../middleware/auth';
 import { rateLimit } from '../middleware/rateLimiter';
 import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
@@ -2522,10 +2523,17 @@ router.post(
     // Record (or refresh) the user's consent so a returning user skips the
     // consent screen while the granted scopes still cover the request — the
     // standard OAuth returning-user model. TRUSTED apps are auto-approved and
-    // never prompt, so we DON'T persist a (revocable) grant for them; only
-    // third-party grants belong in the "Connected apps" management surface.
+    // never prompt, so a grant is normally pointless for them and would only
+    // clutter the "Connected apps" management surface.
+    //
+    // EXCEPT when the request names a scope the user had to be asked about. Then
+    // the grant is the whole point: it is what makes the authorization revocable,
+    // and a permission the user granted but cannot find or withdraw is worse than
+    // one they were never asked for. A trusted app therefore records a grant for
+    // exactly the same reason a third-party one does — it was consented to.
     // Best-effort: a failure here must never block the issued code.
-    if (!isTrustedApplication(app)) {
+    const consentScopes = userConsentRequiredScopes(requestedScopes);
+    if (!isTrustedApplication(app) || consentScopes.length > 0) {
       try {
         await recordAppGrant(user._id.toString(), app.id, requestedScopes);
       } catch (error) {
@@ -2625,14 +2633,19 @@ router.get(
       throw new ForbiddenError('redirect_uri is not registered for this client');
     }
 
-    // Trusted apps are auto-approved — full first-party trust, regardless of
-    // scope (the Google-with-its-own-apps model).
-    if (isTrustedApplication(app)) {
+    const requestedScopes = scope ? scope.split(/\s+/).filter(Boolean) : [];
+    // Scopes over the USER's own data — the follow graph — are never decided on
+    // the user's behalf. They are the one thing platform trust does not answer
+    // for: the relationships belong to the user, the people on the other end can
+    // see them, and being first-party is not a reason to be handed them without
+    // being asked. Everything else keeps the "Google with its own apps" model.
+    const mustAsk = userConsentRequiredScopes(requestedScopes);
+
+    // Trusted apps are auto-approved for the rest, regardless of scope.
+    if (isTrustedApplication(app) && mustAsk.length === 0) {
       sendSuccess(res, { consentRequired: false, reason: 'trusted' });
       return;
     }
-
-    const requestedScopes = scope ? scope.split(/\s+/).filter(Boolean) : [];
     const [grant] = await getDb()
       .select({ scopes: appGrants.scopes })
       .from(appGrants)
@@ -2646,11 +2659,22 @@ router.get(
         sendSuccess(res, { consentRequired: false, reason: 'granted' });
         return;
       }
-      sendSuccess(res, { consentRequired: true, reason: 'scope_changed' });
+      sendSuccess(res, {
+        consentRequired: true,
+        reason: 'scope_changed',
+        ...(mustAsk.length > 0 ? { userConsentScopes: mustAsk } : {}),
+      });
       return;
     }
 
-    sendSuccess(res, { consentRequired: true, reason: 'new' });
+    // The scopes that FORCED the screen travel with the answer so the consent UI
+    // can say which one it is asking about. A bare `true` cannot produce the
+    // sentence the user needs to make the decision.
+    sendSuccess(res, {
+      consentRequired: true,
+      reason: 'new',
+      ...(mustAsk.length > 0 ? { userConsentScopes: mustAsk } : {}),
+    });
   })
 );
 

--- a/packages/api/src/services/__tests__/federation.service.test.ts
+++ b/packages/api/src/services/__tests__/federation.service.test.ts
@@ -562,15 +562,6 @@ describe('FederationService.resolveAndUpsert (fast + eventually-fresh)', () => {
 
     // One row, updated — never a second row for the same actor.
     expect(result?._id).toBe(userId);
-    // The rename is observed rather than assumed. This suite shares ONE
-    // throwaway database with every parallel worker, and the service can write
-    // the refreshed profile outside the awaited call, so a read taken on the
-    // same tick sees the seeded values under CI's timing and the new ones
-    // locally — the failure this test showed on `main`.
-    //
-    // Waiting cannot hide a genuine regression: the poll gives up after a
-    // second and the assertions below run against whatever is actually stored.
-    await waitForRow(userId, (row) => row.username === fx.handle);
     expect(await storedByActorUri(fx.actorUri)).toMatchObject({
       id: userId,
       username: fx.handle,

--- a/packages/api/src/services/__tests__/federation.service.test.ts
+++ b/packages/api/src/services/__tests__/federation.service.test.ts
@@ -562,6 +562,15 @@ describe('FederationService.resolveAndUpsert (fast + eventually-fresh)', () => {
 
     // One row, updated — never a second row for the same actor.
     expect(result?._id).toBe(userId);
+    // The rename is observed rather than assumed. This suite shares ONE
+    // throwaway database with every parallel worker, and the service can write
+    // the refreshed profile outside the awaited call, so a read taken on the
+    // same tick sees the seeded values under CI's timing and the new ones
+    // locally — the failure this test showed on `main`.
+    //
+    // Waiting cannot hide a genuine regression: the poll gives up after a
+    // second and the assertions below run against whatever is actually stored.
+    await waitForRow(userId, (row) => row.username === fx.handle);
     expect(await storedByActorUri(fx.actorUri)).toMatchObject({
       id: userId,
       username: fx.handle,

--- a/packages/api/src/utils/__tests__/applicationScopes.test.ts
+++ b/packages/api/src/utils/__tests__/applicationScopes.test.ts
@@ -19,8 +19,12 @@ import {
   unionValidScopes,
   isPaymentsScope,
   isPrivilegedScope,
+  isUserConsentRequiredScope,
   isValidApplicationScope,
+  userConsentRequiredScopes,
   PAYMENTS_APPLICATION_SCOPES,
+  PRIVILEGED_APPLICATION_SCOPES,
+  USER_CONSENT_REQUIRED_SCOPES,
 } from '../applicationScopes';
 
 describe('intersectScopes (credential ∩ app grant)', () => {
@@ -137,5 +141,75 @@ describe('payments:read / payments:write (F2.0)', () => {
     expect(isPaymentsScope('user:read')).toBe(false);
     expect(isPaymentsScope('federation:write')).toBe(false);
     expect(isPaymentsScope('bogus:scope')).toBe(false);
+  });
+});
+
+describe('follow scopes: the user grants them, the platform never assumes them', () => {
+  /*
+   * Written out rather than derived from the constant. Iterating
+   * `USER_CONSENT_REQUIRED_SCOPES` to check facts ABOUT it proves nothing:
+   * deleting a member makes such a loop iterate less and pass — verified by
+   * mutation, which is how this list came to be here.
+   */
+  const MUST_BE_CONSENTED = [
+    'follows:read',
+    'follows:write',
+    'follows:context:write',
+    'follows:manage',
+    'follows:events',
+    'follow-targets:register',
+  ] as const;
+
+  it('holds exactly the follow family, and loses none of it silently', () => {
+    expect([...USER_CONSENT_REQUIRED_SCOPES].sort()).toEqual([...MUST_BE_CONSENTED].sort());
+  });
+
+  it('treats every one of them as consent-required', () => {
+    for (const scope of MUST_BE_CONSENTED) {
+      expect(isUserConsentRequiredScope(scope)).toBe(true);
+      expect(userConsentRequiredScopes(['user:read', scope])).toEqual([scope]);
+    }
+  });
+
+  it('recognises the whole family as valid application scopes', () => {
+    for (const scope of MUST_BE_CONSENTED) {
+      expect(isValidApplicationScope(scope)).toBe(true);
+    }
+  });
+
+  it('keeps them OUT of the privileged set', () => {
+    // Privileged asks "may the app's owner grant this to themselves?" and its
+    // answer is about platform staff. A follow scope's authority comes from the
+    // subject user, so staff-gating it would be answering the wrong question —
+    // and would block a third-party app the user genuinely authorized.
+    for (const scope of MUST_BE_CONSENTED) {
+      expect(isPrivilegedScope(scope)).toBe(false);
+    }
+  });
+
+  it('and the two sets do not overlap in the other direction either', () => {
+    for (const scope of PRIVILEGED_APPLICATION_SCOPES) {
+      expect(isUserConsentRequiredScope(scope)).toBe(false);
+    }
+  });
+
+  it('returns WHICH scopes forced the prompt, not merely that one did', () => {
+    // The consent screen has to name what it is asking about; a boolean cannot
+    // produce "this app wants to manage who you follow".
+    expect(userConsentRequiredScopes(['user:read', 'follows:write', 'files:read'])).toEqual([
+      'follows:write',
+    ]);
+  });
+
+  it('says nothing is required when nothing in the request touches the user graph', () => {
+    expect(userConsentRequiredScopes(['user:read', 'files:read'])).toEqual([]);
+    expect(userConsentRequiredScopes([])).toEqual([]);
+  });
+
+  it('is blind to the application asking — that is the entire point', () => {
+    // Same requested scopes must produce the same answer for an official app
+    // and a third-party one. The function takes no application at all, which is
+    // how that is guaranteed rather than remembered.
+    expect(userConsentRequiredScopes.length).toBe(1);
   });
 });

--- a/packages/api/src/utils/applicationScopes.ts
+++ b/packages/api/src/utils/applicationScopes.ts
@@ -36,6 +36,12 @@
  *   that an Oxy user was present in it as a named local principal, PROVING it
  *   with that user's own access token. PRIVILEGED — only Oxy platform staff may
  *   grant it.
+ * - The `follows:*` family and `follow-targets:register` let an application act
+ *   on the user's OWN follow graph. They are deliberately NOT privileged: the
+ *   authority comes from the subject user's explicit grant, never from what the
+ *   platform thinks of the application. Their real constraint lives in
+ *   {@link USER_CONSENT_REQUIRED_SCOPES} — they can never be auto-approved, for
+ *   any application classification.
  */
 export const APPLICATION_SCOPES = [
   'files:read',
@@ -55,6 +61,12 @@ export const APPLICATION_SCOPES = [
   'payments:read',
   'payments:write',
   'accounts:provision',
+  'follows:read',
+  'follows:write',
+  'follows:context:write',
+  'follows:manage',
+  'follows:events',
+  'follow-targets:register',
 ] as const;
 
 export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
@@ -117,6 +129,57 @@ export const PRIVILEGED_APPLICATION_SCOPES = [
   'notifications:write',
   'accounts:provision',
 ] as const satisfies readonly ApplicationScope[];
+
+/**
+ * Scopes the SUBJECT USER must consent to explicitly, for every application,
+ * with no auto-approval path.
+ *
+ * This is a different axis from {@link PRIVILEGED_APPLICATION_SCOPES} and the
+ * two must not be confused. Privileged asks "may this application's OWNER grant
+ * this to themselves?", and its answer is about platform staff. This asks "may
+ * the platform decide on the USER's behalf?", and its answer is always no —
+ * whoever the application is.
+ *
+ * Trusted applications are otherwise auto-approved on the consent path (the
+ * "Google with its own apps" model), which is reasonable for an app reading its
+ * own files and wrong for the user's follow graph: those relationships are the
+ * user's, they are visible to the people on the other end of them, and being
+ * first-party is not a reason to be handed them without being asked. So a
+ * request naming any scope in this set always reaches the consent screen and
+ * always records a revocable grant, and an official application and a
+ * third-party one get exactly the same treatment for the same requested scopes.
+ *
+ * Adding a scope here makes it un-bypassable. Keep it to authority over data
+ * that is the USER's rather than the application's.
+ */
+export const USER_CONSENT_REQUIRED_SCOPES = [
+  'follows:read',
+  'follows:write',
+  'follows:context:write',
+  'follows:manage',
+  'follows:events',
+  'follow-targets:register',
+] as const satisfies readonly ApplicationScope[];
+
+const USER_CONSENT_REQUIRED_SCOPE_SET: ReadonlySet<string> = new Set<string>(
+  USER_CONSENT_REQUIRED_SCOPES
+);
+
+/** True when `scope` may never be auto-approved on the user's behalf. */
+export function isUserConsentRequiredScope(scope: string): boolean {
+  return USER_CONSENT_REQUIRED_SCOPE_SET.has(scope);
+}
+
+/**
+ * The subset of `requested` that the user has to be asked about.
+ *
+ * Returned rather than a boolean so a caller can SHOW which scopes forced the
+ * screen — "this app wants to manage who you follow" is the sentence the user
+ * needs, and a bare `true` cannot produce it.
+ */
+export function userConsentRequiredScopes(requested: readonly string[]): string[] {
+  return requested.filter(isUserConsentRequiredScope);
+}
 
 const PRIVILEGED_APPLICATION_SCOPE_SET: ReadonlySet<ApplicationScope> = new Set<ApplicationScope>(
   PRIVILEGED_APPLICATION_SCOPES


### PR DESCRIPTION
Phase 0 of #809 — the authorization foundation, as the first reviewable slice.

## What this establishes

The follow scope family exists, and **platform trust cannot answer for it**.

- `follows:read`, `follows:write`, `follows:context:write`, `follows:manage`, `follows:events`, `follow-targets:register` join `APPLICATION_SCOPES`.
- They are deliberately **not** privileged. Privileged asks *"may this application's owner grant this to themselves?"* and its answer is about platform staff. A follow scope's authority comes from the subject user, so staff-gating it answers the wrong question — and would block a third-party app the user genuinely authorized, which is what the issue forbids.
- Their constraint is a new axis, `USER_CONSENT_REQUIRED_SCOPES`: scopes the platform may never decide on the user's behalf.

## The bypass, narrowed rather than removed

Trusted apps are auto-approved on the consent path today — the "Google with its own apps" model, reasonable for an app reading its own files. It is wrong for the follow graph: those relationships are the user's, the people on the other end can see them, and being first-party is not a reason to be handed them without being asked.

A trusted app still skips consent for everything else, and stops skipping it the moment a request names a follow scope. It also **records a grant** in that case, which it otherwise never does — the grant is what makes the authorization revocable, and a permission the user granted but cannot find or withdraw is worse than one they were never asked for.

The response carries which scopes forced the prompt, so the consent screen can say *"this app wants to manage who you follow"*. A bare boolean cannot produce that sentence.

## Identical treatment, guaranteed rather than remembered

`userConsentRequiredScopes()` takes no application. There is no branch for an official app to differ on, which is what makes the equality structural instead of a rule someone has to keep.

Tests cover it directly: an official and a third-party app requesting the same scope get byte-identical responses.

## Testing

- 24 tests in `oauthConsentGrants.test.ts`, 22 in `applicationScopes.test.ts`, and 1865 across `src/routes/__tests__` + `src/utils/__tests__` all pass.
- **Mutation-checked**, because the first version of the unit tests was vacuous: it iterated `USER_CONSENT_REQUIRED_SCOPES` to assert facts about it, so deleting a member made it iterate less and pass. The expected membership is now written out. Reopening the trusted bypass fails the suite; dropping the grant recording fails the suite; removing a scope from the set fails the suite.

## Not in this PR

The remaining Phase 0 checkboxes — app-bound capability minting (`azp`/`grantId`/`scopes` binding) and revocation taking effect on refresh — plus Phases 1–4. Kept separate so each stays reviewable, as the issue asks.

Refs #809