### PR TITLE
security(core): oxy.auth() authenticated forged tokens as any account

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog — `@oxyhq/core`
 
+## Unreleased
+
+### Security: `oxy.auth()` authenticated forged tokens as any account
+
+**Every backend mounting `oxy.auth()` could be authenticated as any user by an
+unauthenticated attacker.** Upgrade as soon as a version carrying this ships.
+
+`oxy.auth()` decodes the bearer JWT with `jwtDecode`, which does not verify a
+signature — by design, since third-party backends do not hold the Oxy signing
+secret. Two claims were nevertheless trusted:
+
+1. **A token carrying no `sessionId` was accepted on its claims alone.** The
+   middleware skipped the network entirely and set `req.userId` straight from
+   the token's `userId`. Forging a JWT with a victim's id, a future `exp` and a
+   garbage signature was enough. Victim ids are public — `GET
+   /profiles/username/:handle` returns one without authentication.
+
+2. **On the session path, the identity came from the token, not the session.**
+   `GET /session/validate/:sessionId` is unauthenticated and returns whoever
+   owns the session id it is handed; it does not bind the bearer token. A caller
+   holding any live session id — their own, for instance — could pair it with a
+   forged `userId` claim and be trusted as that user.
+
+Both are closed. A user token must now carry a `sessionId`, that session is
+validated server-side, and `req.userId` is taken from the validated session and
+must match the token's claim.
+
+`authSocket()` already required a session and already cross-checked the claimed
+user, and is unaffected. Service tokens are unaffected: they are HMAC-verified
+with `aud` / `iss` / `type` checked, and that path is unchanged.
+
+#### New refusals
+
+| Code | When |
+| --- | --- |
+| `SESSION_REQUIRED` | A user token carries no usable `sessionId`. |
+| `SESSION_USER_MISMATCH` | The token's `userId` is not the user the validated session belongs to. |
+
+`INVALID_SESSION` additionally now covers a validation that returns no user, or
+a user with no usable id.
+
+Under `optional: true` all of these resolve to anonymous (`req.userId = null`)
+rather than to the claimed user.
+
+#### Compatibility
+
+Every user access token the Oxy API issues already carries a `sessionId`, so no
+legitimate caller is affected. Anything that relied on a session-less user token
+resolving to an identity was relying on the vulnerability.
+
+### Fixed
+
+- `oxy.rateLimit()` no longer erases an identity that a preceding middleware
+  resolved. It resolves the session through `createOptionalOxyAuth`, which skips
+  when a user is already present, instead of `oxy.auth({ optional: true })`,
+  which writes `req.userId = null` on every request it cannot authenticate — a
+  mutation of the shared `req` that was visible to every handler downstream of
+  the limiter, not just to the bucket calculation.
+
 ## 20.0.0
 
 ### Licence: AGPL-3.0-only becomes Apache-2.0

--- a/packages/core/src/mixins/OxyServices.utility.ts
+++ b/packages/core/src/mixins/OxyServices.utility.ts
@@ -250,17 +250,40 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
      * Uses server-side session validation for security (not just JWT decode).
      *
      * **Design note — jwtDecode vs jwt.verify:**
-     * This middleware intentionally uses `jwtDecode()` (decode-only, no signature
-     * verification) for user tokens. This is by design, NOT a security gap:
-     * - Third-party apps using `oxy.auth()` don't have the Oxy JWT secret
-     * - Security comes from API-based session validation (`validateSession()`)
-     *   which checks the session server-side on every request
-     * - Service tokens (type: 'service') DO use cryptographic HMAC verification
-     *   via the `jwtSecret` option, since they are stateless. Service tokens
-     *   are additionally checked for `aud`, `iss`, and `type` claims to prevent
+     * This middleware uses `jwtDecode()` (decode-only, NO signature check) for
+     * user tokens, because third-party apps mounting `oxy.auth()` do not hold
+     * the Oxy signing secret. **Every claim in a user token is therefore
+     * attacker-controlled and proves nothing on its own.** The identity comes
+     * from somewhere else entirely:
+     * - A user token MUST carry a `sessionId`. That session is validated
+     *   server-side on every request via `validateSession()`, and the user id
+     *   is read off the VALIDATED SESSION — never off the token. A token whose
+     *   `userId` claim disagrees with the session is refused
+     *   (`SESSION_USER_MISMATCH`); a token with no `sessionId` at all is
+     *   refused outright (`SESSION_REQUIRED`). There is no local-claims path.
+     * - Service tokens (type: 'service') ARE stateless, so they use
+     *   cryptographic HMAC verification via the `jwtSecret` option, and are
+     *   additionally checked for `aud`, `iss`, and `type` claims to prevent
      *   cross-token-type confusion attacks.
      * - The backend's own `authMiddleware` uses `jwt.verify()` because it has
      *   direct access to `SERVICE_TOKEN_SECRET` / `ACCESS_TOKEN_SECRET`.
+     *
+     * **Why session-less user tokens are refused rather than trusted:**
+     * every user access token the Oxy API issues carries a `sessionId` (see
+     * `packages/api/src/utils/sessionUtils.ts`, `generateSessionTokens` — the
+     * only mint site for user tokens, including the OAuth code exchange). So
+     * refusing session-less user tokens costs nothing legitimate, while
+     * accepting them let anyone authenticate as anyone by hand-rolling a JWT
+     * with a `userId` claim and a garbage signature.
+     *
+     * **Why the claimed user id is cross-checked against the session:**
+     * `GET /session/validate/:sessionId` is UNAUTHENTICATED and does not bind
+     * the bearer token — it returns whoever owns the session id it was handed.
+     * Trusting the token's `userId` claim after a successful validation would
+     * therefore let a caller holding ANY live session id (their own, for
+     * instance) pair it with a forged `userId` and be trusted as that user.
+     * `authSocket()` has always cross-checked this; the HTTP middleware now
+     * does too.
      *
      * **Service-token delegation (X-Oxy-User-Id):**
      * When a service token is accompanied by `X-Oxy-User-Id`, the SDK calls
