### PR TITLE
chore(licensing): the server layer moves to the Breathe License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,18 @@
 Licensing for this repository
 =============================================================================
 
-Copyright (c) 2025-present The Oxy Collective Inc
+Copyright (c) 2025-present The Oxy Collective, Inc.
 
-This repository is not licensed as a single work. It is a monorepo holding two
-layers with different licenses, and one repository level license file cannot
+This repository is not licensed as a single work. It is a monorepo holding
+three different situations, and one repository level license file cannot
 express that. Each package under `packages/` carries its own LICENSE file, and
 that file is what governs the package it sits in.
 
+GitHub will report this repository's licence as "Other". That is correct, not a
+misdetection.
 
-The SDK and client layer: Apache License 2.0
+
+1. The SDK and client layer: Apache License 2.0
 -----------------------------------------------------------------------------
 
   packages/contracts        @oxyhq/contracts
@@ -24,37 +27,97 @@ The SDK and client layer: Apache License 2.0
 
 Each of those directories holds a verbatim copy of the Apache License 2.0 and a
 NOTICE file. Use, modification and redistribution of those packages are
-governed by that license alone.
+governed by that license alone. No fee, no source obligation, and no
+attribution requirement beyond the one Apache-2.0 itself states.
 
 These are the packages a third party has to depend on in order to build on Oxy,
 so they are licensed permissively on purpose: if integrating Oxy login cost
 money, nobody would integrate it.
 
 
-Everything else: GNU Affero General Public License v3.0 only
+2. The server layer: The Breathe License 1.0
 -----------------------------------------------------------------------------
 
   packages/api              @oxyhq/api
   packages/db               @oxyhq/db
   packages/node             @oxyhq/node
+
+License identifier `LicenseRef-Breathe-1.0`. Each of those directories holds
+the full license text with its Parameters filled in, plus a NOTICE file.
+
+In short, and the license itself governs rather than this summary:
+
+  - Free for any purpose that is not commercial, perpetually and irrevocably
+    while you comply.
+  - If you deploy it, or a modified version, whether you ship it or serve it
+    over a network, you publish the corresponding source. That binds everyone,
+    including paying commercial licensees. It cannot be bought out of.
+  - Attribution is required of everyone and cannot be waived.
+  - Commercial use requires a paid license. The trigger is revenue, and it
+    includes purely internal use by a business that earns revenue.
+  - Cooperatives, nonprofits, educational institutions, public bodies and
+    worker owned businesses pay no fee. They publish source and give credit
+    like everyone else.
+
+This is **source available, not open source**, and it is worth stating plainly
+rather than hoping nobody checks. It fails clause 6 of the Open Source
+Definition, no discrimination against fields of endeavour, because commercial
+use is conditional on payment. It is not the copyleft that does that; the AGPL
+is copyleft and is OSI approved. Do not describe these packages as open source.
+
+**Nothing here is retroactive.** Every version of these packages already
+published under an earlier license stays under that license, permanently, for
+anyone who has it. `@oxyhq/api` up to and including `1.0.3` was published as MIT
+and remains MIT in those versions, forever. These terms bind the versions
+released from here on, and nothing else.
+
+Commercial Terms:
+<https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md>
+Exemption Policy:
+<https://github.com/OxyHQ/.github/blob/main/licensing/EXEMPTIONS.md>
+Commercial licensing contact: licensing@oxy.so
+
+
+3. Private workspace packages: GNU Affero General Public License v3.0 only
+-----------------------------------------------------------------------------
+
   packages/accounts         packages/auth           packages/commons
   packages/console          packages/inbox          packages/test-app-expo
   packages/test-app-vite
 
   and every other file in this repository that is not inside one of the
-  Apache-2.0 package directories listed above.
+  package directories listed in sections 1 and 2.
 
-The full text is in `LICENSE-AGPL-3.0.txt` in this directory. `packages/api` and
-`packages/db` also carry their own copies, because they are published to npm and
-the license has to travel with the published artifact.
+These are `"private": true` workspace packages. They are never published to a
+registry and are not offered as products, but they sit in a public repository,
+so they need a licence, and they keep the one they already had.
 
-This is the license these parts already carried. Nothing here narrows what was
-previously granted.
+The full text is in `LICENSE-AGPL-3.0.txt` in this directory.
+
+Nothing in this file narrows what was previously granted for any of them.
+Moving them to the Breathe License is a separate decision that has not been
+made.
 
 
 Third party components
 -----------------------------------------------------------------------------
 
 Dependencies are resolved and installed by the package manager and stay under
-their own licenses. Where a package has attribution obligations to record, they
-are recorded in that package's NOTICE file.
+their own licenses. Attribution obligations and dual license elections are
+recorded in each package's NOTICE file. `packages/api/NOTICE` is the one with
+real content: a GPL ffmpeg binary shipped as a separate executable, an LGPL
+native imaging library, and three dual license elections.
+
+
+The layer boundary
+-----------------------------------------------------------------------------
+
+An Apache-2.0 package in section 1 must never depend on a Breathe package in
+section 2. The reverse is fine, and is what section 2 does.
+
+A Breathe package must never take a GPL or AGPL dependency that is linked in
+process, because those licences are mutually incompatible with these terms.
+That constraint is why `@oxyhq/db` is in section 2 rather than staying where it
+was: `@oxyhq/api` imports it directly, so leaving it AGPL while `@oxyhq/api`
+moved to Breathe would have made the combination distributable under neither
+licence.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@oxyhq/services"><img alt="@oxyhq/services" src="https://img.shields.io/npm/v/@oxyhq/services?style=flat-square&label=%40oxyhq%2Fservices&labelColor=440151&color=D26AE7"></a>
   <a href="https://www.npmjs.com/package/@oxyhq/core"><img alt="@oxyhq/core" src="https://img.shields.io/npm/v/@oxyhq/core?style=flat-square&label=%40oxyhq%2Fcore&labelColor=440151&color=D26AE7"></a>
-  <a href="LICENSE"><img alt="Apache-2.0 SDK, AGPL-3.0 server" src="https://img.shields.io/badge/license-Apache--2.0%20SDK%20%C2%B7%20AGPL--3.0%20server-440151?style=flat-square"></a>
+  <a href="LICENSE"><img alt="Apache-2.0 SDK, Breathe server" src="https://img.shields.io/badge/license-Apache--2.0%20SDK%20%C2%B7%20Breathe%20server-440151?style=flat-square"></a>
   <img alt="Bun" src="https://img.shields.io/badge/bun-1.3+-440151?style=flat-square&logo=bun&logoColor=white">
   <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-strict-440151?style=flat-square&logo=typescript&logoColor=white">
 </p>
@@ -196,5 +196,5 @@ Issues and pull requests are welcome, especially from people who will tell us wh
 <br>
 
 <div align="center">
-<sub>Apache-2.0 for the SDK packages · AGPL-3.0-only for everything else · The Oxy Collective Inc · <a href="LICENSE">LICENSE</a></sub>
+<sub>Apache-2.0 for the SDK packages · Breathe License 1.0 for the server layer · The Oxy Collective, Inc. · <a href="LICENSE">LICENSE</a></sub>
 </div>

