### PR TITLE
store: a listing can be written, handed in, and published

### DIFF
--- a/packages/api/src/routes/applications.ts
+++ b/packages/api/src/routes/applications.ts
@@ -39,6 +39,13 @@ import {
   updateApplicationSchema,
   createCredentialSchema,
 } from '../schemas/application.schemas';
+import { storeListingBody } from '../schemas/store.schemas';
+import {
+  getListingForApplication,
+  submitListing,
+  unpublishListing,
+  upsertListing,
+} from '../services/store.service';
 
 /** A stored application row. */
 type ApplicationRow = typeof applications.$inferSelect;
@@ -144,6 +151,21 @@ function requireUserId(req: AuthRequest): string {
     throw new UnauthorizedError('Authentication required');
   }
   return userId;
+}
+
+/**
+ * The application `requireAppPermission` already loaded, narrowed.
+ *
+ * The middleware has thrown 404 if it is absent, so this cannot fire; it
+ * exists because `req.application` is optional on the request type and the
+ * alternative is a non-null assertion, which the house rules forbid for good
+ * reason.
+ */
+function requireApplication(req: AppContextRequest): ApplicationRow {
+  if (!req.application) {
+    throw new NotFoundError('Application not found');
+  }
+  return req.application;
 }
 
 /** Compute the window start date for a usage period. */
@@ -1113,6 +1135,70 @@ router.get(
 
     const period = (req.query.period as string) || '7d';
     res.json(await getUsageStats(application.id, getStartDate(period)));
+  })
+);
+
+// ============================================================================
+// Store listing
+//
+// The publisher's side of the app store hangs off the application, beside
+// credentials, webhooks and usage, because that is what it is: one more thing
+// an app has, edited by whoever may edit the app. It reuses
+// `requireAppPermission` wholesale — a store page must not become a second,
+// weaker way to act for somebody's application.
+//
+// The storefront that READS these pages is `/store`, and knows nothing about
+// applications the caller may administer.
+// ============================================================================
+
+/** The application's listing in whatever state, or null when it has none. */
+router.get(
+  '/:appId/listing',
+  validate({ params: appIdRouteParams }),
+  requireAppPermission('app:read'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    res.json(await getListingForApplication(requireApplication(req).id));
+  })
+);
+
+/**
+ * Create the listing or replace its content. Never its status: publishing is
+ * the store's decision and has its own routes.
+ */
+router.put(
+  '/:appId/listing',
+  validate({ params: appIdRouteParams, body: storeListingBody }),
+  requireAppPermission('app:update'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    const body = req.body as {
+      slug: string;
+      tagline?: string | null;
+      description?: string | null;
+      categorySlug?: string | null;
+      supportUrl?: string | null;
+      supportEmail?: string | null;
+    };
+    res.json(await upsertListing({ applicationId: requireApplication(req).id, ...body }));
+  })
+);
+
+/** Hand the page to the store for review. */
+router.post(
+  '/:appId/listing/submit',
+  validate({ params: appIdRouteParams }),
+  requireAppPermission('app:update'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    res.json(await submitListing(requireApplication(req).id));
+  })
+);
+
+/** Take it down, or withdraw it from the queue. Back to a draft, never deleted. */
+router.post(
+  '/:appId/listing/unpublish',
+  validate({ params: appIdRouteParams }),
+  requireAppPermission('app:update'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    res.json(await unpublishListing(requireApplication(req).id));
   })
 );
 

--- a/packages/api/src/routes/store.ts
+++ b/packages/api/src/routes/store.ts
@@ -20,11 +20,14 @@ import { Router, type Request, type Response } from 'express';
 import { asyncHandler, sendPaginated, sendSuccess } from '../utils/asyncHandler';
 import { authMiddleware, type AuthRequest } from '../middleware/auth';
 import { csrfProtection } from '../middleware/csrf';
