### PR TITLE
feat(updates): wire Oxy Updates OTA into app-preset, Commons and Accounts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -313,6 +313,7 @@
         "expo-status-bar": "catalog:",
         "expo-symbols": "catalog:",
         "expo-system-ui": "catalog:",
+        "expo-updates": "~57.0.11",
         "expo-web-browser": "catalog:",
         "lottie-react-native": "~7.3.8",
         "nativewind": "catalog:",
@@ -3263,6 +3264,8 @@
 
     "expo-document-picker": ["expo-document-picker@57.0.1", "", { "peerDependencies": { "expo": "*" } }, "sha512-qBwM5oxDZ3I9kwFD3pUE1oK/WNv9artoEKO6UpqhQgNRr0XA1ALRVWYjkF4+ge9lUNDRehjTm/jenINkzqg84g=="],
 
+    "expo-eas-client": ["expo-eas-client@57.0.1", "", {}, "sha512-4w51+zsl/ziUHQMJgLgUdgsNhRPAwHBfySpPB1hpWU21X74QS9T4SqDftaRnrDagn/DfcrXUMJvHbDQUxLPJNA=="],
+
     "expo-file-system": ["expo-file-system@57.0.1", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-w7/ERvQFrGP2apTO9lDtZ+O6JQIhfakL7+Xqzh+rfMO9B4LB4qwrz+YvLgir8KFRVX64JHBnRuYBVLY1oQZcqw=="],
 
     "expo-font": ["expo-font@57.0.1", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-QyS9L1Kh9sKJg4gfU6rdbpxpmH+DyzBX8z6jVvXMUDoqLr1GqmkO/Wu379KCXjL///kWbhpNlbi7AgBuj4VdIQ=="],
@@ -3279,6 +3282,8 @@
 
     "expo-image-picker": ["expo-image-picker@57.0.4", "", { "dependencies": { "expo-image-loader": "~57.0.1" }, "peerDependencies": { "expo": "*" } }, "sha512-ypuO99+rMqrjYlTt8EqJ415ff+qIj/gPyEbcOW8g6CFtC6Ljk8OWYyiEFKZg3989Rdljla/fN3IWqXOXKN/2og=="],
 
+    "expo-json-utils": ["expo-json-utils@57.0.1", "", {}, "sha512-cgTe1NqzQdYs/WN+3nIY5IZg8s0pb0xaTUbhYvxQDn137GbwRfHoGM2se3m3Vsl4Qu+B9G4RPEK5WJDEU2Do7g=="],
+
     "expo-keep-awake": ["expo-keep-awake@57.0.1", "", { "peerDependencies": { "expo": "*", "react": "*" } }, "sha512-28lkFImeXTS+bhAjuCFV7w7tW5bXg27BJVrxv+nC/nyYa86qEa0oFeHwqol6ha5k4pdVDQgBF09GM4A1k76Ssg=="],
 
     "expo-linear-gradient": ["expo-linear-gradient@57.0.1", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-CpS8eMqoIWcHVGKV66zbDvzotCw9qYp3f8CuI9N+h1LaO0tMLUzBpkhAKePUsXlpN3yolYlHFSPkfVZ/uSh+iA=="],
@@ -3286,6 +3291,8 @@
     "expo-linking": ["expo-linking@57.0.3", "", { "dependencies": { "expo-constants": "~57.0.5", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-uF5PFfIQ0cjEGijzFuN8gU5eLqWs6BgS29Zp4ddP79XPMobZmS6qzdGyCOZTnZz3UWR17rFAJst1UntuZg9/6Q=="],
 
     "expo-local-authentication": ["expo-local-authentication@57.0.1", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": "*" } }, "sha512-FrXtuXVBmXmwmvDus0OsFWMdzjYTaLd/ZvvVMKnRjXDKDS+LFG2Sz3r9f3Go0goJdpb/hA09wGwGi8XfW3Aa0w=="],
+
+    "expo-manifests": ["expo-manifests@57.0.1", "", { "dependencies": { "expo-json-utils": "~57.0.1" }, "peerDependencies": { "expo": "*" } }, "sha512-qB/mDG2dYdl+EvUeQuqP8KFYCFgFCQjJYdWIHo8SFBgDzMYmdF286DFY2M1M9Okr99wkb5M4tgA3aCcwv3aEQA=="],
 
     "expo-modules-autolinking": ["expo-modules-autolinking@57.0.7", "", { "dependencies": { "@expo/require-utils": "^57.0.3", "@expo/spawn-async": "^1.8.0", "chalk": "^4.1.0", "commander": "^7.2.0" }, "bin": { "expo-modules-autolinking": "bin/expo-modules-autolinking.js" } }, "sha512-arYvWy3odY0JxFwjosVeu8OrS/CvYy+Voroe126X/fYlkdXryJZSYbOsmM1ruol3Eo4ji8HKcfO+mvEVKGxUbQ=="],
 
@@ -3313,9 +3320,15 @@
 
     "expo-status-bar": ["expo-status-bar@57.0.1", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-Xwaq1gAoVRWx5dPG5VhT5RSbnI9OilhZnO5qoPBnUaBAa5VzRzfdS8q0/bsPt0jR2DKLtGuP0bQ6efMJ4RIMDg=="],
 
+    "expo-structured-headers": ["expo-structured-headers@57.0.0", "", {}, "sha512-//t9UNPbJSEysc2x4VKJG/u7Osvv5DYJWsET5bqt/B+qcD1by/JXvSQzX3Q/YAgA96xFPontrz6OAPLbO4JKEA=="],
+
     "expo-symbols": ["expo-symbols@57.0.1", "", { "dependencies": { "@expo-google-fonts/material-symbols": "^0.4.1", "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "expo": "*", "expo-font": "*", "react": "*", "react-native": "*" } }, "sha512-8Zf+a83OywV0vf1NUtSKpNqKcULmO0GTI+zfFnGYl7SLDH9FjL5RcEZoy6CHvCgq2KDrQF21pl3r7Tb4ItPscw=="],
 
     "expo-system-ui": ["expo-system-ui@57.0.1", "", { "dependencies": { "@react-native/normalize-colors": "0.86.0", "debug": "^4.3.2" }, "peerDependencies": { "expo": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native-web"] }, "sha512-r8a6Jk2suL0vI7Uq4iKJab5Eesk8dkB56Q6HksVNkzuAExV0axoikQwZv8aAyHGbu2VHp0artB0N1/PQDLSgBg=="],
+
+    "expo-updates": ["expo-updates@57.0.11", "", { "dependencies": { "@expo/code-signing-certificates": "^0.0.6", "@expo/plist": "^0.8.1", "@expo/spawn-async": "^1.8.0", "arg": "^4.1.0", "chalk": "^4.1.2", "debug": "^4.3.4", "expo-eas-client": "~57.0.1", "expo-manifests": "~57.0.1", "expo-structured-headers": "~57.0.0", "expo-updates-interface": "~57.0.1", "getenv": "^2.0.0", "glob": "^13.0.0", "ignore": "^5.3.1", "nullthrows": "^1.1.1", "resolve-from": "^5.0.0" }, "peerDependencies": { "expo": "*", "expo-dev-client": "*", "react": "*", "react-native": "*" }, "optionalPeers": ["expo-dev-client"], "bin": { "expo-updates": "bin/cli.js" } }, "sha512-V8m+bVHvyUXggjmhxt/t4yyj6oDfdAN0kdx0nAt9p2i7xGci6lkzfWzcwsNUE0ZmStHR4ZyzQVFR1U0vP7C/7g=="],
+
+    "expo-updates-interface": ["expo-updates-interface@57.0.1", "", { "peerDependencies": { "expo": "*" } }, "sha512-+LUWwJ0gf/TEKMVdQAw/Gjih4dvrk+URgy24X9qEGKuuMDZqjBRm9T4yQyBVALGL5TTdPUaB6ILxx3lshm3pwQ=="],
 
     "expo-web-browser": ["expo-web-browser@57.0.1", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-akqnOoJRzKXbFbiqTwxnmn8mVoSfPKEBxwDNxQJHAGElgneL28jlEPYaTDpOONz9azPWVfEHZ/i7kqQgN2ExXg=="],
 
@@ -6299,6 +6312,8 @@
 
     "expo-splash-screen/xml2js": ["xml2js@0.6.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, ""],
 
+    "expo-updates/glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, ""],
+
     "express/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, ""],
 
     "express-slow-down/express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, ""],
@@ -7635,6 +7650,8 @@
 
     "expect/jest-util/@types/node": ["@types/node@25.2.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, ""],
 
+    "expo-updates/glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, ""],
+
     "expo/pretty-format/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, ""],
 
     "expo/pretty-format/react-is": ["react-is@18.3.1", "", {}, ""],
@@ -8505,6 +8522,8 @@
 
     "expect/jest-util/@types/node/undici-types": ["undici-types@7.16.0", "", {}, ""],
 
+    "expo-updates/glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, ""],
+
     "expo/pretty-format/@jest/schemas/@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, ""],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, ""],
@@ -9038,6 +9057,8 @@
     "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
     "eslint-plugin-expo/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, ""],
+
+    "expo-updates/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, ""],
 
     "import-local/pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, ""],
 

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "expo-splash-screen": "catalog:",
         "expo-status-bar": "catalog:",
         "expo-system-ui": "catalog:",
+        "expo-updates": "~57.0.11",
         "expo-web-browser": "catalog:",
         "jszip": "catalog:",
         "lottie-react-native": "~7.3.8",

--- a/packages/accounts/.env.example
+++ b/packages/accounts/.env.example
@@ -1,0 +1,33 @@
+# Accounts by Oxy - environment template. Copy to `.env` and edit as needed.
+# Every variable here is EXPO_PUBLIC_*, so it is inlined into the JS bundle and
+# readable by anyone with the binary. Never put a secret in this file.
+
+# Oxy API origin. Also the origin of the Oxy Updates server (`/updates/v1`), so
+# changing it repoints both the API client and the OTA manifest URL that
+# `app.config.js` bakes into the build.
+# Default: https://api.oxy.so
+EXPO_PUBLIC_API_URL=
+
+# Registered ApplicationCredential publicKey (`oxy_dk_...`) identifying this app
+# to Oxy. Used at runtime for session/OAuth and at build time for the OTA
+# manifest URL. Defaults to the real registered "Accounts by Oxy" credential, so
+# it only needs setting to point a build at a different registered application.
+EXPO_PUBLIC_OXY_CLIENT_ID=
+
+# OTA release channel this binary polls, matching the `--channel` passed to
+# `oxy-ship publish`. Baked into the build; changing it needs a new binary.
+# Default: production
+EXPO_PUBLIC_OXY_UPDATES_CHANNEL=
+
+# Registered OAuth redirect surface for this web origin. Must exactly match a
+# redirectUri on the application record.
+# Default: https://accounts.oxy.so
+EXPO_PUBLIC_OXY_AUTH_REDIRECT_URI=
+
+# Where the app sends someone who needs to create an Oxy account.
+# Default: https://oxy.so/download
+EXPO_PUBLIC_CREATE_ACCOUNT_URL=
+
+# Deep link into the Commons app's key-signed delete-account flow.
+# Default: commons://delete-account
+EXPO_PUBLIC_COMMONS_DELETE_URL=

--- a/packages/accounts/__tests__/updates/app-config-client-id.test.ts
+++ b/packages/accounts/__tests__/updates/app-config-client-id.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The Oxy Updates manifest URL is baked into the binary from `app.config.js`
+ * (CommonJS, build time), while every runtime Oxy call uses `constants/oxy.ts`
+ * (TypeScript, bundled). app.config.js cannot require the TypeScript constant, so
+ * the client id is written in both files, and this test is what keeps them equal.
+ *
+ * If they diverge, the app polls one application's update channel while
+ * authenticating as another, and nothing else in the build would notice.
+ */
+
+import { OXY_CLIENT_ID } from '@/constants/oxy';
+
+const UPDATES_PLUGIN = '@oxyhq/app-preset/plugin/withOxyUpdates';
+
+interface UpdatesPluginOptions {
+  clientId?: unknown;
+  channel?: unknown;
+}
+
+type PluginEntry = string | [string, UpdatesPluginOptions?];
+
+/** The `withOxyUpdates` entries in the app config's plugins array. */
+function updatesPluginEntries(): [string, UpdatesPluginOptions?][] {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const appConfig = require('../../app.config.js') as { expo: { plugins: PluginEntry[] } };
+  return appConfig.expo.plugins.filter(
+    (entry): entry is [string, UpdatesPluginOptions?] =>
+      Array.isArray(entry) && entry[0] === UPDATES_PLUGIN,
+  );
+}
+
+describe('app.config.js Oxy Updates wiring', () => {
+  it('registers the withOxyUpdates plugin exactly once', () => {
+    expect(updatesPluginEntries()).toHaveLength(1);
+  });
+
+  it('passes the same client id the runtime constant uses', () => {
+    // Guard against the assertion below passing vacuously on two empty values.
+    expect(OXY_CLIENT_ID).toMatch(/^oxy_dk_[0-9a-f]{48}$/);
+
+    const [, options] = updatesPluginEntries()[0];
+    expect(options?.clientId).toBe(OXY_CLIENT_ID);
+  });
+
+  it('tracks a non-empty release channel', () => {
+    const [, options] = updatesPluginEntries()[0];
+    expect(typeof options?.channel).toBe('string');
+    expect(options?.channel).not.toBe('');
+  });
+});

--- a/packages/accounts/app.config.js
+++ b/packages/accounts/app.config.js
@@ -8,6 +8,19 @@ const IS_DEV_VARIANT = process.env.APP_VARIANT === 'development';
 const APP_ID = IS_DEV_VARIANT ? 'so.oxy.accounts.dev' : 'so.oxy.accounts';
 const APP_NAME = IS_DEV_VARIANT ? 'Accounts (Dev)' : 'Accounts by Oxy';
 
+// Registered ApplicationCredential publicKey, used at BUILD time to bake this
+// app's Oxy Updates manifest URL into the binary. It must equal the runtime
+// value in `constants/oxy.ts` (that file cannot be required from here: it is
+// TypeScript and app.config.js is plain CommonJS), so
+// `__tests__/updates/app-config-client-id.test.ts` asserts the two agree.
+const OXY_CLIENT_ID =
+  process.env.EXPO_PUBLIC_OXY_CLIENT_ID ??
+  'oxy_dk_00f0e5d5a2e4697740a476d3cfc54f4490f01245d0d2dd05';
+
+// OTA release channel this binary polls. `oxy-ship publish --channel <name>`
+// writes to the matching channel.
+const OXY_UPDATES_CHANNEL = process.env.EXPO_PUBLIC_OXY_UPDATES_CHANNEL ?? 'production';
+
 module.exports = {
   expo: {
     name: APP_NAME,
@@ -101,6 +114,21 @@ module.exports = {
       // module now ships inside @oxyhq/services). Reader-only: it never hosts
       // the provider.
       '@oxyhq/services/plugins/withSharedIdentityReader',
+      // Oxy Updates (OTA). Points expo-updates at this app's manifest endpoint on
+      // the self-hosted update server in oxy-api, sets the runtimeVersion policy
+      // and wires the ecosystem code-signing certificate. `expo-updates` itself
+      // needs no entry here: prebuild applies its config plugin automatically for
+      // every installed versioned Expo SDK package.
+      [
+        '@oxyhq/app-preset/plugin/withOxyUpdates',
+        {
+          clientId: OXY_CLIENT_ID,
+          channel: OXY_UPDATES_CHANNEL,
+          ...(process.env.EXPO_PUBLIC_API_URL
+            ? { apiOrigin: process.env.EXPO_PUBLIC_API_URL }
+            : {}),
+        },
+      ],
     ],
     experiments: {
       typedRoutes: true,

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -55,6 +55,7 @@
     "expo-splash-screen": "catalog:",
     "expo-status-bar": "catalog:",
     "expo-system-ui": "catalog:",
+    "expo-updates": "~57.0.11",
     "expo-web-browser": "catalog:",
     "jszip": "catalog:",
     "lottie-react-native": "~7.3.8",

--- a/packages/app-preset/README.md
+++ b/packages/app-preset/README.md
@@ -17,6 +17,7 @@ and JSON.
 | Config plugin | `['@oxyhq/app-preset', {}]` | `withSharedUserId` + iOS keychain entitlement + `expo-build-properties` + `@oxyhq/services/plugins/withSharedIdentityReader` |
 | Android release build | `@oxyhq/app-preset/plugin/withOxyAndroidRelease` | R8 `-optimize` ProGuard file + shared-keystore release signing (opt-in, see below) |
 | Android WebP resources | `@oxyhq/app-preset/plugin/withOxyAndroidWebp` | re-encoding generated mipmaps/splash bitmaps to real lossless WebP (opt-in, needs `sharp`) |
+| Oxy Updates (OTA) | `@oxyhq/app-preset/plugin/withOxyUpdates` | the `expo-updates` manifest URL, release channel, `runtimeVersion` policy and the shared code-signing certificate (opt-in, see below) |
 | Metro | `@oxyhq/app-preset/metro` | monorepo watch folders, block list, symlink + package-exports resolution, web-font/wasm asset exts, release minifier, NativeWind wrapper |
 | Babel | `@oxyhq/app-preset/babel` | `babel-preset-expo` + `module-resolver` + `react-native-worklets/plugin` |
 | ESLint | `@oxyhq/app-preset/eslint` | `eslint-config-expo/flat` + `dist/*` ignore |
@@ -77,6 +78,57 @@ keystore, so **always verify the artefact's certificate** (`keytool -printcert
 -jarfile <aab>`, `apksigner verify --print-certs <apk>`) instead of assuming.
 
 `withOxyAndroidWebp` requires `sharp` as a devDependency of the app.
+
+#### Oxy Updates (OTA) (opt-in)
+
+`withOxyUpdates` points `expo-updates` at the self-hosted **Oxy Updates** server
+(`/updates/v1` in oxy-api) and wires the ecosystem code-signing certificate. It is
+opt-in because it needs the app's own registered client id.
+
+```js
+plugins: [
+  ['@oxyhq/app-preset/plugin/withOxyUpdates', { clientId: OXY_CLIENT_ID }],
+]
+```
+
+Prerequisites in the app: `expo-updates` as a dependency (at the version
+`expo install expo-updates` resolves for its SDK), and a registered
+`ApplicationCredential` publicKey (`oxy_dk_...`), normally already present as an
+`EXPO_PUBLIC_OXY_CLIENT_ID`-backed constant because the same id identifies the app
+to the session and OAuth flows. `expo-updates` needs no plugin entry of its own:
+prebuild applies its config plugin automatically.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `clientId` | required | The registered `ApplicationCredential` publicKey |
+| `apiOrigin` | `https://api.oxy.so` | Origin serving `/updates/v1` |
+| `channel` | `production` | Release channel this binary polls |
+| `codeSigning` | `auto` | `require` to fail the build when the certificate is missing; `false` to skip signing |
+| `certificatePath` | bundled certificate | Only for a key-rotation overlap |
+| `runtimeVersionPolicy` | `appVersion` | `false` leaves whatever the app declared |
+
+**runtimeVersion is the `appVersion` policy on purpose.** It is the only policy the
+Oxy toolchain resolves end to end: `oxy-ship` derives the publish runtime from
+`expo config --json --type public`, where `fingerprint` resolves only to the
+sentinel `file:fingerprint` (it is a build-time value), so a fingerprint app would
+need `--runtime-version` passed by hand on every publish. The rule that follows:
+**the app `version` is the OTA compatibility boundary. Bump it whenever native
+code changes.** Installs on the old `version` then correctly stop receiving
+updates published under the new one; installs on an unbumped version would
+receive JS assuming native modules they do not have.
+
+**Code signing is one certificate for the whole ecosystem**, shipped in this
+package at `certs/oxy-updates-code-signing.pem` rather than copied into each app
+repo, so a rotation is one preset bump. See `certs/README.md` for how it is
+generated and rotated. Until that file exists, `withOxyUpdates` wires the update
+URL but not signature verification and warns on both platforms; because the
+certificate is baked into the native build, a binary shipped in that state can
+never verify a manifest for its lifetime, so **do not ship a store build of an
+OTA-enabled app before the certificate is committed.** Pass
+`{ codeSigning: 'require' }` to make that a build failure instead of a warning.
+
+Publishing is `oxy-ship` (`@oxyhq/ship`); see that package's README and its
+`templates/publish-update.yml` CI workflow.
 
 ### 2. Metro (`metro.config.js`)
 

--- a/packages/app-preset/__tests__/withOxyUpdates.test.js
+++ b/packages/app-preset/__tests__/withOxyUpdates.test.js
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for the withOxyUpdates config plugin.
+ *
+ * Run with the package's own `bun run test` (Node's built-in test runner, so a
+ * zero-build config package stays dependency-free).
+ *
+ * The certificate cases use a temporary file rather than the real bundled path.
+ * Writing a placeholder into `certs/` would be actively dangerous: a leftover
+ * file there is indistinguishable from a real certificate to every consumer, and
+ * would make builds look signature-verifying while trusting nothing.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const withOxyUpdates = require('../plugin/withOxyUpdates');
+
+const CLIENT_ID = 'oxy_dk_0123456789abcdef0123456789abcdef0123456789abcdef';
+const PROJECT_ROOT = path.join(os.tmpdir(), 'oxy-app-preset-test-project');
+
+/** Minimal ExpoConfig shape carrying the internals a static plugin receives. */
+function baseConfig(extra = {}) {
+  return { name: 'Test', slug: 'test', _internal: { projectRoot: PROJECT_ROOT }, ...extra };
+}
+
+/** Write a throwaway certificate file and hand its path to `fn`, always cleaning up. */
+function withTemporaryCertificate(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oxy-updates-cert-'));
+  const file = path.join(dir, 'oxy-updates-code-signing.pem');
+  fs.writeFileSync(file, '-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n');
+  try {
+    return fn(file);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('rejects a missing or blank clientId', () => {
+  assert.throws(() => withOxyUpdates(baseConfig(), {}), /non-empty `clientId` is required/);
+  assert.throws(() => withOxyUpdates(baseConfig(), { clientId: '  ' }), /non-empty `clientId`/);
+});
+
+test('builds the manifest URL from the client id and the default origin', () => {
+  const config = withOxyUpdates(baseConfig(), { clientId: CLIENT_ID });
+  assert.equal(
+    config.updates.url,
+    `https://api.oxy.so/updates/v1/apps/${CLIENT_ID}/manifest`,
+  );
+});
+
+test('honours an explicit apiOrigin and strips its trailing slashes', () => {
+  const config = withOxyUpdates(baseConfig(), {
+    clientId: CLIENT_ID,
+    apiOrigin: 'http://localhost:3001//',
+  });
+  assert.equal(
+    config.updates.url,
+    `http://localhost:3001/updates/v1/apps/${CLIENT_ID}/manifest`,
+  );
+});
+
+test('sets the channel request header without dropping existing headers', () => {
+  const config = withOxyUpdates(
+    baseConfig({ updates: { requestHeaders: { 'x-existing': 'kept' } } }),
+    { clientId: CLIENT_ID, channel: 'pr-42' },
+  );
+  assert.deepEqual(config.updates.requestHeaders, {
+    'x-existing': 'kept',
+    'expo-channel-name': 'pr-42',
+  });
+});
+
+test('defaults the runtime version to the appVersion policy', () => {
+  const config = withOxyUpdates(baseConfig(), { clientId: CLIENT_ID });
+  assert.deepEqual(config.runtimeVersion, { policy: 'appVersion' });
+});
+
+test('honours another runtime version policy, and leaves the app value alone when false', () => {
+  const fingerprint = withOxyUpdates(baseConfig(), {
+    clientId: CLIENT_ID,
+    runtimeVersionPolicy: 'fingerprint',
+  });
+  assert.deepEqual(fingerprint.runtimeVersion, { policy: 'fingerprint' });
+
+  const untouched = withOxyUpdates(baseConfig({ runtimeVersion: '9.9.9' }), {
+    clientId: CLIENT_ID,
+    runtimeVersionPolicy: false,
+  });
+  assert.equal(untouched.runtimeVersion, '9.9.9');
+});
+
+test('wires the certificate as a project-relative path, with metadata matching the server', () => {
+  withTemporaryCertificate((certificatePath) => {
+    const config = withOxyUpdates(baseConfig(), { clientId: CLIENT_ID, certificatePath });
+
+    // expo-updates resolves this as `path.join(projectRoot, value)`, so the value
+    // must be relative and must land back on the real file.
+    assert.equal(config.updates.codeSigningCertificate, path.relative(PROJECT_ROOT, certificatePath));
+    assert.ok(!path.isAbsolute(config.updates.codeSigningCertificate));
+    assert.equal(
+      path.join(PROJECT_ROOT, config.updates.codeSigningCertificate),
+      certificatePath,
+    );
+
+    // Must equal CODE_SIGNING_KEY_ID / CODE_SIGNING_ALG in oxy-api's
+    // services/updates/signing.service.ts, or every signature check fails.
+    assert.deepEqual(config.updates.codeSigningMetadata, {
+      keyid: 'main',
+      alg: 'rsa-v1_5-sha256',
+    });
+  });
+});
+
+test('skips signing entirely when codeSigning is false, even with a certificate present', () => {
+  withTemporaryCertificate((certificatePath) => {
+    const config = withOxyUpdates(baseConfig(), {
+      clientId: CLIENT_ID,
+      certificatePath,
+      codeSigning: false,
+    });
+    assert.equal(config.updates.codeSigningCertificate, undefined);
+    assert.equal(config.updates.codeSigningMetadata, undefined);
+    // The update URL is still wired: only verification is opted out of.
+    assert.ok(config.updates.url.includes(CLIENT_ID));
+  });
+});
+
+test('throws when the certificate is absent and codeSigning is require', () => {
+  assert.throws(
+    () =>
+      withOxyUpdates(baseConfig(), {
+        clientId: CLIENT_ID,
+        certificatePath: path.join(os.tmpdir(), 'oxy-updates-absent.pem'),
+        codeSigning: 'require',
+      }),
+    /code signing is required but the Oxy Updates certificate is missing/,
+  );
+});
+
+test('wires the URL but no signing when the certificate is absent and codeSigning is auto', () => {
+  const config = withOxyUpdates(baseConfig(), {
+    clientId: CLIENT_ID,
+    certificatePath: path.join(os.tmpdir(), 'oxy-updates-absent.pem'),
+  });
+  assert.ok(config.updates.url.includes(CLIENT_ID));
+  assert.equal(config.updates.codeSigningCertificate, undefined);
+});
+
+test('fails loudly when the project root is unavailable and a certificate must be wired', () => {
+  withTemporaryCertificate((certificatePath) => {
+    assert.throws(
+      () => withOxyUpdates({ name: 'Test', slug: 'test' }, { clientId: CLIENT_ID, certificatePath }),
+      /could not resolve the project root/,
+    );
+  });
+});

--- a/packages/app-preset/certs/README.md
+++ b/packages/app-preset/certs/README.md
@@ -1,0 +1,54 @@
+# Oxy Updates code-signing certificate
+
+`withOxyUpdates` looks for exactly one file in this directory:
+
+```
+oxy-updates-code-signing.pem
+```
+
+It is the **public** half of the Oxy Updates code-signing keypair. It is safe to
+commit, and it lives here rather than in each app repo so that a key rotation is
+one `@oxyhq/app-preset` bump instead of one edit per app.
+
+The file is absent until the ecosystem keypair is generated. While it is absent
+`withOxyUpdates` still wires the update URL, but the resulting binaries do **not**
+verify manifest signatures, and it emits a build warning saying so.
+
+## Provisioning (one time, by the platform owner)
+
+From `packages/api` in the OxyHQServices repo:
+
+```bash
+bun scripts/generate-updates-code-signing.ts \
+  ../app-preset/certs/oxy-updates-code-signing.pem
+```
+
+That writes the certificate here and prints the base64-encoded private key PEM to
+stdout. Then:
+
+1. Set the printed value as the GitHub Actions secret
+   `UPDATES_CODE_SIGNING_PRIVATE_KEY` on the OxyHQServices repo. The deploy
+   workflow syncs it to SSM `/oxy/oxy-api/UPDATES_CODE_SIGNING_PRIVATE_KEY`, and
+   oxy-api reads it in `services/updates/signing.service.ts`.
+2. Commit **only** the certificate. The private key is never written to disk by
+   the script and must never enter the repo.
+3. Clear the terminal scrollback.
+
+Verify the server picked it up: a manifest request that asks for a signature must
+stop returning HTTP 500.
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H 'expo-protocol-version: 1' -H 'expo-platform: ios' \
+  -H 'expo-runtime-version: 1.0.0' -H 'expo-channel-name: production' \
+  -H 'expo-expect-signature: sig, keyid="main", alg="rsa-v1_5-sha256"' \
+  https://api.oxy.so/updates/v1/apps/<clientId>/manifest
+```
+
+## Rotation
+
+The certificate is baked into a native binary at build time, so a rotation only
+reaches devices that install a NEW binary carrying the new certificate. Rotate by
+generating a new pair, shipping the new certificate in a store release first, and
+only switching the server's private key once that release has taken over. Devices
+still on the old binary will reject manifests signed by the new key.

--- a/packages/app-preset/package.json
+++ b/packages/app-preset/package.json
@@ -15,6 +15,7 @@
     "./plugin/withOxyBuildProperties": "./plugin/withOxyBuildProperties.js",
     "./plugin/withOxyAndroidRelease": "./plugin/withOxyAndroidRelease.js",
     "./plugin/withOxyAndroidWebp": "./plugin/withOxyAndroidWebp.js",
+    "./plugin/withOxyUpdates": "./plugin/withOxyUpdates.js",
     "./metro": "./metro/index.js",
     "./babel": "./babel/index.js",
     "./eslint": "./eslint/index.js",
@@ -31,6 +32,7 @@
     "metro",
     "babel",
     "eslint",
+    "certs",
     "css",
     "tsconfig",
     "README.md"
@@ -58,7 +60,7 @@
   },
   "scripts": {
     "prepublishOnly": "node ../../scripts/assert-bun-publish.mjs",
-    "test": "echo \"@oxyhq/app-preset is a zero-build config package — no unit tests\" && exit 0"
+    "test": "node --test __tests__/*.test.js"
   },
   "peerDependencies": {
     "@oxyhq/bloom": "*",

--- a/packages/app-preset/plugin/withOxyUpdates.js
+++ b/packages/app-preset/plugin/withOxyUpdates.js
@@ -1,0 +1,151 @@
+/**
+ * Expo Config Plugin: withOxyUpdates
+ *
+ * Points `expo-updates` at the self-hosted **Oxy Updates** server (`/updates/v1`
+ * in oxy-api) and wires the ecosystem code-signing certificate, so an app opts
+ * into OTA with one plugin entry plus its own client id instead of a hand-written
+ * `updates` block, a per-repo certificate copy, and a per-repo runtime-version
+ * policy that drift apart.
+ *
+ * In app.config.js:
+ *
+ *   plugins: [
+ *     'expo-updates',
+ *     ['@oxyhq/app-preset/plugin/withOxyUpdates', { clientId: OXY_CLIENT_ID }],
+ *   ]
+ *
+ * What it sets:
+ *   - `updates.url` = `<apiOrigin>/updates/v1/apps/<clientId>/manifest`
+ *   - `updates.requestHeaders['expo-channel-name']` = the release channel
+ *   - `updates.codeSigningCertificate` + `updates.codeSigningMetadata` (see below)
+ *   - `runtimeVersion` = `{ policy: 'appVersion' }`
+ *
+ * **runtimeVersion policy: `appVersion`, deliberately.** It is the only policy the
+ * whole Oxy toolchain can resolve end to end. `oxy-ship` derives the publish
+ * runtime from `expo config --json --type public`, and `fingerprint` resolves
+ * there to the sentinel `file:fingerprint` (it is computed at BUILD time, not at
+ * config time), so a fingerprint app would have to pass `--runtime-version` by
+ * hand on every publish. The consequence is a rule to keep: **the app `version`
+ * is the OTA compatibility boundary.** Bump it whenever native code changes.
+ * Installs on the old `version` then correctly stop receiving updates published
+ * under the new one, whereas installs on an UNBUMPED version would receive JS
+ * that assumes native modules they do not have.
+ *
+ * **Code signing.** The Oxy Updates server signs manifests with
+ * `rsa-v1_5-sha256` under keyid `main` (`CODE_SIGNING_ALG` / `CODE_SIGNING_KEY_ID`
+ * in oxy-api's `services/updates/signing.service.ts`); those two values are
+ * mirrored here and must be changed together. The matching PUBLIC certificate is
+ * a single ecosystem-wide file shipped inside this package
+ * (`certs/oxy-updates-code-signing.pem`) rather than copied into every app repo,
+ * so a key rotation is one preset bump instead of thirteen.
+ *
+ * Until that certificate is committed the plugin wires the update URL but NOT
+ * signature verification, and warns on both platforms. A binary built in that
+ * state can never verify a manifest signature for its whole lifetime, because the
+ * certificate is baked into the native build, so **do not ship a store build of
+ * an OTA-enabled app before the certificate exists.** Pass
+ * `{ codeSigning: 'require' }` to turn that warning into a hard build failure.
+ *
+ * @param {import('expo/config').ExpoConfig} config
+ * @param {object} options
+ * @param {string} options.clientId Registered `ApplicationCredential` publicKey
+ *   (`oxy_dk_...`) identifying this app to the update server. Required.
+ * @param {string} [options.apiOrigin='https://api.oxy.so'] Origin serving `/updates/v1`.
+ * @param {string} [options.channel='production'] Release channel this binary tracks.
+ * @param {'auto'|'require'|false} [options.codeSigning='auto'] `auto` wires
+ *   signing when the certificate is present and warns when it is not; `require`
+ *   throws when it is absent; `false` skips signing entirely.
+ * @param {string} [options.certificatePath] Absolute path to a different
+ *   certificate than the bundled one. Normally unset; it exists for the overlap
+ *   window of a key rotation, where one binary has to trust an incoming
+ *   certificate the rest of the ecosystem has not moved to yet.
+ * @param {'appVersion'|'nativeVersion'|'sdkVersion'|'fingerprint'|false} [options.runtimeVersionPolicy='appVersion']
+ *   `false` leaves whatever the app declared.
+ */
+const fs = require('fs');
+const path = require('path');
+const { WarningAggregator } = require('expo/config-plugins');
+
+/** Origin of the Oxy Updates server. `updates.oxy.so` does not exist; oxy-api serves it. */
+const DEFAULT_API_ORIGIN = 'https://api.oxy.so';
+
+/** Channel a binary tracks unless it opts into a preview track. */
+const DEFAULT_CHANNEL = 'production';
+
+/** Mirrors `CODE_SIGNING_KEY_ID` in oxy-api `services/updates/signing.service.ts`. */
+const CODE_SIGNING_KEY_ID = 'main';
+
+/** Mirrors `CODE_SIGNING_ALG` in oxy-api `services/updates/signing.service.ts`. */
+const CODE_SIGNING_ALG = 'rsa-v1_5-sha256';
+
+/**
+ * The one ecosystem-wide PUBLIC code-signing certificate, generated together with
+ * the server's private key by oxy-api's `scripts/generate-updates-code-signing.ts`.
+ */
+const CERTIFICATE_PATH = path.join(__dirname, '..', 'certs', 'oxy-updates-code-signing.pem');
+
+/** Plugin name used in build warnings and errors. */
+const PLUGIN_NAME = '@oxyhq/app-preset/plugin/withOxyUpdates';
+
+module.exports = function withOxyUpdates(config, options = {}) {
+  const {
+    clientId,
+    apiOrigin = DEFAULT_API_ORIGIN,
+    channel = DEFAULT_CHANNEL,
+    codeSigning = 'auto',
+    certificatePath = CERTIFICATE_PATH,
+    runtimeVersionPolicy = 'appVersion',
+  } = options;
+
+  if (typeof clientId !== 'string' || clientId.trim().length === 0) {
+    throw new Error(
+      `[${PLUGIN_NAME}] a non-empty \`clientId\` is required. Pass this app's registered `
+        + 'ApplicationCredential publicKey (oxy_dk_...), normally from an '
+        + 'EXPO_PUBLIC_OXY_CLIENT_ID-backed constant.',
+    );
+  }
+
+  const updates = { ...config.updates };
+  updates.url = `${apiOrigin.replace(/\/+$/, '')}/updates/v1/apps/${clientId}/manifest`;
+  updates.requestHeaders = { ...updates.requestHeaders, 'expo-channel-name': channel };
+
+  if (codeSigning !== false) {
+    if (fs.existsSync(certificatePath)) {
+      const projectRoot = config._internal?.projectRoot;
+      if (typeof projectRoot !== 'string') {
+        throw new Error(
+          `[${PLUGIN_NAME}] could not resolve the project root from the Expo config, so the `
+            + 'code-signing certificate path cannot be made project-relative (expo-updates joins it '
+            + 'onto the project root). Upgrade @expo/config, or pass `{ codeSigning: false }`.',
+        );
+      }
+      // expo-updates reads this as `path.join(projectRoot, value)`, so it must be
+      // relative: an absolute path would be appended to the project root.
+      updates.codeSigningCertificate = path.relative(projectRoot, certificatePath);
+      updates.codeSigningMetadata = { keyid: CODE_SIGNING_KEY_ID, alg: CODE_SIGNING_ALG };
+    } else if (codeSigning === 'require') {
+      throw new Error(
+        `[${PLUGIN_NAME}] code signing is required but the Oxy Updates certificate is missing at `
+          + `${certificatePath}. Generate the ecosystem keypair with oxy-api's `
+          + '`bun scripts/generate-updates-code-signing.ts`, commit the certificate into '
+          + '@oxyhq/app-preset, and set the private key as UPDATES_CODE_SIGNING_PRIVATE_KEY on oxy-api.',
+      );
+    } else {
+      const warning =
+        'The Oxy Updates code-signing certificate is not present in @oxyhq/app-preset, so this build '
+        + 'will accept UNSIGNED update manifests for its entire lifetime (the certificate is baked in '
+        + 'at build time). Do not ship this binary to a store. See the app-preset README, section '
+        + '"Oxy Updates (OTA)".';
+      WarningAggregator.addWarningForPlatform('android', PLUGIN_NAME, warning);
+      WarningAggregator.addWarningForPlatform('ios', PLUGIN_NAME, warning);
+    }
+  }
+
+  const next = { ...config, updates };
+
+  if (runtimeVersionPolicy !== false) {
+    next.runtimeVersion = { policy: runtimeVersionPolicy };
+  }
+
+  return next;
+};

--- a/packages/app-preset/plugin/withOxyUpdates.js
+++ b/packages/app-preset/plugin/withOxyUpdates.js
@@ -105,8 +105,16 @@ module.exports = function withOxyUpdates(config, options = {}) {
     );
   }
 
+  // Trimmed with a loop rather than a `/\/+$/` regex: an anchored repetition is
+  // the polynomial-ReDoS shape CodeQL flags (js/polynomial-redos), and this is
+  // linear and just as clear.
+  let origin = apiOrigin;
+  while (origin.endsWith('/')) {
+    origin = origin.slice(0, -1);
+  }
+
   const updates = { ...config.updates };
-  updates.url = `${apiOrigin.replace(/\/+$/, '')}/updates/v1/apps/${clientId}/manifest`;
+  updates.url = `${origin}/updates/v1/apps/${clientId}/manifest`;
   updates.requestHeaders = { ...updates.requestHeaders, 'expo-channel-name': channel };
 
   if (codeSigning !== false) {

--- a/packages/commons/.env.example
+++ b/packages/commons/.env.example
@@ -1,0 +1,24 @@
+# Commons by Oxy - environment template. Copy to `.env` and edit as needed.
+# Every variable here is EXPO_PUBLIC_*, so it is inlined into the JS bundle and
+# readable by anyone with the binary. Never put a secret in this file.
+
+# Oxy API origin. Also the origin of the Oxy Updates server (`/updates/v1`), so
+# changing it repoints both the API client and the OTA manifest URL that
+# `app.config.js` bakes into the build.
+# Default: https://api.oxy.so
+EXPO_PUBLIC_API_URL=
+
+# Registered ApplicationCredential publicKey (`oxy_dk_...`) identifying this app
+# to Oxy. Used at runtime for session/OAuth and at build time for the OTA
+# manifest URL. Defaults to the real registered "Commons by Oxy" credential, so
+# it only needs setting to point a build at a different registered application.
+EXPO_PUBLIC_OXY_CLIENT_ID=
+
+# OTA release channel this binary polls, matching the `--channel` passed to
+# `oxy-ship publish`. Baked into the build; changing it needs a new binary.
+# Default: production
+EXPO_PUBLIC_OXY_UPDATES_CHANNEL=
+
+# Where the app sends someone who needs to create an Oxy account.
+# Default: https://oxy.so/download
+EXPO_PUBLIC_CREATE_ACCOUNT_URL=

--- a/packages/commons/__tests__/updates/app-config-client-id.test.ts
+++ b/packages/commons/__tests__/updates/app-config-client-id.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The Oxy Updates manifest URL is baked into the binary from `app.config.js`
+ * (CommonJS, build time), while every runtime Oxy call uses `constants/oxy.ts`
+ * (TypeScript, bundled). app.config.js cannot require the TypeScript constant, so
+ * the client id is written in both files, and this test is what keeps them equal.
+ *
+ * If they diverge, the app polls one application's update channel while
+ * authenticating as another, and nothing else in the build would notice.
+ */
+
+import { OXY_CLIENT_ID } from '@/constants/oxy';
+
+const UPDATES_PLUGIN = '@oxyhq/app-preset/plugin/withOxyUpdates';
+
+interface UpdatesPluginOptions {
+  clientId?: unknown;
+  channel?: unknown;
+}
+
+type PluginEntry = string | [string, UpdatesPluginOptions?];
+
+/** The `withOxyUpdates` entries in the app config's plugins array. */
+function updatesPluginEntries(): [string, UpdatesPluginOptions?][] {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const appConfig = require('../../app.config.js') as { expo: { plugins: PluginEntry[] } };
+  return appConfig.expo.plugins.filter(
+    (entry): entry is [string, UpdatesPluginOptions?] =>
+      Array.isArray(entry) && entry[0] === UPDATES_PLUGIN,
+  );
+}
+
+describe('app.config.js Oxy Updates wiring', () => {
+  it('registers the withOxyUpdates plugin exactly once', () => {
+    expect(updatesPluginEntries()).toHaveLength(1);
+  });
+
+  it('passes the same client id the runtime constant uses', () => {
+    // Guard against the assertion below passing vacuously on two empty values.
+    expect(OXY_CLIENT_ID).toMatch(/^oxy_dk_[0-9a-f]{48}$/);
+
+    const [, options] = updatesPluginEntries()[0];
+    expect(options?.clientId).toBe(OXY_CLIENT_ID);
+  });
+
+  it('tracks a non-empty release channel', () => {
+    const [, options] = updatesPluginEntries()[0];
+    expect(typeof options?.channel).toBe('string');
+    expect(options?.channel).not.toBe('');
+  });
+});

--- a/packages/commons/app.config.js
+++ b/packages/commons/app.config.js
@@ -11,6 +11,19 @@ const IS_DEV_VARIANT = process.env.APP_VARIANT === 'development';
 const APP_ID = IS_DEV_VARIANT ? 'so.oxy.commons.dev' : 'so.oxy.commons';
 const APP_NAME = IS_DEV_VARIANT ? 'Commons (Dev)' : 'Commons by Oxy';
 
+// Registered ApplicationCredential publicKey, used at BUILD time to bake this
+// app's Oxy Updates manifest URL into the binary. It must equal the runtime
+// value in `constants/oxy.ts` (that file cannot be required from here: it is
+// TypeScript and app.config.js is plain CommonJS), so
+// `__tests__/updates/app-config-client-id.test.ts` asserts the two agree.
+const OXY_CLIENT_ID =
+  process.env.EXPO_PUBLIC_OXY_CLIENT_ID ??
+  'oxy_dk_f65326da2a0d106bf98e873ce19b0ca9094d6c0c1f845a18';
+
+// Channel this binary polls. `production` unless a preview build overrides it;
+// `oxy-ship publish --channel <name>` writes to the matching channel.
+const OXY_UPDATES_CHANNEL = process.env.EXPO_PUBLIC_OXY_UPDATES_CHANNEL ?? 'production';
+
 module.exports = {
   expo: {
     name: APP_NAME,
@@ -136,6 +149,21 @@ module.exports = {
       // shared identity keypair Commons writes. Commons is the ONLY app that
       // hosts it.
       '@oxyhq/services/plugins/withSharedIdentityProvider',
+      // Oxy Updates (OTA). Points expo-updates at this app's manifest endpoint on
+      // the self-hosted update server in oxy-api, sets the runtimeVersion policy
+      // and wires the ecosystem code-signing certificate. `expo-updates` itself
+      // needs no entry here: prebuild applies its config plugin automatically for
+      // every installed versioned Expo SDK package.
+      [
+        '@oxyhq/app-preset/plugin/withOxyUpdates',
+        {
+          clientId: OXY_CLIENT_ID,
+          channel: OXY_UPDATES_CHANNEL,
+          ...(process.env.EXPO_PUBLIC_API_URL
+            ? { apiOrigin: process.env.EXPO_PUBLIC_API_URL }
+            : {}),
+        },
+      ],
       'expo-secure-store',
       'expo-font',
       'expo-image',

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -51,6 +51,7 @@
     "expo-status-bar": "catalog:",
     "expo-symbols": "catalog:",
     "expo-system-ui": "catalog:",
+    "expo-updates": "~57.0.11",
     "expo-web-browser": "catalog:",
     "lottie-react-native": "~7.3.8",
     "nativewind": "catalog:",

--- a/packages/ship/templates/publish-update.yml
+++ b/packages/ship/templates/publish-update.yml
@@ -8,8 +8,13 @@
 # Prerequisites:
 #   - Repo secrets OXY_SHIP_CLIENT_ID / OXY_SHIP_SECRET: a `service`-type
 #     ApplicationCredential for THIS app, granted the `updates:publish` scope.
+#     This is a DIFFERENT credential from the app's public `oxy_dk_` client id.
 #   - The app embeds the Oxy Updates code-signing certificate and points
 #     expo-updates at https://api.oxy.so/updates/v1/apps/<clientId>/manifest.
+#     Both come from `@oxyhq/app-preset/plugin/withOxyUpdates`; see that
+#     package's README, section "Oxy Updates (OTA)".
+#   - oxy-api has UPDATES_CODE_SIGNING_PRIVATE_KEY configured. Without it every
+#     manifest request that asks for a signature answers HTTP 500.
 #   - `bunx oxy-ship` (from `@oxyhq/ship` on npm, or a workspace checkout).
 #
 # This publishes ONLY the OTA update. It does NOT build native binaries.


### PR DESCRIPTION
## What

The Oxy Updates server (`/updates/v1` in oxy-api) and the `oxy-ship` CLI both already exist and neither had a consumer. Across `Mention`, `Homiio`, `Allo`, `Syra`, `Alia`, `Mercaria`, `Moovo`, `Clarity`, `CrowdSource` and `OxyHQServices`, zero `package.json` depended on `expo-updates` and zero app config carried an `updates` block or a `runtimeVersion`.

The shared half goes into `@oxyhq/app-preset` as a new `withOxyUpdates` config plugin, not into each app. It sets:

- `updates.url` = `<apiOrigin>/updates/v1/apps/<clientId>/manifest`
- `updates.requestHeaders['expo-channel-name']` = the release channel
- `updates.codeSigningCertificate` + `updates.codeSigningMetadata`
- `runtimeVersion` = `{ policy: 'appVersion' }`

Commons and Accounts consume it. Each needed only `expo-updates` plus one plugin entry, because both already had a registered `oxy_dk_` client id.

## Why the preset owns this

The only per-app value is the client id. The manifest URL shape, the channel header, the runtime-version policy, the signing algorithm and the certificate are identical for every Oxy app, so putting them in the preset is the difference between one place and thirteen copies to drift. The certificate matters most: it is a single public file, and shipping it in the preset makes a key rotation one version bump instead of one edit per app repo.

## Why `runtimeVersion: appVersion`

`appVersion` is the only policy the Oxy toolchain can resolve end to end. `oxy-ship` derives the publish runtime from `expo config --json --type public` (`packages/ship/src/metadata.ts` `resolveRuntimeVersion`), and the `fingerprint` policy resolves there only to the sentinel `file:fingerprint`, because it is computed at build time. A fingerprint app would need `--runtime-version` passed by hand on every publish, and `nativeVersion` changes on every build-number bump.

The rule that follows and has to be kept: **the app `version` is the OTA compatibility boundary. Bump it whenever native code changes.** Installs on the old `version` then correctly stop receiving updates published under the new one. Installs on an unbumped version would receive JS assuming native modules they do not have.

## Code signing is not active yet, and that blocks shipping

Verified against production today: a manifest request that asks for a signature answers HTTP 500 for every registered Oxy client id, because oxy-api has no `UPDATES_CODE_SIGNING_PRIVATE_KEY`.

```
$ curl -H 'expo-protocol-version: 1' -H 'expo-platform: ios' \
       -H 'expo-runtime-version: 1.0.0' -H 'expo-channel-name: production' \
       -H 'expo-expect-signature: sig, keyid="main", alg="rsa-v1_5-sha256"' \
       https://api.oxy.so/updates/v1/apps/<commons-client-id>/manifest
500 {"error":"Code signing is not configured on this server."}
```

Without that header the same request returns a valid `noUpdateAvailable` directive, and an unregistered id returns 404, so the route and the app resolution are healthy. The provisioning steps are in `packages/app-preset/certs/README.md`. **No keys were generated in this PR.**

Until the certificate is committed, `withOxyUpdates` wires the update URL but not signature verification, and warns on both platforms through `WarningAggregator`. Because the certificate is baked into the native build, a binary shipped in that state can never verify a manifest for its whole lifetime, so no store build of an OTA-enabled app should go out before the certificate exists. `{ codeSigning: 'require' }` turns the warning into a build failure for anyone who wants the harder guarantee now.

## Verified

- `bunx expo config --json --type prebuild` on Commons and Accounts resolves each app's own manifest URL, `{"policy":"appVersion"}`, and the channel header.
- `bunx expo config --json --type introspect` on Commons (run once against a throwaway certificate, generated in a scratch directory and deleted, never committed and never installed anywhere) embeds `EXUpdatesURL`, `EXUpdatesRuntimeVersion=1.1.0`, `EXUpdatesCodeSigningCertificate` (the PEM read from the preset path) and `EXUpdatesCodeSigningMetadata={"keyid":"main","alg":"rsa-v1_5-sha256"}`, matching `CODE_SIGNING_KEY_ID` / `CODE_SIGNING_ALG` in `packages/api/src/services/updates/signing.service.ts`.
- `oxy-ship publish --dry-run --platform all` against Commons: `expo export` produced iOS and Android Hermes bundles, ship resolved runtime `1.1.0` from the policy and counted 42 unique assets, with no API calls.
- `packages/app-preset`: 11 new tests, all passing. Three mutations (wrong signing alg, absolute certificate path, `auto` silently behaving as `require`) each turn the suite red.
- `packages/commons`: 570 tests across 64 suites pass, `tsc --noEmit` clean. `packages/accounts`: 140 tests across 16 suites pass. Two mutations of the new drift test (divergent client id, missing plugin entry) each turn it red.
- `rm -rf packages/*/node_modules && bun install` after each native dependency change; lockfile byte-stable across two installs and `scripts/check-lockfile-sync.mjs` passes on the committed tree.

## Not verified

- No device or simulator run. Per the repo's on-device hazard rule, nothing was installed on Android.
- No real OTA was published to any channel.
- Signature verification on a device has never been exercised, because no signing key exists.
- `packages/accounts` `tsc --noEmit` fails with one pre-existing `TS2882` on `global.css`. Confirmed pre-existing by reverting both changed accounts files to `HEAD` and reproducing the identical error.
- `expo-doctor` reports the same two pre-existing failures as before (the Metro `unstable_enableSymlinks` note, and packages behind their SDK-expected patch). All but one of those predate this PR; `expo-updates` is pinned `~57.0.11` rather than the `~57.0.12` expo resolves, because the repo's 7-day `minimumReleaseAge` quarantine in `bunfig.toml` blocks 57.0.12 (published 2026-08-04). The range accepts 57.0.12 on the next install once the quarantine lapses.

## Before this can publish anything

1. Generate the ecosystem code-signing keypair and commit the certificate (`packages/app-preset/certs/README.md`), then set `UPDATES_CODE_SIGNING_PRIVATE_KEY` as a GitHub Actions secret on this repo so it syncs to SSM `/oxy/oxy-api/UPDATES_CODE_SIGNING_PRIVATE_KEY`.
2. Mint a `service`-type `ApplicationCredential` with the `updates:publish` scope per app, and set `OXY_SHIP_CLIENT_ID` / `OXY_SHIP_SECRET` in each repo. This is a different credential from the public `oxy_dk_` client id, which cannot publish.
3. Commons still has an empty `extra.eas.projectId`, so it cannot be EAS-built yet. Accounts already has a real one.

## Deliberately not included

- **Inbox.** It has no `eas.json` and deploys only as a Cloudflare Pages web export, so it ships no native binary for an OTA to update. Wiring it would be speculative.
- **The nine other app repos.** Eight of them (`Mention`, `Homiio`, `Allo`, `Syra`, `Alia`, `Mercaria`, `Clarity`, `CrowdSource`) do not depend on `@oxyhq/app-preset` at all, so adopting this needs the preset added first; only `Moovo` already has it, at `^0.1.0`. All of them are blocked on `@oxyhq/app-preset` being republished with `withOxyUpdates`, since the published `0.1.0` does not contain it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
