### PR TITLE
store: reviews people write, and the publisher's answer

### DIFF
--- a/packages/api/src/routes/store.ts
+++ b/packages/api/src/routes/store.ts
@@ -1,27 +1,46 @@
 /**
- * The app store's public reads (`/store`).
+ * The app store (`/store`).
  *
- * Unauthenticated on purpose: a storefront is what somebody looks at before
- * they have an account, and every row these endpoints return is already public
- * — a published listing, an application's name and icon, and reviews their
+ * The reads are unauthenticated on purpose: a storefront is what somebody looks
+ * at before they have an account, and every row they return is already public —
+ * a published listing, an application's name and icon, and reviews their
  * authors wrote to be read.
  *
  * Only `published` listings and `visible` reviews are served. A draft, a
  * rejected page and a hidden review are absent rather than marked, so no client
  * has to be trusted to filter them.
+ *
+ * The writes carry their own `authMiddleware` and `csrfProtection` per route
+ * rather than a mount-wide one, because this router serves both and a blanket
+ * middleware would either lock the storefront or leave the writes open. Reading
+ * a route here tells you what guards it.
  */
 
 import { Router, type Request, type Response } from 'express';
 import { asyncHandler, sendPaginated, sendSuccess } from '../utils/asyncHandler';
+import { authMiddleware, type AuthRequest } from '../middleware/auth';
+import { csrfProtection } from '../middleware/csrf';
 import { validate } from '../middleware/validate';
 import { rateLimit } from '../middleware/rateLimiter';
-import { NotFoundError } from '../utils/error';
-import { storeListingsQuery, storeReviewsQuery, storeSlugParams } from '../schemas/store.schemas';
+import { NotFoundError, UnauthorizedError } from '../utils/error';
 import {
+  storeListingsQuery,
+  storeReplyBody,
+  storeReviewBody,
+  storeReviewParams,
+  storeReviewsQuery,
+  storeSlugParams,
+} from '../schemas/store.schemas';
+import {
+  deleteOwnReview,
+  deleteReply,
+  getOwnReview,
   getPublishedListing,
   listCategories,
   listPublishedListings,
   listReviews,
+  upsertReply,
+  upsertReview,
 } from '../services/store.service';
 
 const router = Router();
@@ -38,6 +57,25 @@ const readLimiter = rateLimit({
   windowMs: WINDOW_1_MIN,
   max: 240,
 });
+
+/**
+ * Writes are keyed on the ACCOUNT, not the IP: one review per app per person is
+ * already a constraint, so the budget that matters is how fast one person can
+ * churn reviews across apps — and an IP key would throttle a whole office
+ * network to one reviewer.
+ */
+const writeLimiter = rateLimit({
+  prefix: 'rl:store:write:',
+  windowMs: WINDOW_1_MIN,
+  max: 20,
+  keyGenerator: (req) => (req as AuthRequest).user?._id?.toString() ?? req.ip ?? 'unknown',
+});
+
+function requireUserId(req: AuthRequest): string {
+  const userId = req.user?._id?.toString();
+  if (!userId) throw new UnauthorizedError('Authentication required');
+  return userId;
+}
 
 /** GET /store/categories — the shelves, in curated order. */
 router.get(
@@ -92,6 +130,102 @@ router.get(
     const result = await listReviews({ slug: req.params.slug, limit, offset, sort });
     if (!result) throw new NotFoundError('App not found');
     sendPaginated(res, result.items, result.total, limit, offset);
+  })
+);
+
+// ============================================================================
+// Writes
+//
+// Who may review: any signed-in Oxy account. Not `users.verified`, which is a
+// standing badge an administrator sets — gating reviews on it would mean almost
+// nobody could write one. Whether the reviewer has actually authorized the app
+// is answered by `app_grants` and shown as `authorUsesApp` on the public list,
+// which is the trust signal a reader wants and one nobody can award themselves.
+// ============================================================================
+
+/** GET /store/apps/:slug/review — the caller's own review, or null. */
+router.get(
+  '/apps/:slug/review',
+  readLimiter,
+  authMiddleware,
+  validate({ params: storeSlugParams }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    sendSuccess(res, await getOwnReview({ slug: req.params.slug, userId: requireUserId(req) }));
+  })
+);
+
+/**
+ * PUT /store/apps/:slug/review — write or rewrite the caller's review.
+ *
+ * `PUT` because a person has one review of an app and this sets it. A `POST`
+ * would promise a second resource on the second call, which the table's unique
+ * constraint would then refuse.
+ */
+router.put(
+  '/apps/:slug/review',
+  writeLimiter,
+  authMiddleware,
+  csrfProtection,
+  validate({ params: storeSlugParams, body: storeReviewBody }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const { rating, title, body } = req.body as { rating: number; title?: string | null; body?: string | null };
+    const review = await upsertReview({
+      slug: req.params.slug,
+      userId: requireUserId(req),
+      rating,
+      title,
+      body,
+    });
+    sendSuccess(res, review);
+  })
+);
+
+/** DELETE /store/apps/:slug/review — withdraw the caller's own review. */
+router.delete(
+  '/apps/:slug/review',
+  writeLimiter,
+  authMiddleware,
+  csrfProtection,
+  validate({ params: storeSlugParams }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    await deleteOwnReview({ slug: req.params.slug, userId: requireUserId(req) });
+    res.status(204).end();
+  })
+);
+
+/**
+ * PUT /store/reviews/:reviewId/reply — the publisher's answer.
+ *
+ * Addressed by review id rather than under the listing's slug: the reply
+ * belongs to the review, which belongs to the application, and a listing can be
+ * renamed or withdrawn out from under it.
+ */
+router.put(
+  '/reviews/:reviewId/reply',
+  writeLimiter,
+  authMiddleware,
+  csrfProtection,
+  validate({ params: storeReviewParams, body: storeReplyBody }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const reply = await upsertReply({
+      reviewId: req.params.reviewId,
+      authorUserId: requireUserId(req),
+      body: (req.body as { body: string }).body,
+    });
+    sendSuccess(res, reply);
+  })
+);
+
+/** DELETE /store/reviews/:reviewId/reply — withdraw it. Same gate. */
+router.delete(
+  '/reviews/:reviewId/reply',
+  writeLimiter,
+  authMiddleware,
+  csrfProtection,
+  validate({ params: storeReviewParams }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    await deleteReply({ reviewId: req.params.reviewId, authorUserId: requireUserId(req) });
+    res.status(204).end();
   })
 );
 