+import { requireStaff } from '../middleware/requireStaff';
 import { validate } from '../middleware/validate';
 import { rateLimit } from '../middleware/rateLimiter';
 import { NotFoundError, UnauthorizedError } from '../utils/error';
 import {
   storeListingsQuery,
+  storeModerationParams,
+  storeModerationQuery,
   storeReplyBody,
   storeReviewBody,
   storeReviewParams,
@@ -32,13 +35,16 @@ import {
   storeSlugParams,
 } from '../schemas/store.schemas';
 import {
+  approveListing,
   deleteOwnReview,
   deleteReply,
   getOwnReview,
   getPublishedListing,
   listCategories,
+  listListingsAwaitingReview,
   listPublishedListings,
   listReviews,
+  rejectListing,
   upsertReply,
   upsertReview,
 } from '../services/store.service';
@@ -226,6 +232,56 @@ router.delete(
   asyncHandler(async (req: AuthRequest, res: Response) => {
     await deleteReply({ reviewId: req.params.reviewId, authorUserId: requireUserId(req) });
     res.status(204).end();
+  })
+);
+
+// ============================================================================
+// Moderation
+//
+// Staff only. A publisher edits their page and hands it in — those routes hang
+// off `/applications/:appId/listing`, beside the credentials and webhooks the
+// same permission guards. Granting the review is the STORE's judgement, and a
+// publisher who could grant it would make the queue decorative, so it lives
+// here and behind `requireStaff`.
+// ============================================================================
+
+/** GET /store/moderation/listings — the queue, oldest submission first. */
+router.get(
+  '/moderation/listings',
+  readLimiter,
+  authMiddleware,
+  requireStaff,
+  validate({ query: storeModerationQuery }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const { limit, offset } = req.query as unknown as { limit: number; offset: number };
+    const { items, total } = await listListingsAwaitingReview({ limit, offset });
+    sendPaginated(res, items, total, limit, offset);
+  })
+);
+
+/** POST /store/moderation/listings/:applicationId/approve — publish it. */
+router.post(
+  '/moderation/listings/:applicationId/approve',
+  writeLimiter,
+  authMiddleware,
+  requireStaff,
+  csrfProtection,
+  validate({ params: storeModerationParams }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    sendSuccess(res, await approveListing(req.params.applicationId));
+  })
+);
+
+/** POST /store/moderation/listings/:applicationId/reject — send it back. */
+router.post(
+  '/moderation/listings/:applicationId/reject',
+  writeLimiter,
+  authMiddleware,
+  requireStaff,
+  csrfProtection,
+  validate({ params: storeModerationParams }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    sendSuccess(res, await rejectListing(req.params.applicationId));
   })
 );
 

--- a/packages/api/src/schemas/store.schemas.ts
+++ b/packages/api/src/schemas/store.schemas.ts
@@ -59,3 +59,46 @@ export const storeReviewParams = z.object({
 export const storeReplyBody = z.object({
   body: z.string().trim().min(1).max(REVIEW_BODY_MAX),
 });
+
+/**
+ * PUT /applications/:appId/listing
+ *
+ * A whole page, not a patch: the console edits one form, and a partial update
+ * would make "clear the tagline" and "leave the tagline alone" the same
+ * request.
+ *
+ * `status` is deliberately absent. Moving a page through review is a
+ * transition with its own route and its own guard, so a publisher cannot
+ * publish themselves by putting a field in a body.
+ */
+export const storeListingBody = z.object({
+  /**
+   * The public URL segment. Lowercase, digits and hyphens, because it is what
+   * every link to the page carries and a slug that needs escaping is a slug
+   * that will be copied wrong.
+   */
+  slug: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .min(2)
+    .max(120)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, digits and single hyphens'),
+  tagline: z.string().trim().max(160).nullish(),
+  description: z.string().trim().max(20000).nullish(),
+  /** A category SLUG, never its id: an id in a form is an id in a bug report. */
+  categorySlug: z.string().trim().min(1).max(120).nullish(),
+  supportUrl: z.string().trim().url().max(2048).nullish(),
+  supportEmail: z.string().trim().email().max(320).nullish(),
+});
+
+/** GET /store/moderation/listings — the review queue. */
+export const storeModerationQuery = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+});
+
+/** An application id in the path, for the moderation decisions. */
+export const storeModerationParams = z.object({
+  applicationId: z.string().trim().min(1).max(64),
+});