--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
     },
     "packages/api": {
       "name": "@oxyhq/api",
-      "version": "1.0.9",
+      "version": "2.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1087.0",
         "@aws-sdk/lib-storage": "3.1076.0",
@@ -488,7 +488,7 @@
     },
     "packages/db": {
       "name": "@oxyhq/db",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "devDependencies": {
         "@biomejs/biome": "catalog:",
         "@types/jest": "^30.0.0",
@@ -651,7 +651,7 @@
     },
     "packages/node": {
       "name": "@oxyhq/node",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@oxyhq/contracts": "workspace:*",
         "@oxyhq/core": "workspace:*",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog: `@oxyhq/api`
+
+## 2.0.0
+
+### Licence: this package moves to the Breathe License 1.0
+
+**Breaking, and a genuine narrowing rather than paperwork.** `@oxyhq/api` is now
+licensed under the Breathe License 1.0, identifier `LicenseRef-Breathe-1.0`. The
+code, the API surface and the behaviour are unchanged in this release; it exists
+to carry the licence change.
+
+What changes for you:
+
+- **Non commercial use stays free**, perpetually and irrevocably while you comply.
+- **Commercial use now requires a paid licence.** The trigger is revenue, and it
+  includes purely internal use inside a business that earns revenue.
+- **If you deploy it, you publish the corresponding source.** That binds everyone,
+  including paying customers, and cannot be bought out of.
+- **Attribution is required of everyone** and cannot be waived.
+- **Cooperatives, nonprofits, educational institutions, public bodies and worker
+  owned businesses pay no fee.**
+
+This is **source available, not open source**. It fails clause 6 of the Open
+Source Definition because commercial use is conditional on payment. Automated
+licence scanners report it as unknown, and GitHub shows it as "Other".
+
+**Nothing here is retroactive, and it could not be.** `@oxyhq/api@1.0.3` was published
+under MIT and stays MIT forever for anyone who has it. They may keep
+using it, commercially, at no charge, indefinitely, and may fork it. A licence
+change binds future versions only.
+
+### `@oxyhq/db` had to move too
+
+The Breathe License is **not compatible with the GPL or the AGPL**, in either
+direction. `@oxyhq/api` imports `@oxyhq/db` in process, and `@oxyhq/db` was
+`AGPL-3.0-only`, so relicensing this package alone would have produced a
+combination distributable under neither licence. Oxy owns both, so this is a
+decision rather than a negotiation, but it IS a decision the migration plan
+never made: `@oxyhq/db` postdates that analysis and sits in no layer.
+
+### `NOTICE` now carries real third party obligations
+
+Attribution binds everyone under this licence, so `NOTICE` matters here in a way
+it did not before. It records the bundled **GPL-3.0-or-later ffmpeg** binary (an
+`optionalDependency` invoked as a separate process, which is aggregation rather
+than linking, plus the source offer the GPL requires), the
+**LGPL-3.0-or-later** native imaging library sharp loads, with its relinking
+statement, and the elections on `node-forge`, `jszip` and `@zone-eu/mailsplit`,
+where the alternative in each case is a GPL licence this package cannot accept.
+
+**The standing rule that follows:** if anyone ever links ffmpeg, or any other GPL
+library, INTO this process, the combination becomes a GPL derivative and this
+package can no longer be distributed under these terms at all.
+
+The major is bumped rather than the change being slipped into a patch. A licence
+narrowing must never reach anyone through a routine install.
+
+### Added
+
+- A `LICENSE` carrying the full Breathe License text with its Parameters filled
+  in, and a `NOTICE`.
+
+### Still outstanding
+
+- The Licensor's jurisdiction of incorporation, registration number and the
+  governing law are **visible placeholders**. They are not guesses, and must be
+  filled in before the commercial arm can invoice.

--- a/packages/api/LICENSE
+++ b/packages/api/LICENSE
@@ -1,679 +1,592 @@
-@oxyhq/api
-Copyright (c) 2025-present The Oxy Collective Inc
-
-This program is free software: you can redistribute it and/or modify it under
-the terms of the GNU Affero General Public License, version 3 only, as
-published by the Free Software Foundation.
-
-This program is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License along
-with this program. If not, see <https://www.gnu.org/licenses/>.
-
-The verbatim text of the license follows.
-
-=============================================================================
-
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-                            Preamble
-
-  The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-our General Public Licenses are intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.
-
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-  Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
-
-  A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate.  Many developers of free software are heartened and
-encouraged by the resulting cooperation.  However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
-
-  The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community.  It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server.  Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
-
-  An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals.  This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU Affero General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Remote Network Interaction; Use with the GNU General Public License.
-
-  Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software.  This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new versions
-will be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
-<https://www.gnu.org/licenses/>.
+# The Breathe License, Version 1.0
+
+**Free to breathe, paid to bottle.**
+
+<!--
+  THIS FILE LICENSES THIS WORK.
+
+  Unlike the template published at
+  https://github.com/OxyHQ/.github/blob/main/LICENSE-BREATHE.md, this copy has
+  its Parameters filled in, so these terms govern the work named in them.
+
+  WHAT THIS LICENSE IS:
+
+    - SOURCE AVAILABLE, NOT OPEN SOURCE. The Breathe License is NOT approved
+      by the Open Source Initiative and is NOT approved by the Free Software
+      Foundation. It does not appear on the SPDX license list. GitHub will
+      display a repository using it as "Other" or "custom", and automated
+      license scanners will report it as unknown.
+
+      It is worth being precise about WHY it is not open source. It is NOT
+      because of the copyleft; the AGPL is copyleft and is OSI approved. It is
+      because Section 2 makes commercial use conditional on a paid license,
+      which is discrimination against a field of endeavour under clause 6 of
+      the Open Source Definition. Anyone who calls software under this license
+      "open source" is using the wrong words. See licensing/README.md.
+
+    - NOT COMPATIBLE WITH THE GPL OR THE AGPL. Code under the GPL or the AGPL
+      cannot be combined into a work licensed under these terms, and a work
+      licensed under these terms cannot be combined into a GPL or AGPL work.
+      This is a hard constraint, not a preference. It is one reason Oxy
+      publishes its SDK and client libraries under Apache-2.0 instead. The
+      other reason is simpler: if integrating Oxy login cost money, nobody
+      would integrate it.
+
+    - COPYLEFT, INCLUDING OVER A NETWORK, FOR EVERYONE. If you deploy this
+      software or anything derived from it, you publish the corresponding
+      source. That applies to every user without exception, including paying
+      commercial licensees. It cannot be bought out of. The obligation is
+      modelled on the AGPL-3.0, but this is an original text and is not the
+      AGPL. The Free Software Foundation neither endorses it nor is
+      associated with it.
+
+    - ATTRIBUTION IS MANDATORY AND CANNOT BE WAIVED. It applies to every copy,
+      every derivative, and every network deployment, including those made by
+      paying commercial licensees. Paying does not buy anonymity.
+
+    - IT IS NOT RETROACTIVE. Any version of this work published under an
+      earlier license stays under that license, permanently, for anyone who
+      already has it. These terms bind this version and later ones.
+
+  THIS DOCUMENT HAS NOT BEEN REVIEWED BY A LAWYER. It was drafted from
+  established templates, which is not legal advice and is no substitute for
+  it. Have a qualified lawyer in the relevant jurisdiction review these terms
+  before applying them to any work that matters commercially.
+-->
+
+## Preamble
+
+This preamble explains the intent of the license. It is not part of the terms
+and creates no rights or obligations.
+
+Oxy is named for oxygen, because oxygen is essential and shared. This license
+tries to work the same way, and it asks for two things in return.
+
+The first is that the software stays open. It was published in the open, and it
+stays that way in every hand it passes through. Anyone may read it, run it,
+study it, change it, and pass it on, and anyone who deploys it or a changed
+version of it publishes the source of what they deployed. **That obligation is
+not for sale.** There is no version of this license under which someone takes
+this work private, and no fee that buys the right to. Everyone breathes the same
+air.
+
+The second is that people who make money with it pay for it. Using it, learning
+from it, and building on it are free. Building a revenue generating business on
+top of somebody else's work, contributing nothing back to it, is not. That is
+the line, and buying a commercial license is the whole of what crosses it: it
+buys the right to use this software commercially. It does not buy secrecy, and
+it does not buy silence about where the software came from.
+
+Cooperatives, nonprofits, educational institutions, and public bodies pay
+nothing. They publish their source and give credit like everyone else. They are
+exempt from the fee, and from nothing else.
+
+Free to breathe, paid to bottle. Breathing is using, studying, changing, and
+sharing in the open, and it is free. Bottling it to sell is the part that costs
+money.
+
+## Parameters
+
+Fill these in for each work. Terms in **bold** are defined in Section 15.
+
+| Parameter | Value |
+| --- | --- |
+| **Licensor** | The Oxy Collective, Inc., incorporated in `<JURISDICTION OF INCORPORATION: NOT YET SUPPLIED>` under registration number `<REGISTRATION NUMBER: NOT YET SUPPLIED>` |
+| **The Software** | `@oxyhq/api`, and each version of it the Licensor makes available under these terms |
+| Copyright notice | Copyright (c) 2025-present The Oxy Collective, Inc. |
+| License identifier | `LicenseRef-Breathe-1.0` |
+| **Commercial Terms** | <https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md> |
+| **Exemption Policy** | <https://github.com/OxyHQ/.github/blob/main/licensing/EXEMPTIONS.md> |
+| Commercial licensing contact | licensing@oxy.so |
+| **Governing Law** | `<GOVERNING LAW: NOT YET SUPPLIED>` |
+
+## 1. Acceptance
+
+To get any license under these terms, you must agree to them as both strict
+obligations and conditions on every license they grant you. If you do not agree
+to them, you have no license to the Software.
+
+## 2. Copyright license
+
+The Licensor grants you a worldwide, royalty free, non exclusive copyright
+license to do everything with the Software that would otherwise infringe the
+Licensor's copyright in it, for any **Permitted Purpose**.
+
+That includes running it, studying it, copying it, modifying it, making
+**Modified Versions** and other works based on it, publicly performing and
+displaying it, **Conveying** it, and making it available to others through
+**Remote Interaction**, in each case for a Permitted Purpose.
+
+This license is granted for as long as you comply with Section 3. It does not
+expire, the Licensor cannot revoke it while you comply, and no fee is payable
+for it.
+
+### 2.1 Permitted Purpose
+
+A **Permitted Purpose** is any purpose that is not **Commercial Use**.
+
+**Commercial Use is not licensed under this document.** To use the Software
+commercially you must take the **Commercial Terms** identified in the Parameters
+table. See Section 4.
+
+### 2.2 Permitted Purposes specifically include
+
+For the avoidance of doubt, each of the following is a Permitted Purpose:
+
+- **(a)** using the Software personally, on your own behalf, where your use is
+  not connected to **Revenue**;
+- **(b)** private study, research, and experiment, whether or not you publish
+  the results;
+- **(c)** teaching, and use by a student or a member of faculty in that
+  capacity;
+- **(d)** academic and non commercial research, including research funded by
+  grants that are not consideration for goods or services;
+- **(e)** evaluating the Software, for up to ninety days, to decide whether to
+  take the Commercial Terms, including evaluation inside an organization that
+  would otherwise need them;
+- **(f)** developing, testing, reporting bugs in, and contributing to the
+  Software itself, including maintaining a fork of it;
+- **(g)** Conveying the Software or a Modified Version to others at no charge,
+  where you derive no Revenue from doing so; and
+- **(h)** use by a hobbyist, a volunteer project, or a community group that
+  generates no Revenue.
+
+### 2.3 Commercial Use specifically includes
+
+Each of the following is Commercial Use and requires the Commercial Terms:
+
+- **(a)** incorporating the Software, in whole or in part, into a product or
+  service **Your Organization** offers for a fee, whether the fee is for a
+  license, a subscription, hosting, support, consulting, or anything else;
+- **(b)** operating the Software, or a Modified Version, as a hosted or managed
+  service that others pay to access;
+- **(c)** using the Software internally to produce, deliver, operate, support,
+  or administer goods or services Your Organization offers for a fee, including
+  internal tooling, back office systems, and infrastructure. **Internal use is
+  not automatically exempt.** If Your Organization earns Revenue and the
+  Software is used in the course of earning it, that is Commercial Use;
+- **(d)** using the Software in a product or service offered at no charge from
+  which Your Organization derives Revenue by other means, including advertising,
+  data licensing, and referral fees; and
+- **(e)** Conveying the Software as part of a paid distribution, appliance,
+  device, or bundle.
+
+The test is the connection between your use and Revenue. It does not matter
+whether the Software itself is the thing being sold.
+
+### 2.4 The Commercial Terms do not change Section 3
+
+Taking the Commercial Terms adds the right to use the Software commercially. It
+changes nothing else. Every condition in Section 3 continues to apply to you in
+full, including publishing source and giving Attribution. See Section 4.
+
+## 3. Conditions
+
+**These conditions apply to everyone using the Software, without exception, and
+whether or not you hold the Commercial Terms.** They are not obligations that
+can be bought out of, and the Licensor does not offer, and will not offer, any
+license that releases anyone from them.
+
+### 3.1 Attribution
+
+**Attribution is mandatory and cannot be waived, by agreement or by payment.**
+
+Wherever you Convey the Software or a Modified Version, or make either available
+through Remote Interaction, you must give **Attribution**.
+
+Attribution means preserving the copyright notice and a copy of these terms in
+the source you Convey, and presenting the following line in at least one place
+your users can reach:
+
+> Built on `@oxyhq/api` by The Oxy Collective, Inc., <https://oxy.so>. Licensed under the Breathe License 1.0.
+
+A reachable "About", "Credits", "Licenses", or "Open source" screen satisfies
+this. So does the documentation, or a `NOTICE` file shipped with the work, if
+the work has no user interface.
+
+**One place is enough, and once per work is enough.** You are not required to
+put Attribution on a home page, a splash screen, a login screen, a marketing
+page, or anywhere else your users have not chosen to look. You are not required
+to name the Licensor in advertising. You may not remove or obscure the
+Licensor's existing copyright and license notices in the source.
+
+**No commercial license, order form, purchase agreement, or other arrangement
+removes this requirement.** A holder of the Commercial Terms owes Attribution on
+exactly the same terms as everybody else. Any provision of any other document
+purporting to waive this Section is void.
+
+### 3.2 Source availability on conveyance
+
+If you Convey the Software or a Modified Version, in source or object form, you
+must make the **Corresponding Source** for what you Conveyed available to every
+recipient, at no charge beyond your reasonable cost of doing so, either by
+including it with what you Convey or by a written offer, valid for at least
+three years, telling recipients where to get it.
+
+### 3.3 Source availability on network use
+
+If you make the Software or a Modified Version available to anyone through
+Remote Interaction, you must offer every user who so interacts with it a
+prominent, no charge way to obtain the Corresponding Source of the version they
+are interacting with, through a network server or another readily accessible
+means.
+
+This condition applies whether or not you also Convey the work, whether or not
+you charge for access, and **whether or not you hold the Commercial Terms**.
+There is no way to pay to avoid it.
+
+**This condition does not reach your separate work.** Section 3.5 says what
+counts as a Modified Version and what does not.
+
+### 3.4 Notices
+
+Anyone who gets any part of the Software or a Modified Version from you must
+also get a copy of these terms, or the URL for them, together with any plain
+text lines beginning with `Required Notice:` that the Licensor supplied with the
+Software.
+
+If you Convey a Modified Version, you must carry prominent notices stating that
+you changed it and the date you changed it. You may add your own copyright
+notice for your own contributions. You may not misrepresent the origin of the
+Software.
+
+### 3.5 What is a Modified Version, and what is not
+
+Using the Software only through its **Documented Public Interfaces** does not by
+itself make your program a Modified Version, and does not put your program under
+these terms. Your own program remains yours, under whatever license you choose,
+and you are not required to publish its source.
+
+For the avoidance of doubt, none of the following makes your program a Modified
+Version:
+
+- **(a)** calling the Software's Documented Public Interfaces, whether in the
+  same process, in a separate process, or across a network;
+- **(b)** importing, linking against, or bundling a client library or SDK
+  published by the Licensor in order to communicate with the Software, where
+  your program uses only that library's Documented Public Interfaces;
+- **(c)** writing a plugin, extension, theme, adapter, or driver that the
+  Software loads through an interface the Software documents for that purpose;
+- **(d)** sending data to, or receiving data from, the Software or a service
+  operated with it;
+- **(e)** deploying the Software alongside your own separate programs, or
+  distributing it with them on the same medium or in the same image, where the
+  programs are independent works that are merely aggregated; or
+- **(f)** configuring, theming, or supplying data to the Software without
+  altering its source.
+
+Your program **is** a Modified Version if you alter the Software's source, copy
+source code out of the Software into your program, or incorporate the Software
+into your program other than through its Documented Public Interfaces.
+
+Section 3.5 concerns only what must be published. It does not affect Section
+2.1: running the Software commercially requires the Commercial Terms even where
+your own separate program stays yours.
+
+### 3.6 No further restrictions
+
+You may not impose any term on a recipient of the Software or a Modified Version
+that restricts the rights these terms grant them, and you may not condition
+their exercise of those rights on the payment of a royalty to you for the
+Software itself. You may charge for your own work, for distribution, for
+support, and for services, subject to Section 2.1.
+
+## 4. The Commercial Terms
+
+If your use is Commercial Use, you need the **Commercial Terms** identified in
+the Parameters table. They are a separate license granted by the Licensor as
+copyright holder, and they are the only way to use the Software commercially.
+
+**What they give you.** The right to use the Software for Commercial Use. That
+is all, and it is deliberate.
+
+**What they do not give you, and what no Oxy license will ever give anyone:**
+
+- **They do not release you from publishing source.** Sections 3.2 and 3.3 apply
+  to commercial licensees in full. If you deploy the Software or a Modified
+  Version, you publish the Corresponding Source, exactly as a non paying user
+  does.
+- **They do not release you from Attribution.** Section 3.1 applies to
+  commercial licensees in full.
+- **They do not permit you to make the Software, or your changes to it,
+  proprietary.** There is no arrangement, at any price, under which the Licensor
+  will agree otherwise. This is a design choice, not an opening negotiating
+  position.
+
+The Licensor grants the Commercial Terms at no charge to **Exempt
+Organizations**. See Section 5.
+
+## 5. Exempt Organizations
+
+The Licensor grants the Commercial Terms at no charge to any **Exempt
+Organization**, on the terms of the published **Exemption Policy**.
+
+**The exemption is from the fee, and from nothing else.** An Exempt Organization
+using the Software commercially is bound by every condition in Section 3 in
+full, including publishing Corresponding Source and giving Attribution, exactly
+as a paying commercial licensee is.
+
+An Exempt Organization may begin Commercial Use immediately in reliance on this
+Section, without waiting for written confirmation from the Licensor. The
+Exemption Policy explains how to obtain written confirmation if you want it for
+your own records.
+
+Many Exempt Organizations will find they do not need the Commercial Terms at
+all, because their use is not Commercial Use in the first place. Section 2.2
+already covers them.
+
+A change to the Exemption Policy does not retroactively withdraw a grant already
+made.
+
+## 6. Third party components
+
+**These terms cover only the parts of the Software that the Licensor owns.**
+
+The Software may contain, bundle, depend on, vendor, or link to components
+authored by third parties and licensed under their own terms. Those components
+remain governed by their own licenses. Nothing in these terms:
+
+- **(a)** overrides, replaces, supersedes, or modifies the license of any third
+  party component;
+- **(b)** reduces, restricts, or conditions any right that a third party
+  component's own license grants you;
+- **(c)** purports to license to you any right in a third party component that
+  the Licensor does not itself hold and is not entitled to grant; or
+- **(d)** creates any obligation for you in respect of a third party component
+  beyond what that component's own license requires.
+
+Where a third party component's license conflicts with these terms in respect of
+that component, that component's license governs it. In particular, a component
+licensed permissively remains usable by you commercially under its own terms,
+whether or not you hold the Commercial Terms for the Software.
+
+**Where to look.** A work licensed under these terms that carries third party
+components lists them in a `NOTICE` or `THIRD-PARTY-LICENSES` file at its root,
+naming each component, its license, and where the full license text can be
+found. Read it. The absence of such a file is not a representation that the work
+carries no third party components; dependency manifests and lockfiles are also
+authoritative.
+
+**What this clause does not do.** It resolves the case where the Software merely
+*contains* separately licensed files alongside the Licensor's own code. It does
+**not** rescue a work that is a **derivative** of copyleft licensed code. If code
+under the GPL, the AGPL, or another copyleft license is combined into the
+Software such that the combination is a derivative or covered work of that code,
+then that copyleft license governs the whole combination, and no third party
+components clause can carve the Licensor's own contributions back out of it. In
+that case the Licensor cannot license the combination under these terms at all,
+because the Licensor does not hold the right to do so.
+
+## 7. Patent license
+
+The Licensor grants you a patent license for the Software covering patent claims
+the Licensor can license, or becomes able to license, that you would infringe by
+using the Software as these terms permit. This patent license runs for as long
+as your copyright license under Section 2 does, and extends to Commercial Use
+only while you hold the Commercial Terms.
+
+No other patent rights are granted, by implication, estoppel, or otherwise.
+
+## 8. Patent defense
+
+If you make any written claim that the Software infringes or contributes to the
+infringement of any patent, your patent license under Section 7 ends
+immediately. If Your Organization makes such a claim, your patent license ends
+immediately for work done on behalf of Your Organization.
+
+## 9. Trademarks
+
+These terms grant you no right to use the Licensor's names, logos, trade names,
+service marks, or product names, including "Oxy" and "Breathe", except as
+Section 3.1 requires in order to state the origin of the Software accurately,
+and except for nominative fair use permitted by law.
+
+You may say your product is built on the Software. You may not say or imply that
+it is published, endorsed, certified, sponsored, or supported by the Licensor
+unless it is.
+
+## 10. Termination and cure
+
+If you violate these terms, your licenses end. But the first time the Licensor
+notifies you in writing of a violation, your licenses are reinstated if you come
+into full compliance, and take practical steps to correct the violation, within
+32 days of receiving that notice. After a first cured violation, further
+violations end your licenses immediately on notice.
+
+If your licenses end, the rights of anyone who received the Software or a
+Modified Version from you are not affected, as long as they comply themselves.
+
+If your Commercial Terms end, for any reason including non payment, your license
+under Section 2 for Permitted Purposes continues, provided you comply with
+Section 3. **You must stop Commercial Use.**
+
+## 11. Severability and partial exclusion
+
+If any part of the Software cannot lawfully be licensed under these terms,
+whether because a third party holds rights in it, because a copyleft obligation
+governs it, or for any other reason, that part is excluded from these terms and
+continues under whatever terms actually govern it. The rest of the Software
+continues under these terms, unaffected.
+
+If any provision of these terms is held invalid, illegal, or unenforceable by a
+court of competent jurisdiction, that provision is severed and the remaining
+provisions continue in full force, with the severed provision replaced by a
+valid provision that comes as close as the law permits to the original intent.
+
+If a condition in Section 3 cannot be enforced against you as a matter of law in
+your jurisdiction, your licenses under Section 2 end rather than continuing
+without that condition.
+
+## 12. No warranty
+
+***As far as the law allows, the Software comes as is, without warranty or
+condition of any kind, express or implied, including any warranty of
+merchantability, fitness for a particular purpose, title, or non infringement.
+The entire risk as to the quality and performance of the Software is with
+you.***
+
+## 13. Limitation of liability
+
+***As far as the law allows, the Licensor will not be liable to you for any
+damages arising out of these terms or out of the use or nature of the Software,
+under any kind of legal claim, including direct, indirect, special, incidental,
+and consequential damages, and including lost profits and lost data, even if the
+Licensor has been advised of the possibility of them.***
+
+Nothing in these terms excludes or limits liability that cannot lawfully be
+excluded or limited, including liability for death or personal injury caused by
+negligence, or for fraud.
+
+## 14. Governing law
+
+These terms are governed by the law of the jurisdiction named in the Parameters
+table, without regard to its conflict of law rules. The courts of that
+jurisdiction have exclusive jurisdiction over any dispute arising out of these
+terms, except that either party may seek injunctive relief in any court of
+competent jurisdiction to protect its intellectual property.
+
+## 15. Definitions
+
+**Licensor** is the entity named in the Parameters table, being the entity that
+holds the copyright in the Licensor authored parts of the Software or that has
+been granted the rights necessary to license them under both these terms and the
+Commercial Terms.
+
+**The Software** is the software and other material identified in the Parameters
+table that the Licensor makes available under these terms, including each
+version the Licensor so makes available.
+
+**You** means the individual or legal entity exercising rights under these
+terms.
+
+**Your Organization** means any legal entity, sole proprietorship, cooperative,
+association, foundation, or other organization you work for or on behalf of,
+together with every organization that controls it, is controlled by it, or is
+under common control with it. **Control** means ownership of more than fifty
+percent of the voting interests or of substantially all the assets of an entity,
+or the power to direct its management and policies by vote, contract, or
+otherwise, whether direct or indirect.
+
+**Permitted Purpose** has the meaning given in Section 2.1.
+
+**Commercial Use** means any use of the Software by or for Your Organization
+that is connected to **Revenue**, whether or not the Software is itself sold.
+Section 2.3 enumerates cases that are Commercial Use. Section 2.2 enumerates
+cases that are not.
+
+**Revenue** means all consideration of any kind received by Your Organization
+from third parties, in cash or in kind, recognized under the accounting
+standards Your Organization ordinarily applies, before deduction of costs. It
+includes subscription fees, license fees, transaction fees, advertising revenue,
+and payments for support or professional services. It excludes grants and
+donations that are not consideration for goods or services, capital raised by
+issuing shares or debt, and proceeds from the sale of capital assets.
+
+**Convey** means any act of propagating the Software that enables another party
+to make or receive copies, including distributing it in source or object form,
+publishing it, and shipping it inside a product or device. Merely interacting
+with users over a network, without transferring a copy, is not Conveying.
+
+**Remote Interaction** means allowing a user to interact with the Software, or
+with a Modified Version, over a computer network, without that user receiving a
+copy. Providing the Software as a hosted or managed service is Remote
+Interaction.
+
+**Modified Version** means a work that is a Modified Version under Section 3.5.
+
+**Corresponding Source** means all the source code needed to generate, install,
+and run the version in question, and to modify it, including the source of the
+work itself, interface definition files associated with it, build scripts,
+configuration needed to reproduce the build, and scripts controlling
+installation. It does not include the Software's own dependencies where those
+are generally available under their own licenses, standard system libraries,
+compilers, or general purpose tools used to produce the build. It does not
+include your credentials, keys, secrets, personal data, or user data.
+
+**Documented Public Interfaces** means the application programming interfaces,
+network protocols, message formats, command line interfaces, plugin interfaces,
+and extension points that the Licensor documents for use by others, in the
+Software's published documentation, its type definitions, or its public package
+exports. An interface the Licensor marks internal, private, unstable, or
+experimental is not a Documented Public Interface.
+
+**Attribution** has the meaning given in Section 3.1.
+
+**Commercial Terms** means the document identified in the Parameters table.
+
+**Exempt Organization** means Your Organization, where Your Organization is any
+of the following. The test applies to Your Organization as a whole, not to a
+department, subsidiary, or project within it.
+
+- **(a) A cooperative.** An entity registered as a cooperative, a mutual, or an
+  equivalent form under the law of its jurisdiction, or whose governing
+  documents bind it to all four of: membership is open and voluntary; members
+  control the entity democratically, with voting power not allocated in
+  proportion to capital contributed; any surplus is returned to members in
+  proportion to their transactions or participation, retained by the entity, or
+  applied to purposes the members approve, rather than distributed to outside
+  investors in proportion to capital; and the entity is not controlled by an
+  entity that is not itself an Exempt Organization.
+
+- **(b) A nonprofit organization.** An entity established on a not for profit
+  basis under the law of its jurisdiction, whose governing documents prohibit
+  distributing profits or assets to members, directors, officers, or
+  shareholders other than as reasonable compensation for services actually
+  rendered, and whose assets on dissolution must pass to another not for profit
+  or public purpose entity. Entities recognized under section 501(c)(3) of the
+  United States Internal Revenue Code, entities on the register of the Charity
+  Commission for England and Wales or its equivalent elsewhere, and entities
+  constituted as an `asociación`, `fundación`, `association loi 1901`, `Verein`,
+  `stichting`, or equivalent, qualify where they meet this test.
+
+- **(c) An educational institution.** A school, college, university, or other
+  institution whose primary purpose is education or academic research, together
+  with its students and faculty acting in that capacity.
+
+- **(d) A public body.** A government, public authority, public health service,
+  or public research institution, acting in a public capacity and not in
+  competition with commercial providers of the Software.
+
+- **(e) A worker owned business.** An entity in which the people performing
+  substantially all of its work also hold substantially all of its voting
+  control, whether directly or through a trust or foundation constituted for
+  that purpose.
+
+An entity does not stop being an Exempt Organization merely because it charges
+for goods or services, earns Revenue, pays market salaries, holds reserves, or
+receives grants or public funding. An entity is not an Exempt Organization if it
+is controlled by an entity that is not one, or if its exempt form is used
+principally to hold or route the economic benefit of the Software to persons or
+entities that would not themselves qualify.
+
+**Exemption Policy** means the document identified in the Parameters table, as
+published by the Licensor from time to time.
+
+**Governing Law** means the jurisdiction named in the Parameters table.
+
+## 16. How to apply these terms
+
+See [`licensing/README.md`](licensing/README.md) for the full procedure: which
+Oxy works use these terms and which use Apache-2.0, the file layout, the license
+identifier, the `package.json` `license` field, the source header, and the
+`NOTICE` file.

--- a/packages/api/NOTICE
+++ b/packages/api/NOTICE
@@ -1,0 +1,106 @@
+=============================================================================
+ NOTICE
+ @oxyhq/api
+ Copyright (c) 2025-present The Oxy Collective, Inc.
+=============================================================================
+
+This product is licensed under the Breathe License 1.0
+(`LicenseRef-Breathe-1.0`). See the LICENSE file in this directory. Commercial
+terms are available; see
+<https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md>.
+
+Attribution under Section 3.1 of the Breathe License is required of everyone,
+including paying commercial licensees, and cannot be waived.
+
+-----------------------------------------------------------------------------
+ THIRD PARTY COMPONENTS
+-----------------------------------------------------------------------------
+
+The Breathe License and the Commercial Terms cover only the parts of this work
+that The Oxy Collective, Inc. owns. The components listed below are authored by
+third parties and remain governed by their own licenses. Nothing in the Oxy
+terms overrides those licenses or reduces the rights they grant you.
+
+--- Separately licensed binaries invoked as separate programs ----------------
+
+  Component:   ffmpeg-static (bundled ffmpeg and ffprobe binaries)
+  Version:     5.x
+  License:     GPL-3.0-or-later
+  How used:    Declared as an optionalDependency and invoked as a separate
+               executable process for video asset variants. It is NOT linked
+               into this work, in process or otherwise, and this work is not a
+               derivative of it. Running two programs alongside each other is
+               aggregation.
+  Obligation:  The binary itself remains under the GPL. Corresponding source
+               for the distributed ffmpeg build is available from
+               <https://ffmpeg.org/download.html> and from the ffmpeg-static
+               project at <https://github.com/eugeneware/ffmpeg-static>, and
+               will be provided on request to licensing@oxy.so for at least
+               three years from the date of distribution.
+
+  WARNING, and the reason this entry is first: the Breathe License is NOT
+  compatible with the GPL. The arrangement above is lawful ONLY because ffmpeg
+  runs as its own process. If anyone ever links libav* or any other GPL library
+  INTO this process, that combination becomes a GPL derivative and this work
+  can no longer be distributed under these terms at all. Do not do it.
+
+--- Dynamically linked libraries under the LGPL ------------------------------
+
+  Component:   libvips, via @img/sharp-libvips-*
+  License:     LGPL-3.0-or-later
+  How used:    Loaded as a native shared library by the sharp Node addon, not
+               statically linked into this work.
+  Obligation:  You may modify libvips and relink it with this work. The object
+               files or the means to relink are available on request at
+               licensing@oxy.so.
+
+  sharp itself is Apache-2.0 and needs no notice beyond this entry for the
+  native library it loads.
+
+--- Dual licensed components: the election Oxy has made ----------------------
+
+  Where a component is offered under more than one license, this is the one Oxy
+  has chosen to receive it under. Recording the election matters: an unrecorded
+  election is what an audit flags, and in each case below the alternative is a
+  GPL license this work cannot accept.
+
+  Component:  node-forge
+  Offered as: BSD-3-Clause OR GPL-2.0
+  Elected:    BSD-3-Clause
+
+  Component:  jszip
+  Offered as: MIT OR GPL-3.0-or-later
+  Elected:    MIT
+
+  Component:  @zone-eu/mailsplit
+  Offered as: MIT OR EUPL-1.1+
+  Elected:    MIT
+
+-----------------------------------------------------------------------------
+ WHAT THIS FILE DOES NOT DO
+-----------------------------------------------------------------------------
+
+This file records components that sit alongside Oxy's own code. It cannot, and
+does not attempt to, separate Oxy's code from a work that is a derivative of
+copyleft licensed code. If GPL or AGPL code were combined into this work such
+that the combination is a derivative of it, that copyleft license would govern
+the whole combination, and no notice file would change that.
+
+That is why this package must not take on a GPL or AGPL dependency that is
+linked in process. If you are adding one, stop and read
+https://github.com/OxyHQ/.github/blob/main/licensing/README.md
+
+-----------------------------------------------------------------------------
+ HOW TO REGENERATE
+-----------------------------------------------------------------------------
+
+  bunx license-checker-rseidelsohn --production --summary
+  bunx license-checker-rseidelsohn --production --json > /tmp/licenses.json
+
+Then curate by hand. Do not commit the raw tool output: it lists hundreds of
+transitive dependencies, most of which need no notice, and it does not record
+dual license elections or the obligations above, which are the parts that
+matter.
+
+Review this file whenever a direct dependency is added or a major version is
+released.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -311,6 +311,10 @@ Response:
 
 ## License
 
-This package is licensed under the GNU Affero General Public License v3.0 only (AGPL-3.0-only), (c) The Oxy Collective Inc. See the [LICENSE](LICENSE) file in this directory for details.
+This package is licensed under the **Breathe License 1.0** (`LicenseRef-Breathe-1.0`), (c) The Oxy Collective, Inc. See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files in this directory.
 
-The SDK packages in this monorepo are Apache-2.0, not AGPL. The repository root [LICENSE](../../LICENSE) states which package is under which.
+Non commercial use is free. Commercial use requires a paid licence; the trigger is revenue and it includes internal use. Source publication and attribution are required of everyone, including paying customers, and cannot be waived. This is **source available, not open source**.
+
+Versions up to and including `1.0.3` were published as MIT and stay MIT permanently; a licence change binds future versions only.
+
+The SDK packages in this monorepo are Apache-2.0, not Breathe. The repository root [LICENSE](../../LICENSE) states which package is under which.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/api",
-  "version": "1.0.9",
+  "version": "2.0.0",
   "description": "OxyHQ API server with authentication, user management, and real-time features",
   "main": "dist/server.js",
   "scripts": {
@@ -48,7 +48,7 @@
     "oxyhq"
   ],
   "author": "OxyHQ",
-  "license": "AGPL-3.0-only",
+  "license": "SEE LICENSE IN LICENSE",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/packages/app-preset/NOTICE
+++ b/packages/app-preset/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/app-preset
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/contracts/NOTICE
+++ b/packages/contracts/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/contracts
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/core/NOTICE
+++ b/packages/core/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/core
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/create-oxy-app/NOTICE
+++ b/packages/create-oxy-app/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  create-oxy-app
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/db/CHANGELOG.md
+++ b/packages/db/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog: `@oxyhq/db`
+
+## 0.2.0
+
+### Licence: this package moves to the Breathe License 1.0
+
+**Breaking, and a genuine narrowing rather than paperwork.** `@oxyhq/db` is now
+licensed under the Breathe License 1.0, identifier `LicenseRef-Breathe-1.0`. The
+code, the API surface and the behaviour are unchanged in this release; it exists
+to carry the licence change.
+
+What changes for you:
+
+- **Non commercial use stays free**, perpetually and irrevocably while you comply.
+- **Commercial use now requires a paid licence.** The trigger is revenue, and it
+  includes purely internal use inside a business that earns revenue.
+- **If you deploy it, you publish the corresponding source.** That binds everyone,
+  including paying customers, and cannot be bought out of.
+- **Attribution is required of everyone** and cannot be waived.
+- **Cooperatives, nonprofits, educational institutions, public bodies and worker
+  owned businesses pay no fee.**
+
+This is **source available, not open source**. It fails clause 6 of the Open
+Source Definition because commercial use is conditional on payment. Automated
+licence scanners report it as unknown, and GitHub shows it as "Other".
+
+**Nothing here is retroactive, and it could not be.** `@oxyhq/db@0.1.0` was published
+under AGPL-3.0-only and stays AGPL-3.0-only forever for anyone who has it. They may keep
+using it, commercially, at no charge, indefinitely, and may fork it. A licence
+change binds future versions only.
+
+`@oxyhq/db` is below 1.0.0, where semver puts the breaking position in the minor and
+`^0.1.2` does not accept `0.2.0`. Bumping the minor is the same signal a major
+gives a 1.x package: nobody picks this up without editing their manifest.
+
+### Added
+
+- A `LICENSE` carrying the full Breathe License text with its Parameters filled
+  in, and a `NOTICE`.
+
+### Still outstanding
+
+- The Licensor's jurisdiction of incorporation, registration number and the
+  governing law are **visible placeholders**. They are not guesses, and must be
+  filled in before the commercial arm can invoice.

--- a/packages/db/NOTICE
+++ b/packages/db/NOTICE
@@ -1,0 +1,25 @@
+=============================================================================
+ NOTICE
+ @oxyhq/db
+ Copyright (c) 2025-present The Oxy Collective, Inc.
+=============================================================================
+
+This product is licensed under the Breathe License 1.0
+(`LicenseRef-Breathe-1.0`). See the LICENSE file in this directory. Commercial
+terms are available; see
+<https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md>.
+
+Attribution under Section 3.1 of the Breathe License is required of everyone,
+including paying commercial licensees, and cannot be waived.
+
+-----------------------------------------------------------------------------
+ THIRD PARTY COMPONENTS
+-----------------------------------------------------------------------------
+
+This package contains no third party source. Its dependencies are resolved and
+installed by the package manager and remain governed by their own licenses.
+
+This package must not take on a GPL or AGPL dependency that is linked in
+process: the Breathe License is not compatible with either, in either
+direction. If you are adding one, stop and read
+https://github.com/OxyHQ/.github/blob/main/licensing/README.md

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/db",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Oxy Postgres substrate — drizzle column and naming helpers, driver-error predicates, the migration ledger and deploy-phase planner, the TTL-replacement sweep, an ephemeral-database harness, and the schema-convention gates every Oxy backend is held to.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -44,7 +44,7 @@
       "assert": ["dist/types/assert/index.d.ts"]
     }
   },
