### PR TITLE
fix(services): drop the false `sideEffects: false`, which blanked /authorize (#784)

### DIFF
--- a/packages/auth/lib/__tests__/authorize-surface-bundle.test.ts
+++ b/packages/auth/lib/__tests__/authorize-surface-bundle.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The authorize page's Commons lane must still render after the bundler has had
+ * its way with it (issue #784).
+ *
+ * WHY THIS TEST IS SHAPED LIKE THIS. `auth.oxy.so/authorize` served a blank page
+ * and React error #130 ("element type is undefined") for every request whose
+ * `client_id` resolved to a real application — the only requests that reach
+ * `CommonsOAuthLane`, and through it `@oxyhq/services`' `OxySignInRequestSurface`.
+ * Nothing was wrong with the source: the same commit rendered the same URL
+ * correctly under `vite` dev, and `components/__tests__/authorize-commons-lane.test.tsx`
+ * was green throughout, because it — like every test in this package — replaces
+ * the whole `@oxyhq/services` specifier with a double. The defect lived in the
+ * production bundle and nowhere else.
+ *
+ * So this test builds the real thing: the app's OWN `vite.config.ts`, in
+ * production mode, over `fixtures/authorize-surface-probe.tsx`. It then
+ * evaluates the emitted chunk and asserts the surface rendered. A regression
+ * fails here, in CI, with the same React message the browser reported.
+ *
+ * WHAT IT COVERS. Every element the surface draws, not just the surface itself —
+ * the probe renders it, so an `undefined` React Native, Bloom or vendored
+ * component anywhere beneath it throws out of `renderToStaticMarkup` too — and
+ * all four of its leading visuals, which between them reach the activity
+ * indicator, the QR plate, the vector-icon glyph and Bloom's button.
+ *
+ * WHAT IT DOES NOT COVER. Only this one surface. It is not a general "the bundle
+ * links" check; nothing here would notice the same defect on another screen. See
+ * `packages/services/README.md` for the condition that caused it, and why that
+ * package cannot declare `sideEffects: false`.
+ */
+
+import { afterAll, describe, expect, test } from "bun:test"
+import { rm } from "node:fs/promises"
+import { resolve } from "node:path"
+import { build } from "vite"
+import {
+    ALTERNATIVE_LABEL,
+    PROBE_CASES,
+    PROBE_GLOBAL,
+    SUBORDINATE_LABEL,
+    type AuthorizeSurfaceProbeResult,
+} from "./fixtures/authorize-surface-probe-contract"
+
+const PACKAGE_ROOT = resolve(import.meta.dir, "../..")
+const PROBE_ENTRY = resolve(import.meta.dir, "fixtures/authorize-surface-probe.tsx")
+/** Inside `dist/`, which is already git-ignored, so no new ignore rule is needed. */
+const OUT_DIR = resolve(PACKAGE_ROOT, "dist/__authorize-surface-probe")
+const BUNDLE = resolve(OUT_DIR, "probe.js")
+
+async function buildAndEvaluateProbe(): Promise<AuthorizeSurfaceProbeResult> {
+    await build({
+        root: PACKAGE_ROOT,
+        // The app's real config — plugins, aliases and platform-extension
+        // resolution included. A bespoke config here would test a bundle the IdP
+        // never ships.
+        configFile: resolve(PACKAGE_ROOT, "vite.config.ts"),
+        mode: "production",
+        logLevel: "error",
+        build: {
+            outDir: OUT_DIR,
+            emptyOutDir: true,
+            // Unminified so a failure names the component instead of a mangled
+            // identifier. Minification does not change how modules are linked,
+            // which is the whole subject of this test.
+            minify: false,
+            rollupOptions: {
+                input: PROBE_ENTRY,
+                output: { entryFileNames: "probe.js", format: "es" },
+            },
+        },
+    })
+
+    // `react-native-web` installs its style sheet at module scope and reads the
+    // global `ShadowRoot` that every browser exposes; `setup-dom.ts` mirrors it
+    // onto `globalThis` for exactly this reason.
+    await import(BUNDLE)
+
+    const probe = (
+        globalThis as typeof globalThis & {
+            [PROBE_GLOBAL]?: AuthorizeSurfaceProbeResult
+        }
+    )[PROBE_GLOBAL]
+
+    if (!probe) {
+        throw new Error(
+            `The built probe did not report on globalThis.${PROBE_GLOBAL} — it threw before it could.`,
+        )
+    }
+    return probe
+}
+
+/**
+ * Built and evaluated ONCE, at module scope, because the bundle is the fixture:
+ * every assertion below reads the same artifact, and doing it per test would pay
+ * for a full Vite build each time. Deliberately not wrapped in a per-test
+ * timeout — that would only measure the assertions, which are instant.
+ */
+const probe = await buildAndEvaluateProbe()
+
+afterAll(async () => {
+    await rm(OUT_DIR, { recursive: true, force: true })
+})
+
+describe("the production bundle renders OxySignInRequestSurface, not undefined", () => {
+    for (const name of Object.values(PROBE_CASES)) {
+        test(`${name}: every element in the tree is a real component`, () => {
+            const result = probe[name]
+            expect(result).toBeDefined()
+            // Asserted before `ok`, so a failure carries React's own message
+            // ("Minified React error #130 … args[]=undefined") rather than just
+            // `false`.
+            expect(result.error).toBeUndefined()
+            expect(result.ok).toBe(true)
+
+            // A surface that rendered NOTHING would also satisfy "did not throw",
+            // so require content: the always-visible subordinate link is on
+            // every branch.
+            expect(result.html ?? "").toContain(SUBORDINATE_LABEL)
+        })
+    }
+
+    test("the preparing branch draws its leading visual", () => {
+        // React Native's `ActivityIndicator` — the element `963f6e57` swapped
+        // Bloom's `Loading` for, and the one the lane shows on first paint.
+        expect(probe[PROBE_CASES.preparing].html ?? "").toContain('role="progressbar"')
+    })
+
+    test("the failed branch reveals the alternatives plainly", () => {
+        // Everywhere else they sit inside Bloom's collapsed disclosure and are
+        // not rendered at all, so this is the one case that proves the revealed
+        // path builds its links.
+        expect(probe[PROBE_CASES.failed].html ?? "").toContain(ALTERNATIVE_LABEL)
+    })
+})

--- a/packages/auth/lib/__tests__/fixtures/authorize-surface-probe-contract.ts
+++ b/packages/auth/lib/__tests__/fixtures/authorize-surface-probe-contract.ts
@@ -1,0 +1,47 @@
+/**
+ * The handshake between `authorize-surface-probe.tsx` and the test that builds
+ * it. Kept in its own module because the probe itself cannot be imported by the
+ * test: it pulls the real `@oxyhq/bloom` and `@oxyhq/services`, whose React
+ * Native dependencies carry Flow syntax that `bun test` refuses to parse. The
+ * probe is only ever reached through Vite, which strips Flow; the test only ever
+ * needs what is declared here.
+ */
+
+/** Label on the subordinate action the probe hands the surface, in every case. */
+export const SUBORDINATE_LABEL = "probe-subordinate-label"
+
+/** Label on the alternative action the probe hands the surface, in every case. */
+export const ALTERNATIVE_LABEL = "probe-alternative-label"
+
+/** The property the built probe reports its outcome on. */
+export const PROBE_GLOBAL = "__authorizeSurfaceProbe"
+
+/**
+ * The branches of `RequestPrimarySurface` the probe renders. Each one reaches a
+ * DIFFERENT leading visual, so between them they cover every component the
+ * surface can put on screen — which is the point, since any one of them arriving
+ * `undefined` from the bundle is the same blank page (issue #784).
+ */
+export const PROBE_CASES = {
+    /** No route resolved yet: React Native's `ActivityIndicator`. */
+    preparing: "preparing",
+    /** The cross-device handoff: `react-native-qrcode-svg` plus Bloom's `Text`. */
+    qr: "qr",
+    /** A route whose surface is elsewhere: `@expo/vector-icons`' glyph. */
+    routeGlyph: "route-glyph",
+    /** Terminally failed: Bloom's `Button`, and the alternatives rendered plainly. */
+    failed: "failed",
+} as const
+
+export type ProbeCase = (typeof PROBE_CASES)[keyof typeof PROBE_CASES]
+
+export interface ProbeCaseResult {
+    /** `true` when the branch rendered; `false` when React refused an element. */
+    ok: boolean
+    /** The static markup, present only when {@link ok}. */
+    html?: string
+    /** The React error message, present only when the render threw. */
+    error?: string
+}
+
+export type AuthorizeSurfaceProbeResult = Record<ProbeCase, ProbeCaseResult>

--- a/packages/auth/lib/__tests__/fixtures/authorize-surface-probe.tsx
+++ b/packages/auth/lib/__tests__/fixtures/authorize-surface-probe.tsx
@@ -1,0 +1,127 @@
+/**
+ * Bundle entry for `authorize-surface-bundle.test.ts`. NOT part of the app.
+ *
+ * This file exists to be built by the IdP's OWN production Vite config and then
+ * evaluated, because the failure it guards against (issue #784) exists only in
+ * the bundle: `@oxyhq/services` and the app agree perfectly in source and under
+ * the dev server, and the binding still arrived `undefined` at render time in
+ * the production build. A source-level test cannot see it — the auth suite
+ * replaces the whole `@oxyhq/services` specifier with a double — so the only
+ * honest check is to render the real surface out of a real production bundle.
+ *
+ * It therefore imports EXACTLY the way `components/commons-oauth-request.tsx`
+ * does: a named import of `OxySignInRequestSurface` from the package root. A
+ * deep or namespace import links differently and would stop reproducing the
+ * defect while still passing, which is the failure mode this test exists to
+ * remove.
+ *
+ * `renderToStaticMarkup` is deliberate: it is synchronous and it throws on an
+ * invalid element type, so an `undefined` component anywhere in the tree — the
+ * surface itself, or any of the React Native, Bloom and vendored children it
+ * draws — comes back as the same React error the browser reported instead of an
+ * empty page.
+ *
+ * Every branch of the surface is rendered, not just the one that broke: the four
+ * leading visuals reach four different sets of components, and the next one to
+ * vanish from a bundle will not be the same one as last time.
+ *
+ * The results are handed over on `globalThis` rather than exported: the test
+ * evaluates this bundle for its side effect, and a rejected top-level promise
+ * would surface as an unhandled rejection instead of a readable assertion.
+ */
+
+import { createElement, type ReactElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { BloomThemeProvider } from "@oxyhq/bloom/theme"
+import { OxySignInRequestSurface } from "@oxyhq/services"
+import {
+    ALTERNATIVE_LABEL,
+    PROBE_CASES,
+    PROBE_GLOBAL,
+    SUBORDINATE_LABEL,
+    type AuthorizeSurfaceProbeResult,
+    type ProbeCase,
+    type ProbeCaseResult,
+} from "./authorize-surface-probe-contract"
+
+/** Carries no real credential — the surface renders nothing derived from it. */
+const QR_PAYLOAD = "oxycommons://approve?v=1&code=probe-code&nonce=probe&exp=1"
+
+/** Handed to every case, so a surface that renders nothing cannot pass. */
+const SUBORDINATE = [
+    { key: "probe-cancel", label: SUBORDINATE_LABEL, onPress: () => undefined },
+] as const
+
+const ALTERNATIVES = [
+    { key: "probe-elsewhere", label: ALTERNATIVE_LABEL, onPress: () => undefined },
+] as const
+
+type SurfaceProps = Parameters<typeof OxySignInRequestSurface>[0]
+
+const CASE_PROPS: Record<ProbeCase, SurfaceProps> = {
+    // The state the Commons lane is in on first paint, and the branch
+    // auth.oxy.so/authorize was actually rendering when it went blank.
+    [PROBE_CASES.preparing]: {
+        route: null,
+        progress: "idle",
+        qrPayload: null,
+        subordinate: SUBORDINATE,
+        alternatives: ALTERNATIVES,
+    },
+    [PROBE_CASES.qr]: {
+        route: "qr",
+        progress: "awaiting-approval",
+        qrPayload: QR_PAYLOAD,
+        subordinate: SUBORDINATE,
+        alternatives: ALTERNATIVES,
+    },
+    [PROBE_CASES.routeGlyph]: {
+        route: "await-push",
+        progress: "awaiting-approval",
+        qrPayload: null,
+        subordinate: SUBORDINATE,
+        alternatives: ALTERNATIVES,
+    },
+    // `failed` also reveals the alternatives, so this is the one case whose
+    // markup carries ALTERNATIVE_LABEL — everywhere else they stay inside
+    // Bloom's collapsed disclosure and are not rendered at all.
+    [PROBE_CASES.failed]: {
+        route: null,
+        progress: "idle",
+        qrPayload: null,
+        failed: true,
+        onRetry: () => undefined,
+        subordinate: SUBORDINATE,
+        alternatives: ALTERNATIVES,
+    },
+}
+
+/** The same theme the IdP mounts in `src/main.tsx`. */
+function themed(child: ReactElement): ReactElement {
+    return createElement(
+        BloomThemeProvider,
+        { mode: "system", colorPreset: "oxy" },
+        child,
+    )
+}
+
+function renderCase(props: SurfaceProps): ProbeCaseResult {
+    try {
+        return {
+            ok: true,
+            html: renderToStaticMarkup(themed(createElement(OxySignInRequestSurface, props))),
+        }
+    } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) }
+    }
+}
+
+const results = {} as AuthorizeSurfaceProbeResult
+for (const name of Object.values(PROBE_CASES)) {
+    results[name] = renderCase(CASE_PROPS[name])
+}
+
+const globalWithProbe = globalThis as typeof globalThis & {
+    [PROBE_GLOBAL]?: AuthorizeSurfaceProbeResult
+}
+globalWithProbe[PROBE_GLOBAL] = results

