### PR TITLE
docs: the API has been on Postgres for a while; the docs still said Mongo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -406,7 +406,7 @@ Single source of truth. Key methods:
 
 ### Types (`@oxyhq/contracts` — `src/reputation.ts`)
 **`@oxyhq/contracts` owns the whole reputation type family** — the closed value sets (`REPUTATION_CATEGORIES`, `TRUST_TIERS`, `REPUTATION_TRANSACTION_STATUSES`, `REPUTATION_TARGET_ENTITY_TYPES`, `REPUTATION_DISPUTE_STATUSES`, `REPUTATION_INFLUENCE_CONTEXTS`), the response entities (`ReputationTransaction`, `ReputationBalanceSummary` / `ReputationBalance` / `ReputationBalanceView`, `ReputationBalanceBreakdown`, `ReputationInfluence`, `ReputationReliability`, `ReputationDispute`, `ReputationRule`, `ReputationLeaderboardUser` / `ReputationLeaderboardEntry`, `ReputationInfluenceResult`, `ReverseReputationTransactionResult`), the write-endpoint request schemas + input types, and the `isFullReputationBalance` narrowing guard. `@oxyhq/core` declares NONE of them and re-exports NONE of them; every consumer imports from `@oxyhq/contracts` directly.
-- The API's mongoose enums (`ReputationTransaction`/`ReputationRule`/`ReputationDispute`/`ReputationBalance`/`User`) and its `validate({ body })` schemas import the SAME tuples/schemas, so a value set cannot be widened on one side only. `packages/api/src/utils/reputation.constants.ts` keeps only the numeric TUNABLES.
+- The API's Drizzle schema enums (`ReputationTransaction`/`ReputationRule`/`ReputationDispute`/`ReputationBalance`/`User`) and its `validate({ body })` schemas import the SAME tuples/schemas, so a value set cannot be widened on one side only. `packages/api/src/utils/reputation.constants.ts` keeps only the numeric TUNABLES.
 - Each serializer in `packages/api/src/routes/reputation.routes.ts` builds a `const dto: <ContractType>` (compile-time guard: a missing field, an undeclared field, or a `Date` where the wire promises an ISO string all fail `tsc` and name the field) and returns `schema.parse(dto)` (runtime guard). Do NOT loosen a serializer's return type back to `Record<string, unknown>` — that is exactly what let the `/:userId/balance` view split diverge from the SDK type silently.
 
 ### SDK (`@oxyhq/core` — `reputation` mixin)
@@ -536,7 +536,7 @@ Self-hosted `expo-updates`-protocol OTA server, namespaced entirely under `/upda
 
 ## No User IPs At Rest (privacy invariant, owner-mandated 2026-07-14)
 
-Threat model: state-actor harassment of users. The platform must **never persist a user IP address** — raw, hashed, or geo-derived (country included, e.g. `cf-ipcountry`) — in MongoDB, logs (pino fields), metrics metadata, or response DTOs. Salted hashes of the IPv4 space are brute-forceable by anyone with server access, so hashing is NOT an acceptable at-rest form.
+Threat model: state-actor harassment of users. The platform must **never persist a user IP address** — raw, hashed, or geo-derived (country included, e.g. `cf-ipcountry`) — in the database, logs (pino fields), metrics metadata, or response DTOs. Salted hashes of the IPv4 space are brute-forceable by anyone with server access, so hashing is NOT an acceptable at-rest form.
 
 - Removed entirely: `SecurityActivity.ipAddress`, `Session.deviceInfo.{ipAddress,location}`, `ApiKeyUsage.ipAddress`, the IP input to `deriveStableDeviceId`, IP-based anomaly detection (`detectRapidIPChanges`), and the civic `shared_ip` anti-sybil signal (`graphExclusion.ts` — device-fingerprint/interaction-history/affinity-throttle only now).
 - **Anonymous rate-limit keys are the one place IPs may be touched, and only transiently:** they MUST go through `hashedIpKey` (`packages/api/src/utils/ipKey.ts` — HMAC(`DEVICE_ID_SALT`), IPv6 /56-bucketed) and live only as a Redis key with the limiter's normal TTL. Never key a limiter on raw `req.ip`.
@@ -911,7 +911,7 @@ Standalone Vite app at `auth.oxy.so` — the **OAuth authorize/consent IdP** for
 
 - **Envelope v2** (`version:2, seq, prev, collection, rkey`): adds sequential ledger semantics on top of the v1 signing envelope. `seq` = monotone counter per `(subject, collection)`; `prev` = SHA-256 of the previous envelope JSON (or null for the first). Forms a per-subject, per-collection hash chain.
 - **`RepoHead`** model (collection `repoheads`): one document per `(subject, collection)`, stores `seq + envelopeHash` — O(1) head lookup without scanning the chain.
-- **`SignedRecord.nsid`** — the MongoDB column name for `collection` is `nsid` (Namespaced Identifier, e.g. `app.oxy.card`, `app.oxy.credential`). Use `nsid` in queries; `collection` is the schema/SDK alias.
+- **`SignedRecord.nsid`** — the column name for `collection` is `nsid` (Namespaced Identifier, e.g. `app.oxy.card`, `app.oxy.credential`). Use `nsid` in queries; `collection` is the schema/SDK alias.
 - **`signedRecordSigningInput` / `canonicalize`** from `packages/core/src/crypto/canonicalJson.ts` — signing input is `canonicalize(envelopeWithoutSignature)`. Used identically by client and server.
 - **`verifyEnvelope` branching** in `packages/api/src/services/signedRecord.service.ts`: issuer === subject → self-signed (verify against subject's current VM); issuer === `OXY_DID` → custodial (verify via `verifySecret`-gated Oxy key); else → untrusted, reject.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,7 +126,7 @@ See [architecture/overview.md](./architecture/overview.md) for the full monorepo
 |                                |                                  |
 |                                v                                  |
 |   +---------------------------------------------------------+    |
-|   |                       MongoDB                            |    |
+|   |                      PostgreSQL                          |    |
 |   |  Users, Sessions, DeviceSessions, Applications, Grants   |    |
 |   +---------------------------------------------------------+    |
 +-----------------------------------------------------------------+

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -23,8 +23,8 @@ ECS Fargate task (oxy-cluster / oxy-api)
    |  linux/arm64, port 8080, assign_public_ip=true
    v
 +------------------+   +----------------------+
-| ElastiCache      |   | MongoDB EC2          |
-| Valkey           |   | (EIP <mongo-public-ip>) |
+| ElastiCache      |   | RDS PostgreSQL 17    |
+| Valkey           |   | (oxy-postgres)       |
 +------------------+   +----------------------+
 ```
 