-  "files": ["dist", "src", "!src/__tests__", "!src/**/*.typetest.ts"],
+  "files": ["NOTICE", "dist", "src", "!src/__tests__", "!src/**/*.typetest.ts"],
   "keywords": ["oxyhq", "postgres", "drizzle", "migrations", "schema"],
   "repository": {
     "type": "git",
@@ -52,7 +52,7 @@
     "directory": "packages/db"
   },
   "author": "OxyHQ",
-  "license": "AGPL-3.0-only",
+  "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://oxy.so",
   "engines": { "node": ">=18.0.0" },
   "scripts": {

--- a/packages/expo-splash/NOTICE
+++ b/packages/expo-splash/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/expo-splash
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/federation/NOTICE
+++ b/packages/federation/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/federation
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog: `@oxyhq/node`
+
+## 0.2.0
+
+### Licence: this package moves to the Breathe License 1.0
+
+**Breaking, and a genuine narrowing rather than paperwork.** `@oxyhq/node` is now
+licensed under the Breathe License 1.0, identifier `LicenseRef-Breathe-1.0`. The
+code, the API surface and the behaviour are unchanged in this release; it exists
+to carry the licence change.
+
+What changes for you:
+
+- **Non commercial use stays free**, perpetually and irrevocably while you comply.
+- **Commercial use now requires a paid licence.** The trigger is revenue, and it
+  includes purely internal use inside a business that earns revenue.
+- **If you deploy it, you publish the corresponding source.** That binds everyone,
+  including paying customers, and cannot be bought out of.
+- **Attribution is required of everyone** and cannot be waived.
+- **Cooperatives, nonprofits, educational institutions, public bodies and worker
+  owned businesses pay no fee.**
+
+This is **source available, not open source**. It fails clause 6 of the Open
+Source Definition because commercial use is conditional on payment. Automated
+licence scanners report it as unknown, and GitHub shows it as "Other".
+
+`@oxyhq/node` has never been published to npm, so no prior release carries an earlier
+licence and nobody is affected.
+
+`@oxyhq/node` is below 1.0.0, where semver puts the breaking position in the minor and
+`^0.1.0` does not accept `0.2.0`. Bumping the minor is the same signal a major
+gives a 1.x package: nobody picks this up without editing their manifest.
+
+### Added
+
+- A `LICENSE` carrying the full Breathe License text with its Parameters filled
+  in, and a `NOTICE`.
+
+### Still outstanding
+
+- The Licensor's jurisdiction of incorporation, registration number and the
+  governing law are **visible placeholders**. They are not guesses, and must be
+  filled in before the commercial arm can invoice.

--- a/packages/node/LICENSE
+++ b/packages/node/LICENSE
@@ -92,7 +92,7 @@ Fill these in for each work. Terms in **bold** are defined in Section 15.
 | Parameter | Value |
 | --- | --- |
 | **Licensor** | The Oxy Collective, Inc., incorporated in `<JURISDICTION OF INCORPORATION: NOT YET SUPPLIED>` under registration number `<REGISTRATION NUMBER: NOT YET SUPPLIED>` |
-| **The Software** | `@oxyhq/db`, and each version of it the Licensor makes available under these terms |
+| **The Software** | `@oxyhq/node`, and each version of it the Licensor makes available under these terms |
 | Copyright notice | Copyright (c) 2025-present The Oxy Collective, Inc. |
 | License identifier | `LicenseRef-Breathe-1.0` |
 | **Commercial Terms** | <https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md> |
@@ -198,7 +198,7 @@ Attribution means preserving the copyright notice and a copy of these terms in
 the source you Convey, and presenting the following line in at least one place
 your users can reach:
 
-> Built on `@oxyhq/db` by The Oxy Collective, Inc., <https://oxy.so>. Licensed under the Breathe License 1.0.
+> Built on `@oxyhq/node` by The Oxy Collective, Inc., <https://oxy.so>. Licensed under the Breathe License 1.0.
 
 A reachable "About", "Credits", "Licenses", or "Open source" screen satisfies
 this. So does the documentation, or a `NOTICE` file shipped with the work, if

--- a/packages/node/NOTICE
+++ b/packages/node/NOTICE
@@ -1,0 +1,25 @@
+=============================================================================
+ NOTICE
+ @oxyhq/node
+ Copyright (c) 2025-present The Oxy Collective, Inc.
+=============================================================================
+
+This product is licensed under the Breathe License 1.0
+(`LicenseRef-Breathe-1.0`). See the LICENSE file in this directory. Commercial
+terms are available; see
+<https://github.com/OxyHQ/.github/blob/main/LICENSE-COMMERCIAL.md>.
+
+Attribution under Section 3.1 of the Breathe License is required of everyone,
+including paying commercial licensees, and cannot be waived.
+
+-----------------------------------------------------------------------------
+ THIRD PARTY COMPONENTS
+-----------------------------------------------------------------------------
+
+This package contains no third party source. Its dependencies are resolved and
+installed by the package manager and remain governed by their own licenses.
+
+This package must not take on a GPL or AGPL dependency that is linked in
+process: the Breathe License is not compatible with either, in either
+direction. If you are adding one, stop and read
+https://github.com/OxyHQ/.github/blob/main/licensing/README.md

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/node",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Oxy personal data node — a self-hostable server that stores and serves a user's own signed records (their personal repo) for Oxy to ingest/mirror (Fase 5 decentralization)",
   "private": true,
   "type": "module",
@@ -21,7 +21,7 @@
     "self-sovereign-identity"
   ],
   "author": "OxyHQ",
