### PR TITLE
store: the storefront's reads

### DIFF
--- a/packages/api/src/routes/store.ts
+++ b/packages/api/src/routes/store.ts
@@ -1,0 +1,98 @@
+/**
+ * The app store's public reads (`/store`).
+ *
+ * Unauthenticated on purpose: a storefront is what somebody looks at before
+ * they have an account, and every row these endpoints return is already public
+ * — a published listing, an application's name and icon, and reviews their
+ * authors wrote to be read.
+ *
+ * Only `published` listings and `visible` reviews are served. A draft, a
+ * rejected page and a hidden review are absent rather than marked, so no client
+ * has to be trusted to filter them.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { asyncHandler, sendPaginated, sendSuccess } from '../utils/asyncHandler';
+import { validate } from '../middleware/validate';
+import { rateLimit } from '../middleware/rateLimiter';
+import { NotFoundError } from '../utils/error';
+import { storeListingsQuery, storeReviewsQuery, storeSlugParams } from '../schemas/store.schemas';
+import {
+  getPublishedListing,
+  listCategories,
+  listPublishedListings,
+  listReviews,
+} from '../services/store.service';
+
+const router = Router();
+
+const WINDOW_1_MIN = 60 * 1000;
+
+/**
+ * Uniquely prefixed, per the shared-store rule: a limiter without its own
+ * prefix shares a counter with every other one on the same Redis and halves
+ * both budgets.
+ */
+const readLimiter = rateLimit({
+  prefix: 'rl:store:read:',
+  windowMs: WINDOW_1_MIN,
+  max: 240,
+});
+
+/** GET /store/categories — the shelves, in curated order. */
+router.get(
+  '/categories',
+  readLimiter,
+  asyncHandler(async (_req: Request, res: Response) => {
+    sendSuccess(res, await listCategories());
+  })
+);
+
+/** GET /store/apps — published listings, newest first, optionally one shelf. */
+router.get(
+  '/apps',
+  readLimiter,
+  validate({ query: storeListingsQuery }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { category, limit, offset } = req.query as unknown as {
+      category?: string;
+      limit: number;
+      offset: number;
+    };
+    const { items, total } = await listPublishedListings({ categorySlug: category, limit, offset });
+    sendPaginated(res, items, total, limit, offset);
+  })
+);
+
+/** GET /store/apps/:slug — one page, or 404 if it is not published. */
+router.get(
+  '/apps/:slug',
+  readLimiter,
+  validate({ params: storeSlugParams }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const listing = await getPublishedListing(req.params.slug);
+    // The same answer for "no such app" and "not published": whether a draft
+    // exists is not something an unauthenticated caller gets to learn.
+    if (!listing) throw new NotFoundError('App not found');
+    sendSuccess(res, listing);
+  })
+);
+
+/** GET /store/apps/:slug/reviews — visible reviews, with the publisher's reply. */
+router.get(
+  '/apps/:slug/reviews',
+  readLimiter,
+  validate({ params: storeSlugParams, query: storeReviewsQuery }),
+  asyncHandler(async (req: Request, res: Response) => {
+    const { limit, offset, sort } = req.query as unknown as {
+      limit: number;
+      offset: number;
+      sort: 'recent' | 'rating';
+    };
+    const result = await listReviews({ slug: req.params.slug, limit, offset, sort });
+    if (!result) throw new NotFoundError('App not found');
+    sendPaginated(res, result.items, result.total, limit, offset);
+  })
+);
+
+export default router;