@@ -50,7 +50,7 @@ Task definitions are versioned (`oxy-oxy-api:N`). New revisions are registered w
 | `ACCESS_TOKEN_SECRET` | JWT signing secret for access tokens |
 | `REFRESH_TOKEN_SECRET` | JWT signing secret for refresh tokens |
 | `DEVICE_ID_SALT` | 64-hex salt for `deriveStableDeviceId` |
-| `MONGODB_URI` | MongoDB cluster URI (no DB name; apps pass `dbName`) |
+| `DATABASE_URL` | Postgres connection string for the `oxy_api` database on `oxy-postgres` |
 | `REDIS_URL` | ElastiCache Valkey URI |
 | `CLOUDFLARE_API_TOKEN` | For Cloudflare Pages deploys + DNS-01 ACM validation |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account |
@@ -78,7 +78,7 @@ The image is built for **linux/arm64** (Graviton). x86 images won't run on the F
 
 | Variable | Description |
 |----------|-------------|
-| `MONGODB_URI` | MongoDB cluster URI (no DB name -- apps pass `dbName` to `mongoose.connect`) |
+| `DATABASE_URL` | Postgres connection string; the database name is part of the URI |
 | `ACCESS_TOKEN_SECRET` | JWT signing secret for access tokens |
 | `REFRESH_TOKEN_SECRET` | JWT signing secret for refresh tokens |
 | `DEVICE_ID_SALT` | 64-hex salt scoping `deriveStableDeviceId` |
@@ -139,6 +139,5 @@ curl https://api.oxy.so/health
 
 - **Logs**: ECS task stdout/stderr is shipped to CloudWatch Logs (`/oxy/ecs`). Use `aws logs tail /oxy/ecs --follow --log-stream-name-prefix oxy-api` (profile `oxy`) to stream the live log.
 - **Rollback**: re-run a previous successful deploy workflow, or `aws ecs update-service --task-definition oxy-oxy-api:<previous-rev>`.
-- **SSH-less access**: the MongoDB EC2 instance has no SSH keys. Use AWS SSM Session Manager: `aws ssm start-session --target <mongo-instance-id>`.
-- **Backups**: `s3://<mongo-backup-bucket>/daily/`. Restore runbook lives in `~/Oxy/oxy-infra/docs/runbooks/10-mongo-restore.md`.
+- **Database access and backups**: `oxy-postgres` is an RDS instance owned by `oxy-infra` — automated snapshots, parameter groups and restore live there, not here. See `~/Oxy/oxy-infra/terraform-uswest2/postgres.tf`.
 - **Excluded from AWS**: the LiveKit cluster still runs on its own external managed host and is migrated separately. Athina, faircoin, TNP, and the OpenSearch `genai-shark` instance also stay outside AWS.

