### PR TITLE
fix(follows): onChange reported intent, and isFollowedGlobally was unexported

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -421,7 +421,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "19.1.0",
+      "version": "19.1.1",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -693,7 +693,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "27.1.0",
+      "version": "27.1.1",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",

--- a/docs/FOLLOWS.md
+++ b/docs/FOLLOWS.md
@@ -80,6 +80,13 @@ Then render:
 <FollowTargetButton targetId={id} verb="subscribe" applicationName="Mercaria" />
 ```
 
+Keeping something else in step with the follow — a local shelf, a ranking
+signal — goes through `onChange`, which fires only on an accepted write:
+
+```tsx
+<FollowTargetButton targetId={id} onChange={(following) => mirror(following)} />
+```
+
 ## Things that will surprise you
 
 **A target's URI is its identity, not its id.** Two applications describing the
@@ -102,6 +109,20 @@ of a follow the user deliberately switched off here. A button that reads it as
 **Only the providing application refreshes a target's metadata.** Whoever
 registered it owns the display snapshot. If a second application could overwrite
 it, the name would flip depending on which app last looked.
+
+**Which is exactly why `metadata` must not contain an environment-dependent
+URL.** The obvious thing to pass is the image URL your app already resolved —
+and in development that is `http://localhost:4120/...`. Because your app is the
+providing one, one developer running one screen overwrites the snapshot every
+other app renders, in production, from their laptop. Pass an Oxy **file id**, or
+an absolute URL that is the same everywhere, or omit the field. There is no
+validation stopping you; this paragraph is the guard.
+
+**`onChange` on the button fires only when the server accepted the write**, and
+the hook's `follow`/`unfollow` resolve to that same boolean. They never reject —
+a refusal becomes error state so the button can render it — so a caller that
+awaits them without reading the result would mirror failures as successes into
+whatever it is keeping in step.
 
 **Deleting your application does not delete anyone's follows.** The
 `origin_application_id` on a relationship is provenance, not ownership — it

