### PR TITLE
release: core 20.1.0 — the app store's client surface

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -424,7 +424,7 @@
     },
     "packages/core": {
       "name": "@oxyhq/core",
-      "version": "20.0.0",
+      "version": "20.1.0",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/hashes": "^1.8.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oxyhq/core",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "description": "OxyHQ SDK Foundation \u2014 API client, authentication, cryptographic identity, and shared utilities",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Publishes the store mixin that landed in #862. Additive — a new mixin and its types, nothing changed or removed — so a minor.

**Why now:** Atlas, the Oxy App Store app, consumes `@oxyhq/core` from npm. The mixin is on `main` and unpublished, so Atlas cannot call the store without either this release or a hand-rolled `makeRequest`, which is the drift the SDK exists to prevent.

## What is not bumped, and why

- **`@oxyhq/services`** declares `@oxyhq/core` as a **peer** at `^20.0.0`, which `20.1.0` satisfies. No bump needed.
- **`@oxyhq/contracts`** stays at `0.25.0`. The rule is to republish contracts first when core starts importing a *new* contracts symbol; this mixin imports none, its types are self-contained. Checked the other half of that trap too — local contracts `0.25.0` is exactly what is published, so the `workspace:^` substitution in the packed manifest resolves to `^0.25.0` and points at a version that exists.

## The lockfile

Bumping a workspace version without regenerating `bun.lock` is the desync `--frozen-lockfile` is blind to, and this repo's gate catches it directly:

```
$ bun scripts/check-lockfile-sync.mjs        # after the bump, before install
Caught by comparing the lockfile to the manifests directly, without an install.
```

`bun install` repaired it in one line (`packages/core.version: 20.0.0 → 20.1.0`), committed here in the same commit as the manifest change. The gate is green on the committed state:

```
bun.lock is in sync with every package.json.
```

Publishing follows once this is on `main` — never from uncommitted state, since an out-of-band publish burns the version number permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)