### PR TITLE
chore(release): create-oxy-app 0.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -472,7 +472,7 @@
     },
     "packages/create-oxy-app": {
       "name": "create-oxy-app",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "create-oxy-app": "dist/index.js",
       },

--- a/packages/create-oxy-app/package.json
+++ b/packages/create-oxy-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oxy-app",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Scaffold a new Oxy ecosystem app — an Expo/React Native + Express monorepo wired to the Oxy SDK (@oxyhq/services, @oxyhq/app-preset) with the canonical provider stack, device-first auth, Bloom theming, and AWS deploy. Run with `bun create oxy-app` or `bunx create-oxy-app`.",
   "type": "commonjs",
   "bin": {


### PR DESCRIPTION
Version bump for #872 (new apps scaffold on PostgreSQL). Minor: no CLI flag or API change, but a generated app is materially different. Publish follows the merge — until then `bun create oxy-app` still generates a Mongoose backend from 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)