### PR TITLE
A chains client in the SDK, so the second app writes less code than the first

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -230,6 +230,13 @@ export type {
 } from './mixins/OxyServices.civic';
 export type { UserNodeStatus, UserNodeMode, UserNodeController, UserNodeLivenessStatus, RegisterNodeInput, RemoveNodeResult } from './mixins/OxyServices.nodes';
 
+/**
+ * Chains — the shared per-person record log. `ChainRecord` is generic over the
+ * app's own lexicon payload, so a consumer types its records without Oxy
+ * knowing any app's schema.
+ */
+export type { ChainRecord, ChainRecordPage, AppendedChainRecord } from './mixins/OxyServices.chains';
+
 // ---------------------------------------------------------------------------
 // Auth helpers (token refresh, error normalisation, retry policies)
 // ---------------------------------------------------------------------------

--- a/packages/core/src/mixins/OxyServices.chains.ts
+++ b/packages/core/src/mixins/OxyServices.chains.ts
@@ -1,0 +1,134 @@
+/**
+ * Chains — the shared record log every Oxy app reads and writes.
+ *
+ * A person has ONE chain. An app appends its own records to it and projects its
+ * feeds from what it reads back, instead of keeping a private copy of the same
+ * person's activity. This mixin is the client half of `/chains` in oxy-api, and
+ * it exists so that adopting the chain costs an app no HTTP of its own — the
+ * whole point of the shared substrate is that the second app writes less code
+ * than the first, not the same amount in a different file.
+ *
+ * ## Both calls are SERVICE-authenticated
+ *
+ * They go through `makeServiceRequest`, so they only work on a backend that has
+ * called `configureServiceAuth()`. That is not an accident of implementation: an
+ * append writes to someone else's chain and a read spans many subjects, so
+ * neither belongs in a browser holding a user session. A frontend that needs
+ * this asks its own backend.
+ *
+ * The authority is checked server-side and cannot be talked out of from here:
+ * `chains:write` plus the application's own `chainNamespaces` for an append,
+ * `chains:read` plus the public-collection policy for a read. A call that
+ * violates either gets a 403 or an empty page — this client adds no
+ * pre-validation that could drift from the server's answer.
+ */
+
+import type { OxyServicesBase } from '../OxyServices.base';
+
+/** A signed record as it comes back from a read. */
+export interface ChainRecord<TRecord = Record<string, unknown>> {
+  recordId: string;
+  /** The subject whose chain it is — the person the record is about. */
+  oxyUserId: string;
+  /** The lexicon NSID, e.g. `app.mention.feed.post`. */
+  collection: string;
+  envelope: {
+    version: number;
+    type: string;
+    subject: string;
+    issuer: string;
+    record: TRecord;
+    issuedAt: number;
+    seq?: number;
+    prev?: string | null;
+    collection?: string;
+    rkey?: string;
+    publicKey: string;
+    alg: string;
+    signature: string;
+  };
+}
+
+/** One page of a multi-subject read. */
+export interface ChainRecordPage<TRecord = Record<string, unknown>> {
+  records: ChainRecord<TRecord>[];
+  /**
+   * Opaque. Hand it back as `since` to continue; `null` at the end of the
+   * stream as of this snapshot. Never construct one.
+   */
+  nextCursor: string | null;
+}
+
+/** What an append returns once the record is on the chain. */
+export interface AppendedChainRecord {
+  recordId: string;
+  seq: number;
+  envelope: ChainRecord['envelope'];
+  verified: boolean;
+}
+
+export function OxyServicesChainsMixin<T extends typeof OxyServicesBase>(Base: T) {
+  return class extends Base {
+    constructor(...args: any[]) {
+      super(...(args as [any]));
+    }
+
+    /** Service-token request, implemented by the auth mixin earlier in the pipeline. */
+    declare makeServiceRequest: <R = unknown>(
+      method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+      url: string,
+      data?: unknown,
+      userId?: string,
+    ) => Promise<R>;
+
+    /**
+     * Append a record to `oxyUserId`'s chain under `collection`/`rkey`.
+     *
+     * Oxy issues and signs it; the calling app never holds a chain signing key.
+     * `rkey` is the app's own id for the thing — reusing it later supersedes the
+     * earlier record for that key, which is how an edit works.
+     *
+     * Requires the `chains:write` scope AND `collection` falling under one of
+     * this application's granted `chainNamespaces`. Both are enforced by the
+     * server; a violation throws with a 403.
+     */
+    async appendChainRecord(params: {
+      oxyUserId: string;
+      collection: string;
+      rkey: string;
+      record: Record<string, unknown>;
+    }): Promise<AppendedChainRecord> {
+      return this.makeServiceRequest<AppendedChainRecord>('POST', '/chains/records', params);
+    }
+
+    /**
+     * Records published by any of `oxyUserIds` under any of `collections`,
+     * oldest first — the read a cross-app feed is projected from.
+     *
+     * Only collections Oxy declares PUBLIC come back, whatever is asked for; a
+     * private one yields nothing rather than an error.
+     *
+     * **Re-poll from slightly BEFORE your last cursor and dedupe by
+     * `recordId`.** The chain's pagination axis is a transaction-start
+     * timestamp, so a record can commit behind a cursor that already passed it.
+     * Re-delivering one costs bytes; skipping one costs a record that never
+     * appears. Projections are expected to be idempotent for exactly this
+     * reason.
+     */
+    async readChainRecords<TRecord = Record<string, unknown>>(params: {
+      oxyUserIds: readonly string[];
+      collections: readonly string[];
+      since?: string | null;
+      limit?: number;
+    }): Promise<ChainRecordPage<TRecord>> {
+      const query = new URLSearchParams({
+        authors: params.oxyUserIds.join(','),
+        collections: params.collections.join(','),
+      });
+      if (params.since) query.set('since', params.since);
+      if (params.limit !== undefined) query.set('limit', String(params.limit));
+
+      return this.makeServiceRequest<ChainRecordPage<TRecord>>('GET', `/chains/records?${query.toString()}`);
+    }
+  };
+}

