### PR TITLE
docs: the app store, for publishers and for clients

### DIFF
--- a/packages/api/docs/store.mdx
+++ b/packages/api/docs/store.mdx
@@ -1,0 +1,191 @@
+---
+title: App store
+description: The storefront's public reads, the reviews people write, and the endpoints a publisher uses to put an app on a shelf.
+order: 1
+---
+
+# App store
+
+The store is a module **over** the platform, not part of it. `applications` answers "may this program act for this person?"; a **listing** answers "should this person choose it?". Turn the store off and OAuth still works, which is the test that keeps the two separable.
+
+That split is why the endpoints live under two prefixes:
+
+- **`/store`** — the storefront. What a visitor reads, and the reviews they write.
+- **`/applications/:appId/listing`** — the publisher's side, beside credentials and webhooks, because that is where the permission guarding it already lives.
+
+<Callout>
+A listing carries no name, icon or legal links. `applications` holds those and the storefront joins them in, so a store page and a consent screen cannot disagree about what an app is called.
+</Callout>
+
+## Two envelopes
+
+Single objects come back under `data`. Pages come back under `data` with their counts under **`pagination`** — not under `meta`.
+
+```json
+// GET /store/apps/mention
+{ "data": { "slug": "mention", "name": "Mention", … } }
+
+// GET /store/apps
+{ "data": [ … ], "pagination": { "total": 42, "limit": 24, "offset": 0, "hasMore": true } }
+```
+
+The publisher's listing endpoints answer with the object itself and **no envelope at all** — they are mounted under `/applications`, which predates the store and does not wrap.
+
+## The storefront
+
+No authentication. Every row served is already public, and a storefront is what somebody looks at before they have an account.
+
+Only `published` listings and `visible` reviews are served. A draft, a rejected page and a hidden review are **absent** rather than marked, so no client has to be trusted to filter them — and an unpublished page answers `404` exactly as an unknown slug does, because whether a draft exists under a name is not something a visitor gets to learn.
+
+| Method | Path | |
+|--------|------|--|
+| `GET` | `/store/categories` | The shelves, in curated order. |
+| `GET` | `/store/apps` | Published listings, newest first. `?category=<slug>&limit=&offset=` |
+| `GET` | `/store/apps/:slug` | One page, with screenshots and the rating breakdown. |
+| `GET` | `/store/apps/:slug/reviews` | Visible reviews. `?sort=recent\|rating&limit=&offset=` |
+
+An unknown `category` slug returns an **empty** shelf rather than every app on the store, so a typo shows nothing instead of everything.
+
+### The rating is computed
+
+There is no stored average and no review counter. Both are aggregated from the visible reviews on every read, so hiding a review takes it out of the average immediately rather than when some counter is next repaired.
+
+`average` is `null` when nobody has reviewed an app — never `0`, which would render as a one-star app that has no reviews.
+
+```json
+"rating": { "average": 4.6, "count": 31 },
+"ratingBreakdown": { "3": 1, "4": 9, "5": 21 }
+```
+
+Absent keys in the breakdown are zero.
+
+## Reviews
+
+Any signed-in Oxy account may review any published app. `Authorization: Bearer <accessToken>`.
+
+| Method | Path | |
+|--------|------|--|
+| `GET` | `/store/apps/:slug/review` | The caller's own review, or `null`. |
+| `PUT` | `/store/apps/:slug/review` | Write or replace it. |
+| `DELETE` | `/store/apps/:slug/review` | Withdraw it. `204`. |
+| `PUT` | `/store/reviews/:reviewId/reply` | The publisher's answer. |
+| `DELETE` | `/store/reviews/:reviewId/reply` | Withdraw it. `204`. |
+
+```http
+PUT /store/apps/mention/review
+Content-Type: application/json
+
+{ "rating": 5, "title": "Fast", "body": "Been using it for a month." }
+```
+
+`PUT`, not `POST`: a person has one review per app and this **sets** it. A second `POST` would promise a second resource, which the unique constraint would then refuse.
+
+Rewriting does not clear a moderator's decision — a hidden review stays hidden when its author edits it, or hiding one would be undone by whoever wrote it. Withdrawing your own review deletes the row: `removed` is a moderator's verdict about someone's words, and an author taking their words back is not that.
+
+### `authorUsesApp`
+
+Each review carries whether its author has authorized the application, read from their grant at request time rather than stored on the review — a flag written at insert would be true then and wrong from the next revocation onwards.
+
+It is `false` for a first-party app nobody has to consent to, so render its absence as nothing at all rather than as a demotion.
+
+### Replying
+
+Requires `app:update` over the application's owning account — the same permission that guards every other write to that application. A store listing is not a second, weaker way to act for somebody's app.
+
+One reply per review, attributed to the person who wrote it rather than to the app, because that is what moderation needs. Editing re-attributes it.
+
+## The publisher's listing
+
+Requires `app:update` (`app:read` to read). Answers with the listing object, unwrapped.
+
+| Method | Path | |
+|--------|------|--|
+| `GET` | `/applications/:appId/listing` | The page in any state, or `null`. |
+| `PUT` | `/applications/:appId/listing` | Write or replace its **content**. |
+| `POST` | `/applications/:appId/listing/submit` | Hand it to the store. |
+| `POST` | `/applications/:appId/listing/unpublish` | Take it down, or withdraw it. |
+
+```http
+PUT /applications/68b0…/listing
+Content-Type: application/json
+
+{
+  "slug": "mention",
+  "tagline": "The fediverse, at home",
+  "description": "# Mention\n\n…",
+  "categorySlug": "social",
+  "supportUrl": "https://mention.earth/help",
+  "supportEmail": null
+}
+```
+
+**`status` is not a field.** The publisher writes the words; the store decides whether they go up. Editing content and moving a page through review are different calls so that a publisher cannot publish themselves by putting a field in a body — and so that saving a correction to a live page leaves it live.
+
+A `PUT` of the whole page rather than a patch of part of it: the console edits one form, and a partial update makes "clear the tagline" and "leave the tagline alone" the same request.
+
+### States
+
+`draft` → `pending_review` → `published`, with `rejected` as the other way out of review. Every transition checks what it is moving **from**, so a draft cannot be published without being submitted and an approval cannot be replayed — a wrong transition answers `409`.
+
+`publishedAt` is stamped once. A page taken down and put back up keeps its original publication date, which is why it is its own column rather than read off `updated_at`.
+
+Unpublishing returns a page to `draft` rather than deleting it. The slug, the words and the screenshots are the publisher's work, and the reviews were never the listing's to take with them.
+
+### Errors
+
+| | |
+|--|--|
+| `404` | No listing, or no such app. |
+| `409` | The slug is taken, or the transition is not legal from the current state. |
+| `400` | The category slug does not exist — named rather than silently filed as uncategorised. |
+
+## Screenshots
+
+| Method | Path | |
+|--------|------|--|
+| `GET` | `…/listing/screenshots` | Every picture, in order. |
+| `POST` | `…/listing/screenshots` | Attach an uploaded image. `201`. |
+| `PUT` | `…/listing/screenshots/order` | Set the order of all of them. |
+| `PATCH` | `…/listing/screenshots/:id` | Its caption or platform. |
+| `DELETE` | `…/listing/screenshots/:id` | Remove it. `204`. |
+
+Upload through the files API first and pass the resulting **file id** — the store keeps a reference, not a second copy of the asset pipeline. The file must be live, an image, and one the caller is entitled to; the foreign key only proves the row exists.
+
+```http
+PUT /applications/68b0…/listing/screenshots/order
+
+{ "screenshotIds": ["s3", "s1", "s2"] }
+```
+
+Send **every** id on the listing, exactly once. A partial list is rejected rather than applied: it would leave the pictures it omits at their old positions, interleaved with the new ones. Sending all of them makes the request a statement of what the page should look like, which is the only shape that cannot half-apply.
+
+Removing a screenshot unpins the image; it does not delete the file, which may be in use elsewhere.
+
+## Moderation
+
+Platform staff only.
+
+| Method | Path | |
+|--------|------|--|
+| `GET` | `/store/moderation/listings` | The queue, oldest submission first. |
+| `POST` | `/store/moderation/listings/:applicationId/approve` | Publish it. |
+| `POST` | `/store/moderation/listings/:applicationId/reject` | Send it back. |
+| `POST` | `/store/moderation/categories` | Add a shelf. `201`. |
+| `PATCH` | `/store/moderation/categories/:slug` | Rename, re-word, reorder. |
+| `DELETE` | `/store/moderation/categories/:slug` | Retire it. |
+
+A category's **slug is not editable**: it is what every link to a category page carries, and a store that silently breaks its own URLs to fix a spelling is worse than one with a misspelled slug.
+
+Retiring a shelf does not delete the listings on it — they fall back to uncategorised, and the call answers with how many moved:
+
+```json
+{ "data": { "listingsUncategorised": 7 } }
+```
+
+## Rate limits
+
+Per minute: **240** reads, **20** writes. Writes are keyed on the **account**, not the IP, so a shared network is not throttled to one reviewer.
+
+## From the client
+
+Everything above is in `@oxyhq/core` — `listStoreApps`, `getStoreApp`, `listStoreReviews`, `writeStoreReview`, `getAppListing`, `writeAppListing`, and the rest. Prefer those over hand-rolled requests: they know which endpoint uses which envelope, which is the one thing about this API that is easy to get silently wrong.

