### PR TITLE
settleProbe waited for any probe, not the one just fired

### DIFF
--- a/packages/api/src/services/__tests__/nodeRegistry.test.ts
+++ b/packages/api/src/services/__tests__/nodeRegistry.test.ts
@@ -127,12 +127,42 @@ async function waitFor<T>(read: () => Promise<T>, done: (value: T) => boolean, w
   }
 }
 
-/** Let the floating post-registration probe finish before the test ends. */
-async function settleProbe(userId: string): Promise<void> {
+/** Probes that have called `safeFetch` since the last `clearAllMocks`. */
+function probesSoFar(): number {
+  return mockSafeFetch.mock.calls.length;
+}
+
+/**
+ * Let the floating post-registration probe finish before the test ends.
+ *
+ * `probesBefore` is {@link probesSoFar} read immediately BEFORE the call that
+ * fired this probe, and a RE-registration must pass it. Without it the wait is
+ * vacuous on the second probe of a test: it asked only whether `lastProbeAt` is
+ * non-null, which the FIRST probe's write already made true, so the settle
+ * returned on its first poll and left the new probe in flight. That probe's
+ * `safeFetch` then landed in whatever test was running when it resolved —
+ * against a spy `beforeEach` had already cleared — which is the flake in #836,
+ * reproduced here 1 full-suite run in 3 and always in the case that follows the
+ * last re-registration.
+ *
+ * Counting the mock's calls rather than comparing timestamps is deliberate:
+ * `lastProbeAt` is a `Date` at millisecond resolution and two probes inside one
+ * millisecond are ordinary against a local database, so a "strictly newer"
+ * comparison would trade this flake for a timeout.
+ *
+ * The default of `0` stays correct for a user with NO prior probe — including
+ * the two-account cases, where another account's probe may already have bumped
+ * the count but this account's `lastProbeAt` is still null and does the waiting.
+ * It is only a RE-registration, where both halves are already satisfied, that
+ * needs the explicit baseline.
+ */
+async function settleProbe(userId: string, probesBefore = 0): Promise<void> {
   await waitFor(
-    () => storedNode(userId),
-    (row) => row === undefined || row.lastProbeAt !== null,
-    'the fire-and-forget liveness probe to write lastProbeAt',
+    async () => ({ row: await storedNode(userId), probes: probesSoFar() }),
+    ({ row, probes }) =>
+      // No row means materialization was skipped, so no probe was ever fired.
+      row === undefined || (probes > probesBefore && row.lastProbeAt !== null),
+    'the fire-and-forget liveness probe to call safeFetch and write lastProbeAt',
   );
 }
 
@@ -198,11 +228,12 @@ describe('materializeNodeFromRecord', () => {
     await settleProbe(userId);
     const before = await storedNode(userId);
 
+    const probesBefore = probesSoFar();
     const second = await materializeNodeFromRecord(userId, nodeRecord({
       endpoint: 'https://moved.example.com',
       mode: 'push',
     }));
-    await settleProbe(userId);
+    await settleProbe(userId, probesBefore);
     const after = await storedNode(userId);
 
     expect(await storedNodeCount(userId)).toBe(1);
@@ -221,10 +252,11 @@ describe('materializeNodeFromRecord', () => {
     await settleProbe(userId);
     await getDb().update(userNodes).set({ lastError: 'boom' }).where(eq(userNodes.userId, userId));
 
+    const probesBefore = probesSoFar();
     await materializeNodeFromRecord(userId, nodeRecord());
 
     expect((await storedNode(userId)).lastError).toBeNull();
-    await settleProbe(userId);
+    await settleProbe(userId, probesBefore);
   });
 
   it('records an Oxy-operated node as managed + controller oxy, together', async () => {
@@ -243,10 +275,13 @@ describe('materializeNodeFromRecord', () => {
     await materializeNodeFromRecord(userId, nodeRecord(), { operator: 'oxy' });
     await settleProbe(userId);
 
+    const probesBefore = probesSoFar();
     await materializeNodeFromRecord(userId, nodeRecord(), { operator: 'self' });
 
     expect(await storedNode(userId)).toMatchObject({ managed: false, controller: 'self' });
-    await settleProbe(userId);
+    // The settle that used to be vacuous, and the one whose leaked probe landed
+    // in the very next case — see `settleProbe`.
+    await settleProbe(userId, probesBefore);
   });
 
   it.each([


### PR DESCRIPTION
Cierra el flake de #836, con la causa reproducida y no adivinada.

## Qué pasaba

`nodeRegistry.test.ts` › `skips materialization for a non-HTTPS endpoint` ve **una** llamada a un mock de `safeFetch` que afirma que nunca se llamó. Aproximadamente **1 de cada 3** ejecuciones del suite completo. CI lo pilló una vez en un PR sin relación y pasó al reejecutar, que es justo cómo se mantuvo invisible.

## La causa

`settleProbe` preguntaba si `lastProbeAt` **no es null**. En un re-registro, el PRIMER sondeo ya lo hizo cierto — así que la segunda espera se cumplía en su primer poll **sin esperar nada**, dejando la sonda nueva en vuelo. Su `safeFetch` aterrizaba en el test que estuviera corriendo cuando resolviera, contra un espía que `beforeEach` ya había limpiado.

Tres tests re-registran, y el último está **inmediatamente antes** del caso que falla. Por eso el fallo aparece siempre ahí.

## Sobre la evidencia

La vacuidad se demuestra **leyendo**, no contando ejecuciones: el predicado es trivialmente cierto en cuanto cualquier sondeo ha escrito. Las seis pasadas limpias del suite completo tras el arreglo son corroboración, no el argumento — a la tasa observada, ese resultado tenía ~9% de probabilidad de salir por azar de todos modos.

Dos correcciones sobre lo que escribí en #836 mientras lo investigaba, para que nadie persiga la pista muerta: la sonda **no** invalida la caché (así que no podía ser `invalidateSpy`), y el test que "no llamaba a `settleProbe`" tampoco fugaba nada, porque la sonda escribe `status`/`lastSeenAt`/`lastProbeAt` en un solo `UPDATE`. El helper era el culpable por **vacuidad**, no por ausencia.

## Sobre el arreglo

Espera a que el contador de llamadas del mock supere el que había ANTES de disparar la sonda, en vez de comparar timestamps. Deliberado: `lastProbeAt` es un `Date` con resolución de milisegundo y dos sondeos dentro del mismo milisegundo son normales contra una base local, así que un "estrictamente más nuevo" habría cambiado este flake por un timeout.

El valor por defecto de `0` sigue siendo correcto donde la cuenta no tiene sondeo previo, incluidos los casos de dos cuentas: el sondeo de otra cuenta puede subir el contador, pero el `lastProbeAt` null de ésta sigue haciendo la espera. Solo un re-registro satisface ambas mitades de entrada, así que solo esos tres sitios pasan baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)