--- a/packages/core/src/mixins/__tests__/chains.test.ts
+++ b/packages/core/src/mixins/__tests__/chains.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The chains client — what it puts on the wire.
+ *
+ * There is exactly one piece of real logic here and it is the read's query
+ * string: joining two lists, and including `since`/`limit` only when the caller
+ * gave them. Everything else is a pass-through, so these cases pin the part that
+ * can actually be wrong rather than restating the method bodies.
+ *
+ * `makeServiceRequest` is stubbed because it belongs to the auth mixin and has
+ * its own suites; what matters here is the method, path and payload it is handed.
+ */
+
+import { OxyServicesChainsMixin } from '../OxyServices.chains';
+
+type Call = { method: string; url: string; data?: unknown };
+
+/** A minimal host carrying the mixin, with the service transport recorded. */
+function client(): { calls: Call[]; api: any } {
+  const calls: Call[] = [];
+  class Base {
+    makeServiceRequest(method: string, url: string, data?: unknown) {
+      calls.push({ method, url, data });
+      return Promise.resolve({ records: [], nextCursor: null });
+    }
+  }
+  const Mixed = OxyServicesChainsMixin(Base as any);
+  return { calls, api: new (Mixed as any)() };
+}
+
+describe('appendChainRecord', () => {
+  it('POSTs the record to /chains/records untouched', async () => {
+    const { calls, api } = client();
+
+    await api.appendChainRecord({
+      oxyUserId: 'u1',
+      collection: 'app.mention.feed.post',
+      rkey: 'p1',
+      record: { text: 'hi' },
+    });
+
+    expect(calls).toEqual([
+      {
+        method: 'POST',
+        url: '/chains/records',
+        data: {
+          oxyUserId: 'u1',
+          collection: 'app.mention.feed.post',
+          rkey: 'p1',
+          record: { text: 'hi' },
+        },
+      },
+    ]);
+  });
+});
+
+describe('readChainRecords', () => {
+  it('joins authors and collections into one comma-separated query each', async () => {
+    const { calls, api } = client();
+
+    await api.readChainRecords({
+      oxyUserIds: ['u1', 'u2'],
+      collections: ['app.mention.feed.post', 'app.mention.feed.like'],
+    });
+
+    const url = new URL(`http://x${calls[0].url}`);
+    expect(calls[0].method).toBe('GET');
+    expect(url.pathname).toBe('/chains/records');
+    expect(url.searchParams.get('authors')).toBe('u1,u2');
+    expect(url.searchParams.get('collections')).toBe('app.mention.feed.post,app.mention.feed.like');
+  });
+
+  it('omits since and limit when the caller gave neither', async () => {
+    // A `since=` or `limit=` sent as an empty string is not the same request —
+    // the server validates both, so an always-present key would 400 a first page.
+    const { calls, api } = client();
+
+    await api.readChainRecords({ oxyUserIds: ['u1'], collections: ['app.mention.feed.post'] });
+
+    const url = new URL(`http://x${calls[0].url}`);
+    expect(url.searchParams.has('since')).toBe(false);
+    expect(url.searchParams.has('limit')).toBe(false);
+  });
+
+  it('sends since and limit when it did', async () => {
+    const { calls, api } = client();
+
+    await api.readChainRecords({
+      oxyUserIds: ['u1'],
+      collections: ['app.mention.feed.post'],
+      since: 'Y3Vyc29y',
+      limit: 25,
+    });
+
+    const url = new URL(`http://x${calls[0].url}`);
+    expect(url.searchParams.get('since')).toBe('Y3Vyc29y');
+    expect(url.searchParams.get('limit')).toBe('25');
+  });
+
+  it('escapes a cursor that is not URL-safe', async () => {
+    // Cursors are opaque to the caller, so this client must not assume the
+    // encoding the server happens to use today.
+    const { calls, api } = client();
+
+    await api.readChainRecords({
+      oxyUserIds: ['u1'],
+      collections: ['app.mention.feed.post'],
+      since: 'a+b/c=',
+    });
+
+    const url = new URL(`http://x${calls[0].url}`);
+    expect(url.searchParams.get('since')).toBe('a+b/c=');
+  });
+});

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -28,6 +28,7 @@ import { OxyServicesContactsMixin } from './OxyServices.contacts';
 import { OxyServicesNotificationsMixin } from './OxyServices.notifications';
 import { OxyServicesAppDataMixin } from './OxyServices.appData';
 import { OxyServicesCivicMixin } from './OxyServices.civic';