--- a/docs/EMAIL.md
+++ b/docs/EMAIL.md
@@ -22,11 +22,11 @@ Inbound:
                          ┌──────────────────┐
                          │  Oxy API         │  Validates recipient against Oxy users,
                          │  emailInbound.ts │  parses MIME, runs spam checks,
-                         │                  │  writes Mailbox/Message documents.
+                         │                  │  writes Mailbox/Message rows.
                          └────────┬─────────┘
                                   │
                                   ▼
-                            MongoDB (EC2)
+                          PostgreSQL (RDS)
                                   │
                                   ▼
                         S3 (attachments)
@@ -536,7 +536,7 @@ In production, email runs entirely on AWS:
                 │
        ┌────────┴────────┐
        ▼                 ▼
-  MongoDB (EC2)     S3 (attachments)
+  PostgreSQL (RDS)  S3 (attachments)
 ```
 
 **Key points:**
@@ -544,7 +544,7 @@ In production, email runs entirely on AWS:
 - **AWS SES** handles transport (delivery + DKIM-signed outbound) and basic spam classification.
 - **Cloudflare Email Routing** delivers inbound mail for `@oxy.so` to the API webhook (`packages/api/src/routes/emailInbound.ts`).
 - The Oxy API runs as an **ECS Fargate** task in `oxy-cluster` behind the ALB — no on-box SMTP server in this path.
-- **MongoDB** is the self-hosted EC2 instance described in [Infrastructure](INFRASTRUCTURE.md).
+- **PostgreSQL** is the shared `oxy-postgres` RDS instance described in [Infrastructure](INFRASTRUCTURE.md).
 - **Auto-deploy**: push to `main` → GitHub Actions builds an `arm64` image → pushes to ECR → `aws ecs update-service --force-new-deployment`. See [Deployment](DEPLOYMENT.md).
 
 ### Self-hosted SMTP (legacy / non-AWS deployments)

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -9,8 +9,7 @@ All Oxy production infrastructure runs on **AWS** in the **us-west-2 (Oregon)** 
 | `oxy-cluster` | ECS Fargate cluster | — | us-west-2 | Runs all 6 backend services as Fargate tasks (linux/arm64) |
 | `oxy-alb` | Application Load Balancer | `<alb-dns-name>` | us-west-2 | HTTPS termination (ACM multi-SAN cert) + path/host routing to ECS services |
 | `oxy-valkey` | ElastiCache (Valkey) | — | us-west-2 | Rate limiting + Socket.IO adapter |
-| `oxy-mongo` | EC2 (MongoDB 8 self-hosted) | `<mongo-instance-id>` (EIP `<mongo-public-ip>`) | us-west-2 | Shared MongoDB for all Oxy apps. `/data` on a 100 GB gp3 EBS volume |
-| `<mongo-backup-bucket>` | S3 bucket | — | us-west-2 | Daily mongodump under `daily/` (14-day retention) |
+| `oxy-postgres` | RDS (PostgreSQL 17) | — | us-west-2 | The API serves from the `oxy_api` database. Shared instance — other Oxy apps sit in their own databases on it |
 | `<terraform-state-bucket>` | S3 bucket | — | us-west-2 | Terraform remote state |
 | ECR repos | `237343248947.dkr.ecr.us-west-2.amazonaws.com/oxy/<app>` | one per service | us-west-2 | linux/arm64 images for each backend |
 | `oxy-github-deploy` | IAM role | — | — | Trust policy for GitHub OIDC; no static AWS keys in GitHub |
@@ -44,34 +43,16 @@ All tasks run `assign_public_ip=true` so there is no NAT gateway in the path.
 - ALB listener on `:443` terminates TLS with the ACM multi-SAN cert (DNS-validated through the Cloudflare API). HTTP `:80` redirects to `:443`.
 - ALB target groups route by `Host:` header to the matching ECS service.
 - Cloudflare DNS is **DNS-only** (grey cloud) for the API hostnames so the ALB sees real client IPs and ACM can complete DNS-01 validation.
-- ECS tasks talk to ElastiCache and the MongoDB EC2 instance over the default VPC inside `us-west-2`.
-- Security group on the MongoDB EC2 instance allows `:27017` only from the ECS task ENIs and from the ops bastion path (SSM Session Manager — no SSH key on disk).
+- ECS tasks talk to ElastiCache and the RDS instance over the default VPC inside `us-west-2`.
+- Security group on the RDS instance allows `:5432` only from the ECS task ENIs and from the ops bastion path (SSM Session Manager — no SSH key on disk).
 
-## Database: MongoDB (self-hosted on EC2)
+## Database: PostgreSQL (RDS `oxy-postgres`)
 
-The MongoDB 8 instance is intentionally self-hosted rather than DocumentDB so we can use the full driver feature set (transactions, change streams, full text search). Backups are written nightly:
+The API's data lives in the `oxy_api` database on the shared `oxy-postgres` RDS instance. It is reached through one `DATABASE_URL` — a single connection string carrying the database name, so there is no per-app database selection at connect time.
 
-- Job: scheduled `mongodump --gzip --archive=…` running inside the instance.
-- Destination: `s3://<mongo-backup-bucket>/daily/<date>.gz`.
-- Retention: 14 days via the bucket lifecycle policy.
-- Restore runbook: `~/Oxy/oxy-infra/docs/runbooks/10-mongo-restore.md`.
+Schema is owned by Drizzle: `packages/api/src/db/schema/` declares it, `drizzle/` holds the generated migrations, and `bun run db:migrate` applies them. `packages/api/src/db/MIGRATION-CONTRACT.md` records the invariants the schema must hold.
 