--- a/packages/auth/lib/__tests__/setup-dom.ts
+++ b/packages/auth/lib/__tests__/setup-dom.ts
@@ -19,6 +19,7 @@ type GlobalWithDOM = typeof globalThis & {
     HTMLInputElement: typeof HTMLInputElement
     Element: typeof Element
     Node: typeof Node
+    ShadowRoot: typeof ShadowRoot
     navigator: Navigator
     getComputedStyle: typeof getComputedStyle
     requestAnimationFrame: typeof requestAnimationFrame
@@ -44,6 +45,11 @@ g.HTMLButtonElement = w.HTMLButtonElement
 g.HTMLInputElement = w.HTMLInputElement
 g.Element = w.Element
 g.Node = w.Node
+// `react-native-web` installs its style sheet at module scope and narrows the
+// insertion target with `root instanceof ShadowRoot`, reading the global rather
+// than `window.ShadowRoot`. Without this, evaluating a bundled RN Web graph
+// (`authorize-surface-bundle.test.ts`) dies on a bare ReferenceError.
+g.ShadowRoot = w.ShadowRoot
 g.navigator = w.navigator
 g.getComputedStyle = w.getComputedStyle.bind(w)
 g.requestAnimationFrame = w.requestAnimationFrame.bind(w)

--- a/packages/auth/scripts/smoke-idp.ts
+++ b/packages/auth/scripts/smoke-idp.ts
@@ -12,8 +12,11 @@
  *
  * What it catches:
  *   - SPA renders blank / build totally broken   → `/`, `/login`, `/signup`, `/authorize` lose the SPA root marker.
- *   - PKCE authorize lane broken (#784)          → `/authorize` with `code_challenge` loses the SPA root marker.
+ *   - `/authorize` not routed at all             → a PKCE-bound authorize URL stops answering 200 with the SPA shell.
  *   - FedCM manifest NOT removed                  → `/.well-known/web-identity` still serves the FedCM config JSON.
+ *
+ * What it CANNOT catch, despite an earlier comment here claiming otherwise: a
+ * client-side render failure such as #784. See {@link checkAuthorizeWithPkce}.
  *
  * Usage:
  *   bun run packages/auth/scripts/smoke-idp.ts
@@ -108,7 +111,22 @@ async function checkSpaPage(hostBase: string, path: string): Promise<void> {
   record(`SPA ${path}`, true, '200 + root marker present');
 }
 
-/** PKCE-bound authorize must render the Commons OAuth lane, not a blank page (#784). */
+/**
+ * A PKCE-bound authorize URL must still be SERVED. That is all this proves, and
+ * it is worth being precise about, because this check was once believed to cover
+ * the blank-page bug in #784 and covers none of it:
+ *
+ *  - the marker it looks for lives in `index.html`, which the static host
+ *    returns for every route whether or not React then dies on the client;
+ *  - `oxy_dk_smoke_client` is not a registered application, and the authorize
+ *    page redirects an unresolvable client to `/login` well before it reaches
+ *    the Commons lane. Using a REAL client id here would not help either — it
+ *    would create a live authorization request against production on every
+ *    deploy — so the substitution is deliberate, not an oversight.
+ *
+ * The render itself is covered where it can actually be observed, against a real
+ * production bundle: `lib/__tests__/authorize-surface-bundle.test.ts`.
+ */
 async function checkAuthorizeWithPkce(hostBase: string): Promise<void> {
   const params = new URLSearchParams({
     client_id: 'oxy_dk_smoke_client',

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -50,6 +50,54 @@ This package (`@oxyhq/services`) is the **single UI SDK** for every React surfac
 
 See [PLATFORM_GUIDE.md](./PLATFORM_GUIDE.md) for the complete architecture guide.
 
+### This package does not declare `sideEffects: false`
+
+It used to, and the declaration was **wrong**. Three modules in the build have
+top-level side effects, one of them the entry itself:
+
+| Module | Effect |
+|---|---|
+| `lib/module/index.js` | `setPlatformOS(Platform.OS)` — configures `@oxyhq/core` |
+| `lib/module/ui/navigation/surfaceBackBridge.js` | `installEscapeHandler()` — installs a global key handler |
+| `lib/module/ui/components/SettingsIcon.js` | assigns `displayName` |
+
+Removing a false declaration would be worth doing on its own. It also fixed a
+production outage, and that is the part worth remembering, because the symptom
+looked nothing like a `package.json` field.
+
+`auth.oxy.so/authorize` rendered a blank page with React error #130 ("element
+type is undefined") for every request that reached `OxySignInRequestSurface`,
+which blocked every OIDC login into Allo ([#784]). Source and dev server were
+fine; only the production bundle was broken. Two facts combined:
+
+1. **The UI graph is one large import cycle.** `ui/context/OxyContext` reaches
+   `ui/navigation/bottomSheetManager` → `navigation/routes`, `routes` reaches
+   every screen (through `require()` calls it makes for Metro's benefit), and
+   every screen reaches back into the context — a 67-module strongly connected
+   component that includes `OxySignInRequestSurface`. A bundler cannot
+   concatenate a cycle, so it emits each member as a lazily-initialized wrapper
+   whose exported bindings are `undefined` until the initializer runs. Modules
+   outside the cycle, `OxyConsentScreen` among them, are emitted inline and were
+   never affected — which is exactly why only some screens broke.
+2. **`sideEffects: false` told the bundler that running those initializers was
+   unobservable**, so rolldown-vite omitted the initializer call at the
+   consuming import site in `packages/auth` while still emitting the reference.
+   The binding was therefore never assigned, and React was handed `undefined`.
+
+The cycle is the deeper defect and is still there. Until it is gone, do not
+re-add `sideEffects` in any form: a narrowed, truthful list would leave every
+component in the cycle exactly as exposed, because none of *them* has a
+top-level side effect either. The cost of not declaring it was measured at the
+time on the IdP's own production bundle, which is the heaviest consumer of this
+package on the web: **5,483.86 kB → 5,489.99 kB raw (+0.11%)** and
+**1,457.31 kB → 1,458.66 kB gzip (+0.09%)**.
+
+`packages/auth/lib/__tests__/authorize-surface-bundle.test.ts` builds the IdP's
+real production bundle and renders the surface out of it, so a regression fails
+in CI with React's own message instead of on auth.oxy.so.
+
+[#784]: https://github.com/OxyHQ/OxyHQServices/issues/784
+
 ## Installation
 
 ```bash

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -7,7 +7,6 @@
   "types": "lib/typescript/commonjs/index.d.ts",
   "react-native": "src/index.ts",
   "source": "src/index.ts",
-  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary

`auth.oxy.so/authorize` rendered a blank page and threw React #130 (`args[]=undefined`) for every request whose `client_id` resolved to a real registered application — the only requests that reach `CommonsOAuthLane` and, through it, `@oxyhq/services`' `OxySignInRequestSurface`. This blocked every OIDC login into Allo.

**The undefined element was `OxySignInRequestSurface` itself**, imported by `packages/auth/components/commons-oauth-request.tsx`. Named by building `packages/auth` in production through the same rolldown pipeline with React's development build: `Element type is invalid … got: undefined. Check the render method of 'CommonsOAuthLane'.`

**Why it was undefined in the bundle and not in dev.** Two facts combined:

1. `@oxyhq/services`' UI graph is one **67-module import cycle** — `ui/context/OxyContext` → `ui/navigation/bottomSheetManager` → `navigation/routes`, `routes` → every screen (via the `require()` calls it makes for Metro's benefit), every screen → back into the context. `OxySignInRequestSurface` is a member. A bundler cannot concatenate a cycle, so rolldown emits each member as a lazily-initialized `__esmMin` wrapper whose exported bindings are hoisted `var`s, `undefined` until the initializer runs. Reachability from that cycle predicts the wrapping exactly: `OxySignInRequestSurface` is inside it and broke; `OxyConsentScreen` is outside it, is emitted inline, and never broke.
2. `sideEffects: false` told rolldown that running those initializers was unobservable, so it **omitted `init_OxySignInRequestSurface()` at the import site in `packages/auth`** while still emitting the reference. Verified directly in the emitted chunk: with the field, the only call site is inside `init_SignInRequestView` (never reached); without it, the call appears in the eagerly-evaluated region.

The declaration was false regardless. Three modules in `lib/module` have top-level side effects, one of them the entry: `index.js` → `setPlatformOS(Platform.OS)`, `surfaceBackBridge.js` → `installEscapeHandler()`, `SettingsIcon.js` → `displayName`.

A narrowed, truthful `sideEffects` list would **not** fix it — no component in the cycle has a top-level side effect either, so all of them would stay equally exposed. The cycle is the deeper defect and is untouched here; `packages/services/README.md` records it, the mechanism, and why the field must not come back.

Two things from the issue history that are wrong and cost time, corrected in the code: it is not PKCE (it is whether `client_id` resolves), and it is not the kind of circular import that was guessed at — rolldown's own `checks.circularDependency` reports none between `packages/auth` and the SDK. `963f6e57` treated a symptom of this same mechanism by not using Bloom's `Loading`; this addresses the mechanism.

Also corrected: `scripts/smoke-idp.ts` claimed to catch #784. It cannot — it looks for `id="root"`, which the static host returns for every route whether or not React then dies, and its `client_id` is unregistered so it never reaches the lane. The comment now says so.

## Test plan

**The proof — the failing URL against a local production build.** `packages/auth` built with `bun run build`, served, and the exact production URL from the issue (real Allo MAS `client_id`, real `redirect_uri`, PKCE) driven in headless Chromium:

| | before | after |
|---|---|---|
| `#root` innerHTML | **0 bytes** | **63,098 bytes** |
| console | `Minified React error #130; args[]=undefined` at `createFiberFromTypeAndProps` ← `createChild` ← `reconcileChildrenArray` | **no errors** |
| rendered | nothing | "Continue to Allo Matrix Authentication Service", QR plate, "Scan with Commons on your phone", Cancel, "Having trouble?" |

**New test — `packages/auth/lib/__tests__/authorize-surface-bundle.test.ts`.** Builds the IdP's own `vite.config.ts` in production mode over a probe entry that imports `OxySignInRequestSurface` exactly as `commons-oauth-request.tsx` does, evaluates the emitted chunk in jsdom, and renders all four branches of the surface with `renderToStaticMarkup` — which throws on an invalid element type, so an `undefined` React Native, Bloom or vendored child anywhere beneath it fails too. The four branches reach the activity indicator, the QR plate (`react-native-qrcode-svg`), the vector-icon glyph (`@expo/vector-icons`) and Bloom's `Button`. No source-level test could catch this: the auth suite replaces the whole `@oxyhq/services` specifier with a double.

**Mutation-tested.** Re-adding `"sideEffects": false` (confirmed on disk with `git diff` and `md5sum` before running) turns all 6 tests red with React's own message: `Received: "Minified React error #130; … args[]=undefined"` — 0 pass / 6 fail. Removing it again: 6 pass / 0 fail.

| check | baseline (`8fdf8e00`) | this branch |
|---|---|---|
| `packages/auth` — `bun test` | 127 pass, 0 fail, 15 files, 418 assertions | **133 pass, 0 fail, 16 files, 436 assertions** (5.75 s cold) |
| `packages/services` — `bun run test` | 640 pass, 72 suites | **640 pass, 72 suites** |
| `packages/auth` — `bunx tsc --noEmit` | clean | **clean** |
| `packages/auth` — `bun run build` | 5,483.86 kB / 1,457.31 kB gzip | **5,489.98 kB / 1,458.65 kB gzip** (+0.11% / +0.09%) |

**Left out, deliberately:** the import cycle itself. Dissolving a 67-module SCC across `OxyContext`, the navigation layer and 40 screens is a separate change with real regression risk on native, and it cannot be validated from here. The new test covers only this one surface — it is not a general "the bundle links" check, and nothing here would notice the same defect on another screen.

Refs #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)