### PR TITLE
fix(core)!: refuse user tokens that are not bound to a validated session

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -424,7 +424,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "20.0.0",
+      "version": "21.0.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",
@@ -768,7 +768,7 @@
       "peerDependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@oxyhq/bloom": ">=0.59.0",
-        "@oxyhq/core": "^20.0.0",
+        "@oxyhq/core": "^21.0.0",
         "@react-native-async-storage/async-storage": "^2.0.0",
         "@react-native-community/netinfo": ">=11.4.1",
         "@tanstack/query-async-storage-persister": "catalog:",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,74 @@
 # Changelog — `@oxyhq/core`
 
+## 21.0.0
+
+### Security: `oxy.auth()` accepted forged user tokens
+
+**Every backend mounting `oxy.auth()`, `oxy.serviceAuth()`,
+`createOxyAuthMiddleware()`, `createOptionalOxyAuth()` or `createOxyRateLimit()`
+should upgrade. Sockets (`oxy.authSocket()`) were never affected.**
+
+`oxy.auth()` decoded the bearer JWT with `jwtDecode`, which does not verify a
+signature, and then trusted what it found. Two paths were wrong:
+
+1. **A user token with no `sessionId` was accepted on its claims alone.** No
+   network call happened at all: `req.userId` was set from the decoded `userId`
+   claim. Anyone could authenticate as any user on any Oxy backend by
+   hand-rolling a JWT with a `userId` claim, a future `exp`, and an invented
+   signature.
+2. **A user token WITH a `sessionId` had its session validated, but `req.userId`
+   still came from the token.** `GET /session/validate/:sessionId` is
+   unauthenticated and does not bind the bearer token, so anyone holding a live
+   session id — their own, for instance — could pair it with a forged `userId`
+   claim and be trusted as that user.
+
+Both are fixed. A user token must now carry a `sessionId`, that session is
+validated server-side, and the identity is read **off the validated session**:
+
+- No `sessionId` → `401 SESSION_REQUIRED`.
+- Session's owner ≠ the token's `userId` claim → `401 SESSION_USER_MISMATCH`.
+- A session that validates but resolves to no usable user → `401 INVALID_SESSION`.
+
+Under `optional: true` all three resolve to anonymous (`req.userId = null`)
+instead of to the claimed user.
+
+`authSocket()` has always enforced exactly this; the HTTP middleware now matches
+it.
+
+#### Who this breaks
+
+Nothing legitimate. Every user access token the Oxy API issues carries a
+`sessionId` (`generateSessionTokens`). The only session-less user JWTs it mints
+are the **2FA challenge token** and the **account-recovery token**, both of
+which are pre-authentication and were previously accepted as a full logged-in
+identity — that was part of the vulnerability, not a feature.
+
+There is deliberately no flag and no "verify it with a shared secret" escape
+hatch: both of those tokens are signed with `ACCESS_TOKEN_SECRET`, so a
+secret-verified session-less path would re-admit precisely them.
+
+The major is bumped because the middleware now refuses input it used to accept.
+
+### `createOxyRateLimit` no longer clobbers a pre-resolved identity
+
+The limiter's module doc claimed its session resolution was "idempotent — it
+skips re-verification if a prior middleware already set `req.user`". It was not:
+it built its resolver from the raw `oxy.auth({ ...auth, optional: true })`,
+which on a request carrying no `Bearer` header unconditionally writes
+`req.userId = null`, erasing an identity a preceding middleware had resolved.
+
+It now uses `createOptionalOxyAuth`, which has the guard, so the claim is true.
+
+`resolveTrustedAuthenticatedKey` no longer additionally requires `req.sessionId`
+before keying per user. That requirement existed as a proxy for
+"server-validated", because `oxy.auth()` could produce an unverified
+claims-only identity; it cannot any more. Dropping it means an application
+running a second authentication scheme of its own (Allo authenticates Matrix
+Authentication Service tokens under an `Authorization: MatrixBearer …` scheme)
+can mount it **ahead of** the limiter and get a per-user bucket, instead of
+being forced behind it and sharing the anonymous per-IP bucket with everyone
+else behind the load balancer.
+
 ## 20.0.0
 
 ### Licence: AGPL-3.0-only becomes Apache-2.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "20.0.0",
+  "version": "21.0.0",
   "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/core/src/mixins/OxyServices.utility.ts
+++ b/packages/core/src/mixins/OxyServices.utility.ts
@@ -250,17 +250,32 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
      * Uses server-side session validation for security (not just JWT decode).
      *
      * **Design note — jwtDecode vs jwt.verify:**