--- a/packages/api/src/db/schema/followTargetKinds.ts
+++ b/packages/api/src/db/schema/followTargetKinds.ts
@@ -50,7 +50,7 @@ import { createdAt, generatedId, updatedAt } from './columns';
  * kind registered carelessly leaks nothing.
  */
 export interface FollowKindCapabilities {
-  verb?: 'follow' | 'subscribe' | 'join';
+  verb?: 'follow' | 'subscribe' | 'join' | 'watch';
   reverse?: 'public' | 'private' | 'aggregate' | 'unavailable';
   /** Whether following this kind has to be projected onto a remote protocol. */
   federated?: boolean;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "19.1.0",
+  "version": "19.1.1",
   "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/mixins/OxyServices.followGraph.ts
+++ b/packages/core/src/mixins/OxyServices.followGraph.ts
@@ -222,7 +222,10 @@ export function OxyServicesFollowGraphMixin<T extends typeof OxyServicesBase>(Ba
       kind: string;
       label?: string;
       capabilities?: {
-        verb?: 'follow' | 'subscribe' | 'join';
+        // Matches `FollowVerb` in @oxyhq/services, which is what renders it. A
+        // kind that can display a verb it cannot record is a kind whose button
+        // and registration disagree.
+        verb?: 'follow' | 'subscribe' | 'join' | 'watch';
         reverse?: 'public' | 'private' | 'aggregate' | 'unavailable';
         federated?: boolean;
       };

--- a/packages/services/__tests__/hooks/useFollowTarget.outcome.test.tsx
+++ b/packages/services/__tests__/hooks/useFollowTarget.outcome.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * What a caller is told when a follow is refused.
+ *
+ * The mutations deliberately never reject — a refusal becomes error state so
+ * the button can render it — which is precisely why they have to return the
+ * outcome. Without it, `await follow()` is indistinguishable from a write that
+ * happened, and an application mirroring the follow into its own store (a
+ * shelf, a ranking signal, a taste profile) mirrors failures as successes and
+ * ends up disagreeing with the button standing next to it.
+ *
+ * Found by wiring Syra, where exactly that mirror exists.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useFollowTarget } from '../../src/ui/hooks/useFollowTarget';
+import { useFollowTargetStore } from '../../src/ui/stores/followTargetStore';
+
+const oxyServices = {
+  getFollowTargetStatus: jest.fn(),
+  followTarget: jest.fn(),
+  unfollowTarget: jest.fn(),
+  setFollowApplicationMode: jest.fn(),
+};
+
+jest.mock('../../src/ui/context/OxyContext', () => ({
+  useOxy: () => ({ oxyServices, canUsePrivateApi: true }),
+}));
+
+const NOT_FOLLOWING = {
+  globalState: 'none' as const,
+  applicationMode: 'inherit' as const,
+  effectiveState: 'not_following' as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useFollowTargetStore.getState().reset();
+  oxyServices.getFollowTargetStatus.mockResolvedValue(NOT_FOLLOWING);
+});
+
+describe('useFollowTarget reports whether the server accepted', () => {
+  it('resolves true when the follow was accepted', async () => {
+    oxyServices.followTarget.mockResolvedValue({
+      relationshipId: 'rel-1',
+      created: true,
+      status: { ...NOT_FOLLOWING, globalState: 'active', effectiveState: 'following' },
+    });
+
+    const { result } = renderHook(() => useFollowTarget('target-1'));
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.follow();
+    });
+
+    expect(outcome).toBe(true);
+    expect(result.current.isFollowing).toBe(true);
+  });
+
+  it('resolves FALSE when the server refuses, and does not reject', async () => {
+    // A refused write is the ordinary case, not an exception: a missing scope,
+    // a revoked grant, a target that has gone. The hook turns it into state.
+    oxyServices.followTarget.mockRejectedValue(new Error('Missing scope: follows:write'));
+
+    const { result } = renderHook(() => useFollowTarget('target-1'));
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.follow();
+    });
+
+    expect(outcome).toBe(false);
+    // The optimistic flip is rolled back, so the button tells the truth...
+    expect(result.current.isFollowing).toBe(false);
+    // ...and the reason is available to render, rather than thrown away.
+    expect(result.current.error).toContain('follows:write');
+  });
+
+  it('resolves false for an unfollow the server refuses', async () => {
+    oxyServices.getFollowTargetStatus.mockResolvedValue({
+      relationshipId: 'rel-1',
+      globalState: 'active',
+      applicationMode: 'inherit',
+      effectiveState: 'following',
+    });
+    oxyServices.unfollowTarget.mockRejectedValue(new Error('nope'));
+
+    const { result } = renderHook(() => useFollowTarget('target-1'));
+    // Let the initial status read settle so a relationship id exists to act on.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.unfollow();
+    });
+
+    expect(outcome).toBe(false);
+    // Still following, because the unfollow did not happen.
+    expect(result.current.isFollowing).toBe(true);
+  });
+
+  it('resolves false without calling the server when there is nothing to act on', async () => {
+    // An optimistic follow has no relationship id until the server answers.
+    // Reporting `true` here would be reporting a write that was never sent.
+    const { result } = renderHook(() => useFollowTarget('target-1'));
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.unfollow();
+    });
+
+    expect(outcome).toBe(false);
+    expect(oxyServices.unfollowTarget).not.toHaveBeenCalled();
+  });
+});

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "27.1.0",
+  "version": "27.1.1",
   "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -288,7 +288,15 @@ export type {
 } from './ui/components/FollowTargetButton';
 export { useFollowTarget } from './ui/hooks/useFollowTarget';
 export type { UseFollowTargetResult } from './ui/hooks/useFollowTarget';
-export { useFollowTargetStore, UNKNOWN_FOLLOW_STATUS } from './ui/stores/followTargetStore';
+export {
+  useFollowTargetStore,
+  UNKNOWN_FOLLOW_STATUS,
+  // The answer to "does the user follow this at all". Documented in
+  // docs/FOLLOWS.md and, until now, not exported — so the one line of that
+  // guide most likely to be reached for did not resolve.
+  isFollowedGlobally,
+  withApplicationMode,
+} from './ui/stores/followTargetStore';
 export { default as OxyPayButton } from './ui/components/OxyPayButton';
 export { LogoIcon } from './ui/components/logo/LogoIcon';
 export { LogoText } from './ui/components/logo/LogoText';

