### PR TITLE
fix(scaffold-smoke): install the preset from a tarball, not a dir override

### DIFF
--- a/.github/workflows/scaffold-smoke.yml
+++ b/.github/workflows/scaffold-smoke.yml
@@ -47,6 +47,20 @@ jobs:
           echo '{"name":"coa-runner","private":true}' > package.json
           bun add "$RUNNER_TEMP"/create-oxy-app-*.tgz
 
+      - name: Pack @oxyhq/app-preset from the monorepo
+        run: |
+          # @oxyhq/app-preset may be unpublished at HEAD, so the generated app has
+          # to take it from this checkout. Install it from a PACKED TARBALL rather
+          # than pointing a `file:` override at the source directory: bun
+          # materializes a `file:` DIRECTORY dependency as a tree of symlinks back
+          # to that directory, and node resolves a symlinked module to its realpath.
+          # Every `require` inside the preset (expo/metro-config, metro-config,
+          # nativewind/metro) would then resolve from THIS checkout's node_modules
+          # instead of the generated app's. A tarball is extracted as real files,
+          # which is exactly what a `bun add @oxyhq/app-preset` from the registry
+          # produces, and it also exercises the package's `files` list.
+          bun pm pack --cwd packages/app-preset --destination "$RUNNER_TEMP"
+
       - name: Scaffold a test app (from the packed tarball)
         run: |
           node "$RUNNER_TEMP/cli/node_modules/create-oxy-app/dist/index.js" "$RUNNER_TEMP/smoke-app" \
@@ -64,22 +78,45 @@ jobs:
       - name: Install the generated app (+ local @oxyhq/app-preset)
         working-directory: ${{ runner.temp }}/smoke-app
         run: |
-          # @oxyhq/app-preset may be unpublished at HEAD. Point the override at
-          # the monorepo copy so resolution passes, then materialize it into
-          # node_modules (bun does not always link a `file:` dir override).
+          # Override @oxyhq/app-preset with the tarball packed above, so the app
+          # installs the HEAD preset the same way a real consumer installs the
+          # published one. See the pack step for why a tarball and not a dir.
           node -e '
             const fs = require("fs");
+            const path = require("path");
+            const dir = process.env.RUNNER_TEMP;
+            const tarball = fs.readdirSync(dir).find((f) => /^oxyhq-app-preset-.*\.tgz$/.test(f));
+            if (!tarball) throw new Error("packed @oxyhq/app-preset tarball not found in " + dir);
+            const local = "file:" + path.join(dir, tarball);
             const p = JSON.parse(fs.readFileSync("package.json", "utf8"));
-            const local = "file:" + process.env.GITHUB_WORKSPACE + "/packages/app-preset";
             p.overrides["@oxyhq/app-preset"] = local;
             p.resolutions["@oxyhq/app-preset"] = local;
             fs.writeFileSync("package.json", JSON.stringify(p, null, 2) + "\n");
           '
           bun install --ignore-scripts
-          rm -rf node_modules/@oxyhq/app-preset
-          cp -r "$GITHUB_WORKSPACE/packages/app-preset" node_modules/@oxyhq/app-preset
-          rm -rf node_modules/@oxyhq/app-preset/node_modules
           bun run build:shared-types
+
+      - name: Assert the app's Metro config stays inside the generated app
+        working-directory: ${{ runner.temp }}/smoke-app/packages/frontend
+        run: |
+          # Every absolute path the preset bakes into the Metro config must point
+          # inside the generated app. Metro can only resolve files under
+          # projectRoot + watchFolders, so a path that escapes to this checkout
+          # fails the bundle 30s in with an opaque "Unable to resolve module
+          # <abs path>". emptyModulePath is the canonical victim: metro-config
+          # computes it with require.resolve at config-build time, so it lands
+          # wherever the preset's own require chain was rooted.
+          node -e '
+            const path = require("path");
+            const appRoot = path.resolve("../..") + path.sep;
+            const assertInsideApp = (label, target) => {
+              if (!target.startsWith(appRoot)) {
+                throw new Error(label + " escaped the generated app: " + target);
+              }
+            };
+            assertInsideApp("@oxyhq/app-preset", require.resolve("@oxyhq/app-preset/metro"));
+            assertInsideApp("resolver.emptyModulePath", require("./metro.config.js").resolver.emptyModulePath);
+          '
 
       - name: Lockfile is stable (no churn on re-install)
         working-directory: ${{ runner.temp }}/smoke-app

