### PR TITLE
feat(follows): one button for everything an Oxy user can follow

### DIFF
--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -278,6 +278,17 @@ export type { RequireOxyAuthProps, RequireOxyAuthPrompt } from './ui/components/
 
 export { default as FollowButton } from './ui/components/FollowButton';
 export type { FollowButtonProps, SingleFollowButtonProps, MultiFollowButtonProps } from './ui/components/FollowButton';
+// The follow graph (#809): follows anything registered, not just users.
+export { FollowTargetButton } from './ui/components/FollowTargetButton';
+export type {
+  FollowTargetButtonProps,
+  FollowVerb,
+  FollowLabels,
+  FollowDuration,
+} from './ui/components/FollowTargetButton';
+export { useFollowTarget } from './ui/hooks/useFollowTarget';
+export type { UseFollowTargetResult } from './ui/hooks/useFollowTarget';
+export { useFollowTargetStore, UNKNOWN_FOLLOW_STATUS } from './ui/stores/followTargetStore';
 export { default as OxyPayButton } from './ui/components/OxyPayButton';
 export { LogoIcon } from './ui/components/logo/LogoIcon';
 export { LogoText } from './ui/components/logo/LogoText';

--- a/packages/services/src/ui/components/FollowTargetButton.tsx
+++ b/packages/services/src/ui/components/FollowTargetButton.tsx
@@ -1,0 +1,323 @@
+/**
+ * `FollowTargetButton` — one button for everything an Oxy user can follow.
+ *
+ * Follows a TARGET of any registered kind: a person, a topic, a channel, a
+ * store, an artist. Nothing in this file branches on what the target is, which
+ * is the property that lets an application this package has never heard of use
+ * it without a release.
+ *
+ * ## Two controls, not one
+ *
+ * The main press does the obvious thing. The chevron beside it opens the
+ * choices that a single press cannot express — follow for a while, stop showing
+ * this here without giving it up everywhere — and those belong behind a
+ * disclosure precisely because they are not what most people want most of the
+ * time. Bloom's `Menu` renders as a bottom sheet on native and a dropdown on
+ * web, so this is one component and not a platform fork.
+ *
+ * ## Verbs
+ *
+ * "Follow" is wrong for half the things in the ecosystem: you subscribe to a
+ * channel, you join a community, you watch a listing. The verb is a prop with a
+ * small vocabulary of defaults and a full override, rather than a lookup keyed
+ * on kind — a kind→verb table in this package would need a release every time
+ * an application invents a kind, which is exactly the coupling #809 removes.
+ *
+ * ## Relationship to the legacy `FollowButton`
+ *
+ * `FollowButton` follows a USER through the Mongo-backed social graph and
+ * remains the correct component for that until the user graph is migrated onto
+ * `/v2/follows`. When it is, that component is deleted and this one takes the
+ * name — not aliased, not deprecated in place.
+ */
+
+import { memo, useCallback, useMemo } from 'react';
+import type { FollowApplicationMode } from '@oxyhq/contracts';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { View } from 'react-native';
+import { Button } from '@oxyhq/bloom/button';
+import { ChevronBottom_Stroke2_Corner0_Rounded as ChevronDown } from '@oxyhq/bloom/icons';
+import { Menu, MenuContent, MenuItem, MenuItemText, MenuTrigger } from '@oxyhq/bloom/menu';
+import { toast } from '@oxyhq/bloom/toast';
+import { useFollowTarget } from '../hooks/useFollowTarget';
+
+/**
+ * The small vocabulary of verbs the ecosystem actually uses. An application
+ * whose verb is not here passes `labels` instead — the escape hatch exists so
+ * this union never has to grow to accommodate one product's wording.
+ */
+export type FollowVerb = 'follow' | 'subscribe' | 'join' | 'watch';
+
+export interface FollowLabels {
+  /** Not following yet. */
+  idle: string;
+  /** Following, and this application acts on it. */
+  active: string;
+  /** Asked, waiting for the other side to accept. */
+  pending: string;
+  /** Following globally, but switched off in this application. */
+  disabled: string;
+}
+
+const VERB_LABELS: Record<FollowVerb, FollowLabels> = {
+  follow: { idle: 'Follow', active: 'Following', pending: 'Requested', disabled: 'Off here' },
+  subscribe: {
+    idle: 'Subscribe',
+    active: 'Subscribed',
+    pending: 'Requested',
+    disabled: 'Off here',
+  },
+  join: { idle: 'Join', active: 'Joined', pending: 'Requested', disabled: 'Off here' },
+  watch: { idle: 'Watch', active: 'Watching', pending: 'Requested', disabled: 'Off here' },
+};
+
+/** A timed-follow choice offered in the menu. */
+export interface FollowDuration {
+  label: string;
+  seconds: number;
+}
+
+const HOUR = 60 * 60;
+
+/**
+ * Defaults chosen for the cases a timed follow is actually for: a live event
+ * tonight, a story running this week. Not a general-purpose duration picker —
+ * an application that needs one passes its own.
+ */
+const DEFAULT_DURATIONS: FollowDuration[] = [
+  { label: '24 hours', seconds: 24 * HOUR },
+  { label: '72 hours', seconds: 72 * HOUR },
+  { label: 'A week', seconds: 7 * 24 * HOUR },
+];
+
+/** One line in the disclosure menu. */
+export interface FollowMenuItem {
+  key: string;
+  label: string;
+  /** What the component should call. Named so the table below stays pure. */
+  action:
+    | { type: 'follow-timed'; seconds: number; durationLabel: string }
+    | { type: 'enable-here' }
+    | { type: 'disable-here' }
+    | { type: 'unfollow' };
+}
+
+/**
+ * Which choices exist, given the state.
+ *
+ * Pure and exported because this is the product decision, not a rendering
+ * detail: a timed follow is only offered before following, turning it off here
+ * is only offered while following, and NEITHER is offered before the server has
+ * answered — every one of them addresses a relationship that does not exist
+ * yet, so offering them mid-write would mean sending a guessed id.
+ */
+export function buildFollowMenuItems(input: {
+  following: boolean;
+  applicationMode: FollowApplicationMode;
+  hasRelationship: boolean;
+  isPending: boolean;
+  durations: FollowDuration[] | false;
+  idleVerb: string;
+  applicationName: string;
+}): FollowMenuItem[] {
+  const items: FollowMenuItem[] = [];
+
+  if (!input.following) {
+    if (input.durations === false) return items;
+    for (const d of input.durations) {
+      items.push({
+        key: `for-${d.seconds}`,
+        label: `${input.idleVerb} for ${d.label.toLowerCase()}`,
+        action: { type: 'follow-timed', seconds: d.seconds, durationLabel: d.label },
+      });
+    }
+    return items;
+  }
+
+  if (!input.hasRelationship || input.isPending) return items;
+
+  items.push(
+    input.applicationMode === 'disabled'
+      ? { key: 'enable-here', label: `Show in ${input.applicationName}`, action: { type: 'enable-here' } }
+      : {
+          key: 'disable-here',
+          label: `Don’t show in ${input.applicationName}`,
+          action: { type: 'disable-here' },
+        }
+  );
+  items.push({
+    // Named for what it does. "Unfollow" beside "don't show here" would read as
+    // the same action twice, and the user would pick the wrong one.
+    key: 'unfollow-everywhere',
+    label: 'Unfollow everywhere',
+    action: { type: 'unfollow' },
+  });
+
+  return items;
+}
+
+export interface FollowTargetButtonProps {
+  /** The registered target's id. Registration is separate — see the SDK. */
+  targetId: string;
+  verb?: FollowVerb;
+  /** Full override, for a verb the vocabulary above does not carry. */
+  labels?: Partial<FollowLabels>;
+  size?: 'small' | 'medium' | 'large';
+  style?: StyleProp<ViewStyle>;
+  disabled?: boolean;
+  /**
+   * Hide the chevron. For a dense list row where the extra target is more
+   * likely to be hit by accident than used on purpose.
+   */
+  showOptions?: boolean;
+  /**
+   * Offer timed follows. Pass `false` where a temporary follow makes no sense —
+   * a store you buy from, an account you know.
+   */
+  durations?: FollowDuration[] | false;
+  /**
+   * This application's name, for the menu line that turns the follow off here.
+   * "Don't show in Mention" is a sentence the user can act on; "disable in this
+   * application" is not.
+   */
+  applicationName?: string;
+  onChange?: (following: boolean) => void;
+}
+
+export const FollowTargetButton = memo(function FollowTargetButton({
+  targetId,
+  verb = 'follow',
+  labels,
+  size = 'medium',
+  style,
+  disabled = false,
+  showOptions = true,
+  durations = DEFAULT_DURATIONS,
+  applicationName,
+  onChange,
+}: FollowTargetButtonProps) {
+  const { status, isUnknown, isPending, follow, unfollow, disableHere, enableHere } =
+    useFollowTarget(targetId);
+
+  const text = useMemo(() => ({ ...VERB_LABELS[verb], ...labels }), [verb, labels]);
+
+  const label = useMemo(() => {
+    if (status.globalState === 'pending') return text.pending;
+    if (!status.following) return text.idle;
+    return status.applicationMode === 'disabled' ? text.disabled : text.active;
+  }, [status.following, status.globalState, status.applicationMode, text]);
+
+  const handlePrimary = useCallback(async () => {
+    if (status.following) {
+      await unfollow();
+      onChange?.(false);
+      return;
+    }
+    await follow();
+    onChange?.(true);
+  }, [status.following, follow, unfollow, onChange]);
+
+  const handleTimed = useCallback(
+    async (seconds: number, durationLabel: string) => {
+      await follow({ expiresIn: seconds });
+      onChange?.(true);
+      // The confirmation is the point: a follow that ends on its own is a
+      // promise, and a user who does not see it made will not believe it.
+      toast.success(`Following for ${durationLabel.toLowerCase()}`);
+    },
+    [follow, onChange]
+  );
+
+  const menuItems = useMemo(
+    () =>
+      buildFollowMenuItems({
+        following: status.following,
+        applicationMode: status.applicationMode,
+        hasRelationship: Boolean(status.relationshipId),
+        isPending,
+        durations,
+        idleVerb: text.idle,
+        applicationName: applicationName ?? 'this app',
+      }),
+    [
+      status.following,
+      status.applicationMode,
+      status.relationshipId,
+      isPending,
+      durations,
+      text.idle,
+      applicationName,
+    ]
+  );
+
+  const runItem = useCallback(
+    (item: FollowMenuItem) => {
+      switch (item.action.type) {
+        case 'follow-timed':
+          void handleTimed(item.action.seconds, item.action.durationLabel);
+          return;
+        case 'enable-here':
+          void enableHere();
+          return;
+        case 'disable-here':
+          void disableHere();
+          return;
+        case 'unfollow':
+          void unfollow();
+          onChange?.(false);
+      }
+    },
+    [handleTimed, enableHere, disableHere, unfollow, onChange]
+  );
+
+  const primary = (
+    <Button
+      variant={status.following ? 'secondary' : 'primary'}
+      size={size}
+      // Unknown is not "not following": the button stays inert until the first
+      // read settles rather than inviting a follow that may already exist.
+      disabled={disabled || isUnknown}
+      loading={isPending}
+      onPress={() => void handlePrimary()}
+      accessibilityLabel={label}
+    >
+      {label}
+    </Button>
+  );
+
+  if (!showOptions || menuItems.length === 0) {
+    return <View style={style}>{primary}</View>;
+  }
+
+  return (
+    <View style={[{ flexDirection: 'row', alignItems: 'center', gap: 4 }, style]}>
+      {primary}
+      <Menu>
+        <MenuTrigger label={`${label} options`} hint="Opens follow options">
+          {({ props }) => (
+            // The trigger's props are mapped rather than spread: `MenuTrigger`
+            // hands back a DOM-ish bag (focus handlers, an accessibility role)
+            // and `Button` accepts a different set, so a spread would pass
+            // props it silently drops.
+            <Button
+              variant="secondary"
+              size={size === 'large' ? 'large' : 'small'}
+              icon={<ChevronDown width={16} />}
+              disabled={disabled || isUnknown}
+              onPress={props.onPress}
+              accessibilityLabel={props.accessibilityLabel}
+              accessibilityHint={props.accessibilityHint}
+            />
+          )}
+        </MenuTrigger>
+        <MenuContent showCancel>
+          {menuItems.map((item) => (
+            <MenuItem key={item.key} label={item.label} onPress={() => runItem(item)}>
+              <MenuItemText>{item.label}</MenuItemText>
+            </MenuItem>
+          ))}
+        </MenuContent>
+      </Menu>
+    </View>
+  );
+});

