### PR TITLE
store: the pictures on a listing

### DIFF
--- a/packages/api/src/routes/applications.ts
+++ b/packages/api/src/routes/applications.ts
@@ -39,11 +39,23 @@ import {
   updateApplicationSchema,
   createCredentialSchema,
 } from '../schemas/application.schemas';
-import { storeListingBody } from '../schemas/store.schemas';
 import {
+  storeListingBody,
+  storeScreenshotBody,
+  storeScreenshotOrderBody,
+  storeScreenshotParams,
+  storeScreenshotPatch,
+} from '../schemas/store.schemas';
+import type { AppScreenshotPlatform } from '../db/schema/appListingScreenshots';
+import {
+  addScreenshot,
+  deleteScreenshot,
   getListingForApplication,
+  listScreenshots,
+  reorderScreenshots,
   submitListing,
   unpublishListing,
+  updateScreenshot,
   upsertListing,
 } from '../services/store.service';
 
@@ -1199,6 +1211,89 @@ router.post(
   requireAppPermission('app:update'),
   asyncHandler(async (req: AppContextRequest, res) => {
     res.json(await unpublishListing(requireApplication(req).id));
+  })
+);
+
+/** Every picture on the listing, in the author's order. */
+router.get(
+  '/:appId/listing/screenshots',
+  validate({ params: appIdRouteParams }),
+  requireAppPermission('app:read'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    res.json(await listScreenshots(requireApplication(req).id));
+  })
+);
+
+/**
+ * Attach an already-uploaded image. Appended to the end; `…/order` moves it.
+ *
+ * The upload itself is `/files`, unchanged: the store stores a reference, not a
+ * second copy of the asset pipeline.
+ */
+router.post(
+  '/:appId/listing/screenshots',
+  validate({ params: appIdRouteParams, body: storeScreenshotBody }),
+  requireAppPermission('app:update'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    const body = req.body as {
+      fileId: string;
+      platform?: AppScreenshotPlatform;
+      caption?: string | null;
+    };
+    res.status(201).json(
+      await addScreenshot({
+        applicationId: requireApplication(req).id,
+        callerUserId: requireUserId(req),
+        ...body,
+      })
+    );
+  })
+);
+
+/**
+ * Set the order of every picture at once.
+ *
+ * Declared before `/:screenshotId` so `order` is read as the route it is, not
+ * as a screenshot with that id — Express matches in declaration order.
+ */
+router.put(
+  '/:appId/listing/screenshots/order',
+  validate({ params: appIdRouteParams, body: storeScreenshotOrderBody }),
+  requireAppPermission('app:update'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    const { screenshotIds } = req.body as { screenshotIds: string[] };
+    res.json(await reorderScreenshots({ applicationId: requireApplication(req).id, screenshotIds }));
+  })
+);
+
+/** Edit a picture's caption or the frame it was taken in. */
+router.patch(
+  '/:appId/listing/screenshots/:screenshotId',
+  validate({ params: storeScreenshotParams, body: storeScreenshotPatch }),
+  requireAppPermission('app:update'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    const body = req.body as { platform?: AppScreenshotPlatform; caption?: string | null };
+    res.json(
+      await updateScreenshot({
+        applicationId: requireApplication(req).id,
+        screenshotId: req.params.screenshotId,
+        ...body,
+      })
+    );
+  })
+);
+
+/** Remove a picture. The file itself stays — it may be in use elsewhere. */
+router.delete(
+  '/:appId/listing/screenshots/:screenshotId',
+  validate({ params: storeScreenshotParams }),
+  requireAppPermission('app:update'),
+  asyncHandler(async (req: AppContextRequest, res) => {
+    await deleteScreenshot({
+      applicationId: requireApplication(req).id,
+      screenshotId: req.params.screenshotId,
+    });
+    res.status(204).end();
   })
 );
 

