### PR TITLE
docs: two comments describing mongoose that is not there

### DIFF
--- a/packages/api/jest.globalSetup.ts
+++ b/packages/api/jest.globalSetup.ts
@@ -12,7 +12,9 @@
  * from failure. Start one with:
  *   docker compose -f docker-compose.dev.yml up -d postgres
  *
- * The Mongo side is untouched: `jest.setup.cjs` still mocks mongoose wholesale.
+ * There is no Mongo side any more. `jest.setup.cjs` mocks `jsonwebtoken` and
+ * `socket.io` and nothing else — no mongoose mock, because there is no mongoose
+ * in this repo to mock.
  */
 
 import { writeFileSync } from 'node:fs';

--- a/packages/api/src/middleware/performance.ts
+++ b/packages/api/src/middleware/performance.ts
@@ -37,8 +37,15 @@ export const performanceMiddleware = (req: Request, res: Response, next: NextFun
 };
 
 /**
- * Database query monitoring middleware
- * Wraps mongoose queries to track performance
+ * Times any promise-returning function under a `db:<operation>` label.
+ *
+ * Not middleware, and nothing to do with mongoose despite what this said until
+ * the Postgres cutover was tidied up: it takes an arbitrary `queryFn`, so it
+ * works for a drizzle query, a raw `postgres.js` call or anything else that
+ * returns a promise. The label is whatever the caller passes.
+ *
+ * A rejection is timed as `success: false` and RETHROWN, so wrapping a call
+ * changes its timing metadata and never its outcome.
  */
 export const monitorDatabaseQuery = async <T>(
   operation: string,


### PR DESCRIPTION
Both assert **current** behaviour, not history, so a reader reasons from them — which is what makes a wrong comment worse than none.

### `packages/api/jest.globalSetup.ts`

> The Mongo side is untouched: `jest.setup.cjs` still mocks mongoose wholesale.

`jest.setup.cjs` mocks `jsonwebtoken` and `socket.io` and contains **no Mongo reference at all**. Someone acting on this goes looking for a mock that does not exist, or assumes mongoose is handled and stops thinking about it.

### `packages/api/src/middleware/performance.ts`

> Database query monitoring middleware / Wraps mongoose queries to track performance

`monitorDatabaseQuery` is **not middleware** and has **nothing to do with mongoose** — it takes an arbitrary `queryFn: () => Promise<T>` and times it under a `db:<operation>` label. This is the more harmful of the two: it reads as dead Mongo code, so the likely next action is to delete a working timer.

### Scope

Comments only — verified that every changed line is a comment and no executable line was touched.

**Found while verifying, deliberately not acted on:** `monitorDatabaseQuery` has **zero callers repo-wide**. Positive control: its neighbour `getMemoryStats` is found in `server.ts`, so the search does locate callers. Whether a generic, unused timer earns its place is a decision for whoever owns the metrics path, not part of removing a false comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)