-  "license": "AGPL-3.0-only",
+  "license": "SEE LICENSE IN LICENSE",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/protocol/NOTICE
+++ b/packages/protocol/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/protocol
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/services/NOTICE
+++ b/packages/services/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/services
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -785,6 +785,6 @@ Comprehensive documentation is available in the `/docs` directory:
 
 ## License
 
-This package is licensed under the Apache License, Version 2.0, (c) The Oxy Collective Inc. See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files for details.
+This package is licensed under the Apache License, Version 2.0, (c) The Oxy Collective, Inc. See the [LICENSE](LICENSE) and [NOTICE](NOTICE) files for details.
 
 Versions published before `28.0.0` were AGPL-3.0-only and stay that way; a licence change binds future versions only.

--- a/packages/ship/NOTICE
+++ b/packages/ship/NOTICE
@@ -1,7 +1,7 @@
 =============================================================================
  NOTICE
  @oxyhq/ship
- Copyright (c) 2025-present The Oxy Collective Inc
+ Copyright (c) 2025-present The Oxy Collective, Inc.
 =============================================================================
 
 This product is licensed under the Apache License, Version 2.0.


### PR DESCRIPTION
The server layer moves to the **Breathe License 1.0**
(`LicenseRef-Breathe-1.0`). This was blocked until now for one reason and the
reason is gone: every Parameters table named **The Oxy Foundation, Inc.**, an
entity that is not registered, and a licence granted by an entity that does not
exist grants nothing. The licensor is now **The Oxy Collective, Inc.**

