### PR TITLE
feat(follows): a namespace claimed by mistake can be given back

### DIFF
--- a/docs/FOLLOWS.md
+++ b/docs/FOLLOWS.md
@@ -131,6 +131,16 @@ a refusal becomes error state so the button can render it — so a caller that
 awaits them without reading the result would mirror failures as successes into
 whatever it is keeping in step.
 
+**A namespace you claimed by mistake can be given back, while it is empty.**
+`DELETE /v2/follow-targets/namespaces/<namespace>`, holder only, refused once
+any kind is registered inside it. This exists because registration is
+client-side and a claim is first-come, so the first person to open a screen on
+*any* build triggers it — including a development build using a fallback client
+id, which would otherwise bind the name to the wrong application permanently.
+Note the asymmetry: a squatted namespace is recoverable, a squatted **target
+URI** is not, because `ensureTarget` returns the existing row with its existing
+kind and silently ignores the one you passed.
+
 **Deleting your application does not delete anyone's follows.** The
 `origin_application_id` on a relationship is provenance, not ownership — it
 records where the user was, and `SET NULL` is what keeps the user's choice when

--- a/packages/api/src/routes/followRegistry.v2.routes.ts
+++ b/packages/api/src/routes/followRegistry.v2.routes.ts
@@ -25,6 +25,7 @@ import {
   getKindCapabilities,
   listKindsForApplication,
   registerKind,
+  releaseNamespace,
   type RegistryFailure,
 } from '../services/followRegistry.service';
 import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
@@ -80,6 +81,10 @@ function raise(reason: RegistryFailure): never {
       // Distinct from the above because claiming anything would not help: the
       // kind row itself belongs to another application.
       throw new ForbiddenError('That kind was registered by another application');
+    case 'namespace_in_use':
+      throw new ConflictError(
+        'That namespace still has kinds registered in it, so it cannot be released'
+      );
     case 'unknown_kind':
       throw new BadRequestError('That kind has not been registered');
     case 'invalid_namespace':
@@ -111,6 +116,26 @@ router.post(
     if (typeof namespace !== 'string') throw new BadRequestError('namespace is required');
 
     const result = await claimNamespace({ capability, namespace });
+    if (!result.ok) raise(result.reason);
+    sendSuccess(res, result.value);
+  })
+);
+
+/**
+ * DELETE /v2/follow-targets/namespaces/:namespace
+ *
+ * Give a namespace back, if you hold it and nothing is registered inside it.
+ *
+ * Exists because a claim is first-come and registration is client-side, so the
+ * first person to open a screen on any build triggers it — including a
+ * development build using a fallback client id, which would otherwise bind the
+ * name to the wrong application permanently.
+ */
+router.delete(
+  '/namespaces/:namespace',
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const capability = await requireRegistrar(req);
+    const result = await releaseNamespace({ capability, namespace: req.params.namespace });
     if (!result.ok) raise(result.reason);
     sendSuccess(res, result.value);
   })

--- a/packages/api/src/services/__tests__/followRegistry.service.test.ts
+++ b/packages/api/src/services/__tests__/followRegistry.service.test.ts
@@ -25,6 +25,7 @@ import {
   getKindCapabilities,
   listKindsForApplication,
   registerKind,
+  releaseNamespace,
 } from '../followRegistry.service';
 
 let userId: string;
@@ -140,6 +141,64 @@ describe('claiming a namespace', () => {
       ok: false,
       reason: 'namespace_taken',
     });
+  });
+});
+
+describe('releasing a namespace', () => {
+  it('lets the holder release an empty namespace, and another application claim it after', async () => {
+    // The recoverable-mistake case: a development build using a fallback client
+    // id claims the name, and without this it is bound to the wrong
+    // application permanently.
+    const ns = await ownedNamespace();
+
+    expect(await releaseNamespace({ capability: capabilityFor(appA), namespace: ns })).toEqual({
+      ok: true,
+      value: { namespace: ns, released: true },
+    });
+    expect(await claimNamespace({ capability: capabilityFor(appB), namespace: ns })).toMatchObject({
+      ok: true,
+      value: { created: true },
+    });
+  });
+
+  it('refuses to release a namespace that has kinds in it', async () => {
+    // The original guarantee, intact: targets and relationships across the
+    // graph derive their meaning from a kind, and a kind from its namespace.
+    const ns = await ownedNamespace();
+    await registerKind({ capability: capabilityFor(appA), kind: `${ns}.store` });
+
+    expect(await releaseNamespace({ capability: capabilityFor(appA), namespace: ns })).toEqual({
+      ok: false,
+      reason: 'namespace_in_use',
+    });
+    // And it is still held afterwards.
+    expect(await claimNamespace({ capability: capabilityFor(appB), namespace: ns })).toEqual({
+      ok: false,
+      reason: 'namespace_taken',
+    });
+  });
+
+  it('refuses to release a namespace another application holds', async () => {
+    // Not a way to take a name from somebody who has not used it yet.
+    const ns = await ownedNamespace();
+    expect(await releaseNamespace({ capability: capabilityFor(appB), namespace: ns })).toEqual({
+      ok: false,
+      reason: 'namespace_not_owned',
+    });
+  });
+
+  it('can never release the platform namespace', async () => {
+    // `oxy` is held by no application row, so no capability matches its holder.
+    expect(await releaseNamespace({ capability: capabilityFor(appA), namespace: 'oxy' })).toEqual({
+      ok: false,
+      reason: 'namespace_not_owned',
+    });
+  });
+
+  it('succeeds when there was nothing to release', async () => {
+    expect(
+      await releaseNamespace({ capability: capabilityFor(appA), namespace: unique('gone') })
+    ).toMatchObject({ ok: true, value: { released: false } });
   });
 });
 

