### PR TITLE
console: a Store tab, and the permission check that was silently false

### DIFF
--- a/packages/console/src/components/apps/app-detail-header.tsx
+++ b/packages/console/src/components/apps/app-detail-header.tsx
@@ -1,14 +1,19 @@
 import { Link } from '@tanstack/react-router';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { ArrowLeft01Icon, RocketIcon, Settings01Icon } from '@hugeicons/core-free-icons';
+import {
+  ArrowLeft01Icon,
+  RocketIcon,
+  Settings01Icon,
+  ShopSignIcon,
+} from '@hugeicons/core-free-icons';
 import { cn } from '@/lib/utils';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { useAuth } from '@oxyhq/services';
 import { resolveStoredImageUrl } from '@/lib/image-upload';
 import type { Application, CallerAccess } from '@/hooks/use-applications';
 
-/** The two top-level sections of an application. */
-export type AppSection = 'settings' | 'updates';
+/** The top-level sections of an application. */
+export type AppSection = 'settings' | 'store' | 'updates';
 
 interface AppDetailHeaderProps {
   application: Application;
@@ -18,13 +23,16 @@ interface AppDetailHeaderProps {
 
 /**
  * Shared header for an application's detail pages: back link, identity, and the
- * top-level section navigation (Settings / Updates). The Updates section is only
- * offered to callers who hold `updates:manage` — the same permission the API
- * enforces on every `/updates/v1` endpoint — so viewers never see a tab that
- * would only 403.
+ * top-level section navigation.
+ *
+ * Each section is offered only to callers holding the permission the API
+ * enforces behind it, so nobody sees a tab that would only 403: `updates:manage`
+ * for Updates, `app:read` for Store — reading a listing needs no more than
+ * reading the app, and the form inside gates its own writes on `app:update`.
  */
 export function AppDetailHeader({ application, access, active }: AppDetailHeaderProps) {
   const { oxyServices } = useAuth();
+  const showStore = access.can('app:read');
   const showUpdates = access.can('updates:manage');
 
   return (
@@ -65,6 +73,15 @@ export function AppDetailHeader({ application, access, active }: AppDetailHeader
           label="Settings"
           isActive={active === 'settings'}
         />
+        {showStore && (
+          <SectionTab
+            to="/apps/$appId/store"
+            appId={application._id}
+            icon={ShopSignIcon}
+            label="Store"
+            isActive={active === 'store'}
+          />
+        )}
         {showUpdates && (
           <SectionTab
             to="/apps/$appId/updates"
@@ -80,7 +97,7 @@ export function AppDetailHeader({ application, access, active }: AppDetailHeader
 }
 
 interface SectionTabProps {
-  to: '/apps/$appId/settings' | '/apps/$appId/updates';
+  to: '/apps/$appId/settings' | '/apps/$appId/store' | '/apps/$appId/updates';
   appId: string;
   icon: typeof Settings01Icon;
   label: string;

--- a/packages/console/src/components/apps/general-section.tsx
+++ b/packages/console/src/components/apps/general-section.tsx
@@ -45,8 +45,8 @@ interface GeneralSectionProps {
 export function GeneralSection({ application, access }: GeneralSectionProps) {
   const navigate = useNavigate();
   const { oxyServices } = useAuth();
-  const canEdit = access.can('apps:update');
-  const canDelete = access.can('apps:delete');
+  const canEdit = access.can('app:update');
+  const canDelete = access.can('app:delete');
   const updateApplication = useUpdateApplication();
   const deleteApplication = useDeleteApplication();
 

--- a/packages/console/src/components/apps/store-section.tsx
+++ b/packages/console/src/components/apps/store-section.tsx
@@ -1,0 +1,461 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '@oxyhq/services';
+import { HugeiconsIcon } from '@hugeicons/react';
+import {
+  ArrowDown01Icon,
+  ArrowUp01Icon,
+  Delete02Icon,
+  Image01Icon,
+} from '@hugeicons/core-free-icons';
+import { toast } from '@oxyhq/bloom/toast';
+import type { Application, CallerAccess } from '@/hooks/use-applications';
+import type { PublisherListing, StoreScreenshot } from '@/hooks/use-store-listing';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { getErrorMessage } from '@/lib/api-error';
+import {
+  resolveStoredImageUrl,
+  uploadPublicImageFileId,
+  validateImageFile,
+} from '@/lib/image-upload';
+import {
+  moveScreenshot,
+  useAddScreenshot,
+  useDeleteScreenshot,
+  useReorderScreenshots,
+  useStoreCategories,
+  useStoreListing,
+  useStoreScreenshots,
+  useSubmitStoreListing,
+  useUnpublishStoreListing,
+  useWriteStoreListing,
+} from '@/hooks/use-store-listing';
+
+/** The four states a page can be in, and what each one means to its publisher. */
+const STATUS_COPY: Record<PublisherListing['status'], { label: string; help: string }> = {
+  draft: {
+    label: 'Draft',
+    help: 'Only you can see this. Submit it when you want the store to review it.',
+  },
+  pending_review: {
+    label: 'In review',
+    help: 'The store is looking at this page. You can withdraw it while it waits.',
+  },
+  published: {
+    label: 'Published',
+    help: 'Live on the store. Edits go out immediately; taking it down returns it to a draft.',
+  },
+  rejected: {
+    label: 'Sent back',
+    help: 'The store did not publish this. Fix what it asked for and submit it again.',
+  },
+};
+
+/** Turn an app name into a plausible first slug, matching the API's rule. */
+function slugFromName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 120);
+}
+
+/** A value the API stores as absent, so a cleared field round-trips as cleared. */
+function orNull(value: string): string | null {
+  return value.trim() || null;
+}
+
+interface StoreSectionProps {
+  application: Application;
+  access: CallerAccess;
+}
+
+/**
+ * The application's store page.
+ *
+ * Editing content and moving the page through review are separate actions here
+ * because they are separate calls in the API, and for the same reason: the words
+ * are the publisher's, the status is the store's. Saving a correction to a live
+ * page therefore leaves it live, which is what the buttons say.
+ */
+export function StoreSection({ application, access }: StoreSectionProps) {
+  const canEdit = access.can('app:update');
+  const { data: listing, isLoading } = useStoreListing(application._id);
+  const { data: categories } = useStoreCategories();
+
+  const writeListing = useWriteStoreListing(application._id);
+  const submitListing = useSubmitStoreListing(application._id);
+  const unpublishListing = useUnpublishStoreListing(application._id);
+
+  const [slug, setSlug] = useState('');
+  const [tagline, setTagline] = useState('');
+  const [description, setDescription] = useState('');
+  const [categorySlug, setCategorySlug] = useState('');
+  const [supportUrl, setSupportUrl] = useState('');
+  const [supportEmail, setSupportEmail] = useState('');
+
+  // The form is seeded from the server's answer once it arrives, and re-seeded
+  // whenever the row itself changes — which is why the effect keys on the
+  // listing's `updatedAt` rather than on the object, and why it is an effect at
+  // all: this is external state arriving, not a value derived from props.
+  const seededAt = useRef<string | null>(null);
+  useEffect(() => {
+    if (isLoading) return;
+    const stamp = listing?.updatedAt ?? 'none';
+    if (seededAt.current === stamp) return;
+    seededAt.current = stamp;
+
+    setSlug(listing?.slug ?? slugFromName(application.name));
+    setTagline(listing?.tagline ?? '');
+    setDescription(listing?.description ?? '');
+    setCategorySlug(listing?.category?.slug ?? '');
+    setSupportUrl(listing?.supportUrl ?? '');
+    setSupportEmail(listing?.supportEmail ?? '');
+  }, [isLoading, listing, application.name]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const handleSave = async () => {
+    if (!slug.trim()) {
+      toast.error('A store address is required');
+      return;
+    }
+
+    try {
+      await writeListing.mutateAsync({
+        slug: slug.trim().toLowerCase(),
+        tagline: orNull(tagline),
+        description: orNull(description),
+        categorySlug: orNull(categorySlug),
+        supportUrl: orNull(supportUrl),
+        supportEmail: orNull(supportEmail),
+      });
+      toast.success(listing ? 'Store page saved' : 'Store page created');
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to save the store page'));
+    }
+  };
+
+  const handleSubmit = async () => {
+    try {
+      await submitListing.mutateAsync();
+      toast.success('Sent to the store for review');
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to submit the store page'));
+    }
+  };
+
+  const handleUnpublish = async () => {
+    try {
+      await unpublishListing.mutateAsync();
+      toast.success('Taken down. It is a draft again.');
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to take the page down'));
+    }
+  };
+
+  const status = listing?.status;
+  const canSubmit = status === 'draft' || status === 'rejected';
+  const canUnpublish = status === 'published' || status === 'pending_review';
+
+  return (
+    <div className="space-y-8">
+      <section className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Store page</h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              {status
+                ? STATUS_COPY[status].help
+                : 'This app is not on the store yet. Write its page and submit it.'}
+            </p>
+          </div>
+          {status && <Badge variant="secondary">{STATUS_COPY[status].label}</Badge>}
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="store-slug">Store address</Label>
+            <Input
+              id="store-slug"
+              value={slug}
+              onChange={(event) => setSlug(event.target.value)}
+              placeholder="mention"
+              disabled={!canEdit}
+            />
+            <p className="text-xs text-muted-foreground">
+              Lowercase letters, digits and hyphens. This is what every link to the page carries, so
+              changing it after publishing breaks the old address.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="store-tagline">Tagline</Label>
+            <Input
+              id="store-tagline"
+              value={tagline}
+              onChange={(event) => setTagline(event.target.value)}
+              placeholder="One line, shown whole on the card"
+              maxLength={160}
+              disabled={!canEdit}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="store-description">Description</Label>
+            <Textarea
+              id="store-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Markdown. The long text on the page."
+              rows={8}
+              disabled={!canEdit}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="store-category">Category</Label>
+            <Select value={categorySlug} onValueChange={setCategorySlug} disabled={!canEdit}>
+              <SelectTrigger id="store-category">
+                <SelectValue placeholder="Uncategorised" />
+              </SelectTrigger>
+              <SelectContent>
+                {(categories ?? []).map((category) => (
+                  <SelectItem key={category.slug} value={category.slug}>
+                    {category.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="store-support-url">Support page</Label>
+              <Input
+                id="store-support-url"
+                value={supportUrl}
+                onChange={(event) => setSupportUrl(event.target.value)}
+                placeholder="https://example.com/help"
+                disabled={!canEdit}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="store-support-email">Support email</Label>
+              <Input
+                id="store-support-email"
+                value={supportEmail}
+                onChange={(event) => setSupportEmail(event.target.value)}
+                placeholder="help@example.com"
+                disabled={!canEdit}
+              />
+            </div>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            The name, icon, website and legal links come from this application's settings. The store
+            reads them rather than keeping its own copy, so they can never disagree.
+          </p>
+        </div>
+
+        {canEdit && (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button onClick={handleSave} disabled={writeListing.isPending}>
+              {writeListing.isPending ? 'Saving…' : listing ? 'Save' : 'Create store page'}
+            </Button>
+            {canSubmit && (
+              <Button variant="outline" onClick={handleSubmit} disabled={submitListing.isPending}>
+                Submit for review
+              </Button>
+            )}
+            {canUnpublish && (
+              <Button
+                variant="outline"
+                onClick={handleUnpublish}
+                disabled={unpublishListing.isPending}
+              >
+                {status === 'published' ? 'Take down' : 'Withdraw'}
+              </Button>
+            )}
+          </div>
+        )}
+      </section>
+
+      {listing && <ScreenshotsSection appId={application._id} canEdit={canEdit} />}
+    </div>
+  );
+}
+
+interface ScreenshotsSectionProps {
+  appId: string;
+  canEdit: boolean;
+}
+
+/**
+ * The pictures on the page.
+ *
+ * Reordering sends the whole order rather than "move this one", because that is
+ * what the API takes — and it takes it that way so a request cannot half-apply.
+ */
+function ScreenshotsSection({ appId, canEdit }: ScreenshotsSectionProps) {
+  const { oxyServices } = useAuth();
+  const { data: screenshots, isLoading } = useStoreScreenshots(appId);
+  const addScreenshot = useAddScreenshot(appId);
+  const deleteScreenshot = useDeleteScreenshot(appId);
+  const reorderScreenshots = useReorderScreenshots(appId);
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleFile = async (file: File) => {
+    const validation = validateImageFile(file);
+    if (!validation.ok) {
+      toast.error(validation.message);
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      // Upload first, then attach: the store stores a REFERENCE to an asset,
+      // and the API refuses a file that is not live, not an image, or not the
+      // caller's — so the id has to exist before it can be named.
+      const fileId = await uploadPublicImageFileId(oxyServices, file);
+      await addScreenshot.mutateAsync({ fileId });
+      toast.success('Screenshot added');
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to add the screenshot'));
+    } finally {
+      setIsUploading(false);
+      if (fileInput.current) fileInput.current.value = '';
+    }
+  };
+
+  const handleMove = async (index: number, direction: -1 | 1) => {
+    const shots = screenshots ?? [];
+    const ids = moveScreenshot(shots, index, direction);
+    try {
+      await reorderScreenshots.mutateAsync(ids);
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to reorder the screenshots'));
+    }
+  };
+
+  const handleDelete = async (screenshot: StoreScreenshot) => {
+    try {
+      await deleteScreenshot.mutateAsync(screenshot.id);
+      toast.success('Screenshot removed');
+    } catch (error) {
+      toast.error(getErrorMessage(error, 'Failed to remove the screenshot'));
+    }
+  };
+
+  const shots = screenshots ?? [];
+
+  return (
+    <section className="space-y-4 border-t border-border pt-8">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">Screenshots</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Shown on the store page in this order.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <Spinner />
+      ) : shots.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No screenshots yet.</p>
+      ) : (
+        <ul className="space-y-2">
+          {shots.map((screenshot, index) => (
+            <li
+              key={screenshot.id}
+              className="flex items-center gap-3 rounded-lg border border-border p-2"
+            >
+              <img
+                src={resolveStoredImageUrl(oxyServices, screenshot.fileId)}
+                alt={screenshot.caption ?? ''}
+                className="h-16 w-24 rounded object-cover bg-muted"
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-foreground truncate">
+                  {screenshot.caption || 'No caption'}
+                </p>
+                <p className="text-xs text-muted-foreground">{screenshot.platform}</p>
+              </div>
+              {canEdit && (
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Move up"
+                    disabled={index === 0 || reorderScreenshots.isPending}
+                    onClick={() => handleMove(index, -1)}
+                  >
+                    <HugeiconsIcon icon={ArrowUp01Icon} size={16} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Move down"
+                    disabled={index === shots.length - 1 || reorderScreenshots.isPending}
+                    onClick={() => handleMove(index, 1)}
+                  >
+                    <HugeiconsIcon icon={ArrowDown01Icon} size={16} />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Remove screenshot"
+                    disabled={deleteScreenshot.isPending}
+                    onClick={() => handleDelete(screenshot)}
+                  >
+                    <HugeiconsIcon icon={Delete02Icon} size={16} />
+                  </Button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {canEdit && (
+        <div>
+          <input
+            ref={fileInput}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            className="sr-only"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) void handleFile(file);
+            }}
+          />
+          <Button
+            variant="outline"
+            onClick={() => fileInput.current?.click()}
+            disabled={isUploading || addScreenshot.isPending}
+          >
+            <HugeiconsIcon icon={Image01Icon} size={16} />
+            {isUploading ? 'Uploading…' : 'Add screenshot'}
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/console/src/components/apps/usage-section.tsx
+++ b/packages/console/src/components/apps/usage-section.tsx
@@ -17,7 +17,7 @@ interface UsageSectionProps {
 }
 
 export function UsageSection({ application, access }: UsageSectionProps) {
-  const canRead = access.can('apps:read');
+  const canRead = access.can('usage:read');
   const [period, setPeriod] = useState('7d');
   const { data: usage, isLoading } = useApplicationUsage(application._id, period, canRead);
 

--- a/packages/console/src/hooks/use-account.tsx
+++ b/packages/console/src/hooks/use-account.tsx
@@ -62,11 +62,7 @@ export type AccountPermission =
   | 'credentials:revoke'
   | 'billing:read'
   | 'billing:manage'
-  | 'ownership:transfer'
-  // Application-scoped permission surfaced on an application's `callerMembership`
-  // (derived from the caller's account role). Gates the Updates surface, which
-  // the API guards with the same `updates:manage` permission.
-  | 'updates:manage';
+  | 'ownership:transfer';
 
 /** Roles assignable via invite/update — everything except `owner`. */
 export type AssignableAccountRole = Exclude<AccountRole, 'owner'>;

--- a/packages/console/src/hooks/use-applications.ts
+++ b/packages/console/src/hooks/use-applications.ts
@@ -17,7 +17,6 @@ import type {
   CreateApplicationInput,
   UpdateApplicationInput,
 } from '@oxyhq/core';
-import type { AccountPermission } from '@/hooks/use-account';
 import { useAccount } from '@/hooks/use-account';
 
 // ===========================================================================
@@ -288,13 +287,47 @@ export function useApplicationUsage(appId: string, period: string = '7d', enable
 // inheritance), so there is no per-application member list to resolve against.
 // ===========================================================================
 
+/**
+ * What an application's `callerMembership.permissions` actually contains.
+ *
+ * NOT `AccountPermission`. The two vocabularies overlap enough to look
+ * interchangeable and are not: an account grants `apps:read` / `apps:update` /
+ * `apps:delete` over the apps it owns, while an APPLICATION grants `app:read` /
+ * `app:update` / `app:delete` over itself. The API derives the second from the
+ * first (`appPermissionsForAccountRole`) and serialises only the second here,
+ * on every path that returns an application.
+ *
+ * Typing this as `AccountPermission` let `access.can('apps:update')` compile and
+ * silently answer false forever, which disabled the whole Settings form for its
+ * owner. The union below is what makes the wrong string a build error instead.
+ */
+export type ApplicationPermission =
+  | 'app:read'
+  | 'app:update'
+  | 'app:delete'
+  | 'members:read'
+  | 'members:invite'
+  | 'members:update'
+  | 'members:remove'
+  | 'credentials:read'
+  | 'credentials:create'
+  | 'credentials:rotate'
+  | 'credentials:revoke'
+  | 'webhooks:read'
+  | 'webhooks:update'
+  | 'usage:read'
+  | 'billing:read'
+  | 'billing:manage'
+  | 'ownership:transfer'
+  | 'updates:manage';
+
 export interface CallerAccess {
   /** The caller's membership in the application's owning account, if any. */
   membership: AccountMember | undefined;
   /** The caller's role in the owning account, if a member. */
   role: AccountRole | undefined;
-  /** Returns true if the caller holds the given permission. */
-  can: (permission: AccountPermission) => boolean;
+  /** Returns true if the caller holds the given permission over THIS application. */
+  can: (permission: ApplicationPermission) => boolean;
   /** True once the application (and its embedded membership) has loaded. */
   isResolved: boolean;
 }

--- a/packages/console/src/hooks/use-store-listing.ts
+++ b/packages/console/src/hooks/use-store-listing.ts
@@ -1,0 +1,218 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@oxyhq/services';
+import type {
+  AddScreenshotInput,
+  PublisherListing,
+  StoreCategory,
+  StoreScreenshot,
+  UpdateScreenshotInput,
+  WriteListingInput,
+} from '@oxyhq/core';
+
+// ===========================================================================
+// The application's store listing.
+//
+// Unlike the Updates hooks next door, these go through named `@oxyhq/core`
+// methods rather than `makeRequest`: the store HAS a mixin, and reaching past
+// it would put URL strings and response-envelope knowledge in the Console —
+// which is exactly the drift the SDK exists to prevent.
+//
+// Every write here needs `app:update`, which is what the API enforces; the
+// caller gates the tab on it so a viewer never sees a form that would 403.
+// Reading needs only `app:read`.
+//
+// A listing may legitimately NOT exist: an application that has never been
+// listed has no page, and `getAppListing` answers `null` rather than 404. The
+// UI reads that null as "not listed yet", which is a different screen from an
+// error.
+// ===========================================================================
+
+export type {
+  PublisherListing,
+  StoreCategory,
+  StoreScreenshot,
+  WriteListingInput,
+  AddScreenshotInput,
+  UpdateScreenshotInput,
+};
+
+const queryKeys = {
+  listing: (appId: string) => ['store-listing', appId] as const,
+  screenshots: (appId: string) => ['store-listing-screenshots', appId] as const,
+  categories: ['store-categories'] as const,
+};
+
+// ===========================================================================
+// Queries
+// ===========================================================================
+
+/** The application's store page in whatever state, or `null` if it has none. */
+export function useStoreListing(appId: string, enabled: boolean = true) {
+  const { oxyServices, isAuthenticated, isReady } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.listing(appId),
+    queryFn: () => oxyServices.getAppListing(appId),
+    enabled: isReady && isAuthenticated && !!appId && enabled,
+    staleTime: 1000 * 30,
+    retry: 1,
+  });
+}
+
+/**
+ * The shelves a publisher can file their page under.
+ *
+ * Public and rarely edited, so it is cached for longer than the listing and is
+ * not scoped to the application.
+ */
+export function useStoreCategories(enabled: boolean = true) {
+  const { oxyServices, isReady } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.categories,
+    queryFn: () => oxyServices.listStoreCategories(),
+    // No `isAuthenticated`: the storefront is readable before anyone signs in,
+    // and the form needs the shelves whether or not the session is ready.
+    enabled: isReady && enabled,
+    staleTime: 1000 * 60 * 10,
+    retry: 1,
+  });
+}
+
+/** Every picture on the listing, in the author's order. */
+export function useStoreScreenshots(appId: string, enabled: boolean = true) {
+  const { oxyServices, isAuthenticated, isReady } = useAuth();
+
+  return useQuery({
+    queryKey: queryKeys.screenshots(appId),
+    queryFn: () => oxyServices.listAppListingScreenshots(appId),
+    enabled: isReady && isAuthenticated && !!appId && enabled,
+    staleTime: 1000 * 30,
+    retry: 1,
+  });
+}
+
+// ===========================================================================
+// Mutations
+//
+// A write to the listing is written back into the cache rather than
+// invalidated: the API answers with the row it just wrote, so refetching would
+// ask for something already in hand. Screenshot writes DO invalidate, because
+// adding, removing or reordering one changes the positions of the others.
+// ===========================================================================
+
+function useWriteListingCache(appId: string) {
+  const queryClient = useQueryClient();
+  return (listing: PublisherListing) => {
+    queryClient.setQueryData(queryKeys.listing(appId), listing);
+  };
+}
+
+/** Create the page, or replace its content. Never its status. */
+export function useWriteStoreListing(appId: string) {
+  const { oxyServices } = useAuth();
+  const writeCache = useWriteListingCache(appId);
+
+  return useMutation({
+    mutationFn: (input: WriteListingInput) => oxyServices.writeAppListing(appId, input),
+    onSuccess: writeCache,
+  });
+}
+
+/** Hand the page to the store for review. */
+export function useSubmitStoreListing(appId: string) {
+  const { oxyServices } = useAuth();
+  const writeCache = useWriteListingCache(appId);
+
+  return useMutation({
+    mutationFn: () => oxyServices.submitAppListing(appId),
+    onSuccess: writeCache,
+  });
+}
+
+/** Take it down, or withdraw it from the queue. Back to a draft. */
+export function useUnpublishStoreListing(appId: string) {
+  const { oxyServices } = useAuth();
+  const writeCache = useWriteListingCache(appId);
+
+  return useMutation({
+    mutationFn: () => oxyServices.unpublishAppListing(appId),
+    onSuccess: writeCache,
+  });
+}
+
+function useInvalidateScreenshots(appId: string) {
+  const queryClient = useQueryClient();
+  return () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.screenshots(appId) });
+  };
+}
+
+/** Attach an already-uploaded image, appended to the end. */
+export function useAddScreenshot(appId: string) {
+  const { oxyServices } = useAuth();
+  const invalidate = useInvalidateScreenshots(appId);
+
+  return useMutation({
+    mutationFn: (input: AddScreenshotInput) => oxyServices.addAppListingScreenshot(appId, input),
+    onSuccess: invalidate,
+  });
+}
+
+/** Edit a picture's caption or the frame it was taken in. */
+export function useUpdateScreenshot(appId: string) {
+  const { oxyServices } = useAuth();
+  const invalidate = useInvalidateScreenshots(appId);
+
+  return useMutation({
+    mutationFn: ({ screenshotId, ...input }: UpdateScreenshotInput & { screenshotId: string }) =>
+      oxyServices.updateAppListingScreenshot(appId, screenshotId, input),
+    onSuccess: invalidate,
+  });
+}
+
+/** Remove a picture. The uploaded file stays. */
+export function useDeleteScreenshot(appId: string) {
+  const { oxyServices } = useAuth();
+  const invalidate = useInvalidateScreenshots(appId);
+
+  return useMutation({
+    mutationFn: (screenshotId: string) =>
+      oxyServices.deleteAppListingScreenshot(appId, screenshotId),
+    onSuccess: invalidate,
+  });
+}
+
+/**
+ * Move a picture one place up or down.
+ *
+ * The API takes the WHOLE order, so this reads the list it was given, swaps a
+ * neighbouring pair and sends every id back. Doing the swap here rather than
+ * asking the server to "move item N" keeps the request a statement of what the
+ * page should look like, which is the only shape that cannot half-apply.
+ */
+export function useReorderScreenshots(appId: string) {
+  const { oxyServices } = useAuth();
+  const invalidate = useInvalidateScreenshots(appId);
+
+  return useMutation({
+    mutationFn: (screenshotIds: Array<string>) =>
+      oxyServices.reorderAppListingScreenshots(appId, screenshotIds),
+    onSuccess: invalidate,
+  });
+}
+
+/** The ids of `screenshots` with the one at `index` moved one place in `direction`. */
+export function moveScreenshot(
+  screenshots: Array<StoreScreenshot>,
+  index: number,
+  direction: -1 | 1
+): Array<string> {
+  const target = index + direction;
+  if (target < 0 || target >= screenshots.length) {
+    return screenshots.map((shot) => shot.id);
+  }
+  const ids = screenshots.map((shot) => shot.id);
+  [ids[index], ids[target]] = [ids[target], ids[index]];
+  return ids;
+}

--- a/packages/console/src/lib/image-upload.ts
+++ b/packages/console/src/lib/image-upload.ts
@@ -103,11 +103,30 @@ export async function uploadPublicImage(
   oxyServices: OxyServices,
   file: File
 ): Promise<string> {
+  const fileId = await uploadPublicImageFileId(oxyServices, file);
+  return stripSensitiveImageUrlQueryParams(oxyServices.getFileDownloadUrl(fileId));
+}
+
+/**
+ * Upload a public image and return the FILE ID.
+ *
+ * The logo widgets store a URL because that is what the Application record
+ * holds; a store screenshot stores the id, because `app_listing_screenshots`
+ * carries a real foreign key to `files` — which is what stops a purged asset
+ * leaving a hole on a published page. Both go through this one upload so the
+ * two surfaces cannot drift on visibility or validation.
+ *
+ * @throws when the upload fails or the response is missing a file id.
+ */
+export async function uploadPublicImageFileId(
+  oxyServices: OxyServices,
+  file: File
+): Promise<string> {
   const response = await oxyServices.uploadRawFile(file, PUBLIC_VISIBILITY);
   if (!isRawFileUploadResponse(response)) {
     throw new Error('Upload did not return a file id');
   }
-  return stripSensitiveImageUrlQueryParams(oxyServices.getFileDownloadUrl(response.file.id));
+  return response.file.id;
 }
 
 /** Resolve a stored file id (or absolute URL) to a renderable image URL. */

--- a/packages/console/src/routeTree.gen.ts
+++ b/packages/console/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as LayoutDocumentationChatCompletionsRouteImport } from './routes
 import { Route as LayoutDocumentationAuthenticationRouteImport } from './routes/_layout/documentation/authentication'
 import { Route as LayoutAppsAppIdIndexRouteImport } from './routes/_layout/apps/$appId/index'
 import { Route as LayoutAppsAppIdUpdatesRouteImport } from './routes/_layout/apps/$appId/updates'
+import { Route as LayoutAppsAppIdStoreRouteImport } from './routes/_layout/apps/$appId/store'
 import { Route as LayoutAppsAppIdSettingsRouteImport } from './routes/_layout/apps/$appId/settings'
 
 const LayoutRoute = LayoutRouteImport.update({
@@ -123,6 +124,11 @@ const LayoutAppsAppIdUpdatesRoute = LayoutAppsAppIdUpdatesRouteImport.update({
   path: '/apps/$appId/updates',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutAppsAppIdStoreRoute = LayoutAppsAppIdStoreRouteImport.update({
+  id: '/apps/$appId/store',
+  path: '/apps/$appId/store',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutAppsAppIdSettingsRoute = LayoutAppsAppIdSettingsRouteImport.update({
   id: '/apps/$appId/settings',
   path: '/apps/$appId/settings',
@@ -146,6 +152,7 @@ export interface FileRoutesByFullPath {
   '/apps/': typeof LayoutAppsIndexRoute
   '/documentation/': typeof LayoutDocumentationIndexRoute
   '/apps/$appId/settings': typeof LayoutAppsAppIdSettingsRoute
+  '/apps/$appId/store': typeof LayoutAppsAppIdStoreRoute
   '/apps/$appId/updates': typeof LayoutAppsAppIdUpdatesRoute
   '/apps/$appId/': typeof LayoutAppsAppIdIndexRoute
 }
@@ -166,6 +173,7 @@ export interface FileRoutesByTo {
   '/apps': typeof LayoutAppsIndexRoute
   '/documentation': typeof LayoutDocumentationIndexRoute
   '/apps/$appId/settings': typeof LayoutAppsAppIdSettingsRoute
+  '/apps/$appId/store': typeof LayoutAppsAppIdStoreRoute
   '/apps/$appId/updates': typeof LayoutAppsAppIdUpdatesRoute
   '/apps/$appId': typeof LayoutAppsAppIdIndexRoute
 }
@@ -188,6 +196,7 @@ export interface FileRoutesById {
   '/_layout/apps/': typeof LayoutAppsIndexRoute
   '/_layout/documentation/': typeof LayoutDocumentationIndexRoute
   '/_layout/apps/$appId/settings': typeof LayoutAppsAppIdSettingsRoute
+  '/_layout/apps/$appId/store': typeof LayoutAppsAppIdStoreRoute
   '/_layout/apps/$appId/updates': typeof LayoutAppsAppIdUpdatesRoute
   '/_layout/apps/$appId/': typeof LayoutAppsAppIdIndexRoute
 }
@@ -210,6 +219,7 @@ export interface FileRouteTypes {
     | '/apps/'
     | '/documentation/'
     | '/apps/$appId/settings'
+    | '/apps/$appId/store'
     | '/apps/$appId/updates'
     | '/apps/$appId/'
   fileRoutesByTo: FileRoutesByTo
@@ -230,6 +240,7 @@ export interface FileRouteTypes {
     | '/apps'
     | '/documentation'
     | '/apps/$appId/settings'
+    | '/apps/$appId/store'
     | '/apps/$appId/updates'
     | '/apps/$appId'
   id:
@@ -251,6 +262,7 @@ export interface FileRouteTypes {
     | '/_layout/apps/'
     | '/_layout/documentation/'
     | '/_layout/apps/$appId/settings'
+    | '/_layout/apps/$appId/store'
     | '/_layout/apps/$appId/updates'
     | '/_layout/apps/$appId/'
   fileRoutesById: FileRoutesById
@@ -388,6 +400,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutAppsAppIdUpdatesRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/apps/$appId/store': {
+      id: '/_layout/apps/$appId/store'
+      path: '/apps/$appId/store'
+      fullPath: '/apps/$appId/store'
+      preLoaderRoute: typeof LayoutAppsAppIdStoreRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/apps/$appId/settings': {
       id: '/_layout/apps/$appId/settings'
       path: '/apps/$appId/settings'
@@ -414,6 +433,7 @@ interface LayoutRouteChildren {
   LayoutAppsIndexRoute: typeof LayoutAppsIndexRoute
   LayoutDocumentationIndexRoute: typeof LayoutDocumentationIndexRoute
   LayoutAppsAppIdSettingsRoute: typeof LayoutAppsAppIdSettingsRoute
+  LayoutAppsAppIdStoreRoute: typeof LayoutAppsAppIdStoreRoute
   LayoutAppsAppIdUpdatesRoute: typeof LayoutAppsAppIdUpdatesRoute
   LayoutAppsAppIdIndexRoute: typeof LayoutAppsAppIdIndexRoute
 }
@@ -436,6 +456,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAppsIndexRoute: LayoutAppsIndexRoute,
   LayoutDocumentationIndexRoute: LayoutDocumentationIndexRoute,
   LayoutAppsAppIdSettingsRoute: LayoutAppsAppIdSettingsRoute,
+  LayoutAppsAppIdStoreRoute: LayoutAppsAppIdStoreRoute,
   LayoutAppsAppIdUpdatesRoute: LayoutAppsAppIdUpdatesRoute,
   LayoutAppsAppIdIndexRoute: LayoutAppsAppIdIndexRoute,
 }

--- a/packages/console/src/routes/_layout/apps/$appId/settings.tsx
+++ b/packages/console/src/routes/_layout/apps/$appId/settings.tsx
@@ -42,7 +42,7 @@ function AppSettingsPage() {
   }
 
   const showCredentialsTab = access.can('credentials:read');
-  const showUsageTab = access.can('apps:read');
+  const showUsageTab = access.can('usage:read');
 
   return (
     <ScrollArea className="flex-1 bg-background">

--- a/packages/console/src/routes/_layout/apps/$appId/store.tsx
+++ b/packages/console/src/routes/_layout/apps/$appId/store.tsx
@@ -1,0 +1,47 @@
+import { Link, createFileRoute } from '@tanstack/react-router';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Spinner } from '@/components/ui/spinner';
+import { useApplication, useCallerAccess } from '@/hooks/use-applications';
+import { AppDetailHeader } from '@/components/apps/app-detail-header';
+import { StoreSection } from '@/components/apps/store-section';
+
+export const Route = createFileRoute('/_layout/apps/$appId/store')({
+  component: AppStorePage,
+});
+
+function AppStorePage() {
+  const { appId } = Route.useParams();
+  const { data: application, isLoading, isError } = useApplication(appId);
+  const access = useCallerAccess(application);
+
+  if (isLoading) {
+    return (
+      <div className="flex-1 bg-background flex items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !application) {
+    return (
+      <div className="flex-1 bg-background flex flex-col items-center justify-center gap-3">
+        <p className="text-sm text-muted-foreground">This application could not be loaded.</p>
+        <Link to="/apps" className="text-sm text-foreground underline underline-offset-4">
+          Back to applications
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <ScrollArea className="flex-1 bg-background">
+      <AppDetailHeader application={application} access={access} active="store" />
+
+      <div className="px-6 py-6">
+        <div className="max-w-4xl">
+          <StoreSection application={application} access={access} />
+        </div>
+      </div>
+    </ScrollArea>
+  );
+}


### PR DESCRIPTION
## Read this part first: a live bug in Settings

Building the tab needed `access.can('app:update')`, which did not type-check. Finding out why exposed a bug that is already shipped.

An application's `callerMembership.permissions` carries **application** permissions — `app:read`, `app:update`, `app:delete`. Every API path that returns an application serialises exactly those, through `appPermissionsForAccountRole`. An **account** grants a different, very similar vocabulary over the apps it owns: `apps:read`, `apps:update`, `apps:delete`. One character apart, and both are real strings in the codebase.

`CallerAccess.can` was typed `AccountPermission`. So `access.can('apps:update')` compiled cleanly and answered **false forever**:

- `/apps/:appId/settings` — every field `disabled`, and the Save and Delete blocks (`{canEdit && …}`, `{canDelete && …}`) never rendered. For **everyone**, including the app's owner.
- The Usage tab and section, gated on `apps:read`, likewise never appeared.

`credentials:*` kept working purely because those four strings happen to exist in both vocabularies — which is why this survived.

**The fix is the type, not the strings.** `can` now takes an `ApplicationPermission` union matching what the API actually sends, so a wrong string is a build error instead of a disabled button. Three call sites move to `app:update`, `app:delete` and `usage:read` — that last one being the permission the API really enforces on `/usage`, rather than `app:read`. And `updates:manage` no longer has to squat in the account union, where someone had added it with a comment to make an earlier instance of exactly this problem compile.

## The tab

`/apps/:appId/store` — write the page, submit it for review, take it down, and manage its screenshots.

Editing content and moving the page through review are **separate actions**, because they are separate calls in the API and for the same reason: the words are the publisher's, the status is the store's. Saving a correction to a live page leaves it live, which is what the buttons say. The status badge carries the sentence that explains what each state means for the publisher.

Everything goes through named `@oxyhq/core` methods rather than `makeRequest`. The store has a mixin now (#862), and reaching past it would put URL strings and envelope knowledge back into the Console — the drift the SDK exists to prevent.

The tab appears for `app:read`, and its writes are gated on `app:update`, matching what the API enforces, so nobody sees a form that would only 403.

## Smaller things

- `uploadPublicImageFileId` is split out of `uploadPublicImage`. The logo widgets store a **URL** because that is what an Application record holds; a screenshot stores a **file id** because `app_listing_screenshots` carries a real foreign key to `files` — which is what stops a purged asset leaving a hole on a published page. Both go through one upload so the two surfaces cannot drift on visibility or validation.
- The icon is `ShopSignIcon`, not `AppStoreIcon` — the latter is Apple's brand mark, and this is not their store.
- Reordering sends the whole order because that is what the API takes, and it takes it that way so a request cannot half-apply.

## Verification

Console build and tests green (9 tests). One pre-existing tsc error remains in `workspace-tree.test.ts` — verified unchanged and present on a clean tree, so it is not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)