| Package | Was | Now | Version |
| --- | --- | --- | --- |
| `@oxyhq/api` | AGPL-3.0-only (npm latest `1.0.3` is **MIT**) | Breathe 1.0 | `1.0.9` -> `2.0.0` |
| `@oxyhq/db` | AGPL-3.0-only | Breathe 1.0 | `0.1.2` -> `0.2.0` |
| `@oxyhq/node` | AGPL-3.0-only, never published | Breathe 1.0 | `0.1.0` -> `0.2.0` |

## `@oxyhq/db` had to move, and that is a decision the plan never made

**The Breathe License is not compatible with the GPL or the AGPL, in either
direction.** `packages/api` imports `@oxyhq/db` **in process**, and `@oxyhq/db`
was `AGPL-3.0-only`. Relicensing `@oxyhq/api` on its own would have produced a
combination distributable under **neither** licence: not under Breathe, because
it contains AGPL code, and not under the AGPL, because Breathe is not
AGPL-compatible.

Oxy owns both, so this is a decision rather than a negotiation. But it is a
decision, and it is one the migration analysis never made: `@oxyhq/db` postdates
that analysis and sits in no layer at all. I raised it as needing an answer in
the previous round and it did not get one, so I have taken the only reading that
makes the instructed change lawful, and flagged it here rather than burying it.
**Reverting `db` means reverting `api` too.** They cannot be separated.

