### PR TITLE
chore(app-preset): 0.3.0 — first release carrying withOxyUpdates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -185,7 +185,7 @@
     },
     "packages/app-preset": {
       "name": "@oxyhq/app-preset",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "peerDependencies": {
         "@oxyhq/bloom": "*",
         "@oxyhq/services": "*",

--- a/packages/app-preset/package.json
+++ b/packages/app-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/app-preset",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The Oxy distro of Expo — centralized Expo config plugin, Metro/Babel/ESLint factories, Tailwind base CSS and TypeScript bases shared by every Oxy app (Mention, Homiio, Allo, accounts, …). A zero-build package: apps replace copy-pasted config with a single dependency bump.",
   "main": "./app.plugin.js",
   "publishConfig": {


### PR DESCRIPTION
## Why

`@oxyhq/app-preset@0.2.0` was published from a worktree cut at `a36753b8`, minutes before #843 merged. The released tarball therefore has **no `plugin/withOxyUpdates.js`** and no `exports['./plugin/withOxyUpdates']`. Verified against a clean install from the registry:

```
$ ls node_modules/@oxyhq/app-preset/plugin/
withOxyAndroidRelease.js  withOxyAndroidWebp.js  withOxyAppPreset.js
withOxyBuildProperties.js withOxyKeychain.js     withSharedUserId.js
$ node -e "require.resolve('@oxyhq/app-preset/plugin/withOxyUpdates')"
ERR_PACKAGE_PATH_NOT_EXPORTED
```

npm never allows republishing a version, so 0.2.0 cannot be repaired. This cuts 0.3.0 as the first release that actually carries the plugin.

## What is in here

Only the version bump plus the regenerated lockfile. **No source change** — the plugin, `certs/` and the `node --test` script all landed in #843; they were simply published-around.

## Verification

- `packages/app-preset/plugin/withOxyUpdates.js` present, and `exports['./plugin/withOxyUpdates']` declared, in this branch.
- `bun.lock` regenerated in the **same commit**; its recorded workspace `version` moves `0.2.0` → `0.3.0` (a plain `bun install` does rewrite it in this repo, as `check-lockfile-sync.mjs` documents). Diff is exactly two lines, no collateral resolution drift.
- `bun scripts/check-lockfile-sync.mjs` → `bun.lock is in sync with every package.json.` (exit 0)
- `bun scripts/test-check-lockfile-sync.mjs` → 8 fixture cases discriminated
- `bun run test` in `packages/app-preset` → 11/11 passing

## Follow-up, not in this PR

`create-oxy-app` pins `oxyAppPreset: '^0.2.0'` in `src/versions.ts`. On a `0.x` version a caret is patch-only (`>=0.2.0 <0.3.0`), so **scaffolded apps will not pick up 0.3.0** — they are the only consumers that resolve `app-preset` from the registry rather than by `workspace:*`. Making 0.3.0 reachable for them needs that pin bumped to `^0.3.0` *and* `create-oxy-app` itself republished. Raised separately since it is a second package release.

(Unrelated pre-existing drift noticed in the same file: `oxyBloom: '^0.67.0'` against a live `0.87.0`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)