### PR TITLE
Declare which chain collections may be published, and default to no

### DIFF
--- a/packages/api/src/config/__tests__/chainCollectionPolicy.test.ts
+++ b/packages/api/src/config/__tests__/chainCollectionPolicy.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The chain-collection policy — the one place that knows which collections on a
+ * person's chain may be served to anyone else.
+ *
+ * The cases that matter are the ones a careless change would break silently: an
+ * undeclared collection must NOT become readable, the derived public list must
+ * stay derived rather than repeated, and the node-bootstrap allowlist must stay
+ * inside what the policy permits. Every one of these is a privacy boundary, so
+ * each is written to fail loudly rather than to describe the current array.
+ */
+
+import {
+  CHAIN_COLLECTION_POLICY,
+  PUBLIC_CHAIN_COLLECTIONS,
+  isPublicChainCollection,
+  publicCollectionsAmong,
+} from '../chainCollectionPolicy';
+import { PUBLIC_LOG_COLLECTIONS } from '../../services/repoLog.service';
+
+describe('chainCollectionPolicy', () => {
+  it('treats an UNDECLARED collection as private', () => {
+    // The default is the whole point: an app that ships a collection and forgets
+    // this file must get silence on a public read, not disclosure.
+    expect(isPublicChainCollection('app.syra.listen')).toBe(false);
+    expect(isPublicChainCollection('app.mention.feed.somethingNew')).toBe(false);
+    expect(isPublicChainCollection('')).toBe(false);
+  });
+
+  it('keeps a saved post private', () => {
+    // Named rather than derived from the array: this is the case the policy
+    // exists for, and a test that read the array would agree with any mistake.
+    expect(isPublicChainCollection('app.mention.feed.bookmark')).toBe(false);
+    expect(PUBLIC_CHAIN_COLLECTIONS).not.toContain('app.mention.feed.bookmark');
+  });
+
+  it('publishes the collections a reader legitimately needs', () => {
+    for (const nsid of [
+      'app.oxy.identity',
+      'app.oxy.profile',
+      'app.oxy.node',
+      'app.mention.feed.post',
+      'app.mention.feed.repost',
+      'app.mention.feed.like',
+      'app.mention.feed.tombstone',
+    ]) {
+      expect(isPublicChainCollection(nsid)).toBe(true);
+    }
+  });
+
+  it('derives the public list from the policy instead of repeating it', () => {
+    const declaredPublic = CHAIN_COLLECTION_POLICY.filter((e) => e.visibility === 'public').map((e) => e.nsid);
+    expect([...PUBLIC_CHAIN_COLLECTIONS].sort()).toEqual([...declaredPublic].sort());
+    // Vacuity floor: an empty or truncated policy would satisfy the equality above.
+    expect(PUBLIC_CHAIN_COLLECTIONS.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('states a reason for every entry, because the next person has to judge by it', () => {
+    for (const entry of CHAIN_COLLECTION_POLICY) {
+      expect(entry.reason.trim().length).toBeGreaterThan(20);
+    }
+  });
+
+  it('declares each collection exactly once', () => {
+    const nsids = CHAIN_COLLECTION_POLICY.map((e) => e.nsid);
+    // A duplicate with a DIFFERENT visibility would resolve by map insertion
+    // order — silently, and differently depending on which entry came last.
+    expect(new Set(nsids).size).toBe(nsids.length);
+  });
+
+  it('keeps the node-bootstrap allowlist inside what the policy permits', () => {
+    // The two lists answer different questions and are deliberately separate
+    // (see `repoLog.service`), but the bootstrap one may never name a collection
+    // this policy calls private.
+    for (const nsid of PUBLIC_LOG_COLLECTIONS) {
+      expect(isPublicChainCollection(nsid)).toBe(true);
+    }
+  });
+
+  describe('publicCollectionsAmong', () => {
+    it('drops the private ones from a caller-supplied filter', () => {
+      expect(
+        publicCollectionsAmong(['app.mention.feed.post', 'app.mention.feed.bookmark']),
+      ).toEqual(['app.mention.feed.post']);
+    });
+
+    it('answers an all-private request with nothing, not with everything', () => {
+      // The failure mode worth pinning: a narrowing that returns the full public
+      // set when the intersection is empty would hand a caller more than it asked
+      // for, which is how "filter" implementations usually break.
+      expect(publicCollectionsAmong(['app.mention.feed.bookmark'])).toEqual([]);
+      expect(publicCollectionsAmong([])).toEqual([]);
+    });
+
+    it('preserves the caller order and does not invent entries', () => {
+      const requested = ['app.mention.feed.like', 'app.syra.listen', 'app.oxy.profile'];
+      expect(publicCollectionsAmong(requested)).toEqual(['app.mention.feed.like', 'app.oxy.profile']);
+    });
+  });
+});

--- a/packages/api/src/config/chainCollectionPolicy.ts
+++ b/packages/api/src/config/chainCollectionPolicy.ts
@@ -1,0 +1,150 @@
+/**
+ * Which chain collections may be published, and why — the committed policy.
+ *
+ * A person has ONE chain, and an app appends its records to it. That chain
+ * therefore interleaves collections meant to be read by anyone with collections
+ * that are private by KIND rather than by any per-record visibility flag: a
+ * Mention post is public because it was published public, while a Mention
+ * bookmark is private no matter what, and both land in the same log under the
+ * same subject.
+ *
+ * The store cannot tell them apart. `oxyRecordStore` filters on `nsid` and knows
+ * nothing about what an `nsid` means — as `repoLog.service` already said of its
+ * own allowlist, "the protocol store has no notion of public collections". So
+ * the knowledge has to be written down, and this is where.
+ *
+ * ## Shape borrowed from `federationBridgePolicy` / `federationBlockPolicy`
+ *
+ * Committed rather than configured, with the reason in the entry, so git is the
+ * audit trail and a change is reviewable by someone who was not there. And
+ * ENFORCEMENT reads the same array a reader would: {@link isPublicChainCollection}
+ * and {@link PUBLIC_CHAIN_COLLECTIONS} both derive from
+ * {@link CHAIN_COLLECTION_POLICY}, so a collection cannot be served publicly
+ * without being listed here as public.
+ *
+ * ## Unknown means PRIVATE
+ *
+ * The default is the whole point. An app that adds a collection and forgets this
+ * file gets it treated as private — its records simply do not appear on a public
+ * read. The opposite default would publish an undeclared collection the first
+ * time anybody wrote one, which is exactly how a private kind leaks: silently,
+ * with no error, at the moment a new feature ships.
+ */
+
+import { NODE_COLLECTION } from '../utils/nodes.constants';
+
+/** Whether a collection's records may be served to a reader who is not the subject. */
+export type ChainCollectionVisibility = 'public' | 'private';
+
+/** One declared collection: what it is, and whether it may be published. */
+export interface ChainCollectionEntry {
+  /** The envelope's `collection` NSID, stored denormalized as `signed_records.nsid`. */
+  nsid: string;
+  visibility: ChainCollectionVisibility;
+  /**
+   * Why it carries that visibility, in terms of what the collection IS. Written
+   * for whoever later has to decide whether a new collection resembles this one.
+   */
+  reason: string;
+}
+
+/**
+ * Every collection Oxy knows about, with its publishability.
+ *
+ * Adding an app collection here is a moderation-shaped decision, not plumbing:
+ * marking one `public` makes every record ever written under it readable by any
+ * consumer of a public read surface, retroactively, because a chain is
+ * append-only and nothing is re-examined.
+ */
+export const CHAIN_COLLECTION_POLICY: readonly ChainCollectionEntry[] = [
+  // ---- Oxy's own collections (the node-bootstrap log) ----------------------
+  {
+    nsid: 'app.oxy.identity',
+    visibility: 'public',
+    reason:
+      'The identity record is what a node or any third party verifies an account against; it is useless if it cannot be fetched.',
+  },
+  {
+    nsid: 'app.oxy.profile',
+    visibility: 'public',
+    reason: 'The profile a user publishes about themselves — public by intent.',
+  },
+  {
+    nsid: NODE_COLLECTION,
+    visibility: 'public',
+    reason:
+      'The node registration is how a self-hosted node is discovered; it advertises an endpoint the user chose to advertise.',
+  },
+
+  // ---- Mention (`app.mention.feed.*`) --------------------------------------
+  //
+  // Visibility here is the APP's knowledge, transcribed. The source of truth for
+  // what each collection is stays `@mention/shared-types`' lexicons module; this
+  // records the publishability decision Oxy enforces.
+  {
+    nsid: 'app.mention.feed.post',
+    visibility: 'public',
+    reason:
+      'Only published, PUBLIC posts are ever emitted as records — `MentionRecordEmitter.isPublicPublishedPost` gates the write, so a private post has no record to leak.',
+  },
+  {
+    nsid: 'app.mention.feed.repost',
+    visibility: 'public',
+    reason: 'A repost is a public act of amplification, and names a post that is itself public.',
+  },
+  {
+    nsid: 'app.mention.feed.like',
+    visibility: 'public',
+    reason:
+      'Likes are attributable in the product — a post shows who liked it — so the record discloses nothing the app does not.',
+  },
+  {
+    nsid: 'app.mention.feed.tombstone',
+    visibility: 'public',
+    reason:
+      'A tombstone supersedes an earlier record; withholding it would leave readers showing content the author deleted.',
+  },
+  {
+    nsid: 'app.mention.feed.bookmark',
+    visibility: 'private',
+    reason:
+      'A saved post is private by KIND, not by any visibility flag — `@mention/shared-types` declares it "excluded from any public log". Publishing it would disclose what a person reads, which they never shared.',
+  },
+];
+
+/** Index for the lookup, built once. */
+const BY_NSID: ReadonlyMap<string, ChainCollectionEntry> = new Map(
+  CHAIN_COLLECTION_POLICY.map((entry) => [entry.nsid, entry]),
+);
+
+/**
+ * Whether records of `nsid` may be served to someone other than the subject.
+ *
+ * An UNDECLARED collection is private — see the module header. Callers must not
+ * "helpfully" fall back to allowing it.
+ */
+export function isPublicChainCollection(nsid: string): boolean {
+  return BY_NSID.get(nsid)?.visibility === 'public';
+}
+
+/**
+ * Every publishable collection, derived from the policy rather than repeated
+ * beside it. This derivation is what makes it impossible to serve a collection
+ * publicly that the policy above calls private.
+ */
+export const PUBLIC_CHAIN_COLLECTIONS: readonly string[] = CHAIN_COLLECTION_POLICY.filter(
+  (entry) => entry.visibility === 'public',
+).map((entry) => entry.nsid);
+
+/**
+ * Narrow a caller-supplied collection filter to the ones that may be published.
+ *
+ * The shape every public read surface should use: a request names what it wants,
+ * and this decides what it may have. Returns the intersection — an empty result
+ * means the caller asked only for private collections, which every read here
+ * answers as an empty page rather than an error, matching how an empty filter
+ * already behaves.
+ */
+export function publicCollectionsAmong(requested: readonly string[]): string[] {
+  return requested.filter((nsid) => isPublicChainCollection(nsid));
+}

--- a/packages/api/src/services/__tests__/oxyRecordStore.test.ts
+++ b/packages/api/src/services/__tests__/oxyRecordStore.test.ts
@@ -529,8 +529,14 @@ describe('listRecordsByAuthors', () => {
       after: first.nextCursor,
     });
 
+    // SORTED on both sides: the property under test is "each record exactly
+    // once, none skipped and none repeated", and the traversal ORDER between two
+    // records sharing a timestamp is not something this API promises. The
+    // tiebreaker is `id`, a uuid v7 whose random bits decide the order of two
+    // rows generated inside the same millisecond — so asserting the sequence
+    // made the case depend on which uuid happened to sort first.
     const seen = [...first.records, ...second.records].map((r) => r.recordId);
-    expect(seen).toEqual([`${userId}-0`, `${userId}-1`].sort());
+    expect([...seen].sort()).toEqual([`${userId}-0`, `${userId}-1`].sort());
     expect(new Set(seen).size).toBe(2);
   });
 

--- a/packages/api/src/services/repoLog.service.ts
+++ b/packages/api/src/services/repoLog.service.ts
@@ -22,7 +22,20 @@ import type { ChainHead } from '@oxyhq/protocol';
 import { oxyRecordStore, subjectKeyForUser, DEFAULT_LOG_LIMIT } from './oxyRecordStore';
 import { NODE_COLLECTION } from '../utils/nodes.constants';
 
-/** Public-safe NSIDs that unauthenticated node bootstrap may export. */
+/**
+ * Public-safe NSIDs that unauthenticated node bootstrap may export.
+ *
+ * DELIBERATELY not derived from `chainCollectionPolicy`'s
+ * `PUBLIC_CHAIN_COLLECTIONS`, and the distinction is load-bearing: that policy
+ * answers "may this collection be published at all", while this answers "does a
+ * bootstrapping node need it". Deriving one from the other would start exporting
+ * every app's public records — Mention posts included — from a CORS-open route
+ * whose purpose is letting a node verify an identity.
+ *
+ * The relationship that DOES hold is containment: nothing here may be a
+ * collection the policy calls private. `__tests__/chainCollectionPolicy.test.ts`
+ * asserts it, so the two cannot drift into disagreeing.
+ */
 export const PUBLIC_LOG_COLLECTIONS = ['app.oxy.identity', 'app.oxy.profile', NODE_COLLECTION] as const;
 
 /**


### PR DESCRIPTION
Cierra **la mitad** del registro que le falta a la fase 1, y arregla de paso un flake que metí yo en #834.

## El problema

Una persona tiene UNA cadena y las apps le añaden registros. Así que esa cadena intercala colecciones pensadas para cualquiera con colecciones **privadas por TIPO**, no por una bandera de visibilidad. Los posts guardados de Mention son el caso: un post es público porque se publicó público —`MentionRecordEmitter.isPublicPublishedPost` cierra esa escritura— mientras que `app.mention.feed.bookmark` es privado pase lo que pase, y ambos aterrizan en el mismo log del mismo sujeto.

Nada podía distinguirlos. `oxyRecordStore` filtra por `nsid` y no sabe qué significa un `nsid`; `repoLog.service` dice lo mismo de su propia lista. Así que el conocimiento se escribe, con la forma que ya usa `federationBlockPolicy`: comprometido, una razón por entrada, y la **aplicación leyendo el mismo array** que leería una persona — una colección no puede servirse públicamente sin figurar como pública.

## Lo declarado sin declarar es PRIVADO

Ese default es el punto entero. Una app que añade una colección y se olvida de este fichero obtiene silencio en una lectura pública, no divulgación en el momento en que se lanza la función.

## `PUBLIC_LOG_COLLECTIONS` NO se re-deriva de esto, a propósito

Contesta otra pregunta: qué necesita un nodo para arrancar, no qué puede publicarse. Derivarla habría empezado a exportar los registros públicos de toda app —posts de Mention incluidos— desde una ruta CORS-abierta cuyo fin es verificar una identidad. Lo que sí debe cumplirse es **contención**, y un test lo afirma para que las dos no deriven a contradecirse.

## Verificación

- 10 casos nuevos, todos verdes. `tsc --noEmit` limpio.
- **Mutation-tested las dos aserciones que cargan peso**: poner el marcador en `public` tumba 3 casos; hacer que una colección desconocida falle ABIERTA tumba 2. Restaurado y re-verificado tras cada una.
- Piso de vacuidad en la derivación, para que una política vaciada no satisfaga la igualdad.

## Y el flake que arreglo aquí

`resumes past a cursor when two records share a timestamp`, que escribí en #834, comparaba la **secuencia** de recorrido. Ambas filas comparten `created_at`, así que desempata el `id` — un uuid v7 cuyos bits aleatorios deciden el orden de dos filas generadas en el mismo milisegundo. El orden nunca fue la propiedad bajo prueba; pasó 24 veces y seis suites completas por suerte antes de fallar en una ejecución que generó los uuid al revés.

Ahora ordenado en ambos lados, y **conserva los dientes**: mutado a `>=` (el cursor se repite) falla, y quitando el row-value para un `created_at >` plano (el cursor se salta el segundo para siempre) también. Quince ejecuciones seguidas del caso reparado pasan.

## Lo que NO trae

La otra mitad del registro: **qué app puede escribir bajo qué namespace**. Eso es propiedad de la Application, no de la colección — vive junto a `redirectUris`/`scopes`, no aquí.

🤖 Generated with [Claude Code](https://claude.com/claude-code)