### PR TITLE
fix(services): export the follow rules an app has to draw for itself

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -692,7 +692,7 @@
     },
     "packages/services": {
       "name": "@oxyhq/services",
-      "version": "27.1.2",
+      "version": "27.1.3",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@simplewebauthn/browser": "^13.3.0",

--- a/packages/services/__tests__/packaging/followSurfaceExported.test.ts
+++ b/packages/services/__tests__/packaging/followSurfaceExported.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Everything the follow-graph guide tells an application to use must be
+ * reachable from the package barrel.
+ *
+ * ## Why this exists, and why it is a gate rather than a convention
+ *
+ * Three symbols were documented and unexported, one after another, and each was
+ * found by an application that had already written a workaround for it:
+ *
+ * - `isFollowedGlobally` — named in `docs/FOLLOWS.md` as the answer to "does
+ *   the user follow this". Syra checked the published `.d.ts` and found it
+ *   absent, and used `useFollowTarget().isFollowing` instead.
+ * - `withApplicationMode` — same omission, same commit.
+ * - `resolveFollowPrimaryAction` — Mention found it. This one bites hardest:
+ *   the rule it encodes is that pressing a follow which is switched off HERE
+ *   must re-enable it here rather than unfollow everywhere. An application
+ *   drawing its own affordance either duplicates that or gets it wrong, and
+ *   Mention had to duplicate it as `resolveTopicChipAction`.
+ *
+ * Three of one shape is a pattern, not bad luck. The barrel is written by hand,
+ * so the only thing that catches an omission is somebody trying to import.
+ *
+ * ## What it does NOT check
+ *
+ * It does not demand that every symbol in those modules be public — plenty are
+ * internal on purpose. It checks a written list, so adding to that list is a
+ * deliberate act. The list is the claim "an application may rely on this"; the
+ * test is what makes the claim true.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const barrel = readFileSync(path.resolve(__dirname, '../../src/index.ts'), 'utf8');
+
+/**
+ * The follow-graph surface an application is told it may use. Every entry here
+ * appears in `docs/FOLLOWS.md`, in a component's own doc comment, or in both.
+ */
+const PUBLIC_SURFACE = [
+  // The button and the pieces of it an app can render itself.
+  'FollowTargetButton',
+  'buildFollowMenuItems',
+  'resolveFollowPrimaryAction',
+  'FOLLOW_ACTION_LEAVES_ACTIVE',
+  // The hook that owns the optimism, the rollback and the outcome boolean.
+  'useFollowTarget',
+  // The store, and the two derivations a caller must not re-implement:
+  // `effectiveState` is not "does the user follow this", and the mode change
+  // has to be computed the same way the server computes it.
+  'useFollowTargetStore',
+  'UNKNOWN_FOLLOW_STATUS',
+  'isFollowedGlobally',
+  'withApplicationMode',
+] as const;
+
+describe('the follow-graph public surface is reachable from the barrel', () => {
+  it('reads a barrel that is plausibly the real one', () => {
+    // Vacuity floor: a mis-resolved path returning an empty string would
+    // otherwise fail every assertion below for the wrong reason, or — if the
+    // check were written the other way round — pass all of them.
+    expect(barrel.length).toBeGreaterThan(1000);
+    expect(barrel).toContain('FollowTargetButton');
+  });
+
+  it.each(PUBLIC_SURFACE)('exports %s', (symbol) => {
+    // Matched as a whole word, so `useFollowTarget` cannot be satisfied by
+    // `useFollowTargetStore` appearing somewhere in the file.
+    expect(new RegExp(`\\b${symbol}\\b`).test(barrel)).toBe(true);
+  });
+
+  it('names each symbol on an export line rather than merely mentioning it', () => {
+    // The stricter form of the check above: a symbol appearing only inside a
+    // comment would satisfy a bare word match, and this file is full of
+    // comments naming exactly these symbols.
+    const exportedLines = barrel
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//') && !line.trim().startsWith('*'))
+      .join('\n');
+
+    const missing = PUBLIC_SURFACE.filter(
+      (symbol) => !new RegExp(`\\b${symbol}\\b`).test(exportedLines)
+    );
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/services",
-  "version": "27.1.2",
+  "version": "27.1.3",
   "description": "OxyHQ Expo/React Native SDK \u2014 UI components, screens, and native features",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -279,7 +279,17 @@ export type { RequireOxyAuthProps, RequireOxyAuthPrompt } from './ui/components/
 export { default as FollowButton } from './ui/components/FollowButton';
 export type { FollowButtonProps, SingleFollowButtonProps, MultiFollowButtonProps } from './ui/components/FollowButton';
 // The follow graph (#809): follows anything registered, not just users.
-export { FollowTargetButton } from './ui/components/FollowTargetButton';
+export {
+  FollowTargetButton,
+  // The product rules the button encodes, for an application drawing its own
+  // affordance instead of using it — a chip grid, a compact row control.
+  // Unexported, they get duplicated, and the duplicate is where the "off here"
+  // rule goes wrong: pressing a follow that is switched off here must re-enable
+  // it here, not unfollow everywhere.
+  buildFollowMenuItems,
+  resolveFollowPrimaryAction,
+  FOLLOW_ACTION_LEAVES_ACTIVE,
+} from './ui/components/FollowTargetButton';
 export type {
   FollowTargetButtonProps,
   FollowVerb,


### PR DESCRIPTION
**Third** documented-and-unexported symbol in this feature, each one found by an application that had already written a workaround for it:

| symbol | found by | workaround they wrote |
|---|---|---|
| `isFollowedGlobally` | Syra, against the published `.d.ts` | used `useFollowTarget().isFollowing` |
| `withApplicationMode` | same omission, same commit | — |
| `resolveFollowPrimaryAction` | Mention | duplicated it as `resolveTopicChipAction` |

The last bites hardest. The rule it encodes is the **"off here"** one: pressing a follow that is switched off in this application must **re-enable it here**, not unfollow everywhere. An app drawing its own affordance instead of using the button either duplicates that or gets it wrong.

`buildFollowMenuItems` and `FOLLOW_ACTION_LEAVES_ACTIVE` go with it for the same reason — a chip grid needs the choices and the reporting rule, not just the button.

## Why a gate and not a fourth fix

Three of one shape is a pattern. The barrel is hand-written, so the only thing catching an omission has been somebody trying to import it, months later, in another repo.

The test checks a **written list** rather than demanding every symbol in those modules be public — plenty are internal on purpose. The list is the claim *"an application may rely on this"*; the test is what makes the claim true, and adding to it stays a deliberate act.

Two defences it needs for itself:

- a **vacuity floor**, so a mis-resolved barrel path cannot pass by being empty;
- a second assertion that **ignores comment lines** — the test file names every one of these symbols in its own prose, so a bare word match would be satisfied by the documentation of the bug rather than by the fix.

Mutation-tested against the exact third instance: removing `resolveFollowPrimaryAction` from the barrel fails two tests, by name.

Patch bump: `@oxyhq/services@27.1.3`.