--- a/bun.lock
+++ b/bun.lock
@@ -185,7 +185,7 @@
     },
     "packages/app-preset": {
       "name": "@oxyhq/app-preset",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "peerDependencies": {
         "@oxyhq/bloom": "*",
         "@oxyhq/services": "*",

--- a/packages/app-preset/CHANGELOG.md
+++ b/packages/app-preset/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog: `@oxyhq/app-preset`
 
+## 0.3.1
+
+### Fixed
+
+The web `ws` shim resolves through Metro's own empty module again
+(`{ type: 'empty' }`), and the `metro/empty-module.js` stub that briefly stood in
+for it is gone.
+
+The stub was added to fix a `scaffold-smoke` CI failure. It did not fix it: the
+failing path was `resolver.emptyModulePath`, which `metro-config` computes with
+`require.resolve` when the config is built, so it never went through the shim at
+all. The real fault was in the workflow, which installed the preset by pointing a
+`file:` override at a directory outside the generated app. Bun materializes that
+as a tree of symlinks, node resolves each one to its realpath, and the preset's
+whole `require` graph landed in the wrong checkout. That is fixed in the
+workflow.
+
+No behaviour changes for apps installing this package from the registry, where
+the preset has always been real files inside the app's own `node_modules`.
+
 ## 0.2.0
 
 ### Licence: MIT becomes Apache-2.0

--- a/packages/app-preset/metro/empty-module.js
+++ b/packages/app-preset/metro/empty-module.js
@@ -1,1 +1,0 @@
-"use strict";

--- a/packages/app-preset/metro/index.js
+++ b/packages/app-preset/metro/index.js
@@ -155,22 +155,13 @@ function createOxyMetroConfig(projectRoot, options = {}) {
  * React Context objects, so `<BloomThemeProvider>` (services) does not satisfy
  * `useTheme()` (app code) and the app crashes.
  */
-function resolveMetroEmptyModule() {
-  // Metro's `{ type: 'empty' }` ws shim resolves `metro-runtime/.../empty-module.js`
-  // from wherever Metro itself was loaded. In scaffold-smoke that is the CI
-  // checkout's node_modules, not the generated app's — the absolute path 404s.
-  // Ship the same one-line stub alongside app-preset instead.
-  return path.join(__dirname, 'empty-module.js');
-}
-
 function withBloomSingleInstance(nativeWindConfig, projectRoot) {
   const parentResolveRequest = nativeWindConfig.resolver.resolveRequest;
   const bloomOrigin = path.join(projectRoot, 'package.json');
-  const webSocketShimPath = resolveMetroEmptyModule();
 
   nativeWindConfig.resolver.resolveRequest = (context, moduleName, platform) => {
     if (platform === 'web' && (moduleName === 'ws' || moduleName === 'node:ws')) {
-      return { type: 'sourceFile', filePath: webSocketShimPath };
+      return { type: 'empty' };
     }
 
     const resolveContext =

--- a/packages/app-preset/package.json
+++ b/packages/app-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/app-preset",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The Oxy distro of Expo — centralized Expo config plugin, Metro/Babel/ESLint factories, Tailwind base CSS and TypeScript bases shared by every Oxy app (Mention, Homiio, Allo, accounts, …). A zero-build package: apps replace copy-pasted config with a single dependency bump.",
   "main": "./app.plugin.js",
   "publishConfig": {
@@ -78,16 +78,38 @@
     "tailwindcss": ">=4.0.0"
   },
   "peerDependenciesMeta": {
-    "@oxyhq/bloom": { "optional": true },
-    "@oxyhq/services": { "optional": true },
-    "babel-plugin-module-resolver": { "optional": true },
-    "babel-preset-expo": { "optional": true },
-    "eslint": { "optional": true },
-    "eslint-config-expo": { "optional": true },
-    "expo-build-properties": { "optional": true },
-    "nativewind": { "optional": true },
-    "react-native-worklets": { "optional": true },
-    "sharp": { "optional": true },
-    "tailwindcss": { "optional": true }
+    "@oxyhq/bloom": {
+      "optional": true
+    },
+    "@oxyhq/services": {
+      "optional": true
+    },
+    "babel-plugin-module-resolver": {
+      "optional": true
+    },
+    "babel-preset-expo": {
+      "optional": true
+    },
+    "eslint": {
+      "optional": true
+    },
+    "eslint-config-expo": {
+      "optional": true
+    },
+    "expo-build-properties": {
+      "optional": true
+    },
+    "nativewind": {
+      "optional": true
+    },
+    "react-native-worklets": {
+      "optional": true
+    },
+    "sharp": {
+      "optional": true
+    },
+    "tailwindcss": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## What was wrong

`scaffold-smoke` has failed on every nightly run since 2026-08-01, and on every PR touching `packages/create-oxy-app` or `packages/app-preset`. Always the same step (**Export web**), always the same error:

```
Error: Unable to resolve module /home/runner/work/oxy/oxy/node_modules/metro-runtime/src/modules/empty-module.js
from /home/runner/work/_temp/smoke-app/packages/frontend/_
```

The generated app, in `$RUNNER_TEMP/smoke-app`, was resolving an absolute path into the **monorepo checkout's** `node_modules`.

## What the resolution actually did

The workflow installed `@oxyhq/app-preset` with a `file:` override pointing at `$GITHUB_WORKSPACE/packages/app-preset`, a directory outside the generated app.

**Bun materializes a `file:` directory dependency as a tree of per-file symlinks back to the source.** Verified in the reproduction:

```
smoke-app/packages/frontend/node_modules/@oxyhq/app-preset/metro/
  index.js -> <monorepo>/packages/app-preset/metro/index.js
```

Node resolves a symlinked module to its realpath, so `metro.config.js` loaded the preset **at its monorepo path**. From there every `require` inside the preset walked the monorepo's `node_modules`, not the app's:

```
expo/metro-config  -> <monorepo>/node_modules/expo/metro-config.js
nativewind/metro   -> <monorepo>/node_modules/nativewind/dist/commonjs/metro.js
metro-config       -> <monorepo>/node_modules/metro-config/src/index.js
```

`metro-config`'s `getDefaultValues()` bakes in

```js
emptyModulePath: require.resolve('metro-runtime/src/modules/empty-module.js')
```

as an absolute path **at config-build time**, resolved from wherever `metro-config` itself was loaded. So the app ended up with:

```
emptyModulePath : <monorepo>/node_modules/metro-runtime/src/modules/empty-module.js
projectRoot     : <smoke-app>/packages/frontend
watchFolders    : [ <smoke-app> ]
```

That file exists on disk, but Metro resolves through its file map, which spans `projectRoot` + `watchFolders` only. A path outside those roots is invisible, hence "None of these files exist". `ModuleResolution._getEmptyModule()` resolves `emptyModulePath` from a fake `<projectRoot>/_` origin, which is the odd `from .../packages/frontend/_` in the error.

The trigger is ordinary: `metro-resolver` returns `{ type: 'empty' }` whenever `redirectModulePath` yields `false`, which is any package.json `"browser": { x: false }` mapping. Nothing exotic is required to hit it.

The workflow did try to avoid this, replacing the installed copy by hand. It only replaced the **root** one. Bun had also put a copy under `packages/frontend/node_modules`, and that is the one node finds first.

## Why the fix is in the workflow

This layout is unique to the workflow.

- **Registry consumers** (`bun add @oxyhq/app-preset`) get real files inside the app's own `node_modules`; every require lands in the app tree and `emptyModulePath` sits inside Metro's roots. `@oxyhq/app-preset@0.3.0` is not broken for anyone.
- **Workspace consumers inside this monorepo** symlink to `packages/app-preset`, whose requires resolve into the same `node_modules` the app already lives in, and the monorepo root is in `watchFolders`.

Only the workflow produced the split: preset in tree A, app in tree B, B's Metro roots excluding A.

So the preset now installs **from a packed tarball**, which bun extracts as real files. That is what a registry install produces, it removes the `rm -rf` + `cp -r` dance entirely, and it exercises the package's `files` list at the same time (the same reason the workflow already packs the CLI).

A new step then asserts both invariants directly, so this cannot silently regress: it fails in a second with a named path instead of 30 seconds into a Metro bundle.

## Also removed: a fix that never worked

`packages/app-preset/metro/empty-module.js` and `resolveMetroEmptyModule()` were added on 2026-08-02 for this exact failure. They could not have fixed it: the failing value is `resolver.emptyModulePath`, which never passes through the `ws` shim, and `path.join(__dirname, ...)` would have produced a monorepo path anyway once `__dirname` was realpath'd. The comment claiming it fixed scaffold-smoke is why this went uninvestigated for five days, so it is gone; the `ws` shim returns `{ type: 'empty' }` again. `@oxyhq/app-preset` is bumped to `0.3.1` with `bun.lock` regenerated in the same commit.

## The `@noble/hashes` warning was a red herring

Unrelated. Its paths are entirely inside the generated app (`smoke-app/node_modules/@noble/hashes/crypto.js`), never the checkout, and it is a benign package-exports fallback warning. **It still appears verbatim in the now-passing export.** No further investigation needed.

## Verified locally

Reproduced the CI failure byte for byte outside CI, then ran the whole job by hand.

| Check | Before | After |
| --- | --- | --- |
| `require.resolve('@oxyhq/app-preset/metro')` | monorepo path | inside the app |
| `resolver.emptyModulePath` | monorepo path | inside the app |
| `bunx expo export --platform web` | same error as CI | **Exported: dist** (7 web bundles) |
| new assertion step | fails, names the escaped path | passes |
| lockfile stable on re-install | n/a | passes |
| typecheck, backend build, android + ios prebuild and their asserts | n/a | pass |
| `create-oxy-app` tests (17), `app-preset` tests (11) | n/a | pass |
| `scripts/check-lockfile-sync.mjs` | n/a | in sync |

The guard was checked in both directions: it fails on the old broken layout, rebuilt deliberately, and passes on the fixed one.

## Not verified

The export was run on linux/x64; CI runs `ubuntu-24.04-arm`. The resolution behaviour is architecture independent, but the run itself was not reproduced on arm64.

Per the Metro rules in `~/Oxy/AGENTS.md`, a green web export says nothing about a native bundle. `expo prebuild` passes for android and ios, but neither native bundle was built here, and the workflow does not build one either.
