### PR TITLE
core: the app store's client surface

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,29 @@ export type {
 } from './mixins/OxyServices.connectedApps';
 
 // ---------------------------------------------------------------------------
+// App store (public storefront + reviews + the listing a publisher edits)
+// ---------------------------------------------------------------------------
+export type {
+    StoreCategory,
+    StoreRating,
+    StoreListingSummary,
+    StoreListingDetail,
+    StoreScreenshot,
+    StoreScreenshotPlatform,
+    StoreReview,
+    StoreOwnReview,
+    WriteStoreReviewInput,
+    StoreListingStatus,
+    PublisherListing,
+    WriteListingInput,
+    AddScreenshotInput,
+    UpdateScreenshotInput,
+    StorePage,
+    StorePageOptions,
+    StoreReviewsOptions,
+} from './mixins/OxyServices.store';
+
+// ---------------------------------------------------------------------------
 // Accounts (unified account graph: tree, membership, roles, bot credentials)
 // plus the applications owned within it (Application = OAuth client).
 // ---------------------------------------------------------------------------

--- a/packages/core/src/mixins/OxyServices.store.ts
+++ b/packages/core/src/mixins/OxyServices.store.ts
@@ -1,0 +1,585 @@
+/**
+ * App Store Methods Mixin
+ *
+ * The client surface for the Oxy app store: the public storefront (`/store`),
+ * the reviews people write there, and the listing a publisher edits for an
+ * application they own (`/applications/:appId/listing`).
+ *
+ * Deliberately separate from `OxyServices.accounts.ts` even though the
+ * publisher's routes hang off an application, for the same reason
+ * `OxyServices.connectedApps.ts` is: those mixins answer "may this program act
+ * for this person?", and this one answers "should this person choose it?". Turn
+ * the store off and OAuth still works — which is the test that says the store is
+ * a module over the platform rather than part of it.
+ *
+ * The two prefixes are one domain. A listing IS the store's page for an
+ * application, so both halves of its life belong to the same surface; the API
+ * puts the publisher's half beside credentials and webhooks because that is
+ * where the permission that guards it already lives, and reusing that permission
+ * is what stops a store page becoming a second, weaker way to act for somebody's
+ * app.
+ *
+ * ## What is NOT duplicated here
+ *
+ * A listing carries no name, icon or legal links: `applications` already holds
+ * them and the storefront joins them in. A rating is computed from the visible
+ * reviews on every read rather than stored, so a hidden review stops counting
+ * the moment it is hidden. Reference listings by their `slug` in the storefront
+ * (it is what every link carries) and applications by their `_id` in the
+ * publisher's calls.
+ */
+import type { OxyServicesBase } from '../OxyServices.base';
+import { CACHE_TIMES } from './mixinHelpers';
+
+/** A shelf on the storefront. */
+export interface StoreCategory {
+  /** The public identifier a link carries. Never the row id. */
+  slug: string;
+  /** What a person reads. Never derived from the slug at render time. */
+  label: string;
+  description?: string | null;
+}
+
+/** The rating of an app, computed from its visible reviews. */
+export interface StoreRating {
+  /** Rounded to one decimal, or `null` when nobody has reviewed it — never 0. */
+  average: number | null;
+  count: number;
+}
+
+/** An app as a card on the storefront: what a listing page needs, and no more. */
+export interface StoreListingSummary {
+  slug: string;
+  /** From the APPLICATION, joined in — the listing keeps no copy. */
+  name: string;
+  tagline: string | null;
+  /** A file id for the app's icon, resolved through the usual image resolver. */
+  icon: string | null;
+  category: StoreCategory | null;
+  rating: StoreRating;
+}
+
+/** A store page in full. */
+export interface StoreListingDetail extends StoreListingSummary {
+  description: string | null;
+  /** These four come from the application; the consent screen shows the same values. */
+  websiteUrl: string | null;
+  privacyPolicyUrl: string | null;
+  termsUrl: string | null;
+  supportUrl: string | null;
+  supportEmail: string | null;
+  publishedAt: string | null;
+  screenshots: StoreScreenshot[];
+  /** How many visible reviews gave each of 1..5. Absent keys are zero. */
+  ratingBreakdown: Record<number, number>;
+}
+
+/** Which frame a screenshot was taken in. The store groups by it on the page. */
+export type StoreScreenshotPlatform = 'phone' | 'tablet' | 'desktop' | 'web';
+
+export interface StoreScreenshot {
+  id: string;
+  /** The uploaded asset's file id. Upload through the assets surface first. */
+  fileId: string;
+  platform: StoreScreenshotPlatform;
+  caption: string | null;
+  position: number;
+}
+
+/** Somebody's review, as it appears on a store page. */
+export interface StoreReview {
+  id: string;
+  rating: number;
+  title: string | null;
+  body: string | null;
+  createdAt: string;
+  author: { id: string; username: string | null };
+  /** The publisher's answer, when there is one. */
+  reply: { body: string; createdAt: string } | null;
+  /**
+   * Whether this author has authorized the application, read from their grant
+   * at request time rather than stored on the review.
+   *
+   * It is not a claim that they still use it, and it is `false` for a
+   * first-party app nobody has to consent to — so render its absence as nothing
+   * at all rather than as a demotion.
+   */
+  authorUsesApp: boolean;
+}
+
+/** A review as its own author sees it, whatever its moderation state. */
+export interface StoreOwnReview {
+  id: string;
+  rating: number;
+  title: string | null;
+  body: string | null;
+  /** An author is told when their review is hidden; the public list is not. */
+  status: 'visible' | 'hidden' | 'flagged' | 'removed';
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** What a person submits about an app. One review each; writing again replaces it. */
+export interface WriteStoreReviewInput {
+  /** Whole stars, 1 to 5. The database enforces the bound too. */
+  rating: number;
+  title?: string | null;
+  body?: string | null;
+}
+
+/** Where a listing is in its life. `pending_review` is the STORE's review of the page. */
+export type StoreListingStatus = 'draft' | 'pending_review' | 'published' | 'rejected';
+
+/** A listing as its publisher sees it: whatever state it is in. */
+export interface PublisherListing {
+  id: string;
+  applicationId: string;
+  slug: string;
+  tagline: string | null;
+  description: string | null;
+  category: StoreCategory | null;
+  supportUrl: string | null;
+  supportEmail: string | null;
+  status: StoreListingStatus;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The whole page, not a patch: sending everything is what makes "clear the
+ * tagline" expressible at all.
+ *
+ * `status` is absent on purpose. Publishing is the store's decision and has its
+ * own calls, so a publisher cannot publish themselves by putting a field in a
+ * body.
+ */
+export interface WriteListingInput {
+  /** Lowercase letters, digits and single hyphens. What every link carries. */
+  slug: string;
+  tagline?: string | null;
+  description?: string | null;
+  /** A category SLUG, never its id. */
+  categorySlug?: string | null;
+  supportUrl?: string | null;
+  supportEmail?: string | null;
+}
+
+export interface AddScreenshotInput {
+  /** An already-uploaded image. Must be live, an image, and yours to publish. */
+  fileId: string;
+  platform?: StoreScreenshotPlatform;
+  caption?: string | null;
+}
+
+export interface UpdateScreenshotInput {
+  platform?: StoreScreenshotPlatform;
+  caption?: string | null;
+}
+
+/**
+ * One page of a paginated store read.
+ *
+ * `hasMore` comes from the API rather than being derived here, so a caller that
+ * pages does not have to re-implement the boundary the server already computed.
+ */
+export interface StorePage<T> {
+  items: T[];
+  total: number;
+  hasMore: boolean;
+}
+
+/** Options for paging the storefront and the reviews under an app. */
+export interface StorePageOptions {
+  limit?: number;
+  offset?: number;
+}
+
+export interface StoreReviewsOptions extends StorePageOptions {
+  /** Newest first by default; `rating` surfaces the strongest opinions. */
+  sort?: 'recent' | 'rating';
+}
+
+/**
+ * The API's paginated envelope. The counts live under `pagination`, NOT under
+ * `meta` — `meta` is what the single-object `sendSuccess` helper uses, and
+ * reading the wrong one yields a `total` of zero on every page with no error
+ * anywhere.
+ */
+interface PaginatedResponse<T> {
+  data?: T[];
+  pagination?: { total?: number; hasMore?: boolean };
+}
+
+/** Read one page out of that envelope. */
+function pageOf<T>(res: PaginatedResponse<T>): StorePage<T> {
+  return {
+    items: res.data ?? [],
+    total: res.pagination?.total ?? 0,
+    hasMore: res.pagination?.hasMore ?? false,
+  };
+}
+
+/**
+ * Build a query string from the options that were actually supplied.
+ *
+ * Generic over the options object rather than taking a `Record`: an interface
+ * has no implicit index signature in TypeScript, so `StoreReviewsOptions` would
+ * not be assignable to one and every call site would need a cast.
+ */
+function queryOf<T extends object>(params: T): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) search.set(key, String(value));
+  }
+  const rendered = search.toString();
+  return rendered ? `?${rendered}` : '';
+}
+
+export function OxyServicesStoreMixin<T extends typeof OxyServicesBase>(Base: T) {
+  return class extends Base {
+    constructor(...args: any[]) {
+      super(...(args as [any]));
+    }
+
+    // =========================================================================
+    // The storefront — /store. No authentication: everything served is public.
+    // =========================================================================
+
+    /** The shelves, in the order the store curates them. */
+    async listStoreCategories(): Promise<StoreCategory[]> {
+      try {
+        const res = await this.makeRequest<{ data: StoreCategory[] }>(
+          'GET',
+          '/store/categories',
+          undefined,
+          { cache: true, cacheTTL: CACHE_TIMES.MEDIUM },
+        );
+        return res.data ?? [];
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Published listings, newest first, optionally one shelf.
+     *
+     * An unknown category slug is an EMPTY shelf, not every app on the store —
+     * so a typo shows nothing rather than showing everything.
+     *
+     * @param options - `category` is a category slug; `limit` defaults to 24.
+     */
+    async listStoreApps(
+      options: StorePageOptions & { category?: string } = {},
+    ): Promise<StorePage<StoreListingSummary>> {
+      try {
+        const res = await this.makeRequest<PaginatedResponse<StoreListingSummary>>(
+          'GET',
+          `/store/apps${queryOf(options)}`,
+          undefined,
+          { cache: true, cacheTTL: CACHE_TIMES.SHORT },
+        );
+        return pageOf(res);
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * One store page.
+     *
+     * A draft answers 404 exactly as an unknown slug does: whether an
+     * unpublished page exists under a name is not something a visitor learns.
+     *
+     * @param slug - The listing's public slug, not an application id.
+     */
+    async getStoreApp(slug: string): Promise<StoreListingDetail> {
+      try {
+        const res = await this.makeRequest<{ data: StoreListingDetail }>(
+          'GET',
+          `/store/apps/${encodeURIComponent(slug)}`,
+          undefined,
+          { cache: true, cacheTTL: CACHE_TIMES.SHORT },
+        );
+        return res.data;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /** Visible reviews for a published app, each with the publisher's reply. */
+    async listStoreReviews(
+      slug: string,
+      options: StoreReviewsOptions = {},
+    ): Promise<StorePage<StoreReview>> {
+      try {
+        const res = await this.makeRequest<PaginatedResponse<StoreReview>>(
+          'GET',
+          `/store/apps/${encodeURIComponent(slug)}/reviews${queryOf(options)}`,
+          undefined,
+          { cache: true, cacheTTL: CACHE_TIMES.SHORT },
+        );
+        return pageOf(res);
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    // =========================================================================
+    // Reviewing — any signed-in Oxy account
+    // =========================================================================
+
+    /** The caller's own review of an app, or `null` if they have not written one. */
+    async getMyStoreReview(slug: string): Promise<StoreOwnReview | null> {
+      try {
+        const res = await this.makeRequest<{ data: StoreOwnReview | null }>(
+          'GET',
+          `/store/apps/${encodeURIComponent(slug)}/review`,
+          undefined,
+          { cache: false },
+        );
+        return res.data ?? null;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Write the caller's review, or replace what they said before.
+     *
+     * A person has one review per app, so this sets it rather than adding one.
+     * Rewriting does not clear a moderator's decision: a hidden review stays
+     * hidden when its author edits it.
+     */
+    async writeStoreReview(slug: string, input: WriteStoreReviewInput): Promise<StoreOwnReview> {
+      try {
+        const res = await this.makeRequest<{ data: StoreOwnReview }>(
+          'PUT',
+          `/store/apps/${encodeURIComponent(slug)}/review`,
+          input,
+          { cache: false },
+        );
+        return res.data;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /** Withdraw the caller's own review. A real delete — the words were theirs. */
+    async deleteMyStoreReview(slug: string): Promise<void> {
+      try {
+        await this.makeRequest<void>(
+          'DELETE',
+          `/store/apps/${encodeURIComponent(slug)}/review`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Answer a review on the publisher's behalf.
+     *
+     * Requires `app:update` over the application's owning account — the same
+     * permission that guards every other write to that application. Addressed
+     * by review id because the reply belongs to the review, and a listing can be
+     * renamed or withdrawn out from under it.
+     */
+    async replyToStoreReview(reviewId: string, body: string): Promise<{ id: string; reviewId: string; body: string }> {
+      try {
+        const res = await this.makeRequest<{ data: { id: string; reviewId: string; body: string } }>(
+          'PUT',
+          `/store/reviews/${encodeURIComponent(reviewId)}/reply`,
+          { body },
+          { cache: false },
+        );
+        return res.data;
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /** Withdraw the publisher's answer. Same permission that wrote it. */
+    async deleteStoreReviewReply(reviewId: string): Promise<void> {
+      try {
+        await this.makeRequest<void>(
+          'DELETE',
+          `/store/reviews/${encodeURIComponent(reviewId)}/reply`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    // =========================================================================
+    // The publisher's listing — /applications/:appId/listing
+    // =========================================================================
+
+    /** The application's store page in whatever state, or `null` if it has none. */
+    async getAppListing(applicationId: string): Promise<PublisherListing | null> {
+      try {
+        return await this.makeRequest<PublisherListing | null>(
+          'GET',
+          `/applications/${encodeURIComponent(applicationId)}/listing`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Create the page or replace its content. Never its status.
+     *
+     * Editing does not move a page: correcting a typo on a live listing leaves
+     * it live, and fixing a rejected one does not re-submit it.
+     */
+    async writeAppListing(applicationId: string, input: WriteListingInput): Promise<PublisherListing> {
+      try {
+        return await this.makeRequest<PublisherListing>(
+          'PUT',
+          `/applications/${encodeURIComponent(applicationId)}/listing`,
+          input,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /** Hand the page to the store for review. From a draft, or a rejected page once fixed. */
+    async submitAppListing(applicationId: string): Promise<PublisherListing> {
+      try {
+        return await this.makeRequest<PublisherListing>(
+          'POST',
+          `/applications/${encodeURIComponent(applicationId)}/listing/submit`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Take the page down, or withdraw it from the queue.
+     *
+     * Back to a draft, never deleted: the slug, the words and the screenshots
+     * are the publisher's work, and the reviews were never the listing's to take
+     * with them.
+     */
+    async unpublishAppListing(applicationId: string): Promise<PublisherListing> {
+      try {
+        return await this.makeRequest<PublisherListing>(
+          'POST',
+          `/applications/${encodeURIComponent(applicationId)}/listing/unpublish`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    // =========================================================================
+    // Screenshots
+    // =========================================================================
+
+    /** Every picture on the listing, in the author's order. */
+    async listAppListingScreenshots(applicationId: string): Promise<StoreScreenshot[]> {
+      try {
+        return await this.makeRequest<StoreScreenshot[]>(
+          'GET',
+          `/applications/${encodeURIComponent(applicationId)}/listing/screenshots`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Attach an already-uploaded image, appended to the end.
+     *
+     * Upload through the assets surface first; the store keeps a reference
+     * rather than a second copy of the asset pipeline. The file must be live, an
+     * image, and one the caller is entitled to.
+     */
+    async addAppListingScreenshot(
+      applicationId: string,
+      input: AddScreenshotInput,
+    ): Promise<StoreScreenshot> {
+      try {
+        return await this.makeRequest<StoreScreenshot>(
+          'POST',
+          `/applications/${encodeURIComponent(applicationId)}/listing/screenshots`,
+          input,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /** Edit a picture's caption or the frame it was taken in. Order is {@link reorderAppListingScreenshots}. */
+    async updateAppListingScreenshot(
+      applicationId: string,
+      screenshotId: string,
+      input: UpdateScreenshotInput,
+    ): Promise<StoreScreenshot> {
+      try {
+        return await this.makeRequest<StoreScreenshot>(
+          'PATCH',
+          `/applications/${encodeURIComponent(applicationId)}/listing/screenshots/${encodeURIComponent(screenshotId)}`,
+          input,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /** Remove a picture. The uploaded file stays — it may be in use elsewhere. */
+    async deleteAppListingScreenshot(applicationId: string, screenshotId: string): Promise<void> {
+      try {
+        await this.makeRequest<void>(
+          'DELETE',
+          `/applications/${encodeURIComponent(applicationId)}/listing/screenshots/${encodeURIComponent(screenshotId)}`,
+          undefined,
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+
+    /**
+     * Set the order of every picture at once.
+     *
+     * Send EVERY id on the listing, exactly once, in the order they should
+     * appear. A partial list is rejected rather than applied: it would leave the
+     * pictures it omits at their old positions, interleaved with the new ones.
+     */
+    async reorderAppListingScreenshots(
+      applicationId: string,
+      screenshotIds: string[],
+    ): Promise<StoreScreenshot[]> {
+      try {
+        return await this.makeRequest<StoreScreenshot[]>(
+          'PUT',
+          `/applications/${encodeURIComponent(applicationId)}/listing/screenshots/order`,
+          { screenshotIds },
+          { cache: false },
+        );
+      } catch (error) {
+        throw this.handleError(error);
+      }
+    }
+  };
+}

--- a/packages/core/src/mixins/__tests__/store.test.ts
+++ b/packages/core/src/mixins/__tests__/store.test.ts
@@ -1,0 +1,304 @@
+/**
+ * App Store Mixin Tests
+ *
+ * `makeRequest` is stubbed, so what these cover is the seam between this client
+ * and the API: the method, the URL, whether a value is URL-encoded, whether a
+ * read is cached, and — the part worth the most here — which envelope a
+ * response is unwrapped from.
+ *
+ * The API has two of those and they are not interchangeable. A single object
+ * comes back under `data`; a page comes back under `data` with its counts under
+ * `pagination`. Reading `meta` instead, which is the plausible mistake, yields
+ * `total: 0` on every page with no error anywhere and no type complaint — so it
+ * is asserted against a fixture that has a non-zero total rather than trusted.
+ *
+ * The publisher's listing routes answer with the object itself, no envelope at
+ * all, which is a third shape and is asserted separately for the same reason.
+ */
+
+import { OxyServices } from '../../OxyServices';
+import type {
+  PublisherListing,
+  StoreCategory,
+  StoreListingDetail,
+  StoreListingSummary,
+  StoreOwnReview,
+  StoreReview,
+  StoreScreenshot,
+} from '../OxyServices.store';
+
+const categoryFixture: StoreCategory = {
+  slug: 'productivity',
+  label: 'Productivity',
+  description: 'Get things done',
+};
+
+const summaryFixture: StoreListingSummary = {
+  slug: 'mention',
+  name: 'Mention',
+  tagline: 'The fediverse, at home',
+  icon: 'file-1',
+  category: categoryFixture,
+  rating: { average: 4.6, count: 31 },
+};
+
+const detailFixture: StoreListingDetail = {
+  ...summaryFixture,
+  description: '# Mention',
+  websiteUrl: 'https://mention.earth',
+  privacyPolicyUrl: null,
+  termsUrl: null,
+  supportUrl: null,
+  supportEmail: null,
+  publishedAt: '2026-08-01T00:00:00.000Z',
+  screenshots: [],
+  ratingBreakdown: { 4: 10, 5: 21 },
+};
+
+const reviewFixture: StoreReview = {
+  id: 'r1',
+  rating: 5,
+  title: null,
+  body: 'Good',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  author: { id: 'u1', username: 'nate' },
+  reply: null,
+  authorUsesApp: true,
+};
+
+const ownReviewFixture: StoreOwnReview = {
+  id: 'r1',
+  rating: 5,
+  title: null,
+  body: 'Good',
+  status: 'visible',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const listingFixture: PublisherListing = {
+  id: 'l1',
+  applicationId: 'app1',
+  slug: 'mention',
+  tagline: 'The fediverse, at home',
+  description: null,
+  category: categoryFixture,
+  supportUrl: null,
+  supportEmail: null,
+  status: 'draft',
+  publishedAt: null,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+};
+
+const screenshotFixture: StoreScreenshot = {
+  id: 's1',
+  fileId: 'file-9',
+  platform: 'desktop',
+  caption: null,
+  position: 0,
+};
+
+describe('OxyServicesStoreMixin', () => {
+  let oxy: OxyServices;
+  let makeRequestSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    oxy = new OxyServices({ baseURL: 'http://test.invalid' });
+    oxy.httpService.setTokens('test-token');
+    makeRequestSpy = jest.spyOn(oxy, 'makeRequest');
+  });
+
+  describe('the storefront', () => {
+    it('unwraps the shelves from `data` and caches the read', async () => {
+      makeRequestSpy.mockResolvedValue({ data: [categoryFixture] });
+
+      expect(await oxy.listStoreCategories()).toEqual([categoryFixture]);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'GET',
+        '/store/categories',
+        undefined,
+        expect.objectContaining({ cache: true }),
+      );
+    });
+
+    it('reads a page count from `pagination`, not from `meta`', async () => {
+      makeRequestSpy.mockResolvedValue({
+        data: [summaryFixture],
+        pagination: { total: 42, limit: 24, offset: 0, hasMore: true },
+      });
+
+      const page = await oxy.listStoreApps();
+
+      // The fixture's total is deliberately not the length of `data`, and not
+      // zero: reading the wrong envelope key would give 0 and reading `length`
+      // would give 1, so only the right one gives 42.
+      expect(page).toEqual({ items: [summaryFixture], total: 42, hasMore: true });
+    });
+
+    it('sends only the options that were supplied', async () => {
+      makeRequestSpy.mockResolvedValue({ data: [], pagination: { total: 0 } });
+
+      await oxy.listStoreApps();
+      expect(makeRequestSpy.mock.calls[0][1]).toBe('/store/apps');
+
+      // An absent option must not travel as `undefined`, which is what a naive
+      // template string produces and what the server would then have to reject.
+      await oxy.listStoreApps({ category: 'productivity', limit: 12 });
+      expect(makeRequestSpy.mock.calls[1][1]).toBe('/store/apps?category=productivity&limit=12');
+    });
+
+    it('survives a response with neither key', async () => {
+      makeRequestSpy.mockResolvedValue({});
+      expect(await oxy.listStoreApps()).toEqual({ items: [], total: 0, hasMore: false });
+    });
+
+    it('URL-encodes a slug in the path', async () => {
+      makeRequestSpy.mockResolvedValue({ data: detailFixture });
+
+      expect(await oxy.getStoreApp('a b/c')).toEqual(detailFixture);
+      expect(makeRequestSpy.mock.calls[0][1]).toBe('/store/apps/a%20b%2Fc');
+    });
+
+    it('pages reviews, and passes the sort through', async () => {
+      makeRequestSpy.mockResolvedValue({
+        data: [reviewFixture],
+        pagination: { total: 3, hasMore: false },
+      });
+
+      const page = await oxy.listStoreReviews('mention', { sort: 'rating', limit: 5 });
+
+      expect(page.total).toBe(3);
+      expect(page.items[0].authorUsesApp).toBe(true);
+
+      // Parsed rather than compared as a string: the parameter ORDER follows
+      // whatever order the caller wrote their options object in, and pinning
+      // that would make the test fail on a harmless edit at the call site.
+      const [path, query] = String(makeRequestSpy.mock.calls[0][1]).split('?');
+      expect(path).toBe('/store/apps/mention/reviews');
+      expect(Object.fromEntries(new URLSearchParams(query))).toEqual({
+        sort: 'rating',
+        limit: '5',
+      });
+    });
+  });
+
+  describe('reviewing', () => {
+    it('answers null when the caller has not written one', async () => {
+      makeRequestSpy.mockResolvedValue({ data: null });
+      expect(await oxy.getMyStoreReview('mention')).toBeNull();
+    });
+
+    it('PUTs the review — one per person, so it sets rather than adds', async () => {
+      makeRequestSpy.mockResolvedValue({ data: ownReviewFixture });
+
+      expect(await oxy.writeStoreReview('mention', { rating: 5, body: 'Good' })).toEqual(
+        ownReviewFixture,
+      );
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'PUT',
+        '/store/apps/mention/review',
+        { rating: 5, body: 'Good' },
+        expect.objectContaining({ cache: false }),
+      );
+    });
+
+    it('withdraws the caller’s own review', async () => {
+      makeRequestSpy.mockResolvedValue(undefined);
+
+      await oxy.deleteMyStoreReview('mention');
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'DELETE',
+        '/store/apps/mention/review',
+        undefined,
+        expect.objectContaining({ cache: false }),
+      );
+    });
+
+    it('addresses a reply by review id, not by the listing’s slug', async () => {
+      makeRequestSpy.mockResolvedValue({ data: { id: 'p1', reviewId: 'r1', body: 'Fixed' } });
+
+      await oxy.replyToStoreReview('r1', 'Fixed');
+      expect(makeRequestSpy.mock.calls[0][1]).toBe('/store/reviews/r1/reply');
+    });
+  });
+
+  describe('the publisher’s listing', () => {
+    it('takes the object straight — these routes carry no envelope', async () => {
+      makeRequestSpy.mockResolvedValue(listingFixture);
+
+      expect(await oxy.getAppListing('app1')).toEqual(listingFixture);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'GET',
+        '/applications/app1/listing',
+        undefined,
+        expect.objectContaining({ cache: false }),
+      );
+    });
+
+    it('PUTs the whole page, without a status field', async () => {
+      makeRequestSpy.mockResolvedValue(listingFixture);
+
+      await oxy.writeAppListing('app1', { slug: 'mention', tagline: 'Hello' });
+
+      const body = makeRequestSpy.mock.calls[0][2];
+      expect(body).toEqual({ slug: 'mention', tagline: 'Hello' });
+      expect(body).not.toHaveProperty('status');
+    });
+
+    it('submits and unpublishes through their own routes', async () => {
+      makeRequestSpy.mockResolvedValue(listingFixture);
+
+      await oxy.submitAppListing('app1');
+      expect(makeRequestSpy.mock.calls[0].slice(0, 2)).toEqual([
+        'POST',
+        '/applications/app1/listing/submit',
+      ]);
+
+      await oxy.unpublishAppListing('app1');
+      expect(makeRequestSpy.mock.calls[1].slice(0, 2)).toEqual([
+        'POST',
+        '/applications/app1/listing/unpublish',
+      ]);
+    });
+
+    it('URL-encodes the application id', async () => {
+      makeRequestSpy.mockResolvedValue(listingFixture);
+      await oxy.getAppListing('a b/c');
+      expect(makeRequestSpy.mock.calls[0][1]).toBe('/applications/a%20b%2Fc/listing');
+    });
+  });
+
+  describe('screenshots', () => {
+    it('attaches an uploaded file', async () => {
+      makeRequestSpy.mockResolvedValue(screenshotFixture);
+
+      await oxy.addAppListingScreenshot('app1', { fileId: 'file-9', platform: 'phone' });
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'POST',
+        '/applications/app1/listing/screenshots',
+        { fileId: 'file-9', platform: 'phone' },
+        expect.objectContaining({ cache: false }),
+      );
+    });
+
+    it('encodes both ids on an edit', async () => {
+      makeRequestSpy.mockResolvedValue(screenshotFixture);
+
+      await oxy.updateAppListingScreenshot('a b', 's/1', { caption: 'Home' });
+      expect(makeRequestSpy.mock.calls[0][1]).toBe('/applications/a%20b/listing/screenshots/s%2F1');
+    });
+
+    it('reorders by sending every id, on its own route', async () => {
+      makeRequestSpy.mockResolvedValue([screenshotFixture]);
+
+      await oxy.reorderAppListingScreenshots('app1', ['s2', 's1']);
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        'PUT',
+        '/applications/app1/listing/screenshots/order',
+        { screenshotIds: ['s2', 's1'] },
+        expect.objectContaining({ cache: false }),
+      );
+    });
+  });
+});

--- a/packages/core/src/mixins/index.ts
+++ b/packages/core/src/mixins/index.ts
@@ -17,6 +17,7 @@ import { OxyServicesReputationMixin } from './OxyServices.reputation';
 import { OxyServicesAssetsMixin } from './OxyServices.assets';
 import { OxyServicesAccountsMixin } from './OxyServices.accounts';
 import { OxyServicesConnectedAppsMixin } from './OxyServices.connectedApps';
+import { OxyServicesStoreMixin } from './OxyServices.store';
 import { OxyServicesLocationMixin } from './OxyServices.location';
 import { OxyServicesAnalyticsMixin } from './OxyServices.analytics';
 import { OxyServicesDevicesMixin } from './OxyServices.devices';
@@ -56,6 +57,7 @@ type AllMixinInstances =
   & InstanceType<ReturnType<typeof OxyServicesAssetsMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesAccountsMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesConnectedAppsMixin<typeof OxyServicesBase>>>
+  & InstanceType<ReturnType<typeof OxyServicesStoreMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesLocationMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesAnalyticsMixin<typeof OxyServicesBase>>>
   & InstanceType<ReturnType<typeof OxyServicesDevicesMixin<typeof OxyServicesBase>>>
@@ -125,6 +127,10 @@ const MIXIN_PIPELINE: MixinFunction[] = [
     // OAuth-consent surface (public app identity + connected-app grants). Kept
     // separate from account ownership.
     OxyServicesConnectedAppsMixin,
+    // The app store: the public storefront, the reviews on it, and the listing a
+    // publisher edits. A module OVER the platform — turn it off and OAuth still
+    // works — so it is its own surface rather than more of `accounts`.
+    OxyServicesStoreMixin,
     OxyServicesLocationMixin,
     OxyServicesAnalyticsMixin,
     OxyServicesDevicesMixin,


### PR DESCRIPTION
The store's API is complete (#857–#861) and nothing can call it. The Console reaches oxy-api through `oxyServices`, never a hand-rolled fetch, so the store needs a mixin before it can have a UI.

`OxyServices.store.ts` covers the whole surface: the public storefront, the reviews on it, the listing a publisher edits, and its screenshots.

## Why its own mixin

For the reason `connectedApps` is its own. Those mixins answer *"may this program act for this person?"*; this one answers *"should this person choose it?"*. Turn the store off and OAuth still works — which is the test that says the store is a module **over** the platform rather than part of it.

The two route prefixes are one domain. A listing **is** the store's page for an application, so both halves of its life belong to one client surface, even though the API puts the publisher's half beside credentials and webhooks — which it does because that is where the permission guarding it already lives.

## One bug, found by reading the server rather than trusting the types

oxy-api has **two** response envelopes:

- `sendSuccess` → a single object under `data`, with an optional `meta`
- `sendPaginated` → a page under `data`, with its counts under **`pagination`**

The first draft of this mixin read `meta.total`. That returns **`total: 0` for every paginated call** — no error, no type complaint, and a storefront that believes it has exactly one page. A third shape exists too: the publisher's listing routes answer with the object itself, no envelope, which is asserted separately.

The fixture that catches it carries a total of **42** behind a **single** item, so neither the wrong envelope (`0`) nor `data.length` (`1`) can pass by accident. Mutating the read to `data.length` turns two tests red.

`hasMore` is passed through from the server rather than derived here, so a caller that pages does not re-implement a boundary the API already computed.

## Verification

17 new tests. The full core suite is still green: **114 suites, 1596 tests** — registering a mixin touches the composition pipeline, so the whole suite is the check, not just the new file.

No version bump. Releases are their own `chore(release)` commit in this repo, and publishing has its own checklist (pack, inspect the tarball, verify propagation) that does not belong in a feature PR.

## Next

The Console's Store tab, which is what this exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)