--- a/packages/api/src/schemas/store.schemas.ts
+++ b/packages/api/src/schemas/store.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { APP_SCREENSHOT_PLATFORMS } from '../db/schema/appListingScreenshots';
 
 /** A store URL segment: the listing's own `slug`, never an application id. */
 export const storeSlugParams = z.object({
@@ -101,4 +102,43 @@ export const storeModerationQuery = z.object({
 /** An application id in the path, for the moderation decisions. */
 export const storeModerationParams = z.object({
   applicationId: z.string().trim().min(1).max(64),
+});
+
+/** POST /applications/:appId/listing/screenshots — attach an uploaded image. */
+export const storeScreenshotBody = z.object({
+  /** An already-uploaded asset. The service checks it is an image, live, and the caller's. */
+  fileId: z.string().trim().min(1).max(64),
+  platform: z.enum(APP_SCREENSHOT_PLATFORMS).optional(),
+  caption: z.string().trim().max(300).nullish(),
+});
+
+/**
+ * PATCH /applications/:appId/listing/screenshots/:screenshotId
+ *
+ * A patch, unlike the listing's `PUT`, because there is nothing to clear
+ * wholesale: a picture is its file, and only its words and its frame are
+ * editable. Position is not here — ordering is the whole-list `PUT` below, so
+ * there is exactly one way to move a picture.
+ */
+export const storeScreenshotPatch = z
+  .object({
+    platform: z.enum(APP_SCREENSHOT_PLATFORMS).optional(),
+    caption: z.string().trim().max(300).nullish(),
+  })
+  .refine((body) => Object.keys(body).length > 0, { message: 'Nothing to change' });
+
+export const storeScreenshotParams = z.object({
+  appId: z.string().trim().min(1).max(64),
+  screenshotId: z.string().trim().min(1).max(64),
+});
+
+/**
+ * PUT /applications/:appId/listing/screenshots/order
+ *
+ * Every id on the listing, exactly once, in the order they should appear. A
+ * partial list would leave the omitted pictures at their old positions,
+ * interleaved with the new ones.
+ */
+export const storeScreenshotOrderBody = z.object({
+  screenshotIds: z.array(z.string().trim().min(1).max(64)).min(1).max(50),
 });

--- a/packages/api/src/services/__tests__/store.screenshots.test.ts
+++ b/packages/api/src/services/__tests__/store.screenshots.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Pictures on a store page.
+ *
+ * Two things here are worth more than the CRUD around them, and both are
+ * covered by cases that FAIL rather than by cases that succeed.
+ *
+ * The first is scoping: every write names the listing as well as the screenshot
+ * id, so holding `app:update` on your own app does not let you edit a picture
+ * on somebody else's by guessing an id. The test for it uses two real listings
+ * and asks one to touch the other's row.
+ *
+ * The second is the file check. The foreign key only proves a row exists; it
+ * says nothing about whether the asset is live, is an image, or is the caller's
+ * to publish.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { appListingScreenshots } from '../../db/schema/appListingScreenshots';
+import { applications } from '../../db/schema/applications';
+import { files } from '../../db/schema/files';
+import { users } from '../../db/schema/users';
+import { BadRequestError, ForbiddenError, NotFoundError } from '../../utils/error';
+import {
+  addScreenshot,
+  deleteScreenshot,
+  listScreenshots,
+  reorderScreenshots,
+  updateScreenshot,
+  upsertListing,
+} from '../store.service';
+
+beforeAll(async () => {
+  await connectPostgres();
+});
+
+afterAll(async () => {
+  await closePostgres();
+});
+
+async function insertUser(): Promise<string> {
+  const suffix = randomUUID().slice(0, 8);
+  const [row] = await getDb()
+    .insert(users)
+    .values({ username: `shot-${suffix}`, email: `shot-${suffix}@example.test` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+/** An application with a listing, plus the account that owns both. */
+async function listedApp(): Promise<{ applicationId: string; ownerId: string }> {
+  const ownerId = await insertUser();
+  const [application] = await getDb()
+    .insert(applications)
+    .values({ name: `App ${randomUUID().slice(0, 8)}`, ownerAccountId: ownerId })
+    .returning({ id: applications.id });
+  await upsertListing({ applicationId: application.id, slug: `slug-${randomUUID().slice(0, 8)}` });
+  return { applicationId: application.id, ownerId };
+}
+
+/** An uploaded asset belonging to `ownerUserId`. */
+async function uploadFile(
+  ownerUserId: string | null,
+  overrides: Partial<typeof files.$inferInsert> = {}
+): Promise<string> {
+  const suffix = randomUUID();
+  const [row] = await getDb()
+    .insert(files)
+    .values({
+      sha256: suffix.replace(/-/g, '').repeat(2).slice(0, 64),
+      size: 1024,
+      mime: 'image/png',
+      ext: 'png',
+      ownerUserId,
+      storageKey: `test/${suffix}.png`,
+      ...overrides,
+    })
+    .returning({ id: files.id });
+  return row.id;
+}
+
+describe('attaching a picture', () => {
+  it('appends it, and hands back where it landed', async () => {
+    const { applicationId, ownerId } = await listedApp();
+
+    const first = await addScreenshot({
+      applicationId,
+      callerUserId: ownerId,
+      fileId: await uploadFile(ownerId),
+      platform: 'phone',
+      caption: 'The inbox',
+    });
+    const second = await addScreenshot({
+      applicationId,
+      callerUserId: ownerId,
+      fileId: await uploadFile(ownerId),
+    });
+
+    expect(first.position).toBe(0);
+    expect(first.platform).toBe('phone');
+    expect(first.caption).toBe('The inbox');
+    expect(second.position).toBe(1);
+    // Not carried over from the previous shot, and not null: the column's own
+    // default is what an unspecified frame means.
+    expect(second.platform).toBe('desktop');
+  });
+
+  it('refuses a file that is not an image', async () => {
+    const { applicationId, ownerId } = await listedApp();
+    const fileId = await uploadFile(ownerId, { mime: 'application/pdf', ext: 'pdf' });
+
+    await expect(addScreenshot({ applicationId, callerUserId: ownerId, fileId })).rejects.toThrow(
+      BadRequestError
+    );
+  });
+
+  it('refuses a file that is in the trash', async () => {
+    const { applicationId, ownerId } = await listedApp();
+    const fileId = await uploadFile(ownerId, { status: 'trash' });
+
+    await expect(addScreenshot({ applicationId, callerUserId: ownerId, fileId })).rejects.toThrow(
+      NotFoundError
+    );
+  });
+
+  it('refuses a stranger’s file — the foreign key would have accepted it', async () => {
+    const { applicationId, ownerId } = await listedApp();
+    const someoneElse = await insertUser();
+    const fileId = await uploadFile(someoneElse);
+
+    await expect(addScreenshot({ applicationId, callerUserId: ownerId, fileId })).rejects.toThrow(
+      ForbiddenError
+    );
+  });
+
+  it('says so when the application has no listing to hold pictures', async () => {
+    const ownerId = await insertUser();
+    const [application] = await getDb()
+      .insert(applications)
+      .values({ name: `App ${randomUUID().slice(0, 8)}`, ownerAccountId: ownerId })
+      .returning({ id: applications.id });
+
+    await expect(
+      addScreenshot({
+        applicationId: application.id,
+        callerUserId: ownerId,
+        fileId: await uploadFile(ownerId),
+      })
+    ).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe('a write names the listing, not just the id', () => {
+  it('will not edit a picture that belongs to another app', async () => {
+    const mine = await listedApp();
+    const theirs = await listedApp();
+    const theirShot = await addScreenshot({
+      applicationId: theirs.applicationId,
+      callerUserId: theirs.ownerId,
+      fileId: await uploadFile(theirs.ownerId),
+      caption: 'Theirs',
+    });
+
+    await expect(
+      updateScreenshot({
+        applicationId: mine.applicationId,
+        screenshotId: theirShot.id,
+        caption: 'Mine now',
+      })
+    ).rejects.toThrow(NotFoundError);
+
+    const [untouched] = await getDb()
+      .select()
+      .from(appListingScreenshots)
+      .where(eq(appListingScreenshots.id, theirShot.id));
+    expect(untouched.caption).toBe('Theirs');
+  });
+
+  it('will not delete one either', async () => {
+    const mine = await listedApp();
+    const theirs = await listedApp();
+    const theirShot = await addScreenshot({
+      applicationId: theirs.applicationId,
+      callerUserId: theirs.ownerId,
+      fileId: await uploadFile(theirs.ownerId),
+    });
+
+    await expect(
+      deleteScreenshot({ applicationId: mine.applicationId, screenshotId: theirShot.id })
+    ).rejects.toThrow(NotFoundError);
+
+    expect(await listScreenshots(theirs.applicationId)).toHaveLength(1);
+  });
+});
+
+describe('editing a picture', () => {
+  it('changes only what was named', async () => {
+    const { applicationId, ownerId } = await listedApp();
+    const shot = await addScreenshot({
+      applicationId,
+      callerUserId: ownerId,
+      fileId: await uploadFile(ownerId),
+      platform: 'tablet',
+      caption: 'Before',
+    });
+
+    const edited = await updateScreenshot({
+      applicationId,
+      screenshotId: shot.id,
+      caption: 'After',
+    });
+
+    expect(edited.caption).toBe('After');
+    expect(edited.platform).toBe('tablet');
+    expect(edited.fileId).toBe(shot.fileId);
+  });
+
+  it('clears a caption when asked to, and blank means cleared', async () => {
+    const { applicationId, ownerId } = await listedApp();
+    const shot = await addScreenshot({
+      applicationId,
+      callerUserId: ownerId,
+      fileId: await uploadFile(ownerId),
+      caption: 'Something',
+    });
+
+    expect((await updateScreenshot({ applicationId, screenshotId: shot.id, caption: null })).caption).toBeNull();
+
+    await updateScreenshot({ applicationId, screenshotId: shot.id, caption: 'Again' });
+    expect(
+      (await updateScreenshot({ applicationId, screenshotId: shot.id, caption: '  ' })).caption
+    ).toBeNull();
+  });
+});
+
+describe('removing a picture', () => {
+  it('removes the row and leaves the file alone', async () => {
+    const { applicationId, ownerId } = await listedApp();
+    const fileId = await uploadFile(ownerId);
+    const shot = await addScreenshot({ applicationId, callerUserId: ownerId, fileId });
+
+    await deleteScreenshot({ applicationId, screenshotId: shot.id });
+
+    expect(await listScreenshots(applicationId)).toEqual([]);
+    // The asset may be in use elsewhere; unpinning it here is not a delete.
+    expect(await getDb().select().from(files).where(eq(files.id, fileId))).toHaveLength(1);
+  });
+
+  it('says so when there is no such picture here', async () => {
+    const { applicationId } = await listedApp();
+
+    await expect(
+      deleteScreenshot({ applicationId, screenshotId: `missing-${randomUUID()}` })
+    ).rejects.toThrow(NotFoundError);
+  });
+});
+
+describe('reordering', () => {
+  async function threeShots(): Promise<{ applicationId: string; ids: string[] }> {
+    const { applicationId, ownerId } = await listedApp();
+    const ids: string[] = [];
+    for (const caption of ['a', 'b', 'c']) {
+      const shot = await addScreenshot({
+        applicationId,
+        callerUserId: ownerId,
+        fileId: await uploadFile(ownerId),
+        caption,
+      });
+      ids.push(shot.id);
+    }
+    return { applicationId, ids };
+  }
+
+  it('puts them in the order asked for', async () => {
+    const { applicationId, ids } = await threeShots();
+
+    const reordered = await reorderScreenshots({
+      applicationId,
+      screenshotIds: [ids[2], ids[0], ids[1]],
+    });
+
+    expect(reordered.map((shot) => shot.id)).toEqual([ids[2], ids[0], ids[1]]);
+    expect(reordered.map((shot) => shot.position)).toEqual([0, 1, 2]);
+    // And the order survives a fresh read, rather than only the returned array.
+    expect((await listScreenshots(applicationId)).map((shot) => shot.caption)).toEqual([
+      'c',
+      'a',
+      'b',
+    ]);
+  });
+
+  it('refuses a partial list, which would interleave what it omits', async () => {
+    const { applicationId, ids } = await threeShots();
+
+    await expect(
+      reorderScreenshots({ applicationId, screenshotIds: [ids[1], ids[0]] })
+    ).rejects.toThrow(BadRequestError);
+    expect((await listScreenshots(applicationId)).map((shot) => shot.id)).toEqual(ids);
+  });
+
+  it('refuses a repeated id, and one that is not on this listing', async () => {
+    const { applicationId, ids } = await threeShots();
+    const elsewhere = await threeShots();
+
+    await expect(
+      reorderScreenshots({ applicationId, screenshotIds: [ids[0], ids[0], ids[1]] })
+    ).rejects.toThrow(BadRequestError);
+    await expect(
+      reorderScreenshots({ applicationId, screenshotIds: [ids[0], ids[1], elsewhere.ids[0]] })
+    ).rejects.toThrow(BadRequestError);
+  });
+});

--- a/packages/api/src/services/store.service.ts
+++ b/packages/api/src/services/store.service.ts
@@ -16,15 +16,19 @@
  * is next repaired.
  */
 
-import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { getDb } from '../config/postgres';
 import { appCategories } from '../db/schema/appCategories';
 import { appGrants } from '../db/schema/appGrants';
-import { appListingScreenshots } from '../db/schema/appListingScreenshots';
+import {
+  appListingScreenshots,
+  type AppScreenshotPlatform,
+} from '../db/schema/appListingScreenshots';
 import { appListings, type AppListingStatus } from '../db/schema/appListings';
 import { appReviewReplies } from '../db/schema/appReviewReplies';
 import { appReviews, type AppReviewStatus } from '../db/schema/appReviews';
 import { applications } from '../db/schema/applications';
+import { files } from '../db/schema/files';
 import { users } from '../db/schema/users';
 import { isUniqueViolation } from '@oxyhq/db';
 import { accountService } from './account.service';
@@ -571,8 +575,11 @@ export interface PublisherListing {
 }
 
 /** Read one listing back with its category resolved, by application. */
-async function publisherListingFor(applicationId: string): Promise<PublisherListing | null> {
-  const [row] = await getDb()
+async function publisherListings(
+  where: SQL | undefined,
+  order?: { limit: number; offset: number }
+): Promise<PublisherListing[]> {
+  const query = getDb()
     .select({
       id: appListings.id,
       applicationId: appListings.applicationId,
@@ -590,16 +597,21 @@ async function publisherListingFor(applicationId: string): Promise<PublisherList
     })
     .from(appListings)
     .leftJoin(appCategories, eq(appCategories.id, appListings.categoryId))
-    .where(eq(appListings.applicationId, applicationId))
-    .limit(1);
+    .where(where)
+    .orderBy(asc(appListings.updatedAt), asc(appListings.id));
 
-  if (!row) return null;
+  const rows = await (order ? query.limit(order.limit).offset(order.offset) : query);
 
-  const { categorySlug, categoryLabel, ...listing } = row;
-  return {
+  return rows.map(({ categorySlug, categoryLabel, ...listing }) => ({
     ...listing,
     category: categorySlug ? { slug: categorySlug, label: categoryLabel! } : null,
-  };
+  }));
+}
+
+/** Read one listing back with its category resolved, by application. */
+async function publisherListingFor(applicationId: string): Promise<PublisherListing | null> {
+  const [listing] = await publisherListings(eq(appListings.applicationId, applicationId));
+  return listing ?? null;
 }
 
 /** The listing for an application, in whatever state, or null if it has none. */
@@ -761,23 +773,14 @@ export async function listListingsAwaitingReview(options: {
   limit: number;
   offset: number;
 }): Promise<{ items: PublisherListing[]; total: number }> {
-  const db = getDb();
   const where = eq(appListings.status, 'pending_review');
 
-  const [rows, [totals]] = await Promise.all([
-    db
-      .select({ applicationId: appListings.applicationId })
-      .from(appListings)
-      .where(where)
-      .orderBy(asc(appListings.updatedAt), asc(appListings.id))
-      .limit(options.limit)
-      .offset(options.offset),
-    db.select({ value: count() }).from(appListings).where(where),
+  const [items, [totals]] = await Promise.all([
+    publisherListings(where, options),
+    getDb().select({ value: count() }).from(appListings).where(where),
   ]);
 
-  const listings = await Promise.all(rows.map((row) => publisherListingFor(row.applicationId)));
-
-  return { items: listings.filter((listing): listing is PublisherListing => listing !== null), total: Number(totals?.value ?? 0) };
+  return { items, total: Number(totals?.value ?? 0) };
 }
 
 /** Publish a page that was submitted for review. */
@@ -797,4 +800,207 @@ export async function rejectListing(applicationId: string): Promise<PublisherLis
     from: ['pending_review'],
     to: 'rejected',
   });
+}
+
+// ============================================================================
+// Screenshots
+//
+// A picture on a store page is a row rather than an entry in a `text[]`, and
+// `app_listing_screenshots` says why: each carries a caption, a platform and a
+// position, and `file_id` is a real foreign key, so a purged asset cannot leave
+// a hole on a published page.
+//
+// Every write below is scoped to the listing as well as to the screenshot id.
+// An id alone would let anyone holding `app:update` on THEIR app edit a picture
+// on somebody else's, which is the shape of every id-guessing bug ever filed.
+// ============================================================================
+
+export interface ListingScreenshot {
+  id: string;
+  fileId: string;
+  platform: AppScreenshotPlatform;
+  caption: string | null;
+  position: number;
+}
+
+const SCREENSHOT_COLUMNS = {
+  id: appListingScreenshots.id,
+  fileId: appListingScreenshots.fileId,
+  platform: appListingScreenshots.platform,
+  caption: appListingScreenshots.caption,
+  position: appListingScreenshots.position,
+} as const;
+
+/** The listing an application must already have before it can hold pictures. */
+async function requireListingId(applicationId: string): Promise<string> {
+  const [listing] = await getDb()
+    .select({ id: appListings.id })
+    .from(appListings)
+    .where(eq(appListings.applicationId, applicationId))
+    .limit(1);
+
+  if (!listing) throw new NotFoundError('This application has no listing');
+  return listing.id;
+}
+
+/** Every picture on a listing, in the author's order. */
+export async function listScreenshots(applicationId: string): Promise<ListingScreenshot[]> {
+  const listingId = await requireListingId(applicationId);
+
+  return getDb()
+    .select(SCREENSHOT_COLUMNS)
+    .from(appListingScreenshots)
+    .where(eq(appListingScreenshots.listingId, listingId))
+    .orderBy(asc(appListingScreenshots.position), asc(appListingScreenshots.id));
+}
+
+/**
+ * Attach an already-uploaded image to the listing.
+ *
+ * The file is checked here rather than left to the foreign key, because the FK
+ * only proves the row exists. Three things have to hold, and each has its own
+ * answer: the asset must not be in the trash, it must be an image, and the
+ * caller must be entitled to it — which is the account graph's question again,
+ * asked of the file's owner, so a colleague can attach an asset the account
+ * owns and nobody can attach a stranger's.
+ */
+export async function addScreenshot(options: {
+  applicationId: string;
+  callerUserId: string;
+  fileId: string;
+  platform?: AppScreenshotPlatform;
+  caption?: string | null;
+}): Promise<ListingScreenshot> {
+  const listingId = await requireListingId(options.applicationId);
+
+  // Three columns rather than the file repository's full record: this asks
+  // "may I attach this?", not "give me the asset", and the repository's read
+  // pulls the variant rows a screenshot has no use for.
+  const [file] = await getDb()
+    .select({ ownerUserId: files.ownerUserId, status: files.status, mime: files.mime })
+    .from(files)
+    .where(eq(files.id, options.fileId))
+    .limit(1);
+
+  if (!file || file.status !== 'active') throw new NotFoundError('No such file');
+  if (!file.mime.startsWith('image/')) throw new BadRequestError('A screenshot must be an image');
+
+  const entitled =
+    file.ownerUserId !== null &&
+    (await accountService.resolveEffectiveAccess(options.callerUserId, file.ownerUserId)) !== null;
+  if (!entitled) throw new ForbiddenError('That file is not yours to publish');
+
+  // Appended, and ties are fine: `position` is deliberately not unique, so two
+  // concurrent adds landing on the same number order by `id` between them
+  // rather than one of them failing.
+  const [{ next } = { next: 0 }] = await getDb()
+    .select({ next: sql<number>`coalesce(max(${appListingScreenshots.position}), -1) + 1` })
+    .from(appListingScreenshots)
+    .where(eq(appListingScreenshots.listingId, listingId));
+
+  const [row] = await getDb()
+    .insert(appListingScreenshots)
+    .values({
+      listingId,
+      fileId: options.fileId,
+      platform: options.platform ?? 'desktop',
+      caption: options.caption?.trim() || null,
+      position: Number(next),
+    })
+    .returning(SCREENSHOT_COLUMNS);
+
+  return row;
+}
+
+/** Edit a picture's caption or the frame it was taken in. Order is `reorderScreenshots`. */
+export async function updateScreenshot(options: {
+  applicationId: string;
+  screenshotId: string;
+  platform?: AppScreenshotPlatform;
+  caption?: string | null;
+}): Promise<ListingScreenshot> {
+  const listingId = await requireListingId(options.applicationId);
+
+  const [row] = await getDb()
+    .update(appListingScreenshots)
+    .set({
+      ...(options.platform === undefined ? {} : { platform: options.platform }),
+      ...(options.caption === undefined ? {} : { caption: options.caption?.trim() || null }),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(appListingScreenshots.id, options.screenshotId),
+        eq(appListingScreenshots.listingId, listingId)
+      )
+    )
+    .returning(SCREENSHOT_COLUMNS);
+
+  if (!row) throw new NotFoundError('No such screenshot on this listing');
+  return row;
+}
+
+/** Remove a picture. The file itself is untouched — it may be in use elsewhere. */
+export async function deleteScreenshot(options: {
+  applicationId: string;
+  screenshotId: string;
+}): Promise<void> {
+  const listingId = await requireListingId(options.applicationId);
+
+  const deleted = await getDb()
+    .delete(appListingScreenshots)
+    .where(
+      and(
+        eq(appListingScreenshots.id, options.screenshotId),
+        eq(appListingScreenshots.listingId, listingId)
+      )
+    )
+    .returning({ id: appListingScreenshots.id });
+
+  if (deleted.length === 0) throw new NotFoundError('No such screenshot on this listing');
+}
+
+/**
+ * Set the order of every picture at once.
+ *
+ * The WHOLE set, not a move: a partial list would leave the pictures it omits
+ * at their old positions, interleaved with the new ones, and the result is an
+ * order nobody asked for. Sending every id makes the request say exactly what
+ * the page should look like, and makes a client that lost a picture along the
+ * way fail loudly instead of scrambling the rest.
+ *
+ * One transaction, because a reorder that stopped halfway is worse than one
+ * that did not happen.
+ */
+export async function reorderScreenshots(options: {
+  applicationId: string;
+  screenshotIds: string[];
+}): Promise<ListingScreenshot[]> {
+  const listingId = await requireListingId(options.applicationId);
+
+  const existing = await getDb()
+    .select({ id: appListingScreenshots.id })
+    .from(appListingScreenshots)
+    .where(eq(appListingScreenshots.listingId, listingId));
+
+  const known = new Set(existing.map((row) => row.id));
+  const asked = new Set(options.screenshotIds);
+  if (
+    asked.size !== options.screenshotIds.length ||
+    asked.size !== known.size ||
+    options.screenshotIds.some((id) => !known.has(id))
+  ) {
+    throw new BadRequestError('Send every screenshot on the listing, exactly once');
+  }
+
+  await getDb().transaction(async (tx) => {
+    for (const [position, id] of options.screenshotIds.entries()) {
+      await tx
+        .update(appListingScreenshots)
+        .set({ position, updatedAt: new Date() })
+        .where(eq(appListingScreenshots.id, id));
+    }
+  });
+
+  return listScreenshots(options.applicationId);
 }


### PR DESCRIPTION
The last write path the store was missing. `app_listing_screenshots` had a schema and a read; nothing could put a row in it.

| | |
|---|---|
| `GET /applications/:appId/listing/screenshots` | every picture, in order |
| `POST …/screenshots` | attach an uploaded image, appended |
| `PATCH …/screenshots/:screenshotId` | its caption or its frame |
| `DELETE …/screenshots/:screenshotId` | remove it |
| `PUT …/screenshots/order` | set the order of all of them |

The upload itself is still `/files`. The store keeps a **reference**, not a second copy of the asset pipeline.

## The two checks that matter, both verified by mutation

**Every write names the LISTING as well as the screenshot id.** Dropping that from the `where` — leaving an id-only match, which is exactly what a careless refactor produces — lets anyone holding `app:update` on their own app edit or delete a picture on somebody else's by guessing an id. Two tests go red, and they use two real listings rather than a hand-built id, so they fail for the reason they claim to.

**The file is checked before it is attached.** The foreign key only proves the row exists. It says nothing about whether the asset is live, is an image, or is the caller's to publish — and that last one is the account graph's question again, asked of the file's **owner**, so a colleague can attach an asset the account owns and nobody can attach a stranger's. Removing the check turns red the one test that guards it.

## Reordering takes the whole set

Every id, exactly once. A partial list would leave the pictures it omits at their old positions, interleaved with the new ones, and the result is an order nobody asked for. Sending every id makes the request say what the page should look like, and makes a client that dropped a picture fail loudly rather than scramble the rest. One transaction, since a reorder that stopped halfway is worse than one that did not happen.

Position is deliberately not unique (the schema says why), so two concurrent adds landing on the same number order by `id` between them rather than one of them failing.

`…/order` is declared **before** `…/:screenshotId` — Express matches in declaration order, and otherwise `order` reads as a screenshot with that id.

## Also in here

Removes an N+1 I left in the moderation queue in #860: it read one listing per row through the same helper the single-listing read uses. That helper now takes a condition and returns many, so the queue is one query again.

## Verification

63 tests against a real Postgres, 14 new. `bun run api:build` clean.

With this the store's API is complete: a page can be written, illustrated, handed in, published, read, reviewed and answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)