--- a/packages/api/src/schemas/store.schemas.ts
+++ b/packages/api/src/schemas/store.schemas.ts
@@ -24,3 +24,38 @@ export const storeReviewsQuery = z.object({
   /** Newest first by default; `rating` surfaces the strongest opinions. */
   sort: z.enum(['recent', 'rating']).default('recent'),
 });
+
+/** How long a review may be. Generous — the limit is against abuse, not prose. */
+const REVIEW_BODY_MAX = 5000;
+const REVIEW_TITLE_MAX = 120;
+
+/**
+ * PUT /store/apps/:slug/review
+ *
+ * `rating` repeats the database's `between 1 and 5` on purpose: the CHECK is
+ * what makes the bound true of the data, and this is what makes a bad request a
+ * 400 rather than a 500 out of the driver.
+ *
+ * Title and body accept `null` as well as absent, because clearing a title you
+ * once wrote has to be expressible — the two are stored the same way.
+ */
+export const storeReviewBody = z.object({
+  rating: z.number().int().min(1).max(5),
+  title: z.string().trim().max(REVIEW_TITLE_MAX).nullish(),
+  body: z.string().trim().max(REVIEW_BODY_MAX).nullish(),
+});
+
+/** A review id in the path, for the publisher's reply. */
+export const storeReviewParams = z.object({
+  reviewId: z.string().trim().min(1).max(64),
+});
+
+/**
+ * PUT /store/reviews/:reviewId/reply
+ *
+ * `min(1)` after the trim: a reply is the publisher speaking, so an empty one
+ * is a delete, and `DELETE` is where that is spelled.
+ */
+export const storeReplyBody = z.object({
+  body: z.string().trim().min(1).max(REVIEW_BODY_MAX),
+});

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -616,9 +616,10 @@ app.use('/link-metadata', userRateLimiter, linkMetadataRoutes);
 // Ecosystem link-preview (URL unfurl) service. Bearer/service-token reads (no
 // cookie writes → no CSRF); the route applies its own per-principal limiter.
 app.use('/links', linksRoutes);
-// The app store's public reads. No auth and no CSRF: every row served is
-// already public, and a storefront is what somebody looks at before they have
-// an account. Writes (reviews, replies) will arrive as their own mount.
+// The app store. Mounted bare because the router serves both a public
+// storefront and authenticated writes, so auth and CSRF are declared per route
+// inside it — a blanket middleware here would lock the storefront or leave the
+// reviews open.
 app.use('/store', storeRoutes);
 app.use('/location-search', locationSearchRoutes);
 app.use('/applications', csrfProtection, applicationRoutes);

