### PR TITLE
feat(core): a failed request keeps the server's message, code and details

### DIFF
--- a/packages/core/src/HttpService.ts
+++ b/packages/core/src/HttpService.ts
@@ -16,7 +16,7 @@
 import { TTLCache, registerCacheForCleanup } from './utils/cache';
 import { RequestDeduplicator, RequestQueue, SimpleLogger } from './utils/requestUtils';
 import { retryAsync } from './utils/asyncUtils';
-import { handleHttpError } from './utils/errorUtils';
+import { handleHttpError, parseHttpErrorBody } from './utils/errorUtils';
 import { jwtDecode } from 'jwt-decode';
 import { isNative, getPlatformOS } from './utils/platform';
 import { isReactNative } from '@oxyhq/protocol';
@@ -632,37 +632,44 @@ export class HttpService {
             }
           }
 
-          // Try to parse error response (handle empty/malformed JSON)
-          let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-          const contentType = response.headers.get('content-type');
-          if (contentType && contentType.includes('application/json')) {
+          // Read the error body (may be absent, non-JSON, empty or malformed).
+          // Anything unreadable leaves `errorBody` undefined and degrades to the
+          // status-based message — an error path that throws its own error is
+          // worse than the error it was reporting.
+          let errorBody: unknown;
+          const errorContentType = response.headers.get('content-type');
+          if (errorContentType?.includes('application/json')) {
             try {
-              const errorData = await response.json() as {
-                message?: string;
-                error?: string;
-                error_description?: string;
-              } | null;
-              // Accept either structured error field from API responses.
-              if (errorData?.message) {
-                errorMessage = errorData.message;
-              } else if (errorData?.error_description) {
-                // RFC 6749 §5.2 / RFC 6750 §3 — OAuth endpoints surface human text here.
-                errorMessage = errorData.error_description;
-              } else if (errorData?.error) {
-                errorMessage = errorData.error;
-              }
+              errorBody = await response.json();
             } catch (parseError) {
               // Malformed JSON or empty response - use status text
               this.logger.warn('Failed to parse error response JSON:', parseError);
             }
           }
 
-          const error = new Error(errorMessage) as Error & {
+          // `parseHttpErrorBody` handles every envelope in use, including the
+          // nested `{ error: { code, message } }` shape — assigning that nested
+          // OBJECT as the message is what produced `"[object Object]"`.
+          const parsed = parseHttpErrorBody(errorBody);
+          const error = new Error(
+            parsed.message ?? `HTTP ${response.status}: ${response.statusText}`,
+          ) as Error & {
             status?: number;
-            response?: { status: number; statusText: string }
+            code?: string;
+            details?: Record<string, unknown>;
+            response?: { status: number; statusText: string; data?: unknown };
           };
           error.status = response.status;
-          error.response = { status: response.status, statusText: response.statusText };
+          error.response = { status: response.status, statusText: response.statusText, data: errorBody };
+          // Only set `code`/`details` when the server actually sent them.
+          // Assigning `undefined` would still create the property, which changes
+          // how `handleHttpError` classifies the error downstream.
+          if (parsed.code !== undefined) {
+            error.code = parsed.code;
+          }
+          if (parsed.details !== undefined) {
+            error.details = parsed.details;
+          }
           throw error;
         }
 

--- a/packages/core/src/__tests__/parseHttpErrorBody.test.ts
+++ b/packages/core/src/__tests__/parseHttpErrorBody.test.ts
@@ -1,0 +1,116 @@
+import { isHttpRequestError, parseHttpErrorBody } from '../utils/errorUtils';
+
+/**
+ * `parseHttpErrorBody` is the ONE place the SDK decides what a failed request's
+ * message, code and details are, across every error envelope the Oxy ecosystem
+ * emits. The bug it exists to prevent is silent: a nested
+ * `{ error: { code, message } }` assigned straight to `new Error(...)` yields
+ * the literal string `"[object Object]"`, which reads as a rendering bug in
+ * whichever app surfaces it, arbitrarily far from here.
+ *
+ * Each case below pins one envelope AND the discrimination it depends on — in
+ * particular, whether the top-level `error` string is a machine CODE or human
+ * prose is decided solely by whether a sibling human field is present, so both
+ * sides of that fork need a fixture or the rule is untested.
+ */
+describe('parseHttpErrorBody', () => {
+    it('reads the nested { error: { code, message, details } } envelope', () => {
+        expect(
+            parseHttpErrorBody({
+                error: { code: 'case_conflict', message: 'A case already exists', details: { caseId: 'c_1' } },
+            }),
+        ).toEqual({
+            message: 'A case already exists',
+            code: 'case_conflict',
+            details: { caseId: 'c_1' },
+        });
+    });
+
+    it("reads oxy-api's { error: '<CODE>', message } shape — error IS the code", () => {
+        expect(parseHttpErrorBody({ error: 'VALIDATION_ERROR', message: 'username is taken' })).toEqual({
+            message: 'username is taken',
+            code: 'VALIDATION_ERROR',
+            details: undefined,
+        });
+    });
+
+    it("reads RFC 6749 { error: '<CODE>', error_description } from the OAuth endpoints", () => {
+        // The OAuth token/userinfo endpoints are the one part of the API that
+        // does not use the `{ error, message }` envelope. Without this arm the
+        // human text is dropped and the raw code is shown to the user.
+        expect(
+            parseHttpErrorBody({ error: 'invalid_grant', error_description: 'Authorization code expired' }),
+        ).toEqual({
+            message: 'Authorization code expired',
+            code: 'invalid_grant',
+            details: undefined,
+        });
+    });
+
+    it("treats a LONE { error: '<text>' } as the message, never as a code", () => {
+        // The discriminator is the ABSENCE of a sibling human field. Promoting a
+        // bare string to `code` would put prose where callers switch on codes,
+        // so this case and the two above have to disagree.
+        expect(parseHttpErrorBody({ error: 'Something went wrong' })).toEqual({
+            message: 'Something went wrong',
+            code: undefined,
+            details: undefined,
+        });
+    });
+
+    it('reads the flat { message, code } shape (CSRF rejections)', () => {
+        expect(parseHttpErrorBody({ message: 'Invalid CSRF token', code: 'CSRF_TOKEN_INVALID' })).toEqual({
+            message: 'Invalid CSRF token',
+            code: 'CSRF_TOKEN_INVALID',
+            details: undefined,
+        });
+    });
+
+    it('ignores whitespace-only strings rather than reporting them as a message', () => {
+        // A blank message is worse than none: it replaces the status fallback
+        // with an empty error surface the user cannot act on.
+        expect(parseHttpErrorBody({ message: '   ', error: '' })).toEqual({
+            message: undefined,
+            code: undefined,
+            details: undefined,
+        });
+    });
+
+    it('ignores a non-object `details` instead of passing it through', () => {
+        expect(parseHttpErrorBody({ message: 'nope', details: 'not-an-object' }).details).toBeUndefined();
+        expect(parseHttpErrorBody({ message: 'nope', details: ['a'] }).details).toBeUndefined();
+    });
+
+    it.each([null, undefined, [], 'a string', 42, true])('returns {} for the non-object body %p', (body) => {
+        expect(parseHttpErrorBody(body)).toEqual({});
+    });
+
+    it('returns {} for an object carrying none of the known fields', () => {
+        expect(parseHttpErrorBody({ unrelated: 'field' })).toEqual({
+            message: undefined,
+            code: undefined,
+            details: undefined,
+        });
+    });
+});
+
+describe('isHttpRequestError', () => {
+    it('accepts an Error carrying a numeric status', () => {
+        const error = Object.assign(new Error('boom'), { status: 409 });
+        expect(isHttpRequestError(error)).toBe(true);
+    });
+
+    it('rejects a plain ApiError object — those are objects, not Errors', () => {
+        // The distinction is load-bearing: an ApiError has to go through
+        // `handleHttpError` first, and a truthy answer here would let a caller
+        // read `.stack`/`.name` off something that has neither.
+        expect(isHttpRequestError({ message: 'boom', status: 409, code: 'CONFLICT' })).toBe(false);
+    });
+
+    it('rejects an Error whose status is a non-number', () => {
+        // `'409'` is the shape a hand-built error most plausibly carries, and
+        // the narrowing promises callers a number they can compare.
+        expect(isHttpRequestError(Object.assign(new Error('boom'), { status: '409' }))).toBe(false);
+        expect(isHttpRequestError(new Error('boom'))).toBe(false);
+    });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -476,8 +476,11 @@ export {
     ErrorCodes,
     createApiError,
     handleHttpError,
+    isHttpRequestError,
+    parseHttpErrorBody,
     validateRequiredFields,
 } from './utils/errorUtils';
+export type { HttpRequestError, ParsedHttpErrorBody } from './utils/errorUtils';
 
 export { retryAsync } from './utils/asyncUtils';
 

--- a/packages/core/src/utils/errorUtils.ts
+++ b/packages/core/src/utils/errorUtils.ts
@@ -37,6 +37,110 @@ export const ErrorCodes = {
 } as const;
 
 /**
+ * The `Error` shape the SDK rejects with when an HTTP request fails.
+ *
+ * `HttpService` throws this for every non-2xx response, and
+ * `OxyServices.handleError` (the wrapper the mixin methods rethrow through)
+ * preserves `message`, `status`, `code` and `details`. `response` only survives
+ * on the raw `HttpService`/`makeRequest` path, so treat it as optional.
+ *
+ * Narrow a caught value with {@link isHttpRequestError} instead of asserting.
+ */
+export interface HttpRequestError extends Error {
+    /** HTTP status of the failed response. */
+    status: number;
+    /** Machine-readable code the server sent, when it sent one. */
+    code?: string;
+    /** Structured error detail the server sent, when it sent an object. */
+    details?: Record<string, unknown>;
+    /**
+     * Present on errors thrown directly by `HttpService`. `data` is the parsed
+     * JSON error body verbatim — the escape hatch for any server field the SDK
+     * does not lift onto `code`/`details`.
+     */
+    response?: {
+        status: number;
+        statusText: string;
+        data?: unknown;
+    };
+}
+
+/**
+ * Narrow a caught value to {@link HttpRequestError}.
+ *
+ * Returns `false` for a plain {@link ApiError} object (those are objects, not
+ * `Error`s) — run an arbitrary thrown value through {@link handleHttpError}
+ * first if you need one normalized.
+ */
+export function isHttpRequestError(value: unknown): value is HttpRequestError {
+    if (!(value instanceof Error)) {
+        return false;
+    }
+    return typeof (value as Partial<HttpRequestError>).status === 'number';
+}
+
+/**
+ * The fields {@link parseHttpErrorBody} lifts off a parsed error response body.
+ */
+export interface ParsedHttpErrorBody {
+    message?: string;
+    code?: string;
+    details?: Record<string, unknown>;
+}
+
+const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const nonEmptyString = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+
+/**
+ * Extract `message` / `code` / `details` from a parsed HTTP error response body.
+ *
+ * Handles every error envelope in use across the Oxy ecosystem:
+ *
+ * - `{ error: { code, message, details? } }` — nested envelope (CrowdSource and
+ *   other Oxy services). Never stringify the nested object: `new Error(obj)`
+ *   yields the literal message `"[object Object]"`.
+ * - `{ error: '<CODE>', message, details? }` — oxy-api's canonical shape
+ *   (`ApiError.toJSON`), where the top-level `error` field IS the code.
+ * - `{ error: '<CODE>', error_description }` — RFC 6749 §5.2 / RFC 6750 §3, the
+ *   OAuth token and userinfo endpoints. `error_description` is the human text
+ *   and `error` is the machine code, so both survive.
+ * - `{ message, code }` — e.g. the API's CSRF rejections.
+ * - `{ error: '<human message>' }` — legacy hand-rolled routes. With no sibling
+ *   `message`/`error_description` the string is the message, not a code: a bare
+ *   `error` string is not machine-readable enough to promote to `code`.
+ *
+ * Anything else — a non-object body (`null`, `[]`, `"str"`, `42`), or an object
+ * carrying none of these fields — yields an empty result, leaving the caller on
+ * its status-based fallback message. Total function: never throws.
+ */
+export function parseHttpErrorBody(body: unknown): ParsedHttpErrorBody {
+    if (!isPlainRecord(body)) {
+        return {};
+    }
+
+    const nested = isPlainRecord(body.error) ? body.error : undefined;
+    const errorString = nonEmptyString(body.error);
+    // A sibling that proves the top-level `error` is a CODE rather than prose.
+    const siblingMessage = nonEmptyString(body.message) ?? nonEmptyString(body.error_description);
+
+    return {
+        message: siblingMessage ?? (nested ? nonEmptyString(nested.message) : errorString),
+        code:
+            (nested ? nonEmptyString(nested.code) : undefined) ??
+            nonEmptyString(body.code) ??
+            (siblingMessage ? errorString : undefined),
+        details: isPlainRecord(body.details)
+            ? body.details
+            : nested && isPlainRecord(nested.details)
+                ? nested.details
+                : undefined,
+    };
+}
+
+/**
  * Create a standardized API error
  */
 export function createApiError(
@@ -98,21 +202,28 @@ export function handleHttpError(error: unknown): ApiError {
 
   // Handle fetch Response errors - check if it has response property with status
   if (error && typeof error === 'object' && 'response' in error) {
-    const fetchError = error as { 
-      response?: { 
-        status: number; 
+    const fetchError = error as {
+      response?: {
+        status: number;
         statusText?: string;
       };
       status?: number;
       message?: string;
+      details?: unknown;
     };
-    
+
     const status = fetchError.response?.status || fetchError.status;
     if (status) {
+      // `details` is carried through when present: a body may ship structured
+      // detail without a machine-readable `code` (which is what routes the
+      // error to the already-an-ApiError branch above), and dropping it here
+      // would make it unreachable to every caller that rethrows via
+      // `OxyServices.handleError`.
       return createApiError(
         fetchError.message || `HTTP ${status} error`,
         getErrorCodeFromStatus(status),
-        status
+        status,
+        isPlainRecord(fetchError.details) ? fetchError.details : undefined
       );
     }
   }


### PR DESCRIPTION
## What

`HttpService` built its thrown error by reaching for `message`, then `error_description`, then `error` — a chain that only reads **flat** bodies. Against the nested `{ error: { code, message } }` envelope several Oxy services emit, `errorData.error` is an object, so `new Error(obj)` produced the literal string `"[object Object]"`. That reaches the user as the entire explanation, and it reads like a rendering bug in whichever app surfaced it — arbitrarily far from the SDK that made it.

`parseHttpErrorBody` replaces the chain with one total function covering every envelope in use:

| body | message | code |
|---|---|---|
| `{ error: { code, message, details } }` | nested `message` | nested `code` |
| `{ error: '<CODE>', message }` (oxy-api) | `message` | `error` |
| `{ error: '<CODE>', error_description }` (OAuth, RFC 6749) | `error_description` | `error` |
| `{ message, code }` (CSRF) | `message` | `code` |
| `{ error: '<text>' }` (legacy) | `error` | — |

Whether a top-level `error` string is a machine code or human prose is decided solely by whether a sibling human field sits beside it. The `error_description` arm is deliberate: the previous chain already handled it, and dropping it would regress every OAuth token/userinfo failure into a raw code.

The thrown error now also carries `code`/`details` when the server sent them, plus `response.data` (the parsed body verbatim) as the escape hatch for any field the SDK does not lift. Both are assigned **only when present** — writing `undefined` still creates the property and changes how `handleHttpError` classifies the error downstream. `handleHttpError` carries `details` through for the same reason: a body may ship structured detail with no `code`, which is what routes it down that branch at all.

`isHttpRequestError` narrows a caught value instead of every call site asserting.

## Evidence

- New `parseHttpErrorBody.test.ts`: **17/17 pass**.
- Full `@oxyhq/core` suite: **1473 pass, 107 suites**.
- `bun run build` clean, and the new symbols are present in `dist/esm` + `dist/types`.
- Fixtures cover both sides of the code-vs-prose fork (a lone `error` string must **not** become a code) and a `status: '409'` string for the narrowing — the shapes where a looser reading and this one disagree.

> Build note for reviewers: building `@oxyhq/core` in a fresh worktree fails `TS2305` until `@oxyhq/contracts` is built first. That is the documented stale-`dist` trap, not this change.

## Provenance

Recovered from uncommitted work in a stale sibling worktree (`OxyHQServices-core-http-errors`, 312 commits behind `main`). Re-applied to current `main` by hand — the original patch no longer applied, and it predated the `error_description` arm now in `HttpService`, which this preserves. Tests are new; the original work had none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)