-Admin credentials live in SSM Parameter Store (private MongoDB admin parameters). They are read by deploy jobs and the backup job — never committed.
-
-### Database naming convention
-
-The `MONGODB_URI` is the cluster URI (no database name embedded). Each app passes `dbName` to `mongoose.connect()`:
-
-```typescript
-const APP_NAME = "mention";
-const ENV_DB_MAP: Record<string, string> = { production: 'prod', development: 'dev' };
-const envSuffix = ENV_DB_MAP[process.env.NODE_ENV] || process.env.NODE_ENV;
-const dbName = `${APP_NAME}-${envSuffix}`;
-
-mongoose.connect(process.env.MONGODB_URI, { dbName });
-```
-
-Examples: `oxy-prod`, `mention-production`, `alia-production`, `homiio-production`, `allo-production`.
+Instance sizing, storage headroom, parameter groups, backup/restore and the tenancy question (which apps share the instance) are owned by `oxy-infra` — see `~/Oxy/oxy-infra/terraform-uswest2/postgres.tf` and `~/Oxy/oxy-infra/docs/postgres-shared-instance-capacity.md`. Deliberately not restated here: this document went stale once by duplicating infrastructure detail it does not own.
 
 ## Cache: ElastiCache Valkey (`oxy-valkey`)
 
@@ -116,14 +97,8 @@ Shared parameters (the shared parameter namespace) include AWS access-key variab
                                              |       |     |
                                              v       v     v
                                    +---------+----+ +-+---+----------+
-                                   | ElastiCache  | |  MongoDB on    |
-                                   |  Valkey      | |  EC2 + EBS     |
-                                   |  oxy-valkey  | |  (EIP)         |
+                                   | ElastiCache  | |  RDS           |
+                                   |  Valkey      | |  PostgreSQL 17 |
+                                   |  oxy-valkey  | |  oxy-postgres  |
                                    +--------------+ +----------------+
-                                                          |
-                                                          v
-                                                 +--------+--------+
-                                                 |  S3 backups     |
-                                                 |  (daily, 14d)   |
-                                                 +-----------------+
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,7 +85,7 @@ topics and remain authoritative for their areas:
 - [AUTHENTICATION.md](AUTHENTICATION.md) — auth integration guide (Expo, Web, Node, WebSockets)
 - [SESSION-ARCHITECTURE.md](SESSION-ARCHITECTURE.md) — session architecture in depth
 - [SERVICE_TOKENS.md](SERVICE_TOKENS.md) — service-to-service auth (OAuth2 client credentials)
-- [INFRASTRUCTURE.md](INFRASTRUCTURE.md) — AWS resources (ECS, ALB, ECR, ElastiCache, MongoDB)
+- [INFRASTRUCTURE.md](INFRASTRUCTURE.md) — AWS resources (ECS, ALB, ECR, ElastiCache, RDS PostgreSQL)
 - [DEPLOYMENT.md](DEPLOYMENT.md) — GitHub OIDC, ECS Fargate, env vars, Cloudflare Pages
 - [REDIS.md](REDIS.md) — ElastiCache Valkey: rate limiting, Socket.IO adapter, caching
 - [EMAIL.md](EMAIL.md) — native email (`username@oxy.so`), DKIM/SPF/DMARC, inbound webhook

--- a/docs/SESSION-ARCHITECTURE.md
+++ b/docs/SESSION-ARCHITECTURE.md
@@ -12,7 +12,7 @@
 ## Principles
 
 - **Server authority.** Which accounts are signed in on a device — and which one is
-  active — lives in one MongoDB document per device. Clients never own that state; they
+  active — lives in one `device_sessions` row per device. Clients never own that state; they
   project it.
 - **Silent cold boot.** `OxyProvider` restores the session on mount with zero UI. It never
   redirects to a login page and never opens a dialog on its own. Signed-out is a silent,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -156,7 +156,7 @@ sequenceDiagram
     participant App as RP app (OxyProvider)
     participant SDK as @oxyhq/core OxyServices
     participant API as api.oxy.so (@oxyhq/api)
