### PR TITLE
fix(create-oxy-app): keep drizzle.config.ts out of the generated dist

### DIFF
--- a/packages/create-oxy-app/src/__tests__/backendTemplate.test.ts
+++ b/packages/create-oxy-app/src/__tests__/backendTemplate.test.ts
@@ -162,3 +162,22 @@ describe('schema barrel', () => {
     expect(() => render('packages', 'backend', 'src', 'config', 'database.ts')).toThrow();
   });
 });
+
+describe('backend tsconfig', () => {
+  test('keeps drizzle.config.ts out of the emitting build', () => {
+    // The config imports `drizzle-kit`, a devDependency the Dockerfile strips
+    // with `bun install --production`. `include: ["**/*.ts"]` sweeps it up, so
+    // without this exclusion tsc emits dist/drizzle.config.js — a module in the
+    // runtime image whose first `require` throws. Nothing requires it today,
+    // which is precisely why it has to be excluded now rather than after
+    // something does.
+    const tsconfig = render('packages', 'backend', 'tsconfig.json');
+    expect(tsconfig).toContain('"drizzle.config.ts"');
+
+    // Read out of the `exclude` array specifically, so the assertion above
+    // cannot be satisfied by the filename merely appearing in a comment.
+    const exclude = /"exclude"\s*:\s*\[([^\]]*)\]/.exec(tsconfig);
+    expect(exclude).not.toBeNull();
+    expect(exclude?.[1]).toContain('"drizzle.config.ts"');
+  });
+});

--- a/packages/create-oxy-app/templates/backend/packages/backend/tsconfig.json
+++ b/packages/create-oxy-app/templates/backend/packages/backend/tsconfig.json
@@ -10,6 +10,13 @@
     }
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "dist"],
+  // drizzle.config.ts is excluded from the EMITTING build on purpose. It imports
+  // `drizzle-kit`, a devDependency the runtime image strips
+  // (`bun install --production` in the Dockerfile), so compiling it puts a module
+  // into dist/ whose first `require` throws in production. Nothing requires it
+  // today, which is exactly what makes it worth excluding now rather than after
+  // something does. drizzle-kit loads and type-checks the config itself when
+  // `db:generate` runs, which is the only place it is ever used.
+  "exclude": ["node_modules", "dist", "drizzle.config.ts"],
   "references": [{ "path": "../shared-types" }]
 }


### PR DESCRIPTION
A small follow-up to #872, found while independently working #871. (My duplicate of #872, PR #881, is closed.)

## The problem

The generated backend's `tsconfig.json` is `include: ["**/*.ts"]` with only `node_modules` and `dist` excluded. `drizzle.config.ts` sits at the package root, so tsc sweeps it up and emits `dist/drizzle.config.js` — a module that imports `drizzle-kit`, which the Dockerfile's runtime stage strips.

## How this was observed

Not inferred from the tsconfig — reproduced end to end on an app scaffolded from `main` itself:

1. Fresh worktree at `origin/main` (`01012294`, the #872 merge), `bun install`, built the CLI, scaffolded an app with `--no-install --no-git`.
2. `bun install` in the generated app, then `bun run --cwd packages/backend build`. The emitted tree contains:

```
packages/backend/dist/drizzle.config.js      <-- this one
packages/backend/dist/server.js
packages/backend/dist/src/db/migrate.js
packages/backend/dist/src/db/migrationsFolder.js
packages/backend/dist/src/db/postgres.js
packages/backend/dist/src/db/schema/{index,notes}.js
packages/backend/dist/src/utils/logger.js
```

3. `grep` of the emitted file confirms `require("drizzle-kit")` and `require("@oxyhq/db")`.
4. Reproduced the runtime stage's dependency set: `rm -rf node_modules && bun install --frozen-lockfile --production --ignore-scripts` (what the Dockerfile runs). Result: `drizzle-kit` **ABSENT**, `@oxyhq/db` **PRESENT** — the control that proves the install actually worked rather than failing wholesale.
5. Loading the emitted module under exactly those conditions:

```
$ node -e 'require("./packages/backend/dist/drizzle.config.js")'
Error: Cannot find module 'drizzle-kit'
```

Control, same tree: `require("./packages/backend/dist/src/db/migrationsFolder.js")` loads fine.

**Worth knowing, because it explains why nobody has tripped over this:** running `bun install --production` *in place* over an existing `node_modules` does NOT prune — `drizzle-kit` survives and the module loads. The failure appears only on a **fresh** production install, which is precisely what the Docker runtime stage does and what a developer never does locally.

## Why fix it now

Nothing requires `dist/drizzle.config.js` today, so this ships as dead weight rather than a live crash. That is exactly what makes it worth excluding now rather than after something does reach for it — a bundler sweep, a dynamic import, or a `require` of the config would each turn this into a container-start failure a long way from its cause.

Verified both directions with the template's own `include`/`exclude`: without the exclusion `dist/drizzle.config.js` is emitted, with it only `dist/server.js` and `dist/src/**` are. `db:generate` is unaffected — drizzle-kit loads and type-checks the config itself, which is the only place it is ever used.

## The test

Added to the existing `backendTemplate.test.ts`. It reads the `exclude` **array**, not the file text, so it cannot be satisfied by the filename merely appearing in the comment beside it. Mutation-tested against both shapes — a plain revert, and moving the filename into a trailing comment — and both go red. Suite: 34 pass / 0 fail.

## Notes for review

- This adds a comment to a `tsconfig.json`. Nothing in the scaffolder or CI `JSON.parse`s the generated tsconfig, tsc accepts JSONC, and `templates/base/tsconfig.json` already carries a comment — following existing precedent rather than setting one.
- `create-oxy-app` 0.3.0 publishes shortly; if this lands after, it ships in 0.3.1.
