### PR TITLE
feat(follows): one command service, one transaction per change

### DIFF
--- a/packages/api/src/db/schema/deferredForeignKeys.ts
+++ b/packages/api/src/db/schema/deferredForeignKeys.ts
@@ -28,6 +28,7 @@ import { authCodes } from './authCodes';
 import { authSessions } from './authSessions';
 import { billingSubscriptions } from './billingSubscriptions';
 import { billingTransactions } from './billingTransactions';
+import { followEvents } from './followEvents';
 import { bookmarks } from './bookmarks';
 import { conductStrikes } from './conductStrikes';
 import { devicePairingSessions } from './devicePairingSessions';
@@ -87,6 +88,23 @@ export const DEFERRED_FOREIGN_KEYS: readonly DeferredForeignKey[] = [
 ];
 
 export const ID_COLUMNS_WITHOUT_FOREIGN_KEY: readonly IdColumnWithoutForeignKey[] = [
+  {
+    table: followEvents,
+    column: followEvents.relationshipId,
+    reason:
+      'The outbox has to OUTLIVE what it describes. `follow.removed` is an event about a ' +
+      'relationship that no longer exists, so a foreign key would delete the record of the ' +
+      'removal at the exact moment a consumer — federation teardown, a notification ' +
+      'projection — needs to read it. The id is kept as a plain column deliberately.',
+  },
+  {
+    table: followEvents,
+    column: followEvents.eventId,
+    reason:
+      'Not a reference at all despite the name: it is this event\u2019s OWN public, ' +
+      'deterministic identity, which consumers dedupe redeliveries on. There is nothing ' +
+      'for it to point at.',
+  },
   {
     table: bookmarks,
     column: bookmarks.postId,

--- a/packages/api/src/services/__tests__/followCommand.service.test.ts
+++ b/packages/api/src/services/__tests__/followCommand.service.test.ts
@@ -1,0 +1,379 @@
+/**
+ * The behaviour #809 specifies, as tests.
+ *
+ * The interesting cases are the ones about what must NOT happen: a second
+ * application consuming an existing relationship must not create a second event
+ * or move counts again, disabling in one application must not touch the global
+ * edge, and an expiry must go down the same path as a manual unfollow rather
+ * than a quiet delete.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { applications } from '../../db/schema/applications';
+import { followApplicationOverrides } from '../../db/schema/followApplicationOverrides';
+import { followEvents } from '../../db/schema/followEvents';
+import { followRelationships } from '../../db/schema/followRelationships';
+import { followTargetKinds } from '../../db/schema/followTargetKinds';
+import { followTargets } from '../../db/schema/followTargets';
+import { userFollows } from '../../db/schema/userFollows';
+import { users } from '../../db/schema/users';
+import type { FollowCapability } from '../followCapability.service';
+import {
+  expireDueFollows,
+  followTarget,
+  getFollowStatus,
+  restoreInheritance,
+  setApplicationMode,
+  unfollowEverywhere,
+} from '../followCommand.service';
+
+let followerId: string;
+let followedId: string;
+let appA: string;
+let appB: string;
+let userTarget: { id: string; canonicalUri: string; kind: string; localUserId: string | null };
+let counter = 0;
+
+const unique = (prefix: string) => `${prefix}${(counter += 1)}`;
+
+function capabilityFor(applicationId: string): FollowCapability {
+  return {
+    userId: followerId,
+    applicationId,
+    grantId: null as unknown as string,
+    scopes: ['follows:read', 'follows:write', 'follows:context:write'],
+    sessionId: 'session',
+  };
+}
+
+async function makeApplication(name: string) {
+  const [app] = await getDb()
+    .insert(applications)
+    .values({ name, status: 'active', ownerAccountId: followerId })
+    .returning({ id: applications.id });
+  return app.id;
+}
+
+async function makeUserTarget(localUserId: string) {
+  const uri = unique('https://oxy.so/users/u');
+  const [row] = await getDb()
+    .insert(followTargets)
+    .values({ canonicalUri: uri, kind: 'oxy.user', localUserId })
+    .returning({ id: followTargets.id });
+  return { id: row.id, canonicalUri: uri, kind: 'oxy.user', localUserId };
+}
+
+async function eventsFor(relationshipId: string) {
+  return getDb()
+    .select({ type: followEvents.type, cause: followEvents.cause })
+    .from(followEvents)
+    .where(eq(followEvents.relationshipId, relationshipId));
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+beforeEach(async () => {
+  const [a] = await getDb().insert(users).values({}).returning({ id: users.id });
+  const [b] = await getDb().insert(users).values({}).returning({ id: users.id });
+  followerId = a.id;
+  followedId = b.id;
+  appA = await makeApplication(unique('App A '));
+  appB = await makeApplication(unique('App B '));
+  userTarget = await makeUserTarget(followedId);
+});
+
+describe('following is global, and happens once', () => {
+  it('writes the relationship, the account graph and the event together', async () => {
+    const result = await followTarget({ capability: capabilityFor(appA), target: userTarget });
+
+    expect(result.created).toBe(true);
+    expect(result.status.effectiveState).toBe('following');
+
+    const [edge] = await getDb()
+      .select({ id: userFollows.id })
+      .from(userFollows)
+      .where(and(eq(userFollows.followerId, followerId), eq(userFollows.followedId, followedId)))
+      .limit(1);
+    expect(edge).toBeDefined();
+    expect(await eventsFor(result.relationshipId)).toEqual([
+      { type: 'follow.created', cause: 'user_action' },
+    ]);
+  });
+
+  it('is idempotent — following twice is one relationship and one event', async () => {
+    const first = await followTarget({ capability: capabilityFor(appA), target: userTarget });
+    const second = await followTarget({ capability: capabilityFor(appA), target: userTarget });
+
+    expect(second.relationshipId).toBe(first.relationshipId);
+    expect(second.created).toBe(false);
+    expect(await eventsFor(first.relationshipId)).toHaveLength(1);
+  });
+
+  it('shows as following in ANOTHER application, and emits nothing for it', async () => {
+    // The rule #809 states directly: follow from app A, and app B sees it
+    // silently. A second event here would become a second "new follower"
+    // notification for the same edge.
+    const created = await followTarget({ capability: capabilityFor(appA), target: userTarget });
+
+    const seenFromB = await getFollowStatus({
+      capability: capabilityFor(appB),
+      targetId: userTarget.id,
+    });
+
+    expect(seenFromB.effectiveState).toBe('following');
+    expect(seenFromB.applicationMode).toBe('inherit');
+    expect(await eventsFor(created.relationshipId)).toHaveLength(1);
+  });
+
+  it('refuses to let a user follow themselves', async () => {
+    const self = await makeUserTarget(followerId);
+
+    await expect(
+      followTarget({ capability: capabilityFor(appA), target: self })
+    ).rejects.toThrow('Cannot follow yourself');
+  });
+});
+
+describe('disabling in one application is private and local', () => {
+  it('leaves the global relationship and the account graph untouched', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+
+    await setApplicationMode({
+      capability: capabilityFor(appB),
+      relationshipId,
+      mode: 'disabled',
+    });
+
+    const [relationship] = await getDb()
+      .select({ state: followRelationships.state })
+      .from(followRelationships)
+      .where(eq(followRelationships.id, relationshipId))
+      .limit(1);
+    expect(relationship.state).toBe('active');
+
+    const [edge] = await getDb()
+      .select({ id: userFollows.id })
+      .from(userFollows)
+      .where(and(eq(userFollows.followerId, followerId), eq(userFollows.followedId, followedId)))
+      .limit(1);
+    expect(edge).toBeDefined();
+  });
+
+  it('changes what THIS application sees and nothing about the others', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+    await setApplicationMode({ capability: capabilityFor(appB), relationshipId, mode: 'disabled' });
+
+    const fromB = await getFollowStatus({
+      capability: capabilityFor(appB),
+      targetId: userTarget.id,
+    });
+    const fromA = await getFollowStatus({
+      capability: capabilityFor(appA),
+      targetId: userTarget.id,
+    });
+
+    expect(fromB.applicationMode).toBe('disabled');
+    expect(fromB.effectiveState).toBe('not_following');
+    // Still following globally, and still visible as such where it was not
+    // disabled — the state the UI has to be able to say out loud.
+    expect(fromB.globalState).toBe('active');
+    expect(fromA.effectiveState).toBe('following');
+  });
+
+  it('restores inheritance by REMOVING the override, not by writing enabled', async () => {
+    // "I never said" and "I said yes here" are different answers, and only the
+    // first keeps following a future change of default.
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+    await setApplicationMode({ capability: capabilityFor(appB), relationshipId, mode: 'disabled' });
+
+    await restoreInheritance({ capability: capabilityFor(appB), relationshipId });
+
+    const rows = await getDb()
+      .select({ id: followApplicationOverrides.id })
+      .from(followApplicationOverrides)
+      .where(eq(followApplicationOverrides.relationshipId, relationshipId));
+    expect(rows).toHaveLength(0);
+  });
+
+  it('refuses to configure a relationship belonging to somebody else', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+    const [stranger] = await getDb().insert(users).values({}).returning({ id: users.id });
+
+    const result = await setApplicationMode({
+      capability: { ...capabilityFor(appA), userId: stranger.id },
+      relationshipId,
+      mode: 'disabled',
+    });
+
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('unfollowing everywhere', () => {
+  it('removes the relationship, the edge and the overrides, and says so once', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+    await setApplicationMode({ capability: capabilityFor(appB), relationshipId, mode: 'disabled' });
+
+    const result = await unfollowEverywhere({ capability: capabilityFor(appA), relationshipId });
+
+    expect(result.removed).toBe(true);
+    expect(
+      await getDb()
+        .select({ id: followRelationships.id })
+        .from(followRelationships)
+        .where(eq(followRelationships.id, relationshipId))
+    ).toHaveLength(0);
+    expect(
+      await getDb()
+        .select({ id: followApplicationOverrides.id })
+        .from(followApplicationOverrides)
+        .where(eq(followApplicationOverrides.relationshipId, relationshipId))
+    ).toHaveLength(0);
+    expect(
+      await getDb()
+        .select({ id: userFollows.id })
+        .from(userFollows)
+        .where(and(eq(userFollows.followerId, followerId), eq(userFollows.followedId, followedId)))
+    ).toHaveLength(0);
+  });
+
+  it('keeps the removal event after the relationship is gone', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+
+    await unfollowEverywhere({ capability: capabilityFor(appA), relationshipId });
+
+    const events = await eventsFor(relationshipId);
+    expect(events).toContainEqual({ type: 'follow.removed', cause: 'user_action' });
+  });
+
+  it('is idempotent, and refuses somebody else’s relationship', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+    const [stranger] = await getDb().insert(users).values({}).returning({ id: users.id });
+
+    expect(
+      await unfollowEverywhere({
+        capability: { ...capabilityFor(appA), userId: stranger.id },
+        relationshipId,
+      })
+    ).toEqual({ removed: false });
+
+    await unfollowEverywhere({ capability: capabilityFor(appA), relationshipId });
+    expect(
+      await unfollowEverywhere({ capability: capabilityFor(appA), relationshipId })
+    ).toEqual({ removed: false });
+  });
+});
+
+describe('a timed follow ends like a manual one', () => {
+  it('expires down the same path, and says the cause was the clock', async () => {
+    // The point of routing expiry through the command service: it emits
+    // `follow.removed`, so federation teardown and count movement happen exactly
+    // as they do for a decision. `cause` is what lets a consumer tell them
+    // apart — nobody was told there was a clock, so nobody is notified.
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+      expiresAt: new Date(Date.now() - 1000),
+    });
+
+    const removed = await expireDueFollows();
+
+    expect(removed).toBeGreaterThanOrEqual(1);
+    expect(await eventsFor(relationshipId)).toContainEqual({
+      type: 'follow.removed',
+      cause: 'expired',
+    });
+    expect(
+      await getDb()
+        .select({ id: userFollows.id })
+        .from(userFollows)
+        .where(and(eq(userFollows.followerId, followerId), eq(userFollows.followedId, followedId)))
+    ).toHaveLength(0);
+  });
+
+  it('leaves a follow whose time has not come', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+
+    await expireDueFollows();
+
+    expect(
+      await getDb()
+        .select({ id: followRelationships.id })
+        .from(followRelationships)
+        .where(eq(followRelationships.id, relationshipId))
+    ).toHaveLength(1);
+  });
+
+  it('never touches a permanent follow', async () => {
+    const { relationshipId } = await followTarget({
+      capability: capabilityFor(appA),
+      target: userTarget,
+    });
+
+    await expireDueFollows();
+
+    expect(
+      await getDb()
+        .select({ id: followRelationships.id })
+        .from(followRelationships)
+        .where(eq(followRelationships.id, relationshipId))
+    ).toHaveLength(1);
+  });
+});
+
+describe('non-user targets', () => {
+  it('follows a target that is not an account, without touching the account graph', async () => {
+    const ns = unique('shopz');
+    await getDb().insert(followTargetKinds).values({ kind: `${ns}.store`, namespace: ns });
+    const uri = unique('https://shop.example/stores/s');
+    const [row] = await getDb()
+      .insert(followTargets)
+      .values({ canonicalUri: uri, kind: `${ns}.store` })
+      .returning({ id: followTargets.id });
+
+    const result = await followTarget({
+      capability: capabilityFor(appA),
+      target: { id: row.id, canonicalUri: uri, kind: `${ns}.store`, localUserId: null },
+    });
+
+    expect(result.created).toBe(true);
+    expect(
+      await getDb()
+        .select({ id: userFollows.id })
+        .from(userFollows)
+        .where(eq(userFollows.followerId, followerId))
+    ).toHaveLength(0);
+  });
+});

--- a/packages/api/src/services/followCommand.service.ts
+++ b/packages/api/src/services/followCommand.service.ts
@@ -1,0 +1,524 @@
+/**
+ * The ONE place a follow relationship changes.
+ *
+ * Every mutation — from an application, from an expiry sweep, from an inbound
+ * federation activity, from a migration — goes through here, and each does
+ * three things in a SINGLE transaction:
+ *
+ *   1. the authoritative row in `follow_relationships`
+ *   2. the `user_follows` projection, when the target is an Oxy account
+ *   3. an event in `follow_events`
+ *
+ * One transaction is the whole design. Two writes that can succeed
+ * independently will eventually disagree, and the disagreement is invisible: a
+ * relationship with no event never federates and never notifies; an event with
+ * no relationship makes a remote server believe in a follow nobody has. Neither
+ * shows up as an error anywhere.
+ *
+ * ## Why `user_follows` stays
+ *
+ * It is the optimized account graph every existing read sits on — recommendations,
+ * mutuals, follows-of-follows, the paginated lists, `graphExclusion`. #809 is
+ * explicit that it must not be removed before its replacement is benchmarked and
+ * every reader has moved. So user-to-user follows write BOTH, in the same
+ * transaction, which is what makes drift unrepresentable rather than merely
+ * unlikely.
+ *
+ * ## Idempotency
+ *
+ * Following twice is one relationship, one event, one count movement. The
+ * unique constraint on (follower, target) does the work, and the command reads
+ * back what actually happened rather than assuming — `created` is the return of
+ * the insert, not a guess made before it.
+ */
+
+import { and, eq, isNotNull, lte } from 'drizzle-orm';
+import { getDb } from '../config/postgres';
+import { followApplicationOverrides } from '../db/schema/followApplicationOverrides';
+import { followEvents, type FollowEventCause, type FollowEventType } from '../db/schema/followEvents';
+import { followRelationships } from '../db/schema/followRelationships';
+import { followTargets } from '../db/schema/followTargets';
+import { userFollows } from '../db/schema/userFollows';
+import { logger } from '../utils/logger';
+import type { FollowCapability } from './followCapability.service';
+
+/** A transaction handle, or the pool when a caller has no transaction of its own. */
+type Db = ReturnType<typeof getDb>;
+type Tx = Parameters<Parameters<Db['transaction']>[0]>[0];
+
+export interface FollowStatus {
+  relationshipId?: string;
+  globalState: 'none' | 'requested' | 'active' | 'rejected';
+  applicationMode: 'inherit' | 'enabled' | 'disabled';
+  effectiveState: 'not_following' | 'requested' | 'following';
+  expiresAt?: string;
+}
+
+/**
+ * The platform acting without an application behind it — expiry, reconciliation,
+ * an inbound federation activity. Deliberately a DIFFERENT type from
+ * {@link FollowCapability}: those carry a user's grant, and this carries the
+ * absence of one, which a caller should have to say out loud.
+ */
+export interface SystemCapability {
+  userId: string;
+  applicationId: string | null;
+  grantId: string | null;
+  scopes: readonly string[];
+  sessionId: string;
+}
+
+export interface FollowResult {
+  relationshipId: string;
+  /** False when the relationship already existed — no event, no count movement. */
+  created: boolean;
+  status: FollowStatus;
+}
+
+/**
+ * A stable event id.
+ *
+ * Deterministic from (type, relationship, moment) rather than random, so a
+ * command retried after a crash between transaction and acknowledgement writes
+ * the same id and the unique constraint absorbs it. Randomness here would make
+ * a retry look like a second event, which is exactly what a consumer cannot
+ * tell apart.
+ */
+function eventId(type: FollowEventType, relationshipId: string, at: Date): string {
+  return `${type}:${relationshipId}:${at.getTime()}`;
+}
+
+/**
+ * Effective state = the global relationship, unless this application says
+ * otherwise.
+ *
+ * Absence of an override means inherit. That is the default and the common
+ * case, so it is expressed as "no row" rather than as a value nobody wrote.
+ */
+function effectiveState(
+  globalState: FollowStatus['globalState'],
+  mode: FollowStatus['applicationMode']
+): FollowStatus['effectiveState'] {
+  if (mode === 'disabled') return 'not_following';
+  if (globalState === 'active') return 'following';
+  if (globalState === 'requested') return 'requested';
+  return 'not_following';
+}
+
+async function readStatus(
+  tx: Tx | Db,
+  userId: string,
+  applicationId: string,
+  targetId: string
+): Promise<FollowStatus> {
+  const [relationship] = await tx
+    .select({
+      id: followRelationships.id,
+      state: followRelationships.state,
+      expiresAt: followRelationships.expiresAt,
+    })
+    .from(followRelationships)
+    .where(
+      and(
+        eq(followRelationships.followerUserId, userId),
+        eq(followRelationships.followTargetId, targetId)
+      )
+    )
+    .limit(1);
+
+  if (!relationship) {
+    return { globalState: 'none', applicationMode: 'inherit', effectiveState: 'not_following' };
+  }
+
+  const [override] = await tx
+    .select({ mode: followApplicationOverrides.mode })
+    .from(followApplicationOverrides)
+    .where(
+      and(
+        eq(followApplicationOverrides.relationshipId, relationship.id),
+        eq(followApplicationOverrides.applicationId, applicationId)
+      )
+    )
+    .limit(1);
+
+  const mode = override?.mode ?? 'inherit';
+  return {
+    relationshipId: relationship.id,
+    globalState: relationship.state,
+    applicationMode: mode,
+    effectiveState: effectiveState(relationship.state, mode),
+    ...(relationship.expiresAt ? { expiresAt: relationship.expiresAt.toISOString() } : {}),
+  };
+}
+
+/** Write the outbox row. Always inside the caller's transaction — never after it. */
+async function emit(
+  tx: Tx,
+  input: {
+    type: FollowEventType;
+    cause: FollowEventCause;
+    /**
+     * `applicationId` and `grantId` are nullable here and nowhere else. A user
+     * action always has both; expiry and reconciliation are the PLATFORM acting
+     * on an instruction the user already gave, so there is no application asking
+     * and no grant to cite. Writing `''` instead would be a foreign key that
+     * names nothing — it fails the insert, and inside a sweep that failure is a
+     * silently skipped expiry.
+     */
+    capability: {
+      userId: string;
+      applicationId?: string | null;
+      grantId?: string | null;
+    };
+    relationshipId: string;
+    targetUri: string;
+    targetKind: string;
+    contextApplicationId?: string;
+    at: Date;
+  }
+): Promise<void> {
+  await tx
+    .insert(followEvents)
+    .values({
+      eventId: eventId(input.type, input.relationshipId, input.at),
+      type: input.type,
+      cause: input.cause,
+      actorUserId: input.capability.userId,
+      relationshipId: input.relationshipId,
+      targetUri: input.targetUri,
+      targetKind: input.targetKind,
+      ...(input.capability.applicationId
+        ? { originApplicationId: input.capability.applicationId }
+        : {}),
+      ...(input.capability.grantId ? { grantId: input.capability.grantId } : {}),
+      ...(input.contextApplicationId ? { contextApplicationId: input.contextApplicationId } : {}),
+    })
+    // A retried command writes the same deterministic id. Absorbing it here is
+    // what makes the retry a no-op instead of a duplicate delivery.
+    .onConflictDoNothing({ target: followEvents.eventId });
+}
+
+/**
+ * Follow a target the caller has already resolved.
+ *
+ * Takes a target ROW rather than a URI: resolving or registering a target is a
+ * separate concern with its own authorization (`follow-targets:register`), and
+ * folding it in here would let a follow silently create registry entries.
+ */
+export async function followTarget(input: {
+  capability: FollowCapability;
+  target: { id: string; canonicalUri: string; kind: string; localUserId: string | null };
+  expiresAt?: Date | null;
+  cause?: FollowEventCause;
+}): Promise<FollowResult> {
+  const { capability, target } = input;
+  const at = new Date();
+
+  if (target.localUserId && target.localUserId === capability.userId) {
+    throw new Error('Cannot follow yourself');
+  }
+
+  return getDb().transaction(async (tx) => {
+    const inserted = await tx
+      .insert(followRelationships)
+      .values({
+        followerUserId: capability.userId,
+        followTargetId: target.id,
+        state: 'active',
+        originApplicationId: capability.applicationId,
+        createdByGrantId: capability.grantId,
+        source: 'app',
+        ...(input.expiresAt ? { expiresAt: input.expiresAt } : {}),
+      })
+      // Following twice is one relationship. The insert reports which case this
+      // was, so `created` is observed rather than predicted.
+      .onConflictDoNothing({
+        target: [followRelationships.followerUserId, followRelationships.followTargetId],
+      })
+      .returning({ id: followRelationships.id });
+
+    const created = inserted.length === 1;
+    const relationshipId = created
+      ? inserted[0].id
+      : (
+          await tx
+            .select({ id: followRelationships.id })
+            .from(followRelationships)
+            .where(
+              and(
+                eq(followRelationships.followerUserId, capability.userId),
+                eq(followRelationships.followTargetId, target.id)
+              )
+            )
+            .limit(1)
+        )[0].id;
+
+    if (created) {
+      // The account graph, in the SAME transaction. Two statements that could
+      // succeed independently is how a follower count starts disagreeing with
+      // the follow list, and nothing would report it.
+      if (target.localUserId) {
+        await tx
+          .insert(userFollows)
+          .values({ followerId: capability.userId, followedId: target.localUserId })
+          .onConflictDoNothing();
+      }
+
+      await emit(tx, {
+        type: 'follow.created',
+        cause: input.cause ?? 'user_action',
+        capability,
+        relationshipId,
+        targetUri: target.canonicalUri,
+        targetKind: target.kind,
+        at,
+      });
+    }
+
+    const status = await readStatus(tx, capability.userId, capability.applicationId, target.id);
+    return { relationshipId, created, status };
+  });
+}
+
+/**
+ * Remove a relationship everywhere.
+ *
+ * Deletes the per-application overrides with it: they describe a relationship
+ * that no longer exists, and leaving them would make a later re-follow inherit
+ * a "disabled here" the user set months ago and has no way to remember.
+ */
+export async function unfollowEverywhere(input: {
+  capability: FollowCapability | SystemCapability;
+  relationshipId: string;
+  cause?: FollowEventCause;
+}): Promise<{ removed: boolean }> {
+  const { capability, relationshipId } = input;
+  const at = new Date();
+
+  return getDb().transaction(async (tx) => {
+    const [relationship] = await tx
+      .select({
+        id: followRelationships.id,
+        followerUserId: followRelationships.followerUserId,
+        targetId: followRelationships.followTargetId,
+      })
+      .from(followRelationships)
+      .where(eq(followRelationships.id, relationshipId))
+      .limit(1);
+
+    // Unfollowing something already gone is a success, not an error — the state
+    // the caller asked for is the state that holds.
+    if (!relationship || relationship.followerUserId !== capability.userId) {
+      return { removed: false };
+    }
+
+    const [target] = await tx
+      .select({
+        canonicalUri: followTargets.canonicalUri,
+        kind: followTargets.kind,
+        localUserId: followTargets.localUserId,
+      })
+      .from(followTargets)
+      .where(eq(followTargets.id, relationship.targetId))
+      .limit(1);
+
+    // The event is written BEFORE the delete, in the same transaction, because
+    // it reads the row it is about. `follow_events.relationship_id` carries no
+    // foreign key precisely so the event outlives this delete.
+    await emit(tx, {
+      type: 'follow.removed',
+      cause: input.cause ?? 'user_action',
+      capability,
+      relationshipId,
+      targetUri: target?.canonicalUri ?? '',
+      targetKind: target?.kind ?? '',
+      at,
+    });
+
+    await tx.delete(followRelationships).where(eq(followRelationships.id, relationshipId));
+
+    if (target?.localUserId) {
+      await tx
+        .delete(userFollows)
+        .where(
+          and(
+            eq(userFollows.followerId, capability.userId),
+            eq(userFollows.followedId, target.localUserId)
+          )
+        );
+    }
+
+    return { removed: true };
+  });
+}
+
+/**
+ * Turn a relationship off, or back on, in ONE application.
+ *
+ * Never touches the global relationship, never moves counts, never notifies the
+ * followed target. The person on the other end is not told which of someone's
+ * applications they appear in — that is the user's business, and telling them
+ * would turn a private preference into a social signal.
+ */
+export async function setApplicationMode(input: {
+  capability: FollowCapability;
+  relationshipId: string;
+  /** The application being configured. Defaults to the caller's own. */
+  applicationId?: string;
+  mode: 'enabled' | 'disabled';
+}): Promise<{ ok: boolean }> {
+  const { capability, relationshipId, mode } = input;
+  const applicationId = input.applicationId ?? capability.applicationId;
+  const at = new Date();
+
+  return getDb().transaction(async (tx) => {
+    const [relationship] = await tx
+      .select({
+        followerUserId: followRelationships.followerUserId,
+        targetId: followRelationships.followTargetId,
+      })
+      .from(followRelationships)
+      .where(eq(followRelationships.id, relationshipId))
+      .limit(1);
+
+    if (!relationship || relationship.followerUserId !== capability.userId) {
+      return { ok: false };
+    }
+
+    const [target] = await tx
+      .select({ canonicalUri: followTargets.canonicalUri, kind: followTargets.kind })
+      .from(followTargets)
+      .where(eq(followTargets.id, relationship.targetId))
+      .limit(1);
+
+    await tx
+      .insert(followApplicationOverrides)
+      .values({ relationshipId, applicationId, mode })
+      .onConflictDoUpdate({
+        target: [followApplicationOverrides.relationshipId, followApplicationOverrides.applicationId],
+        set: { mode, updatedAt: at },
+      });
+
+    await emit(tx, {
+      type: mode === 'disabled' ? 'follow.context_disabled' : 'follow.context_enabled',
+      cause: 'user_action',
+      capability,
+      relationshipId,
+      targetUri: target?.canonicalUri ?? '',
+      targetKind: target?.kind ?? '',
+      contextApplicationId: applicationId,
+      at,
+    });
+
+    return { ok: true };
+  });
+}
+
+/**
+ * Drop an override so the relationship inherits the global state again.
+ *
+ * A DELETE rather than writing `enabled`, because "I never said" and "I said
+ * yes here" are different answers and only the first one keeps following a
+ * future change of default.
+ */
+export async function restoreInheritance(input: {
+  capability: FollowCapability;
+  relationshipId: string;
+  applicationId?: string;
+}): Promise<{ ok: boolean }> {
+  const { capability, relationshipId } = input;
+  const applicationId = input.applicationId ?? capability.applicationId;
+
+  return getDb().transaction(async (tx) => {
+    const [relationship] = await tx
+      .select({ followerUserId: followRelationships.followerUserId })
+      .from(followRelationships)
+      .where(eq(followRelationships.id, relationshipId))
+      .limit(1);
+
+    if (!relationship || relationship.followerUserId !== capability.userId) {
+      return { ok: false };
+    }
+
+    await tx
+      .delete(followApplicationOverrides)
+      .where(
+        and(
+          eq(followApplicationOverrides.relationshipId, relationshipId),
+          eq(followApplicationOverrides.applicationId, applicationId)
+        )
+      );
+
+    return { ok: true };
+  });
+}
+
+/** What the caller's application sees for this target. */
+export async function getFollowStatus(input: {
+  capability: FollowCapability;
+  targetId: string;
+}): Promise<FollowStatus> {
+  return readStatus(
+    getDb(),
+    input.capability.userId,
+    input.capability.applicationId,
+    input.targetId
+  );
+}
+
+/**
+ * Expire the relationships whose time is up.
+ *
+ * Deliberately routed through `unfollowEverywhere` rather than deleting rows
+ * directly: an expiry has to emit `follow.removed`, tear down federation and
+ * move counts exactly like a manual unfollow. A shortcut here would leave the
+ * remote side believing the relationship still exists, and nothing would ever
+ * report it.
+ *
+ * `cause: 'expired'` is what lets a consumer tell it from a decision — the
+ * notification policy cares, because nobody was told there was a clock.
+ */
+export async function expireDueFollows(now = new Date(), limit = 500): Promise<number> {
+  const due = await getDb()
+    .select({
+      id: followRelationships.id,
+      followerUserId: followRelationships.followerUserId,
+      originApplicationId: followRelationships.originApplicationId,
+      createdByGrantId: followRelationships.createdByGrantId,
+    })
+    .from(followRelationships)
+    .where(and(isNotNull(followRelationships.expiresAt), lte(followRelationships.expiresAt, now)))
+    .limit(limit);
+
+  let removed = 0;
+  for (const relationship of due) {
+    try {
+      const result = await unfollowEverywhere({
+        capability: {
+          userId: relationship.followerUserId,
+          // The application that created it, as provenance — NULL when it is
+          // gone. Expiry is the platform acting on an instruction the user
+          // already gave, so there is no grant to check: they authorised this,
+          // with an end date.
+          applicationId: relationship.originApplicationId,
+          grantId: relationship.createdByGrantId,
+          scopes: [],
+          sessionId: '',
+        },
+        relationshipId: relationship.id,
+        cause: 'expired',
+      });
+      if (result.removed) removed += 1;
+    } catch (error) {
+      // One relationship failing must not stop the sweep; it stays due and the
+      // next pass retries it, which is what makes expiry converge rather than
+      // silently skip.
+      logger.warn('[Follows] Expiry failed for one relationship', {
+        relationshipId: relationship.id,
+        err: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return removed;
+}


### PR DESCRIPTION
Phase 1 of #809, stacked on #813. The service every follow mutation goes through.

## One transaction, three writes

The relationship, the `user_follows` projection, and the outbox event — together or not at all.

This is the design, not an implementation detail. Two writes that can succeed independently will eventually disagree, and the disagreement is **invisible**: a relationship with no event never federates and never notifies; an event with no relationship makes a remote server believe in a follow nobody has. Neither surfaces as an error anywhere, which is why the issue asks for an outbox rather than "remember to also…".

`user_follows` stays authoritative for the account graph throughout the migration, as #809 requires, and is written in that same transaction — which makes drift unrepresentable rather than merely unlikely.

## What the tests pin

Mostly the things that must NOT happen:

- Following twice → one relationship, one event, one count movement. `created` comes back from the insert rather than being predicted before it.
- **Follow in app A → app B shows following and emits nothing.** A second event there becomes a second "new follower" notification for one edge.
- Disabling in one application leaves the global relationship and the account graph alone, and changes only that application's view. The status still reports `globalState: 'active'`, so a UI can say *"following globally, disabled here"*.
- Restoring inheritance **deletes** the override rather than writing `enabled` — "I never said" and "I said yes here" are different answers, and only the first follows a future change of default.
- Unfollowing removes the overrides with the relationship, so a re-follow months later does not silently inherit a "disabled here".
- An expiry goes down the **same path** as a manual unfollow, emitting `follow.removed` with `cause: 'expired'`.

## A bug those tests found

The expiry sweep passed `''` for the application and grant ids. Both are foreign keys, so the event insert failed, the sweep's own `try/catch` logged a warning, and **expiry silently did nothing** — timed follows would have lived forever and nothing would have reported it.

Fixed by giving the platform path its own `SystemCapability` type where those ids are `null`. Expiry and reconciliation are the platform acting on an instruction the user already gave, so there is no application asking and no grant to cite; a caller now has to say that out loud instead of passing an empty string that looks like an id.

## Housekeeping

`follow_events.relationship_id` and `.event_id` are registered in `ID_COLUMNS_WITHOUT_FOREIGN_KEY` with reasons, which that gate requires — the first because the outbox must outlive what it describes, the second because it is the event's own identity and points at nothing.

## Not in this PR

The v2 HTTP endpoints, the outbox worker, notification routing, federation delivery, the SDK and the button.

Refs #809