-     * This middleware intentionally uses `jwtDecode()` (decode-only, no signature
-     * verification) for user tokens. This is by design, NOT a security gap:
-     * - Third-party apps using `oxy.auth()` don't have the Oxy JWT secret
-     * - Security comes from API-based session validation (`validateSession()`)
-     *   which checks the session server-side on every request
-     * - Service tokens (type: 'service') DO use cryptographic HMAC verification
-     *   via the `jwtSecret` option, since they are stateless. Service tokens
-     *   are additionally checked for `aud`, `iss`, and `type` claims to prevent
+     * This middleware uses `jwtDecode()` (decode-only, no signature
+     * verification) for user tokens, because third-party apps mounting
+     * `oxy.auth()` do not hold the Oxy signing secret. **Every claim in a user
+     * token is therefore attacker-controlled and proves nothing on its own.**
+     * The identity comes from elsewhere:
+     * - A user token MUST carry a `sessionId`, and that session is validated
+     *   server-side on every request via `validateSession()`. The user id is
+     *   read off the VALIDATED SESSION, not off the token; a token whose
+     *   `userId` claim disagrees with the session is refused
+     *   (`SESSION_USER_MISMATCH`). A session-less user token is refused
+     *   outright (`SESSION_REQUIRED`) — there is no local-claims path.
+     * - Service tokens (type: 'service') are stateless, so they DO use
+     *   cryptographic HMAC verification via the `jwtSecret` option, and are
+     *   additionally checked for `aud`, `iss`, and `type` claims to prevent
      *   cross-token-type confusion attacks.
      * - The backend's own `authMiddleware` uses `jwt.verify()` because it has
      *   direct access to `SERVICE_TOKEN_SECRET` / `ACCESS_TOKEN_SECRET`.
+     *
+     * **Why session-less user tokens are refused rather than verified:**
+     * every user access token the Oxy API issues carries a `sessionId` (see
+     * `utils/sessionUtils.ts`, `generateSessionTokens`). The only session-less
+     * user JWTs it mints are the 2FA challenge token and the account-recovery
+     * token, both of which are PRE-authentication and must never resolve to a
+     * logged-in identity. So there is nothing legitimate to keep working, and
+     * a "verify with a shared secret" escape hatch would re-admit exactly
+     * those two.
      *
      * **Service-token delegation (X-Oxy-User-Id):**
      * When a service token is accompanied by `X-Oxy-User-Id`, the SDK calls
@@ -543,8 +558,8 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
             return next();
           }
 
