### PR TITLE
feat(follows): the SDK surface, with the identities a client cannot state

### DIFF
--- a/packages/contracts/src/followGraph.ts
+++ b/packages/contracts/src/followGraph.ts
@@ -1,0 +1,140 @@
+/**
+ * The follow graph wire contract (`/v2/follows`).
+ *
+ * These types are the boundary between the API that owns the graph and every
+ * application that reads it. They live here — not in the API and not in the
+ * SDK — because both ends have to agree, and a shape defined on one side is a
+ * shape the other side re-declares slightly differently within a release or two.
+ *
+ * ## Why the state is three fields and not a boolean
+ *
+ * A user can follow something globally and turn it off in ONE application. That
+ * is a state the user themselves created, so the client has to be able to see
+ * it and say so — "following, but not shown here" is a sentence a boolean
+ * cannot express. `globalState`, `applicationMode` and `effectiveState` are
+ * therefore reported separately, and only the last one answers "does this
+ * appear in my feed right now".
+ *
+ * ## Why kinds are strings
+ *
+ * `FollowTargetKind` is a plain `string`, not a union. Applications register
+ * their own kinds at runtime (`mercaria.store`, `syra.artist`), so a union here
+ * would mean every new application in the ecosystem needs a release of this
+ * package before it can follow anything. The namespace rule is enforced by the
+ * database, which is the one place that can enforce it for applications this
+ * package has never heard of.
+ */
+
+/**
+ * A registered target kind, always `<namespace>.<thing>`.
+ *
+ * The namespace is the owning application's, so two applications cannot define
+ * or silently redefine each other's kinds.
+ */
+export type FollowTargetKind = string;
+
+/**
+ * Where a relationship stands globally — the user's own decision, independent
+ * of any application.
+ *
+ * `pending` is a real state and not a transient one: a private account has to
+ * accept, and until it does the user has asked and is waiting. A client that
+ * renders it as "not following" invites a second request that changes nothing.
+ */
+export type FollowState = 'active' | 'pending' | 'blocked';
+
+/**
+ * What ONE application does with a relationship.
+ *
+ * `inherit` is the default and means "whatever the user decided globally".
+ * `disabled` is the interesting one: the user still follows, this application
+ * just does not act on it — which is what makes "follow everywhere, mute here"
+ * possible without the user losing the follow.
+ */
+export type FollowApplicationMode = 'inherit' | 'enabled' | 'disabled';
+
+/** A thing that can be followed. */
+export interface FollowTarget {
+  id: string;
+  /**
+   * The stable, global identity of the thing — an Oxy URI for local objects, an
+   * ActivityPub actor URI for remote ones. What makes "the same target" the
+   * same across applications and across servers.
+   */
+  uri: string;
+  kind: FollowTargetKind;
+  /**
+   * A cached display snapshot (name, handle, avatar). Present so a follow list
+   * can render without one lookup per row; never authoritative — the owning
+   * application always holds the current version.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/** One row of the user's central follow list. */
+export interface FollowRecord {
+  relationshipId: string;
+  target: FollowTarget;
+  globalState: FollowState;
+  applicationMode: FollowApplicationMode;
+  /**
+   * Where the user was when they followed. Provenance for the audit trail and
+   * for notification routing — never authority: this application cannot undo
+   * what another one recorded.
+   */
+  originApplicationId: string | null;
+  /** Set only on a timed follow. ISO-8601. */
+  expiresAt?: string;
+  createdAt: string;
+}
+
+/**
+ * The three-part answer to "am I following this".
+ *
+ * `effectiveState` is what a button renders. The other two are what an
+ * explanation renders, and a client that shows a disabled follow as "not
+ * following" will be asked why the button does nothing.
+ */
+export interface FollowStatus {
+  following: boolean;
+  relationshipId: string | null;
+  globalState: FollowState | null;
+  applicationMode: FollowApplicationMode;
+  /**
+   * `active` only when the user follows globally AND this application is not
+   * disabled for it. This is the field a feed query should honour.
+   */
+  effectiveState: FollowState | 'inactive';
+  expiresAt?: string;
+}
+
+/** `PUT /v2/follows/:targetId` — `created: false` means it already existed. */
+export interface FollowMutation {
+  relationshipId: string;
+  state: FollowState;
+  created: boolean;
+  expiresAt?: string;
+}
+
+/** `DELETE /v2/follows/:relationshipId` — `removed: false` means it was already gone. */
+export interface UnfollowMutation {
+  removed: boolean;
+}
+
+/** `GET /v2/me/follows` */
+export interface FollowListPage {
+  follows: FollowRecord[];
+  /** Absent when the last page has been reached. */
+  nextCursor?: string;
+}
+
+/**
+ * Options for `PUT /v2/follows/:targetId`.
+ *
+ * `expiresIn` is the timed follow — seconds from now. Bounded server-side,
+ * because an unbounded value is indistinguishable from a permanent follow the
+ * user believes will end.
+ */
+export interface FollowOptions {
+  expiresIn?: number;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -417,6 +417,19 @@ export type {
     LinkPreviewBatchResponse,
 } from './links';
 
+export type {
+    FollowTargetKind,
+    FollowState,
+    FollowApplicationMode,
+    FollowTarget,
+    FollowRecord,
+    FollowStatus,
+    FollowMutation,
+    UnfollowMutation,
+    FollowListPage,
+    FollowOptions,
+} from './followGraph';
+
 export {
     sessionAccountSchema,
     deviceSessionStateSchema,

--- a/packages/core/src/mixins/OxyServices.followGraph.ts
+++ b/packages/core/src/mixins/OxyServices.followGraph.ts
@@ -1,0 +1,192 @@
+/**
+ * Follow Graph Mixin (`/v2/follows`)
+ *
+ * The user-owned follow graph: one relationship per user and target, shared by
+ * every application, with per-application context on top. This is the SDK half
+ * of #809 and the replacement for the per-app follow endpoints each application
+ * grew for itself.
+ *
+ * ## Why this is not `followUser` with more parameters
+ *
+ * `followUser` answers "does A follow B" and nothing else. This answers "what
+ * does this user follow, anywhere, and which applications act on it" — a
+ * different question with a different owner. The legacy methods stay for the
+ * Mongo-backed social graph they were written for; new kinds (topics, stores,
+ * artists, channels) come here, and users will migrate behind an adapter rather
+ * than through a flag day.
+ *
+ * ## Caching
+ *
+ * Every method is `cache: false`. A follow status is exactly the shape that
+ * must never be served stale: the SDK's GET cache is identity-scoped but
+ * time-based, and a status cached across a write is the "follow reverts after
+ * navigating away and back" bug — which the legacy `followUser` had to fix with
+ * explicit invalidation. Not caching at this layer means an app's own store
+ * (React Query, Zustand) is the single cache authority, which is the rule the
+ * ecosystem already follows for anything written and read in the same session.
+ */
+
+import type {
+  FollowListPage,
+  FollowMutation,
+  FollowOptions,
+  FollowStatus,
+  UnfollowMutation,
+} from '@oxyhq/contracts';
+import type { OxyServicesBase } from '../OxyServices.base';
+import { buildUrl } from '../utils/apiUtils';
+
+export function OxyServicesFollowGraphMixin<T extends typeof OxyServicesBase>(Base: T) {
+  return class extends Base {
+    constructor(...args: any[]) {
+      super(...(args as [any]));
+    }
+
+    /**
+     * Follow a target. Idempotent — following something already followed
+     * returns the same relationship with `created: false`.
+     *
+     * The follower and the acting application are BOTH derived server-side from
+     * the session. There is deliberately no parameter for either: a client that
+     * could name them could forge a follow on another user's behalf, or record
+     * one as coming from an application it is not.
+     *
+     * @param targetId - The registered target's id, not its URI. Registration is
+     *   a separate operation precisely so following cannot silently create
+     *   targets — a typo would otherwise become a permanent row nobody follows.
+     * @param options.expiresIn - Seconds until the follow lapses on its own. For
+     *   an event, a trial, a topic followed for a week. The server bounds it.
+     */
+    async followTarget(targetId: string, options?: FollowOptions): Promise<FollowMutation> {
+      try {
+        return await this.makeRequest<FollowMutation>(
+          'PUT',
+          `/v2/follows/${encodeURIComponent(targetId)}`,
+          options?.expiresIn !== undefined ? { expiresIn: options.expiresIn } : {},
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Unfollow everywhere.
+     *
+     * There is no "unfollow here" — that is `setFollowApplicationMode(...,
+     * 'disabled')`, and keeping the two distinct is the point of the design. An
+     * application that quietly turned a global unfollow into a local one would
+     * leave the user believing they had stopped following something they still
+     * follow everywhere else.
+     *
+     * Idempotent: `removed: false` when it was already gone, because the state
+     * the caller asked for is the state that holds.
+     */
+    async unfollowTarget(relationshipId: string): Promise<UnfollowMutation> {
+      try {
+        return await this.makeRequest<UnfollowMutation>(
+          'DELETE',
+          `/v2/follows/${encodeURIComponent(relationshipId)}`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * The three-part status: globally, in this application, and in effect.
+     *
+     * Render `effectiveState` on the button and keep the other two for the
+     * explanation. A UI that collapses them cannot tell the user why a follow
+     * they can see in their list is not showing up in this app's feed.
+     */
+    async getFollowTargetStatus(targetId: string): Promise<FollowStatus> {
+      try {
+        return await this.makeRequest<FollowStatus>(
+          'GET',
+          `/v2/follows/${encodeURIComponent(targetId)}/status`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Turn a relationship off, or back on, in ONE application.
+     *
+     * Omit `applicationId` and it applies to the calling application, which is
+     * the only form an ordinary app should ever need. Naming a DIFFERENT
+     * application requires `follows:manage` server-side — acting on another
+     * app's behalf is exactly the cross-application authority this design
+     * otherwise refuses, so it is a distinct permission and not a parameter an
+     * app happens to fill in.
+     */
+    async setFollowApplicationMode(
+      relationshipId: string,
+      mode: 'enabled' | 'disabled',
+      applicationId?: string,
+    ): Promise<{ ok: true; mode: 'enabled' | 'disabled' }> {
+      try {
+        return await this.makeRequest(
+          'PUT',
+          `/v2/follows/${encodeURIComponent(relationshipId)}/context`,
+          { mode, ...(applicationId ? { applicationId } : {}) },
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Drop the override so this application follows the global relationship
+     * again. Distinct from setting `enabled`: inheriting means a later global
+     * change takes effect here, and an explicit `enabled` means it does not.
+     */
+    async restoreFollowInheritance(
+      relationshipId: string,
+      applicationId?: string,
+    ): Promise<{ ok: true }> {
+      try {
+        const path = buildUrl(
+          `/v2/follows/${encodeURIComponent(relationshipId)}/context`,
+          applicationId ? { applicationId } : {},
+        );
+        return await this.makeRequest('DELETE', path, undefined, { cache: false });
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Everything the signed-in user follows, newest first.
+     *
+     * Owner-only by construction server-side — there is no parameter naming a
+     * user, so this cannot be pointed at somebody else's graph.
+     *
+     * Paginate by passing back `nextCursor`, never an offset: the list changes
+     * while it is being read, and an offset silently skips or repeats rows
+     * exactly when it does.
+     */
+    async listFollows(params?: {
+      kind?: string;
+      cursor?: string;
+      limit?: number;
+    }): Promise<FollowListPage> {
+      try {
+        const path = buildUrl('/v2/me/follows', {
+          ...(params?.kind ? { kind: params.kind } : {}),
+          ...(params?.cursor ? { cursor: params.cursor } : {}),
+          ...(params?.limit ? { limit: params.limit } : {}),
+        });
+        return await this.makeRequest<FollowListPage>('GET', path, undefined, { cache: false });
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+  };
+}

--- a/packages/core/src/mixins/__tests__/followGraph.test.ts
+++ b/packages/core/src/mixins/__tests__/followGraph.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Follow Graph Mixin Tests
+ *
+ * `makeRequest` is stubbed, so what these assert is the CONTRACT this mixin
+ * offers the applications above it: which request each method makes, and — the
+ * part worth a test rather than a comment — the things it must never send.
+ */
+
+import { OxyServices } from '../../OxyServices';
+
+describe('OxyServices.followGraph', () => {
+  let oxy: OxyServices;
+  let makeRequest: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    oxy.httpService.setTokens('test-token');
+    makeRequest = jest.spyOn(oxy, 'makeRequest').mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    makeRequest.mockRestore();
+  });
+
+  describe('the identities the client must not be able to state', () => {
+    it('never sends a follower id', async () => {
+      await oxy.followTarget('target-1');
+      await oxy.unfollowTarget('rel-1');
+      await oxy.listFollows();
+
+      // A client that could name the follower could forge a follow on somebody
+      // else's behalf. The server derives it from the session; there must be no
+      // parameter here that even looks like an alternative.
+      for (const call of makeRequest.mock.calls) {
+        expect(JSON.stringify(call)).not.toMatch(/user_?[Ii]d|follower/);
+      }
+    });
+
+    it('sends no application id unless the caller explicitly names another app', async () => {
+      await oxy.setFollowApplicationMode('rel-1', 'disabled');
+
+      // The ordinary case is "this application", derived server-side. Sending an
+      // id here by default would make every app's own writes indistinguishable
+      // from one app acting on another's behalf, which is the privileged
+      // operation.
+      expect(makeRequest.mock.calls[0][2]).toEqual({ mode: 'disabled' });
+    });
+
+    it('passes an explicitly named application through, for the privileged path', async () => {
+      await oxy.setFollowApplicationMode('rel-1', 'enabled', 'app-9');
+      expect(makeRequest.mock.calls[0][2]).toEqual({ mode: 'enabled', applicationId: 'app-9' });
+
+      await oxy.restoreFollowInheritance('rel-1', 'app-9');
+      expect(makeRequest.mock.calls[1][1]).toContain('applicationId=app-9');
+    });
+  });
+
+  describe('request shapes', () => {
+    it('follows with PUT and no body when the follow is permanent', async () => {
+      await oxy.followTarget('target-1');
+      const [method, path, body] = makeRequest.mock.calls[0];
+      expect(method).toBe('PUT');
+      expect(path).toBe('/v2/follows/target-1');
+      expect(body).toEqual({});
+    });
+
+    it('carries expiresIn for a timed follow', async () => {
+      await oxy.followTarget('target-1', { expiresIn: 72 * 60 * 60 });
+      expect(makeRequest.mock.calls[0][2]).toEqual({ expiresIn: 259200 });
+    });
+
+    it('unfollows by relationship id, not by target', async () => {
+      // The relationship is the thing that exists; addressing the unfollow by
+      // target would make the server re-derive which relationship was meant,
+      // and get it wrong for any target a user can follow more than one way.
+      await oxy.unfollowTarget('rel-1');
+      expect(makeRequest.mock.calls[0].slice(0, 2)).toEqual(['DELETE', '/v2/follows/rel-1']);
+    });
+
+    it('reads status per target', async () => {
+      await oxy.getFollowTargetStatus('target-1');
+      expect(makeRequest.mock.calls[0].slice(0, 2)).toEqual([
+        'GET',
+        '/v2/follows/target-1/status',
+      ]);
+    });
+
+    it('restores inheritance with no query string when the app means itself', async () => {
+      await oxy.restoreFollowInheritance('rel-1');
+      expect(makeRequest.mock.calls[0][1]).toBe('/v2/follows/rel-1/context');
+    });
+
+    it('paginates by cursor and filters by kind', async () => {
+      await oxy.listFollows({ kind: 'oxy.topic', cursor: '2026-01-01T00:00:00.000Z', limit: 20 });
+      const path = makeRequest.mock.calls[0][1] as string;
+      expect(path).toContain('kind=oxy.topic');
+      expect(path).toContain('limit=20');
+      expect(path).toContain('cursor=');
+      // Never an offset: the list changes while it is read, and an offset skips
+      // or repeats rows exactly when it does.
+      expect(path).not.toContain('offset');
+    });
+
+    it('escapes an id rather than letting it change the path', async () => {
+      await oxy.followTarget('../../admin');
+      expect(makeRequest.mock.calls[0][1]).toBe('/v2/follows/..%2F..%2Fadmin');
+    });
+  });
+
+  describe('caching', () => {
+    it('caches nothing', async () => {
+      await oxy.followTarget('t');
+      await oxy.getFollowTargetStatus('t');
+      await oxy.listFollows();
+      await oxy.unfollowTarget('r');
+      await oxy.setFollowApplicationMode('r', 'disabled');
+      await oxy.restoreFollowInheritance('r');
+
+      // A status cached across a write is the "follow reverts after navigating
+      // away and back" bug the legacy path had to fix with explicit
+      // invalidation. Not caching here leaves the app's own store as the single
+      // cache authority.
+      for (const call of makeRequest.mock.calls) {
+        expect(call[3]).toEqual({ cache: false });
+      }
+    });
+  });
+});

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -30,6 +30,7 @@ import { OxyServicesAppDataMixin } from './OxyServices.appData';
 import { OxyServicesCivicMixin } from './OxyServices.civic';
 import { OxyServicesNodesMixin } from './OxyServices.nodes';
 import { OxyServicesLinksMixin } from './OxyServices.links';
+import { OxyServicesFollowGraphMixin } from './OxyServices.followGraph';
 import { OxyServicesDeviceBootMixin } from './OxyServices.deviceBoot';
 import { OxyServicesDeviceTransferMixin } from './OxyServices.deviceTransfer';
 
@@ -66,6 +67,7 @@ type AllMixinInstances =
   & InstanceType<ReturnType<typeof OxyServicesCivicMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesNodesMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesLinksMixin<typeof OxyServicesBase>>>
+  & InstanceType<ReturnType<typeof OxyServicesFollowGraphMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesDeviceBootMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesDeviceTransferMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesUtilityMixin<typeof OxyServicesBase>>>;
@@ -141,6 +143,9 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     // Link previews / unfurls: SDK-owned link-metadata resolution via oxy-api,
     // so apps stop scraping link metadata locally.
     OxyServicesLinksMixin,
+    // The user-owned follow graph (#809). One relationship per user and target,
+    // shared across applications, with per-application context on top.
+    OxyServicesFollowGraphMixin,
 
     // Device-first token mint: the client half of the zero-cookie transport
     // (`mintFromDeviceSecret` → `POST /session/device/token`).


### PR DESCRIPTION
Phase 1 of #809, stacked on #815. The client half: wire types in `@oxyhq/contracts`, and a `@oxyhq/core` mixin whose methods mirror the v2 endpoints one for one.

```ts
oxyServices.followTarget(targetId, { expiresIn: 72 * 60 * 60 })
oxyServices.unfollowTarget(relationshipId)
oxyServices.getFollowTargetStatus(targetId)
oxyServices.setFollowApplicationMode(relationshipId, 'disabled')
oxyServices.restoreFollowInheritance(relationshipId)
oxyServices.listFollows({ kind: 'oxy.topic', cursor })
```

## Where the types live, and why

In `@oxyhq/contracts`, not in the API and not in the SDK — both ends have to agree, and a shape defined on one side is a shape the other re-declares slightly differently within a release or two.

**`FollowTargetKind` is a plain `string`, not a union.** Applications register their own kinds at runtime (`mercaria.store`, `syra.artist`), so a union here would mean every new application in the ecosystem needs a release of this package before it can follow anything. The namespace rule is enforced by the database, which is the one place that can enforce it for applications this package has never heard of.

## What the mixin deliberately cannot express

Both covered by tests that were **mutation-checked**, not assumed — leaking a follower id fails 3 tests, and caching one read fails the caching test:

- **No parameter for the follower.** A client that could name it could forge a follow on somebody else's behalf.
- **No application id on the ordinary write.** Sending one by default would make an app's own writes indistinguishable from one app acting on another's behalf — which is the privileged operation, and needs `follows:manage`.

## Caching: none

Every method is `cache: false`. A status cached across a write is exactly the *"follow reverts after navigating away and back"* bug the legacy path had to fix with explicit invalidation. Leaving the SDK out of it makes the app's own store the single cache authority, which is the rule the ecosystem already follows for anything written and read in one session.

## Release ordering

`@oxyhq/contracts` publishes **before** `@oxyhq/core` — core now imports symbols that are not in the published contracts yet.

Refs #809