--- a/packages/api/src/schemas/store.schemas.ts
+++ b/packages/api/src/schemas/store.schemas.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+/** A store URL segment: the listing's own `slug`, never an application id. */
+export const storeSlugParams = z.object({
+  slug: z.string().trim().min(1).max(120),
+});
+
+/**
+ * GET /store/apps
+ *
+ * `category` is a category SLUG for the same reason the path carries a listing
+ * slug: an id in a query string is an id in somebody's bookmark.
+ */
+export const storeListingsQuery = z.object({
+  category: z.string().trim().min(1).max(120).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(24),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+/** GET /store/apps/:slug/reviews */
+export const storeReviewsQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+  /** Newest first by default; `rating` surfaces the strongest opinions. */
+  sort: z.enum(['recent', 'rating']).default('recent'),
+});

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -18,6 +18,7 @@ import reputationRoutes from './routes/reputation.routes';
 import moderationReputationRoutes from './routes/moderationReputation.routes';
 import linkMetadataRoutes from './routes/linkMetadata';
 import linksRoutes from './routes/links';
+import storeRoutes from './routes/store';
 import locationSearchRoutes from './routes/locationSearch';
 import authRoutes from './routes/auth';
 import assetRoutes from './routes/assets';
@@ -615,6 +616,10 @@ app.use('/link-metadata', userRateLimiter, linkMetadataRoutes);
 // Ecosystem link-preview (URL unfurl) service. Bearer/service-token reads (no
 // cookie writes → no CSRF); the route applies its own per-principal limiter.
 app.use('/links', linksRoutes);
+// The app store's public reads. No auth and no CSRF: every row served is
+// already public, and a storefront is what somebody looks at before they have
+// an account. Writes (reviews, replies) will arrive as their own mount.
+app.use('/store', storeRoutes);
 app.use('/location-search', locationSearchRoutes);
 app.use('/applications', csrfProtection, applicationRoutes);
 // Unified Account graph (tree + membership + service credentials). Per-route