-          const userId = decoded.userId || decoded.id;
-          if (!userId) {
+          const claimedUserId = decoded.userId || decoded.id;
+          if (!claimedUserId) {
             if (optional) {
               req.userId = null;
               req.user = null;
@@ -580,58 +595,81 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
             return res.status(401).json(error);
           }
 
-          // Validate token against the Oxy API for session-based verification
-          // This ensures the session hasn't been revoked server-side
-          if (decoded.sessionId) {
-            try {
-              const validationResult = await oxyInstance.validateSession(decoded.sessionId, {
-                useHeaderValidation: true,
-              });
-
-              if (!validationResult || !validationResult.valid) {
-                if (optional) {
-                  req.userId = null;
-                  req.user = null;
-                  return next();
-                }
-
-                const error = {
-                  error: 'INVALID_SESSION',
-                  message: 'Session invalid or expired',
-                  code: 'INVALID_SESSION',
-                  status: 401
-                };
-                if (onError) return onError(error);
-                return res.status(401).json(error);
-              }
-
-              // Use validated user data from session validation (already has full user)
-              req.userId = userId;
-              req.accessToken = token;
-              req.sessionId = decoded.sessionId;
-
-              if (loadUser && validationResult.user) {
-                // Session validation already returns full user data
-                req.user = validationResult.user;
-              } else {
-                req.user = { id: userId } as User;
-              }
-
-              if (debug) {
-                logger.debug(`[oxy.auth] OK user=${userId} session=${decoded.sessionId}`, {
-                  component: 'auth',
-                  method: 'auth',
-                });
-              }
-
+          // A server-validated session is mandatory. The JWT signature is not
+          // verified on this path, so a bare decoded token proves nothing —
+          // without the session round-trip a forged token could claim any user
+          // id. Mirrors `authSocket()`, which has always enforced this.
+          if (!decoded.sessionId) {
+            if (optional) {
+              req.userId = null;
+              req.user = null;
               return next();
-            } catch (validationError) {
-              if (debug) {
-                logger.debug('[oxy.auth] Session validation failed', {
-                  component: 'auth',
-                  method: 'auth',
-                }, validationError);
+            }
+
+            const error = {
+              error: 'SESSION_REQUIRED',
+              message: 'Access token is not bound to a session',
+              code: 'SESSION_REQUIRED',
+              status: 401
+            };
+            if (onError) return onError(error);
+            return res.status(401).json(error);
+          }
+
+          // Validate the token against the Oxy API. This both proves the token
+          // corresponds to a real, unrevoked session and yields the identity
+          // that session belongs to.
+          try {
+            const validationResult = await oxyInstance.validateSession(decoded.sessionId, {
+              useHeaderValidation: true,
+            });
+
+            if (!validationResult || !validationResult.valid || !validationResult.user) {
+              if (optional) {
+                req.userId = null;
+                req.user = null;
+                return next();
               }
+
+              const error = {
+                error: 'INVALID_SESSION',
+                message: 'Session invalid or expired',
+                code: 'INVALID_SESSION',
+                status: 401
+              };
+              if (onError) return onError(error);
+              return res.status(401).json(error);
+            }
+
+            // The session is the source of truth. `GET /session/validate/:id`
+            // is unauthenticated and does not bind the bearer token, so a
+            // caller holding ANY live session id could otherwise pair it with
+            // a forged `userId` claim and be trusted as that user.
+            const validatedUserId = getUserIdentityId(validationResult.user);
+            if (!validatedUserId) {
+              if (optional) {
+                req.userId = null;
+                req.user = null;
+                return next();
+              }
+
+              const error = {
+                error: 'INVALID_SESSION',
+                message: 'Session did not resolve to a usable identity',
+                code: 'INVALID_SESSION',
+                status: 401
+              };
+              if (onError) return onError(error);
+              return res.status(401).json(error);
+            }
+
+            if (validatedUserId !== claimedUserId) {
+              logger.warn('[oxy.auth] Token rejected — claimed user does not own the session', {
+                component: 'auth',
+                method: 'auth',
+                claimedUserId,
+                sessionId: decoded.sessionId,
+              });
 
               if (optional) {
                 req.userId = null;
@@ -640,58 +678,53 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
               }
 
               const error = {
-                error: 'SESSION_VALIDATION_ERROR',
-                message: 'Session validation failed',
-                code: 'SESSION_VALIDATION_ERROR',
+                error: 'SESSION_USER_MISMATCH',
+                message: 'Token user does not match the session',
+                code: 'SESSION_USER_MISMATCH',
                 status: 401
               };
               if (onError) return onError(error);
               return res.status(401).json(error);
             }
-          }
 
-          // Non-session token: use local validation only (userId from JWT)
-          req.userId = userId;
-          req.accessToken = token;
-          req.user = { id: userId } as User;
+            req.userId = validatedUserId;
+            req.accessToken = token;
+            req.sessionId = decoded.sessionId;
+            // Session validation already returns the full user, so `loadUser`
+            // costs no extra round-trip.
+            req.user = loadUser ? validationResult.user : ({ id: validatedUserId } as User);
 
-          // If loadUser requested with non-session token, fetch from API
-          if (loadUser) {
-            try {
-              // Temporarily set token to make the API call
-              const prevToken = oxyInstance.getAccessToken();
-              oxyInstance.setTokens(token);
-              const fullUser = await oxyInstance.getCurrentUser();
-              // Restore previous token
-              if (prevToken) {
-                oxyInstance.setTokens(prevToken);
-              } else {
-                oxyInstance.clearTokens();
-              }
-
-              if (fullUser) {
-                req.user = fullUser;
-              }
-            } catch (loadUserError) {
-              // Loading the full user is best-effort here; the basic { id }
-              // object is already attached. Log so misconfigured deployments
-              // can be diagnosed instead of silently failing.
-              logger.warn('[oxy.auth] loadUser fallback — could not fetch full profile', {
+            if (debug) {
+              logger.debug(`[oxy.auth] OK user=${validatedUserId} session=${decoded.sessionId}`, {
                 component: 'auth',
-                method: 'auth.loadUser',
-                userId,
-              }, loadUserError);
+                method: 'auth',
+              });
             }
-          }
 
-          if (debug) {
-            logger.debug(`[oxy.auth] OK user=${userId} (no session)`, {
-              component: 'auth',
-              method: 'auth',
-            });
-          }
+            return next();
+          } catch (validationError) {
+            if (debug) {
+              logger.debug('[oxy.auth] Session validation failed', {
+                component: 'auth',
+                method: 'auth',
+              }, validationError);
+            }
 
-          next();
+            if (optional) {
+              req.userId = null;
+              req.user = null;
+              return next();
+            }
+
+            const error = {
+              error: 'SESSION_VALIDATION_ERROR',
+              message: 'Session validation failed',
+              code: 'SESSION_VALIDATION_ERROR',
+              status: 401
+            };
+            if (onError) return onError(error);
+            return res.status(401).json(error);
+          }
         } catch (error) {
           const handled = oxyInstance.handleError(error) as Error & {
             code?: string;
@@ -1062,9 +1095,5 @@ interface OxyAuthInstance {
     user?: User;
     [key: string]: unknown;
   } | null>;
-  getAccessToken(): string | null;
-  setTokens(accessToken: string): void;
-  clearTokens(): void;
-  getCurrentUser(): Promise<User | null>;
   handleError(error: unknown): Error;
 }

--- a/packages/core/src/mixins/__tests__/userTokenAuth.test.ts
+++ b/packages/core/src/mixins/__tests__/userTokenAuth.test.ts
@@ -1,0 +1,478 @@
+/**
+ * User-token authentication security regression tests
+ *
+ * Locks in the fix for the `oxy.auth()` authentication bypass.
+ *
+ * Before the fix, `auth()` decoded the bearer JWT with `jwtDecode` (which does
+ * NOT verify a signature) and, when the payload carried no `sessionId`, trusted
+ * the decoded `userId` claim outright:
+ *
+ *   req.userId = userId;                 // straight from an unverified claim
+ *   req.user   = { id: userId } as User;
+ *
+ * That let anyone authenticate as anyone on every Oxy backend mounting
+ * `oxy.auth()` / `createOxyAuthMiddleware()` by hand-rolling a JWT with a
+ * `userId` claim, a future `exp`, and a garbage signature. No network call
+ * happened on that path at all.
+ *
+ * Two distinct holes are covered here:
+ *
+ *   1. **Session-less user tokens were trusted.** Every user access token the
+ *      Oxy API mints carries a `sessionId` (`utils/sessionUtils.ts`
+ *      `generateSessionTokens`). The only session-less user JWTs it issues are
+ *      the 2FA challenge token and the account-recovery token — both
+ *      PRE-authentication. Accepting them as a session was an escalation even
+ *      without forgery. There is therefore no legitimate session-less user
+ *      token, and the path is now refused outright rather than gated behind a
+ *      flag.
+ *
+ *   2. **The session path trusted the claimed user id.** `GET
+ *      /session/validate/:sessionId` is unauthenticated and returns whichever
+ *      user owns the session; it does not bind the bearer token. `auth()` then
+ *      set `req.userId` from the JWT claim rather than from the validated
+ *      session, so a caller holding ANY live session id could pair it with a
+ *      forged `userId` and become that user. `authSocket()` already guarded
+ *      this; the HTTP middleware did not.
+ *
+ * These tests exercise a real `OxyServices` instance with `validateSession`
+ * stubbed, so the middleware's own logic runs end to end without the network.
+ */
+
+import crypto from 'node:crypto';
+import { OxyServices } from '../../OxyServices';
+import type { User } from '../../models/interfaces';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface UserTokenClaims {
+  userId?: string;
+  id?: string;
+  sessionId?: string;
+  exp?: number;
+  iat?: number;
+  [key: string]: unknown;
+}
+
+const b64url = (input: Buffer | string): string => {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : input;
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+const ONE_HOUR_FROM_NOW = (): number => Math.floor(Date.now() / 1000) + 3600;
+
+/** A JWT whose signature is invented. Structurally valid, cryptographically worthless. */
+const forgeToken = (claims: UserTokenClaims, signature = 'AAAAcompletely-invented-signature'): string => {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify({ iat: Math.floor(Date.now() / 1000), exp: ONE_HOUR_FROM_NOW(), ...claims }));
+  return `${header}.${payload}.${signature}`;
+};
+
+/** An `alg: none` JWT — the classic unsigned-token attack. */
+const forgeAlgNoneToken = (claims: UserTokenClaims): string => {
+  const header = b64url(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify({ iat: Math.floor(Date.now() / 1000), exp: ONE_HOUR_FROM_NOW(), ...claims }));
+  return `${header}.${payload}.`;
+};
+
+/**
+ * A genuinely signed session access token, byte-identical in shape to what
+ * `jsonwebtoken.sign()` produces in the API's `generateSessionTokens`.
+ * The middleware never checks this signature for user tokens — security comes
+ * from the session round-trip — but signing it keeps the fixtures honest about
+ * what production actually sends.
+ */
+const signSessionToken = (claims: UserTokenClaims, secret: string): string => {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(
+    JSON.stringify({
+      iat: Math.floor(Date.now() / 1000),
+      exp: ONE_HOUR_FROM_NOW(),
+      type: 'access',
+      deviceId: 'device-1',
+      ...claims,
+    }),
+  );
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `${header}.${payload}.${signature}`;
+};
+
+interface MockReq {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  query: Record<string, string>;
+  userId?: string | null;
+  user?: unknown;
+  accessToken?: string;
+  sessionId?: string | null;
+  serviceApp?: unknown;
+  serviceActingAs?: unknown;
+}
+
+interface MockRes {
+  statusCode: number;
+  body: unknown;
+  headersSent: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+}
+
+const makeReq = (overrides: Partial<MockReq> = {}): MockReq => ({
+  method: 'GET',
+  path: '/api/whoami',
+  headers: {},
+  query: {},
+  ...overrides,
+});
+
+const makeRes = (): MockRes => ({
+  statusCode: 0,
+  body: undefined,
+  headersSent: false,
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  },
+  json(body: unknown) {
+    this.body = body;
+    this.headersSent = true;
+    return this;
+  },
+});
+
+/** Run the middleware against the loose Express shape it declares internally. */
+const run = async (
+  middleware: ReturnType<OxyServices['auth']>,
+  req: MockReq,
+  res: MockRes,
+  next: jest.Mock,
+): Promise<void> => {
+  await middleware(req as unknown as never, res as unknown as never, next as unknown as never);
+};
+
+const VICTIM_ID = '507f1f77bcf86cd799439011';
+const ATTACKER_ID = '507f1f77bcf86cd799439022';
+const ACCESS_TOKEN_SECRET = 'test-access-token-secret-not-production';
+
+const asUser = (id: string): User => ({ id }) as User;
+
+// ---------------------------------------------------------------------------
+// Hole 1 — session-less user tokens must never authenticate
+// ---------------------------------------------------------------------------
+
+describe('user tokens without a sessionId are refused', () => {
+  let oxy: OxyServices;
+  let validateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    // Any call here would mean the middleware went to the network on a path
+    // that must be decided locally. Assertions below check it never happens.
+    validateSpy = jest.spyOn(oxy, 'validateSession');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects a forged token whose signature is garbage', async () => {
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+    expect(req.user).toBeUndefined();
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token with an empty signature segment', async () => {
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID }, '')}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects an alg:none token', async () => {
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeAlgNoneToken({ userId: VICTIM_ID })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects a session-less token that carries the id claim instead of userId', async () => {
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeToken({ id: VICTIM_ID })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(req.userId).toBeUndefined();
+  });
+
+  it("rejects the API's 2FA challenge token, which is genuinely signed but pre-authentication", async () => {
+    // controllers/session.controller.ts mints exactly this shape after the
+    // password step and BEFORE the second factor. It is signed with
+    // ACCESS_TOKEN_SECRET and has no sessionId.
+    const loginToken = signSessionToken({ userId: VICTIM_ID, purpose: '2fa_challenge' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${loginToken}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it("rejects the API's account-recovery token", async () => {
+    const recoveryToken = signSessionToken(
+      { type: 'recovery', recoveryId: 'rec-1', userId: VICTIM_ID },
+      ACCESS_TOKEN_SECRET,
+    );
+    const req = makeReq({ headers: { authorization: `Bearer ${recoveryToken}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('never loads a user profile for a session-less token, even with loadUser', async () => {
+    const getCurrentUserSpy = jest.spyOn(oxy, 'getCurrentUser');
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ loadUser: true }), req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(getCurrentUserSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats a session-less token as anonymous under optional auth, never as the claimed user', async () => {
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ optional: true }), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.headersSent).toBe(false);
+    expect(req.userId).toBeNull();
+    expect(req.user).toBeNull();
+  });
+
+  it('reports SESSION_REQUIRED through a custom onError handler', async () => {
+    const onError = jest.fn();
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ onError }), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.headersSent).toBe(false);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'SESSION_REQUIRED', status: 401 }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hole 2 — the identity must come from the validated session, not the claim
+// ---------------------------------------------------------------------------
+
+describe('session-backed user tokens bind identity to the validated session', () => {
+  let oxy: OxyServices;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects a token pairing a live session with a forged userId claim', async () => {
+    // The attacker holds their OWN valid session and swaps the userId claim.
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: true,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      lastActivity: new Date().toISOString(),
+      user: asUser(ATTACKER_ID),
+    });
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'attacker-session' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_USER_MISMATCH' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects a session whose validation returns no user', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: true,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      lastActivity: new Date().toISOString(),
+    } as unknown as Awaited<ReturnType<OxyServices['validateSession']>>);
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'session-1' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('accepts a matching session and takes the id from the server, not the token', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: true,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      lastActivity: new Date().toISOString(),
+      user: asUser(VICTIM_ID),
+    });
+
+    const token = signSessionToken({ userId: VICTIM_ID, sessionId: 'session-1' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.headersSent).toBe(false);
+    expect(req.userId).toBe(VICTIM_ID);
+    expect(req.sessionId).toBe('session-1');
+    expect(req.accessToken).toBe(token);
+    expect(req.user).toEqual({ id: VICTIM_ID });
+  });
+
+  it('accepts a session identified by the raw Mongo _id shape', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: true,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      lastActivity: new Date().toISOString(),
+      user: { _id: VICTIM_ID } as unknown as User,
+    });
+
+    const token = signSessionToken({ userId: VICTIM_ID, sessionId: 'session-1' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.userId).toBe(VICTIM_ID);
+  });
+
+  it('attaches the full validated profile when loadUser is set', async () => {
+    const fullUser = { id: VICTIM_ID, username: 'victim', email: 'victim@example.com' } as User;
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: true,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      lastActivity: new Date().toISOString(),
+      user: fullUser,
+    });
+
+    const token = signSessionToken({ userId: VICTIM_ID, sessionId: 'session-1' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ loadUser: true }), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.user).toEqual(fullUser);
+  });
+
+  it('rejects an invalid session', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: false,
+    } as unknown as Awaited<ReturnType<OxyServices['validateSession']>>);
+
+    const token = signSessionToken({ userId: VICTIM_ID, sessionId: 'revoked' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'INVALID_SESSION' });
+  });
+
+  it('rejects an expired token before any session round-trip', async () => {
+    const validateSpy = jest.spyOn(oxy, 'validateSession');
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'session-1', exp: Math.floor(Date.now() / 1000) - 1 });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'TOKEN_EXPIRED' });
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to anonymous, not to the claim, when optional auth hits a mismatch', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: true,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      lastActivity: new Date().toISOString(),
+      user: asUser(ATTACKER_ID),
+    });
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'attacker-session' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ optional: true }), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.userId).toBeNull();
+    expect(req.user).toBeNull();
+  });
+});

--- a/packages/core/src/server/__tests__/rateLimit.test.ts
+++ b/packages/core/src/server/__tests__/rateLimit.test.ts
@@ -45,6 +45,17 @@ function makeRequest(overrides: Partial<RateLimitTestRequest> = {}): RateLimitTe
   } as RateLimitTestRequest;
 }
 
+/**
+ * Stand-in for the real `oxy.auth({ optional: true })` on a request carrying no
+ * `Bearer` header: it writes nulls unconditionally. That write is what used to
+ * erase an identity resolved by a preceding middleware.
+ */
+function anonymousResolver(req: RateLimitTestRequest, _res: Response, next: NextFunction): void {
+  req.userId = null;
+  req.user = null;
+  next();
+}
+
 /** Run the anonymous limiter for a bare IP and return the store key it produced. */
 function keyForIp(ip: string): string {
   const oxy = makeOxy((_req: Request, _res: Response, next: NextFunction) => next());
@@ -83,12 +94,8 @@ describe('@oxyhq/core/server rate limiter', () => {
     else process.env.DEVICE_ID_SALT = originalEnv.DEVICE_ID_SALT;
   });
 
-  it('does not trust locally decoded non-session JWT identities for quota or bucket keys', () => {
-    const oxy = makeOxy((req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
-      req.userId = 'attacker-controlled-user';
-      req.user = { id: 'attacker-controlled-user' };
-      next();
-    });
+  it('buckets an unauthenticated request by hashed IP on the anonymous quota', () => {
+    const oxy = makeOxy(anonymousResolver);
     const req = makeRequest();
     const next = jest.fn();
 
@@ -142,6 +149,120 @@ describe('@oxyhq/core/server rate limiter', () => {
     expect(req.observedKey).toMatch(HEX24);
     expect(req.observedKey).not.toContain('203.0.113.9');
     expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency. An application may run a SECOND authentication scheme of its
+  // own (Allo authenticates Matrix Authentication Service tokens under an
+  // `Authorization: MatrixBearer …` scheme). Mounted ahead of the limiter, the
+  // identity it resolves must survive: the limiter previously re-ran the raw
+  // `oxy.auth({ optional: true })`, which found no `Bearer` header and wrote
+  // `req.userId = null` over it, dropping the request into the shared
+  // anonymous per-IP bucket behind the load balancer.
+  // -------------------------------------------------------------------------
+
+  describe('idempotent session resolution', () => {
+    it('keeps an identity a preceding middleware already resolved', () => {
+      const resolver = jest.fn(anonymousResolver);
+      const oxy = makeOxy(resolver);
+      const req = makeRequest({ userId: 'mas-user', user: { id: 'mas-user' } });
+
+      createOxyRateLimit(oxy, { authenticatedMax: 5000, anonymousMax: 600 })(
+        req,
+        {} as Response,
+        jest.fn(),
+      );
+
+      expect(resolver).not.toHaveBeenCalled();
+      expect(req.userId).toBe('mas-user');
+      expect(req.observedMax).toBe(5000);
+      expect(req.observedKey).toBe('user:mas-user');
+    });
+
+    it('keeps a preceding identity carried only on user._id', () => {
+      const resolver = jest.fn(anonymousResolver);
+      const oxy = makeOxy(resolver);
+      const req = makeRequest({ user: { _id: 'mongo-user' } });
+
+      createOxyRateLimit(oxy, { authenticatedMax: 5000, anonymousMax: 600 })(
+        req,
+        {} as Response,
+        jest.fn(),
+      );
+
+      expect(resolver).not.toHaveBeenCalled();
+      expect(req.observedKey).toBe('user:mongo-user');
+    });
+
+    it('still resolves the session when no preceding middleware set one', () => {
+      const resolver = jest.fn((req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+        req.userId = 'validated-user';
+        req.user = { id: 'validated-user' };
+        req.sessionId = 'validated-session';
+        next();
+      });
+      const oxy = makeOxy(resolver as unknown as RequestHandler);
+      const req = makeRequest();
+
+      createOxyRateLimit(oxy)(req, {} as Response, jest.fn());
+
+      expect(resolver).toHaveBeenCalledTimes(1);
+      expect(req.observedKey).toBe('user:validated-user');
+    });
+
+    it('skips both session resolution and limiting on exempt paths', () => {
+      const resolver = jest.fn(anonymousResolver);
+      const oxy = makeOxy(resolver);
+      const req = makeRequest({ path: '/health' });
+      const next = jest.fn();
+
+      createOxyRateLimit(oxy)(req, {} as Response, next);
+
+      expect(resolver).not.toHaveBeenCalled();
+      expect(req.observedKey).toBeUndefined();
+      expect(next).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('service tokens', () => {
+    it('buckets a service token acting as itself under the app', () => {
+      const oxy = makeOxy((req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+        req.userId = null;
+        req.user = null;
+        req.serviceApp = { appId: 'app-1' };
+        next();
+      });
+      const req = makeRequest();
+
+      createOxyRateLimit(oxy, { authenticatedMax: 5000, anonymousMax: 600 })(
+        req,
+        {} as Response,
+        jest.fn(),
+      );
+
+      expect(req.observedMax).toBe(5000);
+      expect(req.observedKey).toBe('service:app-1');
+    });
+
+    it('buckets a delegated service request under the delegated user', () => {
+      const oxy = makeOxy((req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+        req.userId = 'delegated-user';
+        req.user = { id: 'delegated-user' };
+        req.serviceApp = { appId: 'app-1' };
+        req.serviceActingAs = { userId: 'delegated-user' };
+        next();
+      });
+      const req = makeRequest();
+
+      createOxyRateLimit(oxy, { authenticatedMax: 5000, anonymousMax: 600 })(
+        req,
+        {} as Response,
+        jest.fn(),
+      );
+
+      expect(req.observedMax).toBe(5000);
+      expect(req.observedKey).toBe('user:delegated-user');
+    });
   });
 
   describe('anonymous key hashing', () => {

--- a/packages/core/src/server/rateLimit.ts
+++ b/packages/core/src/server/rateLimit.ts
@@ -3,6 +3,7 @@ import { isIPv4, isIPv6 } from 'node:net';
 import type { Request, RequestHandler } from 'express';
 import rateLimit, { type Store } from 'express-rate-limit';
 import type { OxyServices } from '../OxyServices';
+import { createOptionalOxyAuth, getOxyUserId } from './auth';
 
 /**
  * Server-only rate limiting for Oxy backends.
@@ -25,8 +26,8 @@ import type { OxyServices } from '../OxyServices';
  * WHAT IT PROVIDES
  * ----------------
  * `createOxyRateLimit(oxy, options)` returns a SINGLE composed middleware that:
- *   1. Resolves the user via `oxy.auth({ optional: true })` (idempotent — it
- *      skips re-verification if a prior middleware already set `req.user`).
+ *   1. Resolves the user via `createOptionalOxyAuth` (idempotent — it skips
+ *      resolution entirely if a prior middleware already resolved a user).
  *   2. Applies an `express-rate-limit` limiter keyed PER USER when
  *      authenticated, falling back to the (IPv6-safe) IP otherwise, with
  *      generous, media-app-realistic defaults and sensible exemptions.
@@ -37,6 +38,11 @@ import type { OxyServices } from '../OxyServices';
  * app.use(oxy.rateLimit({ store }));   // resolves session + limits per user
  * app.use('/api', apiRouter);
  * ```
+ *
+ * Because step 1 is idempotent, an application running a SECOND authentication
+ * scheme of its own can mount it either side of the limiter. Mounted first, its
+ * identity survives and gets a per-user bucket; mounted after, the limiter
+ * simply finds no Oxy session and buckets the request by IP.
  */
 
 /** Minimal shape of the request after Oxy session resolution. */
@@ -203,15 +209,26 @@ function hashAnonymousIp(ip: string): string {
 /**
  * Resolve the trusted authenticated rate-limit key.
  *
- * `oxy.auth({ optional: true })` preserves legacy non-session user tokens by
- * decoding their JWT claims locally. Those claims are not cryptographically
- * verified and therefore MUST NOT influence abuse-control buckets. Only use
- * identities that came from a server-validated session or a verified service
- * token/delegation.
+ * Every `req.userId` reaching this point is trustworthy, and that is a
+ * property of the middleware that set it rather than of anything checked here:
+ *
+ *   - `oxy.auth()` sets it only from a session it validated against the Oxy
+ *     API, or from a verified service token holding an explicit delegation
+ *     grant. It used to also accept a session-less user token on decoded
+ *     claims alone, which is why this function once demanded `req.sessionId`
+ *     as a proxy for "server-validated"; that path no longer exists.
+ *   - Any other identity was resolved by a middleware the application
+ *     deliberately mounted ahead of the limiter (e.g. a second bearer scheme).
+ *     The app already trusts it for authorization, so trusting it to pick a
+ *     rate-limit bucket is strictly weaker.
+ *
+ * Dropping the `sessionId` requirement is what lets those other schemes get a
+ * per-user bucket instead of sharing the anonymous per-IP one behind a load
+ * balancer.
  */
 function resolveTrustedAuthenticatedKey(req: OxyAuthedRequest): string | null {
-  const userId = req.userId ?? req.user?.id ?? req.user?._id;
-  if (userId && req.sessionId) {
+  const userId = getOxyUserId(req);
+  if (userId) {
     return `user:${userId}`;
   }
 
@@ -260,7 +277,13 @@ export function createOxyRateLimit(
 
   // Idempotent optional-auth resolver. Reuses the SAME session resolution as
   // every protected route, so the limiter keys by the real user identity.
-  const resolveSession = oxy.auth({ ...auth, optional: true });
+  //
+  // `createOptionalOxyAuth` — not the raw `oxy.auth({ optional: true })` —
+  // because only the former skips resolution when a preceding middleware has
+  // already resolved a user. The raw middleware unconditionally writes
+  // `req.userId = null` on a request carrying no `Bearer` header, which would
+  // erase that identity and drop the request into the anonymous bucket.
+  const resolveSession = createOptionalOxyAuth(oxy, { auth });
 
   const skip = (req: Request): boolean =>
     isBuiltInExempt(req) || (exempt ? exempt(req) : false);

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -190,7 +190,7 @@
   "peerDependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@oxyhq/bloom": ">=0.59.0",
-    "@oxyhq/core": "^20.0.0",
+    "@oxyhq/core": "^21.0.0",
     "@react-native-async-storage/async-storage": "^2.0.0",
     "@react-native-community/netinfo": ">=11.4.1",
     "@tanstack/query-async-storage-persister": "catalog:",

--- a/wiki/Authentication.md
+++ b/wiki/Authentication.md
@@ -71,11 +71,28 @@ const userId = getRequiredOxyUserId(req);
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `req.userId` | `string \| null` | User ID from token |
+| `req.userId` | `string \| null` | User ID, read off the server-validated session (NOT off the token) |
 | `req.user` | `User \| null` | User object (minimal unless full profile requested) |
 | `req.accessToken` | `string` | The validated access token |
-| `req.sessionId` | `string \| undefined` | Session ID (if session-based token) |
+| `req.sessionId` | `string \| undefined` | Session ID (always set for user tokens; absent for service tokens) |
 | `req.serviceApp` | `ServiceApp \| undefined` | Service app metadata (if service token) |
+
+### A user token must be bound to a session
+
+The middleware decodes the bearer JWT without verifying its signature — a
+third-party backend does not hold the Oxy signing secret — so **no claim in a
+user token is trusted**. A user token must carry a `sessionId`; that session is
+validated against the Oxy API on every request, and `req.userId` comes from the
+validated session. Two consequences:
+
+- A token with no `sessionId` is rejected with `SESSION_REQUIRED`. Every user
+  access token the Oxy API issues has one, so this only ever rejects a forgery
+  or a pre-authentication token (the 2FA challenge, account recovery).
+- A token whose `userId` claim disagrees with the session's owner is rejected
+  with `SESSION_USER_MISMATCH`.
+
+Under `optional: true` both cases resolve to anonymous (`req.userId = null`)
+rather than to the claimed user.
 
 ## Socket.IO authentication
 


### PR DESCRIPTION
## Summary

`oxy.auth()` decoded the bearer JWT with `jwtDecode` (no signature verification) and then trusted what it found:

1. **A user token with no `sessionId` was accepted on its claims alone.** No network call happened; `req.userId` came straight off the decoded `userId`. Anyone could authenticate as any user on any Oxy backend with a hand-rolled JWT carrying a `userId`, a future `exp`, and an invented signature.
2. **A user token *with* a `sessionId` had its session validated, but `req.userId` still came from the token.** `GET /session/validate/:sessionId` is unauthenticated and does not bind the bearer, so anyone holding a live session id could pair it with a forged `userId` and be trusted as that user.

A user token must now carry a `sessionId`, that session is validated server-side, and the identity is read **off the validated session** — `SESSION_REQUIRED`, `SESSION_USER_MISMATCH`, `INVALID_SESSION`. Under `optional: true` all three give anonymous rather than the claimed user. `authSocket()` already enforced this; the HTTP middleware now matches it.

Nothing legitimate breaks: every user access token the Oxy API issues carries a `sessionId`. The only session-less user JWTs it mints are the 2FA challenge and account-recovery tokens, both pre-authentication and both previously accepted as a full logged-in identity.

Also makes `createOxyRateLimit`'s session resolution actually idempotent (it uses `createOptionalOxyAuth` now, so it no longer clobbers an identity a preceding middleware resolved), which lets an app running a second auth scheme mount it ahead of the limiter and get a per-user bucket.

`@oxyhq/core` 20.0.0 → 21.0.0.

## Test plan

- New `packages/core/src/mixins/__tests__/userTokenAuth.test.ts`: 17 cases — forged signature, empty signature, `alg: none`, `id` claim instead of `userId`, the real 2FA challenge and recovery token shapes, `loadUser`, `optional`, `onError`; and on the session path a forged `userId` against a live session, a session with no user, `_id`-shaped identities, expiry, and the legitimate paths still working. **12 of them fail on `main` and pass here.**
- `packages/core/src/server/__tests__/rateLimit.test.ts`: rewrote the case whose premise was "`oxy.auth()` can produce an unverified non-session identity" (that path no longer exists) and added idempotency + service-token bucket coverage.
- `bun run core:build`, `tsc --noEmit`, and the full core suite: **1572 tests, 113 suites, all passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)