--- a/packages/services/src/ui/components/FollowTargetButton.tsx
+++ b/packages/services/src/ui/components/FollowTargetButton.tsx
@@ -226,28 +226,35 @@ export const FollowTargetButton = memo(function FollowTargetButton({
     return status.applicationMode === 'disabled' ? text.disabled : text.active;
   }, [isFollowing, status.globalState, status.applicationMode, text]);
 
+  // `onChange` fires ONLY when the server accepted the write.
+  //
+  // The mutations never reject — a refusal becomes error state so the button
+  // can render it — so an unconditional `onChange` after `await` reports
+  // INTENT rather than outcome. A caller mirroring the follow somewhere else
+  // (a local shelf, a ranking signal) would then mirror failures too, and the
+  // button beside it would show the server's truth while the mirror showed a
+  // press that did not happen. Same shape of trap as reading `effectiveState`
+  // as "does the user follow this".
   const handlePrimary = useCallback(async () => {
     switch (resolveFollowPrimaryAction({ isFollowing, applicationMode: status.applicationMode })) {
       case 'enable-here':
-        await enableHere();
-        onChange?.(true);
+        if (await enableHere()) onChange?.(true);
         return;
       case 'unfollow':
-        await unfollow();
-        onChange?.(false);
+        if (await unfollow()) onChange?.(false);
         return;
       case 'follow':
-        await follow();
-        onChange?.(true);
+        if (await follow()) onChange?.(true);
     }
   }, [isFollowing, status.applicationMode, follow, unfollow, enableHere, onChange]);
 
   const handleTimed = useCallback(
     async (seconds: number, durationLabel: string) => {
-      await follow({ expiresIn: seconds });
+      if (!(await follow({ expiresIn: seconds }))) return;
       onChange?.(true);
       // The confirmation is the point: a follow that ends on its own is a
       // promise, and a user who does not see it made will not believe it.
+      // Which is also why it must not appear when the promise was not made.
       toast.success(`Following for ${durationLabel.toLowerCase()}`);
     },
     [follow, onChange]
@@ -288,8 +295,9 @@ export const FollowTargetButton = memo(function FollowTargetButton({
           void disableHere();
           return;
         case 'unfollow':
-          void unfollow();
-          onChange?.(false);
+          void unfollow().then((ok) => {
+            if (ok) onChange?.(false);
+          });
       }
     },
     [handleTimed, enableHere, disableHere, unfollow, onChange]

--- a/packages/services/src/ui/hooks/useFollowTarget.ts
+++ b/packages/services/src/ui/hooks/useFollowTarget.ts
@@ -36,11 +36,20 @@ export interface UseFollowTargetResult {
   isUnknown: boolean;
   isPending: boolean;
   error: string | undefined;
-  follow: (options?: { expiresIn?: number }) => Promise<void>;
-  unfollow: () => Promise<void>;
+  /**
+   * Every mutation resolves to whether the server ACCEPTED it.
+   *
+   * They never reject — a refusal becomes `error` in the store, so the button
+   * can render it — which means a caller that only awaits them cannot tell a
+   * write that happened from one that did not. Returning the outcome is what
+   * lets a caller mirror the change somewhere else without mirroring failures
+   * too.
+   */
+  follow: (options?: { expiresIn?: number }) => Promise<boolean>;
+  unfollow: () => Promise<boolean>;
   /** Stop acting on this follow HERE, without giving it up everywhere. */
-  disableHere: () => Promise<void>;
-  enableHere: () => Promise<void>;
+  disableHere: () => Promise<boolean>;
+  enableHere: () => Promise<boolean>;
   refresh: () => Promise<void>;
 }
 
@@ -103,8 +112,8 @@ export function useFollowTarget(
       optimistic: FollowStatus,
       run: () => Promise<FollowStatus | void>,
       failureMessage: string
-    ) => {
-      if (!targetId) return;
+    ): Promise<boolean> => {
+      if (!targetId) return false;
       const store = useFollowTargetStore.getState();
       const previous = store.statuses[targetId];
       store.setStatus(targetId, optimistic);
@@ -113,12 +122,14 @@ export function useFollowTarget(
       try {
         const settled = await run();
         if (settled) useFollowTargetStore.getState().setStatus(targetId, settled);
+        return true;
       } catch (e) {
         const s = useFollowTargetStore.getState();
         // Back to what was true, not to a guess. Clearing the entry instead
         // would make the next render ask again and flash the wrong state.
         if (previous) s.setStatus(targetId, previous);
         s.setError(targetId, e instanceof Error ? e.message : failureMessage);
+        return false;
       } finally {
         useFollowTargetStore.getState().setPending(targetId, false);
       }
@@ -130,8 +141,8 @@ export function useFollowTarget(
 
   const follow = useCallback(
     async (opts?: { expiresIn?: number }) => {
-      if (!targetId) return;
-      await mutate(
+      if (!targetId) return false;
+      return mutate(
         {
           ...withApplicationMode({ ...current, globalState: 'active' }, current.applicationMode),
           ...(opts?.expiresIn
@@ -150,8 +161,8 @@ export function useFollowTarget(
 
   const unfollow = useCallback(async () => {
     const relationshipId = current.relationshipId;
-    if (!targetId || !relationshipId) return;
-    await mutate(
+    if (!targetId || !relationshipId) return false;
+    return mutate(
       { ...UNKNOWN_FOLLOW_STATUS },
       async () => {
         await oxyServices.unfollowTarget(relationshipId);
@@ -163,8 +174,8 @@ export function useFollowTarget(
 
   const disableHere = useCallback(async () => {
     const relationshipId = current.relationshipId;
-    if (!targetId || !relationshipId) return;
-    await mutate(
+    if (!targetId || !relationshipId) return false;
+    return mutate(
       withApplicationMode(current, 'disabled'),
       async () => {
         await oxyServices.setFollowApplicationMode(relationshipId, 'disabled');
@@ -175,8 +186,8 @@ export function useFollowTarget(
 
   const enableHere = useCallback(async () => {
     const relationshipId = current.relationshipId;
-    if (!targetId || !relationshipId) return;
-    await mutate(
+    if (!targetId || !relationshipId) return false;
+    return mutate(
       withApplicationMode(current, 'inherit'),
       async () => {
         await oxyServices.restoreFollowInheritance(relationshipId);


### PR DESCRIPTION
Both found by wiring **Syra**, the first real consumer. Two of that integration's four findings are defects rather than doc gaps.

## `isFollowedGlobally` was documented and not exported

`docs/FOLLOWS.md` names it as the answer to *"does the user follow this"*. It was not in the barrel — verified against the published `.d.ts`, not just the source — so the single line of that guide most likely to be reached for did not resolve. Exported, with `withApplicationMode` for the same reason.

## `onChange` fired on a write the server refused

The mutations deliberately never reject: a refusal becomes error state so the button can render it. Which is exactly why `await follow(); onChange(true)` reports **intent**, not outcome.

An application mirroring the follow into its own store — Syra keeps a library shelf and a taste signal in step — would mirror failures as successes and then disagree with the button standing next to it.

This is the same shape of trap as reading `effectiveState` as "does the user follow this", and that is not a coincidence: both are a value that looks like the answer to a question it is not answering.

`follow` / `unfollow` / `disableHere` / `enableHere` now resolve to whether the server accepted. The button acts only on a settled write — including the timed-follow toast, which had the same bug and would have promised "following for 72 hours" after a refusal.

## A kind could render a verb it could not record

`registerFollowKind` accepted `'follow' | 'subscribe' | 'join'`; the button's `FollowVerb` adds `'watch'`, and the doc names *"you watch a listing"* as a real ecosystem verb. Aligned in core and in the API's own type — the column is `jsonb` with no CHECK, so no migration.

## Docs

The two things Syra had to work out for itself: `onChange`'s semantics, and that **`metadata` must never carry an environment-dependent URL**. Because only the *providing* application refreshes that snapshot, one developer's `localhost:4120` image URL would overwrite what every app renders in production, from their laptop.

## Verification

The outcome contract is **mutation-tested through the real hook**: making a refused write report success turns two tests red.

The first version of that test modelled the logic locally rather than exercising it, so it could not have failed. It was deleted, not kept.

Patch bumps: `@oxyhq/core@19.1.1`, `@oxyhq/services@27.1.1`.