@@ -543,8 +566,10 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
             return next();
           }
 
-          const userId = decoded.userId || decoded.id;
-          if (!userId) {
+          // The CLAIMED user id. Never trusted as an identity — it is only ever
+          // compared against the id the validated session resolves to.
+          const claimedUserId = readStringClaim(decoded.userId) ?? readStringClaim(decoded.id);
+          if (!claimedUserId) {
             if (optional) {
               req.userId = null;
               req.user = null;
@@ -580,58 +605,82 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
             return res.status(401).json(error);
           }
 
-          // Validate token against the Oxy API for session-based verification
-          // This ensures the session hasn't been revoked server-side
-          if (decoded.sessionId) {
-            try {
-              const validationResult = await oxyInstance.validateSession(decoded.sessionId, {
-                useHeaderValidation: true,
-              });
-
-              if (!validationResult || !validationResult.valid) {
-                if (optional) {
-                  req.userId = null;
-                  req.user = null;
-                  return next();
-                }
-
-                const error = {
-                  error: 'INVALID_SESSION',
-                  message: 'Session invalid or expired',
-                  code: 'INVALID_SESSION',
-                  status: 401
-                };
-                if (onError) return onError(error);
-                return res.status(401).json(error);
-              }
-
-              // Use validated user data from session validation (already has full user)
-              req.userId = userId;
-              req.accessToken = token;
-              req.sessionId = decoded.sessionId;
-
-              if (loadUser && validationResult.user) {
-                // Session validation already returns full user data
-                req.user = validationResult.user;
-              } else {
-                req.user = { id: userId } as User;
-              }
-
-              if (debug) {
-                logger.debug(`[oxy.auth] OK user=${userId} session=${decoded.sessionId}`, {
-                  component: 'auth',
-                  method: 'auth',
-                });
-              }
-
+          // A server-validated session is MANDATORY for a user token. The JWT
+          // signature is not verified on this path, so a bare decoded token
+          // proves nothing: without the session round-trip a forged token could
+          // claim any user id. Mirrors `authSocket()`, which has always
+          // required this.
+          const sessionId = readStringClaim(decoded.sessionId);
+          if (!sessionId) {
+            if (optional) {
+              req.userId = null;
+              req.user = null;
               return next();
-            } catch (validationError) {
-              if (debug) {
-                logger.debug('[oxy.auth] Session validation failed', {
-                  component: 'auth',
-                  method: 'auth',
-                }, validationError);
+            }
+
+            const error = {
+              error: 'SESSION_REQUIRED',
+              message: 'Access token is not bound to a session',
+              code: 'SESSION_REQUIRED',
+              status: 401
+            };
+            if (onError) return onError(error);
+            return res.status(401).json(error);
+          }
+
+          // Validate the token against the Oxy API. This proves the session is
+          // real and unrevoked, AND yields the identity it belongs to.
+          try {
+            const validationResult = await oxyInstance.validateSession(sessionId, {
+              useHeaderValidation: true,
+            });
+
+            if (!validationResult || !validationResult.valid || !validationResult.user) {
+              if (optional) {
+                req.userId = null;
+                req.user = null;
+                return next();
               }
+
+              const error = {
+                error: 'INVALID_SESSION',
+                message: 'Session invalid or expired',
+                code: 'INVALID_SESSION',
+                status: 401
+              };
+              if (onError) return onError(error);
+              return res.status(401).json(error);
+            }
+
+            // The session — not the token — is the source of truth for identity.
+            const validatedUserId = getUserIdentityId(validationResult.user);
+            if (!validatedUserId) {
+              if (optional) {
+                req.userId = null;
+                req.user = null;
+                return next();
+              }
+
+              const error = {
+                error: 'INVALID_SESSION',
+                message: 'Session did not resolve to a usable identity',
+                code: 'INVALID_SESSION',
+                status: 401
+              };
+              if (onError) return onError(error);
+              return res.status(401).json(error);
+            }
+
+            if (validatedUserId !== claimedUserId) {
+              // Session-id/claim confusion: the caller presented a live session
+              // that belongs to somebody else. Worth a warning — it has no
+              // benign cause. Ids only; never the token or the payload.
+              logger.warn('[oxy.auth] Token rejected — claimed user does not own the session', {
+                component: 'auth',
+                method: 'auth',
+                claimedUserId,
+                validatedUserId,
+              });
 
               if (optional) {
                 req.userId = null;
@@ -640,58 +689,53 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
               }
 
               const error = {
-                error: 'SESSION_VALIDATION_ERROR',
-                message: 'Session validation failed',
-                code: 'SESSION_VALIDATION_ERROR',
+                error: 'SESSION_USER_MISMATCH',
+                message: 'Token user does not match the session',
+                code: 'SESSION_USER_MISMATCH',
                 status: 401
               };
               if (onError) return onError(error);
               return res.status(401).json(error);
             }
-          }
 
-          // Non-session token: use local validation only (userId from JWT)
-          req.userId = userId;
-          req.accessToken = token;
-          req.user = { id: userId } as User;
+            req.userId = validatedUserId;
+            req.accessToken = token;
+            req.sessionId = sessionId;
+            // Session validation already returned the full user, so `loadUser`
+            // costs no extra round-trip.
+            req.user = loadUser ? validationResult.user : ({ id: validatedUserId } as User);
 
-          // If loadUser requested with non-session token, fetch from API
-          if (loadUser) {
-            try {
-              // Temporarily set token to make the API call
-              const prevToken = oxyInstance.getAccessToken();
-              oxyInstance.setTokens(token);
-              const fullUser = await oxyInstance.getCurrentUser();
-              // Restore previous token
-              if (prevToken) {
-                oxyInstance.setTokens(prevToken);
-              } else {
-                oxyInstance.clearTokens();
-              }
-
-              if (fullUser) {
-                req.user = fullUser;
-              }
-            } catch (loadUserError) {
-              // Loading the full user is best-effort here; the basic { id }
-              // object is already attached. Log so misconfigured deployments
-              // can be diagnosed instead of silently failing.
-              logger.warn('[oxy.auth] loadUser fallback — could not fetch full profile', {
+            if (debug) {
+              logger.debug(`[oxy.auth] OK user=${validatedUserId} session=${sessionId}`, {
                 component: 'auth',
-                method: 'auth.loadUser',
-                userId,
-              }, loadUserError);
+                method: 'auth',
+              });
             }
-          }
 
-          if (debug) {
-            logger.debug(`[oxy.auth] OK user=${userId} (no session)`, {
-              component: 'auth',
-              method: 'auth',
-            });
-          }
+            return next();
+          } catch (validationError) {
+            if (debug) {
+              logger.debug('[oxy.auth] Session validation failed', {
+                component: 'auth',
+                method: 'auth',
+              }, validationError);
+            }
 
-          next();
+            if (optional) {
+              req.userId = null;
+              req.user = null;
+              return next();
+            }
+
+            const error = {
+              error: 'SESSION_VALIDATION_ERROR',
+              message: 'Session validation failed',
+              code: 'SESSION_VALIDATION_ERROR',
+              status: 401
+            };
+            if (onError) return onError(error);
+            return res.status(401).json(error);
+          }
         } catch (error) {
           const handled = oxyInstance.handleError(error) as Error & {
             code?: string;
@@ -768,7 +812,7 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
             return next(new Error('Invalid token'));
           }
 
-          const claimedUserId = decoded.userId || decoded.id;
+          const claimedUserId = readStringClaim(decoded.userId) ?? readStringClaim(decoded.id);
           if (!claimedUserId) {
             return next(new Error('Invalid token payload'));
           }
@@ -781,13 +825,14 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
           // A server-validated session is mandatory. A bare decoded JWT proves
           // nothing — the signature is not verified here, so without a session
           // round-trip a forged token could claim any user id.
-          if (!decoded.sessionId) {
+          const sessionId = readStringClaim(decoded.sessionId);
+          if (!sessionId) {
             return next(new Error('Session required'));
           }
 
           let userId = claimedUserId;
           try {
-            const result = await oxyInstance.validateSession(decoded.sessionId, {
+            const result = await oxyInstance.validateSession(sessionId, {
               useHeaderValidation: true,
             });
             if (!result || !result.valid || !result.user) {
@@ -819,10 +864,10 @@ export function OxyServicesUtilityMixin<T extends typeof OxyServicesBase>(Base: 
           // reads from `socket.user.id`.
           socket.data = socket.data || {};
           socket.data.userId = userId;
-          socket.data.sessionId = decoded.sessionId || null;
+          socket.data.sessionId = sessionId;
           socket.data.token = token;
 
-          socket.user = { id: userId, userId, sessionId: decoded.sessionId };
+          socket.user = { id: userId, userId, sessionId };
 
           if (debug) {
             logger.debug(`[oxy.authSocket] OK user=${userId}`, {
@@ -978,12 +1023,17 @@ async function verifyServiceTokenSignature(token: string, secret: string): Promi
 }
 
 /**
- * Verify that a decoded service-token payload carries the expected `aud`,
- * `iss`, and `type` claims. Throws `ServiceTokenClaimError` on mismatch.
- * This is the defence against the H4 vulnerability where a recovery / 2FA /
- * access token signed by the same shared secret could be replayed as a
- * service token because no claim binding existed.
+ * Read a JWT claim that is only usable as a non-empty string.
+ *
+ * A decoded payload is attacker-controlled JSON: a claim the type declares as
+ * `string` can arrive as a number, an object, or `null`. Narrowing here keeps
+ * those values out of URL construction and identity comparison, so an
+ * unexpected shape becomes a 401 rather than a stringified surprise.
  */
+function readStringClaim(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
 /**
  * Resolve the canonical user id from a validated session's user object.
  *
@@ -997,6 +1047,13 @@ function getUserIdentityId(user: User): string | null {
   return typeof candidate === 'string' && candidate.length > 0 ? candidate : null;
 }
 
+/**
+ * Verify that a decoded service-token payload carries the expected `aud`,
+ * `iss`, and `type` claims. Throws `ServiceTokenClaimError` on mismatch.
+ * This is the defence against the H4 vulnerability where a recovery / 2FA /
+ * access token signed by the same shared secret could be replayed as a
+ * service token because no claim binding existed.
+ */
 function verifyServiceTokenClaims(
   decoded: JwtPayload,
   expected: { audience: string; issuer: string },
@@ -1062,9 +1119,5 @@ interface OxyAuthInstance {
     user?: User;
     [key: string]: unknown;
   } | null>;
-  getAccessToken(): string | null;
-  setTokens(accessToken: string): void;
-  clearTokens(): void;
-  getCurrentUser(): Promise<User | null>;
   handleError(error: unknown): Error;
 }

--- a/packages/core/src/mixins/__tests__/userTokenAuth.test.ts
+++ b/packages/core/src/mixins/__tests__/userTokenAuth.test.ts
@@ -1,0 +1,746 @@
+/**
+ * User-token authentication security regression tests
+ *
+ * Locks in the fix for the `oxy.auth()` authentication bypass.
+ *
+ * `auth()` decodes the bearer JWT with `jwtDecode`, which does NOT verify a
+ * signature — deliberately, since third-party backends mounting this middleware
+ * do not hold the Oxy signing secret. Every claim is therefore attacker
+ * controlled, and the middleware previously trusted two of them anyway:
+ *
+ *   1. **Session-less tokens were trusted outright.** When the payload carried
+ *      no `sessionId`, the middleware skipped the network entirely and did:
+ *
+ *          req.userId = userId;                 // straight from the claim
+ *          req.user   = { id: userId } as User;
+ *
+ *      Anyone could authenticate as anyone on every Oxy backend mounting
+ *      `oxy.auth()` / `createOxyAuthMiddleware()` by hand-rolling a JWT with a
+ *      `userId` claim, a future `exp`, and a garbage signature. Victim ids are
+ *      public (`GET /profiles/username/:handle`).
+ *
+ *   2. **The session path trusted the claimed user id.** `GET
+ *      /session/validate/:sessionId` is UNAUTHENTICATED and returns whichever
+ *      user owns the session id it is handed; it does not bind the bearer
+ *      token. `auth()` then set `req.userId` from the JWT claim rather than
+ *      from the validated session, so a caller holding ANY live session id —
+ *      their own, for instance — could pair it with a forged `userId` and be
+ *      trusted as that user. `authSocket()` already cross-checked this; the
+ *      HTTP middleware did not.
+ *
+ * Both are now closed: a user token MUST carry a `sessionId`, and `req.userId`
+ * comes off the validated session, never off the token.
+ *
+ * There is nothing legitimate to preserve on the session-less path: every user
+ * access token the Oxy API issues carries a `sessionId`
+ * (`packages/api/src/utils/sessionUtils.ts`, `generateSessionTokens`, which is
+ * the only user-token mint site — the OAuth code exchange routes through it
+ * too). The `pre-authentication token shapes` block below covers the class of
+ * signed-but-session-less token that must never resolve to a logged-in
+ * identity, using the two shapes the API used to mint before they were removed.
+ *
+ * These tests exercise a real `OxyServices` instance with `validateSession`
+ * stubbed, so the middleware's own logic runs end to end without the network.
+ */
+
+import crypto from 'node:crypto';
+import { OxyServices } from '../../OxyServices';
+import type { User } from '../../models/interfaces';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface UserTokenClaims {
+  userId?: unknown;
+  id?: unknown;
+  sessionId?: unknown;
+  exp?: number;
+  iat?: number;
+  [key: string]: unknown;
+}
+
+const b64url = (input: Buffer | string): string => {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : input;
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+const ONE_HOUR_FROM_NOW = (): number => Math.floor(Date.now() / 1000) + 3600;
+
+/** A JWT whose signature is invented. Structurally valid, cryptographically worthless. */
+const forgeToken = (
+  claims: UserTokenClaims,
+  signature = 'AAAAcompletely-invented-signature',
+): string => {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(
+    JSON.stringify({ iat: Math.floor(Date.now() / 1000), exp: ONE_HOUR_FROM_NOW(), ...claims }),
+  );
+  return `${header}.${payload}.${signature}`;
+};
+
+/** An `alg: none` JWT — the classic unsigned-token attack. */
+const forgeAlgNoneToken = (claims: UserTokenClaims): string => {
+  const header = b64url(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const payload = b64url(
+    JSON.stringify({ iat: Math.floor(Date.now() / 1000), exp: ONE_HOUR_FROM_NOW(), ...claims }),
+  );
+  return `${header}.${payload}.`;
+};
+
+/**
+ * A genuinely HS256-signed token, byte-identical in shape to what
+ * `jsonwebtoken.sign()` produces in the API. The middleware never checks this
+ * signature for user tokens — security comes from the session round-trip — but
+ * signing the fixtures keeps them honest about what production sends, and
+ * proves the refusal is not merely "the signature looked wrong".
+ */
+const signToken = (claims: UserTokenClaims, secret: string): string => {
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = b64url(
+    JSON.stringify({
+      iat: Math.floor(Date.now() / 1000),
+      exp: ONE_HOUR_FROM_NOW(),
+      type: 'access',
+      deviceId: 'device-1',
+      ...claims,
+    }),
+  );
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${payload}`)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `${header}.${payload}.${signature}`;
+};
+
+interface MockReq {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  query: Record<string, string>;
+  userId?: string | null;
+  user?: unknown;
+  accessToken?: string;
+  sessionId?: string | null;
+  serviceApp?: unknown;
+  serviceActingAs?: unknown;
+}
+
+interface MockRes {
+  statusCode: number;
+  body: unknown;
+  headersSent: boolean;
+  status(code: number): MockRes;
+  json(body: unknown): MockRes;
+}
+
+const makeReq = (overrides: Partial<MockReq> = {}): MockReq => ({
+  method: 'GET',
+  path: '/api/whoami',
+  headers: {},
+  query: {},
+  ...overrides,
+});
+
+const makeRes = (): MockRes => ({
+  statusCode: 0,
+  body: undefined,
+  headersSent: false,
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  },
+  json(body: unknown) {
+    this.body = body;
+    this.headersSent = true;
+    return this;
+  },
+});
+
+/** Run the middleware against the loose Express shape it declares internally. */
+const run = async (
+  middleware: ReturnType<OxyServices['auth']>,
+  req: MockReq,
+  res: MockRes,
+  next: jest.Mock,
+): Promise<void> => {
+  await middleware(req as unknown as never, res as unknown as never, next as unknown as never);
+};
+
+const VICTIM_ID = '507f1f77bcf86cd799439011';
+const ATTACKER_ID = '507f1f77bcf86cd799439022';
+const ACCESS_TOKEN_SECRET = 'test-access-token-secret-not-production';
+
+const asUser = (id: string): User => ({ id }) as User;
+
+const validSessionFor = (user: User) => ({
+  valid: true as const,
+  expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  lastActivity: new Date().toISOString(),
+  user,
+});
+
+// ---------------------------------------------------------------------------
+// Hole 1 — session-less user tokens must never authenticate
+// ---------------------------------------------------------------------------
+
+describe('user tokens without a sessionId are refused', () => {
+  let oxy: OxyServices;
+  let validateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    // Any call here would mean the middleware went to the network on a path
+    // that must be decided locally. Assertions below check it never happens.
+    validateSpy = jest.spyOn(oxy, 'validateSession');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects a forged token whose signature is garbage', async () => {
+    const req = makeReq({
+      headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+    expect(req.user).toBeUndefined();
+    expect(req.accessToken).toBeUndefined();
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token with an empty signature segment', async () => {
+    const req = makeReq({
+      headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID }, '')}` },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects an alg:none token', async () => {
+    const req = makeReq({
+      headers: { authorization: `Bearer ${forgeAlgNoneToken({ userId: VICTIM_ID })}` },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects a session-less token that carries the id claim instead of userId', async () => {
+    const req = makeReq({ headers: { authorization: `Bearer ${forgeToken({ id: VICTIM_ID })}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects a genuinely signed session-less token, so the refusal is not about the signature', async () => {
+    const token = signToken({ userId: VICTIM_ID }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('treats a non-string sessionId claim as no session at all', async () => {
+    // A decoded payload is attacker-supplied JSON: `sessionId` can be an
+    // object, and a truthiness check would have let it through into URL
+    // construction.
+    const req = makeReq({
+      headers: {
+        authorization: `Bearer ${forgeToken({ userId: VICTIM_ID, sessionId: { toString: 'x' } })}`,
+      },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty-string sessionId claim as no session at all', async () => {
+    const req = makeReq({
+      headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID, sessionId: '' })}` },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('never loads a user profile for a session-less token, even with loadUser', async () => {
+    const getCurrentUserSpy = jest.spyOn(oxy, 'getCurrentUser');
+    const req = makeReq({
+      headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ loadUser: true }), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+    expect(getCurrentUserSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats a session-less token as anonymous under optional auth, never as the claimed user', async () => {
+    const req = makeReq({
+      headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ optional: true }), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.headersSent).toBe(false);
+    expect(req.userId).toBeNull();
+    expect(req.user).toBeNull();
+    expect(req.accessToken).toBeUndefined();
+  });
+
+  it('does not admit a session-less token via the jwtSecret / service-token path', async () => {
+    // `jwtSecret` exists to verify SERVICE tokens. A user token must not gain
+    // anything by its presence, whether or not it is signed with that secret.
+    const token = signToken({ userId: VICTIM_ID }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ jwtSecret: ACCESS_TOKEN_SECRET }), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+    expect(req.serviceApp).toBeUndefined();
+  });
+
+  it('does not admit a session-less token via the X-Oxy-User-Id delegation header', async () => {
+    // Delegation is a SERVICE-token feature. The header must not turn a user
+    // token into an acting-as grant, nor reach the grant lookup at all.
+    const grantSpy = jest.spyOn(oxy, 'verifyServiceActingAs');
+    const req = makeReq({
+      headers: {
+        authorization: `Bearer ${forgeToken({ userId: ATTACKER_ID })}`,
+        'x-oxy-user-id': VICTIM_ID,
+      },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ jwtSecret: ACCESS_TOKEN_SECRET }), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+    expect(req.serviceActingAs).toBeUndefined();
+    expect(grantSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports SESSION_REQUIRED through a custom onError handler', async () => {
+    const onError = jest.fn();
+    const req = makeReq({
+      headers: { authorization: `Bearer ${forgeToken({ userId: VICTIM_ID })}` },
+    });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ onError }), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.headersSent).toBe(false);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'SESSION_REQUIRED', status: 401 }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The pre-authentication token class
+// ---------------------------------------------------------------------------
+
+describe('pre-authentication token shapes never resolve to a logged-in identity', () => {
+  let oxy: OxyServices;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * These two shapes were minted by `controllers/session.controller.ts` and
+   * signed with `ACCESS_TOKEN_SECRET`, carrying `userId` and no `sessionId`.
+   * Both were issued BEFORE authentication completed — one between the password
+   * step and the second factor, one to a caller proving only that they had
+   * received a recovery code — and the old middleware accepted either as the
+   * fully signed-in user.
+   *
+   * The password / 2FA / recovery backend was removed in `8bfdd965`, so neither
+   * token exists on `main` today. They stay here as the regression fixtures for
+   * the CLASS: any future signed, session-less, pre-authentication token must
+   * be refused by construction rather than by nobody happening to mint one.
+   */
+  it('refuses the 2FA-challenge shape (signed, userId, no sessionId)', async () => {
+    const loginToken = signToken(
+      { userId: VICTIM_ID, purpose: '2fa_challenge' },
+      ACCESS_TOKEN_SECRET,
+    );
+    const req = makeReq({ headers: { authorization: `Bearer ${loginToken}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('refuses the account-recovery shape (signed, userId, no sessionId)', async () => {
+    const recoveryToken = signToken(
+      { type: 'recovery', recoveryId: 'rec-1', userId: VICTIM_ID },
+      ACCESS_TOKEN_SECRET,
+    );
+    const req = makeReq({ headers: { authorization: `Bearer ${recoveryToken}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_REQUIRED' });
+    expect(req.userId).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hole 2 — the identity must come from the validated session, not the claim
+// ---------------------------------------------------------------------------
+
+describe('session-backed user tokens bind identity to the validated session', () => {
+  let oxy: OxyServices;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects a token pairing a live session with a forged userId claim', async () => {
+    // The attacker holds their OWN valid session and swaps the userId claim.
+    // `/session/validate/:id` is unauthenticated, so obtaining a live session
+    // id is not the hard part — binding it to an identity is.
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue(validSessionFor(asUser(ATTACKER_ID)));
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'attacker-session' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_USER_MISMATCH' });
+    expect(req.userId).toBeUndefined();
+    expect(req.user).toBeUndefined();
+    expect(req.accessToken).toBeUndefined();
+  });
+
+  it('rejects a session whose validation returns no user', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: true,
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      lastActivity: new Date().toISOString(),
+    } as unknown as Awaited<ReturnType<OxyServices['validateSession']>>);
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'session-1' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'INVALID_SESSION' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects a session whose user carries no usable id', async () => {
+    jest
+      .spyOn(oxy, 'validateSession')
+      .mockResolvedValue(validSessionFor({ username: 'ghost' } as unknown as User));
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'session-1' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'INVALID_SESSION' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('accepts a matching session and takes the id from the server, not the token', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue(validSessionFor(asUser(VICTIM_ID)));
+
+    const token = signToken({ userId: VICTIM_ID, sessionId: 'session-1' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.headersSent).toBe(false);
+    expect(req.userId).toBe(VICTIM_ID);
+    expect(req.sessionId).toBe('session-1');
+    expect(req.accessToken).toBe(token);
+    expect(req.user).toEqual({ id: VICTIM_ID });
+  });
+
+  it('accepts a session identified by the raw Mongo _id shape', async () => {
+    jest
+      .spyOn(oxy, 'validateSession')
+      .mockResolvedValue(validSessionFor({ _id: VICTIM_ID } as unknown as User));
+
+    const token = signToken({ userId: VICTIM_ID, sessionId: 'session-1' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.userId).toBe(VICTIM_ID);
+  });
+
+  it('attaches the full validated profile when loadUser is set, with no extra round-trip', async () => {
+    const fullUser = {
+      id: VICTIM_ID,
+      username: 'victim',
+      email: 'victim@example.com',
+    } as User;
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue(validSessionFor(fullUser));
+    const getCurrentUserSpy = jest.spyOn(oxy, 'getCurrentUser');
+
+    const token = signToken({ userId: VICTIM_ID, sessionId: 'session-1' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ loadUser: true }), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.user).toEqual(fullUser);
+    expect(getCurrentUserSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid session', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue({
+      valid: false,
+    } as unknown as Awaited<ReturnType<OxyServices['validateSession']>>);
+
+    const token = signToken({ userId: VICTIM_ID, sessionId: 'revoked' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'INVALID_SESSION' });
+  });
+
+  it('rejects when session validation throws', async () => {
+    jest.spyOn(oxy, 'validateSession').mockRejectedValue(new Error('session not found'));
+
+    const token = signToken({ userId: VICTIM_ID, sessionId: 'nope' }, ACCESS_TOKEN_SECRET);
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'SESSION_VALIDATION_ERROR' });
+    expect(req.userId).toBeUndefined();
+  });
+
+  it('rejects an expired token before any session round-trip', async () => {
+    const validateSpy = jest.spyOn(oxy, 'validateSession');
+    const token = forgeToken({
+      userId: VICTIM_ID,
+      sessionId: 'session-1',
+      exp: Math.floor(Date.now() / 1000) - 1,
+    });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ code: 'TOKEN_EXPIRED' });
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to anonymous, not to the claim, when optional auth hits a mismatch', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue(validSessionFor(asUser(ATTACKER_ID)));
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'attacker-session' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth({ optional: true }), req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.headersSent).toBe(false);
+    expect(req.userId).toBeNull();
+    expect(req.user).toBeNull();
+  });
+
+  it('never logs the token or the decoded payload when refusing a mismatch', async () => {
+    // The warn on this path names ids (public) and nothing else.
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue(validSessionFor(asUser(ATTACKER_ID)));
+
+    const token = forgeToken({ userId: VICTIM_ID, sessionId: 'attacker-session' });
+    const req = makeReq({ headers: { authorization: `Bearer ${token}` } });
+    const res = makeRes();
+    const next = jest.fn();
+
+    await run(oxy.auth(), req, res, next);
+
+    const logged = warnSpy.mock.calls.map((call) => JSON.stringify(call)).join('\n');
+    expect(logged).not.toContain(token);
+    expect(logged).not.toContain('attacker-session');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Socket auth keeps the same contract
+// ---------------------------------------------------------------------------
+
+describe('authSocket keeps refusing session-less tokens', () => {
+  let oxy: OxyServices;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  interface MockSocket {
+    handshake: { auth: { token?: string } };
+    data?: Record<string, unknown>;
+    user?: { id: string; userId: string; sessionId?: string | null };
+  }
+
+  const runSocket = async (socket: MockSocket, next: jest.Mock): Promise<void> => {
+    await oxy.authSocket()(socket as unknown as never, next as unknown as never);
+  };
+
+  it('refuses a session-less token', async () => {
+    const validateSpy = jest.spyOn(oxy, 'validateSession');
+    const next = jest.fn();
+
+    await runSocket({ handshake: { auth: { token: forgeToken({ userId: VICTIM_ID }) } } }, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'Session required' }));
+    expect(validateSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses a live session paired with a forged userId claim', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue(validSessionFor(asUser(ATTACKER_ID)));
+    const next = jest.fn();
+    const socket: MockSocket = {
+      handshake: { auth: { token: forgeToken({ userId: VICTIM_ID, sessionId: 'attacker-session' }) } },
+    };
+
+    await runSocket(socket, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'Session user mismatch' }));
+    expect(socket.user).toBeUndefined();
+  });
+
+  it('accepts a matching session', async () => {
+    jest.spyOn(oxy, 'validateSession').mockResolvedValue(validSessionFor(asUser(VICTIM_ID)));
+    const next = jest.fn();
+    const socket: MockSocket = {
+      handshake: {
+        auth: { token: signToken({ userId: VICTIM_ID, sessionId: 'session-1' }, ACCESS_TOKEN_SECRET) },
+      },
+    };
+
+    await runSocket(socket, next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(socket.user).toEqual({ id: VICTIM_ID, userId: VICTIM_ID, sessionId: 'session-1' });
+    expect(socket.data?.sessionId).toBe('session-1');
+  });
+});

--- a/packages/core/src/server/__tests__/rateLimit.test.ts
+++ b/packages/core/src/server/__tests__/rateLimit.test.ts
@@ -125,6 +125,53 @@ describe('@oxyhq/core/server rate limiter', () => {
     expect(req.observedKey).toBe('user:validated-user');
   });
 
+  it('does not clobber an identity a preceding middleware already resolved', () => {
+    // The limiter mutates the SHARED `req`, so the unconditional
+    // `req.userId = null` that `oxy.auth({ optional: true })` writes for every
+    // request it cannot authenticate is not merely a bucketing detail — it
+    // erases the identity for every handler downstream of the limiter too.
+    // The resolver must therefore skip entirely when a user is already present.
+    // This handler stands in for that erasure.
+    const clobberingAuth = jest.fn(
+      (req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+        req.userId = null;
+        req.user = null;
+        req.sessionId = null;
+        next();
+      },
+    );
+    const oxy = makeOxy(clobberingAuth as unknown as RequestHandler);
+    const req = makeRequest({
+      userId: 'resolved-by-the-app',
+      user: { id: 'resolved-by-the-app' },
+      sessionId: 'app-session',
+    });
+
+    createOxyRateLimit(oxy)(req, {} as Response, jest.fn());
+
+    expect(req.userId).toBe('resolved-by-the-app');
+    expect(req.user).toEqual({ id: 'resolved-by-the-app' });
+    expect(req.sessionId).toBe('app-session');
+    expect(req.observedKey).toBe('user:resolved-by-the-app');
+    expect(clobberingAuth).not.toHaveBeenCalled();
+  });
+
+  it('still resolves the session when no identity is present yet', () => {
+    const authHandler = jest.fn((req: RateLimitTestRequest, _res: Response, next: NextFunction) => {
+      req.userId = 'resolved-by-oxy';
+      req.user = { id: 'resolved-by-oxy' };
+      req.sessionId = 'oxy-session';
+      next();
+    });
+    const oxy = makeOxy(authHandler as unknown as RequestHandler);
+    const req = makeRequest();
+
+    createOxyRateLimit(oxy)(req, {} as Response, jest.fn());
+
+    expect(authHandler).toHaveBeenCalledTimes(1);
+    expect(req.observedKey).toBe('user:resolved-by-oxy');
+  });
+
   it('continues through the anonymous limiter if optional auth returns an error', () => {
     const oxy = makeOxy((_req: Request, _res: Response, next: NextFunction) => {
       next(new Error('token rejected'));

--- a/packages/core/src/server/rateLimit.ts
+++ b/packages/core/src/server/rateLimit.ts
@@ -3,6 +3,7 @@ import { isIPv4, isIPv6 } from 'node:net';
 import type { Request, RequestHandler } from 'express';
 import rateLimit, { type Store } from 'express-rate-limit';
 import type { OxyServices } from '../OxyServices';
+import { createOptionalOxyAuth } from './auth';
 
 /**
  * Server-only rate limiting for Oxy backends.
@@ -25,8 +26,9 @@ import type { OxyServices } from '../OxyServices';
  * WHAT IT PROVIDES
  * ----------------
  * `createOxyRateLimit(oxy, options)` returns a SINGLE composed middleware that:
- *   1. Resolves the user via `oxy.auth({ optional: true })` (idempotent — it
- *      skips re-verification if a prior middleware already set `req.user`).
+ *   1. Resolves the user via `createOptionalOxyAuth` (idempotent — it skips
+ *      resolution entirely if a prior middleware already resolved a user, so
+ *      the limiter can never erase an identity it did not create).
  *   2. Applies an `express-rate-limit` limiter keyed PER USER when
  *      authenticated, falling back to the (IPv6-safe) IP otherwise, with
  *      generous, media-app-realistic defaults and sensible exemptions.
@@ -203,11 +205,12 @@ function hashAnonymousIp(ip: string): string {
 /**
  * Resolve the trusted authenticated rate-limit key.
  *
- * `oxy.auth({ optional: true })` preserves legacy non-session user tokens by
- * decoding their JWT claims locally. Those claims are not cryptographically
- * verified and therefore MUST NOT influence abuse-control buckets. Only use
- * identities that came from a server-validated session or a verified service
- * token/delegation.
+ * Only identities that came from a server-validated session or a verified
+ * service token/delegation may pick a bucket. `req.sessionId` is the marker
+ * for the former: `oxy.auth()` sets it only after `validateSession()` came
+ * back valid, so requiring it here means an identity written by some OTHER
+ * middleware — which this package cannot vouch for — shares the anonymous
+ * per-IP bucket rather than getting the authenticated quota.
  */
 function resolveTrustedAuthenticatedKey(req: OxyAuthedRequest): string | null {
   const userId = req.userId ?? req.user?.id ?? req.user?._id;
@@ -260,7 +263,14 @@ export function createOxyRateLimit(
 
   // Idempotent optional-auth resolver. Reuses the SAME session resolution as
   // every protected route, so the limiter keys by the real user identity.
-  const resolveSession = oxy.auth({ ...auth, optional: true });
+  //
+  // `createOptionalOxyAuth` — NOT the raw `oxy.auth({ optional: true })` —
+  // because only the former skips resolution when a preceding middleware has
+  // already resolved a user. The raw middleware writes `req.userId = null` on
+  // every request it cannot authenticate, and because it mutates the shared
+  // `req` that erasure is visible to every handler downstream of the limiter,
+  // not just to the bucket calculation.
+  const resolveSession = createOptionalOxyAuth(oxy, { auth });
 
   const skip = (req: Request): boolean =>
     isBuiltInExempt(req) || (exempt ? exempt(req) : false);


### PR DESCRIPTION
## The bypass

`oxy.auth()` decodes the bearer JWT with `jwtDecode`, which does not verify a signature — deliberately, since third-party backends mounting this middleware do not hold the Oxy signing secret. Two claims were trusted anyway.

**1. A token with no `sessionId` was accepted on its claims alone.** The middleware skipped the network entirely and set `req.userId` straight from the token's `userId` claim.

**2. On the session path, the identity came from the token, not the session.** `GET /session/validate/:sessionId` is unauthenticated and returns whoever owns the session id it is handed — it does not bind the bearer token. A caller holding *any* live session id (their own) could pair it with a forged `userId` claim and be trusted as that user.

## The attacker request

No credentials, no secret. Mint a JWT with a victim id, a future `exp` and an invented signature:

```
Authorization: Bearer <base64url({"alg":"HS256"})>.<base64url({"userId":"<victim>","exp":<future>})>.invented
```

Victim ids are public: `GET /profiles/username/:handle` returns one unauthenticated. `alg: none` works too.

## Affected

Every backend mounting `oxy.auth()` / `createOxyAuthMiddleware()`: **Mention, Homiio, tnp, Allo**. `api.oxy.so` uses its own `jwt.verify` path and is not affected. `oxy.authSocket()` already required a session and already cross-checked the claimed user — not affected.

**Consumers will need this fix.** How it ships is left to the maintainer; this PR does not bump the version.

## Escalation via pre-authentication tokens

The 2FA-challenge token (`{userId, purpose: '2fa_challenge'}`) and the account-recovery token (`{type:'recovery', recoveryId, userId}`) were genuinely signed with `ACCESS_TOKEN_SECRET` and carried `userId` with no `sessionId`, so they satisfied the vulnerable branch — a *pre*-authentication token authenticating as the fully logged-in user, no forgery required.

**Those two tokens no longer exist on `main`:** the password / social / 2FA backend was removed in `8bfdd965`, and the three remaining JWT mint sites are the session access + refresh tokens (both carry `sessionId`) and the service token (`type: 'service'`). The escalation is therefore historical, not live. The shapes are kept as regression fixtures so the *class* stays closed by construction rather than by nobody happening to mint one.

## The fix

A user token must carry a `sessionId`; that session is validated server-side; `req.userId` comes from the validated session and must equal the token's claim.

| Code | When |
| --- | --- |
| `SESSION_REQUIRED` | user token carries no usable `sessionId` |
| `SESSION_USER_MISMATCH` | token's `userId` is not the session's owner |

`INVALID_SESSION` now also covers a validation returning no user, or a user with no usable id. Under `optional: true` all of these resolve to anonymous, never to the claimed user. Claims that must be strings are narrowed before use, so an object `sessionId` is *no* session rather than a stringified URL segment.

Service tokens are untouched — still HMAC-verified with `aud`/`iss`/`type` checked. Nothing legitimate relied on the old path: every user access token the API issues carries a `sessionId` (`api/src/utils/sessionUtils.ts` `generateSessionTokens`, the only user-token mint site, which the OAuth code exchange also routes through).

Also fixed: `oxy.rateLimit()` erased an identity a preceding middleware had resolved. It now resolves through `createOptionalOxyAuth` (skips when a user is present) rather than `oxy.auth({ optional: true })`, which writes `req.userId = null` on every request it cannot authenticate — a mutation of the shared `req` visible to every handler downstream, not just to the bucket calculation.

## Test plan

**Reproduction against the built `dist/cjs`** (real Express app + fake Oxy API), before → after:

| probe | before | after |
| --- | --- | --- |
| forged, no `sessionId` | **200 as victim** | 401 `SESSION_REQUIRED` |
| forged, `id` claim, no `sessionId` | **200 as victim** | 401 `SESSION_REQUIRED` |
| `alg:none`, no `sessionId` | **200 as victim** | 401 `SESSION_REQUIRED` |
| signed pre-auth shape (2FA / recovery) | **200 as victim** | 401 `SESSION_REQUIRED` |
| live session + forged `userId` | **200 as victim** | 401 `SESSION_USER_MISMATCH` |
| forged session-less + `X-Oxy-User-Id` | **200** | 401 `SESSION_REQUIRED` |
| `optional`, forged session-less | **200 as victim** | 200 anonymous |
| real session token | 200 | 200 |
| real session + `loadUser` | 200 | 200 |
| service token | 200 | 200 |

**Suite:** `@oxyhq/core` 112 suites / 1549 tests on `origin/main` → **113 suites / 1579 tests**, all passing. `tsc --noEmit` clean. `@oxyhq/services`, `@oxyhq/node`, `@oxyhq/federation`, `@oxyhq/api` all still build.

**Mutation testing** — each mutation asserted present on disk *before* the suite ran and byte-identical again after; all eight turn the suite red:

| | mutation | result |
| --- | --- | --- |
| M1 | session-less tokens accepted again | red (14 failed) |
| M2 | identity taken from the claim (guard removed + claim used) | red (2 failed) |
| M3 | `optional:true` falls through to the claim | red (1 failed) |
| M4 | a `userId`/session mismatch passes | red (2 failed) |
| M5 | rate limiter clobbers a resolved `req.userId` | red (1 failed) |
| M6 | `sessionId` accepted on truthiness, not narrowed | red (1 failed) |
| M7 | session validation stops requiring a `user` | red (1 failed) |
| M8 | `authSocket` stops requiring a session | red (1 failed) |

Mutating `req.userId = validatedUserId` → `claimedUserId` *alone* survives, and should: the strict-equality guard directly above makes the two provably identical at that point. M2 and M4 are what cover the property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)