### PR TITLE
Name the privacy boundary the multi-author read sits on

### DIFF
--- a/packages/api/src/services/oxyRecordStore.ts
+++ b/packages/api/src/services/oxyRecordStore.ts
@@ -387,6 +387,24 @@ class OxyRecordStoreImpl implements RecordStore {
    * Only `verified` rows with an `nsid` are returned: an unverified row has no
    * business in anyone's feed, and a v1 row has no lexicon to filter on.
    *
+   * ## `collections` is a POLICY, and here it is a privacy boundary
+   *
+   * The store has no notion of a public collection — `getPublicLogSince` takes
+   * its allowlist for the same reason, and `repoLog.service`'s
+   * `PUBLIC_LOG_COLLECTIONS` is where that policy is written down. It matters
+   * more on THIS read: that one serves one subject's bootstrap log under a
+   * constant, while this one spans subjects and serves app records, and a
+   * person's chain interleaves an app's PUBLIC and PRIVATE collections in one
+   * log. Mention's `app.mention.feed.bookmark` is declared in
+   * `@mention/shared-types` as "a private bookmark (excluded from any public
+   * log)" — a fact Oxy cannot derive, because which of an app's collections are
+   * publishable is the APP's knowledge and no registry carries it yet.
+   *
+   * So a read surface built on this MUST pass an allowlist it owns, in the shape
+   * `PUBLIC_LOG_COLLECTIONS` already has. Passing a request-supplied list
+   * straight through hands every caller everyone's saved posts, and nothing
+   * below this line would notice.
+   *
    * THROWS rather than truncating when a cap is exceeded. A silently shortened
    * author list reads as "these people published nothing".
    */


### PR DESCRIPTION
Solo documentación, en el sitio donde alguien la va a leer justo antes de meter la pata.

## Lo que encontré

Al revisar si el endpoint HTTP de la lectura multi-autor seguía bloqueado (lo dejé fuera de #834 diciendo que hacía falta un filtro de visibilidad), resultó que **el filtro que hacía falta no era el que yo pensaba**.

Los posts están a salvo por construcción: `MentionRecordEmitter.isPublicPublishedPost` solo emite registro para `published` + `PUBLIC`. Pero ese guard cubre `emitPostCreated` **y solo ése** — correctamente, porque el problema real no es la visibilidad de un post:

> `/** A private bookmark (excluded from any public log). */`
> — `@mention/shared-types`, `MENTION_BOOKMARK_COLLECTION`

Un marcador es privado **por tipo**, no por visibilidad, y se escribe en la misma cadena que los posts. Así que la cadena de una persona intercala colecciones públicas y privadas de una app en un solo log.

## Por qué importa ahora

Oxy no puede deducir cuáles son cuáles. `repoLog.service` lo dice de su propia lista: *"the protocol store has no notion of public collections"*, y `PUBLIC_LOG_COLLECTIONS` es una constante comprometida con las tres colecciones de Oxy. Con `app_record` ya admitido (#835), esa lista tendrá que crecer con colecciones de app — y quien la haga crecer necesita saber que `app.mention.feed.bookmark` no entra.

`listRecordsByAuthors` toma `collections` del llamante, igual que `getPublicLogSince`. En aquél el riesgo está acotado: un sujeto, una ruta de bootstrap, una constante. En éste no: cruza sujetos y sirve registros de app.

**Nada está expuesto hoy** — el método no tiene llamante HTTP, que es exactamente por lo que la superficie de lectura se dejó fuera. Esto deja escrito el porqué donde se lee antes de cablear una, en vez de en un fichero de plan que ningún consumidor abre.

## La convergencia que conviene ver

"Qué colecciones de una app son publicables" y "qué app puede escribir bajo qué namespace" son **el mismo registro que falta**. Ninguna de las dos preguntas la puede contestar Oxy solo, y las dos bloquean la mitad que queda de la fase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)