-    participant DB as MongoDB
+    participant DB as PostgreSQL
 
     Note over App,SDK: device-first cold boot restored a session (see auth docs)
     App->>SDK: oxyServices.getProfileByUsername("nate")

--- a/docs/identity/README.md
+++ b/docs/identity/README.md
@@ -123,9 +123,9 @@ graph LR
     B --> H["RepoHead<br/>{ seq: 2, headRecordId: R2, recordCount: 3 }"]
 ```
 
-`RepoHead` (collection `repoheads`) is one document per `(subject, collection)`
+`RepoHead` (table `repo_heads`) is one row per `(subject, collection)`
 holding `{ seq, headRecordId, recordCount }` — an O(1) head pointer so the server
-never scans the chain to find the tip. In MongoDB the `SignedRecord` column for
+never scans the chain to find the tip. The `SignedRecord` column for
 `collection` is named **`nsid`** (query by `nsid`; `collection` is the
 schema/SDK alias).
 

--- a/docs/reputation/README.md
+++ b/docs/reputation/README.md
@@ -35,17 +35,17 @@ hash chain, and the *trigger* is always a verified signature from a third party.
 
 ## 2. The reputation ledger
 
-Three MongoDB models back the ledger (`packages/api/src/models/`):
+Three Postgres tables back the ledger (`packages/api/src/db/schema/`):
 
-- **`ReputationTransaction`** (`reputationtransactions`) — the append-only ledger.
+- **`ReputationTransaction`** (`reputation_transactions`) — the append-only ledger.
   `status` ∈ `active | disputed | reversed | voided` — **only `active` counts
   toward balance**. `category` ∈ `content | social | trust | moderation |
   physical | penalty | other`. `sourceActionId` gives idempotency.
-- **`ReputationBalance`** (`reputationbalances`) — a cached per-user snapshot:
+- **`ReputationBalance`** (`reputation_balances`) — a cached per-user snapshot:
   `total`, `positive`, `negative`, `breakdown`, `reliability`, `trustTier`,
   `influence`; recalculated on demand. Read back in **two views** — see
   [Who may read a balance](#who-may-read-a-balance).
-- **`ReputationDispute`** (`reputationdisputes`) — dispute lifecycle.
+- **`ReputationDispute`** (`reputation_disputes`) — dispute lifecycle.
 
 Reversals never delete: `reverseTransaction` marks the original `reversed` and
 inserts a compensating `-points active` transaction (nets to zero);
@@ -107,9 +107,9 @@ twice:
 | Guard | Catches |
 | --- | --- |
 | `const dto: <ContractType>` | a missing required field, a field the contract does not declare (excess-property checking), a `Date` left where the wire promises an ISO string — all at `tsc` time, naming the field |
-| `schema.parse(dto)` | what the compiler cannot see: a mongoose path typed required that an old document actually lacks |
+| `schema.parse(dto)` | what the compiler cannot see: a column typed required that an old row actually lacks |
 
-The same closed-value tuples back the mongoose enums, so a seventh category
+The same closed-value tuples back the schema enums, so a seventh category
 cannot be added on one side only. Before this, the serializers returned
 `Record<string, unknown>` and imported no reputation type from anywhere — the
 [view split below](#read-authorization) shipped server-side while the SDK type

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -10,7 +10,7 @@ A comprehensive Node.js/TypeScript backend server providing JWT-based authentica
 - ⚡ **Express.js Server** - RESTful API with comprehensive middleware
 - 🔒 **Security Features** - Rate limiting, CORS, password hashing, brute force protection
 - 📝 **TypeScript** - Full type safety and developer experience
-- 📁 **File Management** - GridFS-based file upload, storage, and streaming
+- 📁 **File Management** - S3-backed file upload, storage, and streaming
 - 👥 **Social Features** - User profiles, following system, recommendations
 - 🔔 **Real-time Notifications** - Socket.IO powered notifications
 - 💳 **Payment Processing** - Payment method validation and processing
@@ -50,13 +50,18 @@ bun run dev
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Client Apps   │    │    Oxy API      │    │    MongoDB      │
+│   Client Apps   │    │    Oxy API      │    │   PostgreSQL    │
 │                 │    │                 │    │                 │
-│ Frontend/Backend│◄──►│ Express Server  │◄──►│   Database      │
-│ with OxyServices│    │ + Auth Routes   │    │ + Collections   │
-│                 │    │ + File Storage  │    │ + GridFS        │
-│                 │    │ + Socket.IO     │    │ + Analytics     │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
+│ Frontend/Backend│◄──►│ Express Server  │◄──►│  Drizzle schema │
+│ with OxyServices│    │ + Auth Routes   │    │  + migrations   │
+│                 │    │ + Socket.IO     │    │                 │
+└─────────────────┘    └────────┬────────┘    └─────────────────┘
+                                │
+                                ▼
+                       ┌─────────────────┐
+                       │   S3 storage    │
+                       │  (file assets)  │
+                       └─────────────────┘
 ```
 
 ## API Endpoints