--- a/packages/api/src/services/__tests__/store.service.test.ts
+++ b/packages/api/src/services/__tests__/store.service.test.ts
@@ -1,0 +1,264 @@
+/**
+ * The store's reads, against a REAL Postgres.
+ *
+ * These are joins and aggregates, and `CONVENTIONS.md` records what that costs:
+ * a query written wrong here returns an empty array with no error at all. So
+ * every case asserts a value that could only come from the database — a name
+ * that lives on `applications`, an average over rows this test inserted, a
+ * reply attached to the right review — rather than that a call resolved.
+ *
+ * Every fixture carries a per-test random identifier, so nothing depends on the
+ * tables being empty.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { appCategories } from '../../db/schema/appCategories';
+import { appListings } from '../../db/schema/appListings';
+import { appReviewReplies } from '../../db/schema/appReviewReplies';
+import { appReviews } from '../../db/schema/appReviews';
+import { applications } from '../../db/schema/applications';
+import { users } from '../../db/schema/users';
+import {
+  getPublishedListing,
+  listCategories,
+  listPublishedListings,
+  listReviews,
+} from '../store.service';
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+async function insertUser(): Promise<string> {
+  const suffix = randomUUID().slice(0, 8);
+  const [row] = await getDb()
+    .insert(users)
+    .values({ username: `store-${suffix}`, email: `store-${suffix}@example.test` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function insertApplication(owner: string, name: string): Promise<string> {
+  const [row] = await getDb()
+    .insert(applications)
+    .values({ name, ownerAccountId: owner, icon: 'file-icon-id' })
+    .returning({ id: applications.id });
+  return row.id;
+}
+
+async function insertListing(
+  applicationId: string,
+  values: Partial<typeof appListings.$inferInsert> = {}
+): Promise<{ id: string; slug: string }> {
+  const slug = `listing-${randomUUID().slice(0, 8)}`;
+  const [row] = await getDb()
+    .insert(appListings)
+    .values({ applicationId, slug, status: 'published', publishedAt: new Date(), ...values })
+    .returning({ id: appListings.id, slug: appListings.slug });
+  return row;
+}
+
+async function review(applicationId: string, rating: number, extra: Partial<typeof appReviews.$inferInsert> = {}) {
+  const userId = await insertUser();
+  const [row] = await getDb()
+    .insert(appReviews)
+    .values({ applicationId, userId, rating, ...extra })
+    .returning({ id: appReviews.id });
+  return row.id;
+}
+
+describe('a listing is served with what the application knows', () => {
+  it('carries the name and icon from `applications`, not a copy', async () => {
+    const owner = await insertUser();
+    const name = `App ${randomUUID().slice(0, 8)}`;
+    const applicationId = await insertApplication(owner, name);
+    const { slug } = await insertListing(applicationId, { tagline: 'One line' });
+
+    const listing = await getPublishedListing(slug);
+
+    expect(listing).not.toBeNull();
+    expect(listing!.name).toBe(name);
+    expect(listing!.icon).toBe('file-icon-id');
+    expect(listing!.tagline).toBe('One line');
+  });
+
+  it('answers null for a draft, the same as for a slug that does not exist', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId, { status: 'draft', publishedAt: null });
+
+    expect(await getPublishedListing(slug)).toBeNull();
+    expect(await getPublishedListing(`missing-${randomUUID()}`)).toBeNull();
+  });
+});
+
+describe('the rating is computed from the reviews that are visible', () => {
+  it('averages them, and rounds to one decimal', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId);
+    for (const rating of [5, 4, 4]) await review(applicationId, rating);
+
+    const listing = await getPublishedListing(slug);
+
+    // 13 / 3 = 4.333…
+    expect(listing!.rating).toEqual({ average: 4.3, count: 3 });
+    expect(listing!.ratingBreakdown).toEqual({ 4: 2, 5: 1 });
+  });
+
+  it('drops a hidden review from the average immediately', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId);
+    await review(applicationId, 5);
+    await review(applicationId, 1, { status: 'hidden' });
+
+    const listing = await getPublishedListing(slug);
+
+    expect(listing!.rating).toEqual({ average: 5, count: 1 });
+  });
+
+  it('says null rather than zero when nobody has reviewed it', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId);
+
+    expect((await getPublishedListing(slug))!.rating).toEqual({ average: null, count: 0 });
+  });
+});
+
+describe('the listing page reads one shelf at a time', () => {
+  it('returns only the listings on the category asked for', async () => {
+    const owner = await insertUser();
+    const slugValue = `cat-${randomUUID().slice(0, 8)}`;
+    const [category] = await getDb()
+      .insert(appCategories)
+      .values({ slug: slugValue, label: 'Productivity' })
+      .returning({ id: appCategories.id });
+
+    const onShelf = await insertApplication(owner, `On ${randomUUID().slice(0, 8)}`);
+    const offShelf = await insertApplication(owner, `Off ${randomUUID().slice(0, 8)}`);
+    const listed = await insertListing(onShelf, { categoryId: category.id });
+    await insertListing(offShelf);
+
+    const { items } = await listPublishedListings({ categorySlug: slugValue, limit: 50, offset: 0 });
+
+    expect(items.map((item) => item.slug)).toEqual([listed.slug]);
+    expect(items[0].category).toEqual({ slug: slugValue, label: 'Productivity' });
+  });
+
+  it('treats an unknown shelf as empty, not as no filter at all', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    await insertListing(applicationId);
+
+    const { items, total } = await listPublishedListings({
+      categorySlug: `nope-${randomUUID()}`,
+      limit: 50,
+      offset: 0,
+    });
+
+    expect(items).toEqual([]);
+    expect(total).toBe(0);
+  });
+
+  it('rates every card in the page — the aggregate is not per-card', async () => {
+    const owner = await insertUser();
+    const slugValue = `cat-${randomUUID().slice(0, 8)}`;
+    const [category] = await getDb()
+      .insert(appCategories)
+      .values({ slug: slugValue, label: 'Tools' })
+      .returning({ id: appCategories.id });
+
+    const first = await insertApplication(owner, `A ${randomUUID().slice(0, 8)}`);
+    const second = await insertApplication(owner, `B ${randomUUID().slice(0, 8)}`);
+    await insertListing(first, { categoryId: category.id });
+    await insertListing(second, { categoryId: category.id });
+    await review(first, 5);
+    await review(second, 3);
+    await review(second, 3);
+
+    const { items } = await listPublishedListings({ categorySlug: slugValue, limit: 50, offset: 0 });
+
+    expect(items.map((item) => item.rating)).toEqual(
+      expect.arrayContaining([
+        { average: 5, count: 1 },
+        { average: 3, count: 2 },
+      ])
+    );
+  });
+});
+
+describe('reviews come back with their replies attached', () => {
+  it('puts each reply on its own review and leaves the rest null', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId);
+    const answered = await review(applicationId, 2, { body: 'Slow' });
+    await review(applicationId, 5, { body: 'Fast' });
+    await getDb()
+      .insert(appReviewReplies)
+      .values({ reviewId: answered, authorUserId: owner, body: 'Fixed in 2.1' });
+
+    const result = await listReviews({ slug, limit: 50, offset: 0, sort: 'recent' });
+
+    expect(result).not.toBeNull();
+    expect(result!.total).toBe(2);
+    const withReply = result!.items.find((item) => item.id === answered);
+    expect(withReply!.reply!.body).toBe('Fixed in 2.1');
+    expect(result!.items.filter((item) => item.reply === null)).toHaveLength(1);
+  });
+
+  it('hides a hidden review from the list as well as from the average', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId);
+    await review(applicationId, 5, { body: 'Visible' });
+    await review(applicationId, 1, { body: 'Hidden', status: 'hidden' });
+
+    const result = await listReviews({ slug, limit: 50, offset: 0, sort: 'recent' });
+
+    expect(result!.items.map((item) => item.body)).toEqual(['Visible']);
+  });
+
+  it('sorts by rating when asked, and by recency otherwise', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId);
+    await review(applicationId, 1);
+    await review(applicationId, 5);
+    await review(applicationId, 3);
+
+    const byRating = await listReviews({ slug, limit: 50, offset: 0, sort: 'rating' });
+    expect(byRating!.items.map((item) => item.rating)).toEqual([5, 3, 1]);
+  });
+
+  it('answers null for a listing that is not published', async () => {
+    const owner = await insertUser();
+    const applicationId = await insertApplication(owner, `App ${randomUUID().slice(0, 8)}`);
+    const { slug } = await insertListing(applicationId, { status: 'draft', publishedAt: null });
+
+    expect(await listReviews({ slug, limit: 10, offset: 0, sort: 'recent' })).toBeNull();
+  });
+});
+
+describe('the shelves', () => {
+  it('come back in their curated order', async () => {
+    const prefix = randomUUID().slice(0, 8);
+    await getDb()
+      .insert(appCategories)
+      .values([
+        { slug: `${prefix}-b`, label: 'Second', order: 20 },
+        { slug: `${prefix}-a`, label: 'First', order: 10 },
+      ]);
+
+    const ours = (await listCategories()).filter((category) => category.slug.startsWith(prefix));
+
+    expect(ours.map((category) => category.label)).toEqual(['First', 'Second']);
+  });
+});

--- a/packages/api/src/services/store.service.ts
+++ b/packages/api/src/services/store.service.ts
@@ -1,0 +1,301 @@
+/**
+ * The app store's reads.
+ *
+ * Every query here joins a listing to the `applications` row it decorates,
+ * because the store owns the page and the platform owns the app: the name, the
+ * icon and the legal links come from the application, and the shelf, the copy
+ * and the pictures from the listing. Nothing is duplicated between them, so
+ * nothing can disagree.
+ *
+ * ## The rating is computed
+ *
+ * There is no stored average or count — see `db/schema/appListings.ts` for why.
+ * These queries aggregate `app_reviews` on the index that exists for it
+ * (`application_id, status, created_at`), filtered to `visible`, so a hidden
+ * review stops counting the moment it is hidden rather than when some counter
+ * is next repaired.
+ */
+
+import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
+import { getDb } from '../config/postgres';
+import { appCategories } from '../db/schema/appCategories';
+import { appListingScreenshots } from '../db/schema/appListingScreenshots';
+import { appListings } from '../db/schema/appListings';
+import { appReviewReplies } from '../db/schema/appReviewReplies';
+import { appReviews } from '../db/schema/appReviews';
+import { applications } from '../db/schema/applications';
+import { users } from '../db/schema/users';
+
+/** What a card needs, and nothing more. */
+export interface StoreListingSummary {
+  slug: string;
+  name: string;
+  tagline: string | null;
+  icon: string | null;
+  category: { slug: string; label: string } | null;
+  rating: { average: number | null; count: number };
+}
+
+export interface StoreListingDetail extends StoreListingSummary {
+  description: string | null;
+  websiteUrl: string | null;
+  privacyPolicyUrl: string | null;
+  termsUrl: string | null;
+  supportUrl: string | null;
+  supportEmail: string | null;
+  publishedAt: Date | null;
+  screenshots: { id: string; fileId: string; platform: string; caption: string | null }[];
+  /** 1..5 → how many visible reviews gave it. Absent keys are zero. */
+  ratingBreakdown: Record<number, number>;
+}
+
+/**
+ * Ratings for a set of applications, in ONE query.
+ *
+ * A per-listing aggregate would be a query per card, which is the shape that
+ * turns a 24-item page into 25 round trips. `inArray` over the same index the
+ * reviews list uses answers all of them at once.
+ */
+async function ratingsFor(applicationIds: string[]): Promise<Map<string, { average: number | null; count: number }>> {
+  if (applicationIds.length === 0) return new Map();
+
+  const rows = await getDb()
+    .select({
+      applicationId: appReviews.applicationId,
+      average: sql<string>`avg(${appReviews.rating})`,
+      total: count(),
+    })
+    .from(appReviews)
+    .where(and(inArray(appReviews.applicationId, applicationIds), eq(appReviews.status, 'visible')))
+    .groupBy(appReviews.applicationId);
+
+  return new Map(
+    rows.map((row) => [
+      row.applicationId,
+      // `avg` comes back as a numeric string; rounding here rather than in the
+      // client keeps every surface showing the same 4.6.
+      { average: row.average === null ? null : Math.round(Number(row.average) * 10) / 10, count: Number(row.total) },
+    ])
+  );
+}
+
+/** Published listings, newest first, optionally on one shelf. */
+export async function listPublishedListings(options: {
+  categorySlug?: string;
+  limit: number;
+  offset: number;
+}): Promise<{ items: StoreListingSummary[]; total: number }> {
+  const db = getDb();
+  const filters = [eq(appListings.status, 'published')];
+
+  if (options.categorySlug) {
+    const [category] = await db
+      .select({ id: appCategories.id })
+      .from(appCategories)
+      .where(eq(appCategories.slug, options.categorySlug))
+      .limit(1);
+    // An unknown shelf is an empty shelf, not every app on the store.
+    if (!category) return { items: [], total: 0 };
+    filters.push(eq(appListings.categoryId, category.id));
+  }
+
+  const where = and(...filters);
+
+  const [rows, [totals]] = await Promise.all([
+    db
+      .select({
+        applicationId: appListings.applicationId,
+        slug: appListings.slug,
+        tagline: appListings.tagline,
+        name: applications.name,
+        icon: applications.icon,
+        categorySlug: appCategories.slug,
+        categoryLabel: appCategories.label,
+      })
+      .from(appListings)
+      .innerJoin(applications, eq(applications.id, appListings.applicationId))
+      .leftJoin(appCategories, eq(appCategories.id, appListings.categoryId))
+      .where(where)
+      .orderBy(desc(appListings.publishedAt), asc(appListings.id))
+      .limit(options.limit)
+      .offset(options.offset),
+    db.select({ value: count() }).from(appListings).where(where),
+  ]);
+
+  const ratings = await ratingsFor(rows.map((row) => row.applicationId));
+
+  return {
+    items: rows.map((row) => ({
+      slug: row.slug,
+      name: row.name,
+      tagline: row.tagline,
+      icon: row.icon,
+      category: row.categorySlug ? { slug: row.categorySlug, label: row.categoryLabel! } : null,
+      rating: ratings.get(row.applicationId) ?? { average: null, count: 0 },
+    })),
+    total: Number(totals?.value ?? 0),
+  };
+}
+
+/** One page. Returns null when the slug is unknown or the listing is not published. */
+export async function getPublishedListing(slug: string): Promise<StoreListingDetail | null> {
+  const db = getDb();
+
+  const [row] = await db
+    .select({
+      id: appListings.id,
+      applicationId: appListings.applicationId,
+      slug: appListings.slug,
+      tagline: appListings.tagline,
+      description: appListings.description,
+      supportUrl: appListings.supportUrl,
+      supportEmail: appListings.supportEmail,
+      publishedAt: appListings.publishedAt,
+      name: applications.name,
+      icon: applications.icon,
+      websiteUrl: applications.websiteUrl,
+      privacyPolicyUrl: applications.privacyPolicyUrl,
+      termsUrl: applications.termsUrl,
+      categorySlug: appCategories.slug,
+      categoryLabel: appCategories.label,
+    })
+    .from(appListings)
+    .innerJoin(applications, eq(applications.id, appListings.applicationId))
+    .leftJoin(appCategories, eq(appCategories.id, appListings.categoryId))
+    .where(and(eq(appListings.slug, slug), eq(appListings.status, 'published')))
+    .limit(1);
+
+  if (!row) return null;
+
+  const [screenshots, breakdown, ratings] = await Promise.all([
+    db
+      .select({
+        id: appListingScreenshots.id,
+        fileId: appListingScreenshots.fileId,
+        platform: appListingScreenshots.platform,
+        caption: appListingScreenshots.caption,
+      })
+      .from(appListingScreenshots)
+      .where(eq(appListingScreenshots.listingId, row.id))
+      .orderBy(asc(appListingScreenshots.position), asc(appListingScreenshots.id)),
+    db
+      .select({ rating: appReviews.rating, total: count() })
+      .from(appReviews)
+      .where(and(eq(appReviews.applicationId, row.applicationId), eq(appReviews.status, 'visible')))
+      .groupBy(appReviews.rating),
+    ratingsFor([row.applicationId]),
+  ]);
+
+  return {
+    slug: row.slug,
+    name: row.name,
+    tagline: row.tagline,
+    description: row.description,
+    icon: row.icon,
+    websiteUrl: row.websiteUrl,
+    privacyPolicyUrl: row.privacyPolicyUrl,
+    termsUrl: row.termsUrl,
+    supportUrl: row.supportUrl,
+    supportEmail: row.supportEmail,
+    publishedAt: row.publishedAt,
+    category: row.categorySlug ? { slug: row.categorySlug, label: row.categoryLabel! } : null,
+    rating: ratings.get(row.applicationId) ?? { average: null, count: 0 },
+    ratingBreakdown: Object.fromEntries(breakdown.map((entry) => [entry.rating, Number(entry.total)])),
+    screenshots,
+  };
+}
+
+export interface StoreReview {
+  id: string;
+  rating: number;
+  title: string | null;
+  body: string | null;
+  createdAt: Date;
+  author: { id: string; username: string | null };
+  reply: { body: string; createdAt: Date } | null;
+}
+
+/**
+ * Visible reviews for a published listing.
+ *
+ * Replies are fetched for the page's reviews in one query rather than joined,
+ * because most reviews have none and a LEFT JOIN would carry the reply columns
+ * on every row to say so.
+ */
+export async function listReviews(options: {
+  slug: string;
+  limit: number;
+  offset: number;
+  sort: 'recent' | 'rating';
+}): Promise<{ items: StoreReview[]; total: number } | null> {
+  const db = getDb();
+
+  const [listing] = await db
+    .select({ applicationId: appListings.applicationId })
+    .from(appListings)
+    .where(and(eq(appListings.slug, options.slug), eq(appListings.status, 'published')))
+    .limit(1);
+
+  if (!listing) return null;
+
+  const where = and(eq(appReviews.applicationId, listing.applicationId), eq(appReviews.status, 'visible'));
+  const order =
+    options.sort === 'rating'
+      ? [desc(appReviews.rating), desc(appReviews.createdAt), asc(appReviews.id)]
+      : [desc(appReviews.createdAt), asc(appReviews.id)];
+
+  const [rows, [totals]] = await Promise.all([
+    db
+      .select({
+        id: appReviews.id,
+        rating: appReviews.rating,
+        title: appReviews.title,
+        body: appReviews.body,
+        createdAt: appReviews.createdAt,
+        authorId: users.id,
+        authorUsername: users.username,
+      })
+      .from(appReviews)
+      .innerJoin(users, eq(users.id, appReviews.userId))
+      .where(where)
+      .orderBy(...order)
+      .limit(options.limit)
+      .offset(options.offset),
+    db.select({ value: count() }).from(appReviews).where(where),
+  ]);
+
+  const replies = rows.length
+    ? await db
+        .select({
+          reviewId: appReviewReplies.reviewId,
+          body: appReviewReplies.body,
+          createdAt: appReviewReplies.createdAt,
+        })
+        .from(appReviewReplies)
+        .where(inArray(appReviewReplies.reviewId, rows.map((row) => row.id)))
+    : [];
+  const replyByReview = new Map(replies.map((reply) => [reply.reviewId, reply]));
+
+  return {
+    items: rows.map((row) => ({
+      id: row.id,
+      rating: row.rating,
+      title: row.title,
+      body: row.body,
+      createdAt: row.createdAt,
+      author: { id: row.authorId, username: row.authorUsername },
+      reply: replyByReview.get(row.id)
+        ? { body: replyByReview.get(row.id)!.body, createdAt: replyByReview.get(row.id)!.createdAt }
+        : null,
+    })),
+    total: Number(totals?.value ?? 0),
+  };
+}
+
+/** The shelves, in their curated order. */
+export async function listCategories(): Promise<{ slug: string; label: string; description: string | null }[]> {
+  return getDb()
+    .select({ slug: appCategories.slug, label: appCategories.label, description: appCategories.description })
+    .from(appCategories)
+    .orderBy(asc(appCategories.order), asc(appCategories.id));
+}