## The root `LICENSE` now describes three situations

1. **Apache-2.0**, the nine SDK packages. Unchanged.
2. **Breathe 1.0**, `api`, `db`, `node`.
3. **AGPL-3.0-only**, the seven `"private": true` workspace packages
   (`accounts`, `auth`, `commons`, `console`, `inbox`, `test-app-expo`,
   `test-app-vite`), which **keep exactly what they had**.

Nothing in this PR narrows anything previously granted to anyone. Section 3 is a
no-change: those packages were AGPL under the old repository licence and stay
AGPL. Moving them to Breathe is a separate decision that has not been made, and
I have not made it.

## `packages/api/NOTICE` is new, and it carries real obligations

Attribution binds everyone under Breathe, paying customers included, so this
file matters here in a way it did not under the old licence.

- **`ffmpeg-static`, GPL-3.0-or-later.** An `optionalDependency`, so it *is*
  installed and distributed. It is invoked as a **separate executable process**,
  which is aggregation rather than linking, so `@oxyhq/api` is not a GPL
  derivative. The binary stays GPL, and the NOTICE carries the source offer the
  GPL requires. **The standing rule:** if anyone ever links `libav*`, or any
  other GPL library, INTO this process, the combination becomes a GPL derivative
  and this package can no longer be distributed under these terms at all.