--- a/packages/services/src/ui/components/__tests__/followTargetButton.test.ts
+++ b/packages/services/src/ui/components/__tests__/followTargetButton.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The follow button's product decisions, as a table.
+ *
+ * `buildFollowMenuItems` is pure and tested here rather than through a render
+ * because what matters is WHICH choices exist in which state — an assertion a
+ * rendering test would make about the DOM, one layout change away from being
+ * about nothing.
+ *
+ * `withApplicationMode` sits beside it because the two have to agree: the menu
+ * offers "don't show here", and the store computes what that does to the
+ * effective state. If they disagree the button offers something it then fails
+ * to reflect.
+ */
+
+import { buildFollowMenuItems } from '../FollowTargetButton';
+import { UNKNOWN_FOLLOW_STATUS, withApplicationMode } from '../../stores/followTargetStore';
+
+const DURATIONS = [
+  { label: '24 hours', seconds: 86400 },
+  { label: 'A week', seconds: 604800 },
+];
+
+const base = {
+  following: false,
+  applicationMode: 'inherit' as const,
+  hasRelationship: false,
+  isPending: false,
+  durations: DURATIONS,
+  idleVerb: 'Follow',
+  applicationName: 'Mention',
+};
+
+const keys = (items: ReturnType<typeof buildFollowMenuItems>) => items.map((i) => i.key);
+
+describe('buildFollowMenuItems', () => {
+  describe('before following', () => {
+    it('offers the timed follows and nothing else', () => {
+      const items = buildFollowMenuItems(base);
+      expect(keys(items)).toEqual(['for-86400', 'for-604800']);
+      // Nothing that addresses a relationship, because there is none.
+      expect(keys(items).some((k) => k.includes('unfollow') || k.includes('here'))).toBe(false);
+    });
+
+    it('phrases the option with the application’s own verb', () => {
+      expect(buildFollowMenuItems({ ...base, idleVerb: 'Subscribe' })[0].label).toBe(
+        'Subscribe for 24 hours'
+      );
+    });
+
+    it('offers nothing when the application turned timed follows off', () => {
+      expect(buildFollowMenuItems({ ...base, durations: false })).toEqual([]);
+    });
+  });
+
+  describe('while following', () => {
+    const following = { ...base, following: true, hasRelationship: true };
+
+    it('offers turning it off here, and unfollowing everywhere', () => {
+      expect(keys(buildFollowMenuItems(following))).toEqual([
+        'disable-here',
+        'unfollow-everywhere',
+      ]);
+    });
+
+    it('names the application, so the line is a sentence the user can act on', () => {
+      expect(buildFollowMenuItems(following)[0].label).toBe('Don’t show in Mention');
+    });
+
+    it('offers turning it back on once it is off here', () => {
+      const items = buildFollowMenuItems({ ...following, applicationMode: 'disabled' });
+      expect(keys(items)).toEqual(['enable-here', 'unfollow-everywhere']);
+      expect(items[0].label).toBe('Show in Mention');
+    });
+
+    it('never offers a timed follow', () => {
+      // Extending a follow is a different operation from starting one, and
+      // offering "Follow for 24 hours" to somebody already following would read
+      // as shortening it.
+      expect(keys(buildFollowMenuItems(following)).some((k) => k.startsWith('for-'))).toBe(false);
+    });
+
+    it('offers nothing while a write is in flight', () => {
+      // Every entry addresses the relationship id, which an optimistic follow
+      // does not have yet. Offering them here would mean sending a guess.
+      expect(buildFollowMenuItems({ ...following, isPending: true })).toEqual([]);
+    });
+
+    it('offers nothing when the relationship id is not known', () => {
+      expect(buildFollowMenuItems({ ...following, hasRelationship: false })).toEqual([]);
+    });
+  });
+});
+
+describe('withApplicationMode', () => {
+  const active = { ...UNKNOWN_FOLLOW_STATUS, following: true, globalState: 'active' as const };
+
+  it('makes a disabled follow inactive without giving up the follow', () => {
+    const next = withApplicationMode(active, 'disabled');
+    expect(next.effectiveState).toBe('inactive');
+    // The distinction the whole design exists for: still following globally.
+    expect(next.following).toBe(true);
+    expect(next.globalState).toBe('active');
+  });
+
+  it('restores the global state when enabled again', () => {
+    expect(withApplicationMode(withApplicationMode(active, 'disabled'), 'enabled')).toMatchObject({
+      applicationMode: 'enabled',
+      effectiveState: 'active',
+    });
+  });
+
+  it('keeps a pending follow pending rather than promoting it', () => {
+    const pending = { ...active, globalState: 'pending' as const };
+    expect(withApplicationMode(pending, 'enabled').effectiveState).toBe('pending');
+  });
+
+  it('stays inactive when there is no global relationship to act on', () => {
+    expect(withApplicationMode(UNKNOWN_FOLLOW_STATUS, 'enabled').effectiveState).toBe('inactive');
+  });
+});