### PR DESCRIPTION
Four public endpoints over the tables #857 landed.

| endpoint | answers |
|---|---|
| `GET /store/categories` | the shelves, in curated order |
| `GET /store/apps` | published listings, newest first, optionally one shelf |
| `GET /store/apps/:slug` | one page: copy, screenshots, rating and its breakdown |
| `GET /store/apps/:slug/reviews` | visible reviews with the publisher's reply |

**Unauthenticated on purpose.** A storefront is what somebody looks at before they have an account, and every row served is already public. Only `published` listings and `visible` reviews leave the service — a draft or a hidden review is *absent*, not flagged, so no client is trusted to filter. A draft and an unknown slug return the same 404: whether a draft exists is not something an anonymous caller gets to learn.

**Nothing duplicated.** Name, icon and legal links come off `applications` in the same join. There is no second copy to drift.

Two shapes worth a look in review:

- **The rating is computed.** No stored average, no counter. For a page of cards it is ONE aggregate over `inArray` — the alternative turns a 24-item page into 25 round trips. A hidden review stops counting the moment it is hidden, rather than when a counter is next repaired.
- **Replies are fetched, not joined.** Most reviews have none, and a LEFT JOIN would carry the reply columns on every row to say so.

## Verification

```
Tests: 13 passed, 13 total
```

Against a real Postgres, and every case asserts a value only the database could produce — a name that lives on `applications`, an average over rows the test inserted, a reply attached to the right review. `CONVENTIONS.md` is explicit that a join written wrong here returns `[]` with no error at all, so "the call resolved" is not an assertion.

## Not in this PR

Writes: posting and editing a review, the publisher's reply and the `AccountMember` check behind it, and `app_grants` read for the verified-user mark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)