- **libvips via `@img/sharp-libvips-*`, LGPL-3.0-or-later.** Loaded as a shared
  library, with the relinking statement the LGPL requires. `sharp` itself is
  Apache-2.0.
- **Three dual licence elections recorded**: `node-forge` (BSD-3-Clause),
  `jszip` (MIT), `@zone-eu/mailsplit` (MIT). In every case the alternative is a
  GPL licence this package cannot accept, which is exactly why the election
  needs to be on the record rather than implied.

## `"SEE LICENSE IN LICENSE"`, not `"LicenseRef-Breathe-1.0"`

Measured rather than assumed. npm's own validator:

```
validate-npm-package-license("LicenseRef-Breathe-1.0")
  -> { validForNewPackages: false, validForOldPackages: false, spdx: true,
       warnings: ['license should be a valid SPDX license expression
                   (without "LicenseRef"), "UNLICENSED", or
                   "SEE LICENSE IN <filename>"'] }
```

So the manifest gets `SEE LICENSE IN LICENSE`, and the SPDX identifier lives in
the LICENSE Parameters table, which is where the licence itself puts it.

## Not retroactive

`@oxyhq/api@1.0.3` is **MIT on npm** and stays MIT forever for anyone who has
it: usable commercially, at no charge, indefinitely, and forkable. Same for
every published `@oxyhq/db` version under AGPL. A licence change binds future
versions only. This is worth saying in the announcement too, because a narrowing
is easy to misread as a revocation. It is not one, and could not be one.