--- a/packages/console/docs/store.mdx
+++ b/packages/console/docs/store.mdx
@@ -1,0 +1,103 @@
+---
+title: Listing on the app store
+description: Writing your app's store page, submitting it for review, screenshots, and replying to reviews.
+order: 4
+---
+
+# Listing on the app store
+
+A **store listing** is the page people read before they decide whether to use your app. It is separate from the app itself: registering a [developer app](/developers/docs/console#developer-apps) gets you an OAuth client, and a listing is what puts that client on a shelf where somebody can find it.
+
+The two stay separate on purpose. Turn the store off and OAuth still works; delete a listing and the app keeps running for everyone who already uses it.
+
+Not every app wants one. An internal tool, a service credential, a first-party client nobody chooses — those simply have no listing, which is why it is a separate record and not more fields on the app.
+
+## What the listing holds, and what it does not
+
+Your store page carries the things that only make sense in a store:
+
+| Field | |
+|-------|--|
+| **Store address** | The slug in the URL — `oxy.so/apps/mention`. Lowercase letters, digits and single hyphens. |
+| **Tagline** | One line, shown whole on the card. |
+| **Description** | Markdown. The long text on the page. |
+| **Category** | One shelf. |
+| **Support page / email** | Where somebody goes when it misbehaves. |
+| **Screenshots** | In the order you set. |
+
+It does **not** carry your app's name, icon, website, privacy policy or terms. Those live on the app record and the store reads them, so the consent screen and the store page cannot disagree about what your app is called or where its privacy policy is. Edit them under **Apps → your app → Settings**.
+
+It also carries no version history and no install count. The store renders your published updates and your grant records directly — a copy here would be a second number that drifts.
+
+<Callout>
+**The rating is not a field.** It is computed from the visible reviews every time the page is read, so hiding an abusive review takes it out of the average immediately rather than when some counter is next repaired.
+</Callout>
+
+## Writing the page
+
+**Apps → your app → Store.**
+
+The form is the whole page. Saving replaces what was there, which is what makes clearing a tagline expressible at all — leave a field empty and it is stored as empty, not skipped.
+
+A new page starts as a **draft**. Only you and the rest of your account's members can see it.
+
+## The four states
+
+```
+draft ──submit──▶ in review ──approve──▶ published
+  ▲                   │                     │
+  └──withdraw─────────┘                     │
+  ▲                   │                     │
+  │                   └──reject──▶ sent back│
+  └──────────────────────────────────────take down
+```
+
+| State | What it means |
+|-------|---------------|
+| **Draft** | Only you can see it. Submit it when you want the store to look. |
+| **In review** | With the store. You can withdraw it while it waits. |
+| **Published** | Live. |
+| **Sent back** | The store did not publish it. Fix what it asked for and submit again. |
+
+Two things follow from this that are worth knowing before you are surprised by them:
+
+**Saving does not move the page.** Correcting a typo on a live listing leaves it live, and the correction is visible immediately. Fixing a rejected page does not re-submit it — press **Submit for review** when you are ready.
+
+**Taking a page down returns it to a draft.** It does not delete anything: the slug, the words and the screenshots are yours and stay. Nor does it touch the reviews, which are about the app rather than the page.
+
+<Callout variant="warning">
+**Changing the store address after publishing breaks the old one.** Every link anyone has saved carries the slug. Pick it before you submit.
+</Callout>
+
+## Screenshots
+
+Upload an image and it is appended to the end. Move them with the arrows; the order you see is the order on the page.
+
+Removing a screenshot unpins the image from the listing — it does not delete the uploaded file, which may be in use elsewhere.
+
+The file has to be an image, has to be live, and has to belong to you or to an account you can act for. That last one is the same membership check that governs every other write to your app, so a colleague can attach an asset the account owns and nobody can attach a stranger's.
+
+## Reviews, and replying to them
+
+Anyone signed in to Oxy can review your app: one review each, whole stars from one to five, and writing again replaces what they said rather than adding a second.
+
+A reader can see whether a reviewer has actually authorized your app — it is read from their grant when the page loads, not stored on the review, so it stops being true the moment they disconnect. It is absent for a first-party app nobody has to consent to, so its absence means nothing in particular.
+
+**You can answer each review once.** The reply shows under it and is attributed to whoever wrote it, not to the app — moderation needs a person's name on it. Editing the reply re-attributes it to whoever edited.
+
+Replying needs the same permission as editing the app itself, so an **owner**, an **admin** or an **editor** on the owning account can do it, and a **viewer**, a **developer** or a **billing** member cannot.
+
+## Who can do what
+
+Everything on this page derives from your role on the account that **owns** the app — there is no separate store membership.
+
+| | Read the page | Edit it, submit, reply |
+|--|--|--|
+| Owner, admin, editor | ✅ | ✅ |
+| Developer, billing, viewer | ✅ | — |
+
+If a control is missing rather than disabled, it is because your role does not carry it.
+
+## Doing it from code
+
+Everything here is in the `@oxyhq/core` client — `getAppListing`, `writeAppListing`, `submitAppListing`, `unpublishAppListing`, and the screenshot calls. See the [REST reference](/developers/docs/api) for the endpoints behind them.


### PR DESCRIPTION
The store shipped across six PRs (#857–#864) and has no documentation. A developer opening the Console's new **Store** tab finds a form with no explanation of what a slug commits them to, what happens on submit, or why saving a live page does not take it down.

Two documents, for the two audiences the docs site already separates.

## `console/docs/store.mdx` — the publisher's guide

What the listing holds and what it deliberately does **not** (no name, icon or legal links — the app record owns those, so a store page and a consent screen cannot disagree). The four states, with the two things that surprise people:

- **Saving does not move the page.** Correcting a typo on a live listing leaves it live; fixing a rejected one does not re-submit it.
- **Taking a page down returns it to a draft.** The slug, the words and the screenshots stay, and the reviews were never the page's to take with them.

Plus screenshots, replying to reviews, and a table of which account role can do what — because a control that is missing rather than disabled needs explaining.

## `api/docs/store.mdx` — the reference

Every endpoint across all three surfaces (storefront, publisher, moderation), with the reasoning a caller has to know rather than discover: why an unknown category is an empty shelf and not every app, why `average` is `null` and never `0`, why the reorder call takes the whole set, why a draft 404s exactly like a missing slug.

**The envelope section is there because it is the one thing about this API that is easy to get silently wrong.** A page's counts live under `pagination`; a single object's optional metadata lives under `meta`. Reading the wrong one yields `total: 0` on every page with no error and no type complaint — a mistake made and caught while writing the SDK in #862, which is exactly why it belongs in the docs rather than in a comment.

## Verified by rendering, not by inspection

`docs/` is the one place a wrong claim persists indefinitely, so this was checked end to end rather than eyeballed:

1. Pointed the website's `docs-registry.json` at this worktree
2. Ran `sync-docs` — both files landed in `_synced/{api,console}/main/`
3. Built the site — the MDX compiled, `<Callout variant="warning">` resolved against the real component map
4. Confirmed both pages **prerender with their prose in the HTML**, not just a shell

The registry and the two generated index files were reverted afterwards; the website tree is byte-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)