+import { OxyServicesChainsMixin } from './OxyServices.chains';
 import { OxyServicesNodesMixin } from './OxyServices.nodes';
 import { OxyServicesLinksMixin } from './OxyServices.links';
 import { OxyServicesFollowGraphMixin } from './OxyServices.followGraph';
@@ -65,6 +66,7 @@ type AllMixinInstances =
   & InstanceType<ReturnType<typeof OxyServicesNotificationsMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesAppDataMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesCivicMixin<typeof OxyServicesBase>>>
+  & InstanceType<ReturnType<typeof OxyServicesChainsMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesNodesMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesLinksMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesFollowGraphMixin<typeof OxyServicesBase>>>
@@ -137,6 +139,7 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     OxyServicesAppDataMixin,
     // Civic / Commons "Oxy ID" (public signed cards, Oxy ID QR payload)
     OxyServicesCivicMixin,
+    OxyServicesChainsMixin,
     // User nodes / decentralization (Fase 5): register/read/revoke/manage the
     // caller's personal data node + ingest hint.
     OxyServicesNodesMixin,


### PR DESCRIPTION
`/chains` ya existe en oxy-api (#848 escritura, #849 lectura). Sin esto, cada app que lo adopte se escribe a mano las mismas dos llamadas HTTP — y el sentido de un sustrato compartido es que a la siguiente app le cueste **menos**, no lo mismo en otro fichero. Es literalmente el criterio §11 del plan.

## Dos decisiones que conviene ver

**Ambas llamadas van por `makeServiceRequest`**, así que solo funcionan en un backend con auth de servicio configurada. Es deliberado, no un accidente de implementación: un append escribe en la cadena de OTRA persona y una lectura cruza muchos sujetos, así que ninguna de las dos pinta en un navegador con sesión de usuario. Un frontend que lo necesite se lo pide a su propio backend.

**Cero pre-validación de autoridad en el cliente.** El scope `chains:write` más los `chainNamespaces` de la Application, y `chains:read` más la política de colecciones públicas, se comprueban en el servidor. Un espejo aquí solo podría desviarse de la respuesta real — y un llamante que se fiara del espejo se estaría fiando del equivocado.

`ChainRecord` es genérico sobre el payload de la app, así que un consumidor tipa su lexicon sin que Oxy sepa nada de su esquema.

## Verificación

5/5, y pinchan lo único con lógica real —la query de lectura— en vez de repetir los pass-throughs: las dos listas unidas por comas, y `since`/`limit` presentes solo si se pasan. Ese último caso importa: un `since=` vacío es otra petición, y el servidor daría 400 a una primera página que lo llevara.

`tsc` limpio en `@oxyhq/core`.

## Contexto

Con esto, lo que le queda a una app para sumarse a la cadena es: pedir su `chainNamespaces`, definir sus lexicons, llamar a `appendChainRecord`, y proyectar lo que `readChainRecords` le devuelve. Nada de HTTP propio, nada de firmar, nada de ActivityPub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)