@@ -304,8 +309,8 @@ Response:
 
 ## Performance
 
-- **File Streaming**: Efficient file serving via GridFS streams
-- **Database Indexing**: Optimized MongoDB queries
+- **File Streaming**: Efficient file serving from S3
+- **Database Indexing**: Optimized Postgres queries
 - **Caching**: Response caching for static content
 - **Connection Pooling**: Efficient database connections
 

--- a/wiki/Deployment.md
+++ b/wiki/Deployment.md
@@ -25,8 +25,8 @@ ECS Fargate task (oxy-cluster / oxy-api)
    |  linux/arm64, port 8080, assign_public_ip=true
    v
 +------------------+   +----------------------+
-| ElastiCache      |   | MongoDB EC2          |
-| Valkey           |   | (EIP <mongo-public-ip>) |
+| ElastiCache      |   | RDS PostgreSQL 17    |
+| Valkey           |   | (oxy-postgres)       |
 +------------------+   +----------------------+
 ```
 
@@ -52,7 +52,7 @@ Task definitions are versioned (`oxy-oxy-api:N`). New revisions are registered w
 | `ACCESS_TOKEN_SECRET` | JWT signing secret for access tokens |
 | `REFRESH_TOKEN_SECRET` | JWT signing secret for refresh tokens |
 | `DEVICE_ID_SALT` | 64-hex salt for `deriveStableDeviceId` |
-| `MONGODB_URI` | MongoDB cluster URI (no DB name) |
+| `DATABASE_URL` | Postgres connection string for the `oxy_api` database on `oxy-postgres` |
 | `REDIS_URL` | ElastiCache Valkey URI |
 | `CLOUDFLARE_API_TOKEN` | Cloudflare Pages deploys + DNS-01 ACM validation |
 | `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account |
@@ -91,7 +91,7 @@ CMD ["bun", "run", "packages/api/dist/server.js"]
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `MONGODB_URI` | MongoDB cluster URI (no DB name -- apps pass `dbName`) | `mongodb://<private-mongo-host>:27017` |
+| `DATABASE_URL` | Postgres connection string; the database name is part of the URI | `postgres://<user>:<pass>@<private-rds-host>:5432/oxy_api` |
 | `ACCESS_TOKEN_SECRET` | JWT signing secret for access tokens | 64+ hex |
 | `REFRESH_TOKEN_SECRET` | JWT signing secret for refresh tokens | 64+ hex |
 | `DEVICE_ID_SALT` | 64-hex salt scoping `deriveStableDeviceId` | 64 hex |
@@ -150,5 +150,4 @@ curl https://api.oxy.so/health
 
 - **Logs**: ECS task stdout/stderr -> CloudWatch Logs (`/oxy/ecs`). `aws logs tail /oxy/ecs --follow --log-stream-name-prefix oxy-api` (profile `oxy`) streams live output.
 - **Rollback**: re-run a prior successful deploy workflow, or `aws ecs update-service --task-definition oxy-oxy-api:<previous-rev>`.
-- **SSH-less ops**: MongoDB EC2 has no SSH keys. Use `aws ssm start-session --target <mongo-instance-id>`.
-- **Backups**: `s3://<mongo-backup-bucket>/daily/`. Restore runbook: `~/Oxy/oxy-infra/docs/runbooks/10-mongo-restore.md`.
+- **Database access and backups**: `oxy-postgres` is an RDS instance owned by `oxy-infra` — snapshots, parameter groups and restore live there (`terraform-uswest2/postgres.tf`).

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,7 +7,7 @@ Monorepo for the Oxy platform — authentication, user management, real-time fea
 | Page | Description |
 |------|-------------|
 | [[Architecture]] | Monorepo structure, packages, dependency graph |
-| [[Infrastructure]] | AWS resources (ECS, ALB, ECR, ElastiCache, MongoDB on EC2) |
+| [[Infrastructure]] | AWS resources (ECS, ALB, ECR, ElastiCache, RDS PostgreSQL) |
 | [[Deployment]] | GitHub OIDC, ECS Fargate, env vars, Cloudflare Pages |
 | [[Authentication]] | JWT flow, device sessions, session validation, CSRF protection |
 | [[Service Tokens]] | Internal service-to-service auth (OAuth2 Client Credentials) |

--- a/wiki/Infrastructure.md
+++ b/wiki/Infrastructure.md
@@ -9,8 +9,7 @@ All Oxy production infrastructure runs on **AWS** in the **us-west-2 (Oregon)** 
 | `oxy-cluster` | ECS Fargate cluster | — | us-west-2 | All 6 backend services as Fargate tasks (linux/arm64) |
 | `oxy-alb` | Application Load Balancer | `<alb-dns-name>` | us-west-2 | HTTPS termination (ACM multi-SAN cert) + host-based routing |
 | `oxy-valkey` | ElastiCache (Valkey) | — | us-west-2 | Rate limiting + Socket.IO adapter |
