### PR TITLE
chore(release): bump contracts, core and services for the follow graph

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -408,7 +408,7 @@
     },
     "packages/contracts": {
       "name": "@oxyhq/contracts",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "dependencies": {
         "zod": "^3.25.64",
       },
@@ -421,7 +421,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "19.0.0",
+      "version": "19.1.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -693,7 +693,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "27.0.0",
+      "version": "27.1.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/contracts",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "OxyHQ API contracts — single source of truth for request/response Zod schemas and inferred types, shared by the backend and the client SDKs",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "19.0.0",
+  "version": "19.1.0",
   "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "27.0.0",
+  "version": "27.1.0",
   "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",


### PR DESCRIPTION
Version bumps only, so the release can be cut from a commit that is on `main`.

| package | from | to |
|---|---|---|
| `@oxyhq/contracts` | 0.23.0 | **0.24.0** |
| `@oxyhq/core` | 19.0.0 | **19.1.0** |
| `@oxyhq/services` | 27.0.0 | **27.1.0** |

Minor on all three, because every change from #820 is **additive**: new exported types, new SDK methods, a new component and hook. Nothing removed or renamed, so no consumer breaks by upgrading.

The bump lands here first because publishing from uncommitted state collides with the committed release and **npm never lets a version number be reused**.

Publish order is `contracts` → `core` → `services`: core imports contracts symbols that are not in the published contracts yet, and services imports core methods that are not in the published core.

`bun.lock` regenerated in the same commit; `check-lockfile-sync` reports in sync.