### PR TITLE
seed: register Atlas as a first-party application

### DIFF
--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -259,6 +259,17 @@ const SEED_APPS: SeedAppSpec[] = [
     ],
   },
   {
+    name: 'Atlas',
+    description:
+      'The Oxy App Store — the storefront people browse before they choose an app, and where they review one afterwards.',
+    websiteUrl: 'https://apps.oxy.so',
+    type: 'first_party',
+    // The storefront is readable signed out, so this client exists for exactly
+    // one thing: signing somebody in to write a review. Only the app's own
+    // origin is listed; there is no second surface.
+    redirectUris: ['https://apps.oxy.so'],
+  },
+  {
     name: 'CrowdSource',
     description:
       'Official Oxy participatory moderation platform — reviewers are assigned cases by the server and review them blind.',

--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -262,12 +262,12 @@ const SEED_APPS: SeedAppSpec[] = [
     name: 'Atlas',
     description:
       'The Oxy App Store — the storefront people browse before they choose an app, and where they review one afterwards.',
-    websiteUrl: 'https://apps.oxy.so',
+    websiteUrl: 'https://atlas.oxy.so',
     type: 'first_party',
     // The storefront is readable signed out, so this client exists for exactly
     // one thing: signing somebody in to write a review. Only the app's own
     // origin is listed; there is no second surface.
-    redirectUris: ['https://apps.oxy.so'],
+    redirectUris: ['https://atlas.oxy.so'],
   },
   {
     name: 'CrowdSource',


### PR DESCRIPTION
Atlas (the Oxy App Store, OxyHQ/Atlas) needs a client id before anyone can sign in to write a review. A declaration is not a registration — the id is the public key of a credential minted at seed time — so this adds it to `SEED_APPS` and the run mints it.

One redirect URI, the app's own origin: the storefront is readable signed out, so this client exists for exactly one thing.

Merging does not mint anything. The **Seed Oxy applications** workflow does, with `only_apps='Atlas'`, dry first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)