### PR TITLE
docs(api): an account id is ObjectId OR uuid v7, not "MongoDB ObjectId"

### DIFF
--- a/packages/api/openapi.base.yaml
+++ b/packages/api/openapi.base.yaml
@@ -198,8 +198,19 @@ components:
       properties:
         id:
           type: string
-          description: Stable Oxy user ID (MongoDB ObjectId).
-          example: 64f7c2a1b8e9d3f4a1c2b3d4
+          description: >-
+            Stable Oxy user ID, in one of TWO formats. Accounts created before
+            the Postgres cutover keep their 24-character hexadecimal id
+            verbatim; every account created since is a uuid v7. The column is a
+            uniform string — only the value format is mixed — so treat this as
+            an opaque identifier and never assume the 24-hex shape. A client
+            that validates against ObjectId alone rejects every account created
+            after the cutover.
+          pattern: >-
+            ^(?:[0-9a-fA-F]{24}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$
+          examples:
+            - 019fb834-d8a6-73fc-9073-da304c940f28
+            - 64f7c2a1b8e9d3f4a1c2b3d4
         username:
           type: string
           example: alice

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -132,8 +132,12 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Stable Oxy user ID (MongoDB ObjectId).",
-            "example": "64f7c2a1b8e9d3f4a1c2b3d4"
+            "description": "Stable Oxy user ID, in one of TWO formats. Accounts created before the Postgres cutover keep their 24-character hexadecimal id verbatim; every account created since is a uuid v7. The column is a uniform string — only the value format is mixed — so treat this as an opaque identifier and never assume the 24-hex shape. A client that validates against ObjectId alone rejects every account created after the cutover.",
+            "pattern": "^(?:[0-9a-fA-F]{24}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$",
+            "examples": [
+              "019fb834-d8a6-73fc-9073-da304c940f28",
+              "64f7c2a1b8e9d3f4a1c2b3d4"
+            ]
           },
           "username": {
             "type": "string",


### PR DESCRIPTION
The published spec described `User.id` as **"Stable Oxy user ID (MongoDB ObjectId)."** That is wrong about **every account created since the Postgres cutover**.

`isAccountIdFormat` (`packages/api/src/utils/validation.ts`) accepts **either** a 24-character hex id — kept verbatim so foreign keys survived the backfill — **or** a uuid v7. `isValidObjectId` deliberately rejects the uuid, and `idFormatCutover.test.ts` pins both shapes.

Unlike a stale code comment, this document **leaves the repo**: consumers generate clients and validate payloads against it, and the website syncs it via `git show <ref>:openapi.json`. A client validating on ObjectId alone rejects every new account.

### What changed

- `description` states both formats and tells callers to treat the id as opaque
- `pattern` added, mirroring `ACCOUNT_ID_PATTERN`
- `examples` carries one of each shape, instead of a single ObjectId

### The subtle bit

The pattern uses `[0-9a-fA-F]` where the source regex relies on its `/i` flag, because an OpenAPI `pattern` carries no flags. Spelling it `[0-9a-f]` would have published a spec **stricter than the server** — the same class of false claim this PR removes.

Verified against the real predicate over nine inputs (both cases of both formats, the 12-char string mongoose used to accept, short hex, empty, the federation sentinel): the spec pattern accepts **exactly** what the server accepts. An ObjectId-only control disagrees on the uuid, so the comparison is not vacuous.

### Why `openapi.json` was not regenerated

It is generated from `openapi.base.yaml`, so the JSON node was derived **from the parsed YAML** rather than hand-edited, and the two are asserted identical. A wholesale `openapi:generate` was rejected because it currently emits a **degraded** document unless `@oxyhq/contracts` and `@oxyhq/db` are built first — three schema imports fail and `components.schemas` drops **7 → 4** — and it would also sweep in 9 unrelated path changes, since the committed JSON is stale against the routes (268 vs 277 paths). Both are worth fixing, separately.

Every other node is byte-identical; `paths` 268 and `schemas` 7 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)