-| `oxy-mongo` | EC2 (MongoDB 8 self-hosted) | `<mongo-instance-id>` (EIP `<mongo-public-ip>`) | us-west-2 | Shared MongoDB for all Oxy apps. `/data` on a 100 GB gp3 EBS volume |
-| `<mongo-backup-bucket>` | S3 bucket | — | us-west-2 | Daily `mongodump` archives under `daily/` (14-day retention) |
+| `oxy-postgres` | RDS (PostgreSQL 17) | — | us-west-2 | The API serves from the `oxy_api` database. Shared instance — other Oxy apps sit in their own databases on it |
 | `<terraform-state-bucket>` | S3 bucket | — | us-west-2 | Terraform remote state |
 | ECR | `237343248947.dkr.ecr.us-west-2.amazonaws.com/oxy/<app>` | one per service | us-west-2 | linux/arm64 images |
 | `oxy-github-deploy` | IAM role | — | — | GitHub OIDC trust; no static AWS keys in repo secrets |
@@ -43,40 +42,16 @@ All tasks run with `assign_public_ip = true` (no NAT gateway).
 - HTTP `:80` redirects to `:443`.
 - ALB target groups route by `Host:` header to the matching ECS service.
 - Cloudflare DNS is **DNS-only** (grey cloud) for all API hostnames so the ALB sees real client IPs and ACM can complete DNS-01 validation.
-- ECS tasks reach ElastiCache and the MongoDB EC2 instance over the default VPC.
-- The MongoDB EC2 security group accepts `:27017` only from the ECS task ENIs (security-group-to-security-group rule). Ops access uses AWS SSM Session Manager — there are no SSH keys on disk.
+- ECS tasks reach ElastiCache and the RDS instance over the default VPC.
+- The RDS security group accepts `:5432` only from the ECS task ENIs (security-group-to-security-group rule). Ops access uses AWS SSM Session Manager — there are no SSH keys on disk.
 
-## Database: MongoDB (self-hosted on EC2)
+## Database: PostgreSQL (RDS `oxy-postgres`)
 
-Self-hosted rather than DocumentDB so we can use the full driver feature set (transactions, change streams, full text search).
+The API serves from the `oxy_api` database on the shared `oxy-postgres` RDS instance, reached through a single `DATABASE_URL` that carries the database name.
 
-- Daily `mongodump --gzip --archive=…` cron job inside the instance.
-- Archives uploaded to `s3://<mongo-backup-bucket>/daily/<date>.gz`.
-- 14-day retention via the bucket lifecycle policy.
-- Restore runbook: `~/Oxy/oxy-infra/docs/runbooks/10-mongo-restore.md`.
+Schema is owned by Drizzle: `packages/api/src/db/schema/` declares it, `drizzle/` holds the generated migrations, `bun run db:migrate` applies them, and `packages/api/src/db/MIGRATION-CONTRACT.md` records the invariants it must hold.
 
-Admin credentials live in SSM (private MongoDB admin parameters). Read by deploy jobs and the backup cron. Never committed.
-
-### Database naming convention
-
-```
-{appName}-{NODE_ENV_suffix}
-```
-
-| `NODE_ENV` | Suffix |
-|------------|--------|
-| `production` | `prod` |
-| `development` | `dev` |
-
-Each app passes `dbName` to `mongoose.connect()`:
-
-```typescript
-const APP_NAME = "mention";
-const ENV_DB_MAP = { production: 'prod', development: 'dev' } as const;
-const envSuffix = ENV_DB_MAP[process.env.NODE_ENV] ?? process.env.NODE_ENV;
-const dbName = `${APP_NAME}-${envSuffix}`;
-mongoose.connect(process.env.MONGODB_URI, { dbName });
-```
+Sizing, storage headroom, parameter groups, snapshots and restore belong to `oxy-infra` (`terraform-uswest2/postgres.tf`, `docs/postgres-shared-instance-capacity.md`) and are deliberately not restated here — duplicating them is how this page went stale before.
 
 ## Cache: ElastiCache Valkey
 