--- a/packages/services/src/ui/hooks/useFollowTarget.ts
+++ b/packages/services/src/ui/hooks/useFollowTarget.ts
@@ -1,0 +1,197 @@
+/**
+ * `useFollowTarget` — the one hook every application uses to follow anything.
+ *
+ * Wraps the `/v2/follows` SDK methods with the store above, an optimistic
+ * update, and a rollback. Nothing in here knows what kind of thing it is
+ * following, which is the property that lets an application the SDK has never
+ * heard of use it without a release of this package.
+ *
+ * ## Optimism, and its one limit
+ *
+ * A follow flips the button immediately and rolls back if the server refuses,
+ * because the round trip is long enough to feel like a bug otherwise. But an
+ * optimistic follow has no relationship id until the server answers, and every
+ * other operation addresses the relationship — so those stay disabled for the
+ * width of one request rather than being sent with a guessed id.
+ */
+
+import { useCallback, useEffect } from 'react';
+import type { FollowStatus } from '@oxyhq/contracts';
+import { useOxy } from '../context/OxyContext';
+import {
+  UNKNOWN_FOLLOW_STATUS,
+  useFollowTargetStore,
+  withApplicationMode,
+} from '../stores/followTargetStore';
+
+export interface UseFollowTargetResult {
+  status: FollowStatus;
+  /** True until the first read settles. Distinct from "not following". */
+  isUnknown: boolean;
+  isPending: boolean;
+  error: string | undefined;
+  follow: (options?: { expiresIn?: number }) => Promise<void>;
+  unfollow: () => Promise<void>;
+  /** Stop acting on this follow HERE, without giving it up everywhere. */
+  disableHere: () => Promise<void>;
+  enableHere: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useFollowTarget(
+  targetId: string | undefined,
+  options?: { initialStatus?: FollowStatus }
+): UseFollowTargetResult {
+  const { oxyServices, canUsePrivateApi } = useOxy();
+
+  const status = useFollowTargetStore(
+    useCallback((s) => (targetId ? s.statuses[targetId] : undefined), [targetId])
+  );
+  const isPending = useFollowTargetStore(
+    useCallback((s) => (targetId ? (s.pending[targetId] ?? false) : false), [targetId])
+  );
+  const error = useFollowTargetStore(
+    useCallback((s) => (targetId ? s.errors[targetId] : undefined), [targetId])
+  );
+
+  const initialStatus = options?.initialStatus;
+
+  // A caller that already knows the status — a follow list, a feed payload —
+  // seeds it rather than making this hook re-ask once per rendered row.
+  useEffect(() => {
+    if (!targetId || !initialStatus) return;
+    const store = useFollowTargetStore.getState();
+    if (!store.statuses[targetId]) store.setStatus(targetId, initialStatus);
+  }, [targetId, initialStatus]);
+
+  const refresh = useCallback(async () => {
+    // Gated on `canUsePrivateApi`, not on `isAuthenticated`: during the session
+    // cold boot the second is true well before the first, and a read sent in
+    // that window 401s and would leave the button stuck reporting an error the
+    // user cannot act on.
+    if (!targetId || !canUsePrivateApi) return;
+    try {
+      const next = await oxyServices.getFollowTargetStatus(targetId);
+      useFollowTargetStore.getState().setStatus(targetId, next);
+      useFollowTargetStore.getState().setError(targetId, undefined);
+    } catch (e) {
+      useFollowTargetStore
+        .getState()
+        .setError(targetId, e instanceof Error ? e.message : 'Could not read follow status');
+    }
+  }, [targetId, canUsePrivateApi, oxyServices]);
+
+  useEffect(() => {
+    if (!targetId || !canUsePrivateApi) return;
+    if (useFollowTargetStore.getState().statuses[targetId]) return;
+    void refresh();
+  }, [targetId, canUsePrivateApi, refresh]);
+
+  /**
+   * Run a mutation optimistically: show `optimistic` at once, keep the previous
+   * value, and put it back if the server refuses. Every mutation below goes
+   * through this so the rollback cannot be forgotten in one of them.
+   */
+  const mutate = useCallback(
+    async (
+      optimistic: FollowStatus,
+      run: () => Promise<FollowStatus | void>,
+      failureMessage: string
+    ) => {
+      if (!targetId) return;
+      const store = useFollowTargetStore.getState();
+      const previous = store.statuses[targetId];
+      store.setStatus(targetId, optimistic);
+      store.setPending(targetId, true);
+      store.setError(targetId, undefined);
+      try {
+        const settled = await run();
+        if (settled) useFollowTargetStore.getState().setStatus(targetId, settled);
+      } catch (e) {
+        const s = useFollowTargetStore.getState();
+        // Back to what was true, not to a guess. Clearing the entry instead
+        // would make the next render ask again and flash the wrong state.
+        if (previous) s.setStatus(targetId, previous);
+        s.setError(targetId, e instanceof Error ? e.message : failureMessage);
+      } finally {
+        useFollowTargetStore.getState().setPending(targetId, false);
+      }
+    },
+    [targetId]
+  );
+
+  const current = status ?? UNKNOWN_FOLLOW_STATUS;
+
+  const follow = useCallback(
+    async (opts?: { expiresIn?: number }) => {
+      if (!targetId) return;
+      await mutate(
+        {
+          ...current,
+          following: true,
+          globalState: 'active',
+          effectiveState: current.applicationMode === 'disabled' ? 'inactive' : 'active',
+          ...(opts?.expiresIn
+            ? { expiresAt: new Date(Date.now() + opts.expiresIn * 1000).toISOString() }
+            : {}),
+        },
+        async () => {
+          const result = await oxyServices.followTarget(targetId, opts);
+          return {
+            ...current,
+            following: true,
+            relationshipId: result.relationshipId,
+            globalState: result.state,
+            effectiveState: current.applicationMode === 'disabled' ? 'inactive' : result.state,
+            ...(result.expiresAt ? { expiresAt: result.expiresAt } : {}),
+          };
+        },
+        'Could not follow'
+      );
+    },
+    [targetId, current, mutate, oxyServices]
+  );
+
+  const unfollow = useCallback(async () => {
+    const relationshipId = current.relationshipId;
+    if (!targetId || !relationshipId) return;
+    await mutate(
+      { ...UNKNOWN_FOLLOW_STATUS },
+      async () => {
+        await oxyServices.unfollowTarget(relationshipId);
+        return { ...UNKNOWN_FOLLOW_STATUS };
+      },
+      'Could not unfollow'
+    );
+  }, [targetId, current.relationshipId, mutate, oxyServices]);
+
+  const setMode = useCallback(
+    async (mode: 'enabled' | 'disabled') => {
+      const relationshipId = current.relationshipId;
+      if (!targetId || !relationshipId) return;
+      await mutate(
+        withApplicationMode(current, mode),
+        async () => {
+          await oxyServices.setFollowApplicationMode(relationshipId, mode);
+        },
+        'Could not change this app’s setting for this follow'
+      );
+    },
+    [targetId, current, mutate, oxyServices]
+  );
+
+  const disableHere = useCallback(() => setMode('disabled'), [setMode]);
+  const enableHere = useCallback(() => setMode('enabled'), [setMode]);
+
+  return {
+    status: current,
+    isUnknown: status === undefined,
+    isPending,
+    error,
+    follow,
+    unfollow,
+    disableHere,
+    enableHere,
+    refresh,
+  };
+}

--- a/packages/services/src/ui/stores/followTargetStore.ts
+++ b/packages/services/src/ui/stores/followTargetStore.ts
@@ -1,0 +1,106 @@
+/**
+ * The follow-graph store — the client's single cache authority for #809.
+ *
+ * The SDK caches none of these reads on purpose (a status cached across a write
+ * is the "follow reverts after navigating away and back" bug), which makes this
+ * store the one place a status lives between a write and the next read. If a
+ * second cache appears above it, the two will disagree the moment one is
+ * invalidated and the other is not.
+ *
+ * ## Keyed by target id, not by user id
+ *
+ * The legacy `followStore` is keyed by user id because the only followable
+ * thing was a user. Here a key is a target of any kind — a topic, a store, an
+ * artist, a channel — so nothing in this file may assume what it is looking at.
+ * That is the property that lets an application the SDK has never heard of use
+ * it without a release.
+ *
+ * ## Why the status is stored whole
+ *
+ * Not a boolean. `globalState`, `applicationMode` and `effectiveState` are
+ * three separate answers, and a UI that keeps only the last one cannot explain
+ * why a follow the user can see in their list does nothing in this app.
+ */
+
+import { create } from 'zustand';
+import type { FollowApplicationMode, FollowStatus } from '@oxyhq/contracts';
+
+/** The status of one target, or `undefined` when it has never been read. */
+type StatusMap = Record<string, FollowStatus | undefined>;
+
+interface FollowTargetState {
+  statuses: StatusMap;
+  /** In-flight writes, per target. Reads do not set this — only mutations do. */
+  pending: Record<string, boolean>;
+  errors: Record<string, string | undefined>;
+
+  setStatus: (targetId: string, status: FollowStatus) => void;
+  /**
+   * Seed many statuses at once — from a follow list, a feed payload, anything
+   * that already knows. Saves one request per rendered row, which is the
+   * difference between a list that paints and a list that flickers.
+   */
+  seed: (entries: Record<string, FollowStatus>) => void;
+  setPending: (targetId: string, pending: boolean) => void;
+  setError: (targetId: string, error: string | undefined) => void;
+  /** Drop everything. Called on identity change — see the note below. */
+  reset: () => void;
+}
+
+/**
+ * The state one target is in before the server has been asked. Distinct from
+ * "not following": a button that renders `following: false` while the answer is
+ * unknown invites a second follow that the user did not intend.
+ */
+export const UNKNOWN_FOLLOW_STATUS: FollowStatus = {
+  following: false,
+  relationshipId: null,
+  globalState: null,
+  applicationMode: 'inherit',
+  effectiveState: 'inactive',
+};
+
+export const useFollowTargetStore = create<FollowTargetState>((set) => ({
+  statuses: {},
+  pending: {},
+  errors: {},
+
+  setStatus: (targetId, status) =>
+    set((s) => ({ statuses: { ...s.statuses, [targetId]: status } })),
+
+  seed: (entries) => set((s) => ({ statuses: { ...s.statuses, ...entries } })),
+
+  setPending: (targetId, pending) =>
+    set((s) => ({ pending: { ...s.pending, [targetId]: pending } })),
+
+  setError: (targetId, error) => set((s) => ({ errors: { ...s.errors, [targetId]: error } })),
+
+  // Every entry here is scoped to whoever was signed in when it was read. On an
+  // account switch the whole map is wrong, not stale — the next user's follows
+  // are a different set entirely, and showing one user their previous
+  // account's follow state is a privacy failure rather than a rendering one.
+  reset: () => set({ statuses: {}, pending: {}, errors: {} }),
+}));
+
+/**
+ * Apply a mode change to a cached status without a round trip.
+ *
+ * Exported because the optimistic path and the settled path must agree on what
+ * `effectiveState` becomes; deriving it in two places is how they drift.
+ */
+export function withApplicationMode(
+  status: FollowStatus,
+  mode: FollowApplicationMode
+): FollowStatus {
+  return {
+    ...status,
+    applicationMode: mode,
+    effectiveState:
+      mode === 'disabled' || status.globalState === null
+        ? 'inactive'
+        : // `enabled` and `inherit` both act on the global state here; what
+          // separates them is what happens to a LATER global change, which is
+          // the server's business and not visible in this snapshot.
+          status.globalState,
+  };
+}


### PR DESCRIPTION
Phase 1 of #809, stacked on #816. `FollowTargetButton`, `useFollowTarget`, and the store behind them.

```tsx
<FollowTargetButton targetId={id} />                              // Follow / Following
<FollowTargetButton targetId={id} verb="subscribe" />             // Subscribe / Subscribed
<FollowTargetButton targetId={id} applicationName="Mention" />    // names itself in the menu
<FollowTargetButton targetId={id} durations={false} />            // no timed follows here
<FollowTargetButton targetId={id} labels={{ idle: 'Seguir' }} />  // full override
```

## Two controls, not one

The main press does the obvious thing. The chevron opens what a single press cannot express:

| state | menu offers |
|---|---|
| not following | Follow for 24 hours / 72 hours / a week |
| following | Don't show in *Mention* · Unfollow everywhere |
| off in this app | Show in *Mention* · Unfollow everywhere |
| write in flight | *nothing* |

That last row is the one worth reading twice. Every menu entry addresses a **relationship id**, which an optimistic follow does not have until the server answers — so offering them mid-write would mean sending a guess. The chevron is simply unavailable for the width of one request.

Bloom's `Menu` is a bottom sheet on native and a dropdown on web, so this is one component and not a platform fork.

## Verbs

"Follow" is wrong for half the ecosystem: you subscribe to a channel, join a community, watch a listing. The verb is a **prop** with a small vocabulary and a full override — **not** a lookup keyed on kind. A kind→verb table in this package would need a release of it every time an application invents a kind, which is exactly the coupling #809 exists to remove.

## What is tested, and how I know the tests work

`buildFollowMenuItems` is pure and exported, so the product decision — which choices exist in which state — is testable without a render. A rendering test here would assert about a DOM one layout change away from meaning nothing.

Both load-bearing rules were **mutation-checked**: dropping the in-flight guard fails *"offers nothing while a write is in flight"*, and dropping the disabled-means-inactive derivation fails *"makes a disabled follow inactive without giving up the follow"*. 13 tests green, `tsc` clean.

## The store

The client's single cache authority, because the SDK deliberately caches none of these reads. It **resets on identity change** — the next user's follows are a different set entirely, and showing one account's follow state to another is a privacy failure rather than a rendering one.

## The legacy button

`FollowButton` still follows a *user* through the Mongo-backed social graph and stays correct for that until the user graph moves onto `/v2/follows`. When it does, that component is **deleted** and this one takes the name — not aliased, not deprecated in place.

Refs #809