## Also in here

The entity name is normalised to `The Oxy Collective, Inc.` **with the comma**
across the thirteen NOTICE and README files the Apache pass wrote without it.

## `scaffold` fails, and it is not this PR

`scaffold-smoke` is red, one step further along than it was last round. The
version-pin problem is gone (the SDK packages are published now), and the job
gets all the way to **Export web** before dying on a Metro resolution error:

```
Error: Unable to resolve module
  /home/runner/work/oxy/oxy/node_modules/metro-runtime/src/modules/empty-module.js
  from /home/runner/work/_temp/smoke-app/packages/frontend/_
```

That is a scaffolded app resolving an **absolute path back into the monorepo's
own `node_modules`** from `$RUNNER_TEMP`. Nothing in this diff touches Metro
config, the scaffolder templates, or any resolver.

**Verified pre-existing rather than asserted:** the identical error, at the
identical step, appears on `chore/app-preset-0.3.0`
([run 31068206254](https://github.com/OxyHQ/oxy/actions/runs/31068206254)), an
unrelated branch that was merged at 03:21, before this branch was cut. It is a
real bug in the scaffolder or its CI wiring, it is worth its own issue, and it
is not a licensing problem.

## Verification

- All three Breathe `LICENSE` files: the operative text from `## 1. Acceptance`
  onward is **byte identical** to the org template and to each other. Only the
  Parameters, the Section 3.1 attribution example, and the header comment
  differ, and the header no longer claims to be a template that licenses
  nothing.
- Every touched `package.json` re-parsed as JSON.
- `bun install`: the `bun.lock` diff is exactly the three version fields.
- SDK build chain (`contracts`, `protocol`, `core`, `db`): all exit 0.
- `bun run lint` in `packages/api`: **0 errors**.
- `create-oxy-app` drift guard: **17 pass, 0 fail**.

## What is still outstanding

**Three Parameters are visible placeholders, not guesses:** jurisdiction of
incorporation, registration number, and governing law. They read
`NOT YET SUPPLIED` in the licence. The licence grant itself works without them,
because the Licensor is now a real entity, but **the commercial arm cannot
invoice until they are filled in.**

**No CLA is switched on.** The agreement text is settled and now names
The Oxy Collective, Inc., with a successor clause so that moving the work to a
foundation later does not force every signatory to sign again
([OxyHQ/.github#7](https://github.com/OxyHQ/.github/pull/7)). But no bot is
installed and no signature has been taken, and that is deliberate: it changes
the contribution flow on every pull request. **Until it is on, one merged
outside contribution to this repository permanently breaks its commercial arm**,
because Oxy cannot offer commercial terms over somebody else's copyright.

## The merge-order prerequisite is already satisfied

The Breathe License is not compatible with the AGPL in either direction, so this
could not have merged while the SDK packages this repository depends on were
AGPL on npm. **They no longer are.** The Apache-2.0 layer was merged and
published while this work was in progress, and I verified it against the
registry rather than assuming:

| Package | npm today |
| --- | --- |
| `@oxyhq/core` | `20.0.0`, **Apache-2.0** |
| `@oxyhq/services` | `28.0.0`, **Apache-2.0** |
| `@oxyhq/contracts` | `0.25.0`, **Apache-2.0** |
| `@oxyhq/bloom` | `0.87.0`, **Apache-2.0** |

Apache-2.0 into Breathe is fine: permissive inbound is exactly what the two
layer split is for. So there is no ordering constraint left on this PR.

**Opened as a draft on purpose.** The org convention is that green CI means
merge; this one needs a decision and an ordering, not an automatic merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)