### PR TITLE
store: the shelves, and a curator who can change them

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,7 +23,8 @@
     "prepublishOnly": "node ../../scripts/assert-bun-publish.mjs && bun run clean && bun run build",
     "release": "rm -rf dist && bun run build && release-it",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "bun run src/db/migrate.ts --phase=all"
+    "db:migrate": "bun run src/db/migrate.ts --phase=all",
+    "seed:store-categories": "bun run scripts/seed-store-categories.ts"
   },
   "release-it": {
     "git": {

--- a/packages/api/scripts/seed-store-categories.ts
+++ b/packages/api/scripts/seed-store-categories.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env bun
+/**
+ * Idempotent seed: give the app store its opening shelves.
+ *
+ * The store's API is complete and `app_categories` is empty, which means a
+ * publisher opening the Console's Store tab finds an empty category select and
+ * nothing to file their page under. This puts the first shelves in.
+ *
+ * ## Insert-only, on purpose
+ *
+ * `app_categories` is a table rather than a CHECK-constrained column precisely
+ * so the vocabulary belongs to whoever curates the store rather than to a
+ * migration (see `db/schema/appCategories.ts`). So this script ADDS shelves it
+ * does not find and never touches one that already exists: a curator who
+ * renames "Housing" to "Homes" through `PATCH /store/moderation/categories`
+ * must not have it renamed back the next time somebody runs a seed.
+ *
+ * Re-running therefore reports zero inserts once seeded, which is also the
+ * check that it is idempotent.
+ *
+ * ## Why these shelves
+ *
+ * Every one of them has a real Oxy app that could sit on it today —
+ * `scripts/seed-oxy-applications.ts` is the list. Shelves for a catalogue that
+ * does not exist yet (Games, Health, Education) are left out: an empty shelf on
+ * a storefront reads as a store that is missing things, and adding one later is
+ * a single POST.
+ *
+ * Run (inside the oxy-api image, working dir /app):
+ *   bun run packages/api/scripts/seed-store-categories.ts
+ *
+ * Env:
+ *   DATABASE_URL   required (injected by ECS from SSM)
+ *   DRY_RUN=1|true plan only, no writes
+ */
+
+import { inArray } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../src/config/postgres';
+import { appCategories } from '../src/db/schema/appCategories';
+import { logger } from '../src/utils/logger';
+
+interface SeedCategory {
+  slug: string;
+  label: string;
+  description: string;
+  /** Running order. Spaced by ten so a shelf can be slotted between two. */
+  order: number;
+}
+
+const SHELVES: SeedCategory[] = [
+  {
+    slug: 'social',
+    label: 'Social',
+    description: 'Places to post, follow and talk in the open.',
+    order: 10,
+  },
+  {
+    slug: 'messaging',
+    label: 'Messaging',
+    description: 'Private conversation, one to one and in groups.',
+    order: 20,
+  },
+  {
+    slug: 'productivity',
+    label: 'Productivity',
+    description: 'Mail, notes, calendars and the rest of the working day.',
+    order: 30,
+  },
+  {
+    slug: 'finance',
+    label: 'Finance',
+    description: 'Money: holding it, sending it and keeping track of it.',
+    order: 40,
+  },
+  {
+    slug: 'shopping',
+    label: 'Shopping',
+    description: 'Marketplaces and storefronts.',
+    order: 50,
+  },
+  {
+    slug: 'housing',
+    label: 'Housing',
+    description: 'Finding somewhere to live, and letting somewhere out.',
+    order: 60,
+  },
+  {
+    slug: 'developer-tools',
+    label: 'Developer tools',
+    description: 'Things you build with, and things you run.',
+    order: 70,
+  },
+  {
+    slug: 'ai',
+    label: 'AI',
+    description: 'Assistants, agents and the models behind them.',
+    order: 80,
+  },
+  {
+    slug: 'utilities',
+    label: 'Utilities',
+    description: 'Small things that do one job well.',
+    order: 90,
+  },
+];
+
+function isDryRun(): boolean {
+  const value = process.env.DRY_RUN;
+  return value === '1' || value === 'true';
+}
+
+async function seed(): Promise<void> {
+  const dryRun = isDryRun();
+  await connectPostgres();
+
+  const slugs = SHELVES.map((shelf) => shelf.slug);
+  const existing = await getDb()
+    .select({ slug: appCategories.slug })
+    .from(appCategories)
+    .where(inArray(appCategories.slug, slugs));
+
+  const present = new Set(existing.map((row) => row.slug));
+  const missing = SHELVES.filter((shelf) => !present.has(shelf.slug));
+
+  logger.info('Store categories seed plan', {
+    dryRun,
+    total: SHELVES.length,
+    alreadyPresent: present.size,
+    toInsert: missing.map((shelf) => shelf.slug),
+  });
+
+  if (missing.length === 0) {
+    logger.info('Every shelf is already there. Nothing to do.');
+    await closePostgres();
+    return;
+  }
+
+  if (dryRun) {
+    logger.info('DRY_RUN — no writes performed');
+    await closePostgres();
+    return;
+  }
+
+  // `onConflictDoNothing` as well as the read above: the read is what makes the
+  // log honest, and this is what makes a concurrent run safe.
+  const inserted = await getDb()
+    .insert(appCategories)
+    .values(
+      missing.map((shelf) => ({
+        slug: shelf.slug,
+        label: shelf.label,
+        description: shelf.description,
+        order: shelf.order,
+      }))
+    )
+    .onConflictDoNothing({ target: appCategories.slug })
+    .returning({ slug: appCategories.slug });
+
+  logger.info('Store categories seeded', {
+    inserted: inserted.map((row) => row.slug),
+    insertedCount: inserted.length,
+  });
+
+  await closePostgres();
+}
+
+seed().catch(async (error: unknown) => {
+  logger.error(
+    'Store categories seed failed',
+    error instanceof Error ? error : new Error(String(error))
+  );
+  await closePostgres().catch(() => undefined);
+  process.exit(1);
+});

--- a/packages/api/src/routes/store.ts
+++ b/packages/api/src/routes/store.ts
@@ -25,6 +25,9 @@ import { validate } from '../middleware/validate';
 import { rateLimit } from '../middleware/rateLimiter';
 import { NotFoundError, UnauthorizedError } from '../utils/error';
 import {
+  storeCategoryBody,
+  storeCategoryParams,
+  storeCategoryPatch,
   storeListingsQuery,
   storeModerationParams,
   storeModerationQuery,
@@ -36,6 +39,8 @@ import {
 } from '../schemas/store.schemas';
 import {
   approveListing,
+  createCategory,
+  deleteCategory,
   deleteOwnReview,
   deleteReply,
   getOwnReview,
@@ -45,6 +50,7 @@ import {
   listPublishedListings,
   listReviews,
   rejectListing,
+  updateCategory,
   upsertReply,
   upsertReview,
 } from '../services/store.service';
@@ -282,6 +288,66 @@ router.post(
   validate({ params: storeModerationParams }),
   asyncHandler(async (req: AuthRequest, res: Response) => {
     sendSuccess(res, await rejectListing(req.params.applicationId));
+  })
+);
+
+/**
+ * The shelves are curated, not migrated.
+ *
+ * `app_categories` is a table rather than a CHECK-constrained column exactly so
+ * a curator can rename a shelf or reorder the storefront without a deploy —
+ * these three routes are what make that claim true. Same `requireStaff` gate as
+ * the review queue: a shelf is a decision about the store's shape.
+ */
+
+/** POST /store/moderation/categories — add a shelf. */
+router.post(
+  '/moderation/categories',
+  writeLimiter,
+  authMiddleware,
+  requireStaff,
+  csrfProtection,
+  validate({ body: storeCategoryBody }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const body = req.body as {
+      slug: string;
+      label: string;
+      description?: string | null;
+      order?: number;
+    };
+    sendSuccess(res, await createCategory(body), 201);
+  })
+);
+
+/** PATCH /store/moderation/categories/:slug — rename, re-word, or reorder it. */
+router.patch(
+  '/moderation/categories/:slug',
+  writeLimiter,
+  authMiddleware,
+  requireStaff,
+  csrfProtection,
+  validate({ params: storeCategoryParams, body: storeCategoryPatch }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    const patch = req.body as { label?: string; description?: string | null; order?: number };
+    sendSuccess(res, await updateCategory(req.params.slug, patch));
+  })
+);
+
+/**
+ * DELETE /store/moderation/categories/:slug — retire it.
+ *
+ * Answers with how many listings just became uncategorised rather than 204,
+ * because a curator tidying the taxonomy should be told what they moved.
+ */
+router.delete(
+  '/moderation/categories/:slug',
+  writeLimiter,
+  authMiddleware,
+  requireStaff,
+  csrfProtection,
+  validate({ params: storeCategoryParams }),
+  asyncHandler(async (req: AuthRequest, res: Response) => {
+    sendSuccess(res, await deleteCategory(req.params.slug));
   })
 );
 

--- a/packages/api/src/schemas/store.schemas.ts
+++ b/packages/api/src/schemas/store.schemas.ts
@@ -142,3 +142,43 @@ export const storeScreenshotParams = z.object({
 export const storeScreenshotOrderBody = z.object({
   screenshotIds: z.array(z.string().trim().min(1).max(64)).min(1).max(50),
 });
+
+/** A category slug in the path, for the curator's routes. */
+export const storeCategoryParams = z.object({
+  slug: z.string().trim().min(1).max(120),
+});
+
+/**
+ * POST /store/moderation/categories
+ *
+ * The slug follows the same rule a listing's does, and for the same reason: it
+ * is what a link to the category page carries.
+ */
+export const storeCategoryBody = z.object({
+  slug: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .min(2)
+    .max(120)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, 'Use lowercase letters, digits and single hyphens'),
+  label: z.string().trim().min(1).max(120),
+  description: z.string().trim().max(300).nullish(),
+  /** Running order on the storefront. Ties break by id, so duplicates are fine. */
+  order: z.coerce.number().int().min(0).max(10000).optional(),
+});
+
+/**
+ * PATCH /store/moderation/categories/:slug
+ *
+ * The slug itself is absent: it is what every link carries, and a store that
+ * silently breaks its own URLs to fix a spelling is worse than one with a
+ * misspelled slug.
+ */
+export const storeCategoryPatch = z
+  .object({
+    label: z.string().trim().min(1).max(120).optional(),
+    description: z.string().trim().max(300).nullish(),
+    order: z.coerce.number().int().min(0).max(10000).optional(),
+  })
+  .refine((body) => Object.keys(body).length > 0, { message: 'Nothing to change' });

--- a/packages/api/src/services/__tests__/store.listing.test.ts
+++ b/packages/api/src/services/__tests__/store.listing.test.ts
@@ -22,12 +22,16 @@ import { users } from '../../db/schema/users';
 import { BadRequestError, ConflictError, NotFoundError } from '../../utils/error';
 import {
   approveListing,
+  createCategory,
+  deleteCategory,
   getListingForApplication,
   getPublishedListing,
+  listCategories,
   listListingsAwaitingReview,
   rejectListing,
   submitListing,
   unpublishListing,
+  updateCategory,
   upsertListing,
 } from '../store.service';
 
@@ -254,5 +258,61 @@ describe('taking a page down', () => {
     await upsertListing({ applicationId, slug: freshSlug() });
 
     await expect(unpublishListing(applicationId)).rejects.toThrow(ConflictError);
+  });
+});
+
+describe('curating the shelves', () => {
+  it('adds one, and the storefront lists it in the curated order', async () => {
+    const prefix = randomUUID().slice(0, 8);
+    await createCategory({ slug: `${prefix}-late`, label: 'Late', order: 9000 });
+    await createCategory({ slug: `${prefix}-early`, label: 'Early', order: 8000 });
+
+    const ours = (await listCategories()).filter((row) => row.slug.startsWith(prefix));
+
+    expect(ours.map((row) => row.label)).toEqual(['Early', 'Late']);
+  });
+
+  it('refuses a slug that is taken', async () => {
+    const slug = `cat-${randomUUID().slice(0, 8)}`;
+    await createCategory({ slug, label: 'First' });
+
+    await expect(createCategory({ slug, label: 'Second' })).rejects.toThrow(ConflictError);
+  });
+
+  it('renames and reorders without touching the slug', async () => {
+    const slug = `cat-${randomUUID().slice(0, 8)}`;
+    await createCategory({ slug, label: 'Housing', description: 'Homes', order: 10 });
+
+    const updated = await updateCategory(slug, { label: 'Homes', order: 15 });
+
+    expect(updated).toMatchObject({ slug, label: 'Homes', order: 15 });
+    // Untouched, because the patch did not name it.
+    expect(updated.description).toBe('Homes');
+  });
+
+  it('says so when there is no such shelf', async () => {
+    await expect(updateCategory(`missing-${randomUUID()}`, { label: 'x' })).rejects.toThrow(
+      NotFoundError
+    );
+    await expect(deleteCategory(`missing-${randomUUID()}`)).rejects.toThrow(NotFoundError);
+  });
+
+  it('retiring a shelf uncategorises its listings rather than deleting them', async () => {
+    const slug = `cat-${randomUUID().slice(0, 8)}`;
+    await createCategory({ slug, label: 'Doomed' });
+    const applicationId = await unlistedApp();
+    const listingSlug = freshSlug();
+    await upsertListing({ applicationId, slug: listingSlug, categorySlug: slug, tagline: 'Alive' });
+    await submitListing(applicationId);
+    await approveListing(applicationId);
+
+    const { listingsUncategorised } = await deleteCategory(slug);
+
+    expect(listingsUncategorised).toBe(1);
+    // The page is still published and still says what it said — only its shelf
+    // is gone. `CASCADE` here would have deleted somebody's listing because a
+    // curator tidied the taxonomy.
+    const page = await getPublishedListing(listingSlug);
+    expect(page).toMatchObject({ slug: listingSlug, tagline: 'Alive', category: null });
   });
 });

--- a/packages/api/src/services/store.service.ts
+++ b/packages/api/src/services/store.service.ts
@@ -335,10 +335,31 @@ export async function listReviews(options: {
   };
 }
 
+/**
+ * A shelf as everyone sees it.
+ *
+ * `order` is included: the storefront does not need it, but a curator moving a
+ * shelf has to be able to see where it currently sits, and one shape for one
+ * row is better than two that differ by a field.
+ */
+export interface StoreCategoryRow {
+  slug: string;
+  label: string;
+  description: string | null;
+  order: number;
+}
+
+const CATEGORY_COLUMNS = {
+  slug: appCategories.slug,
+  label: appCategories.label,
+  description: appCategories.description,
+  order: appCategories.order,
+} as const;
+
 /** The shelves, in their curated order. */
-export async function listCategories(): Promise<{ slug: string; label: string; description: string | null }[]> {
+export async function listCategories(): Promise<StoreCategoryRow[]> {
   return getDb()
-    .select({ slug: appCategories.slug, label: appCategories.label, description: appCategories.description })
+    .select(CATEGORY_COLUMNS)
     .from(appCategories)
     .orderBy(asc(appCategories.order), asc(appCategories.id));
 }
@@ -1003,4 +1024,101 @@ export async function reorderScreenshots(options: {
   });
 
   return listScreenshots(options.applicationId);
+}
+
+// ============================================================================
+// Curating the shelves
+//
+// `app_categories` is a table rather than a CHECK-constrained column precisely
+// so the vocabulary can be edited by whoever curates the store instead of by a
+// migration — see the schema. These are the calls that make that true; without
+// them a typo in a shelf name could only be fixed with SQL.
+//
+// Staff only, like the review queue: a shelf is a decision about the store's
+// shape, not about any one publisher's app.
+// ============================================================================
+
+export interface WriteCategoryInput {
+  slug: string;
+  label: string;
+  description?: string | null;
+  order?: number;
+}
+
+/** Add a shelf. */
+export async function createCategory(input: WriteCategoryInput): Promise<StoreCategoryRow> {
+  try {
+    const [row] = await getDb()
+      .insert(appCategories)
+      .values({
+        slug: input.slug,
+        label: input.label,
+        description: input.description?.trim() || null,
+        order: input.order ?? 0,
+      })
+      .returning(CATEGORY_COLUMNS);
+    return row;
+  } catch (error) {
+    if (isUniqueViolation(error, 'app_categories_slug_unique')) {
+      throw new ConflictError(`A category with the slug "${input.slug}" already exists`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Rename a shelf, re-word it, or move it in the running order.
+ *
+ * The SLUG is not editable. It is what every link to a category page carries,
+ * and a store that silently breaks its own URLs to fix a spelling is worse than
+ * one with a misspelled slug — retiring the shelf and adding a new one is the
+ * honest way to change it, and leaves the listings recoverable.
+ */
+export async function updateCategory(
+  slug: string,
+  patch: { label?: string; description?: string | null; order?: number }
+): Promise<StoreCategoryRow> {
+  const [row] = await getDb()
+    .update(appCategories)
+    .set({
+      ...(patch.label === undefined ? {} : { label: patch.label }),
+      ...(patch.description === undefined ? {} : { description: patch.description?.trim() || null }),
+      ...(patch.order === undefined ? {} : { order: patch.order }),
+      updatedAt: new Date(),
+    })
+    .where(eq(appCategories.slug, slug))
+    .returning(CATEGORY_COLUMNS);
+
+  if (!row) throw new NotFoundError('No such category');
+  return row;
+}
+
+/**
+ * Retire a shelf.
+ *
+ * The listings on it are NOT deleted: the foreign key is `SET NULL`, so they
+ * fall back to uncategorised and someone re-files them. That is the whole
+ * reason the reference is nullable — `CASCADE` here would delete a publisher's
+ * page because a curator tidied the taxonomy.
+ */
+export async function deleteCategory(slug: string): Promise<{ listingsUncategorised: number }> {
+  const db = getDb();
+
+  const [category] = await db
+    .select({ id: appCategories.id })
+    .from(appCategories)
+    .where(eq(appCategories.slug, slug))
+    .limit(1);
+  if (!category) throw new NotFoundError('No such category');
+
+  // Counted BEFORE the delete, because afterwards there is nothing to count
+  // against — and a curator deserves to be told how many pages they just moved.
+  const [affected] = await db
+    .select({ value: count() })
+    .from(appListings)
+    .where(eq(appListings.categoryId, category.id));
+
+  await db.delete(appCategories).where(eq(appCategories.id, category.id));
+
+  return { listingsUncategorised: Number(affected?.value ?? 0) };
 }


### PR DESCRIPTION
The store is **live in production** — I checked rather than assumed:

```
$ curl https://api.oxy.so/store/categories
{"data":[]}
$ curl 'https://api.oxy.so/store/apps?limit=3'
{"data":[],"pagination":{"total":0,"limit":3,"offset":0,"hasMore":false}}
```

Migrations applied, routes serving, and the two envelopes exactly as #862 reads them — confirmed against the real server, not against my reading of the code.

Both empty. No categories exist, so the Console's Store tab offers an empty select and a publisher has nothing to file their page under. This unblocks that.

## Nine shelves

Social · Messaging · Productivity · Finance · Shopping · Housing · Developer tools · AI · Utilities

Every one has a real Oxy app that could sit on it today — `scripts/seed-oxy-applications.ts` is the list I picked from. Shelves for a catalogue that does not exist yet (Games, Health, Education) are deliberately left out: an empty shelf reads as a store that is missing things, and adding one later is now a single POST.

**They are easy to change** — the list is a plain array at the top of the script, and after seeding they are editable through the API.

## Insert-only, which is the decision worth reviewing

`app_categories` is a table rather than a CHECK-constrained column *precisely* so the vocabulary belongs to whoever curates the store rather than to a migration — the schema says so. So the seed adds what it does not find and **never touches what exists**. A curator who renames a shelf must not have it renamed back by the next person who runs a seed.

Verified rather than asserted: renaming `housing` to "Homes" in the database and re-running leaves it "Homes".

That position is only coherent if a curator can actually edit them, and until now **nobody could** — there was no route at all, so fixing a typo in a shelf name meant SQL. Three staff-only routes close that:

| | |
|---|---|
| `POST /store/moderation/categories` | add a shelf |
| `PATCH /store/moderation/categories/:slug` | rename, re-word, reorder |
| `DELETE /store/moderation/categories/:slug` | retire it |

**The slug is not editable.** It is what every link to a category page carries, and a store that silently breaks its own URLs to fix a spelling is worse than one with a misspelled slug. Retiring the shelf and adding a new one is the honest way, and it leaves the listings recoverable.

**Retiring a shelf does not delete the listings on it.** The foreign key is `SET NULL`, so they fall back to uncategorised and someone re-files them — that is why the reference is nullable, and `CASCADE` here would delete a publisher's page because a curator tidied the taxonomy. The call answers with how many pages just moved rather than 204, because a curator should be told what they touched.

## Verification

The seed, four ways against a real Postgres:

1. `DRY_RUN=1` — plans nine, writes nothing
2. real run — inserts nine
3. re-run — `alreadyPresent: 9`, `toInsert: []`
4. a curator's rename survives a re-run

68 tests, 5 new. `bun run api:build` and the scripts typecheck both clean.

## To run it in production

As a one-off ECS task in the oxy-api image, the same way `seed:oxy-applications` runs:

```
bun run packages/api/scripts/seed-store-categories.ts
```

Not run yet — the shelf names are a public, curatorial choice, so they are yours to approve first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)