### PR TITLE
feat(follows): the follow-graph outbox worker (#809 phase 1)

### DIFF
--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -199,3 +199,11 @@ NODE_ENV=production
 # RSPAMD_URL=http://localhost:11333
 # SPAM_THRESHOLD=5
 # SPAM_REJECT_THRESHOLD=15
+
+# Follow-graph outbox worker (`follow_events`)
+# OFF by default: acknowledging an event asserts its delivery happened, and the
+# handler set today observes rather than delivers. Writing the events is never
+# gated, so they accumulate until the loop is switched on.
+# FOLLOW_OUTBOX_WORKER_ENABLED=false
+# FOLLOW_OUTBOX_POLL_INTERVAL_MS=5000
+# FOLLOW_OUTBOX_BATCH_SIZE=50

--- a/packages/api/drizzle/0020_follow_events_claim.sql
+++ b/packages/api/drizzle/0020_follow_events_claim.sql
@@ -1,0 +1,47 @@
+-- oxy:deploy-phase=pre
+--
+-- PRE despite the DROP INDEX, and the reason is worth stating rather than
+-- assuming. `post` exists because drizzle selects COLUMNS by name, so removing
+-- one 500s every read the image still serving performs. An index is never named
+-- by a query — and `follow_events` has exactly one consumer in the image now
+-- live, the INSERT in `followCommand.service.ts`, which this cannot affect.
+-- Marking it `post` would be the harmful choice: the arriving image's worker
+-- would claim against a table whose claim query has no index until somebody
+-- dispatched the second half.
+--
+-- The five columns are additive and defaulted; the index is REPLACED rather
+-- than added beside the old one, because two overlapping partial indexes on one
+-- queue table is write amplification for a predicate nothing would use. The
+-- narrower predicate exists so a dead-lettered event stops being scanned past:
+-- dead letters are by definition the OLDEST unprocessed rows, so under the old
+-- predicate every future claim would walk the whole graveyard first.
+--
+-- DROP + CREATE, not CONCURRENTLY: the migrator runs inside a transaction, and
+-- `follow_events` holds only what has been written since 0016 reached
+-- production, so the SHARE lock is taken over approximately nothing.
+--
+-- WHAT `drizzle-kit generate` ALSO EMITTED HERE, AND WHY IT WAS REMOVED
+--
+-- The generated file additionally contained `CREATE TABLE follow_namespaces`,
+-- the namespace foreign key, and all five CHECK constraints — everything 0018
+-- and 0019 already do. Both of those were hand-written with no snapshot beside
+-- them, so `meta/`'s chain still ended at 0016 and drizzle diffed today's
+-- TypeScript schema against a model of the database two migrations stale. Every
+-- one of those statements has already been applied, production included;
+-- `CREATE TABLE follow_namespaces` would fail outright.
+--
+-- So the SQL below is only what has NOT been applied, while
+-- `meta/0020_snapshot.json` is kept exactly as generated — it is the first
+-- snapshot that models 0018 and 0019, and keeping it is what stops the next
+-- `generate` proposing them a second time. Snapshot and SQL therefore describe
+-- different things deliberately, the same way 0016's header records that its
+-- snapshot omits `users.organization_category`. Do not "reconcile" this file by
+-- regenerating it; that re-arms the problem.
+DROP INDEX "follow_events_pending_idx";--> statement-breakpoint
+ALTER TABLE "follow_events" ADD COLUMN "claimed_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "follow_events" ADD COLUMN "claimed_by" text;--> statement-breakpoint
+ALTER TABLE "follow_events" ADD COLUMN "attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "follow_events" ADD COLUMN "failed_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "follow_events" ADD COLUMN "last_error" text;--> statement-breakpoint
+CREATE INDEX "follow_events_dead_letter_idx" ON "follow_events" USING btree ("failed_at") WHERE "follow_events"."failed_at" is not null;--> statement-breakpoint
+CREATE INDEX "follow_events_pending_idx" ON "follow_events" USING btree ("created_at") WHERE "follow_events"."processed_at" is null and "follow_events"."failed_at" is null;

--- a/packages/api/drizzle/meta/0020_snapshot.json
+++ b/packages/api/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,16995 @@
+{
+  "id": "9b97b22e-0f0b-4f7b-9dc7-4babd762b4eb",
+  "prevId": "6d4b2c9c-89a5-4fd0-a6b9-4955480da68d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_credentials": {
+      "name": "account_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'service'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_credential_id": {
+          "name": "rotated_from_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_credentials_account_id_status_idx": {
+          "name": "account_credentials_account_id_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_credentials_account_id_users_id_fk": {
+          "name": "account_credentials_account_id_users_id_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_credentials_created_by_user_id_users_id_fk": {
+          "name": "account_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "account_credentials_rotated_from_fk": {
+          "name": "account_credentials_rotated_from_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "account_credentials",
+          "columnsFrom": [
+            "rotated_from_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_credentials_public_key_key": {
+          "name": "account_credentials_public_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_credentials_type_check": {
+          "name": "account_credentials_type_check",
+          "value": "\"account_credentials\".\"type\" in ('service')"
+        },
+        "account_credentials_environment_check": {
+          "name": "account_credentials_environment_check",
+          "value": "\"account_credentials\".\"environment\" in ('development', 'staging', 'production')"
+        },
+        "account_credentials_status_check": {
+          "name": "account_credentials_status_check",
+          "value": "\"account_credentials\".\"status\" in ('active', 'deprecated', 'revoked')"
+        },
+        "account_credentials_scopes_check": {
+          "name": "account_credentials_scopes_check",
+          "value": "\"account_credentials\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register']::text[]"
+        },
+        "account_credentials_rotated_from_not_self_check": {
+          "name": "account_credentials_rotated_from_not_self_check",
+          "value": "\"account_credentials\".\"rotated_from_credential_id\" <> \"account_credentials\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_members": {
+      "name": "account_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_grants": {
+          "name": "permission_grants",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "permission_revokes": {
+          "name": "permission_revokes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "inherit": {
+          "name": "inherit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_members_member_user_id_status_idx": {
+          "name": "account_members_member_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "member_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_members_account_id_users_id_fk": {
+          "name": "account_members_account_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_members_member_user_id_users_id_fk": {
+          "name": "account_members_member_user_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_members_invited_by_user_id_users_id_fk": {
+          "name": "account_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_members_account_id_member_user_id_key": {
+          "name": "account_members_account_id_member_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_id",
+            "member_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_members_role_check": {
+          "name": "account_members_role_check",
+          "value": "\"account_members\".\"role\" in ('owner', 'admin', 'editor', 'developer', 'billing', 'viewer')"
+        },
+        "account_members_status_check": {
+          "name": "account_members_status_check",
+          "value": "\"account_members\".\"status\" in ('active', 'invited', 'removed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key_usage_events": {
+      "name": "api_key_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_key'"
+        },
+        "service_app": {
+          "name": "service_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_key_usage_events_application_id_created_at_idx": {
+          "name": "api_key_usage_events_application_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_user_id_created_at_idx": {
+          "name": "api_key_usage_events_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_api_key_id_created_at_idx": {
+          "name": "api_key_usage_events_api_key_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_created_at_idx": {
+          "name": "api_key_usage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_usage_events_api_key_id_developer_api_keys_id_fk": {
+          "name": "api_key_usage_events_api_key_id_developer_api_keys_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "developer_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_usage_events_user_id_users_id_fk": {
+          "name": "api_key_usage_events_user_id_users_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_usage_events_application_id_applications_id_fk": {
+          "name": "api_key_usage_events_application_id_applications_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "api_key_usage_events_method_check": {
+          "name": "api_key_usage_events_method_check",
+          "value": "\"api_key_usage_events\".\"method\" in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')"
+        },
+        "api_key_usage_events_auth_type_check": {
+          "name": "api_key_usage_events_auth_type_check",
+          "value": "\"api_key_usage_events\".\"auth_type\" in ('api_key', 'session', 'internal')"
+        },
+        "api_key_usage_events_status_code_check": {
+          "name": "api_key_usage_events_status_code_check",
+          "value": "\"api_key_usage_events\".\"status_code\" >= 100 and \"api_key_usage_events\".\"status_code\" < 600"
+        },
+        "api_key_usage_events_consumption_check": {
+          "name": "api_key_usage_events_consumption_check",
+          "value": "\"api_key_usage_events\".\"tokens_used\" >= 0 and \"api_key_usage_events\".\"credits_used\" >= 0\n        and (\"api_key_usage_events\".\"response_time\" is null or \"api_key_usage_events\".\"response_time\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_affinity_edges": {
+      "name": "app_affinity_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affinity": {
+          "name": "affinity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_affinity_edges_application_id_from_user_id_affinity_idx": {
+          "name": "app_affinity_edges_application_id_from_user_id_affinity_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affinity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_affinity_edges_application_id_to_user_id_idx": {
+          "name": "app_affinity_edges_application_id_to_user_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_affinity_edges_application_id_applications_id_fk": {
+          "name": "app_affinity_edges_application_id_applications_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_affinity_edges_from_user_id_users_id_fk": {
+          "name": "app_affinity_edges_from_user_id_users_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_affinity_edges_to_user_id_users_id_fk": {
+          "name": "app_affinity_edges_to_user_id_users_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_affinity_edges_directed_edge_key": {
+          "name": "app_affinity_edges_directed_edge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "from_user_id",
+            "to_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_affinity_edges_not_self_check": {
+          "name": "app_affinity_edges_not_self_check",
+          "value": "\"app_affinity_edges\".\"from_user_id\" <> \"app_affinity_edges\".\"to_user_id\""
+        },
+        "app_affinity_edges_affinity_check": {
+          "name": "app_affinity_edges_affinity_check",
+          "value": "\"app_affinity_edges\".\"affinity\" >= 0 and \"app_affinity_edges\".\"event_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_affinity_seen_events": {
+      "name": "app_affinity_seen_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_affinity_seen_events_created_at_idx": {
+          "name": "app_affinity_seen_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_affinity_seen_events_application_id_applications_id_fk": {
+          "name": "app_affinity_seen_events_application_id_applications_id_fk",
+          "tableFrom": "app_affinity_seen_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_affinity_seen_events_application_id_event_id_key": {
+          "name": "app_affinity_seen_events_application_id_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_endorsement_edges": {
+      "name": "app_endorsement_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_endorsement_edges_application_id_member_id_idx": {
+          "name": "app_endorsement_edges_application_id_member_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_endorsement_edges_application_id_applications_id_fk": {
+          "name": "app_endorsement_edges_application_id_applications_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_endorsement_edges_owner_id_users_id_fk": {
+          "name": "app_endorsement_edges_owner_id_users_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_endorsement_edges_member_id_users_id_fk": {
+          "name": "app_endorsement_edges_member_id_users_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_endorsement_edges_idempotency_key": {
+          "name": "app_endorsement_edges_idempotency_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "application_id",
+            "owner_id",
+            "member_id",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_endorsement_edges_not_self_check": {
+          "name": "app_endorsement_edges_not_self_check",
+          "value": "\"app_endorsement_edges\".\"owner_id\" <> \"app_endorsement_edges\".\"member_id\""
+        },
+        "app_endorsement_edges_source_id_check": {
+          "name": "app_endorsement_edges_source_id_check",
+          "value": "\"app_endorsement_edges\".\"source_id\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_grants": {
+      "name": "app_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "first_granted_at": {
+          "name": "first_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_grants_application_id_idx": {
+          "name": "app_grants_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_grants_user_id_users_id_fk": {
+          "name": "app_grants_user_id_users_id_fk",
+          "tableFrom": "app_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_grants_application_id_applications_id_fk": {
+          "name": "app_grants_application_id_applications_id_fk",
+          "tableFrom": "app_grants",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_grants_user_id_application_id_key": {
+          "name": "app_grants_user_id_application_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_update_assets": {
+      "name": "app_update_assets",
+      "schema": "",
+      "columns": {
+        "app_update_id": {
+          "name": "app_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_extension": {
+          "name": "file_extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_update_assets_sha256_idx": {
+          "name": "app_update_assets_sha256_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_update_assets_app_update_id_app_updates_id_fk": {
+          "name": "app_update_assets_app_update_id_app_updates_id_fk",
+          "tableFrom": "app_update_assets",
+          "tableTo": "app_updates",
+          "columnsFrom": [
+            "app_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_update_assets_sha256_update_assets_sha256_fk": {
+          "name": "app_update_assets_sha256_update_assets_sha256_fk",
+          "tableFrom": "app_update_assets",
+          "tableTo": "update_assets",
+          "columnsFrom": [
+            "sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_update_assets_pkey": {
+          "name": "app_update_assets_pkey",
+          "columns": [
+            "app_update_id",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_update_assets_ordinal_check": {
+          "name": "app_update_assets_ordinal_check",
+          "value": "\"app_update_assets\".\"ordinal\" >= 0"
+        },
+        "app_update_assets_sha256_check": {
+          "name": "app_update_assets_sha256_check",
+          "value": "\"app_update_assets\".\"sha256\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_updates": {
+      "name": "app_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "update_id": {
+          "name": "update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "launch_asset_sha256": {
+          "name": "launch_asset_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_key": {
+          "name": "launch_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_content_type": {
+          "name": "launch_asset_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_file_extension": {
+          "name": "launch_asset_file_extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rollout_percent": {
+          "name": "rollout_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "git_commit": {
+          "name": "git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_from_update_id": {
+          "name": "promoted_from_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_updates_head_idx": {
+          "name": "app_updates_head_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_updates_channel_id_idx": {
+          "name": "app_updates_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_updates_application_id_applications_id_fk": {
+          "name": "app_updates_application_id_applications_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_updates_channel_id_update_channels_id_fk": {
+          "name": "app_updates_channel_id_update_channels_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "update_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_updates_launch_asset_sha256_update_assets_sha256_fk": {
+          "name": "app_updates_launch_asset_sha256_update_assets_sha256_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "update_assets",
+          "columnsFrom": [
+            "launch_asset_sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "app_updates_promoted_from_update_id_app_updates_update_id_fk": {
+          "name": "app_updates_promoted_from_update_id_app_updates_update_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "app_updates",
+          "columnsFrom": [
+            "promoted_from_update_id"
+          ],
+          "columnsTo": [
+            "update_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_updates_update_id_key": {
+          "name": "app_updates_update_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "update_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_updates_platform_check": {
+          "name": "app_updates_platform_check",
+          "value": "\"app_updates\".\"platform\" in ('ios', 'android')"
+        },
+        "app_updates_status_check": {
+          "name": "app_updates_status_check",
+          "value": "\"app_updates\".\"status\" in ('published', 'superseded', 'rolled_back')"
+        },
+        "app_updates_update_id_check": {
+          "name": "app_updates_update_id_check",
+          "value": "\"app_updates\".\"update_id\" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'"
+        },
+        "app_updates_launch_asset_sha256_check": {
+          "name": "app_updates_launch_asset_sha256_check",
+          "value": "\"app_updates\".\"launch_asset_sha256\" ~ '^[a-f0-9]{64}$'"
+        },
+        "app_updates_rollout_percent_check": {
+          "name": "app_updates_rollout_percent_check",
+          "value": "\"app_updates\".\"rollout_percent\" >= 0 and \"app_updates\".\"rollout_percent\" <= 100"
+        },
+        "app_updates_extra_expo_client_check": {
+          "name": "app_updates_extra_expo_client_check",
+          "value": "jsonb_typeof(\"app_updates\".\"extra\" -> 'expoClient') is not distinct from 'object'"
+        },
+        "app_updates_metadata_check": {
+          "name": "app_updates_metadata_check",
+          "value": "jsonb_typeof(\"app_updates\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_signals": {
+      "name": "app_user_signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endorsement_score": {
+          "name": "endorsement_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interest_score": {
+          "name": "interest_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_endorsed_at": {
+          "name": "last_endorsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "app_user_signals_application_id_endorsement_score_idx": {
+          "name": "app_user_signals_application_id_endorsement_score_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endorsement_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_signals_user_id_idx": {
+          "name": "app_user_signals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_signals_application_id_applications_id_fk": {
+          "name": "app_user_signals_application_id_applications_id_fk",
+          "tableFrom": "app_user_signals",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_user_signals_user_id_users_id_fk": {
+          "name": "app_user_signals_user_id_users_id_fk",
+          "tableFrom": "app_user_signals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_user_signals_application_id_user_id_key": {
+          "name": "app_user_signals_application_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_user_signals_interest_score_check": {
+          "name": "app_user_signals_interest_score_check",
+          "value": "\"app_user_signals\".\"interest_score\" >= 0 and \"app_user_signals\".\"interest_score\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_credentials": {
+      "name": "application_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_credential_id": {
+          "name": "rotated_from_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_credentials_application_id_status_idx": {
+          "name": "application_credentials_application_id_status_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_credentials_application_id_applications_id_fk": {
+          "name": "application_credentials_application_id_applications_id_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_credentials_created_by_user_id_users_id_fk": {
+          "name": "application_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_credentials_rotated_from_fk": {
+          "name": "application_credentials_rotated_from_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "rotated_from_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_credentials_public_key_key": {
+          "name": "application_credentials_public_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "application_credentials_type_check": {
+          "name": "application_credentials_type_check",
+          "value": "\"application_credentials\".\"type\" in ('public', 'confidential', 'service')"
+        },
+        "application_credentials_environment_check": {
+          "name": "application_credentials_environment_check",
+          "value": "\"application_credentials\".\"environment\" in ('development', 'staging', 'production')"
+        },
+        "application_credentials_status_check": {
+          "name": "application_credentials_status_check",
+          "value": "\"application_credentials\".\"status\" in ('active', 'deprecated', 'revoked')"
+        },
+        "application_credentials_scopes_check": {
+          "name": "application_credentials_scopes_check",
+          "value": "\"application_credentials\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register']::text[]"
+        },
+        "application_credentials_rotated_from_not_self_check": {
+          "name": "application_credentials_rotated_from_not_self_check",
+          "value": "\"application_credentials\".\"rotated_from_credential_id\" <> \"application_credentials\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_moderation_trust": {
+      "name": "application_moderation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standing": {
+          "name": "standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sandbox'"
+        },
+        "evidence_integrity": {
+          "name": "evidence_integrity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "identity_binding_reliability": {
+          "name": "identity_binding_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "decision_overturn_rate": {
+          "name": "decision_overturn_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "policy_quality": {
+          "name": "policy_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "global_reputation_effects_allowed": {
+          "name": "global_reputation_effects_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "application_moderation_trust_standing_idx": {
+          "name": "application_moderation_trust_standing_idx",
+          "columns": [
+            {
+              "expression": "standing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_moderation_trust_application_id_applications_id_fk": {
+          "name": "application_moderation_trust_application_id_applications_id_fk",
+          "tableFrom": "application_moderation_trust",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_moderation_trust_reviewed_by_user_id_users_id_fk": {
+          "name": "application_moderation_trust_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "application_moderation_trust",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_moderation_trust_application_id_key": {
+          "name": "application_moderation_trust_application_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "application_moderation_trust_standing_check": {
+          "name": "application_moderation_trust_standing_check",
+          "value": "\"application_moderation_trust\".\"standing\" in ('sandbox', 'trusted', 'restricted')"
+        },
+        "application_moderation_trust_scores_check": {
+          "name": "application_moderation_trust_scores_check",
+          "value": "\"application_moderation_trust\".\"evidence_integrity\" between 0 and 1\n        and \"application_moderation_trust\".\"identity_binding_reliability\" between 0 and 1\n        and \"application_moderation_trust\".\"decision_overturn_rate\" between 0 and 1\n        and \"application_moderation_trust\".\"policy_quality\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'third_party'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_official": {
+          "name": "is_official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_webhook_url": {
+          "name": "dev_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "applications_owner_account_id_created_at_idx": {
+          "name": "applications_owner_account_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_capabilities_idx": {
+          "name": "applications_capabilities_idx",
+          "columns": [
+            {
+              "expression": "capabilities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_owner_account_id_users_id_fk": {
+          "name": "applications_owner_account_id_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_user_id_users_id_fk": {
+          "name": "applications_created_by_user_id_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "applications_type_check": {
+          "name": "applications_type_check",
+          "value": "\"applications\".\"type\" in ('first_party', 'third_party', 'internal', 'system')"
+        },
+        "applications_status_check": {
+          "name": "applications_status_check",
+          "value": "\"applications\".\"status\" in ('active', 'suspended', 'deleted', 'pending_review')"
+        },
+        "applications_scopes_check": {
+          "name": "applications_scopes_check",
+          "value": "\"applications\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register']::text[]"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_challenges": {
+      "name": "auth_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signin'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_challenges_expires_at_idx": {
+          "name": "auth_challenges_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_challenges_challenge_key": {
+          "name": "auth_challenges_challenge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_challenges_purpose_check": {
+          "name": "auth_challenges_purpose_check",
+          "value": "\"auth_challenges\".\"purpose\" in ('signin', 'rotate_key')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_codes": {
+      "name": "auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_codes_user_id_idx": {
+          "name": "auth_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_codes_application_id_idx": {
+          "name": "auth_codes_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_codes_expires_at_idx": {
+          "name": "auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_codes_user_id_users_id_fk": {
+          "name": "auth_codes_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_operated_by_user_id_users_id_fk": {
+          "name": "auth_codes_operated_by_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_application_id_applications_id_fk": {
+          "name": "auth_codes_application_id_applications_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_codes_code_hash_key": {
+          "name": "auth_codes_code_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_codes_code_challenge_method_check": {
+          "name": "auth_codes_code_challenge_method_check",
+          "value": "\"auth_codes\".\"code_challenge_method\" in ('S256')"
+        },
+        "auth_codes_pkce_pair_check": {
+          "name": "auth_codes_pkce_pair_check",
+          "value": "(\"auth_codes\".\"code_challenge\" is null) = (\"auth_codes\".\"code_challenge_method\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorize_code": {
+          "name": "authorize_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_origin": {
+          "name": "bound_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_verified": {
+          "name": "origin_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requester_label": {
+          "name": "requester_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge_nonce": {
+          "name": "challenge_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device_sign_in'"
+        },
+        "oauth_redirect_uri": {
+          "name": "oauth_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_code_challenge": {
+          "name": "oauth_code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_code_challenge_method": {
+          "name": "oauth_code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_subject_account_id": {
+          "name": "oauth_subject_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_auth_code_id": {
+          "name": "finalized_auth_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_by": {
+          "name": "authorized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_user_id": {
+          "name": "authorized_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_sent_at": {
+          "name": "push_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_sessions_application_id_idx": {
+          "name": "auth_sessions_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_application_id_applications_id_fk": {
+          "name": "auth_sessions_application_id_applications_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_sessions_oauth_subject_account_id_users_id_fk": {
+          "name": "auth_sessions_oauth_subject_account_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "oauth_subject_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_sessions_authorized_user_id_users_id_fk": {
+          "name": "auth_sessions_authorized_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorized_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_key": {
+          "name": "auth_sessions_session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        },
+        "auth_sessions_authorize_code_key": {
+          "name": "auth_sessions_authorize_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authorize_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_sessions_status_check": {
+          "name": "auth_sessions_status_check",
+          "value": "\"auth_sessions\".\"status\" in ('pending', 'authorized', 'consumed', 'expired', 'cancelled')"
+        },
+        "auth_sessions_purpose_check": {
+          "name": "auth_sessions_purpose_check",
+          "value": "\"auth_sessions\".\"purpose\" in ('device_sign_in', 'oauth_authorization')"
+        },
+        "auth_sessions_denied_reason_check": {
+          "name": "auth_sessions_denied_reason_check",
+          "value": "\"auth_sessions\".\"denied_reason\" in ('declined', 'not_me')"
+        },
+        "auth_sessions_oauth_code_challenge_method_check": {
+          "name": "auth_sessions_oauth_code_challenge_method_check",
+          "value": "\"auth_sessions\".\"oauth_code_challenge_method\" in ('S256')"
+        },
+        "auth_sessions_oauth_binding_check": {
+          "name": "auth_sessions_oauth_binding_check",
+          "value": "(\"auth_sessions\".\"oauth_redirect_uri\" is null and \"auth_sessions\".\"oauth_code_challenge\" is null and \"auth_sessions\".\"oauth_code_challenge_method\" is null and \"auth_sessions\".\"oauth_scopes\" is null)\n        or (\"auth_sessions\".\"oauth_redirect_uri\" is not null and \"auth_sessions\".\"oauth_code_challenge\" is not null and \"auth_sessions\".\"oauth_code_challenge_method\" is not null and \"auth_sessions\".\"oauth_scopes\" is not null)"
+        },
+        "auth_sessions_oauth_purpose_check": {
+          "name": "auth_sessions_oauth_purpose_check",
+          "value": "(\"auth_sessions\".\"purpose\" = 'oauth_authorization') = (\"auth_sessions\".\"oauth_redirect_uri\" is not null)"
+        },
+        "auth_sessions_oauth_subject_requires_binding_check": {
+          "name": "auth_sessions_oauth_subject_requires_binding_check",
+          "value": "\"auth_sessions\".\"oauth_subject_account_id\" is null or \"auth_sessions\".\"oauth_redirect_uri\" is not null"
+        },
+        "auth_sessions_requester_label_length_check": {
+          "name": "auth_sessions_requester_label_length_check",
+          "value": "\"auth_sessions\".\"requester_label\" is null or char_length(\"auth_sessions\".\"requester_label\") <= 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_subscriptions": {
+      "name": "billing_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_credits_per_month": {
+          "name": "plan_credits_per_month",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_price_minor_units": {
+          "name": "plan_price_minor_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_currency": {
+          "name": "plan_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_subscriptions_user_id_status_idx": {
+          "name": "billing_subscriptions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_subscriptions_user_id_users_id_fk": {
+          "name": "billing_subscriptions_user_id_users_id_fk",
+          "tableFrom": "billing_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_subscriptions_stripe_subscription_id_key": {
+          "name": "billing_subscriptions_stripe_subscription_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "billing_subscriptions_status_check": {
+          "name": "billing_subscriptions_status_check",
+          "value": "\"billing_subscriptions\".\"status\" in ('active', 'canceled', 'incomplete', 'incomplete_expired', 'past_due', 'paused', 'trialing', 'unpaid')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_transactions": {
+      "name": "billing_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_period_start": {
+          "name": "stripe_subscription_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor_units": {
+          "name": "amount_minor_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "billing_transactions_subscription_period_key": {
+          "name": "billing_transactions_subscription_period_key",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing_transactions\".\"type\" = 'subscription_payment' and \"billing_transactions\".\"stripe_subscription_id\" is not null and \"billing_transactions\".\"stripe_subscription_period_start\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_transactions_payment_intent_key": {
+          "name": "billing_transactions_payment_intent_key",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing_transactions\".\"type\" = 'credit_purchase' and \"billing_transactions\".\"stripe_payment_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_transactions_user_id_created_at_idx": {
+          "name": "billing_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_transactions_user_id_users_id_fk": {
+          "name": "billing_transactions_user_id_users_id_fk",
+          "tableFrom": "billing_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_transactions_type_check": {
+          "name": "billing_transactions_type_check",
+          "value": "\"billing_transactions\".\"type\" in ('credit_purchase', 'subscription_payment', 'refund')"
+        },
+        "billing_transactions_status_check": {
+          "name": "billing_transactions_status_check",
+          "value": "\"billing_transactions\".\"status\" in ('pending', 'completed', 'failed', 'refunded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_blocked_id_idx": {
+          "name": "blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_user_id_users_id_fk": {
+          "name": "blocks_user_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocks_blocked_id_users_id_fk": {
+          "name": "blocks_blocked_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocks_user_id_blocked_id_key": {
+          "name": "blocks_user_id_blocked_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_id_idx": {
+          "name": "bookmarks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder-outline'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#5F6368'"
+        },
+        "match_labels": {
+          "name": "match_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bundles_user_id_lower_name_key": {
+          "name": "bundles_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundles_user_id_users_id_fk": {
+          "name": "bundles_user_id_users_id_fk",
+          "tableFrom": "bundles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.civic_nonces": {
+      "name": "civic_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "civic_nonces_expires_at_idx": {
+          "name": "civic_nonces_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "civic_nonces_subject_user_id_users_id_fk": {
+          "name": "civic_nonces_subject_user_id_users_id_fk",
+          "tableFrom": "civic_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "civic_nonces_nonce_hash_key": {
+          "name": "civic_nonces_nonce_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conduct_strikes": {
+      "name": "conduct_strikes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_points": {
+          "name": "risk_points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conduct_strikes_user_id_status_idx": {
+          "name": "conduct_strikes_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_user_id_family_created_at_idx": {
+          "name": "conduct_strikes_user_id_family_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "family",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_decision_id_decision_revision_idx": {
+          "name": "conduct_strikes_decision_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_expires_at_idx": {
+          "name": "conduct_strikes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conduct_strikes\".\"status\" = 'active' and \"conduct_strikes\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conduct_strikes_user_id_users_id_fk": {
+          "name": "conduct_strikes_user_id_users_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_application_id_applications_id_fk": {
+          "name": "conduct_strikes_application_id_applications_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_transaction_id_reputation_transactions_id_fk": {
+          "name": "conduct_strikes_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_policy_version_fk": {
+          "name": "conduct_strikes_policy_version_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_version"
+          ],
+          "columnsTo": [
+            "policy_version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conduct_strikes_incident_id_user_id_effect_type_revision_key": {
+          "name": "conduct_strikes_incident_id_user_id_effect_type_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "incident_id",
+            "user_id",
+            "effect_type",
+            "decision_revision"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conduct_strikes_effect_type_check": {
+          "name": "conduct_strikes_effect_type_check",
+          "value": "\"conduct_strikes\".\"effect_type\" in ('conduct_penalty', 'report_abuse_penalty', 'review_abuse_penalty')"
+        },
+        "conduct_strikes_severity_check": {
+          "name": "conduct_strikes_severity_check",
+          "value": "\"conduct_strikes\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "conduct_strikes_status_check": {
+          "name": "conduct_strikes_status_check",
+          "value": "\"conduct_strikes\".\"status\" in ('active', 'expired', 'reversed')"
+        },
+        "conduct_strikes_decision_revision_check": {
+          "name": "conduct_strikes_decision_revision_check",
+          "value": "\"conduct_strikes\".\"decision_revision\" >= 0"
+        },
+        "conduct_strikes_resolution_complete_check": {
+          "name": "conduct_strikes_resolution_complete_check",
+          "value": "(\"conduct_strikes\".\"status\" = 'active') = (\"conduct_strikes\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_collected": {
+          "name": "auto_collected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(name, '') || ' ' || coalesce(email, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_user_id_email_key": {
+          "name": "contacts_user_id_email_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_search_vector_idx": {
+          "name": "contacts_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "contacts_starred_idx": {
+          "name": "contacts_starred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"contacts\".\"starred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_user_id_users_id_fk": {
+          "name": "contacts_user_id_users_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.developer_api_keys": {
+      "name": "developer_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"chat:completions\",\"models:read\"}'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_requests_per_minute": {
+          "name": "rate_limit_requests_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_requests_per_day": {
+          "name": "rate_limit_requests_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1000
+        },
+        "rate_limit_tokens_per_minute": {
+          "name": "rate_limit_tokens_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_tokens_per_day": {
+          "name": "rate_limit_tokens_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "developer_api_keys_user_id_is_active_idx": {
+          "name": "developer_api_keys_user_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "developer_api_keys_application_id_is_active_idx": {
+          "name": "developer_api_keys_application_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "developer_api_keys_user_id_users_id_fk": {
+          "name": "developer_api_keys_user_id_users_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "developer_api_keys_application_id_applications_id_fk": {
+          "name": "developer_api_keys_application_id_applications_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "developer_api_keys_key_hash_key": {
+          "name": "developer_api_keys_key_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "developer_api_keys_scopes_check": {
+          "name": "developer_api_keys_scopes_check",
+          "value": "\"developer_api_keys\".\"scopes\" <@ array['chat:completions', 'models:read', 'files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive']::text[]"
+        },
+        "developer_api_keys_rate_limit_check": {
+          "name": "developer_api_keys_rate_limit_check",
+          "value": "(\"developer_api_keys\".\"rate_limit_requests_per_minute\" is null or \"developer_api_keys\".\"rate_limit_requests_per_minute\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_requests_per_day\" is null or \"developer_api_keys\".\"rate_limit_requests_per_day\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_tokens_per_minute\" is null or \"developer_api_keys\".\"rate_limit_tokens_per_minute\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_tokens_per_day\" is null or \"developer_api_keys\".\"rate_limit_tokens_per_day\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_pairing_sessions": {
+      "name": "device_pairing_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pairing_id": {
+          "name": "pairing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_device_ephemeral_public_key": {
+          "name": "new_device_ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_device_label": {
+          "name": "new_device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_device_ephemeral_public_key": {
+          "name": "old_device_ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "device_pairing_sessions_expires_at_idx": {
+          "name": "device_pairing_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_pairing_sessions_approved_by_user_id_users_id_fk": {
+          "name": "device_pairing_sessions_approved_by_user_id_users_id_fk",
+          "tableFrom": "device_pairing_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_pairing_sessions_pairing_id_key": {
+          "name": "device_pairing_sessions_pairing_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pairing_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_pairing_sessions_status_check": {
+          "name": "device_pairing_sessions_status_check",
+          "value": "\"device_pairing_sessions\".\"status\" in ('pending', 'approved', 'denied', 'expired')"
+        },
+        "device_pairing_sessions_sealed_payload_check": {
+          "name": "device_pairing_sessions_sealed_payload_check",
+          "value": "(\"device_pairing_sessions\".\"old_device_ephemeral_public_key\" is null and \"device_pairing_sessions\".\"ciphertext\" is null and \"device_pairing_sessions\".\"nonce\" is null)\n        or (\"device_pairing_sessions\".\"old_device_ephemeral_public_key\" is not null and \"device_pairing_sessions\".\"ciphertext\" is not null and \"device_pairing_sessions\".\"nonce\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_session_accounts": {
+      "name": "device_session_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_session_id": {
+          "name": "device_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authuser": {
+          "name": "authuser",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_session_accounts_account_id_idx": {
+          "name": "device_session_accounts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_session_accounts_operated_by_user_id_idx": {
+          "name": "device_session_accounts_operated_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "operated_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"device_session_accounts\".\"operated_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_session_accounts_device_session_id_device_sessions_id_fk": {
+          "name": "device_session_accounts_device_session_id_device_sessions_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "device_sessions",
+          "columnsFrom": [
+            "device_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_session_accounts_account_id_users_id_fk": {
+          "name": "device_session_accounts_account_id_users_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_session_accounts_operated_by_user_id_users_id_fk": {
+          "name": "device_session_accounts_operated_by_user_id_users_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_session_accounts_device_session_id_account_id_key": {
+          "name": "device_session_accounts_device_session_id_account_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_session_id",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_session_accounts_authuser_check": {
+          "name": "device_session_accounts_authuser_check",
+          "value": "\"device_session_accounts\".\"authuser\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_sessions": {
+      "name": "device_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_account_id": {
+          "name": "active_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_hash": {
+          "name": "prev_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_expires_at": {
+          "name": "prev_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_hash": {
+          "name": "background_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_account_id": {
+          "name": "background_secret_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_expires_at": {
+          "name": "background_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_sessions_active_account_id_users_id_fk": {
+          "name": "device_sessions_active_account_id_users_id_fk",
+          "tableFrom": "device_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "active_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "device_sessions_background_secret_account_id_users_id_fk": {
+          "name": "device_sessions_background_secret_account_id_users_id_fk",
+          "tableFrom": "device_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "background_secret_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_sessions_device_id_key": {
+          "name": "device_sessions_device_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_id"
+          ]
+        },
+        "device_sessions_secret_hash_key": {
+          "name": "device_sessions_secret_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_verifications": {
+      "name": "domain_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "domain_verifications_user_id_lower_domain_key": {
+          "name": "domain_verifications_user_id_lower_domain_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_verifications_expires_at_idx": {
+          "name": "domain_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_verifications_user_id_users_id_fk": {
+          "name": "domain_verifications_user_id_users_id_fk",
+          "tableFrom": "domain_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_filter_actions": {
+      "name": "email_filter_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filter_id": {
+          "name": "filter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_filter_actions_filter_id_email_filters_id_fk": {
+          "name": "email_filter_actions_filter_id_email_filters_id_fk",
+          "tableFrom": "email_filter_actions",
+          "tableTo": "email_filters",
+          "columnsFrom": [
+            "filter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_filter_actions_filter_id_ord_key": {
+          "name": "email_filter_actions_filter_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filter_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_filter_actions_type_check": {
+          "name": "email_filter_actions_type_check",
+          "value": "\"email_filter_actions\".\"type\" in ('move', 'label', 'star', 'mark-read', 'archive', 'delete', 'forward')"
+        },
+        "email_filter_actions_ord_check": {
+          "name": "email_filter_actions_ord_check",
+          "value": "\"email_filter_actions\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_filter_conditions": {
+      "name": "email_filter_conditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filter_id": {
+          "name": "filter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_filter_conditions_filter_id_email_filters_id_fk": {
+          "name": "email_filter_conditions_filter_id_email_filters_id_fk",
+          "tableFrom": "email_filter_conditions",
+          "tableTo": "email_filters",
+          "columnsFrom": [
+            "filter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_filter_conditions_filter_id_ord_key": {
+          "name": "email_filter_conditions_filter_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filter_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_filter_conditions_field_check": {
+          "name": "email_filter_conditions_field_check",
+          "value": "\"email_filter_conditions\".\"field\" in ('from', 'to', 'subject', 'has-attachment', 'size')"
+        },
+        "email_filter_conditions_operator_check": {
+          "name": "email_filter_conditions_operator_check",
+          "value": "\"email_filter_conditions\".\"operator\" in ('contains', 'equals', 'not-contains', 'starts-with', 'ends-with', 'greater-than', 'less-than')"
+        },
+        "email_filter_conditions_ord_check": {
+          "name": "email_filter_conditions_ord_check",
+          "value": "\"email_filter_conditions\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_filters": {
+      "name": "email_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "match_all": {
+          "name": "match_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_filters_user_id_enabled_order_idx": {
+          "name": "email_filters_user_id_enabled_order_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_filters_user_id_users_id_fk": {
+          "name": "email_filters_user_id_users_id_fk",
+          "tableFrom": "email_filters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_templates_user_id_lower_name_key": {
+          "name": "email_templates_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_user_id_users_id_fk": {
+          "name": "email_templates_user_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_key_pairs": {
+      "name": "federation_key_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_pem": {
+          "name": "private_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_key_pairs_key_id_key": {
+          "name": "federation_key_pairs_key_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_links": {
+      "name": "file_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_links_app_entity_type_entity_id_created_by_idx": {
+          "name": "file_links_app_entity_type_entity_id_created_by_idx",
+          "columns": [
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_links_created_by_idx": {
+          "name": "file_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_links_file_id_files_id_fk": {
+          "name": "file_links_file_id_files_id_fk",
+          "tableFrom": "file_links",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_links_created_by_users_id_fk": {
+          "name": "file_links_created_by_users_id_fk",
+          "tableFrom": "file_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_links_file_id_app_entity_key": {
+          "name": "file_links_file_id_app_entity_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_id",
+            "app",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_variants": {
+      "name": "file_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_variants_file_id_type_idx": {
+          "name": "file_variants_file_id_type_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_variants_file_id_files_id_fk": {
+          "name": "file_variants_file_id_files_id_fk",
+          "tableFrom": "file_variants",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_variants_size_check": {
+          "name": "file_variants_size_check",
+          "value": "\"file_variants\".\"size\" is null or \"file_variants\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_owner": {
+          "name": "system_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "files_sha256_live_key": {
+          "name": "files_sha256_live_key",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"status\" in ('active', 'trash')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_owner_user_id_status_idx": {
+          "name": "files_owner_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_owner_user_id_visibility_status_idx": {
+          "name": "files_owner_user_id_visibility_status_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_visibility_status_idx": {
+          "name": "files_visibility_status_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_sha256_status_idx": {
+          "name": "files_sha256_status_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_purpose_owner_user_id_status_idx": {
+          "name": "files_purpose_owner_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_created_at_idx": {
+          "name": "files_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_owner_user_id_users_id_fk": {
+          "name": "files_owner_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "files_status_check": {
+          "name": "files_status_check",
+          "value": "\"files\".\"status\" in ('active', 'trash', 'deleted')"
+        },
+        "files_visibility_check": {
+          "name": "files_visibility_check",
+          "value": "\"files\".\"visibility\" in ('private', 'public', 'unlisted')"
+        },
+        "files_purpose_check": {
+          "name": "files_purpose_check",
+          "value": "\"files\".\"purpose\" in ('user', 'federation-media-cache', 'link-preview')"
+        },
+        "files_system_owner_check": {
+          "name": "files_system_owner_check",
+          "value": "\"files\".\"system_owner\" is null or \"files\".\"system_owner\" in ('__federation__', '__federation_media_cache__', '__link_preview_cache__')"
+        },
+        "files_owner_exclusive_check": {
+          "name": "files_owner_exclusive_check",
+          "value": "(\"files\".\"owner_user_id\" is null) <> (\"files\".\"system_owner\" is null)"
+        },
+        "files_size_check": {
+          "name": "files_size_check",
+          "value": "\"files\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_namespaces": {
+      "name": "follow_namespaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_namespaces_application_idx": {
+          "name": "follow_namespaces_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_namespaces_application_id_applications_id_fk": {
+          "name": "follow_namespaces_application_id_applications_id_fk",
+          "tableFrom": "follow_namespaces",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_namespaces_namespace_key": {
+          "name": "follow_namespaces_namespace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_namespaces_shape_check": {
+          "name": "follow_namespaces_shape_check",
+          "value": "\"follow_namespaces\".\"namespace\" ~ '^[a-z][a-z0-9_]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_target_kinds": {
+      "name": "follow_target_kinds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_target_kinds_namespace_idx": {
+          "name": "follow_target_kinds_namespace_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_target_kinds_namespace_follow_namespaces_namespace_fk": {
+          "name": "follow_target_kinds_namespace_follow_namespaces_namespace_fk",
+          "tableFrom": "follow_target_kinds",
+          "tableTo": "follow_namespaces",
+          "columnsFrom": [
+            "namespace"
+          ],
+          "columnsTo": [
+            "namespace"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "follow_target_kinds_application_id_applications_id_fk": {
+          "name": "follow_target_kinds_application_id_applications_id_fk",
+          "tableFrom": "follow_target_kinds",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_target_kinds_kind_key": {
+          "name": "follow_target_kinds_kind_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_target_kinds_namespace_prefix_check": {
+          "name": "follow_target_kinds_namespace_prefix_check",
+          "value": "\"follow_target_kinds\".\"kind\" like \"follow_target_kinds\".\"namespace\" || '.%'"
+        },
+        "follow_target_kinds_namespace_shape_check": {
+          "name": "follow_target_kinds_namespace_shape_check",
+          "value": "\"follow_target_kinds\".\"namespace\" ~ '^[a-z][a-z0-9_]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_targets": {
+      "name": "follow_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canonical_uri": {
+          "name": "canonical_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_user_id": {
+          "name": "local_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_snapshot": {
+          "name": "metadata_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_targets_kind_idx": {
+          "name": "follow_targets_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_targets_provider_application_id_idx": {
+          "name": "follow_targets_provider_application_id_idx",
+          "columns": [
+            {
+              "expression": "provider_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_targets_kind_follow_target_kinds_kind_fk": {
+          "name": "follow_targets_kind_follow_target_kinds_kind_fk",
+          "tableFrom": "follow_targets",
+          "tableTo": "follow_target_kinds",
+          "columnsFrom": [
+            "kind"
+          ],
+          "columnsTo": [
+            "kind"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "follow_targets_provider_application_id_applications_id_fk": {
+          "name": "follow_targets_provider_application_id_applications_id_fk",
+          "tableFrom": "follow_targets",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "provider_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_targets_local_user_id_users_id_fk": {
+          "name": "follow_targets_local_user_id_users_id_fk",
+          "tableFrom": "follow_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "local_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_targets_canonical_uri_key": {
+          "name": "follow_targets_canonical_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "canonical_uri"
+          ]
+        },
+        "follow_targets_local_user_id_key": {
+          "name": "follow_targets_local_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "local_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow_relationships": {
+      "name": "follow_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_user_id": {
+          "name": "follower_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_target_id": {
+          "name": "follow_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "origin_application_id": {
+          "name": "origin_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_grant_id": {
+          "name": "created_by_grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_relationships_follower_created_idx": {
+          "name": "follow_relationships_follower_created_idx",
+          "columns": [
+            {
+              "expression": "follower_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_relationships_target_idx": {
+          "name": "follow_relationships_target_idx",
+          "columns": [
+            {
+              "expression": "follow_target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_relationships_origin_application_id_idx": {
+          "name": "follow_relationships_origin_application_id_idx",
+          "columns": [
+            {
+              "expression": "origin_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_relationships_expires_at_idx": {
+          "name": "follow_relationships_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"follow_relationships\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_relationships_follower_user_id_users_id_fk": {
+          "name": "follow_relationships_follower_user_id_users_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_relationships_follow_target_id_follow_targets_id_fk": {
+          "name": "follow_relationships_follow_target_id_follow_targets_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "follow_targets",
+          "columnsFrom": [
+            "follow_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_relationships_origin_application_id_applications_id_fk": {
+          "name": "follow_relationships_origin_application_id_applications_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "origin_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_relationships_created_by_grant_id_app_grants_id_fk": {
+          "name": "follow_relationships_created_by_grant_id_app_grants_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "app_grants",
+          "columnsFrom": [
+            "created_by_grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_relationships_follower_target_key": {
+          "name": "follow_relationships_follower_target_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_user_id",
+            "follow_target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_relationships_state_check": {
+          "name": "follow_relationships_state_check",
+          "value": "\"follow_relationships\".\"state\" in ('requested', 'active', 'rejected')"
+        },
+        "follow_relationships_source_check": {
+          "name": "follow_relationships_source_check",
+          "value": "\"follow_relationships\".\"source\" in ('app', 'federation_inbound', 'migration', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_application_overrides": {
+      "name": "follow_application_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relationship_id": {
+          "name": "relationship_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_application_overrides_application_idx": {
+          "name": "follow_application_overrides_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_application_overrides_relationship_id_follow_relationships_id_fk": {
+          "name": "follow_application_overrides_relationship_id_follow_relationships_id_fk",
+          "tableFrom": "follow_application_overrides",
+          "tableTo": "follow_relationships",
+          "columnsFrom": [
+            "relationship_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_application_overrides_application_id_applications_id_fk": {
+          "name": "follow_application_overrides_application_id_applications_id_fk",
+          "tableFrom": "follow_application_overrides",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_application_overrides_relationship_application_key": {
+          "name": "follow_application_overrides_relationship_application_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "relationship_id",
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_application_overrides_mode_check": {
+          "name": "follow_application_overrides_mode_check",
+          "value": "\"follow_application_overrides\".\"mode\" in ('enabled', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_events": {
+      "name": "follow_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship_id": {
+          "name": "relationship_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_application_id": {
+          "name": "origin_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_application_id": {
+          "name": "context_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_events_pending_idx": {
+          "name": "follow_events_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"follow_events\".\"processed_at\" is null and \"follow_events\".\"failed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_events_dead_letter_idx": {
+          "name": "follow_events_dead_letter_idx",
+          "columns": [
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"follow_events\".\"failed_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_events_relationship_idx": {
+          "name": "follow_events_relationship_idx",
+          "columns": [
+            {
+              "expression": "relationship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_events_actor_idx": {
+          "name": "follow_events_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_events_actor_user_id_users_id_fk": {
+          "name": "follow_events_actor_user_id_users_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_events_origin_application_id_applications_id_fk": {
+          "name": "follow_events_origin_application_id_applications_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "origin_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_events_grant_id_app_grants_id_fk": {
+          "name": "follow_events_grant_id_app_grants_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "app_grants",
+          "columnsFrom": [
+            "grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_events_context_application_id_applications_id_fk": {
+          "name": "follow_events_context_application_id_applications_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "context_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_events_event_id_key": {
+          "name": "follow_events_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_events_type_check": {
+          "name": "follow_events_type_check",
+          "value": "\"follow_events\".\"type\" in ('follow.created', 'follow.removed', 'follow.requested', 'follow.accepted', 'follow.rejected', 'follow.context_enabled', 'follow.context_disabled')"
+        },
+        "follow_events_cause_check": {
+          "name": "follow_events_cause_check",
+          "value": "\"follow_events\".\"cause\" in ('user_action', 'expired', 'federation_inbound', 'reconciliation', 'migration')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.identity_backups": {
+      "name": "identity_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_id_hash": {
+          "name": "lookup_id_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_hint": {
+          "name": "public_key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kdf_info": {
+          "name": "kdf_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_created_at": {
+          "name": "client_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "identity_backups_user_id_users_id_fk": {
+          "name": "identity_backups_user_id_users_id_fk",
+          "tableFrom": "identity_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "identity_backups_user_id_key": {
+          "name": "identity_backups_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "identity_backups_lookup_id_hash_key": {
+          "name": "identity_backups_lookup_id_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lookup_id_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_bindings": {
+      "name": "identity_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_principal_id": {
+          "name": "local_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "identity_bindings_application_id_local_principal_id_active_key": {
+          "name": "identity_bindings_application_id_local_principal_id_active_key",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"identity_bindings\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_bindings_application_id_user_id_status_idx": {
+          "name": "identity_bindings_application_id_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_bindings_user_id_idx": {
+          "name": "identity_bindings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_bindings_application_id_applications_id_fk": {
+          "name": "identity_bindings_application_id_applications_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "identity_bindings_user_id_users_id_fk": {
+          "name": "identity_bindings_user_id_users_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "identity_bindings_credential_id_application_credentials_id_fk": {
+          "name": "identity_bindings_credential_id_application_credentials_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "identity_bindings_binding_type_check": {
+          "name": "identity_bindings_binding_type_check",
+          "value": "\"identity_bindings\".\"binding_type\" in ('oauth_grant', 'session_proof', 'commons_signature', 'federated_actor')"
+        },
+        "identity_bindings_status_check": {
+          "name": "identity_bindings_status_check",
+          "value": "\"identity_bindings\".\"status\" in ('active', 'revoked')"
+        },
+        "identity_bindings_revoked_at_check": {
+          "name": "identity_bindings_revoked_at_check",
+          "value": "(\"identity_bindings\".\"status\" = 'revoked') = (\"identity_bindings\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4285f4'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "labels_user_id_lower_name_key": {
+          "name": "labels_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_user_id_users_id_fk": {
+          "name": "labels_user_id_users_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.link_previews": {
+      "name": "link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_url": {
+          "name": "requested_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_image_url": {
+          "name": "origin_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_favicon_url": {
+          "name": "origin_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "link_previews_status_idx": {
+          "name": "link_previews_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "link_previews_updated_at_idx": {
+          "name": "link_previews_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "link_previews_status_check": {
+          "name": "link_previews_status_check",
+          "value": "\"link_previews\".\"status\" in ('resolved', 'pending', 'empty')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mailboxes": {
+      "name": "mailboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "special_use": {
+          "name": "special_use",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mailboxes_user_id_path_key": {
+          "name": "mailboxes_user_id_path_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_user_id_special_use_idx": {
+          "name": "mailboxes_user_id_special_use_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "special_use",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mailboxes_user_id_users_id_fk": {
+          "name": "mailboxes_user_id_users_id_fk",
+          "tableFrom": "mailboxes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_attachments": {
+      "name": "message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_inline": {
+          "name": "is_inline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "message_attachments_file_id_idx": {
+          "name": "message_attachments_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_attachments_message_id_messages_id_fk": {
+          "name": "message_attachments_message_id_messages_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_attachments_file_id_files_id_fk": {
+          "name": "message_attachments_file_id_files_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_attachments_message_id_ord_key": {
+          "name": "message_attachments_message_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "message_attachments_size_check": {
+          "name": "message_attachments_size_check",
+          "value": "\"message_attachments\".\"size\" >= 0"
+        },
+        "message_attachments_ord_check": {
+          "name": "message_attachments_ord_check",
+          "value": "\"message_attachments\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_recipients": {
+      "name": "message_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_recipients_address_idx": {
+          "name": "message_recipients_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_recipients_message_id_messages_id_fk": {
+          "name": "message_recipients_message_id_messages_id_fk",
+          "tableFrom": "message_recipients",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_recipients_message_id_kind_ord_key": {
+          "name": "message_recipients_message_id_kind_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "kind",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "message_recipients_kind_check": {
+          "name": "message_recipients_kind_check",
+          "value": "\"message_recipients\".\"kind\" in ('to', 'cc', 'bcc')"
+        },
+        "message_recipients_ord_check": {
+          "name": "message_recipients_ord_check",
+          "value": "\"message_recipients\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_name": {
+          "name": "reply_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_address": {
+          "name": "reply_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "encrypted_body": {
+          "name": "encrypted_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "answered": {
+          "name": "answered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forwarded": {
+          "name": "forwarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_data": {
+          "name": "card_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_confidence": {
+          "name": "card_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_extracted_at": {
+          "name": "card_extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spam_action": {
+          "name": "spam_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "alias_tag": {
+          "name": "alias_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_from_mailbox": {
+          "name": "snoozed_from_mailbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_receipt_requested": {
+          "name": "read_receipt_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_receipt_sent": {
+          "name": "read_receipt_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(subject, '')), 'A') || setweight(to_tsvector('english', coalesce(\"text\", '')), 'D')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_user_id_mailbox_id_pinned_date_idx": {
+          "name": "messages_user_id_mailbox_id_pinned_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_message_id_idx": {
+          "name": "messages_user_id_message_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_in_reply_to_idx": {
+          "name": "messages_user_id_in_reply_to_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_references_idx": {
+          "name": "messages_references_idx",
+          "columns": [
+            {
+              "expression": "references",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_unseen_idx": {
+          "name": "messages_unseen_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"messages\".\"seen\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_starred_idx": {
+          "name": "messages_starred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"starred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_search_vector_idx": {
+          "name": "messages_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_labels_idx": {
+          "name": "messages_labels_idx",
+          "columns": [
+            {
+              "expression": "labels",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_user_id_alias_tag_idx": {
+          "name": "messages_user_id_alias_tag_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_from_address_date_idx": {
+          "name": "messages_user_id_from_address_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_pinned_date_idx": {
+          "name": "messages_user_id_pinned_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_snoozed_until_idx": {
+          "name": "messages_snoozed_until_idx",
+          "columns": [
+            {
+              "expression": "snoozed_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"snoozed_until\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_scheduled_at_idx": {
+          "name": "messages_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"scheduled_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_mailbox_id_received_at_idx": {
+          "name": "messages_mailbox_id_received_at_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_mailbox_id_mailboxes_id_fk": {
+          "name": "messages_mailbox_id_mailboxes_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "mailboxes",
+          "columnsFrom": [
+            "mailbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_snoozed_from_mailbox_mailboxes_id_fk": {
+          "name": "messages_snoozed_from_mailbox_mailboxes_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "mailboxes",
+          "columnsFrom": [
+            "snoozed_from_mailbox"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_card_type_check": {
+          "name": "messages_card_type_check",
+          "value": "\"messages\".\"card_type\" is null or \"messages\".\"card_type\" in ('trip', 'purchase', 'event', 'bill', 'package')"
+        },
+        "messages_card_complete_check": {
+          "name": "messages_card_complete_check",
+          "value": "\"messages\".\"card_type\" is not null or (\"messages\".\"card_data\" is null and \"messages\".\"card_confidence\" is null and \"messages\".\"card_extracted_at\" is null)"
+        },
+        "messages_size_check": {
+          "name": "messages_size_check",
+          "value": "\"messages\".\"size\" >= 0"
+        },
+        "messages_reply_to_complete_check": {
+          "name": "messages_reply_to_complete_check",
+          "value": "\"messages\".\"reply_to_address\" is not null or \"messages\".\"reply_to_name\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_effects": {
+      "name": "moderation_effects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_risk": {
+          "name": "active_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_multiplier": {
+          "name": "repetition_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_multiplier": {
+          "name": "multi_finding_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strike_id": {
+          "name": "strike_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_transaction_id": {
+          "name": "reversal_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version_universal": {
+          "name": "policy_version_universal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version_application": {
+          "name": "policy_version_application",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version_oxy_conduct": {
+          "name": "policy_version_oxy_conduct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_hash": {
+          "name": "proof_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_reason": {
+          "name": "reversal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "moderation_effects_decision_id_decision_revision_idx": {
+          "name": "moderation_effects_decision_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_effects_incident_id_decision_revision_idx": {
+          "name": "moderation_effects_incident_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_effects_principal_id_applied_at_idx": {
+          "name": "moderation_effects_principal_id_applied_at_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "applied_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_effects_principal_id_users_id_fk": {
+          "name": "moderation_effects_principal_id_users_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_binding_id_identity_bindings_id_fk": {
+          "name": "moderation_effects_binding_id_identity_bindings_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "identity_bindings",
+          "columnsFrom": [
+            "binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_application_id_applications_id_fk": {
+          "name": "moderation_effects_application_id_applications_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_credential_id_application_credentials_id_fk": {
+          "name": "moderation_effects_credential_id_application_credentials_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_transaction_id_reputation_transactions_id_fk": {
+          "name": "moderation_effects_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_strike_id_conduct_strikes_id_fk": {
+          "name": "moderation_effects_strike_id_conduct_strikes_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "conduct_strikes",
+          "columnsFrom": [
+            "strike_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_reversal_transaction_id_reputation_transactions_id_fk": {
+          "name": "moderation_effects_reversal_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "reversal_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_policy_version_oxy_conduct_fk": {
+          "name": "moderation_effects_policy_version_oxy_conduct_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_version_oxy_conduct"
+          ],
+          "columnsTo": [
+            "policy_version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_effects_incident_principal_type_revision_key": {
+          "name": "moderation_effects_incident_principal_type_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "incident_id",
+            "principal_id",
+            "effect_type",
+            "decision_revision"
+          ]
+        },
+        "moderation_effects_event_id_key": {
+          "name": "moderation_effects_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_effects_effect_type_check": {
+          "name": "moderation_effects_effect_type_check",
+          "value": "\"moderation_effects\".\"effect_type\" in ('conduct_penalty', 'report_abuse_penalty', 'review_abuse_penalty')"
+        },
+        "moderation_effects_status_check": {
+          "name": "moderation_effects_status_check",
+          "value": "\"moderation_effects\".\"status\" in ('applied', 'reversed')"
+        },
+        "moderation_effects_severity_check": {
+          "name": "moderation_effects_severity_check",
+          "value": "\"moderation_effects\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "moderation_effects_decision_revision_check": {
+          "name": "moderation_effects_decision_revision_check",
+          "value": "\"moderation_effects\".\"decision_revision\" >= 0"
+        },
+        "moderation_effects_reversal_complete_check": {
+          "name": "moderation_effects_reversal_complete_check",
+          "value": "(\"moderation_effects\".\"status\" = 'reversed') = (\"moderation_effects\".\"reversed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policies": {
+      "name": "moderation_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "conduct_families": {
+          "name": "conduct_families",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_multipliers": {
+          "name": "repetition_multipliers",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_window_days": {
+          "name": "repetition_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_secondary_share": {
+          "name": "multi_finding_secondary_share",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_cap": {
+          "name": "multi_finding_cap",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisional_effects_allowed": {
+          "name": "provisional_effects_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "moderation_policies_status_idx": {
+          "name": "moderation_policies_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policies_policy_version_key": {
+          "name": "moderation_policies_policy_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policies_status_check": {
+          "name": "moderation_policies_status_check",
+          "value": "\"moderation_policies\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policy_severity_rules": {
+      "name": "moderation_policy_severity_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_points": {
+          "name": "risk_points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_expiry_days": {
+          "name": "risk_expiry_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderation_policy_severity_rules_policy_id_fk": {
+          "name": "moderation_policy_severity_rules_policy_id_fk",
+          "tableFrom": "moderation_policy_severity_rules",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policy_severity_rules_policy_id_severity_key": {
+          "name": "moderation_policy_severity_rules_policy_id_severity_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_id",
+            "severity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policy_severity_rules_severity_check": {
+          "name": "moderation_policy_severity_rules_severity_check",
+          "value": "\"moderation_policy_severity_rules\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "moderation_policy_severity_rules_risk_expiry_days_check": {
+          "name": "moderation_policy_severity_rules_risk_expiry_days_check",
+          "value": "\"moderation_policy_severity_rules\".\"risk_expiry_days\" is null or \"moderation_policy_severity_rules\".\"risk_expiry_days\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policy_standing_thresholds": {
+      "name": "moderation_policy_standing_thresholds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standing": {
+          "name": "standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_risk": {
+          "name": "min_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderation_policy_standing_thresholds_policy_id_fk": {
+          "name": "moderation_policy_standing_thresholds_policy_id_fk",
+          "tableFrom": "moderation_policy_standing_thresholds",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policy_standing_thresholds_policy_id_standing_key": {
+          "name": "moderation_policy_standing_thresholds_policy_id_standing_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_id",
+            "standing"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policy_standing_thresholds_standing_check": {
+          "name": "moderation_policy_standing_thresholds_standing_check",
+          "value": "\"moderation_policy_standing_thresholds\".\"standing\" in ('good', 'watch', 'limited', 'restricted')"
+        },
+        "moderation_policy_standing_thresholds_min_risk_check": {
+          "name": "moderation_policy_standing_thresholds_min_risk_check",
+          "value": "\"moderation_policy_standing_thresholds\".\"min_risk\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.node_ingest_witnesses": {
+      "name": "node_ingest_witnesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witness_signature": {
+          "name": "witness_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "node_ingest_witnesses_user_id_created_at_idx": {
+          "name": "node_ingest_witnesses_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_ingest_witnesses_user_id_users_id_fk": {
+          "name": "node_ingest_witnesses_user_id_users_id_fk",
+          "tableFrom": "node_ingest_witnesses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "node_ingest_witnesses_record_id_signed_records_record_id_fk": {
+          "name": "node_ingest_witnesses_record_id_signed_records_record_id_fk",
+          "tableFrom": "node_ingest_witnesses",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_ingest_witnesses_recordId_unique": {
+          "name": "node_ingest_witnesses_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_id_created_at_idx": {
+          "name": "notifications_recipient_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_recipient_id_actor_id_type_entity_id_key": {
+          "name": "notifications_recipient_id_actor_id_type_entity_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_id",
+            "actor_id",
+            "type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "notifications_type_check": {
+          "name": "notifications_type_check",
+          "value": "\"notifications\".\"type\" in ('like', 'reply', 'mention', 'follow', 'repost', 'quote', 'welcome')"
+        },
+        "notifications_entity_type_check": {
+          "name": "notifications_entity_type_check",
+          "value": "\"notifications\".\"entity_type\" in ('post', 'reply', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personhood_statuses": {
+      "name": "personhood_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_real_person": {
+          "name": "is_real_person",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vouch_count": {
+          "name": "vouch_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "real_life_count": {
+          "name": "real_life_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "biometric_bound": {
+          "name": "biometric_bound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sybil_penalty": {
+          "name": "sybil_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_vouch_signal": {
+          "name": "breakdown_vouch_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_real_life_signal": {
+          "name": "breakdown_real_life_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_biometric_signal": {
+          "name": "breakdown_biometric_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_evidence": {
+          "name": "breakdown_evidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_sybil_penalty": {
+          "name": "breakdown_sybil_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_seed": {
+          "name": "breakdown_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personhood_statuses_score_idx": {
+          "name": "personhood_statuses_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personhood_statuses_is_real_person_idx": {
+          "name": "personhood_statuses_is_real_person_idx",
+          "columns": [
+            {
+              "expression": "is_real_person",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personhood_statuses_user_id_users_id_fk": {
+          "name": "personhood_statuses_user_id_users_id_fk",
+          "tableFrom": "personhood_statuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personhood_statuses_userId_unique": {
+          "name": "personhood_statuses_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personhood_statuses_counts_check": {
+          "name": "personhood_statuses_counts_check",
+          "value": "\"personhood_statuses\".\"vouch_count\" >= 0 and \"personhood_statuses\".\"real_life_count\" >= 0"
+        },
+        "personhood_statuses_signals_check": {
+          "name": "personhood_statuses_signals_check",
+          "value": "\"personhood_statuses\".\"score\" between 0 and 1 and \"personhood_statuses\".\"sybil_penalty\" between 0 and 1 and \"personhood_statuses\".\"breakdown_vouch_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_real_life_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_biometric_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_evidence\" between 0 and 1 and \"personhood_statuses\".\"breakdown_sybil_penalty\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personhood_vouches": {
+      "name": "personhood_vouches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voucher_user_id": {
+          "name": "voucher_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake_amount": {
+          "name": "stake_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "personhood_vouches_active_pair_key": {
+          "name": "personhood_vouches_active_pair_key",
+          "columns": [
+            {
+              "expression": "voucher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"personhood_vouches\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personhood_vouches_subject_id_status_idx": {
+          "name": "personhood_vouches_subject_id_status_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personhood_vouches_voucher_user_id_users_id_fk": {
+          "name": "personhood_vouches_voucher_user_id_users_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voucher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personhood_vouches_subject_user_id_users_id_fk": {
+          "name": "personhood_vouches_subject_user_id_users_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personhood_vouches_record_id_signed_records_record_id_fk": {
+          "name": "personhood_vouches_record_id_signed_records_record_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "personhood_vouches_status_check": {
+          "name": "personhood_vouches_status_check",
+          "value": "\"personhood_vouches\".\"status\" in ('active', 'slashed', 'withdrawn')"
+        },
+        "personhood_vouches_stake_check": {
+          "name": "personhood_vouches_stake_check",
+          "value": "\"personhood_vouches\".\"stake_amount\" >= 0"
+        },
+        "personhood_vouches_not_self_check": {
+          "name": "personhood_vouches_not_self_check",
+          "value": "\"personhood_vouches\".\"voucher_user_id\" <> \"personhood_vouches\".\"subject_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_tokens_user_id_application_id_idx": {
+          "name": "push_tokens_user_id_application_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_tokens_user_id_users_id_fk": {
+          "name": "push_tokens_user_id_users_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "push_tokens_application_id_applications_id_fk": {
+          "name": "push_tokens_application_id_applications_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_user_id_token_key": {
+          "name": "push_tokens_user_id_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('ios', 'android', 'web')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_message_id": {
+          "name": "related_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reminders_user_id_completed_remind_at_idx": {
+          "name": "reminders_user_id_completed_remind_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remind_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reminders_due_idx": {
+          "name": "reminders_due_idx",
+          "columns": [
+            {
+              "expression": "remind_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"reminders\".\"completed\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_user_id_users_id_fk": {
+          "name": "reminders_user_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_related_message_id_messages_id_fk": {
+          "name": "reminders_related_message_id_messages_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "related_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_heads": {
+      "name": "repo_heads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "repo_heads_user_id_users_id_fk": {
+          "name": "repo_heads_user_id_users_id_fk",
+          "tableFrom": "repo_heads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_heads_head_record_id_signed_records_record_id_fk": {
+          "name": "repo_heads_head_record_id_signed_records_record_id_fk",
+          "tableFrom": "repo_heads",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "head_record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repo_heads_userId_unique": {
+          "name": "repo_heads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repo_heads_seq_check": {
+          "name": "repo_heads_seq_check",
+          "value": "\"repo_heads\".\"seq\" >= 0"
+        },
+        "repo_heads_record_count_check": {
+          "name": "repo_heads_record_count_check",
+          "value": "\"repo_heads\".\"record_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reporter_reputation_profiles": {
+      "name": "reporter_reputation_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed": {
+          "name": "confirmed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected": {
+          "name": "rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate": {
+          "name": "duplicate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "malicious": {
+          "name": "malicious",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_by_family": {
+          "name": "confirmed_by_family",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rejected_by_family": {
+          "name": "rejected_by_family",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reliability": {
+          "name": "reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_outcome_at": {
+          "name": "last_outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reporter_reputation_profiles_user_id_users_id_fk": {
+          "name": "reporter_reputation_profiles_user_id_users_id_fk",
+          "tableFrom": "reporter_reputation_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reporter_reputation_profiles_user_id_key": {
+          "name": "reporter_reputation_profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reporter_reputation_profiles_confirmed_by_family_object_check": {
+          "name": "reporter_reputation_profiles_confirmed_by_family_object_check",
+          "value": "jsonb_typeof(\"reporter_reputation_profiles\".\"confirmed_by_family\") = 'object'"
+        },
+        "reporter_reputation_profiles_rejected_by_family_object_check": {
+          "name": "reporter_reputation_profiles_rejected_by_family_object_check",
+          "value": "jsonb_typeof(\"reporter_reputation_profiles\".\"rejected_by_family\") = 'object'"
+        },
+        "reporter_reputation_profiles_counts_check": {
+          "name": "reporter_reputation_profiles_counts_check",
+          "value": "\"reporter_reputation_profiles\".\"confirmed\" >= 0 and \"reporter_reputation_profiles\".\"rejected\" >= 0 and \"reporter_reputation_profiles\".\"duplicate\" >= 0 and \"reporter_reputation_profiles\".\"malicious\" >= 0"
+        },
+        "reporter_reputation_profiles_reliability_check": {
+          "name": "reporter_reputation_profiles_reliability_check",
+          "value": "\"reporter_reputation_profiles\".\"reliability\" >= 0 and \"reporter_reputation_profiles\".\"reliability\" <= 1"
+        },
+        "reporter_reputation_profiles_confidence_check": {
+          "name": "reporter_reputation_profiles_confidence_check",
+          "value": "\"reporter_reputation_profiles\".\"confidence\" >= 0 and \"reporter_reputation_profiles\".\"confidence\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_balances": {
+      "name": "reputation_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "positive": {
+          "name": "positive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "negative": {
+          "name": "negative",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_content": {
+          "name": "breakdown_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_social": {
+          "name": "breakdown_social",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_trust": {
+          "name": "breakdown_trust",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_moderation": {
+          "name": "breakdown_moderation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_physical": {
+          "name": "breakdown_physical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_penalties": {
+          "name": "breakdown_penalties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trust_tier": {
+          "name": "trust_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "influence_default_weight": {
+          "name": "influence_default_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_report_weight": {
+          "name": "influence_report_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_moderation_weight": {
+          "name": "influence_moderation_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_ranking_feedback_weight": {
+          "name": "influence_ranking_feedback_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_accurate_reports": {
+          "name": "reliability_accurate_reports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_rejected_reports": {
+          "name": "reliability_rejected_reports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_report_accuracy_score": {
+          "name": "reliability_report_accuracy_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_abuse_score": {
+          "name": "reliability_abuse_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "personhood_status": {
+          "name": "personhood_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "personhood_score": {
+          "name": "personhood_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contribution_points": {
+          "name": "contribution_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contribution_tier": {
+          "name": "contribution_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "conduct_standing": {
+          "name": "conduct_standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'good'"
+        },
+        "conduct_active_risk": {
+          "name": "conduct_active_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conduct_active_strikes": {
+          "name": "conduct_active_strikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conduct_next_expiry_at": {
+          "name": "conduct_next_expiry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporting_reliability": {
+          "name": "reporting_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "reporting_confidence": {
+          "name": "reporting_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_confirmed": {
+          "name": "reporting_confirmed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_rejected": {
+          "name": "reporting_rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_malicious": {
+          "name": "reporting_malicious",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviewing_global_reliability": {
+          "name": "reviewing_global_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "contextual_report_priority_weight": {
+          "name": "contextual_report_priority_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contextual_review_selection_weight": {
+          "name": "contextual_review_selection_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contextual_ranking_weight": {
+          "name": "contextual_ranking_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_transaction_id": {
+          "name": "last_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recalculated_at": {
+          "name": "recalculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reputation_balances_total_idx": {
+          "name": "reputation_balances_total_idx",
+          "columns": [
+            {
+              "expression": "total",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_balances_trust_tier_idx": {
+          "name": "reputation_balances_trust_tier_idx",
+          "columns": [
+            {
+              "expression": "trust_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_balances_conduct_standing_idx": {
+          "name": "reputation_balances_conduct_standing_idx",
+          "columns": [
+            {
+              "expression": "conduct_standing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_balances_user_id_users_id_fk": {
+          "name": "reputation_balances_user_id_users_id_fk",
+          "tableFrom": "reputation_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_balances_last_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_balances_last_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_balances",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "last_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reputation_balances_userId_unique": {
+          "name": "reputation_balances_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reputation_balances_trust_tier_check": {
+          "name": "reputation_balances_trust_tier_check",
+          "value": "\"reputation_balances\".\"trust_tier\" in ('restricted', 'new', 'trusted', 'high_trust', 'verified')"
+        },
+        "reputation_balances_personhood_status_check": {
+          "name": "reputation_balances_personhood_status_check",
+          "value": "\"reputation_balances\".\"personhood_status\" in ('unknown', 'probable', 'verified')"
+        },
+        "reputation_balances_contribution_tier_check": {
+          "name": "reputation_balances_contribution_tier_check",
+          "value": "\"reputation_balances\".\"contribution_tier\" in ('new', 'trusted', 'high_trust')"
+        },
+        "reputation_balances_conduct_standing_check": {
+          "name": "reputation_balances_conduct_standing_check",
+          "value": "\"reputation_balances\".\"conduct_standing\" in ('good', 'watch', 'limited', 'restricted')"
+        },
+        "reputation_balances_positive_check": {
+          "name": "reputation_balances_positive_check",
+          "value": "\"reputation_balances\".\"positive\" >= 0"
+        },
+        "reputation_balances_negative_check": {
+          "name": "reputation_balances_negative_check",
+          "value": "\"reputation_balances\".\"negative\" <= 0"
+        },
+        "reputation_balances_penalties_check": {
+          "name": "reputation_balances_penalties_check",
+          "value": "\"reputation_balances\".\"breakdown_penalties\" >= 0"
+        },
+        "reputation_balances_contribution_points_check": {
+          "name": "reputation_balances_contribution_points_check",
+          "value": "\"reputation_balances\".\"contribution_points\" >= 0"
+        },
+        "reputation_balances_reliability_counts_check": {
+          "name": "reputation_balances_reliability_counts_check",
+          "value": "\"reputation_balances\".\"reliability_accurate_reports\" >= 0 and \"reputation_balances\".\"reliability_rejected_reports\" >= 0"
+        },
+        "reputation_balances_reporting_counts_check": {
+          "name": "reputation_balances_reporting_counts_check",
+          "value": "\"reputation_balances\".\"reporting_confirmed\" >= 0 and \"reputation_balances\".\"reporting_rejected\" >= 0 and \"reputation_balances\".\"reporting_malicious\" >= 0"
+        },
+        "reputation_balances_conduct_check": {
+          "name": "reputation_balances_conduct_check",
+          "value": "\"reputation_balances\".\"conduct_active_risk\" >= 0 and \"reputation_balances\".\"conduct_active_strikes\" >= 0"
+        },
+        "reputation_balances_scores_check": {
+          "name": "reputation_balances_scores_check",
+          "value": "\"reputation_balances\".\"reliability_report_accuracy_score\" between 0 and 1 and \"reputation_balances\".\"reliability_abuse_score\" between 0 and 1 and \"reputation_balances\".\"personhood_score\" between 0 and 1 and \"reputation_balances\".\"reporting_reliability\" between 0 and 1 and \"reputation_balances\".\"reporting_confidence\" between 0 and 1 and \"reputation_balances\".\"reviewing_global_reliability\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_reviewing_reliability": {
+      "name": "reputation_reviewing_reliability",
+      "schema": "",
+      "columns": {
+        "balance_id": {
+          "name": "balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reliability": {
+          "name": "reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reputation_reviewing_reliability_balance_id_reputation_balances_id_fk": {
+          "name": "reputation_reviewing_reliability_balance_id_reputation_balances_id_fk",
+          "tableFrom": "reputation_reviewing_reliability",
+          "tableTo": "reputation_balances",
+          "columnsFrom": [
+            "balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reputation_reviewing_reliability_pkey": {
+          "name": "reputation_reviewing_reliability_pkey",
+          "columns": [
+            "balance_id",
+            "scope",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_reviewing_reliability_scope_check": {
+          "name": "reputation_reviewing_reliability_scope_check",
+          "value": "\"reputation_reviewing_reliability\".\"scope\" in ('category', 'language')"
+        },
+        "reputation_reviewing_reliability_value_check": {
+          "name": "reputation_reviewing_reliability_value_check",
+          "value": "\"reputation_reviewing_reliability\".\"reliability\" between 0 and 1"
+        },
+        "reputation_reviewing_reliability_key_check": {
+          "name": "reputation_reviewing_reliability_key_check",
+          "value": "length(\"reputation_reviewing_reliability\".\"key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_disputes": {
+      "name": "reputation_disputes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reputation_disputes_user_id_status_idx": {
+          "name": "reputation_disputes_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_disputes_status_idx": {
+          "name": "reputation_disputes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_disputes_transaction_id_idx": {
+          "name": "reputation_disputes_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_disputes_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_disputes_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_disputes_user_id_users_id_fk": {
+          "name": "reputation_disputes_user_id_users_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_disputes_resolved_by_user_id_users_id_fk": {
+          "name": "reputation_disputes_resolved_by_user_id_users_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_disputes_status_check": {
+          "name": "reputation_disputes_status_check",
+          "value": "\"reputation_disputes\".\"status\" in ('open', 'accepted', 'rejected', 'needs_review')"
+        },
+        "reputation_disputes_resolution_check": {
+          "name": "reputation_disputes_resolution_check",
+          "value": "(\"reputation_disputes\".\"status\" in ('open', 'needs_review') and \"reputation_disputes\".\"resolved_at\" is null) or (\"reputation_disputes\".\"status\" in ('accepted', 'rejected') and \"reputation_disputes\".\"resolved_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_rules": {
+      "name": "reputation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooldown_in_minutes": {
+          "name": "cooldown_in_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reputation_rules_actionType_unique": {
+          "name": "reputation_rules_actionType_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "action_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reputation_rules_category_check": {
+          "name": "reputation_rules_category_check",
+          "value": "\"reputation_rules\".\"category\" in ('content', 'social', 'trust', 'moderation', 'physical', 'penalty', 'other')"
+        },
+        "reputation_rules_cooldown_check": {
+          "name": "reputation_rules_cooldown_check",
+          "value": "\"reputation_rules\".\"cooldown_in_minutes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_transactions": {
+      "name": "reputation_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_id": {
+          "name": "source_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_type": {
+          "name": "source_action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_entity_id": {
+          "name": "target_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_entity_type": {
+          "name": "target_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reversed_transaction_id": {
+          "name": "reversed_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reputation_transactions_user_id_status_idx": {
+          "name": "reputation_transactions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_user_id_created_at_idx": {
+          "name": "reputation_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_application_id_idx": {
+          "name": "reputation_transactions_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reputation_transactions\".\"application_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_source_action_key": {
+          "name": "reputation_transactions_source_action_key",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_status_idx": {
+          "name": "reputation_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_transactions_user_id_users_id_fk": {
+          "name": "reputation_transactions_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_application_id_applications_id_fk": {
+          "name": "reputation_transactions_application_id_applications_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_credential_id_application_credentials_id_fk": {
+          "name": "reputation_transactions_credential_id_application_credentials_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_reversed_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_transactions_reversed_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "reversed_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_created_by_user_id_users_id_fk": {
+          "name": "reputation_transactions_created_by_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_reviewed_by_user_id_users_id_fk": {
+          "name": "reputation_transactions_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_transactions_category_check": {
+          "name": "reputation_transactions_category_check",
+          "value": "\"reputation_transactions\".\"category\" in ('content', 'social', 'trust', 'moderation', 'physical', 'penalty', 'other')"
+        },
+        "reputation_transactions_status_check": {
+          "name": "reputation_transactions_status_check",
+          "value": "\"reputation_transactions\".\"status\" in ('active', 'disputed', 'reversed', 'voided')"
+        },
+        "reputation_transactions_target_entity_type_check": {
+          "name": "reputation_transactions_target_entity_type_check",
+          "value": "\"reputation_transactions\".\"target_entity_type\" is null or \"reputation_transactions\".\"target_entity_type\" in ('post', 'comment', 'report', 'purchase', 'event', 'check_in', 'manual_review', 'user', 'other')"
+        },
+        "reputation_transactions_reversal_not_self_check": {
+          "name": "reputation_transactions_reversal_not_self_check",
+          "value": "\"reputation_transactions\".\"reversed_transaction_id\" is null or \"reputation_transactions\".\"reversed_transaction_id\" <> \"reputation_transactions\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.restrictions": {
+      "name": "restrictions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted_id": {
+          "name": "restricted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "restrictions_user_id_users_id_fk": {
+          "name": "restrictions_user_id_users_id_fk",
+          "tableFrom": "restrictions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "restrictions_restricted_id_users_id_fk": {
+          "name": "restrictions_restricted_id_users_id_fk",
+          "tableFrom": "restrictions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "restricted_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "restrictions_user_id_restricted_id_key": {
+          "name": "restrictions_user_id_restricted_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "restricted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviewer_reputation_profiles": {
+      "name": "reviewer_reputation_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "agreements": {
+          "name": "agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disagreements": {
+          "name": "disagreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gold_passed": {
+          "name": "gold_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gold_failed": {
+          "name": "gold_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overturned": {
+          "name": "overturned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "global_reliability": {
+          "name": "global_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "category_reliability": {
+          "name": "category_reliability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "language_reliability": {
+          "name": "language_reliability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "unlocked_categories": {
+          "name": "unlocked_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seed_weight": {
+          "name": "seed_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reviewer_reputation_profiles_status_idx": {
+          "name": "reviewer_reputation_profiles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviewer_reputation_profiles_user_id_users_id_fk": {
+          "name": "reviewer_reputation_profiles_user_id_users_id_fk",
+          "tableFrom": "reviewer_reputation_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviewer_reputation_profiles_user_id_key": {
+          "name": "reviewer_reputation_profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviewer_reputation_profiles_status_check": {
+          "name": "reviewer_reputation_profiles_status_check",
+          "value": "\"reviewer_reputation_profiles\".\"status\" in ('active', 'probation', 'suspended')"
+        },
+        "reviewer_reputation_profiles_category_reliability_object_check": {
+          "name": "reviewer_reputation_profiles_category_reliability_object_check",
+          "value": "jsonb_typeof(\"reviewer_reputation_profiles\".\"category_reliability\") = 'object'"
+        },
+        "reviewer_reputation_profiles_language_reliability_object_check": {
+          "name": "reviewer_reputation_profiles_language_reliability_object_check",
+          "value": "jsonb_typeof(\"reviewer_reputation_profiles\".\"language_reliability\") = 'object'"
+        },
+        "reviewer_reputation_profiles_counts_check": {
+          "name": "reviewer_reputation_profiles_counts_check",
+          "value": "\"reviewer_reputation_profiles\".\"agreements\" >= 0 and \"reviewer_reputation_profiles\".\"disagreements\" >= 0 and \"reviewer_reputation_profiles\".\"gold_passed\" >= 0 and \"reviewer_reputation_profiles\".\"gold_failed\" >= 0 and \"reviewer_reputation_profiles\".\"overturned\" >= 0"
+        },
+        "reviewer_reputation_profiles_global_reliability_check": {
+          "name": "reviewer_reputation_profiles_global_reliability_check",
+          "value": "\"reviewer_reputation_profiles\".\"global_reliability\" >= 0 and \"reviewer_reputation_profiles\".\"global_reliability\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_activities": {
+      "name": "security_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "security_activities_user_id_occurred_at_idx": {
+          "name": "security_activities_user_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_user_id_event_type_occurred_at_idx": {
+          "name": "security_activities_user_id_event_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_user_id_device_id_occurred_at_idx": {
+          "name": "security_activities_user_id_device_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_occurred_at_idx": {
+          "name": "security_activities_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_activities_user_id_users_id_fk": {
+          "name": "security_activities_user_id_users_id_fk",
+          "tableFrom": "security_activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_activities_event_type_check": {
+          "name": "security_activities_event_type_check",
+          "value": "\"security_activities\".\"event_type\" in ('sign_in', 'sign_out', 'email_changed', 'profile_updated', 'device_added', 'device_removed', 'account_recovery', 'security_settings_changed', 'private_key_exported', 'backup_created', 'suspicious_activity')"
+        },
+        "security_activities_severity_check": {
+          "name": "security_activities_severity_check",
+          "value": "\"security_activities\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sender_avatars": {
+      "name": "sender_avatars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sender_avatars_email_key": {
+          "name": "sender_avatars_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sender_avatars_expires_at_idx": {
+          "name": "sender_avatars_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sender_avatars_source_check": {
+          "name": "sender_avatars_source_check",
+          "value": "\"sender_avatars\".\"source\" in ('oxy', 'bimi', 'gravatar', 'favicon', 'none')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_fingerprint": {
+          "name": "device_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_refresh_token": {
+          "name": "previous_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_rotated_at": {
+          "name": "token_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh": {
+          "name": "last_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_device_id_idx": {
+          "name": "sessions_user_id_device_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_is_active_expires_at_idx": {
+          "name": "sessions_user_id_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_device_id_is_active_expires_at_idx": {
+          "name": "sessions_device_id_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_previous_refresh_token_rotated_at_idx": {
+          "name": "sessions_previous_refresh_token_rotated_at_idx",
+          "columns": [
+            {
+              "expression": "previous_refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_rotated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"previous_refresh_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_device_fingerprint_is_active_expires_at_idx": {
+          "name": "sessions_device_fingerprint_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "device_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"device_fingerprint\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_operated_by_user_id_users_id_fk": {
+          "name": "sessions_operated_by_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_id_key": {
+          "name": "sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        },
+        "sessions_access_token_key": {
+          "name": "sessions_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "sessions_refresh_token_key": {
+          "name": "sessions_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signed_records": {
+      "name": "signed_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nsid": {
+          "name": "nsid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "signed_records_subject_did_idx": {
+          "name": "signed_records_subject_did_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_type_created_at_idx": {
+          "name": "signed_records_user_id_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_seq_key": {
+          "name": "signed_records_user_id_seq_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_nsid_rkey_created_at_idx": {
+          "name": "signed_records_user_id_nsid_rkey_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nsid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"signed_records\".\"nsid\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signed_records_user_id_users_id_fk": {
+          "name": "signed_records_user_id_users_id_fk",
+          "tableFrom": "signed_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signed_records_prev_signed_records_record_id_fk": {
+          "name": "signed_records_prev_signed_records_record_id_fk",
+          "tableFrom": "signed_records",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "prev"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signed_records_recordId_unique": {
+          "name": "signed_records_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "signed_records_type_check": {
+          "name": "signed_records_type_check",
+          "value": "\"signed_records\".\"type\" in ('identity', 'profile', 'reputation_attestation', 'real_life_attestation', 'validation_verdict', 'personhood_vouch', 'credential', 'node')"
+        },
+        "signed_records_seq_check": {
+          "name": "signed_records_seq_check",
+          "value": "\"signed_records\".\"seq\" is null or \"signed_records\".\"seq\" >= 0"
+        },
+        "signed_records_chain_completeness_check": {
+          "name": "signed_records_chain_completeness_check",
+          "value": "(\"signed_records\".\"seq\" is null and \"signed_records\".\"record_id\" is null and \"signed_records\".\"nsid\" is null and \"signed_records\".\"rkey\" is null) or (\"signed_records\".\"record_id\" is not null and \"signed_records\".\"nsid\" is not null and \"signed_records\".\"rkey\" is not null)"
+        },
+        "signed_records_prev_not_self_check": {
+          "name": "signed_records_prev_not_self_check",
+          "value": "\"signed_records\".\"prev\" is null or \"signed_records\".\"prev\" <> \"signed_records\".\"record_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_renew": {
+          "name": "auto_renew",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_invoice": {
+          "name": "latest_invoice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_analytics": {
+          "name": "feature_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_premium_badge": {
+          "name": "feature_premium_badge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_unlimited_following": {
+          "name": "feature_unlimited_following",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_higher_upload_limits": {
+          "name": "feature_higher_upload_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_promoted_posts": {
+          "name": "feature_promoted_posts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_business_tools": {
+          "name": "feature_business_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_status_idx": {
+          "name": "subscriptions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_active_end_date_idx": {
+          "name": "subscriptions_active_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"subscriptions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "subscriptions_plan_check": {
+          "name": "subscriptions_plan_check",
+          "value": "\"subscriptions\".\"plan\" in ('basic', 'pro', 'business')"
+        },
+        "subscriptions_status_check": {
+          "name": "subscriptions_status_check",
+          "value": "\"subscriptions\".\"status\" in ('active', 'canceled', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "parent_topic_id": {
+          "name": "parent_topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "translations": {
+          "name": "translations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(display_name, '')), 'B') || setweight(to_tsvector('english', replace(array_to_tsvector(coalesce(aliases, '{}'::text[]))::text, '''', ' ')), 'C') || setweight(to_tsvector('english', coalesce(description, '')), 'D')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_is_active_type_idx": {
+          "name": "topics_is_active_type_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_parent_topic_id_idx": {
+          "name": "topics_parent_topic_id_idx",
+          "columns": [
+            {
+              "expression": "parent_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"topics\".\"parent_topic_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_search_vector_idx": {
+          "name": "topics_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_parent_topic_id_topics_id_fk": {
+          "name": "topics_parent_topic_id_topics_id_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "parent_topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topics_name_key": {
+          "name": "topics_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topics_slug_key": {
+          "name": "topics_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "topics_type_check": {
+          "name": "topics_type_check",
+          "value": "\"topics\".\"type\" in ('category', 'topic', 'entity')"
+        },
+        "topics_source_check": {
+          "name": "topics_source_check",
+          "value": "\"topics\".\"source\" in ('seed', 'ai', 'manual', 'system')"
+        },
+        "topics_translations_object_check": {
+          "name": "topics_translations_object_check",
+          "value": "\"topics\".\"translations\" is null or jsonb_typeof(\"topics\".\"translations\") = 'object'"
+        },
+        "topics_parent_topic_id_not_self_check": {
+          "name": "topics_parent_topic_id_not_self_check",
+          "value": "\"topics\".\"parent_topic_id\" <> \"topics\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference": {
+          "name": "external_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transactions_user_id_created_at_idx": {
+          "name": "transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recipient_id_created_at_idx": {
+          "name": "transactions_recipient_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"recipient_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_recipient_id_users_id_fk": {
+          "name": "transactions_recipient_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transactions_type_check": {
+          "name": "transactions_type_check",
+          "value": "\"transactions\".\"type\" in ('deposit', 'withdrawal', 'transfer', 'purchase')"
+        },
+        "transactions_status_check": {
+          "name": "transactions_status_check",
+          "value": "\"transactions\".\"status\" in ('pending', 'completed', 'failed', 'cancelled')"
+        },
+        "transactions_amount_check": {
+          "name": "transactions_amount_check",
+          "value": "\"transactions\".\"amount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_anchors": {
+      "name": "transparency_checkpoint_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txid": {
+          "name": "txid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmations": {
+          "name": "confirmations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anchored_at": {
+          "name": "anchored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_anchors_txid_key": {
+          "name": "transparency_checkpoint_anchors_txid_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "txid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_anchors_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_anchors_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_anchors",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_anchors_confirmations_check": {
+          "name": "transparency_checkpoint_anchors_confirmations_check",
+          "value": "\"transparency_checkpoint_anchors\".\"confirmations\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_signatures": {
+      "name": "transparency_checkpoint_signatures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_signatures_position_key": {
+          "name": "transparency_checkpoint_signatures_position_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transparency_checkpoint_signatures_signer_key": {
+          "name": "transparency_checkpoint_signatures_signer_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_signatures_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_signatures_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_signatures",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_signatures_alg_check": {
+          "name": "transparency_checkpoint_signatures_alg_check",
+          "value": "\"transparency_checkpoint_signatures\".\"alg\" in ('ES256K-DER-SHA256')"
+        },
+        "transparency_checkpoint_signatures_position_check": {
+          "name": "transparency_checkpoint_signatures_position_check",
+          "value": "\"transparency_checkpoint_signatures\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_snapshot_entries": {
+      "name": "transparency_checkpoint_snapshot_entries",
+      "schema": "",
+      "columns": {
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_index": {
+          "name": "leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_snapshot_entries_subject_key": {
+          "name": "transparency_checkpoint_snapshot_entries_subject_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_snapshot_entries_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_snapshot_entries_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_snapshot_entries",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transparency_checkpoint_snapshot_entries_pkey": {
+          "name": "transparency_checkpoint_snapshot_entries_pkey",
+          "columns": [
+            "checkpoint_id",
+            "leaf_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_snapshot_entries_leaf_index_check": {
+          "name": "transparency_checkpoint_snapshot_entries_leaf_index_check",
+          "value": "\"transparency_checkpoint_snapshot_entries\".\"leaf_index\" >= 0"
+        },
+        "transparency_checkpoint_snapshot_entries_seq_check": {
+          "name": "transparency_checkpoint_snapshot_entries_seq_check",
+          "value": "\"transparency_checkpoint_snapshot_entries\".\"seq\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoints": {
+      "name": "transparency_checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_size": {
+          "name": "tree_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_checkpoint_hash": {
+          "name": "prev_checkpoint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transparency_checkpoints_index_unique": {
+          "name": "transparency_checkpoints_index_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoints_index_check": {
+          "name": "transparency_checkpoints_index_check",
+          "value": "\"transparency_checkpoints\".\"index\" >= 0"
+        },
+        "transparency_checkpoints_tree_size_check": {
+          "name": "transparency_checkpoints_tree_size_check",
+          "value": "\"transparency_checkpoints\".\"tree_size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_assets": {
+      "name": "update_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "'public/updates/assets/' || sha256",
+            "type": "stored"
+          }
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "update_assets_sha256_key": {
+          "name": "update_assets_sha256_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "update_assets_status_check": {
+          "name": "update_assets_status_check",
+          "value": "\"update_assets\".\"status\" in ('pending', 'uploaded')"
+        },
+        "update_assets_sha256_check": {
+          "name": "update_assets_sha256_check",
+          "value": "\"update_assets\".\"sha256\" ~ '^[a-f0-9]{64}$'"
+        },
+        "update_assets_size_check": {
+          "name": "update_assets_size_check",
+          "value": "\"update_assets\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_channel_rollbacks": {
+      "name": "update_channel_rollbacks",
+      "schema": "",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_time": {
+          "name": "commit_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "update_channel_rollbacks_channel_id_update_channels_id_fk": {
+          "name": "update_channel_rollbacks_channel_id_update_channels_id_fk",
+          "tableFrom": "update_channel_rollbacks",
+          "tableTo": "update_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "update_channel_rollbacks_pkey": {
+          "name": "update_channel_rollbacks_pkey",
+          "columns": [
+            "channel_id",
+            "runtime_version",
+            "platform"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "update_channel_rollbacks_platform_check": {
+          "name": "update_channel_rollbacks_platform_check",
+          "value": "\"update_channel_rollbacks\".\"platform\" in ('ios', 'android')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_channels": {
+      "name": "update_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "update_channels_application_id_applications_id_fk": {
+          "name": "update_channels_application_id_applications_id_fk",
+          "tableFrom": "update_channels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "update_channels_application_id_name_key": {
+          "name": "update_channels_application_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_analytics": {
+      "name": "user_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_views": {
+          "name": "post_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "profile_views": {
+          "name": "profile_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_likes": {
+          "name": "engagement_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_replies": {
+          "name": "engagement_replies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_reposts": {
+          "name": "engagement_reposts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_quotes": {
+          "name": "engagement_quotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_bookmarks": {
+          "name": "engagement_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reach_impressions": {
+          "name": "reach_impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reach_unique_viewers": {
+          "name": "reach_unique_viewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "demographics_countries": {
+          "name": "demographics_countries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "demographics_languages": {
+          "name": "demographics_languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "peak_activity_hour": {
+          "name": "peak_activity_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "peak_activity_count": {
+          "name": "peak_activity_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_analytics_user_id_users_id_fk": {
+          "name": "user_analytics_user_id_users_id_fk",
+          "tableFrom": "user_analytics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_analytics_user_id_period_date_key": {
+          "name": "user_analytics_user_id_period_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "period",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_analytics_period_check": {
+          "name": "user_analytics_period_check",
+          "value": "\"user_analytics\".\"period\" in ('daily', 'weekly', 'monthly', 'yearly')"
+        },
+        "user_analytics_peak_activity_hour_check": {
+          "name": "user_analytics_peak_activity_hour_check",
+          "value": "\"user_analytics\".\"peak_activity_hour\" >= 0 and \"user_analytics\".\"peak_activity_hour\" < 24"
+        },
+        "user_analytics_demographics_countries_object_check": {
+          "name": "user_analytics_demographics_countries_object_check",
+          "value": "jsonb_typeof(\"user_analytics\".\"demographics_countries\") = 'object'"
+        },
+        "user_analytics_demographics_languages_object_check": {
+          "name": "user_analytics_demographics_languages_object_check",
+          "value": "jsonb_typeof(\"user_analytics\".\"demographics_languages\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_ancestors": {
+      "name": "user_ancestors",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_id": {
+          "name": "ancestor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_ancestors_ancestor_id_idx": {
+          "name": "user_ancestors_ancestor_id_idx",
+          "columns": [
+            {
+              "expression": "ancestor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ancestors_user_id_users_id_fk": {
+          "name": "user_ancestors_user_id_users_id_fk",
+          "tableFrom": "user_ancestors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_ancestors_ancestor_id_users_id_fk": {
+          "name": "user_ancestors_ancestor_id_users_id_fk",
+          "tableFrom": "user_ancestors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ancestor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_ancestors_pkey": {
+          "name": "user_ancestors_pkey",
+          "columns": [
+            "user_id",
+            "depth"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_ancestors_depth_check": {
+          "name": "user_ancestors_depth_check",
+          "value": "\"user_ancestors\".\"depth\" >= 0 and \"user_ancestors\".\"depth\" < 8"
+        },
+        "user_ancestors_not_self_check": {
+          "name": "user_ancestors_not_self_check",
+          "value": "\"user_ancestors\".\"ancestor_id\" <> \"user_ancestors\".\"user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_app_data": {
+      "name": "user_app_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_app_data_user_id_users_id_fk": {
+          "name": "user_app_data_user_id_users_id_fk",
+          "tableFrom": "user_app_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_app_data_user_id_namespace_key_key": {
+          "name": "user_app_data_user_id_namespace_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "namespace",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_app_data_namespace_check": {
+          "name": "user_app_data_namespace_check",
+          "value": "\"user_app_data\".\"namespace\" ~ '^[a-z0-9_-]{1,64}$'"
+        },
+        "user_app_data_key_check": {
+          "name": "user_app_data_key_check",
+          "value": "\"user_app_data\".\"key\" ~ '^[a-z0-9_-]{1,64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_auth_methods": {
+      "name": "user_auth_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "method_public_key": {
+          "name": "method_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_email": {
+          "name": "method_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_credential_id": {
+          "name": "method_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_name": {
+          "name": "method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_auth_methods_user_id_idx": {
+          "name": "user_auth_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_auth_methods_lower_method_public_key_key": {
+          "name": "user_auth_methods_lower_method_public_key_key",
+          "columns": [
+            {
+              "expression": "lower(\"method_public_key\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_auth_methods\".\"method_public_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_auth_methods_method_credential_id_key": {
+          "name": "user_auth_methods_method_credential_id_key",
+          "columns": [
+            {
+              "expression": "method_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_auth_methods\".\"method_credential_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_auth_methods_user_id_users_id_fk": {
+          "name": "user_auth_methods_user_id_users_id_fk",
+          "tableFrom": "user_auth_methods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_auth_methods_type_check": {
+          "name": "user_auth_methods_type_check",
+          "value": "\"user_auth_methods\".\"type\" in ('identity', 'webauthn')"
+        },
+        "user_auth_methods_identifier_check": {
+          "name": "user_auth_methods_identifier_check",
+          "value": "(\"user_auth_methods\".\"type\" = 'identity' and \"user_auth_methods\".\"method_public_key\" is not null) or (\"user_auth_methods\".\"type\" = 'webauthn' and \"user_auth_methods\".\"method_credential_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_credits": {
+      "name": "user_credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits_free": {
+          "name": "credits_free",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "credits_free_limit": {
+          "name": "credits_free_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "credits_daily_refresh": {
+          "name": "credits_daily_refresh",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "credits_last_refresh": {
+          "name": "credits_last_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "credits_paid": {
+          "name": "credits_paid",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_credits_stripe_customer_id_key": {
+          "name": "user_credits_stripe_customer_id_key",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_credits\".\"stripe_customer_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_credits_user_id_users_id_fk": {
+          "name": "user_credits_user_id_users_id_fk",
+          "tableFrom": "user_credits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_credits_credits_free_check": {
+          "name": "user_credits_credits_free_check",
+          "value": "\"user_credits\".\"credits_free\" >= 0"
+        },
+        "user_credits_credits_paid_check": {
+          "name": "user_credits_credits_paid_check",
+          "value": "\"user_credits\".\"credits_paid\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followed_id": {
+          "name": "followed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_follows_followed_id_created_at_id_idx": {
+          "name": "user_follows_followed_id_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "followed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_created_at_id_idx": {
+          "name": "user_follows_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_followed_id_users_id_fk": {
+          "name": "user_follows_followed_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follows_follower_id_followed_id_key": {
+          "name": "user_follows_follower_id_followed_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "followed_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_follows_not_self_check": {
+          "name": "user_follows_not_self_check",
+          "value": "\"user_follows\".\"follower_id\" <> \"user_follows\".\"followed_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_link_metadata": {
+      "name": "user_link_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_link_metadata_user_id_position_key": {
+          "name": "user_link_metadata_user_id_position_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_link_metadata_user_id_users_id_fk": {
+          "name": "user_link_metadata_user_id_users_id_fk",
+          "tableFrom": "user_link_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_locations": {
+      "name": "user_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_key": {
+          "name": "location_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street_number": {
+          "name": "street_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street_details": {
+          "name": "street_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(longitude, latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_id": {
+          "name": "osm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_type": {
+          "name": "osm_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(name, '') || ' ' || coalesce(formatted_address, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_locations_user_id_location_key_key": {
+          "name": "user_locations_user_id_location_key_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_city_country_idx": {
+          "name": "user_locations_city_country_idx",
+          "columns": [
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_country_idx": {
+          "name": "user_locations_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_type_city_idx": {
+          "name": "user_locations_type_city_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_country_code_city_idx": {
+          "name": "user_locations_country_code_city_idx",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_search_vector_idx": {
+          "name": "user_locations_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_locations_geo_idx": {
+          "name": "user_locations_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_locations_user_id_users_id_fk": {
+          "name": "user_locations_user_id_users_id_fk",
+          "tableFrom": "user_locations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_locations_type_check": {
+          "name": "user_locations_type_check",
+          "value": "\"user_locations\".\"type\" in ('home', 'work', 'school', 'other')"
+        },
+        "user_locations_latitude_check": {
+          "name": "user_locations_latitude_check",
+          "value": "\"user_locations\".\"latitude\" is null or (\"user_locations\".\"latitude\" >= -90 and \"user_locations\".\"latitude\" <= 90)"
+        },
+        "user_locations_longitude_check": {
+          "name": "user_locations_longitude_check",
+          "value": "\"user_locations\".\"longitude\" is null or (\"user_locations\".\"longitude\" >= -180 and \"user_locations\".\"longitude\" <= 180)"
+        },
+        "user_locations_coordinates_complete_check": {
+          "name": "user_locations_coordinates_complete_check",
+          "value": "(\"user_locations\".\"latitude\" is null) = (\"user_locations\".\"longitude\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_nodes": {
+      "name": "user_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_did": {
+          "name": "node_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_public_key": {
+          "name": "node_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pull'"
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_at": {
+          "name": "last_probe_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_nodes_status_idx": {
+          "name": "user_nodes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nodes_user_id_users_id_fk": {
+          "name": "user_nodes_user_id_users_id_fk",
+          "tableFrom": "user_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nodes_userId_unique": {
+          "name": "user_nodes_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_nodes_mode_check": {
+          "name": "user_nodes_mode_check",
+          "value": "\"user_nodes\".\"mode\" in ('pull', 'push')"
+        },
+        "user_nodes_controller_check": {
+          "name": "user_nodes_controller_check",
+          "value": "\"user_nodes\".\"controller\" in ('self', 'oxy')"
+        },
+        "user_nodes_status_check": {
+          "name": "user_nodes_status_check",
+          "value": "\"user_nodes\".\"status\" in ('active', 'unreachable', 'revoked')"
+        },
+        "user_nodes_cursor_check": {
+          "name": "user_nodes_cursor_check",
+          "value": "\"user_nodes\".\"cursor\" is null or \"user_nodes\".\"cursor\" >= 0"
+        },
+        "user_nodes_managed_controller_check": {
+          "name": "user_nodes_managed_controller_check",
+          "value": "(\"user_nodes\".\"managed\" = true and \"user_nodes\".\"controller\" = 'oxy') or (\"user_nodes\".\"managed\" = false and \"user_nodes\".\"controller\" = 'self')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_verified_domains": {
+      "name": "user_verified_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_verified_domains_user_id_lower_domain_key": {
+          "name": "user_verified_domains_user_id_lower_domain_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_verified_domains_lower_domain_idx": {
+          "name": "user_verified_domains_lower_domain_idx",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_verified_domains_user_id_users_id_fk": {
+          "name": "user_verified_domains_user_id_users_id_fk",
+          "tableFrom": "user_verified_domains",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_verified_domains_method_check": {
+          "name": "user_verified_domains_method_check",
+          "value": "\"user_verified_domains\".\"method\" in ('dns-txt', 'well-known')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_email": {
+          "name": "hashed_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when btrim(coalesce(email, '')) = '' then null else encode(sha256(decode(replace(lower(btrim(email)), '\\', '\\\\'), 'escape')), 'hex') end",
+            "type": "stored"
+          }
+        },
+        "hashed_phone": {
+          "name": "hashed_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when regexp_replace(coalesce(phone, ''), '[^0-9]', '', 'g') = '' then null else encode(sha256(decode(replace('+' || regexp_replace(phone, '[^0-9]', '', 'g'), '\\', '\\\\'), 'escape')), 'hex') end",
+            "type": "stored"
+          }
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_first": {
+          "name": "name_first",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_last": {
+          "name": "name_last",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_display": {
+          "name": "name_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "account_categories": {
+          "name": "account_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "parent_account_id": {
+          "name": "parent_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_account_id": {
+          "name": "root_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "federation_actor_uri": {
+          "name": "federation_actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_domain": {
+          "name": "federation_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_actor_id": {
+          "name": "federation_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_last_avatar_fetched_at": {
+          "name": "federation_last_avatar_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_avatar_e_tag": {
+          "name": "federation_avatar_e_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_avatar_last_modified": {
+          "name": "federation_avatar_last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_last_resolved_at": {
+          "name": "federation_last_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_unavailable_at": {
+          "name": "federation_unavailable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_unavailable_reason": {
+          "name": "federation_unavailable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_owner_id": {
+          "name": "automation_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reputation_rank_weight": {
+          "name": "reputation_rank_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.1
+        },
+        "reputation_tier": {
+          "name": "reputation_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "is_staff": {
+          "name": "is_staff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_seed_verifier": {
+          "name": "is_seed_verifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"en-US\"}'"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_expires_after_inactivity_days": {
+          "name": "account_expires_after_inactivity_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_is_private_account": {
+          "name": "privacy_is_private_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_online_status": {
+          "name": "privacy_hide_online_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_last_seen": {
+          "name": "privacy_hide_last_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_profile_visibility": {
+          "name": "privacy_profile_visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_login_alerts": {
+          "name": "privacy_login_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_block_screenshots": {
+          "name": "privacy_block_screenshots",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_login": {
+          "name": "privacy_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_biometric_login": {
+          "name": "privacy_biometric_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_show_activity": {
+          "name": "privacy_show_activity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_tagging": {
+          "name": "privacy_allow_tagging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_mentions": {
+          "name": "privacy_allow_mentions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_hide_read_receipts": {
+          "name": "privacy_hide_read_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_allow_direct_messages": {
+          "name": "privacy_allow_direct_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_data_sharing": {
+          "name": "privacy_data_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_location_sharing": {
+          "name": "privacy_location_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_analytics_sharing": {
+          "name": "privacy_analytics_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_sensitive_content": {
+          "name": "privacy_sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_auto_filter": {
+          "name": "privacy_auto_filter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_mute_keywords": {
+          "name": "privacy_mute_keywords",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_discoverable_by_email": {
+          "name": "privacy_discoverable_by_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_discoverable_by_phone": {
+          "name": "privacy_discoverable_by_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_fediverse_sharing": {
+          "name": "privacy_fediverse_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_signature": {
+          "name": "email_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_enabled": {
+          "name": "auto_reply_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reply_subject": {
+          "name": "auto_reply_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_body": {
+          "name": "auto_reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_start_date": {
+          "name": "auto_reply_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_end_date": {
+          "name": "auto_reply_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_forward_to": {
+          "name": "auto_forward_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_forward_keep_copy": {
+          "name": "auto_forward_keep_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_push_enabled": {
+          "name": "notification_push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email_digest": {
+          "name": "notification_email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_security_alerts": {
+          "name": "notification_security_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_marketing_emails": {
+          "name": "notification_marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preference_language": {
+          "name": "preference_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_theme": {
+          "name": "preference_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "preference_reduce_motion": {
+          "name": "preference_reduce_motion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preference_timezone": {
+          "name": "preference_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference_mode": {
+          "name": "theme_preference_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference_color_preset": {
+          "name": "theme_preference_color_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_lower_username_key": {
+          "name": "users_lower_username_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"username\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_lower_email_key": {
+          "name": "users_lower_email_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"email\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_lower_public_key_key": {
+          "name": "users_lower_public_key_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"public_key\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_actor_uri_key": {
+          "name": "users_federation_actor_uri_key",
+          "columns": [
+            {
+              "expression": "federation_actor_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_hashed_email_idx": {
+          "name": "users_hashed_email_idx",
+          "columns": [
+            {
+              "expression": "hashed_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"hashed_email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_hashed_phone_idx": {
+          "name": "users_hashed_phone_idx",
+          "columns": [
+            {
+              "expression": "hashed_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"hashed_phone\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_kind_parent_account_id_idx": {
+          "name": "users_kind_parent_account_id_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_parent_account_id_idx": {
+          "name": "users_parent_account_id_idx",
+          "columns": [
+            {
+              "expression": "parent_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"parent_account_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_root_account_id_idx": {
+          "name": "users_root_account_id_idx",
+          "columns": [
+            {
+              "expression": "root_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"root_account_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_type_idx": {
+          "name": "users_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_domain_idx": {
+          "name": "users_federation_domain_idx",
+          "columns": [
+            {
+              "expression": "federation_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_domain\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_last_resolved_at_idx": {
+          "name": "users_federation_last_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "federation_last_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_last_resolved_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_unavailable_at_idx": {
+          "name": "users_federation_unavailable_at_idx",
+          "columns": [
+            {
+              "expression": "federation_unavailable_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_unavailable_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_automation_owner_id_idx": {
+          "name": "users_automation_owner_id_idx",
+          "columns": [
+            {
+              "expression": "automation_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"automation_owner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_reputation_rank_weight_idx": {
+          "name": "users_reputation_rank_weight_idx",
+          "columns": [
+            {
+              "expression": "reputation_rank_weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_reputation_tier_idx": {
+          "name": "users_reputation_tier_idx",
+          "columns": [
+            {
+              "expression": "reputation_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_is_sensitive_idx": {
+          "name": "users_is_sensitive_idx",
+          "columns": [
+            {
+              "expression": "is_sensitive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_parent_account_id_users_id_fk": {
+          "name": "users_parent_account_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "parent_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_root_account_id_users_id_fk": {
+          "name": "users_root_account_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "root_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_automation_owner_id_users_id_fk": {
+          "name": "users_automation_owner_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "automation_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "users_kind_check": {
+          "name": "users_kind_check",
+          "value": "\"users\".\"kind\" in ('personal', 'organization', 'project', 'bot', 'channel')"
+        },
+        "users_account_categories_check": {
+          "name": "users_account_categories_check",
+          "value": "\"users\".\"account_categories\" <@ array['news', 'politics', 'business', 'startup', 'finance', 'crypto', 'marketplace', 'retail', 'real_estate', 'agency', 'landlord', 'cooperative', 'architecture', 'technology', 'software', 'ai', 'security', 'automation', 'science', 'education', 'books', 'health', 'fitness', 'sports', 'gaming', 'music', 'film', 'podcast', 'art', 'photography', 'comedy', 'food', 'travel', 'fashion', 'home_garden', 'diy', 'automotive', 'animals', 'family', 'nonprofit', 'government', 'community', 'activism', 'environment', 'religion', 'other']::text[]"
+        },
+        "users_account_categories_max_check": {
+          "name": "users_account_categories_max_check",
+          "value": "cardinality(\"users\".\"account_categories\") <= 4"
+        },
+        "users_account_categories_kind_check": {
+          "name": "users_account_categories_kind_check",
+          "value": "\"users\".\"kind\" in ('organization', 'project', 'bot', 'channel') or cardinality(\"users\".\"account_categories\") = 0"
+        },
+        "users_account_status_check": {
+          "name": "users_account_status_check",
+          "value": "\"users\".\"account_status\" in ('active', 'archived')"
+        },
+        "users_type_check": {
+          "name": "users_type_check",
+          "value": "\"users\".\"type\" in ('local', 'federated', 'agent', 'automated')"
+        },
+        "users_reputation_tier_check": {
+          "name": "users_reputation_tier_check",
+          "value": "\"users\".\"reputation_tier\" in ('restricted', 'new', 'trusted', 'high_trust', 'verified')"
+        },
+        "users_preference_theme_check": {
+          "name": "users_preference_theme_check",
+          "value": "\"users\".\"preference_theme\" in ('light', 'dark', 'system')"
+        },
+        "users_color_check": {
+          "name": "users_color_check",
+          "value": "\"users\".\"color\" in ('teal', 'blue', 'green', 'amber', 'red', 'purple', 'pink', 'sky', 'orange', 'mint', 'oxy') or \"users\".\"color\" ~* '^#([0-9a-f]{3}|[0-9a-f]{6})$'"
+        },
+        "users_account_expires_after_inactivity_days_check": {
+          "name": "users_account_expires_after_inactivity_days_check",
+          "value": "\"users\".\"account_expires_after_inactivity_days\" is null or \"users\".\"account_expires_after_inactivity_days\" in (30, 90, 180, 365)"
+        },
+        "users_theme_preference_check": {
+          "name": "users_theme_preference_check",
+          "value": "(\"users\".\"theme_preference_mode\" is null and \"users\".\"theme_preference_color_preset\" is null) or (\"users\".\"theme_preference_mode\" is not null and \"users\".\"theme_preference_color_preset\" is not null and length(\"users\".\"theme_preference_color_preset\") > 0)"
+        },
+        "users_parent_account_id_not_self_check": {
+          "name": "users_parent_account_id_not_self_check",
+          "value": "\"users\".\"parent_account_id\" <> \"users\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_request_validators": {
+      "name": "validation_request_validators",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "validation_request_validators_user_id_idx": {
+          "name": "validation_request_validators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_request_validators_position_key": {
+          "name": "validation_request_validators_position_key",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_request_validators_request_id_validation_requests_id_fk": {
+          "name": "validation_request_validators_request_id_validation_requests_id_fk",
+          "tableFrom": "validation_request_validators",
+          "tableTo": "validation_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_request_validators_user_id_users_id_fk": {
+          "name": "validation_request_validators_user_id_users_id_fk",
+          "tableFrom": "validation_request_validators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "validation_request_validators_pkey": {
+          "name": "validation_request_validators_pkey",
+          "columns": [
+            "request_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_request_validators_position_check": {
+          "name": "validation_request_validators_position_check",
+          "value": "\"validation_request_validators\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_requests": {
+      "name": "validation_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_id": {
+          "name": "source_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_value": {
+          "name": "high_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rng_seed": {
+          "name": "rng_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "validation_requests_subject_user_id_idx": {
+          "name": "validation_requests_subject_user_id_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_requests_status_expires_at_idx": {
+          "name": "validation_requests_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_requests_open_source_action_key": {
+          "name": "validation_requests_open_source_action_key",
+          "columns": [
+            {
+              "expression": "source_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"validation_requests\".\"status\" in ('pending', 'quorum_met')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_requests_subject_user_id_users_id_fk": {
+          "name": "validation_requests_subject_user_id_users_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_requests_application_id_applications_id_fk": {
+          "name": "validation_requests_application_id_applications_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "validation_requests_resolved_txn_id_reputation_transactions_id_fk": {
+          "name": "validation_requests_resolved_txn_id_reputation_transactions_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_requests_status_check": {
+          "name": "validation_requests_status_check",
+          "value": "\"validation_requests\".\"status\" in ('pending', 'quorum_met', 'validated', 'rejected', 'expired')"
+        },
+        "validation_requests_outcome_check": {
+          "name": "validation_requests_outcome_check",
+          "value": "\"validation_requests\".\"outcome\" is null or \"validation_requests\".\"outcome\" in ('validated', 'rejected')"
+        },
+        "validation_requests_quorum_check": {
+          "name": "validation_requests_quorum_check",
+          "value": "\"validation_requests\".\"quorum\" > 0"
+        },
+        "validation_requests_threshold_check": {
+          "name": "validation_requests_threshold_check",
+          "value": "\"validation_requests\".\"threshold\" >= \"validation_requests\".\"quorum\""
+        },
+        "validation_requests_terminal_check": {
+          "name": "validation_requests_terminal_check",
+          "value": "(\"validation_requests\".\"status\" in ('validated', 'rejected') and \"validation_requests\".\"outcome\" is not null and \"validation_requests\".\"status\" = \"validation_requests\".\"outcome\") or (\"validation_requests\".\"status\" in ('pending', 'quorum_met', 'expired') and \"validation_requests\".\"outcome\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_votes": {
+      "name": "validation_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_user_id": {
+          "name": "validator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake_weight": {
+          "name": "stake_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "validation_votes_request_validator_key": {
+          "name": "validation_votes_request_validator_key",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "validator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_votes_validator_user_id_idx": {
+          "name": "validation_votes_validator_user_id_idx",
+          "columns": [
+            {
+              "expression": "validator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_votes_request_id_validation_requests_id_fk": {
+          "name": "validation_votes_request_id_validation_requests_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "validation_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_votes_validator_user_id_users_id_fk": {
+          "name": "validation_votes_validator_user_id_users_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_votes_record_id_signed_records_record_id_fk": {
+          "name": "validation_votes_record_id_signed_records_record_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_votes_verdict_check": {
+          "name": "validation_votes_verdict_check",
+          "value": "\"validation_votes\".\"verdict\" in ('valid', 'invalid', 'abstain')"
+        },
+        "validation_votes_stake_weight_check": {
+          "name": "validation_votes_stake_weight_check",
+          "value": "\"validation_votes\".\"stake_weight\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validator_affinities": {
+      "name": "validator_affinities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "validator_a": {
+          "name": "validator_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_b": {
+          "name": "validator_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_vote_count": {
+          "name": "co_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_co_vote_at": {
+          "name": "last_co_vote_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "validator_affinities_pair_key": {
+          "name": "validator_affinities_pair_key",
+          "columns": [
+            {
+              "expression": "validator_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "validator_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validator_affinities_validator_a_users_id_fk": {
+          "name": "validator_affinities_validator_a_users_id_fk",
+          "tableFrom": "validator_affinities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validator_affinities_validator_b_users_id_fk": {
+          "name": "validator_affinities_validator_b_users_id_fk",
+          "tableFrom": "validator_affinities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validator_affinities_co_vote_count_check": {
+          "name": "validator_affinities_co_vote_count_check",
+          "value": "\"validator_affinities\".\"co_vote_count\" >= 0"
+        },
+        "validator_affinities_canonical_pair_check": {
+          "name": "validator_affinities_canonical_pair_check",
+          "value": "\"validator_affinities\".\"validator_a\" < \"validator_affinities\".\"validator_b\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifiable_credentials": {
+      "name": "verifiable_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_user_id": {
+          "name": "holder_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_did": {
+          "name": "holder_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_user_id": {
+          "name": "issuer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer_did": {
+          "name": "issuer_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claims": {
+          "name": "claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verifiable_credentials_holder_status_idx": {
+          "name": "verifiable_credentials_holder_status_idx",
+          "columns": [
+            {
+              "expression": "holder_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifiable_credentials_issuer_did_idx": {
+          "name": "verifiable_credentials_issuer_did_idx",
+          "columns": [
+            {
+              "expression": "issuer_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verifiable_credentials_holder_user_id_users_id_fk": {
+          "name": "verifiable_credentials_holder_user_id_users_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "holder_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "verifiable_credentials_issuer_user_id_users_id_fk": {
+          "name": "verifiable_credentials_issuer_user_id_users_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issuer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "verifiable_credentials_record_id_signed_records_record_id_fk": {
+          "name": "verifiable_credentials_record_id_signed_records_record_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verifiable_credentials_recordId_unique": {
+          "name": "verifiable_credentials_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "verifiable_credentials_status_check": {
+          "name": "verifiable_credentials_status_check",
+          "value": "\"verifiable_credentials\".\"status\" in ('active', 'revoked', 'expired')"
+        },
+        "verifiable_credentials_revocation_check": {
+          "name": "verifiable_credentials_revocation_check",
+          "value": "(\"verifiable_credentials\".\"status\" = 'revoked' and \"verifiable_credentials\".\"revoked_at\" is not null) or (\"verifiable_credentials\".\"status\" <> 'revoked' and \"verifiable_credentials\".\"revoked_at\" is null)"
+        },
+        "verifiable_credentials_expiry_check": {
+          "name": "verifiable_credentials_expiry_check",
+          "value": "\"verifiable_credentials\".\"expires_at\" is null or \"verifiable_credentials\".\"expires_at\" > \"verifiable_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(38, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_user_id_key": {
+          "name": "wallets_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "wallets_balance_check": {
+          "name": "wallets_balance_check",
+          "value": "\"wallets\".\"balance\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webauthn_challenges_expires_at_idx": {
+          "name": "webauthn_challenges_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webauthn_challenges_challenge_key": {
+          "name": "webauthn_challenges_challenge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webauthn_challenges_type_check": {
+          "name": "webauthn_challenges_type_check",
+          "value": "\"webauthn_challenges\".\"type\" in ('registration', 'authentication')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webauthn_credentials": {
+      "name": "webauthn_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_verified": {
+          "name": "user_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webauthn_credentials_user_id_idx": {
+          "name": "webauthn_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webauthn_credentials_user_id_users_id_fk": {
+          "name": "webauthn_credentials_user_id_users_id_fk",
+          "tableFrom": "webauthn_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webauthn_credentials_credential_id_key": {
+          "name": "webauthn_credentials_credential_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webauthn_credentials_device_type_check": {
+          "name": "webauthn_credentials_device_type_check",
+          "value": "\"webauthn_credentials\".\"device_type\" in ('singleDevice', 'multiDevice')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1785813000000,
       "tag": "0019_follow_enum_checks",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1785814925471,
+      "tag": "0020_follow_events_claim",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema/followEvents.ts
+++ b/packages/api/src/db/schema/followEvents.ts
@@ -27,7 +27,7 @@
  */
 
 import { sql } from 'drizzle-orm';
-import { check, index, jsonb, pgTable, text, unique } from 'drizzle-orm/pg-core';
+import { check, index, integer, jsonb, pgTable, text, unique } from 'drizzle-orm/pg-core';
 import { appGrants } from './appGrants';
 import { applications } from './applications';
 import { createdAt, generatedId, timestamptz } from './columns';
@@ -99,8 +99,48 @@ export const followEvents = pgTable(
     contextApplicationId: text().references(() => applications.id, { onDelete: 'set null' }),
     /** Bounded extra detail. Never required to interpret the event. */
     payload: jsonb().$type<Record<string, unknown>>(),
-    /** When the worker finished with it. NULL means still to be processed. */
+    /**
+     * When the worker finished with it. NULL means still to be processed.
+     *
+     * Written ONLY after the side effect succeeded. An event acknowledged before
+     * its effect is an event silently lost, and nothing downstream can tell the
+     * difference between "delivered" and "marked delivered".
+     */
     processedAt: timestamptz(),
+    /**
+     * ## The claim, as three columns
+     *
+     * A worker leases an event rather than holding a row lock for as long as it
+     * takes to act on it: a lock lives inside a transaction, so keeping one
+     * across the side effect means a database connection is pinned for the
+     * duration of a remote delivery. The lease is what lets the claiming
+     * transaction commit immediately and the work happen outside it.
+     */
+    /** When the current claim was taken. NULL means unclaimed. */
+    claimedAt: timestamptz(),
+    /**
+     * Which worker holds it. Checked on acknowledgement, so a worker whose lease
+     * expired mid-flight cannot mark an event another worker has since taken —
+     * the second worker is the one that will report an outcome for it.
+     */
+    claimedBy: text(),
+    /**
+     * How many times this event has been CLAIMED, not how many times a handler
+     * has thrown. A process killed mid-handler never gets to record a failure,
+     * so counting at failure time lets an event that crashes its worker retry
+     * forever across restarts. Counting at claim time bounds it, at the cost of
+     * spending an attempt on an event that was interrupted by a deploy.
+     */
+    attempts: integer().notNull().default(0),
+    /**
+     * Dead letter. Set once an event has exhausted its attempts, or when it can
+     * never succeed (an event type no handler knows). A dead-lettered event is
+     * never claimed again and is deliberately NOT marked processed — its effect
+     * did not happen, and a queue that hides that is worse than one that stops.
+     */
+    failedAt: timestamptz(),
+    /** Why the last attempt failed. Bounded; provenance for whoever triages it. */
+    lastError: text(),
     createdAt: createdAt(),
   },
   (t) => [
@@ -108,6 +148,11 @@ export const followEvents = pgTable(
     // The repo's convention for a closed value set, which 0016 skipped: the
     // drizzle `enum` above is a COMPILE-TIME claim, and nothing stopped a
     // repair script or a future service from writing a type no consumer knows.
+    //
+    // A second line of defence, not a replacement for the worker's own guard:
+    // this constrains what can be WRITTEN from now on, and says nothing about a
+    // row that predates it — so `followOutbox.worker.ts` still dead-letters a
+    // type it has no handler for rather than trusting the column.
     check(
       'follow_events_type_check',
       sql`${t.type} in ('follow.created', 'follow.removed', 'follow.requested', 'follow.accepted', 'follow.rejected', 'follow.context_enabled', 'follow.context_disabled')`
@@ -116,12 +161,23 @@ export const followEvents = pgTable(
       'follow_events_cause_check',
       sql`${t.cause} in ('user_action', 'expired', 'federation_inbound', 'reconciliation', 'migration')`
     ),
-    // The worker's read: unprocessed, oldest first. Partial, so the index stays
+    // The worker's read: claimable, oldest first. Partial, so the index stays
     // the size of the backlog rather than the size of all history — which is the
     // difference between a queue and a table that used to be one.
+    //
+    // Dead letters are excluded for the same reason, and it is not cosmetic:
+    // they are by definition the OLDEST unprocessed rows, so leaving them in a
+    // `created_at`-ordered index makes every future claim scan past all of them
+    // first, forever.
     index('follow_events_pending_idx')
       .on(t.createdAt)
-      .where(sql`${t.processedAt} is null`),
+      .where(sql`${t.processedAt} is null and ${t.failedAt} is null`),
+    // The dead-letter read. Without it the only way to find the events that
+    // stopped is a scan of all history, and a marker nobody can find is not a
+    // marker.
+    index('follow_events_dead_letter_idx')
+      .on(t.failedAt)
+      .where(sql`${t.failedAt} is not null`),
     // "What happened to this relationship" — reconciliation and support.
     index('follow_events_relationship_idx').on(t.relationshipId),
     index('follow_events_actor_idx').on(t.actorUserId, t.createdAt),

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -76,6 +76,10 @@ import updatesManifestRoutes from './routes/updates';
 import updatesAdminRoutes from './routes/updatesAdmin';
 import { startSmtpInbound, stopSmtpInbound } from './services/smtp.inbound';
 import { smtpOutbound } from './services/smtp.outbound';
+import {
+  startFollowOutboxWorker,
+  stopFollowOutboxWorker,
+} from './services/followOutbox.worker';
 import { startBackgroundJobs, stopBackgroundJobs } from './queue/backgroundJobs';
 import { startNodeIngestJobs, stopNodeIngestJobs } from './queue/nodeIngest.queue';
 import {
@@ -438,6 +442,7 @@ async function gracefulShutdown(signal: string) {
     logger.info('HTTP server closed');
   });
 
+  stopFollowOutboxWorker();
   await stopBackgroundJobs();
   await stopNodeIngestJobs();
   await stopTransparencyCheckpointJobs();
@@ -1001,6 +1006,12 @@ export async function bootstrap(
       logger.error('SMTP inbound server failed to start', err instanceof Error ? err : new Error(String(err)));
     }
   }
+
+  // Drain the `follow_events` outbox. OFF unless this deployment asks for it:
+  // acknowledging an event is a claim that its delivery happened, and the
+  // handler set today observes rather than delivers. The WRITE is never gated —
+  // events accumulate regardless, so switching the loop on later loses nothing.
+  startFollowOutboxWorker();
 
   // Start background jobs: durable BullMQ scheduling when REDIS_URL is set,
   // otherwise the in-process cron fallback. Never throws.

--- a/packages/api/src/services/__tests__/followOutbox.worker.test.ts
+++ b/packages/api/src/services/__tests__/followOutbox.worker.test.ts
@@ -1,0 +1,509 @@
+/**
+ * The outbox worker's guarantees, against a real Postgres.
+ *
+ * Every interesting case here is about something that must NOT happen: two
+ * workers must not both act on one event, an event whose handler threw must not
+ * be marked done, and a permanently-failing event must not be retried forever.
+ * None of those is observable without real row locking, so this suite runs
+ * against the throwaway database `jest.globalSetup.ts` creates rather than
+ * against a mock — a mocked `db` would agree with whatever the worker did.
+ *
+ * ## Why nothing here asserts a batch's totals
+ *
+ * `jest.globalSetup.ts` provisions one database per WORKER, not per file, and
+ * jest runs several files in each worker one after another. So any file that ran
+ * before this one in the same worker — `followCommand.service.test.ts` writes an
+ * event per follow — has left pending events in this database, and the worker
+ * under test claims whatever is pending. A `claimed`/`processed` count is
+ * therefore not this file's to predict.
+ *
+ * Every assertion is instead scoped to rows this test created: what the handler
+ * saw for THOSE events, and what the database holds for THOSE rows afterwards.
+ * The properties under test are per-event anyway, which is what makes the
+ * scoping honest rather than a workaround.
+ */
+
+import { eq, sql } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { applications } from '../../db/schema/applications';
+import { FOLLOW_EVENT_TYPES, followEvents } from '../../db/schema/followEvents';
+import { followTargets } from '../../db/schema/followTargets';
+import { users } from '../../db/schema/users';
+import type { FollowCapability } from '../followCapability.service';
+import { followTarget } from '../followCommand.service';
+import {
+  claimableFollowEvents,
+  FOLLOW_OUTBOX_MAX_ATTEMPTS,
+  followEventHandlers,
+  runFollowOutboxBatch,
+  type FollowEventHandler,
+  type FollowEventHandlerRegistry,
+} from '../followOutbox.worker';
+
+/** Big enough that a batch drains everything pending, this file's rows included. */
+const DRAIN_BATCH = 500;
+
+let followerId: string;
+let appId: string;
+let counter = 0;
+
+const unique = (prefix: string) => `${prefix}${(counter += 1)}`;
+
+/** A registry whose every entry is the same handler — the unit under test. */
+function registryOf(handler: FollowEventHandler): FollowEventHandlerRegistry {
+  return {
+    'follow.created': handler,
+    'follow.removed': handler,
+    'follow.requested': handler,
+    'follow.accepted': handler,
+    'follow.rejected': handler,
+    'follow.context_enabled': handler,
+    'follow.context_disabled': handler,
+  };
+}
+
+/**
+ * Apply `handler` to this test's own events and nothing else.
+ *
+ * Another test file's events land in the same batch; they must be acknowledged
+ * normally rather than dragged into whatever this test is doing.
+ */
+function scopedTo(eventIds: Set<string>, handler: FollowEventHandler): FollowEventHandlerRegistry {
+  return registryOf(async (event) => {
+    if (eventIds.has(event.eventId)) await handler(event);
+  });
+}
+
+function capability(): FollowCapability {
+  return {
+    userId: followerId,
+    applicationId: appId,
+    grantId: null as unknown as string,
+    scopes: ['follows:read', 'follows:write'],
+    sessionId: 'session',
+  };
+}
+
+/**
+ * Create a follow, and hand back the `follow.created` event it wrote.
+ *
+ * Goes through the command service rather than inserting a row, so the events
+ * under test are the ones production actually produces.
+ */
+async function makeEvent(): Promise<{ rowId: string; eventId: string }> {
+  const [followed] = await getDb().insert(users).values({}).returning({ id: users.id });
+  const uri = unique('https://oxy.so/users/outbox');
+  const [target] = await getDb()
+    .insert(followTargets)
+    .values({ canonicalUri: uri, kind: 'oxy.user', localUserId: followed.id })
+    .returning({ id: followTargets.id });
+
+  const { relationshipId } = await followTarget({
+    capability: capability(),
+    target: { id: target.id, canonicalUri: uri, kind: 'oxy.user', localUserId: followed.id },
+  });
+
+  const [event] = await getDb()
+    .select({ rowId: followEvents.id, eventId: followEvents.eventId })
+    .from(followEvents)
+    .where(eq(followEvents.relationshipId, relationshipId))
+    .limit(1);
+
+  return event;
+}
+
+async function readEvent(rowId: string) {
+  const [row] = await getDb()
+    .select({
+      processedAt: followEvents.processedAt,
+      failedAt: followEvents.failedAt,
+      attempts: followEvents.attempts,
+      claimedBy: followEvents.claimedBy,
+      lastError: followEvents.lastError,
+    })
+    .from(followEvents)
+    .where(eq(followEvents.id, rowId))
+    .limit(1);
+  return row;
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+beforeEach(async () => {
+  const [follower] = await getDb().insert(users).values({}).returning({ id: users.id });
+  followerId = follower.id;
+  const [app] = await getDb()
+    .insert(applications)
+    .values({ name: unique('Outbox App '), status: 'active', ownerAccountId: followerId })
+    .returning({ id: applications.id });
+  appId = app.id;
+});
+
+describe('claiming', () => {
+  it('acknowledges only after the handler returned', async () => {
+    const event = await makeEvent();
+    // Captured rather than asserted inside the handler: an expectation that
+    // throws in there is caught by the worker and recorded as a handler
+    // failure, which would leave the test asserting on the wrong thing.
+    let processedAtMidFlight: Date | null | undefined;
+
+    await runFollowOutboxBatch({
+      ownerId: 'worker-a',
+      batchSize: DRAIN_BATCH,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        processedAtMidFlight = (await readEvent(event.rowId)).processedAt;
+      }),
+    });
+
+    expect(processedAtMidFlight).toBeNull();
+    const row = await readEvent(event.rowId);
+    expect(row.processedAt).not.toBeNull();
+    expect(row.claimedBy).toBe('worker-a');
+    expect(row.attempts).toBe(1);
+  });
+
+  it('leaves an acknowledged event alone on the next pass', async () => {
+    const event = await makeEvent();
+    await runFollowOutboxBatch({ ownerId: 'worker-a', batchSize: DRAIN_BATCH });
+
+    // `leaseMs: 0` so the lease is NOT what keeps it out of this batch —
+    // otherwise a claim query that forgot `processed_at is null` entirely would
+    // still pass here, hidden behind the lease it left behind.
+    let redispatched = false;
+    await runFollowOutboxBatch({
+      ownerId: 'worker-b',
+      batchSize: DRAIN_BATCH,
+      leaseMs: 0,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        redispatched = true;
+      }),
+    });
+
+    expect(redispatched).toBe(false);
+    expect((await readEvent(event.rowId)).attempts).toBe(1);
+  });
+
+  it('does not re-claim an event whose lease is still live', async () => {
+    const event = await makeEvent();
+
+    // Claim it and leave no outcome, exactly as a killed worker would: the
+    // claim is committed, the acknowledgement never is.
+    await runFollowOutboxBatch({
+      ownerId: 'worker-a',
+      batchSize: DRAIN_BATCH,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        throw new Error('interrupted');
+      }),
+    });
+
+    let redispatched = false;
+    await runFollowOutboxBatch({
+      ownerId: 'worker-b',
+      batchSize: DRAIN_BATCH,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        redispatched = true;
+      }),
+    });
+
+    expect(redispatched).toBe(false);
+    const row = await readEvent(event.rowId);
+    expect(row.claimedBy).toBe('worker-a');
+    expect(row.attempts).toBe(1);
+    expect(row.processedAt).toBeNull();
+  });
+
+  it('lets another worker take over once the lease has run out', async () => {
+    const event = await makeEvent();
+
+    await runFollowOutboxBatch({
+      ownerId: 'worker-a',
+      batchSize: DRAIN_BATCH,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        throw new Error('interrupted');
+      }),
+    });
+
+    // `leaseMs: 0` is a dead worker's claim seen from far enough in the future.
+    await runFollowOutboxBatch({ ownerId: 'worker-b', batchSize: DRAIN_BATCH, leaseMs: 0 });
+
+    const row = await readEvent(event.rowId);
+    expect(row.claimedBy).toBe('worker-b');
+    expect(row.processedAt).not.toBeNull();
+    expect(row.attempts).toBe(2);
+  });
+});
+
+describe('two workers running at once', () => {
+  it('never hands one event to both', async () => {
+    // Two pending events and `batchSize: 1` apiece, so a batch can only take
+    // part of what is available — with a batch big enough for everything the
+    // first claim to execute wins the lot and there is no race left to observe.
+    const mine = [await makeEvent(), await makeEvent()];
+
+    // Both handlers block until two dispatches are in flight, so the two claims
+    // provably overlap rather than running one after the other. Recording is
+    // NOT scoped to this test's events: a duplicate dispatch of anybody's event
+    // is the failure this is looking for.
+    let inFlight = 0;
+    let release = (): void => {};
+    const overlapping = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const dispatched: string[] = [];
+    const handlers = registryOf(async (event) => {
+      dispatched.push(event.eventId);
+      inFlight += 1;
+      if (inFlight >= 2) release();
+      // Bounded, so a worker that claimed nothing cannot hang the run — it
+      // surfaces as the `claimed` expectation below instead.
+      await Promise.race([
+        overlapping,
+        new Promise<void>((resolve) => setTimeout(resolve, 2_000)),
+      ]);
+    });
+
+    const [a, b] = await Promise.all([
+      runFollowOutboxBatch({ ownerId: 'worker-a', batchSize: 1, handlers }),
+      runFollowOutboxBatch({ ownerId: 'worker-b', batchSize: 1, handlers }),
+    ]);
+
+    // Both workers found work — without this the no-duplicates assertion below
+    // would pass vacuously on a batch that claimed nothing.
+    expect(a.claimed).toBe(1);
+    expect(b.claimed).toBe(1);
+
+    // The property: two claims, two DIFFERENT events.
+    expect(dispatched).toHaveLength(2);
+    expect(new Set(dispatched).size).toBe(2);
+
+    // …and the same thing read back from the database, which is where a double
+    // claim would leave its mark whatever the handlers saw.
+    for (const event of mine) {
+      const row = await readEvent(event.rowId);
+      expect(row.attempts).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('refuses an acknowledgement from a worker that lost the lease', async () => {
+    const event = await makeEvent();
+
+    // A slow worker: while its handler runs, a second worker takes the event
+    // over — which is what an expired lease looks like from the inside.
+    const result = await runFollowOutboxBatch({
+      ownerId: 'worker-slow',
+      batchSize: DRAIN_BATCH,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        await runFollowOutboxBatch({ ownerId: 'worker-fast', batchSize: DRAIN_BATCH, leaseMs: 0 });
+      }),
+    });
+
+    // The slow worker's handler returned, but its acknowledgement matched
+    // nothing — the event belongs to the worker that took it over.
+    expect(result.claimed).toBeGreaterThanOrEqual(1);
+    const row = await readEvent(event.rowId);
+    expect(row.claimedBy).toBe('worker-fast');
+    expect(row.processedAt).not.toBeNull();
+  });
+});
+
+describe('failure', () => {
+  it('leaves processedAt null when the handler throws', async () => {
+    const event = await makeEvent();
+
+    await runFollowOutboxBatch({
+      ownerId: 'worker-a',
+      batchSize: DRAIN_BATCH,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        throw new Error('delivery refused');
+      }),
+    });
+
+    const row = await readEvent(event.rowId);
+    expect(row.processedAt).toBeNull();
+    expect(row.failedAt).toBeNull();
+    expect(row.lastError).toBe('delivery refused');
+  });
+
+  it('retries, then stops at the attempt limit and says why', async () => {
+    const event = await makeEvent();
+    let dispatches = 0;
+
+    // `leaseMs: 0` collapses the backoff so the bound can be observed without
+    // waiting `MAX_ATTEMPTS × LEASE`. It changes when a retry happens, never
+    // how many are permitted.
+    for (let pass = 0; pass < FOLLOW_OUTBOX_MAX_ATTEMPTS + 3; pass += 1) {
+      await runFollowOutboxBatch({
+        ownerId: `worker-${pass}`,
+        batchSize: DRAIN_BATCH,
+        leaseMs: 0,
+        handlers: scopedTo(new Set([event.eventId]), async () => {
+          dispatches += 1;
+          throw new Error('upstream is down');
+        }),
+      });
+    }
+
+    expect(dispatches).toBe(FOLLOW_OUTBOX_MAX_ATTEMPTS);
+
+    const row = await readEvent(event.rowId);
+    expect(row.attempts).toBe(FOLLOW_OUTBOX_MAX_ATTEMPTS);
+    expect(row.failedAt).not.toBeNull();
+    expect(row.lastError).toBe('upstream is down');
+    // Dead-lettered, never acknowledged: the effect did not happen, and a queue
+    // that marked it done would be hiding that.
+    expect(row.processedAt).toBeNull();
+  });
+
+  it('one failing event does not stop the ones behind it', async () => {
+    const poison = await makeEvent();
+    const healthy = await makeEvent();
+
+    await runFollowOutboxBatch({
+      ownerId: 'worker-a',
+      batchSize: DRAIN_BATCH,
+      handlers: scopedTo(new Set([poison.eventId]), async () => {
+        throw new Error('poison');
+      }),
+    });
+
+    expect((await readEvent(healthy.rowId)).processedAt).not.toBeNull();
+    expect((await readEvent(poison.rowId)).processedAt).toBeNull();
+  });
+
+  it('dead-letters an event whose worker keeps dying before it can record anything', async () => {
+    const event = await makeEvent();
+
+    // Claims with no outcome — a worker killed mid-handler every time. Nothing
+    // ever writes `last_error`, so only the attempt count bounds it.
+    await getDb()
+      .update(followEvents)
+      .set({ attempts: FOLLOW_OUTBOX_MAX_ATTEMPTS })
+      .where(eq(followEvents.id, event.rowId));
+
+    let redispatched = false;
+    await runFollowOutboxBatch({
+      ownerId: 'worker-a',
+      batchSize: DRAIN_BATCH,
+      leaseMs: 0,
+      handlers: scopedTo(new Set([event.eventId]), async () => {
+        redispatched = true;
+      }),
+    });
+
+    // Claimed one last time — that claim is how the marker gets written — but
+    // never handed to a handler.
+    expect(redispatched).toBe(false);
+    const row = await readEvent(event.rowId);
+    expect(row.attempts).toBe(FOLLOW_OUTBOX_MAX_ATTEMPTS + 1);
+    expect(row.failedAt).not.toBeNull();
+    expect(row.processedAt).toBeNull();
+    expect(row.lastError).toContain('Attempt limit reached');
+  });
+
+  it('dead-letters an event type its registry does not cover, without retrying it', async () => {
+    const event = await makeEvent();
+
+    // An earlier version of this wrote a made-up `type` straight into the row.
+    // `follow_events_type_check` (0019) refuses that now, which is the whole
+    // point of the constraint — so do not restore it.
+    //
+    // The reachable shape is the other one, and it is the one that matters: a
+    // registry that does not cover a type the column legitimately holds. That
+    // is every rolling deploy after the constraint is widened, when the
+    // previous image keeps claiming events written under a type it has never
+    // heard of.
+    const incomplete: Record<string, FollowEventHandler> = { ...followEventHandlers };
+    delete incomplete['follow.created'];
+
+    await runFollowOutboxBatch({
+      ownerId: 'worker-a',
+      batchSize: DRAIN_BATCH,
+      handlers: incomplete,
+    });
+
+    const row = await readEvent(event.rowId);
+    expect(row.failedAt).not.toBeNull();
+    expect(row.processedAt).toBeNull();
+    expect(row.attempts).toBe(1);
+    expect(row.lastError).toContain('No handler is registered');
+  });
+});
+
+describe('the handler registry', () => {
+  it('covers every event type the schema can write, and nothing else', () => {
+    // A type added to `FOLLOW_EVENT_TYPES` with no handler is a compile error;
+    // this is the runtime half — that the registry carries no extra keys
+    // either, so a renamed type leaves a dead entry behind rather than
+    // silently matching nothing.
+    expect(Object.keys(followEventHandlers).sort()).toEqual([...FOLLOW_EVENT_TYPES].sort());
+  });
+
+  it('acknowledges through the shipped handlers, so the loop is exercisable', async () => {
+    const event = await makeEvent();
+
+    await runFollowOutboxBatch({ ownerId: 'worker-a', batchSize: DRAIN_BATCH });
+
+    const row = await readEvent(event.rowId);
+    expect(row.processedAt).not.toBeNull();
+    expect(row.failedAt).toBeNull();
+  });
+});
+
+describe('the claim query', () => {
+  it('is served by follow_events_pending_idx', async () => {
+    await makeEvent();
+
+    // EXPLAIN of the REAL claim candidate query — the same builder the claim
+    // UPDATE uses, so this cannot pass against a stale copy of the predicate.
+    //
+    // `enable_seqscan = off` because the throwaway database holds a handful of
+    // rows and the planner would rightly scan them. What is under test is
+    // whether the partial index is USABLE for this predicate at all, which is a
+    // question about the two predicates matching, not about table size.
+    const db = getDb();
+    const plan = await db.transaction(async (tx) => {
+      await tx.execute(sql`set local enable_seqscan = off`);
+      const rows = await tx.execute(sql`explain ${claimableFollowEvents(db, new Date(), 50)}`);
+      return rows.map((row) => String(Object.values(row)[0])).join('\n');
+    });
+
+    expect(plan).toContain('follow_events_pending_idx');
+  });
+
+  it('filters on processed_at is null, and locks without blocking', () => {
+    // The properties the plan above and the concurrency test depend on,
+    // asserted directly so a change that drops either fails here too.
+    const { sql: text } = claimableFollowEvents(getDb(), new Date(), 50).toSQL();
+    expect(text).toContain('"processed_at" is null');
+    expect(text).toContain('"failed_at" is null');
+    expect(text).toContain('for update skip locked');
+  });
+});
+
+describe('the write is never gated on the worker', () => {
+  it('accumulates events while nothing is reading them, and drains later', async () => {
+    const first = await makeEvent();
+    const second = await makeEvent();
+
+    // Written and untouched: no worker has run since they were created.
+    for (const event of [first, second]) {
+      const row = await readEvent(event.rowId);
+      expect(row.attempts).toBe(0);
+      expect(row.claimedBy).toBeNull();
+      expect(row.processedAt).toBeNull();
+    }
+
+    await runFollowOutboxBatch({ ownerId: 'worker-a', batchSize: DRAIN_BATCH });
+
+    for (const event of [first, second]) {
+      expect((await readEvent(event.rowId)).processedAt).not.toBeNull();
+    }
+  });
+});

--- a/packages/api/src/services/followOutbox.worker.ts
+++ b/packages/api/src/services/followOutbox.worker.ts
@@ -1,0 +1,523 @@
+/**
+ * The `follow_events` outbox worker — claim, dispatch, acknowledge.
+ *
+ * `followCommand.service.ts` writes an event in the SAME transaction as the
+ * relationship change it describes, and delivers nothing. This is the other
+ * half: the loop that picks those events up.
+ *
+ * ## What it does NOT decide
+ *
+ * No delivery policy lives here. The worker claims an event, hands it to the
+ * handler registered for its `type`, and acknowledges it. Which of a person's
+ * followers get told, what federates where, whether a `follow.removed` caused by
+ * an expiry is worth a notification — all of that belongs to the handlers, and
+ * through them to the services that will own it. A worker that also decided
+ * would be a second place the policy lives.
+ *
+ * ## The handler set TODAY
+ *
+ * Every one of the seven event types is registered to an OBSERVING handler: it
+ * records the event and the intent a real handler would carry out, and performs
+ * no side effect. There is no notification service and no federation delivery
+ * wired to the follow graph yet, and a handler that pretended otherwise would be
+ * worse than none — it would acknowledge events nothing acted on.
+ *
+ * That is also why {@link startFollowOutboxWorker} is OFF unless
+ * `FOLLOW_OUTBOX_WORKER_ENABLED` says otherwise. An acknowledgement is a claim
+ * that the work happened; running observing handlers against production traffic
+ * would consume the backlog that the real handlers, when they exist, have to
+ * deliver. The WRITE is never gated — events accumulate whether or not anything
+ * is reading them, which is the property that makes turning the loop on later a
+ * safe operation rather than a lossy one.
+ *
+ * ## The claim: a lease, not a held lock
+ *
+ * Several API tasks run this loop, so an event has to be claimed by exactly one
+ * of them. Both mechanisms are here, each doing the job it is actually good at:
+ *
+ *   - `FOR UPDATE SKIP LOCKED`, inside the claiming statement, is what makes two
+ *     tasks racing for the same row resolve instantly instead of blocking — the
+ *     loser skips to the next claimable event rather than waiting.
+ *   - a LEASE (`claimed_at` / `claimed_by`) is what survives the commit. A row
+ *     lock lives inside a transaction, so claiming with the lock alone would
+ *     mean holding a transaction — and a database connection — open for as long
+ *     as the side effect takes, which for a federation delivery is a network
+ *     round trip to a server that may be down.
+ *
+ * A dead task strands nothing: its lease simply stops being renewed, and after
+ * {@link FOLLOW_OUTBOX_LEASE_MS} the event is claimable again. The owner check
+ * on acknowledgement is the other side of that — a worker whose lease expired
+ * mid-flight cannot mark an event that another worker has since taken, because
+ * the second worker is the one that will report an outcome for it.
+ *
+ * Delivery is therefore AT LEAST ONCE, deliberately. `follow_events.event_id` is
+ * deterministic and consumer-facing precisely so a redelivery is recognisable;
+ * see the schema's docblock.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { hostname } from 'node:os';
+import { and, asc, eq, inArray, isNull, lt, or, sql } from 'drizzle-orm';
+import { getEnvBoolean, getEnvNumber } from '../config/env';
+import { getDb, type Database } from '../config/postgres';
+import {
+  FOLLOW_EVENT_TYPES,
+  followEvents,
+  type FollowEventCause,
+  type FollowEventType,
+} from '../db/schema/followEvents';
+import { logger } from '../utils/logger';
+
+/**
+ * Times an event may be dispatched before it is dead-lettered.
+ *
+ * Bounds a permanently-failing event so it stops consuming the loop, counted in
+ * CLAIMS rather than in recorded failures — see `attempts` in the schema for why
+ * the two are not the same number. An event whose worker died before recording
+ * anything is claimed once beyond this, and that claim writes the dead letter
+ * instead of dispatching.
+ */
+export const FOLLOW_OUTBOX_MAX_ATTEMPTS = 8;
+
+/**
+ * How long a claim is honoured before another worker may take the event.
+ *
+ * It is also the retry backoff, and that is the point: a failed attempt does NOT
+ * release its claim, so the lease that protects an in-flight handler is the same
+ * mechanism that keeps a failing event from being retried in a tight loop. One
+ * timer, one behaviour to reason about, and a permanently-failing event reaches
+ * its attempt limit in `MAX_ATTEMPTS × LEASE` rather than in one tick.
+ */
+export const FOLLOW_OUTBOX_LEASE_MS = 60_000;
+
+/** Events claimed per tick. Small: each is dispatched one at a time. */
+const DEFAULT_BATCH_SIZE = 50;
+
+/** How often the loop looks for work. */
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Characters of a failure kept in `last_error`. Enough to recognise the failure,
+ * bounded so a handler with a large error cannot bloat the row it describes.
+ */
+const MAX_RECORDED_ERROR_LENGTH = 500;
+
+/** Recorded when the attempt limit is reached with no outcome ever written. */
+const ATTEMPTS_EXHAUSTED_REASON =
+  'Attempt limit reached without a recorded outcome; the worker was interrupted mid-handler.';
+
+/** Recorded for an event whose `type` no handler is registered for. */
+const UNKNOWN_TYPE_REASON = 'No handler is registered for this event type.';
+
+/** The columns a handler receives. */
+const EVENT_COLUMNS = {
+  id: followEvents.id,
+  eventId: followEvents.eventId,
+  type: followEvents.type,
+  cause: followEvents.cause,
+  actorUserId: followEvents.actorUserId,
+  relationshipId: followEvents.relationshipId,
+  targetUri: followEvents.targetUri,
+  targetKind: followEvents.targetKind,
+  originApplicationId: followEvents.originApplicationId,
+  grantId: followEvents.grantId,
+  contextApplicationId: followEvents.contextApplicationId,
+  payload: followEvents.payload,
+  attempts: followEvents.attempts,
+} as const;
+
+/**
+ * One claimed event, as a handler sees it.
+ *
+ * Self-contained by construction — `target_uri` and `target_kind` are
+ * denormalized onto the event so a handler never has to read a relationship that
+ * a `follow.removed` has already deleted.
+ */
+export interface FollowOutboxEvent {
+  /** Row id. Internal; the identity a consumer dedupes on is `eventId`. */
+  id: string;
+  eventId: string;
+  type: FollowEventType;
+  cause: FollowEventCause;
+  actorUserId: string;
+  relationshipId: string;
+  targetUri: string;
+  targetKind: string;
+  originApplicationId: string | null;
+  grantId: string | null;
+  contextApplicationId: string | null;
+  payload: Record<string, unknown> | null;
+  /** Claims so far, this one included. 1 on the first delivery. */
+  attempts: number;
+}
+
+/**
+ * What happens to an event of one type.
+ *
+ * Throwing is how a handler says "not yet" — the event keeps its claim, is
+ * retried when the lease expires, and is dead-lettered once the attempts run
+ * out. Returning is a promise that the effect HAPPENED, because it is what
+ * causes `processed_at` to be written.
+ */
+export type FollowEventHandler = (event: FollowOutboxEvent) => Promise<void>;
+
+/**
+ * Every event type maps to exactly one handler.
+ *
+ * `Record<FollowEventType, …>` rather than a partial map, so adding a type to
+ * `FOLLOW_EVENT_TYPES` without deciding what happens to it is a compile error
+ * rather than an event that quietly reaches the dead-letter queue in production.
+ */
+export type FollowEventHandlerRegistry = Readonly<Record<FollowEventType, FollowEventHandler>>;
+
+/**
+ * A handler that performs no side effect and records the one it stands in for.
+ *
+ * `info`, not `debug`: while this is the whole handler set, the log line IS the
+ * output of the phase, and a worker somebody deliberately switched on to watch
+ * should not need a log-level change to say anything.
+ */
+function observing(intent: string): FollowEventHandler {
+  return async (event) => {
+    await Promise.resolve();
+    logger.info('[FollowOutbox] Observed follow event', {
+      eventId: event.eventId,
+      type: event.type,
+      cause: event.cause,
+      actorUserId: event.actorUserId,
+      relationshipId: event.relationshipId,
+      targetKind: event.targetKind,
+      intent,
+    });
+  };
+}
+
+/**
+ * The handler set. Every entry OBSERVES — see this module's docblock for why
+ * none of them delivers anything yet. The intent each carries is what the
+ * handler that replaces it will be responsible for.
+ */
+export const followEventHandlers: FollowEventHandlerRegistry = {
+  'follow.created': observing('federate the follow and tell the target they have a new follower'),
+  'follow.removed': observing('federate the undo and withdraw any pending notification'),
+  'follow.requested': observing('deliver the request to the target for a decision'),
+  'follow.accepted': observing('federate the accept and tell the follower they were let in'),
+  'follow.rejected': observing('federate the reject; the follower is told nothing else'),
+  'follow.context_enabled': observing(
+    'reproject the relationship for this application; never notify the target'
+  ),
+  'follow.context_disabled': observing(
+    'reproject the relationship for this application; never notify the target'
+  ),
+};
+
+export interface FollowOutboxBatchOptions {
+  /**
+   * Who is claiming. Must be unique per worker INSTANCE, not per process — two
+   * loops in one process sharing an id could acknowledge each other's events.
+   */
+  ownerId: string;
+  batchSize?: number;
+  handlers?: FollowEventHandlerRegistry;
+  /** Overridable so a test can make a claim reclaimable without waiting a minute. */
+  leaseMs?: number;
+}
+
+export interface FollowOutboxBatchResult {
+  claimed: number;
+  /** Acknowledged — the handler returned and `processed_at` was written. */
+  processed: number;
+  /** The handler threw. Retried when the lease expires. */
+  failed: number;
+  /** Marked `failed_at`: out of attempts, or an event type nothing handles. */
+  deadLettered: number;
+}
+
+function describeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > MAX_RECORDED_ERROR_LENGTH
+    ? `${message.slice(0, MAX_RECORDED_ERROR_LENGTH)}…`
+    : message;
+}
+
+/**
+ * The events this worker may take: unprocessed, not dead-lettered, and either
+ * never claimed or holding a lease that has run out.
+ *
+ * A separate function because the claim UPDATE and the test that asserts
+ * `follow_events_pending_idx` still serves it must be looking at the SAME query
+ * — a test carrying its own copy would keep passing after the real one changed.
+ *
+ * `FOR UPDATE SKIP LOCKED` makes a race resolve rather than block: two workers
+ * reaching the same row in the same instant do not queue behind each other, the
+ * loser moves on to the next claimable event.
+ *
+ * Deliberately NOT filtered on `attempts`: an exhausted event is claimed one
+ * final time and dead-lettered instead of dispatched, which is what keeps the
+ * bound enforceable from an indexed, LIMITed statement. Excluding it here
+ * instead would mean sweeping for exhausted events separately, and that sweep
+ * has no bound — it would walk the entire pending backlog on every tick to find
+ * the handful of rows it exists for.
+ */
+export function claimableFollowEvents(db: Database, claimedBefore: Date, limit: number) {
+  return db
+    .select({ id: followEvents.id })
+    .from(followEvents)
+    .where(
+      and(
+        isNull(followEvents.processedAt),
+        isNull(followEvents.failedAt),
+        or(isNull(followEvents.claimedAt), lt(followEvents.claimedAt, claimedBefore))
+      )
+    )
+    .orderBy(asc(followEvents.createdAt))
+    .limit(limit)
+    .for('update', { skipLocked: true });
+}
+
+/**
+ * Dead-letter an event that ran out of attempts without ever recording an
+ * outcome.
+ *
+ * The failure path below marks its own dead letters as it records them, so this
+ * only catches the case it cannot: a worker killed mid-handler, every time.
+ * `attempts` is incremented when the claim is taken, so such an event still
+ * counts down — but nothing ever writes `failed_at` for it, and without this it
+ * would be retried forever, which is precisely what a bound is for.
+ *
+ * `coalesce` keeps a real error an earlier attempt already recorded; the stated
+ * reason is for the row that has none.
+ */
+async function deadLetterExhausted(db: Database, rowId: string, ownerId: string): Promise<void> {
+  await db
+    .update(followEvents)
+    .set({
+      failedAt: new Date(),
+      lastError: sql`coalesce(${followEvents.lastError}, ${ATTEMPTS_EXHAUSTED_REASON})`,
+    })
+    .where(
+      and(
+        eq(followEvents.id, rowId),
+        eq(followEvents.claimedBy, ownerId),
+        isNull(followEvents.processedAt)
+      )
+    );
+}
+
+/**
+ * Mark an event done — and ONLY here, after its handler returned.
+ *
+ * The owner check is what makes an expired lease harmless: if another worker
+ * took the event while this one was still working, this update matches nothing
+ * and the other worker's outcome stands.
+ */
+async function acknowledge(db: Database, rowId: string, ownerId: string): Promise<boolean> {
+  const acknowledged = await db
+    .update(followEvents)
+    .set({ processedAt: new Date(), lastError: null })
+    .where(
+      and(
+        eq(followEvents.id, rowId),
+        eq(followEvents.claimedBy, ownerId),
+        isNull(followEvents.processedAt)
+      )
+    )
+    .returning({ id: followEvents.id });
+
+  return acknowledged.length === 1;
+}
+
+/**
+ * Record a failure. Deliberately does NOT clear the claim: the remaining lease
+ * is the backoff before the next attempt.
+ */
+async function recordFailure(
+  db: Database,
+  rowId: string,
+  ownerId: string,
+  reason: string,
+  deadLetter: boolean
+): Promise<void> {
+  await db
+    .update(followEvents)
+    .set({ lastError: reason, ...(deadLetter ? { failedAt: new Date() } : {}) })
+    .where(
+      and(
+        eq(followEvents.id, rowId),
+        eq(followEvents.claimedBy, ownerId),
+        isNull(followEvents.processedAt)
+      )
+    );
+}
+
+/**
+ * Claim a batch, dispatch each event, acknowledge what succeeded.
+ *
+ * Exported so a test — and, later, a scheduled job — can run one pass without
+ * the interval. Never throws for a single event's failure: one poison event must
+ * not stop the batch behind it.
+ */
+export async function runFollowOutboxBatch(
+  options: FollowOutboxBatchOptions
+): Promise<FollowOutboxBatchResult> {
+  const db = getDb();
+  const handlers = options.handlers ?? followEventHandlers;
+  const batchSize = options.batchSize ?? getEnvNumber('FOLLOW_OUTBOX_BATCH_SIZE', DEFAULT_BATCH_SIZE);
+  const leaseMs = options.leaseMs ?? FOLLOW_OUTBOX_LEASE_MS;
+  const claimedBefore = new Date(Date.now() - leaseMs);
+
+  // ONE statement: the rows are selected, locked and stamped together, so there
+  // is no window between deciding to claim and having claimed.
+  const claimed = await db
+    .update(followEvents)
+    .set({
+      claimedAt: new Date(),
+      claimedBy: options.ownerId,
+      attempts: sql`${followEvents.attempts} + 1`,
+    })
+    .where(inArray(followEvents.id, claimableFollowEvents(db, claimedBefore, batchSize)))
+    .returning(EVENT_COLUMNS);
+
+  const result: FollowOutboxBatchResult = {
+    claimed: claimed.length,
+    processed: 0,
+    failed: 0,
+    deadLettered: 0,
+  };
+
+  for (const event of claimed) {
+    // Past the bound with nothing ever recorded: every previous claim was
+    // interrupted before its handler could report. Dead-lettered WITHOUT being
+    // dispatched — this claim exists only to write the marker.
+    if (event.attempts > FOLLOW_OUTBOX_MAX_ATTEMPTS) {
+      await deadLetterExhausted(db, event.id, options.ownerId);
+      result.deadLettered += 1;
+      logger.error('[FollowOutbox] Dead-lettered an event that exhausted its attempts', {
+        eventId: event.eventId,
+        type: event.type,
+        attempts: event.attempts,
+      });
+      continue;
+    }
+
+    // A type this build has no handler for. `follow_events_type_check` (0019)
+    // keeps an arbitrary value out of the column, but it does not make this
+    // unreachable: widening that constraint is one migration, and during the
+    // rollout that follows it the previous image is still claiming events —
+    // including ones written under a type its own registry has never heard of.
+    // Widened here rather than trusted, and a miss is not retryable: no number
+    // of attempts makes a handler appear.
+    const registry: Readonly<Partial<Record<string, FollowEventHandler>>> = handlers;
+    const handler = registry[event.type];
+
+    if (!handler) {
+      await recordFailure(db, event.id, options.ownerId, UNKNOWN_TYPE_REASON, true);
+      result.deadLettered += 1;
+      logger.error('[FollowOutbox] Dead-lettered an event no handler is registered for', {
+        eventId: event.eventId,
+        type: event.type,
+        knownTypes: FOLLOW_EVENT_TYPES,
+      });
+      continue;
+    }
+
+    try {
+      await handler(event);
+    } catch (error) {
+      const exhausted = event.attempts >= FOLLOW_OUTBOX_MAX_ATTEMPTS;
+      await recordFailure(db, event.id, options.ownerId, describeError(error), exhausted);
+      result.failed += 1;
+      if (exhausted) result.deadLettered += 1;
+      logger.error('[FollowOutbox] Handler failed', error, {
+        eventId: event.eventId,
+        type: event.type,
+        attempts: event.attempts,
+        deadLettered: exhausted,
+      });
+      continue;
+    }
+
+    if (await acknowledge(db, event.id, options.ownerId)) {
+      result.processed += 1;
+    } else {
+      // Not an error: the lease expired mid-handler and another worker owns the
+      // event now. Worth saying, because it means the handler ran twice.
+      logger.warn('[FollowOutbox] Lease was lost before the event could be acknowledged', {
+        eventId: event.eventId,
+        type: event.type,
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * This worker instance.
+ *
+ * Host and pid make it readable in a `claimed_by` an operator is looking at;
+ * the random suffix is what keeps it unique across a pid the kernel reused.
+ */
+const WORKER_OWNER_ID = `${hostname()}:${process.pid}:${randomBytes(4).toString('hex')}`;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let tickInFlight = false;
+
+async function tick(): Promise<void> {
+  // A tick that overruns its interval must not stack on itself: a second pass
+  // would claim the next batch while the first is still dispatching, which turns
+  // a slow handler into unbounded concurrency.
+  if (tickInFlight) return;
+  tickInFlight = true;
+  try {
+    await runFollowOutboxBatch({ ownerId: WORKER_OWNER_ID });
+  } catch (error) {
+    // Reaching here means the CLAIM failed — the database is unreachable, or the
+    // statement is wrong. Never rethrown: an unhandled rejection out of an
+    // interval takes the process down, and the next tick retries anyway.
+    logger.error(
+      '[FollowOutbox] Batch failed',
+      error instanceof Error ? error : new Error(String(error))
+    );
+  } finally {
+    tickInFlight = false;
+  }
+}
+
+/**
+ * Start the loop, if this deployment says to.
+ *
+ * OFF by default — see this module's docblock. Idempotent, and never throws:
+ * boot must not depend on it.
+ *
+ * @returns Whether the loop is now running.
+ */
+export function startFollowOutboxWorker(): boolean {
+  if (!getEnvBoolean('FOLLOW_OUTBOX_WORKER_ENABLED', false)) {
+    logger.info(
+      '[FollowOutbox] Worker disabled (FOLLOW_OUTBOX_WORKER_ENABLED) — follow events accumulate for whenever it is enabled'
+    );
+    return false;
+  }
+
+  if (timer) return true;
+
+  const intervalMs = getEnvNumber('FOLLOW_OUTBOX_POLL_INTERVAL_MS', DEFAULT_POLL_INTERVAL_MS);
+  timer = setInterval(() => {
+    void tick();
+  }, intervalMs);
+  // Never keeps the process alive on its own — in jest an interval that does
+  // hangs the whole run.
+  timer.unref?.();
+
+  logger.info('[FollowOutbox] Worker started', { ownerId: WORKER_OWNER_ID, intervalMs });
+  return true;
+}
+
+/** Stop the loop. Safe to call when it never started. */
+export function stopFollowOutboxWorker(): void {
+  if (!timer) return;
+  clearInterval(timer);
+  timer = null;
+  logger.info('[FollowOutbox] Worker stopped', { ownerId: WORKER_OWNER_ID });
+}


### PR DESCRIPTION
The `follow_events` table has had a writer since the endpoints branch and no reader. This is the reader: a claim–dispatch–acknowledge loop in `packages/api/src/services/followOutbox.worker.ts`.

## The claim mechanism, and why it is both

Two mechanisms are in play, each doing the job it is actually good at.

**`FOR UPDATE SKIP LOCKED`**, inside the claiming statement, is what makes a race resolve instead of block. Two API tasks reaching the same row in the same instant do not queue behind each other — the loser skips to the next claimable event.

**A lease** (`claimed_at` / `claimed_by`) is what survives the commit. A row lock lives inside a transaction, so claiming with the lock alone means holding a transaction — and a database connection — open for as long as the side effect takes. For a federation delivery that is a network round trip to a server that may be down. The claim is therefore one statement:

```sql
update follow_events set claimed_at = …, claimed_by = …, attempts = attempts + 1
where id in (
  select id from follow_events
  where processed_at is null and failed_at is null
    and (claimed_at is null or claimed_at < <now - lease>)
  order by created_at asc limit … for update skip locked
)
returning …
```

The rows are selected, locked and stamped together, so there is no window between deciding to claim and having claimed.

A dead task strands nothing: its lease simply stops being renewed and after `FOLLOW_OUTBOX_LEASE_MS` (60s) the event is claimable again. The **owner check on acknowledgement** is the other side of that — a worker whose lease expired mid-flight cannot mark an event another worker has since taken, because the second worker is the one that will report an outcome for it. Delivery is at-least-once, deliberately; `follow_events.event_id` is deterministic and consumer-facing precisely so a redelivery is recognisable.

`processed_at` is written **only** after the handler returned.

## Failures do not spin

A failure records its reason and **keeps its claim**, so the remaining lease is the retry backoff — one timer, one behaviour, and a permanently-failing event reaches its limit in `MAX_ATTEMPTS × LEASE` rather than in one tick.

`attempts` counts **claims**, not recorded failures. A process killed mid-handler never gets to record anything, so counting at failure time would let an event that crashes its worker retry forever across restarts. After `FOLLOW_OUTBOX_MAX_ATTEMPTS` (8) the event is dead-lettered: `failed_at` set, `last_error` populated, and **never acknowledged** — its effect did not happen, and a queue that marked it done would be hiding that.

The crash-loop case (attempts exhausted with no outcome ever recorded) is caught by claiming the event one final time and dead-lettering it *instead of* dispatching it. The earlier shape — a separate sweep for exhausted rows — was removed because it had no bound: it would walk the entire pending backlog on every tick to find the handful of rows it exists for.

## What the handler registry does and does not do

It maps each `FollowEventType` to exactly one `FollowEventHandler`. It is `Record<FollowEventType, …>`, not a partial map, so adding a type to `FOLLOW_EVENT_TYPES` without deciding what happens to it is a compile error rather than an event that quietly dead-letters in production. An event type that reaches the worker with no handler — only writable by a build that does not know this enum — is dead-lettered immediately rather than retried; no number of attempts makes a handler appear.

**Today every one of the seven handlers OBSERVES**: it records the event and the intent a real handler will carry out, and performs no side effect. There is no notification service and no federation delivery wired to the follow graph yet, and a handler that pretended otherwise would be worse than none.

That is also why `startFollowOutboxWorker()` is **OFF** unless `FOLLOW_OUTBOX_WORKER_ENABLED` says otherwise. An acknowledgement is a claim that the work happened; running observing handlers against production traffic would consume the backlog that the real handlers, when they exist, have to deliver. **The write is never gated** — events accumulate whether or not anything reads them, which is what makes switching the loop on later a safe operation rather than a lossy one.

No delivery policy lives in the worker. Which followers get told, what federates where, whether an expiry-caused `follow.removed` is worth a notification — all of that belongs to the handlers.

## Migration `0017_follow_events_claim` (`pre`)

Adds `claimed_at`, `claimed_by`, `attempts`, `failed_at`, `last_error`, and a partial `follow_events_dead_letter_idx` so a dead letter can actually be found.

It also **replaces** `follow_events_pending_idx` with `where processed_at is null and failed_at is null`. Not cosmetic: dead letters are by definition the oldest unprocessed rows, so under the old predicate every future claim would scan past the whole graveyard first, forever.

`pre` despite the `DROP INDEX`, and the file says why: `post` exists because drizzle selects *columns* by name, and an index is never named by a query. `follow_events` has exactly one consumer in the previous image (the `INSERT` in `followCommand.service.ts`), so neither the drop nor the recreate can affect it. `post` would be the harmful choice — the arriving image's worker would claim against a table with no index until somebody dispatched the second half.

## Tests

`src/services/__tests__/followOutbox.worker.test.ts`, 16 tests against the real Postgres the other follow suites use. Nothing asserts a batch's totals: the throwaway database is shared by every test file in the run, so `claimed`/`processed` counts are not this file's to predict — every assertion is scoped to rows the test created.

Covered: acknowledgement waits for the handler; a live lease is not re-claimed; an expired lease is; two concurrent workers never hand one event to both (with a barrier so the claims provably overlap, and a `claimed === 1` floor apiece so the no-duplicates assertion cannot pass vacuously); a lost lease refuses the stale acknowledgement; `processed_at` stays null when the handler throws; retries stop at the bound and say why; a poison event does not stop the batch behind it; both dead-letter paths; and the claim query being served by `follow_events_pending_idx` — `EXPLAIN` of the *real* exported query builder, under `enable_seqscan = off`, so it cannot pass against a stale copy of the predicate.

### Mutation results (run against the final code, restored byte-identical after)

| mutation | result |
|---|---|
| remove the lease predicate from the claim | **2 red** — `does not re-claim an event whose lease is still live`, `never hands one event to both` |
| move `acknowledge` before `await handler(event)` | **7 red** — including `acknowledges only after the handler returned` and `leaves processedAt null when the handler throws` |
| remove `processed_at is null` from the claim | **3 red** — `leaves an acknowledged event alone on the next pass`, `is served by follow_events_pending_idx`, `filters on processed_at is null` |

The third mutation is why one test changed shape: on the first run it killed only the two query-shape tests, because the *behavioural* test was masked by the lease the first pass left behind. That test now runs its second pass with `leaseMs: 0`, so only `processed_at is null` can keep the event out of it — and it now goes red too.

## Verification

- `bunx tsc --noEmit` clean in `packages/api`
- `eslint` clean on every file touched (the 10 `no-explicit-any` warnings in `server.ts` are pre-existing, all far from the three lines added there)
- 123 tests green across `followOutbox.worker`, `followCommand.service`, `followCapability.service` and `src/db/__tests__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)