--- a/packages/api/src/services/followRegistry.service.ts
+++ b/packages/api/src/services/followRegistry.service.ts
@@ -65,6 +65,7 @@ export type RegistryFailure =
   | 'invalid_kind'
   | 'namespace_taken'
   | 'namespace_not_owned'
+  | 'namespace_in_use'
   | 'kind_not_owned'
   | 'unknown_kind'
   | 'metadata_too_large'
@@ -156,6 +157,79 @@ export async function claimNamespace(input: {
   }
 
   return { ok: true, value: { namespace, created: true } };
+}
+
+/**
+ * Release a namespace the caller holds, provided nothing has been registered
+ * inside it.
+ *
+ * ## Why this exists
+ *
+ * A claim is first-come and otherwise permanent, and registration is
+ * user-delegated and therefore client-side — so the first person to open a
+ * screen on ANY build of an application triggers it. Mention found the sharp
+ * edge before it cost anything: its local `.env` uses a fallback client id that
+ * is deliberately not the production one, so a developer reaching that screen
+ * while signed in would have bound `mention` to the DEV application, for good.
+ * That agent declined to run registration against production at all, which was
+ * right and should not have been necessary.
+ *
+ * Releasing makes the mistake recoverable. It is safe precisely because it is
+ * narrow:
+ *
+ * - Only the HOLDER may release. Another application asking is refused, so this
+ *   is not a way to take a name from somebody who has not used it yet.
+ * - Only an EMPTY namespace may go. The foreign key from `follow_target_kinds`
+ *   is `RESTRICT`, so the database refuses while any kind still points at it —
+ *   and that is what keeps the original guarantee intact: a namespace that
+ *   anything in the graph names can never be re-granted, because targets and
+ *   relationships across the whole graph derive their meaning from it.
+ *
+ * The unowned platform namespace (`oxy`, `application_id` NULL) can therefore
+ * never be released by anyone: no capability matches a NULL holder.
+ */
+export async function releaseNamespace(input: {
+  capability: FollowCapability;
+  namespace: string;
+}): Promise<RegistryResult<{ namespace: string; released: boolean }>> {
+  const namespace = input.namespace.trim().toLowerCase();
+  if (!NAMESPACE_SHAPE.test(namespace)) return fail('invalid_namespace');
+
+  const [existing] = await getDb()
+    .select({ applicationId: followNamespaces.applicationId })
+    .from(followNamespaces)
+    .where(eq(followNamespaces.namespace, namespace))
+    .limit(1);
+
+  // Releasing something nobody holds is the state the caller asked for, so it
+  // succeeds rather than erroring — same reasoning as an idempotent unfollow.
+  if (!existing) return { ok: true, value: { namespace, released: false } };
+
+  if (existing.applicationId !== input.capability.applicationId) {
+    return fail('namespace_not_owned');
+  }
+
+  const [kind] = await getDb()
+    .select({ kind: followTargetKinds.kind })
+    .from(followTargetKinds)
+    .where(eq(followTargetKinds.namespace, namespace))
+    .limit(1);
+
+  // Checked here so the caller gets a reason rather than a constraint name; the
+  // RESTRICT below is still what actually enforces it, including against a kind
+  // registered between this read and the delete.
+  if (kind) return fail('namespace_in_use');
+
+  await getDb()
+    .delete(followNamespaces)
+    .where(
+      and(
+        eq(followNamespaces.namespace, namespace),
+        eq(followNamespaces.applicationId, input.capability.applicationId)
+      )
+    );
+
+  return { ok: true, value: { namespace, released: true } };
 }
 
 /**


### PR DESCRIPTION
Mention found this before it cost anything, and **declined to run registration against production because of it**.

A claim is first-come and otherwise permanent. Registration is user-delegated and therefore client-side, so the first person to open a screen on *any* build triggers it — and Mention's local `.env` uses a fallback client id that is deliberately **not** the production one. A developer reaching that screen while signed in would have bound `mention` to the **dev** application, for good.

That agent was right to refuse, and should not have had to.

## Narrow on purpose, and both properties are mutation-tested

- **Only the holder may release.** Another application asking is refused, so this is not a way to take a name from somebody who has not used it yet. The platform's own `oxy` namespace — held by no application row — can never be released by anyone, because no capability matches a `NULL` holder.
- **Only an empty namespace may go.** The foreign key from `follow_target_kinds` is `RESTRICT`, so the database refuses while any kind still points at it. That is what keeps the original guarantee intact: a namespace anything in the graph names can never be re-granted, because targets and relationships derive their meaning from it.

Releasing one nobody holds **succeeds** rather than erroring — the state the caller asked for is the state that holds, the same reasoning as an idempotent unfollow.

```
DELETE /v2/follow-targets/namespaces/<namespace>
```

## The asymmetry, now in the docs

Also Mention's: a squatted **namespace** is recoverable after this; a squatted **target URI** is not, because `ensureTarget` returns the existing row with its existing kind and silently ignores the one you passed. The response carries `kind`, which is the only detection a client gets.

## Verification

28 tests against a real Postgres. Mutations: allowing a release with kinds present fails one test; dropping the holder check fails two, including the platform-namespace one.