--- a/packages/api/src/services/__tests__/store.listing.test.ts
+++ b/packages/api/src/services/__tests__/store.listing.test.ts
@@ -1,0 +1,258 @@
+/**
+ * A listing's life: written by its publisher, published by the store.
+ *
+ * The transitions are the reason this runs against a real database. Each one
+ * checks what the page is moving FROM, and the states it refuses are as
+ * load-bearing as the ones it allows — a guard that let a rejected page be
+ * published by replaying a request would pass any test that only asserted the
+ * happy path.
+ *
+ * The two rules easiest to break by accident are covered explicitly: editing a
+ * live page must not unpublish it, and a page taken down and put back up keeps
+ * its ORIGINAL publication date.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { appCategories } from '../../db/schema/appCategories';
+import { appListings } from '../../db/schema/appListings';
+import { applications } from '../../db/schema/applications';
+import { users } from '../../db/schema/users';
+import { BadRequestError, ConflictError, NotFoundError } from '../../utils/error';
+import {
+  approveListing,
+  getListingForApplication,
+  getPublishedListing,
+  listListingsAwaitingReview,
+  rejectListing,
+  submitListing,
+  unpublishListing,
+  upsertListing,
+} from '../store.service';
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+/** An application with no listing, which is where every publisher starts. */
+async function unlistedApp(): Promise<string> {
+  const suffix = randomUUID().slice(0, 8);
+  const [owner] = await getDb()
+    .insert(users)
+    .values({ username: `pub-${suffix}`, email: `pub-${suffix}@example.test` })
+    .returning({ id: users.id });
+  const [application] = await getDb()
+    .insert(applications)
+    .values({ name: `App ${suffix}`, ownerAccountId: owner.id })
+    .returning({ id: applications.id });
+  return application.id;
+}
+
+function freshSlug(): string {
+  return `slug-${randomUUID().slice(0, 8)}`;
+}
+
+/** A page all the way to `published`, which several cases need as a starting point. */
+async function publishedListing(): Promise<{ applicationId: string; slug: string }> {
+  const applicationId = await unlistedApp();
+  const slug = freshSlug();
+  await upsertListing({ applicationId, slug, tagline: 'One line' });
+  await submitListing(applicationId);
+  await approveListing(applicationId);
+  return { applicationId, slug };
+}
+
+describe('writing the page', () => {
+  it('creates it as a draft — publishing is not the publisher’s to do', async () => {
+    const applicationId = await unlistedApp();
+
+    const listing = await upsertListing({
+      applicationId,
+      slug: freshSlug(),
+      tagline: 'Does one thing',
+      description: '# About\n\nAt length.',
+    });
+
+    expect(listing.status).toBe('draft');
+    expect(listing.publishedAt).toBeNull();
+    expect(listing.tagline).toBe('Does one thing');
+  });
+
+  it('files it on a shelf by slug, and answers with the shelf’s label', async () => {
+    const applicationId = await unlistedApp();
+    const categorySlug = `cat-${randomUUID().slice(0, 8)}`;
+    await getDb().insert(appCategories).values({ slug: categorySlug, label: 'Productivity' });
+
+    const listing = await upsertListing({ applicationId, slug: freshSlug(), categorySlug });
+
+    expect(listing.category).toEqual({ slug: categorySlug, label: 'Productivity' });
+  });
+
+  it('names a shelf that does not exist rather than filing it nowhere', async () => {
+    const applicationId = await unlistedApp();
+
+    await expect(
+      upsertListing({ applicationId, slug: freshSlug(), categorySlug: `nope-${randomUUID()}` })
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  it('replaces the one listing rather than adding a second', async () => {
+    const applicationId = await unlistedApp();
+    const first = await upsertListing({ applicationId, slug: freshSlug(), tagline: 'Before' });
+
+    const second = await upsertListing({ applicationId, slug: freshSlug(), tagline: 'After' });
+
+    expect(second.id).toBe(first.id);
+    expect(second.tagline).toBe('After');
+    const stored = await getDb()
+      .select()
+      .from(appListings)
+      .where(eq(appListings.applicationId, applicationId));
+    expect(stored).toHaveLength(1);
+  });
+
+  it('refuses a slug another app already holds, and says which', async () => {
+    const taken = freshSlug();
+    await upsertListing({ applicationId: await unlistedApp(), slug: taken });
+
+    await expect(upsertListing({ applicationId: await unlistedApp(), slug: taken })).rejects.toThrow(
+      ConflictError
+    );
+  });
+
+  it('does NOT unpublish a live page when its words are corrected', async () => {
+    const { applicationId, slug } = await publishedListing();
+
+    const edited = await upsertListing({ applicationId, slug, tagline: 'Corrected' });
+
+    expect(edited.status).toBe('published');
+    expect(await getPublishedListing(slug)).not.toBeNull();
+  });
+});
+
+describe('handing the page in', () => {
+  it('takes a draft into the queue', async () => {
+    const applicationId = await unlistedApp();
+    await upsertListing({ applicationId, slug: freshSlug() });
+
+    expect((await submitListing(applicationId)).status).toBe('pending_review');
+  });
+
+  it('takes a rejected page back into the queue once it is fixed', async () => {
+    const applicationId = await unlistedApp();
+    await upsertListing({ applicationId, slug: freshSlug() });
+    await submitListing(applicationId);
+    await rejectListing(applicationId);
+
+    expect((await submitListing(applicationId)).status).toBe('pending_review');
+  });
+
+  it('refuses to re-submit a page that is already live', async () => {
+    const { applicationId } = await publishedListing();
+
+    await expect(submitListing(applicationId)).rejects.toThrow(ConflictError);
+  });
+
+  it('says so when there is no page to submit', async () => {
+    await expect(submitListing(await unlistedApp())).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe('the store’s decision', () => {
+  it('publishes a page that was submitted, and stamps when', async () => {
+    const applicationId = await unlistedApp();
+    const slug = freshSlug();
+    await upsertListing({ applicationId, slug });
+    await submitListing(applicationId);
+
+    const approved = await approveListing(applicationId);
+
+    expect(approved.status).toBe('published');
+    expect(approved.publishedAt).toBeInstanceOf(Date);
+    expect(await getPublishedListing(slug)).toMatchObject({ slug });
+  });
+
+  it('will not publish a draft that was never submitted', async () => {
+    const applicationId = await unlistedApp();
+    await upsertListing({ applicationId, slug: freshSlug() });
+
+    await expect(approveListing(applicationId)).rejects.toThrow(ConflictError);
+  });
+
+  it('will not approve the same submission twice', async () => {
+    const { applicationId } = await publishedListing();
+
+    await expect(approveListing(applicationId)).rejects.toThrow(ConflictError);
+  });
+
+  it('sends a page back, and the storefront stops serving it', async () => {
+    const applicationId = await unlistedApp();
+    const slug = freshSlug();
+    await upsertListing({ applicationId, slug });
+    await submitListing(applicationId);
+
+    expect((await rejectListing(applicationId)).status).toBe('rejected');
+    expect(await getPublishedListing(slug)).toBeNull();
+  });
+
+  it('lists what is waiting, and nothing that is not', async () => {
+    const waiting = await unlistedApp();
+    await upsertListing({ applicationId: waiting, slug: freshSlug() });
+    await submitListing(waiting);
+    const drafting = await unlistedApp();
+    await upsertListing({ applicationId: drafting, slug: freshSlug() });
+
+    const { items } = await listListingsAwaitingReview({ limit: 100, offset: 0 });
+    const queued = items.map((item) => item.applicationId);
+
+    expect(queued).toContain(waiting);
+    expect(queued).not.toContain(drafting);
+    expect(items.every((item) => item.status === 'pending_review')).toBe(true);
+  });
+});
+
+describe('taking a page down', () => {
+  it('returns it to a draft rather than deleting the publisher’s work', async () => {
+    const { applicationId, slug } = await publishedListing();
+
+    const down = await unpublishListing(applicationId);
+
+    expect(down.status).toBe('draft');
+    expect(down.slug).toBe(slug);
+    expect(down.tagline).toBe('One line');
+    expect(await getPublishedListing(slug)).toBeNull();
+  });
+
+  it('withdraws a submission from the queue', async () => {
+    const applicationId = await unlistedApp();
+    await upsertListing({ applicationId, slug: freshSlug() });
+    await submitListing(applicationId);
+
+    expect((await unpublishListing(applicationId)).status).toBe('draft');
+  });
+
+  it('keeps the ORIGINAL publication date when a page goes back up', async () => {
+    const { applicationId } = await publishedListing();
+    const firstPublishedAt = (await getListingForApplication(applicationId))!.publishedAt;
+
+    await unpublishListing(applicationId);
+    await submitListing(applicationId);
+    const republished = await approveListing(applicationId);
+
+    // A page has one publication date and many edits, which is the whole
+    // reason `published_at` is its own column rather than read off `updated_at`.
+    expect(republished.publishedAt).toEqual(firstPublishedAt);
+  });
+
+  it('refuses to take down a page that is already a draft', async () => {
+    const applicationId = await unlistedApp();
+    await upsertListing({ applicationId, slug: freshSlug() });
+
+    await expect(unpublishListing(applicationId)).rejects.toThrow(ConflictError);
+  });
+});

--- a/packages/api/src/services/store.service.ts
+++ b/packages/api/src/services/store.service.ts
@@ -21,14 +21,21 @@ import { getDb } from '../config/postgres';
 import { appCategories } from '../db/schema/appCategories';
 import { appGrants } from '../db/schema/appGrants';
 import { appListingScreenshots } from '../db/schema/appListingScreenshots';
-import { appListings } from '../db/schema/appListings';
+import { appListings, type AppListingStatus } from '../db/schema/appListings';
 import { appReviewReplies } from '../db/schema/appReviewReplies';
 import { appReviews, type AppReviewStatus } from '../db/schema/appReviews';
 import { applications } from '../db/schema/applications';
 import { users } from '../db/schema/users';
+import { isUniqueViolation } from '@oxyhq/db';
 import { accountService } from './account.service';
 import { appPermissionsForAccountRole } from '../utils/accountRoles';
-import { ForbiddenError, NotFoundError } from '../utils/error';
+import {
+  BadRequestError,
+  ConflictError,
+  ForbiddenError,
+  InternalServerError,
+  NotFoundError,
+} from '../utils/error';
 
 /** What a card needs, and nothing more. */
 export interface StoreListingSummary {
@@ -530,4 +537,264 @@ export async function deleteReply(options: {
     .returning({ id: appReviewReplies.id });
 
   if (deleted.length === 0) throw new NotFoundError('This review has no reply');
+}
+
+// ============================================================================
+// The publisher's side of a listing
+//
+// Everything above is read by, or written by, whoever is looking at the store.
+// What follows is written by whoever OWNS the app, and the split it respects is
+// the one `app_listings` documents: the publisher writes the words and the
+// pictures; the STATUS is not theirs to set. Editing content and moving a page
+// through review are therefore different calls, not one call with a `status`
+// field somebody could pass `published` to.
+//
+// Authorisation lives in the routes, on `requireAppPermission('app:update')` —
+// the same middleware that guards credentials and webhooks. This module never
+// re-derives who may act for an application.
+// ============================================================================
+
+/** A listing as its owner sees it: whatever state it is in, with its shelf. */
+export interface PublisherListing {
+  id: string;
+  applicationId: string;
+  slug: string;
+  tagline: string | null;
+  description: string | null;
+  category: { slug: string; label: string } | null;
+  supportUrl: string | null;
+  supportEmail: string | null;
+  status: AppListingStatus;
+  publishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/** Read one listing back with its category resolved, by application. */
+async function publisherListingFor(applicationId: string): Promise<PublisherListing | null> {
+  const [row] = await getDb()
+    .select({
+      id: appListings.id,
+      applicationId: appListings.applicationId,
+      slug: appListings.slug,
+      tagline: appListings.tagline,
+      description: appListings.description,
+      supportUrl: appListings.supportUrl,
+      supportEmail: appListings.supportEmail,
+      status: appListings.status,
+      publishedAt: appListings.publishedAt,
+      createdAt: appListings.createdAt,
+      updatedAt: appListings.updatedAt,
+      categorySlug: appCategories.slug,
+      categoryLabel: appCategories.label,
+    })
+    .from(appListings)
+    .leftJoin(appCategories, eq(appCategories.id, appListings.categoryId))
+    .where(eq(appListings.applicationId, applicationId))
+    .limit(1);
+
+  if (!row) return null;
+
+  const { categorySlug, categoryLabel, ...listing } = row;
+  return {
+    ...listing,
+    category: categorySlug ? { slug: categorySlug, label: categoryLabel! } : null,
+  };
+}
+
+/** The listing for an application, in whatever state, or null if it has none. */
+export async function getListingForApplication(
+  applicationId: string
+): Promise<PublisherListing | null> {
+  return publisherListingFor(applicationId);
+}
+
+/**
+ * Create or replace the CONTENT of an application's listing.
+ *
+ * A `PUT` of the whole page rather than a patch of some of it: the console
+ * edits one form, and a partial update would make "the tagline is absent" and
+ * "leave the tagline alone" the same request.
+ *
+ * The status is untouched — a new page starts as a `draft` by the column's
+ * default, and an existing page keeps whatever review state it is in. So
+ * correcting a typo on a live page does not silently unpublish it, and editing
+ * a rejected one does not re-submit it.
+ */
+export async function upsertListing(options: {
+  applicationId: string;
+  slug: string;
+  tagline?: string | null;
+  description?: string | null;
+  categorySlug?: string | null;
+  supportUrl?: string | null;
+  supportEmail?: string | null;
+}): Promise<PublisherListing> {
+  const db = getDb();
+
+  let categoryId: string | null = null;
+  if (options.categorySlug) {
+    const [category] = await db
+      .select({ id: appCategories.id })
+      .from(appCategories)
+      .where(eq(appCategories.slug, options.categorySlug))
+      .limit(1);
+    // Named, not ignored: silently filing a page under "uncategorised" because
+    // a shelf was misspelled is the kind of thing nobody notices until a
+    // publisher asks why their app is nowhere.
+    if (!category) throw new BadRequestError(`No such category: ${options.categorySlug}`);
+    categoryId = category.id;
+  }
+
+  const content = {
+    slug: options.slug,
+    tagline: options.tagline?.trim() || null,
+    description: options.description?.trim() || null,
+    categoryId,
+    supportUrl: options.supportUrl?.trim() || null,
+    supportEmail: options.supportEmail?.trim() || null,
+  };
+
+  try {
+    await db
+      .insert(appListings)
+      .values({ applicationId: options.applicationId, ...content })
+      .onConflictDoUpdate({
+        target: appListings.applicationId,
+        set: { ...content, updatedAt: new Date() },
+      });
+  } catch (error) {
+    // Named, not bare: `app_listings` carries TWO unique constraints, and a
+    // bare check would report "the slug is taken" for whichever of them fired.
+    // `application_id` is the conflict target here so it cannot raise today —
+    // pinning the name is what keeps the message honest if that ever changes.
+    if (isUniqueViolation(error, 'app_listings_slug_unique')) {
+      throw new ConflictError(`The slug "${options.slug}" is already taken`);
+    }
+    throw error;
+  }
+
+  // Re-read rather than `returning()`: the caller needs the category resolved
+  // to its slug and label, which an insert cannot join.
+  const listing = await publisherListingFor(options.applicationId);
+  if (!listing) throw new InternalServerError('The listing vanished as it was written');
+  return listing;
+}
+
+/**
+ * Move a listing between states, checking what it is moving FROM.
+ *
+ * The guard is the point: a transition that did not check would let a rejected
+ * page be published by replaying a request, and would let a submission
+ * "succeed" against a page already live.
+ */
+async function transitionListing(options: {
+  applicationId: string;
+  from: readonly AppListingStatus[];
+  to: AppListingStatus;
+  publishedAt?: Date | null;
+}): Promise<PublisherListing> {
+  const [current] = await getDb()
+    .select({ status: appListings.status, publishedAt: appListings.publishedAt })
+    .from(appListings)
+    .where(eq(appListings.applicationId, options.applicationId))
+    .limit(1);
+
+  if (!current) throw new NotFoundError('This application has no listing');
+  if (!options.from.includes(current.status)) {
+    throw new ConflictError(`A ${current.status} listing cannot become ${options.to}`);
+  }
+
+  await getDb()
+    .update(appListings)
+    .set({
+      status: options.to,
+      // `publishedAt` is only ever written on the first publish: a page taken
+      // down and put back up has one publication date and many edits.
+      ...(options.publishedAt !== undefined && current.publishedAt === null
+        ? { publishedAt: options.publishedAt }
+        : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(appListings.applicationId, options.applicationId));
+
+  const listing = await publisherListingFor(options.applicationId);
+  if (!listing) throw new NotFoundError('This application has no listing');
+  return listing;
+}
+
+/** Hand a draft — or a rejected page, once fixed — to the store for review. */
+export async function submitListing(applicationId: string): Promise<PublisherListing> {
+  return transitionListing({
+    applicationId,
+    from: ['draft', 'rejected'],
+    to: 'pending_review',
+  });
+}
+
+/**
+ * Take a page down, or withdraw it from the queue.
+ *
+ * Back to `draft` rather than deleted: the slug, the words and the screenshots
+ * are the publisher's work, and unlisting an app should not destroy them. It
+ * also keeps the reviews, which hang off the application and were never the
+ * listing's to take with it.
+ */
+export async function unpublishListing(applicationId: string): Promise<PublisherListing> {
+  return transitionListing({
+    applicationId,
+    from: ['published', 'pending_review'],
+    to: 'draft',
+  });
+}
+
+// ============================================================================
+// Store moderation
+//
+// Staff-only, and separate from the publisher's calls above for the reason the
+// two states exist: `pending_review` is the store's judgement of a page, and a
+// publisher who could grant it would make the queue decorative.
+// ============================================================================
+
+/** The review queue, oldest first — a submission should not wait behind newer ones. */
+export async function listListingsAwaitingReview(options: {
+  limit: number;
+  offset: number;
+}): Promise<{ items: PublisherListing[]; total: number }> {
+  const db = getDb();
+  const where = eq(appListings.status, 'pending_review');
+
+  const [rows, [totals]] = await Promise.all([
+    db
+      .select({ applicationId: appListings.applicationId })
+      .from(appListings)
+      .where(where)
+      .orderBy(asc(appListings.updatedAt), asc(appListings.id))
+      .limit(options.limit)
+      .offset(options.offset),
+    db.select({ value: count() }).from(appListings).where(where),
+  ]);
+
+  const listings = await Promise.all(rows.map((row) => publisherListingFor(row.applicationId)));
+
+  return { items: listings.filter((listing): listing is PublisherListing => listing !== null), total: Number(totals?.value ?? 0) };
+}
+
+/** Publish a page that was submitted for review. */
+export async function approveListing(applicationId: string): Promise<PublisherListing> {
+  return transitionListing({
+    applicationId,
+    from: ['pending_review'],
+    to: 'published',
+    publishedAt: new Date(),
+  });
+}
+
+/** Send a page back. It returns to the publisher, who may fix it and re-submit. */
+export async function rejectListing(applicationId: string): Promise<PublisherListing> {
+  return transitionListing({
+    applicationId,
+    from: ['pending_review'],
+    to: 'rejected',
+  });
 }


### PR DESCRIPTION
The storefront shipped in #858 and its reviews in #859. Until now an `app_listings` row could only appear by hand in SQL — this is the lifecycle that puts one there.

## The split it respects

`app_listings` documents it: a publisher writes the words, the shelf and the support links; the **status is not theirs to set**. So editing content and moving a page through review are different calls, not one call with a `status` field somebody could pass `published` to.

| | |
|---|---|
| `GET /applications/:appId/listing` | the page in whatever state, or null |
| `PUT /applications/:appId/listing` | write or replace its **content** |
| `POST /applications/:appId/listing/submit` | hand it to the store |
| `POST /applications/:appId/listing/unpublish` | take it down, or withdraw it |
| `GET /store/moderation/listings` | the queue, oldest first (staff) |
| `POST /store/moderation/listings/:applicationId/approve` | publish it (staff) |
| `POST /store/moderation/listings/:applicationId/reject` | send it back (staff) |

**The publisher's routes hang off the application**, beside credentials, webhooks and usage, and reuse `requireAppPermission` wholesale. A store page must not become a second, weaker way to act for somebody's application, and the way to guarantee that is to not write a second permission check.

**Moderation is staff-only and lives on the store.** `pending_review` is the store's judgement of a page; a publisher who could grant it would make the queue decorative.

## Verified by mutation, not asserted

**The transition guard.** Every transition checks what it is moving FROM. Deleting that check turns **four** tests red: a draft can be published without ever being submitted, a rejected page can be published by replaying a request, an approval can be replayed, a live page can be re-submitted. The refused states are as load-bearing as the allowed ones, and a happy-path suite would not have noticed.

**The publication date.** A page taken down and put back up keeps its **original** `published_at` — which is the whole reason that column exists rather than being read off `updated_at`. Mutating the write to always stamp it kills exactly the one test that guards it.

## Smaller decisions

- **Editing does not move a page.** Correcting a typo on a live listing leaves it live; fixing a rejected one does not re-submit it. Both are covered, because both are what silently starts happening once a status is written alongside content.
- **Unpublishing returns a page to `draft`**, never deletes it. The slug, the words and the screenshots are the publisher's work, and the reviews were never the listing's to take with them.
- **The category is taken by slug**, never id — an id in a form is an id in a bug report.
- **A misspelled category is named, not ignored.** Silently filing a page under "uncategorised" is the kind of thing nobody notices until a publisher asks why their app is nowhere.
- **The slug clash is caught on the named constraint** (`app_listings_slug_unique`), not on a bare `23505`. The table carries two unique constraints and a bare check would report "the slug is taken" for whichever fired.

## Not here

Screenshots — `app_listing_screenshots` has no write path yet. Next PR.

## Verification

49 tests against a real Postgres, 19 new. `bun run api:build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)