@@ -121,14 +96,8 @@ The shared parameter namespace covers AWS access-key variables (for SES / app-le
                                              |       |     |
                                              v       v     v
                                    +---------+----+ +-+---+----------+
-                                   | ElastiCache  | |  MongoDB EC2   |
-                                   |  Valkey      | |  + EBS         |
-                                   |  oxy-valkey  | |  + EIP         |
+                                   | ElastiCache  | |  RDS           |
+                                   |  Valkey      | |  PostgreSQL 17 |
+                                   |  oxy-valkey  | |  oxy-postgres  |
                                    +--------------+ +----------------+
-                                                          |
-                                                          v
-                                                 +--------+--------+
-                                                 |  S3 backups     |
-                                                 |  (daily, 14d)   |
-                                                 +-----------------+
 ```

--- a/wiki/Redis-&-Valkey.md
+++ b/wiki/Redis-&-Valkey.md
@@ -116,11 +116,15 @@ This makes Socket.IO rooms and events fan out across all ECS tasks.
 Redis is closed during `SIGINT` / `SIGTERM` (ECS sends `SIGTERM` before killing the container):
 
 ```typescript
-process.on('SIGINT', async () => {
+async function gracefulShutdown(signal: string) {
+  // ...stop accepting work first, then release the backing stores
   await closeRedis();
-  await mongoose.connection.close();
+  await closePostgres();
   process.exit(0);
-});
+}
+
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 ```
 
 ## Health check


### PR DESCRIPTION
## What

Docs-only. `docs/INFRASTRUCTURE.md`, `docs/DEPLOYMENT.md` and their `wiki/` mirrors described **MongoDB on EC2 as this API's datastore**, listed `MONGODB_URI` as a required deploy secret, and documented a `mongoose.connect(…, { dbName })` database-naming convention.

None of that has been true since the Postgres cutover. Four of the edited files contained **zero occurrences of the word "Postgres"**, so this wasn't drift at the margins — a reader following `DEPLOYMENT.md` would have provisioned the wrong database and set a secret the API ignores.

## Evidence the API is not on Mongo

- Live task definition carries `DATABASE_URL`, no `MONGODB_URI`; `deploy-aws.yml`'s `API_SECRETS` list has no Mongo entry.
- `api.oxy.so/health` → `{"database":"connected"}` against that definition.
- `src/config/env.ts` hard-requires `DATABASE_URL`; `src/config/` has no `MONGODB_URI` reference at all, and `src/config/__tests__/env.test.ts` has a case named *"boots with no MONGODB_URI at all — Mongo left the serving path"*.
- **Nothing in the serving path imports mongoose.** `src/routes`, `src/services`, `src/controllers`, `src/middleware`, `src/queue`, `src/utils` reference it only inside `__tests__`. `src/server.ts` mentions Mongo only in comments explaining what was removed.
- **Nothing outside `src/models/`, `scripts/`, `src/scripts/`, `src/db/backfill/` and tests imports `models/`** — zero runtime importers.

## Also corrected, same root cause

| File | Was | Now |
|---|---|---|
| `packages/api/README.md` | GridFS file storage | S3 (`s3Service`; no GridFS left in `src/`) |
| `docs/reputation/README.md` | `reputationbalances` etc. | `reputation_balances`, `reputation_transactions`, `reputation_disputes` |
| `docs/identity/README.md` | "one document per…" | `repo_heads` rows |
| `docs/SESSION-ARCHITECTURE.md` | "one MongoDB document per device" | one `device_sessions` row per device |
| `wiki/Redis-&-Valkey.md` | shutdown closes `mongoose.connection` | closes Redis then Postgres (matches `server.ts`) |
| `AGENTS.md` | "mongoose enums" | Drizzle schema enums |

Table/column names were read out of `src/db/schema/*.ts` rather than guessed.

The infra sections no longer restate sizing, backups or parameter groups — those belong to `oxy-infra`, and duplicating them here is exactly how this document went stale. They now point at `terraform-uswest2/postgres.tf`.

## Deliberately kept

- `packages/api/src/db/MIGRATION-CONTRACT.md` and all of `src/db/backfill/` — still a **live** subsystem: its own CI job (`api-backfill-test`, `mongo:7` service container, ~150 tests) and its own `docker-compose.dev.yml` service.
- `AGENTS.md`'s *"MongoDB (optional) — only needed for backfill/admin scripts… the API serving path does NOT connect to Mongo"*, which already stated the truth these docs contradicted.
- Mongo rationale comments in `src/server.ts`, and `@oxyhq/db`'s `mongoose_artifact` schema check — that one is a **Postgres-side guard** against `_id`/`__v` columns leaking in, not Mongo code.

## Not attempted here (deferred, sized in the review notes)

Removing the remaining Mongo **code** is its own project, not a sweep: 82 Mongoose models, ~30 one-shot scripts, an 18k-line backfill engine wired into CI, and a global `jest.mock('mongoose')` that ~30 suites opt out of. Reported separately rather than half-done.

## Gates

Docs only — `git diff --name-only` is 15 files, all `.md`, no source touched. No test or build step reads any of them (the two suites that mention `AGENTS.md` do so in comments). Every path cited in the new text was checked to resolve, and no dangling `<mongo-*>` placeholder references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)