--- a/packages/api/src/services/__tests__/store.writes.test.ts
+++ b/packages/api/src/services/__tests__/store.writes.test.ts
@@ -1,0 +1,283 @@
+/**
+ * The store's writes, against a REAL Postgres.
+ *
+ * The reads' suite explains why these run against a database rather than a
+ * mock; the writes have a second reason. Three of the rules here are enforced
+ * by the schema and by nothing else — `unique(application_id, user_id)`,
+ * `unique(review_id)` and `rating between 1 and 5` — so a test that stubbed the
+ * driver would be testing the stub's opinion of them.
+ *
+ * The permission cases are the ones worth reading closely: they build a real
+ * `account_members` row and assert that the SAME call succeeds or throws purely
+ * on the role, so a check that stopped consulting the account graph would fail
+ * here rather than ship.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { accountMembers } from '../../db/schema/accountMembers';
+import { appGrants } from '../../db/schema/appGrants';
+import { appListings } from '../../db/schema/appListings';
+import { appReviewReplies } from '../../db/schema/appReviewReplies';
+import { appReviews } from '../../db/schema/appReviews';
+import { applications } from '../../db/schema/applications';
+import { users } from '../../db/schema/users';
+import { ForbiddenError, NotFoundError } from '../../utils/error';
+import {
+  deleteOwnReview,
+  deleteReply,
+  getOwnReview,
+  listReviews,
+  upsertReply,
+  upsertReview,
+} from '../store.service';
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+async function insertUser(): Promise<string> {
+  const suffix = randomUUID().slice(0, 8);
+  const [row] = await getDb()
+    .insert(users)
+    .values({ username: `writer-${suffix}`, email: `writer-${suffix}@example.test` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+/** A published app owned by a fresh account, which is the shape a write needs. */
+async function publishedApp(): Promise<{ slug: string; applicationId: string; ownerId: string }> {
+  const ownerId = await insertUser();
+  const [application] = await getDb()
+    .insert(applications)
+    .values({ name: `App ${randomUUID().slice(0, 8)}`, ownerAccountId: ownerId })
+    .returning({ id: applications.id });
+  const slug = `listing-${randomUUID().slice(0, 8)}`;
+  await getDb()
+    .insert(appListings)
+    .values({
+      applicationId: application.id,
+      slug,
+      status: 'published',
+      publishedAt: new Date(),
+    });
+  return { slug, applicationId: application.id, ownerId };
+}
+
+/** Give `memberId` a role on `accountId`, the way the account graph grants one. */
+async function grantRole(accountId: string, memberId: string, role: 'editor' | 'viewer') {
+  await getDb()
+    .insert(accountMembers)
+    .values({ accountId, memberUserId: memberId, role, status: 'active' });
+}
+
+describe('writing a review', () => {
+  it('stores what was written, and hands it straight back', async () => {
+    const { slug } = await publishedApp();
+    const userId = await insertUser();
+
+    const review = await upsertReview({ slug, userId, rating: 4, title: 'Good', body: 'Works.' });
+
+    expect(review.rating).toBe(4);
+    expect(review.title).toBe('Good');
+    expect(review.status).toBe('visible');
+    expect(await getOwnReview({ slug, userId })).toMatchObject({ id: review.id, rating: 4 });
+  });
+
+  it('replaces the same person’s review rather than adding a second', async () => {
+    const { slug, applicationId } = await publishedApp();
+    const userId = await insertUser();
+
+    const first = await upsertReview({ slug, userId, rating: 1, body: 'Broken' });
+    const second = await upsertReview({ slug, userId, rating: 5, body: 'Fixed now' });
+
+    expect(second.id).toBe(first.id);
+    expect(second.body).toBe('Fixed now');
+    const stored = await getDb().select().from(appReviews).where(eq(appReviews.applicationId, applicationId));
+    expect(stored).toHaveLength(1);
+  });
+
+  it('keeps a hidden review hidden when its author rewrites it', async () => {
+    const { slug, applicationId } = await publishedApp();
+    const userId = await insertUser();
+    await upsertReview({ slug, userId, rating: 1, body: 'Abusive' });
+    await getDb().update(appReviews).set({ status: 'hidden' }).where(eq(appReviews.applicationId, applicationId));
+
+    const rewritten = await upsertReview({ slug, userId, rating: 5, body: 'Polite now' });
+
+    expect(rewritten.status).toBe('hidden');
+    const page = await listReviews({ slug, limit: 10, offset: 0, sort: 'recent' });
+    expect(page!.items).toEqual([]);
+  });
+
+  it('stores a blank title as absent rather than as an empty string', async () => {
+    const { slug } = await publishedApp();
+    const userId = await insertUser();
+
+    const review = await upsertReview({ slug, userId, rating: 3, title: '   ', body: 'Fine' });
+
+    expect(review.title).toBeNull();
+  });
+
+  it('refuses a rating the database would not accept', async () => {
+    const { slug } = await publishedApp();
+    const userId = await insertUser();
+
+    // The route's zod schema 400s this first; the CHECK is what makes it true
+    // of the data, so it has to hold when the route is not in the picture.
+    await expect(upsertReview({ slug, userId, rating: 9 })).rejects.toThrow();
+  });
+
+  it('will not attach a review to a listing that is not published', async () => {
+    const ownerId = await insertUser();
+    const [application] = await getDb()
+      .insert(applications)
+      .values({ name: `App ${randomUUID().slice(0, 8)}`, ownerAccountId: ownerId })
+      .returning({ id: applications.id });
+    const slug = `draft-${randomUUID().slice(0, 8)}`;
+    await getDb().insert(appListings).values({ applicationId: application.id, slug, status: 'draft' });
+
+    await expect(upsertReview({ slug, userId: await insertUser(), rating: 5 })).rejects.toThrow(
+      NotFoundError
+    );
+  });
+});
+
+describe('withdrawing a review', () => {
+  it('removes the row rather than marking it', async () => {
+    const { slug, applicationId } = await publishedApp();
+    const userId = await insertUser();
+    await upsertReview({ slug, userId, rating: 2 });
+
+    await deleteOwnReview({ slug, userId });
+
+    expect(await getDb().select().from(appReviews).where(eq(appReviews.applicationId, applicationId))).toEqual([]);
+  });
+
+  it('says so when there is nothing of yours to withdraw', async () => {
+    const { slug } = await publishedApp();
+
+    await expect(deleteOwnReview({ slug, userId: await insertUser() })).rejects.toThrow(NotFoundError);
+  });
+
+  it('withdraws only the caller’s own, never a neighbour’s', async () => {
+    const { slug } = await publishedApp();
+    const mine = await insertUser();
+    const theirs = await insertUser();
+    await upsertReview({ slug, userId: mine, rating: 1 });
+    await upsertReview({ slug, userId: theirs, rating: 5 });
+
+    await deleteOwnReview({ slug, userId: mine });
+
+    const page = await listReviews({ slug, limit: 10, offset: 0, sort: 'recent' });
+    expect(page!.items.map((item) => item.author.id)).toEqual([theirs]);
+  });
+});
+
+describe('the publisher’s reply is the account graph’s decision', () => {
+  it('lets the owner of the app answer', async () => {
+    const { slug, ownerId } = await publishedApp();
+    const reviewId = (await upsertReview({ slug, userId: await insertUser(), rating: 2 })).id;
+
+    const reply = await upsertReply({ reviewId, authorUserId: ownerId, body: 'Sorry, fixed in 2.1' });
+
+    expect(reply.reviewId).toBe(reviewId);
+    const page = await listReviews({ slug, limit: 10, offset: 0, sort: 'recent' });
+    expect(page!.items[0].reply!.body).toBe('Sorry, fixed in 2.1');
+  });
+
+  it('lets a member whose role carries app:update answer', async () => {
+    const { slug, ownerId } = await publishedApp();
+    const editor = await insertUser();
+    await grantRole(ownerId, editor, 'editor');
+    const reviewId = (await upsertReview({ slug, userId: await insertUser(), rating: 3 })).id;
+
+    await expect(upsertReply({ reviewId, authorUserId: editor, body: 'Noted' })).resolves.toMatchObject({
+      body: 'Noted',
+    });
+  });
+
+  it('refuses a member whose role does not — the same person, one role apart', async () => {
+    const { slug, ownerId } = await publishedApp();
+    const viewer = await insertUser();
+    await grantRole(ownerId, viewer, 'viewer');
+    const reviewId = (await upsertReview({ slug, userId: await insertUser(), rating: 3 })).id;
+
+    await expect(upsertReply({ reviewId, authorUserId: viewer, body: 'Nope' })).rejects.toThrow(
+      ForbiddenError
+    );
+  });
+
+  it('refuses a stranger, and the review’s own author', async () => {
+    const { slug } = await publishedApp();
+    const author = await insertUser();
+    const reviewId = (await upsertReview({ slug, userId: author, rating: 1 })).id;
+
+    await expect(upsertReply({ reviewId, authorUserId: author, body: 'I answer myself' })).rejects.toThrow(
+      ForbiddenError
+    );
+    await expect(
+      upsertReply({ reviewId, authorUserId: await insertUser(), body: 'Hello' })
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it('rewrites the one reply rather than adding a second, and re-attributes it', async () => {
+    const { slug, ownerId } = await publishedApp();
+    const editor = await insertUser();
+    await grantRole(ownerId, editor, 'editor');
+    const reviewId = (await upsertReview({ slug, userId: await insertUser(), rating: 2 })).id;
+
+    await upsertReply({ reviewId, authorUserId: ownerId, body: 'First answer' });
+    const second = await upsertReply({ reviewId, authorUserId: editor, body: 'Better answer' });
+
+    const stored = await getDb().select().from(appReviewReplies).where(eq(appReviewReplies.reviewId, reviewId));
+    expect(stored).toHaveLength(1);
+    expect(stored[0].authorUserId).toBe(editor);
+    expect(second.body).toBe('Better answer');
+  });
+
+  it('withdraws a reply under the same gate that wrote it', async () => {
+    const { slug, ownerId } = await publishedApp();
+    const viewer = await insertUser();
+    await grantRole(ownerId, viewer, 'viewer');
+    const reviewId = (await upsertReview({ slug, userId: await insertUser(), rating: 4 })).id;
+    await upsertReply({ reviewId, authorUserId: ownerId, body: 'Thanks' });
+
+    await expect(deleteReply({ reviewId, authorUserId: viewer })).rejects.toThrow(ForbiddenError);
+    await deleteReply({ reviewId, authorUserId: ownerId });
+
+    expect(await getDb().select().from(appReviewReplies).where(eq(appReviewReplies.reviewId, reviewId))).toEqual([]);
+  });
+
+  it('answers 404 for a review that does not exist, without consulting a role', async () => {
+    await expect(
+      upsertReply({ reviewId: `missing-${randomUUID()}`, authorUserId: await insertUser(), body: 'x' })
+    ).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe('a reviewer who has authorized the app is marked as one', () => {
+  it('reads the mark from `app_grants`, and drops it when consent is revoked', async () => {
+    const { slug, applicationId } = await publishedApp();
+    const consenting = await insertUser();
+    const passerby = await insertUser();
+    await upsertReview({ slug, userId: consenting, rating: 5 });
+    await upsertReview({ slug, userId: passerby, rating: 1 });
+    await getDb().insert(appGrants).values({ userId: consenting, applicationId, scopes: ['read'] });
+
+    const withGrant = await listReviews({ slug, limit: 10, offset: 0, sort: 'recent' });
+    const marks = new Map(withGrant!.items.map((item) => [item.author.id, item.authorUsesApp]));
+    expect(marks.get(consenting)).toBe(true);
+    expect(marks.get(passerby)).toBe(false);
+
+    await getDb().delete(appGrants).where(and(eq(appGrants.userId, consenting), eq(appGrants.applicationId, applicationId)));
+
+    const afterRevoke = await listReviews({ slug, limit: 10, offset: 0, sort: 'recent' });
+    expect(afterRevoke!.items.every((item) => item.authorUsesApp === false)).toBe(true);
+  });
+});

--- a/packages/api/src/services/store.service.ts
+++ b/packages/api/src/services/store.service.ts
@@ -19,12 +19,16 @@
 import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
 import { getDb } from '../config/postgres';
 import { appCategories } from '../db/schema/appCategories';
+import { appGrants } from '../db/schema/appGrants';
 import { appListingScreenshots } from '../db/schema/appListingScreenshots';
 import { appListings } from '../db/schema/appListings';
 import { appReviewReplies } from '../db/schema/appReviewReplies';
-import { appReviews } from '../db/schema/appReviews';
+import { appReviews, type AppReviewStatus } from '../db/schema/appReviews';
 import { applications } from '../db/schema/applications';
 import { users } from '../db/schema/users';
+import { accountService } from './account.service';
+import { appPermissionsForAccountRole } from '../utils/accountRoles';
+import { ForbiddenError, NotFoundError } from '../utils/error';
 
 /** What a card needs, and nothing more. */
 export interface StoreListingSummary {
@@ -213,6 +217,17 @@ export interface StoreReview {
   createdAt: Date;
   author: { id: string; username: string | null };
   reply: { body: string; createdAt: Date } | null;
+  /**
+   * Whether this author has ever authorized the application — read from
+   * `app_grants` at request time rather than stored on the review, which is the
+   * whole reason `app_reviews` carries no such column: a flag written at insert
+   * would be true then and wrong from the next revocation onwards.
+   *
+   * It is not a claim that they still use it, and it is false for a first-party
+   * app nobody has to consent to, so a client should render its absence as
+   * nothing at all rather than as a demotion.
+   */
+  authorUsesApp: boolean;
 }
 
 /**
@@ -264,30 +279,47 @@ export async function listReviews(options: {
     db.select({ value: count() }).from(appReviews).where(where),
   ]);
 
-  const replies = rows.length
-    ? await db
-        .select({
-          reviewId: appReviewReplies.reviewId,
-          body: appReviewReplies.body,
-          createdAt: appReviewReplies.createdAt,
-        })
-        .from(appReviewReplies)
-        .where(inArray(appReviewReplies.reviewId, rows.map((row) => row.id)))
-    : [];
+  // Both are per-PAGE lookups keyed on the rows just read, so neither grows
+  // with the number of reviews the app has.
+  const [replies, grants] = rows.length
+    ? await Promise.all([
+        db
+          .select({
+            reviewId: appReviewReplies.reviewId,
+            body: appReviewReplies.body,
+            createdAt: appReviewReplies.createdAt,
+          })
+          .from(appReviewReplies)
+          .where(inArray(appReviewReplies.reviewId, rows.map((row) => row.id))),
+        db
+          .select({ userId: appGrants.userId })
+          .from(appGrants)
+          .where(
+            and(
+              eq(appGrants.applicationId, listing.applicationId),
+              inArray(appGrants.userId, rows.map((row) => row.authorId))
+            )
+          ),
+      ])
+    : [[], []];
+
   const replyByReview = new Map(replies.map((reply) => [reply.reviewId, reply]));
+  const authorsWithGrant = new Set(grants.map((grant) => grant.userId));
 
   return {
-    items: rows.map((row) => ({
-      id: row.id,
-      rating: row.rating,
-      title: row.title,
-      body: row.body,
-      createdAt: row.createdAt,
-      author: { id: row.authorId, username: row.authorUsername },
-      reply: replyByReview.get(row.id)
-        ? { body: replyByReview.get(row.id)!.body, createdAt: replyByReview.get(row.id)!.createdAt }
-        : null,
-    })),
+    items: rows.map((row) => {
+      const reply = replyByReview.get(row.id);
+      return {
+        id: row.id,
+        rating: row.rating,
+        title: row.title,
+        body: row.body,
+        createdAt: row.createdAt,
+        author: { id: row.authorId, username: row.authorUsername },
+        reply: reply ? { body: reply.body, createdAt: reply.createdAt } : null,
+        authorUsesApp: authorsWithGrant.has(row.authorId),
+      };
+    }),
     total: Number(totals?.value ?? 0),
   };
 }
@@ -298,4 +330,204 @@ export async function listCategories(): Promise<{ slug: string; label: string; d
     .select({ slug: appCategories.slug, label: appCategories.label, description: appCategories.description })
     .from(appCategories)
     .orderBy(asc(appCategories.order), asc(appCategories.id));
+}
+
+// ============================================================================
+// Writes
+//
+// The reads above answer `null` because "this slug is not a published listing"
+// is the only way they fail. A write has several distinct outcomes — no such
+// page, nothing of yours to delete, not yours to answer — and one sentinel
+// cannot say which, so these throw the error that names the outcome and the
+// routes stay free of translation.
+// ============================================================================
+
+/** A review as its own author sees it, whatever its moderation state. */
+export interface StoreOwnReview {
+  id: string;
+  rating: number;
+  title: string | null;
+  body: string | null;
+  /** Its own author is told when their review is hidden; the public list is not. */
+  status: AppReviewStatus;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** The columns an author is served for their own review. */
+const OWN_REVIEW_COLUMNS = {
+  id: appReviews.id,
+  rating: appReviews.rating,
+  title: appReviews.title,
+  body: appReviews.body,
+  status: appReviews.status,
+  createdAt: appReviews.createdAt,
+  updatedAt: appReviews.updatedAt,
+} as const;
+
+/** The application behind a published listing, or a 404. */
+async function requirePublishedApplicationId(slug: string): Promise<string> {
+  const [listing] = await getDb()
+    .select({ applicationId: appListings.applicationId })
+    .from(appListings)
+    .where(and(eq(appListings.slug, slug), eq(appListings.status, 'published')))
+    .limit(1);
+  // The same answer a read gives: whether an unpublished page exists under this
+  // slug is not something a write attempt gets to reveal either.
+  if (!listing) throw new NotFoundError('App not found');
+  return listing.applicationId;
+}
+
+/**
+ * Write the caller's review of an app, creating it or replacing what they said
+ * before.
+ *
+ * One statement, because `unique(application_id, user_id)` is what actually
+ * enforces one-review-per-person: a read-then-insert passes its own check
+ * twice under concurrency and the second insert is the one that raises. The
+ * conflict clause turns that race into the edit the person asked for.
+ *
+ * Editing does NOT reset moderation — a hidden review stays hidden when its
+ * author rewrites it, or hiding one would be undone by whoever wrote it.
+ */
+export async function upsertReview(options: {
+  slug: string;
+  userId: string;
+  rating: number;
+  title?: string | null;
+  body?: string | null;
+}): Promise<StoreOwnReview> {
+  const applicationId = await requirePublishedApplicationId(options.slug);
+
+  // Absent stays absent and blank becomes absent: an empty string is a value,
+  // and `app_reviews` keeps "wrote no title" as NULL rather than as `''`.
+  const title = options.title?.trim() || null;
+  const body = options.body?.trim() || null;
+
+  const [row] = await getDb()
+    .insert(appReviews)
+    .values({ applicationId, userId: options.userId, rating: options.rating, title, body })
+    .onConflictDoUpdate({
+      target: [appReviews.applicationId, appReviews.userId],
+      set: { rating: options.rating, title, body, updatedAt: new Date() },
+    })
+    .returning(OWN_REVIEW_COLUMNS);
+
+  return row;
+}
+
+/** The caller's own review of an app, or null if they have not written one. */
+export async function getOwnReview(options: {
+  slug: string;
+  userId: string;
+}): Promise<StoreOwnReview | null> {
+  const applicationId = await requirePublishedApplicationId(options.slug);
+
+  const [row] = await getDb()
+    .select(OWN_REVIEW_COLUMNS)
+    .from(appReviews)
+    .where(and(eq(appReviews.applicationId, applicationId), eq(appReviews.userId, options.userId)))
+    .limit(1);
+
+  return row ?? null;
+}
+
+/**
+ * Withdraw the caller's own review.
+ *
+ * A real delete, not a status change: `removed` is a moderator's verdict about
+ * someone's words, and an author taking their own words back is not that.
+ */
+export async function deleteOwnReview(options: { slug: string; userId: string }): Promise<void> {
+  const applicationId = await requirePublishedApplicationId(options.slug);
+
+  const deleted = await getDb()
+    .delete(appReviews)
+    .where(and(eq(appReviews.applicationId, applicationId), eq(appReviews.userId, options.userId)))
+    .returning({ id: appReviews.id });
+
+  if (deleted.length === 0) throw new NotFoundError('You have not reviewed this app');
+}
+
+/**
+ * Authorise `userId` to answer `reviewId` on the publisher's behalf.
+ *
+ * The right to reply is not a store concept: it is `app:update` over the
+ * application's owning account, resolved through the same
+ * `AccountMember` graph — with inheritance, per-member revokes and all — that
+ * governs every other write to that application. So a store listing cannot
+ * become a second, weaker way to act as somebody's app.
+ */
+async function requirePublisherAccess(reviewId: string, userId: string): Promise<void> {
+  const [review] = await getDb()
+    .select({ ownerAccountId: applications.ownerAccountId })
+    .from(appReviews)
+    .innerJoin(applications, eq(applications.id, appReviews.applicationId))
+    .where(eq(appReviews.id, reviewId))
+    .limit(1);
+
+  if (!review) throw new NotFoundError('Review not found');
+
+  const access = await accountService.resolveEffectiveAccess(userId, review.ownerAccountId);
+  if (!access || !appPermissionsForAccountRole(access.role).includes('app:update')) {
+    throw new ForbiddenError('You cannot reply on behalf of this app');
+  }
+}
+
+export interface StoreReply {
+  id: string;
+  reviewId: string;
+  body: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Post or rewrite the publisher's answer to a review.
+ *
+ * `unique(review_id)` is why this is an upsert rather than an insert: one
+ * answer per review is the shape the table declares, and two people holding
+ * `app:update` pressing reply at once must not produce two.
+ *
+ * `author_user_id` is overwritten with whoever wrote the current text, because
+ * attribution that survived an edit by a colleague would name the wrong person.
+ */
+export async function upsertReply(options: {
+  reviewId: string;
+  authorUserId: string;
+  body: string;
+}): Promise<StoreReply> {
+  await requirePublisherAccess(options.reviewId, options.authorUserId);
+
+  const [row] = await getDb()
+    .insert(appReviewReplies)
+    .values({ reviewId: options.reviewId, authorUserId: options.authorUserId, body: options.body })
+    .onConflictDoUpdate({
+      target: appReviewReplies.reviewId,
+      set: { body: options.body, authorUserId: options.authorUserId, updatedAt: new Date() },
+    })
+    .returning({
+      id: appReviewReplies.id,
+      reviewId: appReviewReplies.reviewId,
+      body: appReviewReplies.body,
+      createdAt: appReviewReplies.createdAt,
+      updatedAt: appReviewReplies.updatedAt,
+    });
+
+  return row;
+}
+
+/** Withdraw the publisher's answer. Same gate as writing it. */
+export async function deleteReply(options: {
+  reviewId: string;
+  authorUserId: string;
+}): Promise<void> {
+  await requirePublisherAccess(options.reviewId, options.authorUserId);
+
+  const deleted = await getDb()
+    .delete(appReviewReplies)
+    .where(eq(appReviewReplies.reviewId, options.reviewId))
+    .returning({ id: appReviewReplies.id });
+
+  if (deleted.length === 0) throw new NotFoundError('This review has no reply');
 }


### PR DESCRIPTION
The writes behind the reads that shipped in #858. With this the store module is complete on the API side: a storefront anyone can read, reviews any signed-in Oxy account can write, and an answer the publisher can post.

## What is here

| | |
|---|---|
| `GET /store/apps/:slug/review` | the caller's own review, or null |
| `PUT /store/apps/:slug/review` | write or rewrite it |
| `DELETE /store/apps/:slug/review` | withdraw it |
| `PUT /store/reviews/:reviewId/reply` | the publisher's answer |
| `DELETE /store/reviews/:reviewId/reply` | withdraw it |

## Three decisions worth reviewing

**One review per person is enforced by the constraint, not above it.** `PUT` rather than `POST`, and one statement with `onConflictDoUpdate` rather than read-then-insert: two concurrent submits both pass any check written in the service, and only `unique(application_id, user_id)` stops the second. Rewriting deliberately does **not** reset moderation, or hiding a review would be undone by whoever wrote it.

**The right to reply is the account graph's decision, not the store's.** It is `app:update` over the application's owning account, through the same `AccountMember` resolution — inheritance, per-member revokes and all — that governs every other write to that application. A store listing must not become a second, weaker way to act as somebody's app.

Verified by mutation rather than asserted: relaxing the check to `if (!access)` — "has any access at all" — turns exactly two tests red. The discriminating fixture is an `editor` and a `viewer` on the same account, differing only by role, because a suite where every non-owner is a stranger cannot tell a permission check from a membership check.

**Who may review: any signed-in Oxy account.** Deliberately not `users.verified`, which is a standing badge an administrator sets; gating on it would mean almost nobody could write a review. The signal a reader actually wants is whether the reviewer authorized the app, so the public list now carries `authorUsesApp`, read from `app_grants` at request time — one query per page, not per review. That is exactly why `app_reviews` carries no such column: a flag written at insert would be true then and wrong from the next revocation onwards. It is false for a first-party app nobody consents to, so a client should render its absence as nothing rather than as a demotion.

## Smaller things

- Withdrawing your own review **deletes the row**. `removed` is a moderator's verdict about someone's words, and an author taking their words back is not that.
- Auth and CSRF are per route, not at the mount: this router now serves a public storefront and authenticated writes, and one blanket middleware would either lock the storefront or leave the reviews open.
- The write rate limiter keys on the **account**, not the IP, or one office network throttles to one reviewer.
- Reads answer `null`; writes throw. A read fails one way; a write fails several — no such page, nothing of yours to delete, not yours to answer — and one sentinel cannot say which.

## Verification

30 tests against a real Postgres, 17 new. The schema rules (`unique(application_id, user_id)`, `unique(review_id)`, `rating between 1 and 5`) are covered against the database rather than a mock, since a stub would only be testing its own opinion of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)