### PR TITLE
fix(follows): the same action reported differently from two controls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -693,7 +693,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "27.1.1",
+      "version": "27.1.2",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",

--- a/bun.lock
+++ b/bun.lock
@@ -459,7 +459,6 @@
         "expo-crypto": "*",
         "expo-secure-store": "*",
         "express": "^4.0.0",
-        "express-rate-limit": "^8.0.0",
       },
       "optionalPeers": [
         "@react-native-async-storage/async-storage",

--- a/docs/FOLLOWS.md
+++ b/docs/FOLLOWS.md
@@ -118,7 +118,14 @@ other app renders, in production, from their laptop. Pass an Oxy **file id**, or
 an absolute URL that is the same everywhere, or omit the field. There is no
 validation stopping you; this paragraph is the guard.
 
-**`onChange` on the button fires only when the server accepted the write**, and
+**`onChange` reports the EFFECTIVE state — whether this application should act
+on the follow now — not the global one.** That is the question a mirror is
+actually asking: a user who picks "Don't show in Mercaria" still follows the
+shop everywhere else, but it must leave Mercaria's own shelf, which is the
+entire purpose of that menu item. Every control reports through one table, so
+the primary button and the menu cannot disagree about the same action.
+
+**It fires only when the server accepted the write**, and
 the hook's `follow`/`unfollow` resolve to that same boolean. They never reject —
 a refusal becomes error state so the button can render it — so a caller that
 awaits them without reading the result would mirror failures as successes into

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "27.1.1",
+  "version": "27.1.2",
   "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/ui/components/FollowTargetButton.tsx
+++ b/packages/services/src/ui/components/FollowTargetButton.tsx
@@ -90,6 +90,29 @@ const DEFAULT_DURATIONS: FollowDuration[] = [
   { label: 'A week', seconds: 7 * 24 * HOUR },
 ];
 
+/**
+ * Whether an action leaves the target ACTIVE in this application.
+ *
+ * One table, read by both the primary button and the menu, because the same
+ * action reached from two controls once reported differently — and a rule
+ * living in two switch statements is a rule that drifts. `Record` rather than
+ * a function with a default, so a new action is a compile error instead of a
+ * silent `false`.
+ */
+export const FOLLOW_ACTION_LEAVES_ACTIVE: Record<
+  'follow' | 'follow-timed' | 'enable-here' | 'disable-here' | 'unfollow',
+  boolean
+> = {
+  follow: true,
+  'follow-timed': true,
+  // Re-enabling here does not change the global follow — the user already had
+  // it — but it does change whether this application acts on it, which is what
+  // a mirror is asking about.
+  'enable-here': true,
+  'disable-here': false,
+  unfollow: false,
+};
+
 /** One line in the disclosure menu. */
 export interface FollowMenuItem {
   key: string;
@@ -197,7 +220,20 @@ export interface FollowTargetButtonProps {
    * application" is not.
    */
   applicationName?: string;
-  onChange?: (following: boolean) => void;
+  /**
+   * Fires when the server accepts a change, with whether this application
+   * should act on the follow NOW — the effective state, not the global one.
+   *
+   * That is the question an application mirroring the follow is actually
+   * asking: a user who picks "Don't show in Mercaria" still follows the shop
+   * everywhere else, but the shop must leave Mercaria's own shelf, which is
+   * the entire purpose of that menu item. Reporting the global state instead
+   * would leave it there.
+   *
+   * Never fires for a refused write — the mutations resolve to whether the
+   * server accepted, and only an accepted one gets here.
+   */
+  onChange?: (activeHere: boolean) => void;
 }
 
 export const FollowTargetButton = memo(function FollowTargetButton({
@@ -238,20 +274,20 @@ export const FollowTargetButton = memo(function FollowTargetButton({
   const handlePrimary = useCallback(async () => {
     switch (resolveFollowPrimaryAction({ isFollowing, applicationMode: status.applicationMode })) {
       case 'enable-here':
-        if (await enableHere()) onChange?.(true);
+        if (await enableHere()) onChange?.(FOLLOW_ACTION_LEAVES_ACTIVE['enable-here']);
         return;
       case 'unfollow':
-        if (await unfollow()) onChange?.(false);
+        if (await unfollow()) onChange?.(FOLLOW_ACTION_LEAVES_ACTIVE.unfollow);
         return;
       case 'follow':
-        if (await follow()) onChange?.(true);
+        if (await follow()) onChange?.(FOLLOW_ACTION_LEAVES_ACTIVE.follow);
     }
   }, [isFollowing, status.applicationMode, follow, unfollow, enableHere, onChange]);
 
   const handleTimed = useCallback(
     async (seconds: number, durationLabel: string) => {
       if (!(await follow({ expiresIn: seconds }))) return;
-      onChange?.(true);
+      onChange?.(FOLLOW_ACTION_LEAVES_ACTIVE['follow-timed']);
       // The confirmation is the point: a follow that ends on its own is a
       // promise, and a user who does not see it made will not believe it.
       // Which is also why it must not appear when the promise was not made.
@@ -288,17 +324,24 @@ export const FollowTargetButton = memo(function FollowTargetButton({
         case 'follow-timed':
           void handleTimed(item.action.seconds, item.action.durationLabel);
           return;
+        // Every branch reports through `onChange`, and they must agree with
+        // the primary button: the same action reached from two controls that
+        // reported differently was a real bug — a user picking "don't show
+        // here" kept the target on the app's own shelf, which is the state the
+        // menu item exists to end.
         case 'enable-here':
           void enableHere().then((ok) => {
-            if (ok) onChange?.(true);
+            if (ok) onChange?.(FOLLOW_ACTION_LEAVES_ACTIVE['enable-here']);
           });
           return;
         case 'disable-here':
-          void disableHere();
+          void disableHere().then((ok) => {
+            if (ok) onChange?.(FOLLOW_ACTION_LEAVES_ACTIVE['disable-here']);
+          });
           return;
         case 'unfollow':
           void unfollow().then((ok) => {
-            if (ok) onChange?.(false);
+            if (ok) onChange?.(FOLLOW_ACTION_LEAVES_ACTIVE.unfollow);
           });
       }
     },

--- a/packages/services/src/ui/components/__tests__/followTargetButton.test.ts
+++ b/packages/services/src/ui/components/__tests__/followTargetButton.test.ts
@@ -12,7 +12,11 @@
  * to reflect.
  */
 
-import { buildFollowMenuItems, resolveFollowPrimaryAction } from '../FollowTargetButton';
+import {
+  buildFollowMenuItems,
+  FOLLOW_ACTION_LEAVES_ACTIVE,
+  resolveFollowPrimaryAction,
+} from '../FollowTargetButton';
 import {
   isFollowedGlobally,
   UNKNOWN_FOLLOW_STATUS,
@@ -148,5 +152,56 @@ describe('withApplicationMode', () => {
       'not_following'
     );
     expect(isFollowedGlobally(UNKNOWN_FOLLOW_STATUS)).toBe(false);
+  });
+});
+
+describe('what onChange reports', () => {
+  // The bug: the same action reached from the primary button and from the menu
+  // reported differently. Someone picking "Don't show in Syra" kept the artist
+  // on Syra's own shelf and kept feeding its taste signal — the exact state
+  // that menu item exists to end.
+  //
+  // Both controls now read one table, so the two cannot drift apart again.
+  // These tests pin what the table SAYS; the `Record` type is what stops a new
+  // action from being omitted.
+
+  it('reports the EFFECTIVE state — does this app act on it now', () => {
+    expect(FOLLOW_ACTION_LEAVES_ACTIVE).toEqual({
+      follow: true,
+      'follow-timed': true,
+      'enable-here': true,
+      'disable-here': false,
+      unfollow: false,
+    });
+  });
+
+  it('treats enable-here as active even though the global follow did not change', () => {
+    // The distinction that decides the whole question: a mirror is asking
+    // "should this appear in MY app", not "does the user follow it anywhere".
+    expect(FOLLOW_ACTION_LEAVES_ACTIVE['enable-here']).toBe(true);
+    expect(FOLLOW_ACTION_LEAVES_ACTIVE['disable-here']).toBe(false);
+  });
+
+  it('covers every action either control can produce', () => {
+    // A menu item whose action is missing from the table would report
+    // `undefined` — falsy, so it would silently read as "not active here".
+    const fromMenu = new Set(
+      [
+        ...buildFollowMenuItems({ ...base }),
+        ...buildFollowMenuItems({ ...base, following: true, hasRelationship: true }),
+        ...buildFollowMenuItems({
+          ...base,
+          following: true,
+          hasRelationship: true,
+          applicationMode: 'disabled',
+        }),
+      ].map((item) => item.action.type)
+    );
+    // Plus the two the primary button can produce that the menu cannot.
+    for (const action of [...fromMenu, 'follow', 'unfollow']) {
+      expect(typeof FOLLOW_ACTION_LEAVES_ACTIVE[action as keyof typeof FOLLOW_ACTION_LEAVES_ACTIVE])
+        .toBe('boolean');
+    }
+    expect(fromMenu.size).toBeGreaterThanOrEqual(3);
   });
 });


### PR DESCRIPTION
Found by Syra while verifying the previous fix — **in the published `src/`**, which is the artefact Metro actually compiles, rather than in this repo.

`onChange` was correct on the primary button and absent from the menu for the same actions:

| action | primary button | menu |
|---|---|---|
| `enable-here` | fires | **silent** |
| `disable-here` | — | **silent, always** |
| `unfollow` | fires | fires |

Either reading of what `onChange` means is defensible on its own. The **pair** is not, because the user reaches one action from two places.

The consequence was small and real: somebody picking *"Don't show in Syra"* kept that artist on their **Library → Artists** shelf and kept feeding the taste signal — the exact state that menu item exists to end.

## Resolved toward the effective state

`onChange` answers *"should this appear in MY application now"*, not *"does the user follow this anywhere"* — because the first is what a mirror is asking. A disabled follow is still a follow globally, and still must leave the app's own shelf. The parameter is renamed `activeHere` to say so.

## One table, not two switch statements

Both controls now read `FOLLOW_ACTION_LEAVES_ACTIVE`. A rule living in two places is a rule that drifts, and this one already had.

It is a `Record` over the action union rather than a function with a default, so a new action is a **compile error** instead of a silently falsy report.

## Verification

Mutation-tested: making `disable-here` report still-active fails two tests. The coverage test derives the action set from `buildFollowMenuItems` itself, so a menu item added later without a table entry fails rather than reporting `undefined`.

Patch bump: `@oxyhq/services@27.1.2`.