### PR TITLE
fix(openapi): the generator wrote a partial contract and said nothing

### DIFF
--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -275,7 +275,7 @@
       },
       "AuthSuccess": {
         "type": "object",
-        "description": "Successful authentication response from /auth/signup, /auth/login, or /auth/verify.",
+        "description": "Successful authentication response from /auth/verify, /auth/webauthn/login/verify, or /auth/oauth/token.",
         "properties": {
           "user": {
             "$ref": "#/components/schemas/User"
@@ -302,2854 +302,13 @@
     }
   },
   "paths": {
-    "/users/me": {
+    "/.well-known/did.json": {
       "get": {
         "tags": [
-          "Users"
+          "Identity"
         ],
-        "summary": "Get the current authenticated user",
-        "description": "Returns the full profile for the bearer-token holder, including privacy settings, identity flags, and connected account types. This is the canonical \"who am I\" endpoint that every Oxy app calls on startup.\n",
-        "responses": {
-          "200": {
-            "description": "Current user profile.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
-                },
-                "examples": {
-                  "success": {
-                    "value": {
-                      "id": "64f7c2a1b8e9d3f4a1c2b3d4",
-                      "username": "alice",
-                      "name": {
-                        "first": "Alice",
-                        "last": "Example"
-                      },
-                      "description": "Coffee, code, and open source.",
-                      "type": "local",
-                      "_count": {
-                        "followers": 42,
-                        "following": 17
-                      },
-                      "createdAt": "2024-01-15T12:34:56.789Z",
-                      "updatedAt": "2025-05-12T09:00:00.000Z"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Update the current authenticated user",
-        "description": "Partial profile update for the authenticated user. Only fields supplied in the body are touched — missing fields keep their existing values. The server enforces uniqueness on `email` and `username`; conflicts return 409. Always invalidates the in-memory user cache so the next read returns the updated record.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "username": {
-                    "type": "string",
-                    "minLength": 3,
-                    "maxLength": 30,
-                    "pattern": "^[a-zA-Z0-9]{3,30}$",
-                    "example": "alice"
-                  },
-                  "email": {
-                    "type": "string",
-                    "format": "email",
-                    "example": "alice@placeholder.example"
-                  },
-                  "name": {
-                    "type": "object",
-                    "properties": {
-                      "first": {
-                        "type": "string",
-                        "example": "Alice"
-                      },
-                      "last": {
-                        "type": "string",
-                        "example": "Example"
-                      }
-                    }
-                  },
-                  "description": {
-                    "type": "string",
-                    "example": "Updated bio."
-                  },
-                  "avatar": {
-                    "type": "string",
-                    "description": "Asset ID or absolute URL.",
-                    "example": "64f7c2a1b8e9d3f4a1c2b3d4"
-                  }
-                }
-              },
-              "examples": {
-                "rename": {
-                  "summary": "Update the display name",
-                  "value": {
-                    "name": {
-                      "first": "Alice",
-                      "last": "Example"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated user profile.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "409": {
-            "description": "Email or username conflict.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Permanently delete the current account",
-        "description": "Hard-delete the authenticated user's account. To prove identity at the time of deletion the client signs `delete:{publicKey}:{timestamp}` with the local secp256k1 private key (see `KeyManager.sign` in `@oxyhq/core`). The signature is rejected if it is older than 5 minutes, if the confirmation text does not match the account's username, or if the account has no associated public key.\nSuccessful deletion removes all mailboxes, messages, and S3 attachments owned by the user.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "signature",
-                  "timestamp",
-                  "confirmText"
-                ],
-                "properties": {
-                  "signature": {
-                    "type": "string",
-                    "description": "Hex-encoded secp256k1 signature over `delete:{publicKey}:{timestamp}`.",
-                    "example": "3045022100abcd...3045022100efgh"
-                  },
-                  "timestamp": {
-                    "type": "integer",
-                    "description": "Unix milliseconds when the signature was produced.",
-                    "example": 1714576800000
-                  },
-                  "confirmText": {
-                    "type": "string",
-                    "description": "Must equal the account's username.",
-                    "example": "alice"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Account deleted.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "Account deleted successfully"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing field, expired signature, or mismatched confirmText.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Invalid signature.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "User not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/users/me/app-data/{namespace}/{key}": {
-      "get": {
-        "tags": [
-          "UserAppData"
-        ],
-        "summary": "Read a single per-user JSON value",
-        "description": "Returns the value stored under `(namespace, key)` for the authenticated user. The response body is always `{ value }`. If no value has ever been stored, `value` is `null` (the endpoint does not 404 on missing entries — a missing entry is semantically a `null` value).\n",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "namespace",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9_-]{1,64}$"
-            }
-          },
-          {
-            "in": "path",
-            "name": "key",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9_-]{1,64}$"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Current value (or null when not stored).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "description": "Arbitrary JSON value previously stored, or null."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "UserAppData"
-        ],
-        "summary": "Upsert a single per-user JSON value",
-        "description": "Stores (or replaces) the value under `(namespace, key)` for the authenticated user. Body must be `{ value: <any JSON-serializable value> }`. Serialized JSON is capped at 64 KB.\n",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "namespace",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9_-]{1,64}$"
-            }
-          },
-          {
-            "in": "path",
-            "name": "key",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9_-]{1,64}$"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "value"
-                ],
-                "properties": {
-                  "value": {
-                    "description": "Arbitrary JSON value to persist."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "The stored value, echoed back.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "description": "The value that is now stored."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed (bad namespace/key, oversized value)."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "429": {
-            "description": "Per-user write rate limit exceeded."
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "UserAppData"
-        ],
-        "summary": "Delete a single per-user JSON value",
-        "description": "Removes the value under `(namespace, key)` for the authenticated user. Idempotent — succeeds with 204 whether or not the entry existed.\n",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "namespace",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9_-]{1,64}$"
-            }
-          },
-          {
-            "in": "path",
-            "name": "key",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9_-]{1,64}$"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Deleted (or was already absent)."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "429": {
-            "description": "Per-user write rate limit exceeded."
-          }
-        }
-      }
-    },
-    "/users/me/app-data/{namespace}": {
-      "get": {
-        "tags": [
-          "UserAppData"
-        ],
-        "summary": "List every value in a namespace for the current user",
-        "description": "Returns `{ entries }` where `entries` is a `key -> value` map of everything stored under `namespace` for the authenticated user. The response is bounded by the 128-key namespace quota and by the 64 KB cap per individual value. If an older namespace exceeds the current quota, the endpoint refuses to materialize it in one response.\n",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "namespace",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "pattern": "^[a-z0-9_-]{1,64}$"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Map of every key in the namespace to its value.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "entries": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "description": "Stored JSON value."
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/storage/usage": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Get the authenticated user's storage usage",
-        "description": "Return the total bytes used and the user's storage quota for the file-storage feature. Used by the storage settings UI to render progress bars and quota warnings.\n",
-        "responses": {
-          "200": {
-            "description": "Storage usage.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "used": {
-                      "type": "integer",
-                      "description": "Bytes consumed.",
-                      "example": 1073741824
-                    },
-                    "quota": {
-                      "type": "integer",
-                      "description": "Bytes available.",
-                      "example": 10737418240
-                    },
-                    "percent": {
-                      "type": "number",
-                      "description": "Percentage used (0-1).",
-                      "example": 0.1
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/session/user/{sessionId}": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Resolve a session ID to the user it belongs to",
-        "description": "Look up the user record for a given session ID. Requires a valid access token whose user owns the referenced session — callers cannot look up sessions belonging to other users. Used by SDK clients (e.g. `@oxyhq/core`) to hydrate user state from a stored session reference. Expired, revoked, or non-owned sessions return 404.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "sess_64f7c2a1b8e9d3f4a1c2b3d4"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User attached to this session.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed sessionId.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found or expired.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/session/sessions/{sessionId}": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "List all sessions for the user of the given session",
-        "description": "Return every active session the user has across all devices, with a flag marking the current session. Requires a valid access token whose user owns the referenced session.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Active sessions for the user.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Session"
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found or expired."
-          }
-        }
-      }
-    },
-    "/session/logout/{sessionId}": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Sign out the given session",
-        "description": "Revoke the session identified by `sessionId`. After this call any bearer token tied to that session is rejected. Idempotent — calling twice is a no-op on the second call.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Session revoked."
-          },
-          "404": {
-            "description": "Session not found."
-          }
-        }
-      }
-    },
-    "/session/logout/{sessionId}/{targetSessionId}": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Sign another session out via an authenticated session",
-        "description": "Use `sessionId` (which must be a valid active session) to revoke a different session identified by `targetSessionId`. This is how the \"sign out other devices\" flow works.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "targetSessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Target session revoked."
-          },
-          "401": {
-            "description": "The acting session is not valid."
-          },
-          "404": {
-            "description": "Target session not found."
-          }
-        }
-      }
-    },
-    "/session/logout-all/{sessionId}": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Sign out every session for this user",
-        "description": "Revoke every session belonging to the user behind `sessionId`, including the calling session itself. Recommended after a password reset or suspected compromise.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "All sessions revoked."
-          },
-          "404": {
-            "description": "Session not found."
-          }
-        }
-      }
-    },
-    "/session/validate/{sessionId}": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "security": [],
-        "summary": "Validate a session ID",
-        "description": "Cheap liveness check — returns 200 with a small payload if the session is still active, 404 otherwise. Use this in lieu of the heavier `/session/user/:id` lookup when you only need a yes/no.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Session is active.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "valid": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found or expired."
-          }
-        }
-      }
-    },
-    "/session/validate-header/{sessionId}": {
-      "get": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Validate a session using a header-bound bearer token",
-        "description": "Like `/session/validate/:sessionId` but cross-checks the bearer token against the session — returns 200 only if the token still belongs to the session.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Session and bearer token match."
-          },
-          "401": {
-            "description": "Token does not match the session."
-          },
-          "404": {
-            "description": "Session not found."
-          }
-        }
-      }
-    },
-    "/session/device/sessions/{sessionId}": {
-      "get": {
-        "tags": [
-          "Devices"
-        ],
-        "summary": "List sessions on the same device as the given session",
-        "description": "Return every active session that shares the device fingerprint of the supplied session. Used to power \"this device has these accounts\" UI in the auth picker.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Sessions on this device.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Session"
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Session not found."
-          }
-        }
-      }
-    },
-    "/session/device/logout-all/{sessionId}": {
-      "post": {
-        "tags": [
-          "Devices"
-        ],
-        "summary": "Sign out every session on this device",
-        "description": "Revoke every session that shares the device fingerprint of the supplied session. Useful for a one-click \"sign out this device\" button.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Device sessions revoked."
-          },
-          "404": {
-            "description": "Session not found."
-          }
-        }
-      }
-    },
-    "/session/device/name/{sessionId}": {
-      "put": {
-        "tags": [
-          "Devices"
-        ],
-        "summary": "Rename the device for the given session",
-        "description": "Update the human-readable device label shown in the user's devices list. The change applies to every session sharing the device fingerprint.\n",
-        "parameters": [
-          {
-            "name": "sessionId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "deviceName"
-                ],
-                "properties": {
-                  "deviceName": {
-                    "type": "string",
-                    "example": "Living room iPad"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Device renamed."
-          },
-          "400": {
-            "description": "Validation failed."
-          },
-          "404": {
-            "description": "Session not found."
-          }
-        }
-      }
-    },
-    "/session/users/batch": {
-      "post": {
-        "tags": [
-          "Sessions"
-        ],
-        "summary": "Resolve multiple session IDs in one call",
-        "description": "Batch counterpart of `/session/user/:sessionId`. Pass an array of session IDs and get back a map of user records — used by clients that need to render multiple connected accounts at once (e.g. the account switcher).\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "sessionIds"
-                ],
-                "properties": {
-                  "sessionIds": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              },
-              "examples": {
-                "pair": {
-                  "value": {
-                    "sessionIds": [
-                      "sess_64f7c2a1b8e9d3f4a1c2b3d4",
-                      "sess_74f7c2a1b8e9d3f4a1c2b3d5"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "User records keyed by session ID. Missing sessions are omitted.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "$ref": "#/components/schemas/User"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed."
-          }
-        }
-      }
-    },
-    "/security/activity": {
-      "get": {
-        "tags": [
-          "Security"
-        ],
-        "summary": "Account activity log with pagination",
-        "description": "Return security-relevant events for the authenticated user — sign-ins, email changes, device add/remove, private-key exports, backup creations, suspicious activity flags. Always scoped to the bearer's own account; there is no parameter that widens it to another user. Used to power the activity history screen.\n\nNo event carries an IP address, a country or any other network-derived location: the platform stores no user IPs at rest, in any form. Do not add such a field here or to the underlying table.\n",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "description": "Rows to skip. Offset/limit paging — there is no cursor.",
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0
-            }
-          },
-          {
-            "name": "eventType",
-            "in": "query",
-            "required": false,
-            "description": "Restrict to one event type. An unknown value is a 400.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "sign_in",
-                "sign_out",
-                "email_changed",
-                "profile_updated",
-                "device_added",
-                "device_removed",
-                "account_recovery",
-                "security_settings_changed",
-                "private_key_exported",
-                "backup_created",
-                "suspicious_activity"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Activity events, newest first.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "userId": {
-                            "type": "string"
-                          },
-                          "eventType": {
-                            "type": "string",
-                            "example": "sign_in"
-                          },
-                          "eventDescription": {
-                            "type": "string"
-                          },
-                          "metadata": {
-                            "type": "object",
-                            "additionalProperties": true
-                          },
-                          "userAgent": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "deviceId": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "timestamp": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "When the EVENT happened."
-                          },
-                          "severity": {
-                            "type": "string",
-                            "enum": [
-                              "low",
-                              "medium",
-                              "high",
-                              "critical"
-                            ]
-                          },
-                          "createdAt": {
-                            "type": "string",
-                            "format": "date-time",
-                            "description": "When the row was written."
-                          }
-                        }
-                      }
-                    },
-                    "pagination": {
-                      "type": "object",
-                      "properties": {
-                        "total": {
-                          "type": "integer"
-                        },
-                        "limit": {
-                          "type": "integer"
-                        },
-                        "offset": {
-                          "type": "integer"
-                        },
-                        "hasMore": {
-                          "type": "boolean"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Unknown eventType."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/security/activity/private-key-exported": {
-      "post": {
-        "tags": [
-          "Security"
-        ],
-        "summary": "Log a \"private key exported\" event",
-        "description": "Record that the local identity wallet exported its private key for backup. The event surfaces in the activity log and is used to remind the user to safely store the key.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "deviceId": {
-                    "type": "string",
-                    "description": "Device that performed the export. Optional."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Event recorded."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/security/activity/backup-created": {
-      "post": {
-        "tags": [
-          "Security"
-        ],
-        "summary": "Log a \"backup created\" event",
-        "description": "Record that the local identity wallet wrote a backup of its keys.",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "deviceId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Event recorded."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/profiles/username/{username}": {
-      "get": {
-        "tags": [
-          "Profiles"
-        ],
-        "security": [],
-        "summary": "Public profile lookup by username",
-        "description": "Resolve a username to a public profile, with follower/following counts. Federated handles (`user@domain`) are resolved on the fly via WebFinger + ActivityPub; if the actor has never been seen the endpoint will upsert it as a federated user before returning.\nThis endpoint is unauthenticated and may be cached by edge.\n",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "description": "Local username (alphanumeric, 3-30 chars) or fediverse handle.",
-              "examples": {
-                "local": "alice",
-                "federated": "alice@mastodon.social"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Profile found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/User"
-                },
-                "examples": {
-                  "local": {
-                    "value": {
-                      "id": "64f7c2a1b8e9d3f4a1c2b3d4",
-                      "username": "alice",
-                      "name": {
-                        "first": "Alice",
-                        "last": "Example"
-                      },
-                      "description": "Coffee, code, and open source.",
-                      "type": "local",
-                      "_count": {
-                        "followers": 42,
-                        "following": 17
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Malformed username.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Profile not found (and federation lookup failed).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/privacy/{id}/privacy": {
-      "get": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "Get a user's privacy settings",
-        "description": "Return the full privacy settings record for the user. Some fields are only visible to the owner; non-owner callers see a redacted projection.\n",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Privacy settings.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                },
-                "examples": {
-                  "default": {
-                    "value": {
-                      "profileVisibility": "public",
-                      "showActivity": true,
-                      "allowDirectMessages": "contacts-only",
-                      "discoverableByEmail": false,
-                      "discoverableByPhone": false
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "404": {
-            "description": "User not found."
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "Update a user's privacy settings (owner only)",
-        "description": "Partial update of the user's privacy settings. Only the owner of the account may patch their settings — other callers get 403. Invalidates the in-memory user cache so subsequent reads return fresh values.\n",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": true
-              },
-              "examples": {
-                "tighten": {
-                  "summary": "Make profile private and disable email discovery",
-                  "value": {
-                    "profileVisibility": "private",
-                    "discoverableByEmail": false
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Updated privacy settings."
-          },
-          "400": {
-            "description": "Validation failed."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "403": {
-            "description": "Caller is not the owner."
-          }
-        }
-      }
-    },
-    "/privacy/blocked": {
-      "get": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "List blocked users",
-        "description": "Return the users the authenticated caller has blocked.",
-        "responses": {
-          "200": {
-            "description": "List of blocked users."
-          }
-        }
-      }
-    },
-    "/privacy/blocked/{targetId}": {
-      "post": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "Block a user",
-        "description": "Block `targetId` for the authenticated caller. Blocking is symmetric — neither account can see the other's posts, profile, or reach the other in DMs.\n",
-        "parameters": [
-          {
-            "name": "targetId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User blocked."
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "Unblock a user",
-        "parameters": [
-          {
-            "name": "targetId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User unblocked."
-          }
-        }
-      }
-    },
-    "/privacy/restricted": {
-      "get": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "List restricted users",
-        "description": "Return the users the authenticated caller has restricted.",
-        "responses": {
-          "200": {
-            "description": "List of restricted users."
-          }
-        }
-      }
-    },
-    "/privacy/restricted/{targetId}": {
-      "post": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "Restrict a user",
-        "description": "Restrict `targetId` — they can still see public content but their replies and DMs are silently filtered out of the caller's view.\n",
-        "parameters": [
-          {
-            "name": "targetId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User restricted."
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Privacy"
-        ],
-        "summary": "Unrestrict a user",
-        "parameters": [
-          {
-            "name": "targetId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "User unrestricted."
-          }
-        }
-      }
-    },
-    "/devices": {
-      "get": {
-        "tags": [
-          "Devices"
-        ],
-        "summary": "List the user's devices",
-        "description": "Return every device that has at least one active session for the authenticated user. Useful for \"Where am I signed in?\" screens.\n",
-        "responses": {
-          "200": {
-            "description": "List of devices.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Device"
-                  }
-                },
-                "examples": {
-                  "twoDevices": {
-                    "value": [
-                      {
-                        "id": "dev_64f7c2a1b8e9d3f4a1c2b3d4",
-                        "name": "MacBook Pro 16",
-                        "platform": "macOS",
-                        "firstSeenAt": "2024-01-15T12:34:56.789Z",
-                        "lastSeenAt": "2025-05-12T09:00:00.000Z",
-                        "sessionCount": 2
-                      },
-                      {
-                        "id": "dev_74f7c2a1b8e9d3f4a1c2b3d5",
-                        "name": "iPhone 15 Pro",
-                        "platform": "iOS",
-                        "firstSeenAt": "2024-02-01T08:00:00.000Z",
-                        "lastSeenAt": "2025-05-12T08:55:00.000Z",
-                        "sessionCount": 1
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/devices/security": {
-      "get": {
-        "tags": [
-          "Devices",
-          "Security"
-        ],
-        "summary": "Get aggregate security info for the user's devices",
-        "description": "Return high-level security signals across the user's devices (count of active sessions, unusual logins, last suspicious activity, etc.). Used to surface a security health summary on the account dashboard.\n",
-        "responses": {
-          "200": {
-            "description": "Security info payload."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/devices/{deviceId}": {
-      "delete": {
-        "tags": [
-          "Devices"
-        ],
-        "summary": "Remove a device",
-        "description": "Revoke every active session attached to the given device. The user on that device will be signed out the next time their client tries to refresh its access token.\n",
-        "parameters": [
-          {
-            "name": "deviceId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "example": "dev_64f7c2a1b8e9d3f4a1c2b3d4"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Device removed."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "404": {
-            "description": "Device not found."
-          }
-        }
-      }
-    },
-    "/contacts/discover": {
-      "post": {
-        "tags": [
-          "Contacts"
-        ],
-        "summary": "Discover which contacts are on Oxy",
-        "description": "Privacy-preserving contact-book matching. Clients SHA-256 hash each email and phone number locally (lowercased; phone numbers normalised to E.164 — see `utils/contactHash.ts` in `@oxyhq/core`) and upload only the resulting 64-character hex digests. The server intersects them against the indexed `users.hashed_email` / `users.hashed_phone` columns and returns matched Oxy user IDs only when the matched user has opted in to contact discovery for that identifier type.\nPrivacy invariants:\n  - Raw email / phone never traverses this endpoint.\n  - The response contains no PII — only Oxy user IDs and the hash the\n    caller supplied (so the client can map matches back to the local\n    contact that produced them).\n  - The endpoint never writes to the database. Discovery is stateless.\n\nRate limits: 5 requests per minute per authenticated user; up to 200 hashed identifiers per channel (~400 total) per request. Service tokens are explicitly rejected with 403.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "hashedEmails": {
-                    "type": "array",
-                    "maxItems": 200,
-                    "items": {
-                      "type": "string",
-                      "pattern": "^[a-f0-9]{64}$",
-                      "description": "SHA-256 hex of `email.toLowerCase().trim()`."
-                    }
-                  },
-                  "hashedPhones": {
-                    "type": "array",
-                    "maxItems": 200,
-                    "items": {
-                      "type": "string",
-                      "pattern": "^[a-f0-9]{64}$",
-                      "description": "SHA-256 hex of the E.164-normalised phone number."
-                    }
-                  }
-                }
-              },
-              "examples": {
-                "addressBook": {
-                  "summary": "Mixed email + phone request",
-                  "value": {
-                    "hashedEmails": [
-                      "7c211433f02071597741e6ff5a8ea34789abbf43b9c1abcdef0123456789abcd"
-                    ],
-                    "hashedPhones": [
-                      "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Discovery completed. Empty `matches` means no overlap.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "matches": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "required": [
-                          "userId",
-                          "hashedIdentifier",
-                          "matchType"
-                        ],
-                        "properties": {
-                          "userId": {
-                            "type": "string",
-                            "example": "64f7c2a1b8e9d3f4a1c2b3d4"
-                          },
-                          "hashedIdentifier": {
-                            "type": "string",
-                            "example": "7c211433f02071597741e6ff5a8ea34789abbf43b9c1abcdef0123456789abcd"
-                          },
-                          "matchType": {
-                            "type": "string",
-                            "enum": [
-                              "email",
-                              "phone"
-                            ]
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "examples": {
-                  "oneMatch": {
-                    "value": {
-                      "matches": [
-                        {
-                          "userId": "64f7c2a1b8e9d3f4a1c2b3d4",
-                          "hashedIdentifier": "7c211433f02071597741e6ff5a8ea34789abbf43b9c1abcdef0123456789abcd",
-                          "matchType": "email"
-                        }
-                      ]
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed (empty payload, malformed hash, oversized batch).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "403": {
-            "description": "Service token used — must use a user session token."
-          },
-          "429": {
-            "description": "Rate limit exceeded (5 requests / minute / user)."
-          }
-        }
-      }
-    },
-    "/cdn/{id}": {
-      "get": {
-        "summary": "Resolve a public asset id to its cloud.oxy.so CDN URL (302).",
-        "description": "Public CDN origin endpoint (no auth). Redirects to the `cloud.oxy.so` CDN URL for a PUBLIC, CDN-backed asset. Private/unlisted assets, files that are not active, files with no public copy, and unknown ids all return 404 — this path never streams bytes and never exposes a non-public asset.\n",
-        "tags": [
-          "Assets"
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "variant",
-            "required": false,
-            "schema": {
-              "type": "string"
-            },
-            "description": "Optional variant (e.g. `thumb`, `w320`); omitted = original."
-          }
-        ],
-        "responses": {
-          "302": {
-            "description": "Redirect to the public cloud.oxy.so CDN URL."
-          },
-          "404": {
-            "description": "No public CDN-backed asset for this id."
-          }
-        }
-      }
-    },
-    "/auth/register": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Register a new account with a public key",
-        "description": "Create a passwordless account bound to a local secp256k1 identity. The client generates a key pair (see `KeyManager` in `@oxyhq/core`), signs `register:{publicKey}:{timestamp}`, and submits the signature. Username and email are optional but recommended for discoverability.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "publicKey",
-                  "signature",
-                  "timestamp"
-                ],
-                "properties": {
-                  "publicKey": {
-                    "type": "string",
-                    "description": "secp256k1 public key (hex)."
-                  },
-                  "signature": {
-                    "type": "string",
-                    "description": "Hex signature over `register:{publicKey}:{timestamp}`."
-                  },
-                  "timestamp": {
-                    "type": "integer",
-                    "description": "Unix ms when the signature was produced (max 5 minutes old)."
-                  },
-                  "email": {
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "username": {
-                    "type": "string",
-                    "minLength": 3,
-                    "maxLength": 30,
-                    "pattern": "^[a-zA-Z0-9]{3,30}$"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Account created and the first session issued.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthSuccess"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid signature, malformed key, or duplicate username/email.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/auth/challenge": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Request a sign-in challenge for a public key",
-        "description": "Step 1 of the passwordless public-key login. Returns a short-lived random challenge that the client must sign with the matching private key, then submit to `POST /auth/verify`.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "publicKey"
-                ],
-                "properties": {
-                  "publicKey": {
-                    "type": "string",
-                    "description": "secp256k1 public key (hex)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Challenge issued.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "challenge": {
-                      "type": "string",
-                      "description": "Opaque challenge string to sign."
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "No account registered for this public key."
-          },
-          "429": {
-            "description": "Rate limit exceeded (10 / minute / IP)."
-          }
-        }
-      }
-    },
-    "/auth/verify": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Verify a signed challenge and create a session",
-        "description": "Step 2 of the passwordless public-key login. Submit the challenge returned by `/auth/challenge` together with its signature; on success a new session is created and the standard `AuthSuccess` payload is returned.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "publicKey",
-                  "challenge",
-                  "signature",
-                  "timestamp"
-                ],
-                "properties": {
-                  "publicKey": {
-                    "type": "string"
-                  },
-                  "challenge": {
-                    "type": "string"
-                  },
-                  "signature": {
-                    "type": "string",
-                    "description": "Hex signature of the challenge."
-                  },
-                  "timestamp": {
-                    "type": "integer",
-                    "description": "Unix ms."
-                  },
-                  "deviceName": {
-                    "type": "string"
-                  },
-                  "deviceFingerprint": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Session created.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthSuccess"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Signature invalid or challenge expired."
-          },
-          "429": {
-            "description": "Rate limit exceeded (5 / minute / IP)."
-          }
-        }
-      }
-    },
-    "/auth/validate": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Validate authentication status",
-        "description": "Check whether the current request carries valid authentication.",
-        "responses": {
-          "200": {
-            "description": "Authentication is valid",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "valid": {
-                      "type": "boolean",
-                      "example": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/auth/check-username/{username}": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Check username availability",
-        "description": "Check whether a username is available for registration.",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "username",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 3,
-              "maxLength": 30
-            },
-            "example": "johndoe"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Availability check result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "available": {
-                      "type": "boolean"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid username format",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded"
-          }
-        }
-      }
-    },
-    "/auth/lookup/{username}": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Lookup user by username",
-        "description": "Lightweight lookup that returns minimal public info for the login flow. Returns whether the user exists along with their color preset, avatar, and display name.",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "username",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 3
-            },
-            "example": "nate"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Lookup result"
-          },
-          "429": {
-            "description": "Rate limit exceeded"
-          }
-        }
-      }
-    },
-    "/auth/check-email/{email}": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Check email availability",
-        "description": "Check whether an email address is available for registration.",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "email",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "email"
-            },
-            "example": "user@example.com"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Availability check result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "available": {
-                      "type": "boolean"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid email format",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded"
-          }
-        }
-      }
-    },
-    "/auth/session/create": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Open a cross-app auth session (OAuth-like flow)",
-        "description": "Begin a cross-app sign-in handshake. A third-party / first-party client generates a one-time `sessionToken` and opens this endpoint; the user is then directed to Oxy Accounts where they authorise the session via `POST /auth/session/authorize/{sessionToken}`. The client polls `GET /auth/session/status/{sessionToken}` until the session is authorised, cancelled, or expires (default 5 minutes).\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "sessionToken"
-                ],
-                "properties": {
-                  "sessionToken": {
-                    "type": "string",
-                    "description": "Random opaque token the client generates and keeps secret.",
-                    "example": "at_random_4e9c2a1b8e9d3f4a1c2b3d4"
-                  },
-                  "clientId": {
-                    "type": "string",
-                    "description": "OAuth client_id (ApplicationCredential public key) of the requesting application. Provide this OR `applicationId`.\n",
-                    "example": "oxy_dk_1a2b3c4d"
-                  },
-                  "applicationId": {
-                    "type": "string",
-                    "description": "Application _id of the requesting application. Provide this OR `clientId`.\n",
-                    "example": "64f7c2a1b8e9d3f4a1c2b3d4"
-                  },
-                  "expiresAt": {
-                    "oneOf": [
-                      {
-                        "type": "string",
-                        "format": "date-time"
-                      },
-                      {
-                        "type": "integer",
-                        "description": "Unix ms."
-                      }
-                    ],
-                    "description": "Optional explicit expiry (capped at 5 minutes)."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Auth session pending.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "sessionToken": {
-                      "type": "string"
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "status": {
-                      "type": "string",
-                      "enum": [
-                        "pending",
-                        "authorized",
-                        "cancelled",
-                        "expired"
-                      ],
-                      "example": "pending"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing/invalid application reference or token already in use."
-          },
-          "403": {
-            "description": "Application is not available (suspended/deleted/pending review)."
-          }
-        }
-      }
-    },
-    "/auth/session/status/{sessionToken}": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Poll the status of a cross-app auth session",
-        "description": "Polled by the client that opened a session via `POST /auth/session/create`. Returns the session's current `status` and, once authorised, the `sessionId` / `userId` that the client should now treat as its own session.\n",
-        "parameters": [
-          {
-            "name": "sessionToken",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Current status of the auth session.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "status": {
-                      "type": "string",
-                      "enum": [
-                        "pending",
-                        "authorized",
-                        "cancelled",
-                        "expired"
-                      ]
-                    },
-                    "authorized": {
-                      "type": "boolean"
-                    },
-                    "sessionToken": {
-                      "type": "string"
-                    },
-                    "application": {
-                      "nullable": true,
-                      "description": "Sanitized public metadata of the registered Application bound to this session, for the consent UI. Null only if the app was hard-deleted after the session was created.\n",
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string"
-                        },
-                        "icon": {
-                          "type": "string"
-                        },
-                        "websiteUrl": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "first_party",
-                            "third_party",
-                            "internal",
-                            "system"
-                          ]
-                        },
-                        "isOfficial": {
-                          "type": "boolean"
-                        },
-                        "isInternal": {
-                          "type": "boolean"
-                        },
-                        "scopes": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "developerName": {
-                          "type": "string",
-                          "description": "Best-effort owner display name (non-official apps only)."
-                        }
-                      }
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "pushSentAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "nullable": true,
-                      "description": "Delivery progress, not a status: when the pending request was pushed to the approving identity's capable installs. Null when no push was delivered.\n"
-                    },
-                    "openedAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "nullable": true,
-                      "description": "Delivery progress, not a status: when the approval surface first opened the request. Written at most once.\n"
-                    },
-                    "sessionId": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "publicKey": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "userId": {
-                      "type": "string",
-                      "nullable": true
-                    }
-                  }
-                },
-                "examples": {
-                  "pending": {
-                    "value": {
-                      "status": "pending",
-                      "authorized": false,
-                      "sessionToken": "at_random_4e9c2a1b8e9d3f4a1c2b3d4",
-                      "application": {
-                        "id": "64f7c2a1b8e9d3f4a1c2b3d4",
-                        "name": "Oxy Accounts",
-                        "type": "first_party",
-                        "isOfficial": true,
-                        "isInternal": false,
-                        "scopes": [
-                          "user:read"
-                        ]
-                      },
-                      "expiresAt": "2025-05-25T12:39:56.000Z",
-                      "sessionId": null,
-                      "publicKey": null,
-                      "userId": null
-                    }
-                  },
-                  "authorized": {
-                    "value": {
-                      "status": "authorized",
-                      "authorized": true,
-                      "sessionToken": "at_random_4e9c2a1b8e9d3f4a1c2b3d4",
-                      "application": {
-                        "id": "64f7c2a1b8e9d3f4a1c2b3d4",
-                        "name": "Acme Widgets",
-                        "type": "third_party",
-                        "isOfficial": false,
-                        "isInternal": false,
-                        "scopes": [
-                          "files:read",
-                          "user:read"
-                        ],
-                        "websiteUrl": "https://acme.example",
-                        "developerName": "Ada Lovelace"
-                      },
-                      "expiresAt": "2025-05-25T12:39:56.000Z",
-                      "sessionId": "sess_64f7c2a1b8e9d3f4a1c2b3d4",
-                      "publicKey": "02a1b2c3d4e5f6...",
-                      "userId": "64f7c2a1b8e9d3f4a1c2b3d4"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Auth session not found."
-          }
-        }
-      }
-    },
-    "/auth/session/authorize/{sessionToken}": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Authorise a pending cross-app auth session",
-        "description": "Called by the Oxy Accounts app (or any first-party UI) after the user accepts a cross-app sign-in prompt. Requires the authorising user's access token via the `Authorization: Bearer` header — the authenticated principal is the only valid source of \"who is authorising\". The previous `x-session-id`-based path has been removed (fixes C2).\n",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "sessionToken",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": false,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "deviceName": {
-                    "type": "string"
-                  },
-                  "deviceFingerprint": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Session authorised.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "example": true
-                    },
-                    "sessionId": {
-                      "type": "string"
-                    },
-                    "user": {
-                      "$ref": "#/components/schemas/User"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Session expired, or malformed body."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "404": {
-            "description": "Auth session not found or already processed."
-          }
-        }
-      }
-    },
-    "/auth/session/claim": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Exchange a sessionToken for the first access token (device flow)",
-        "description": "Final step of the QR-code / \"Open Oxy Auth\" device sign-in flow. After another authenticated device has approved this session via `POST /auth/session/authorize/{sessionToken}`, the originating client — which alone knows the secret `sessionToken` — calls this endpoint to atomically claim the resulting access token, refresh token, and session ID.\nNo `Authorization` header is required: the 128-bit `sessionToken` (held only by the originating client, never echoed back to observers) IS the credential, exactly as in RFC 8628 §3.4. The exchange is single-use: a successful claim transitions the AuthSession status from `authorized` -> `consumed`, so a replayed sessionToken is rejected. Time-bound by the AuthSession TTL (default 5 minutes). Status-bound: only `authorized` rows are claimable.\nThis endpoint is the only device-flow token handoff: the originating client starts with no bearer token, so it must claim exactly once with the secret sessionToken it created.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "sessionToken"
-                ],
-                "properties": {
-                  "sessionToken": {
-                    "type": "string",
-                    "description": "The same 128-bit sessionToken issued by `POST /auth/session/create`."
-                  },
-                  "deviceFingerprint": {
-                    "type": "string",
-                    "description": "Optional fingerprint of the originating client device."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "First access token issued.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "accessToken": {
-                      "type": "string"
-                    },
-                    "deviceSecret": {
-                      "type": "string"
-                    },
-                    "sessionId": {
-                      "type": "string"
-                    },
-                    "deviceId": {
-                      "type": "string"
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "user": {
-                      "$ref": "#/components/schemas/User"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed."
-          },
-          "401": {
-            "description": "SessionToken is unknown, expired, cancelled, not yet authorized, or already consumed."
-          }
-        }
-      }
-    },
-    "/auth/session/finalize/{sessionToken}": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Finalize an approved OAuth-bound auth session into an authorization code",
-        "description": "Terminal step of an OAuth authorization request created with `POST /auth/session/create` + an `oauth` binding and approved through any delivery surface (popup, push, QR, verified app link). Mints the ONE single-use `AuthCode` the relying party redeems at `POST /auth/oauth/token` with its PKCE verifier.\nNo `Authorization` header: the 128-bit `sessionToken` — held only by the originating client, never echoed to observers — IS the credential, exactly as on `POST /auth/session/claim`. No access token is ever handed out here.\nAtomic and single-use: the authorization code's identity is reserved by the same update that spends the request, so a request can never mint a second code, even under concurrent calls. Every failure mode collapses to one generic `invalid_grant` (RFC 6749 §5.2) — nothing enumerates which precondition failed.\n",
-        "parameters": [
-          {
-            "name": "sessionToken",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Authorization code issued.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string"
-                    },
-                    "redirectUri": {
-                      "type": "string",
-                      "format": "uri"
-                    },
-                    "expiresIn": {
-                      "type": "integer",
-                      "example": 60
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unknown, not an OAuth request, not approved, expired, already finalized, no longer permitted, or its application/redirect binding is no longer valid.\n"
-          }
-        }
-      }
-    },
-    "/auth/oauth/authorize": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Issue an OAuth2 authorization code (after user consent)",
-        "description": "Called by the Oxy auth UI after the user clicks \"Allow\" on a third-party app's consent screen. Requires the authenticated user's Bearer access token. Returns a short-lived single-use code that the client app exchanges for tokens via `POST /auth/oauth/token`.\nThe `redirectUri` MUST exactly match one of the Application's registered `redirectUris` — otherwise the request is rejected.\n",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "clientId",
-                  "redirectUri"
-                ],
-                "properties": {
-                  "clientId": {
-                    "type": "string",
-                    "description": "ApplicationCredential publicKey (OAuth client_id)"
-                  },
-                  "redirectUri": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "state": {
-                    "type": "string",
-                    "description": "Opaque CSRF token forwarded back to the client."
-                  },
-                  "codeChallenge": {
-                    "type": "string",
-                    "description": "PKCE code challenge (S256). Required for public clients."
-                  },
-                  "codeChallengeMethod": {
-                    "type": "string",
-                    "enum": [
-                      "S256"
-                    ]
-                  },
-                  "scope": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Authorization code issued."
-          },
-          "400": {
-            "description": "Validation failed."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "403": {
-            "description": "Redirect URI is not registered for this client."
-          }
-        }
-      }
-    },
-    "/auth/oauth/consent": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Server-authoritative decision on whether OAuth consent is needed",
-        "description": "Called by the auth UI before rendering the consent screen. Resolves the `clientId` to an Application (validating the `redirectUri` exactly like `POST /auth/oauth/authorize`) and decides whether the user must consent:\n- TRUSTED apps (first-party / internal / system / official) are\n  auto-approved → `consentRequired: false, reason: 'trusted'`.\n- A prior grant whose scopes cover the requested `scope` →\n  `consentRequired: false, reason: 'granted'`.\n- A prior grant missing some requested scope →\n  `consentRequired: true, reason: 'scope_changed'`.\n- No prior grant → `consentRequired: true, reason: 'new'`.\n",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "in": "query",
-            "name": "clientId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "redirectUri",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uri"
-            }
-          },
-          {
-            "in": "query",
-            "name": "scope",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Consent decision."
-          },
-          "400": {
-            "description": "Invalid client."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "403": {
-            "description": "Redirect URI is not registered for this client."
-          }
-        }
-      }
-    },
-    "/auth/grants": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "List the third-party apps the user has authorized (Connected apps)",
-        "description": "Returns the user's revocable OAuth grants joined with the application's name + logo + granted scopes + timestamps. Trusted (auto-approved) apps are never recorded as grants, so they never appear here.\n",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The user's connected applications."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/auth/grants/{applicationId}": {
-      "delete": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Revoke a connected app's OAuth grant",
-        "description": "Deletes the user's AppGrant for the application so the next OAuth authorize for this app prompts for consent again.\n",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "in": "path",
-            "name": "applicationId",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Grant revoked. Idempotent, and total: an `applicationId` that names no application — or one the caller never granted — deletes nothing and answers the same way, so nothing here is an existence oracle.\n"
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/auth/oauth/token": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Exchange an OAuth2 authorization code for tokens (RFC 6749)",
-        "description": "Standards-compliant RFC 6749 §4.1.3 token endpoint. Single-use exchange of an authorization code (from `POST /auth/oauth/authorize`) for a bearer access token, rotating device credentials, and session ID.\nThe request MUST be `application/x-www-form-urlencoded` with `grant_type=authorization_code`. Confidential clients authenticate with `client_secret` — either in the body (`client_secret_post`) or via HTTP Basic (`client_secret_basic`), never both. Public clients send `client_id` plus the PKCE `code_verifier`.\nThe response is a FLAT JSON document (no `data` wrapper) sent with `Cache-Control: no-store`, as RFC 6749 §5.1 requires. Alongside the standard `access_token` / `token_type` / `expires_in` it carries Oxy's device-first extras (`session_id`, `deviceId`, `deviceSecret`, `user`), which §5.1 permits as additional parameters.\nErrors follow RFC 6749 §5.2 (`{ \"error\": ..., \"error_description\": ... }`). Replaying an already-used code, sending a code past its 60-second TTL, or mismatching the `redirect_uri` all return the same `400 invalid_grant` with no detail about which check failed.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "grant_type",
-                  "code",
-                  "redirect_uri"
-                ],
-                "properties": {
-                  "grant_type": {
-                    "type": "string",
-                    "enum": [
-                      "authorization_code"
-                    ]
-                  },
-                  "code": {
-                    "type": "string"
-                  },
-                  "redirect_uri": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "client_id": {
-                    "type": "string",
-                    "description": "Required unless supplied via HTTP Basic authentication."
-                  },
-                  "client_secret": {
-                    "type": "string",
-                    "description": "Confidential clients only. Mutually exclusive with HTTP Basic."
-                  },
-                  "code_verifier": {
-                    "type": "string",
-                    "description": "PKCE verifier. Required for public clients."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Access token issued.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "access_token": {
-                      "type": "string"
-                    },
-                    "token_type": {
-                      "type": "string",
-                      "enum": [
-                        "Bearer"
-                      ]
-                    },
-                    "expires_in": {
-                      "type": "integer"
-                    },
-                    "scope": {
-                      "type": "string",
-                      "description": "Space-delimited granted scopes. Omitted when the grant carries none."
-                    },
-                    "session_id": {
-                      "type": "string"
-                    },
-                    "deviceId": {
-                      "type": "string"
-                    },
-                    "deviceSecret": {
-                      "type": "string"
-                    },
-                    "user": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "RFC 6749 §5.2 error — `invalid_request`, `invalid_grant`, or `unsupported_grant_type`.\n",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OAuthError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "`invalid_client` — unknown client, or client authentication failed. Carries a `WWW-Authenticate: Basic` challenge.\n",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OAuthError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/auth/oauth/userinfo": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "OpenID Connect userinfo for the bearer's account",
-        "description": "Returns the standard OpenID Connect claims for the account the access token belongs to. The response is a FLAT JSON document (no `data` wrapper) so any OIDC client can read it, and `sub` is the account's permanent id — NEVER the username, which is mutable and case-sensitive.\n`name` is omitted for accounts with no real name (the API never synthesizes one from the handle) and `picture` is omitted for accounts with no avatar. Also accepts POST, as OIDC Core §5.3.1 requires; the token is read only from the `Authorization` header.\n",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The bearer's claims.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "required": [
-                    "sub"
-                  ],
-                  "properties": {
-                    "sub": {
-                      "type": "string",
-                      "description": "Permanent, immutable account identifier."
-                    },
-                    "preferred_username": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "picture": {
-                      "type": "string",
-                      "format": "uri"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "`invalid_request` — the token was sent in the query string.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OAuthError"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "`invalid_token` — missing, malformed, or expired bearer token. Carries a `WWW-Authenticate: Bearer` challenge.\n",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OAuthError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "POST /auth/oauth/userinfo",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/auth.ts` to fill in summary, description, request/response examples.",
+        "summary": "GET /.well-known/did.json",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/did.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -3169,840 +328,6 @@
         "security": [
           {}
         ]
-      }
-    },
-    "/auth/oauth/client/{clientId}": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "security": [],
-        "summary": "Public lookup of an application's consent-UI metadata",
-        "description": "Resolves an OAuth `client_id` (= ApplicationCredential public key) to the sanitized public metadata of its registered Application so the auth web consent screen can render the app's name, icon, official badge, and requested scopes. No bearer token is required. Secrets, webhook config, owner identity, and capabilities are never returned. Returns a generic 404 for unknown, revoked, expired, or inactive clients (no enumeration).\n",
-        "parameters": [
-          {
-            "name": "clientId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Sanitized application metadata.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "application": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "string"
-                        },
-                        "name": {
-                          "type": "string"
-                        },
-                        "description": {
-                          "type": "string"
-                        },
-                        "icon": {
-                          "type": "string"
-                        },
-                        "websiteUrl": {
-                          "type": "string"
-                        },
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "first_party",
-                            "third_party",
-                            "internal",
-                            "system"
-                          ]
-                        },
-                        "isOfficial": {
-                          "type": "boolean"
-                        },
-                        "isInternal": {
-                          "type": "boolean"
-                        },
-                        "scopes": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
-                          }
-                        },
-                        "developerName": {
-                          "type": "string",
-                          "description": "Best-effort owner display name (non-official apps only)."
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Application not found."
-          }
-        }
-      }
-    },
-    "/auth/service-token": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Exchange credentials for a service token",
-        "description": "Internal service-to-service authentication endpoint. Exchange ApplicationCredential credentials (apiKey = publicKey, apiSecret = plaintext secret) for a short-lived service JWT (1 hour). Requires a usable credential of type `service` on an active application: either `active`, or `deprecated` but still within its rotation grace window (a credential rotated within the last 7 days keeps minting tokens until its grace `expiresAt`). `revoked` and grace-expired credentials are rejected. The minted JWT carries `appId` (Application `_id`) and `credentialId` (the minting ApplicationCredential `_id`).\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "apiKey",
-                  "apiSecret"
-                ],
-                "properties": {
-                  "apiKey": {
-                    "type": "string",
-                    "description": "ApplicationCredential publicKey",
-                    "example": "oxy_dk_abc123"
-                  },
-                  "apiSecret": {
-                    "type": "string",
-                    "description": "ApplicationCredential plaintext secret"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Service token issued",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "token": {
-                      "type": "string",
-                      "description": "Short-lived JWT for service-to-service calls"
-                    },
-                    "expiresIn": {
-                      "type": "integer",
-                      "description": "Token lifetime in seconds",
-                      "example": 3600
-                    },
-                    "appName": {
-                      "type": "string",
-                      "description": "Name of the authenticated app"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing apiKey or apiSecret",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Credential is not a service credential",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded"
-          }
-        }
-      }
-    },
-    "/assets": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "List the user's files",
-        "description": "Paginated list of files owned by the authenticated user, including upload status, deduplication info (`sha256`), variants (thumbnails, resized renditions), and any entity links.\n",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1,
-              "maximum": 100,
-              "default": 50
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paginated file list.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "files": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    },
-                    "total": {
-                      "type": "integer"
-                    },
-                    "hasMore": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/assets/init": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Initialise a file upload",
-        "description": "First call in the two-step upload flow. Submit the file's SHA-256, size, and MIME type and receive a `fileId` plus a pre-signed S3 upload URL. If a file with the same SHA-256 already exists for the caller, the server short-circuits and returns the existing record (de-duplication).\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "sha256",
-                  "size",
-                  "mime"
-                ],
-                "properties": {
-                  "sha256": {
-                    "type": "string",
-                    "minLength": 64,
-                    "maxLength": 64,
-                    "example": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-                  },
-                  "size": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "example": 12345
-                  },
-                  "mime": {
-                    "type": "string",
-                    "example": "image/png"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Upload initialised.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "fileId": {
-                      "type": "string"
-                    },
-                    "uploadUrl": {
-                      "type": "string",
-                      "description": "Pre-signed S3 PUT URL."
-                    },
-                    "storageKey": {
-                      "type": "string"
-                    },
-                    "deduplicated": {
-                      "type": "boolean",
-                      "description": "True if the SHA-256 was already present."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/assets/complete": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Complete a file upload",
-        "description": "Second call in the two-step upload flow. Call this after the client has finished PUTing the file to the pre-signed S3 URL returned by `/assets/init`. Commits the metadata, marks the file ready, and enqueues variant generation (thumbnails, image resizes) where applicable.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "fileId",
-                  "originalName",
-                  "size",
-                  "mime"
-                ],
-                "properties": {
-                  "fileId": {
-                    "type": "string"
-                  },
-                  "originalName": {
-                    "type": "string",
-                    "example": "profile.png"
-                  },
-                  "size": {
-                    "type": "integer",
-                    "example": 12345
-                  },
-                  "mime": {
-                    "type": "string",
-                    "example": "image/png"
-                  },
-                  "visibility": {
-                    "type": "string",
-                    "enum": [
-                      "private",
-                      "public",
-                      "unlisted"
-                    ],
-                    "default": "private"
-                  },
-                  "metadata": {
-                    "type": "object",
-                    "additionalProperties": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "File committed.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "assetId": {
-                      "type": "string"
-                    },
-                    "file": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/assets/upload": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Upload a file in a single request",
-        "description": "Convenience endpoint that wraps the init/PUT/complete flow into a single multipart upload. The backend computes the SHA-256 itself. Use this for small files where the round-trip cost outweighs the benefit of direct-to-S3 streaming.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "file"
-                ],
-                "properties": {
-                  "file": {
-                    "type": "string",
-                    "format": "binary"
-                  },
-                  "visibility": {
-                    "type": "string",
-                    "enum": [
-                      "private",
-                      "public",
-                      "unlisted"
-                    ],
-                    "default": "private"
-                  },
-                  "metadata": {
-                    "type": "string",
-                    "description": "Optional JSON-encoded metadata object."
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "File uploaded and committed."
-          },
-          "400": {
-            "description": "Missing file or malformed metadata."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          }
-        }
-      }
-    },
-    "/assets/service/by-ids": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Batch-resolve asset metadata for a service",
-        "description": "Service-token-only batch metadata read. Given up to 100 file ids, returns the content hash (`sha256`), `mime`, `size`, and `status` for each KNOWN, non-deleted file. This is a METADATA-ONLY surface — it never returns bytes, signed URLs, owner ids, links, or any other field, so a service token can map a file id to its content hash without being able to read private file contents. Unknown, invalid, or deleted ids are silently omitted from `data` (the batch never 404s as a whole).\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "ids"
-                ],
-                "properties": {
-                  "ids": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Resolved asset metadata (order not guaranteed).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string"
-                          },
-                          "sha256": {
-                            "type": "string"
-                          },
-                          "mime": {
-                            "type": "string"
-                          },
-                          "size": {
-                            "type": "integer"
-                          },
-                          "status": {
-                            "type": "string",
-                            "enum": [
-                              "active",
-                              "trash"
-                            ]
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed (empty array or more than 100 ids)."
-          },
-          "401": {
-            "description": "Missing or expired service token."
-          },
-          "403": {
-            "description": "Not a service token, or missing the files:read scope."
-          }
-        }
-      }
-    },
-    "/assets/service/by-sha256": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Reverse content-address resolve assets by SHA-256",
-        "description": "Service-token-only batch REVERSE lookup. Given up to 100 lowercase hex SHA-256 content hashes, resolves each to the live (non-deleted) Oxy asset holding that content: its file `id`, `mime`, byte `size`, `status`, and — for ACTIVE, PUBLIC, CDN-reachable assets only — a public `url` (`cloud.oxy.so`). This is the inverse of `POST /assets/service/by-ids`: callers (e.g. Mention's MTN materializer / node-blob sync) that hold a record's `blob.sha256` use it to find the servable asset for that content. Private/unlisted assets omit `url`. Unknown, invalid, or deleted hashes are silently omitted from `data` (the batch never 404s as a whole); the result may be shorter than the requested list — map by `sha256`.\n",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "sha256s"
-                ],
-                "properties": {
-                  "sha256s": {
-                    "type": "array",
-                    "minItems": 1,
-                    "maxItems": 100,
-                    "items": {
-                      "type": "string",
-                      "pattern": "^[a-f0-9]{64}$"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Resolved asset metadata (order not guaranteed).",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "sha256": {
-                            "type": "string"
-                          },
-                          "id": {
-                            "type": "string"
-                          },
-                          "mime": {
-                            "type": "string"
-                          },
-                          "size": {
-                            "type": "integer"
-                          },
-                          "status": {
-                            "type": "string",
-                            "enum": [
-                              "active",
-                              "trash"
-                            ]
-                          },
-                          "url": {
-                            "type": "string",
-                            "description": "Public CDN URL; present only for active, public, CDN-reachable assets."
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation failed (empty array, > 100 hashes, or a non-hex digest)."
-          },
-          "401": {
-            "description": "Missing or expired service token."
-          },
-          "403": {
-            "description": "Not a service token, or missing the files:read scope."
-          }
-        }
-      }
-    },
-    "/assets/{id}": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Get file metadata",
-        "description": "Return metadata for the file (size, MIME, SHA-256, variants, links, usage count, status). Only the owner can fetch metadata; signed URLs (`/assets/:id/url` or `/assets/:id/stream`) are the public access path.\n",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "File metadata."
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "404": {
-            "description": "File not found."
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Delete file with impact summary",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/assets/{id}/url": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Get a download URL for a file",
-        "description": "Return a CDN URL (for public files) or a pre-signed S3 URL (for private files) suitable for `<img src>` or direct download. The URL is valid for `expiresIn` seconds (default 3600).\n",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "variant",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "description": "Variant name (e.g. \"thumb-256\", \"medium\")."
-            }
-          },
-          {
-            "name": "expiresIn",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "default": 3600,
-              "description": "Seconds the signed URL stays valid."
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Signed URL.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "url": {
-                      "type": "string",
-                      "format": "uri"
-                    },
-                    "variant": {
-                      "type": "string",
-                      "nullable": true
-                    },
-                    "expiresIn": {
-                      "type": "integer"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Missing or invalid bearer token."
-          },
-          "404": {
-            "description": "File not found."
-          }
-        }
-      }
-    },
-    "/assets/{id}/stream": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Stream file bytes (with correct headers)",
-        "description": "Public endpoint that streams the raw file bytes back to the caller. Sends correct `Content-Type` and `Cache-Control` headers and falls back to a placeholder if the underlying object is missing (`?fallback=placeholder|placeholderVisible|icon`). For private files the caller must supply a bearer token.\n",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "variant",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "fallback",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "placeholder",
-                "placeholderVisible",
-                "icon"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "File bytes streamed (or placeholder if fallback requested)."
-          },
-          "302": {
-            "description": "Redirect to pre-signed S3 URL."
-          },
-          "403": {
-            "description": "Access denied."
-          },
-          "404": {
-            "description": "File not found (and no fallback requested)."
-          }
-        }
       }
     },
     "/accounts": {
@@ -4059,13 +384,63 @@
         ]
       }
     },
-    "/accounts/{id}/switch": {
+    "/accounts/service/channels": {
       "post": {
         "tags": [
           "Users"
         ],
-        "summary": "Switch INTO a managed/org account — a TRUE account switch (the whole app",
-        "description": "becomes that account), NOT a per-request delegation. Mints a REAL session\nwhose `user` IS the target account, exactly like switching device accounts.\n\nThe caller (operator) must hold `account:act_as` over the target. The minted\nsession records the operator (`operatedByUserId`) for audit and binds its\nvalidity to that membership — revoking it kills the session (re-checked on\nvalidate + refresh).\n\nThe minted managed session is registered into the operator's device set\nserver-side (`deviceSessionService.addAccount`, broadcast to the device room)\nso it survives reload and syncs across the device's apps via the socket.\n\nReturns the SAME shape as login / claimSession (`SessionAuthResponse`) so the\nclient plants it as the active session.",
+        "summary": "Mint a `channel` account under `ownerUserId`, who becomes its `owner` member.",
+        "description": "`kind` is NOT accepted from the body — it is hardcoded, so this credential can\nnever mint an account that anyone could subsequently act as.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts/service/channels/{id}/members": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Grant membership on a CHANNEL. `owner` is not assignable (the schema's role",
+        "description": "enum excludes it) — ownership moves only via transfer-ownership.",
         "parameters": [
           {
             "name": "id",
@@ -4082,6 +457,26 @@
           },
           "400": {
             "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
             "content": {
               "application/json": {
                 "schema": {
@@ -4112,7 +507,96 @@
           }
         },
         "security": [
-          {}
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
+    "/accounts/service/channels/{id}/members/{memberUserId}": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Revoke membership on a CHANNEL. Keyed on the member's USER id rather than the",
+        "description": "membership row id: the caller knows who it is removing, not which row records\nit. Removing the owner is refused by `accountService.removeMember`.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "memberUserId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
         ]
       }
     },
@@ -4340,13 +824,68 @@
         ]
       }
     },
-    "/accounts/{id}/tree": {
+    "/accounts/{id}/credentials": {
       "get": {
         "tags": [
           "Users"
         ],
-        "summary": "The full subtree rooted at an account (`children:read`), including itself.",
+        "summary": "List an account's service credentials (`credentials:read`).",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Create a service credential for a bot account (`credentials:create`). The",
+        "description": "plaintext secret is returned EXACTLY ONCE. Privileged scopes are staff-gated.",
         "parameters": [
           {
             "name": "id",
@@ -4397,16 +936,89 @@
         ]
       }
     },
-    "/accounts/{id}/move": {
+    "/accounts/{id}/credentials/{credId}": {
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Revoke a credential (`credentials:revoke`).",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "credId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/accounts/{id}/credentials/{credId}/rotate": {
       "post": {
         "tags": [
           "Users"
         ],
-        "summary": "Re-parent an account (`children:update` on the account being moved). The",
-        "description": "caller must ALSO hold `children:create` on the destination parent.",
+        "summary": "Rotate a credential — zero-downtime (`credentials:rotate`).",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
             "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "credId",
             "in": "path",
             "required": true,
             "schema": {
@@ -4459,8 +1071,8 @@
         "tags": [
           "Users"
         ],
-        "summary": "List direct members of an account (`members:read`).",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
+        "summary": "List the members of an account (`members:read`) — its own rows plus the",
+        "description": "ancestor rows that cascade into it, each carrying the `source` that says\nwhich. See {@link AccountService.listMembers} for why an inherited holder\nbelongs in this list and what changes by including them (disclosure, not\npermission).",
         "parameters": [
           {
             "name": "id",
@@ -4571,8 +1183,8 @@
         "tags": [
           "Users"
         ],
-        "summary": "Change a member's role/inheritance (`members:update`).",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
+        "summary": "Change a member's role, inheritance and/or per-member permissions",
+        "description": "(`members:update`).\n\n## The escalation guards\n\n`members:update` is held by owner and admin, and an admin's baseline is a\nPROPER SUBSET of an owner's — it carries neither `account:delete` nor\n`ownership:transfer`. Without a bound on what may be conferred, this endpoint\nwould hand an admin both of those (via a confederate's row, or their own) and\nwith them the account. The two rules below are what stop that, and the\nFIRST is the load-bearing one:\n\n 1. **An actor may only grant what they themselves effectively hold.** This is\n    transitive-closure-safe on its own: whatever chain of members grant each\n    other, no permission enters the account that was not already inside it.\n    Compared against the actor's EFFECTIVE set, so an actor whose own\n    `credentials:create` was revoked cannot re-mint it through somebody else.\n 2. **An actor may not edit their OWN membership row.** Rule 1 already refuses\n    the dangerous half of a self-edit, so this is not what closes the hole; it\n    is here because rule 1 evaluated against the very row being rewritten is a\n    read-modify-write racing itself, and because \"you cannot rewrite your own\n    permissions\" is the property an operator will assume holds.\n\nEscalation to OWNER is refused structurally rather than by a rule: `role` is\ntyped to the assignable roles (owner is not among them), and `updateMember`\nrefuses an owner ROW outright, so neither the actor nor their target can reach\nownership through this endpoint at all.\n\nREVOKES are deliberately NOT subject to rule 1. An admin may revoke a\npermission they do not hold themselves — taking something away is not a\nconferral, and the alternative would leave a permission granted by a\nsince-departed owner with nobody able to withdraw it.",
         "parameters": [
           {
             "name": "id",
@@ -4694,6 +1306,120 @@
         ]
       }
     },
+    "/accounts/{id}/move": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Re-parent an account (`children:update` on the account being moved). The",
+        "description": "caller must ALSO hold `children:create` on the destination parent.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/accounts/{id}/switch": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Switch INTO a managed/org account — a TRUE account switch (the whole app",
+        "description": "becomes that account), NOT a per-request delegation. Mints a REAL session\nwhose `user` IS the target account, exactly like switching device accounts.\n\nThe caller (operator) must hold `account:act_as` over the target. The minted\nsession records the operator (`operatedByUserId`) for audit and binds its\nvalidity to that membership — revoking it kills the session (re-checked on\nvalidate + refresh).\n\nThe minted managed session is registered into the operator's device set\nserver-side (`deviceSessionService.addAccount`, broadcast to the device room)\nso it survives reload and syncs across the device's apps via the socket.\n\nReturns the SAME shape as login / claimSession (`SessionAuthResponse`) so the\nclient plants it as the active session.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/accounts/{id}/transfer-ownership": {
       "post": {
         "tags": [
@@ -4751,201 +1477,16 @@
         ]
       }
     },
-    "/accounts/{id}/credentials": {
+    "/accounts/{id}/tree": {
       "get": {
         "tags": [
           "Users"
         ],
-        "summary": "List an account's service credentials (`credentials:read`).",
+        "summary": "The full subtree rooted at an account (`children:read`), including itself.",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
             "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      },
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Create a service credential for a bot account (`credentials:create`). The",
-        "description": "plaintext secret is returned EXACTLY ONCE. Privileged scopes are staff-gated.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/accounts/{id}/credentials/{credId}/rotate": {
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Rotate a credential — zero-downtime (`credentials:rotate`).",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "credId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/accounts/{id}/credentials/{credId}": {
-      "delete": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Revoke a credential (`credentials:revoke`).",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/accounts.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "credId",
             "in": "path",
             "required": true,
             "schema": {
@@ -5141,6 +1682,34 @@
         ]
       }
     },
+    "/analytics/followers": {
+      "get": {
+        "tags": [
+          "Analytics"
+        ],
+        "summary": "GET /analytics/followers",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/analytics.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/analytics/update": {
       "post": {
         "tags": [
@@ -5197,41 +1766,13 @@
         ]
       }
     },
-    "/analytics/followers": {
-      "get": {
-        "tags": [
-          "Analytics"
-        ],
-        "summary": "GET /analytics/followers",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/analytics.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/app-signals/ingest": {
+    "/app-signals/events": {
       "post": {
         "tags": [
           "Analytics"
         ],
-        "summary": "Ingest endorsement and/or interest signals for the requesting application.",
-        "description": "Idempotent — re-ingesting the same edges is a no-op; an interest signal is\nlast-write-wins.",
+        "summary": "Ingest a batch of directed interaction-affinity events for the requesting",
+        "description": "application (`fromUserId → toUserId`, typed, optionally weighted). Each event\nis folded into a per-app, time-decayed affinity edge; self-edges are dropped\nand a supplied `eventId` is deduped. Idempotent for events carrying an\n`eventId`; at-least-once (additive/decayed) for events without one.",
         "parameters": [],
         "responses": {
           "200": {
@@ -5275,13 +1816,13 @@
         ]
       }
     },
-    "/app-signals/events": {
+    "/app-signals/ingest": {
       "post": {
         "tags": [
           "Analytics"
         ],
-        "summary": "Ingest a batch of directed interaction-affinity events for the requesting",
-        "description": "application (`fromUserId → toUserId`, typed, optionally weighted). Each event\nis folded into a per-app, time-decayed affinity edge; self-edges are dropped\nand a supplied `eventId` is deduped. Idempotent for events carrying an\n`eventId`; at-least-once (additive/decayed) for events without one.",
+        "summary": "Ingest endorsement and/or interest signals for the requesting application.",
+        "description": "Idempotent — re-ingesting the same edges is a no-op; an interest signal is\nlast-write-wins.",
         "parameters": [],
         "responses": {
           "200": {
@@ -5499,7 +2040,16 @@
                         "reputation:binding:register",
                         "notifications:write",
                         "payments:read",
-                        "payments:write"
+                        "payments:write",
+                        "accounts:provision",
+                        "follows:read",
+                        "follows:write",
+                        "follows:context:write",
+                        "follows:manage",
+                        "follows:events",
+                        "follow-targets:register",
+                        "chains:write",
+                        "chains:read"
                       ]
                     }
                   }
@@ -5716,7 +2266,16 @@
                         "reputation:binding:register",
                         "notifications:write",
                         "payments:read",
-                        "payments:write"
+                        "payments:write",
+                        "accounts:provision",
+                        "follows:read",
+                        "follows:write",
+                        "follows:context:write",
+                        "follows:manage",
+                        "follows:events",
+                        "follow-targets:register",
+                        "chains:write",
+                        "chains:read"
                       ]
                     }
                   },
@@ -6008,7 +2567,16 @@
                         "reputation:binding:register",
                         "notifications:write",
                         "payments:read",
-                        "payments:write"
+                        "payments:write",
+                        "accounts:provision",
+                        "follows:read",
+                        "follows:write",
+                        "follows:context:write",
+                        "follows:manage",
+                        "follows:events",
+                        "follow-targets:register",
+                        "chains:write",
+                        "chains:read"
                       ]
                     }
                   }
@@ -6022,6 +2590,73 @@
             }
           }
         }
+      }
+    },
+    "/applications/{appId}/credentials/{credId}": {
+      "delete": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Revoke a credential. Revoked credentials can no longer authenticate.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/applications.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "credId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
       }
     },
     "/applications/{appId}/credentials/{credId}/rotate": {
@@ -6091,12 +2726,12 @@
         ]
       }
     },
-    "/applications/{appId}/credentials/{credId}": {
-      "delete": {
+    "/applications/{appId}/listing": {
+      "get": {
         "tags": [
           "Developer"
         ],
-        "summary": "Revoke a credential. Revoked credentials can no longer authenticate.",
+        "summary": "The application's listing in whatever state, or null when it has none.",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/applications.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
@@ -6107,9 +2742,472 @@
               "type": "string",
               "minLength": 1
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "put": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Create the listing or replace its content. Never its status: publishing is",
+        "description": "the store's decision and has its own routes.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/applications/{appId}/listing/screenshots": {
+      "get": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Every picture on the listing, in the author's order.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/applications.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "post": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Attach an already-uploaded image. Appended to the end; `…/order` moves it.",
+        "description": "The upload itself is `/files`, unchanged: the store stores a reference, not a\nsecond copy of the asset pipeline.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/applications/{appId}/listing/screenshots/order": {
+      "put": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Set the order of every picture at once.",
+        "description": "Declared before `/:screenshotId` so `order` is read as the route it is, not\nas a screenshot with that id — Express matches in declaration order.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/applications/{appId}/listing/screenshots/{screenshotId}": {
+      "patch": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Edit a picture's caption or the frame it was taken in.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/applications.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "name": "credId",
+            "name": "screenshotId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Remove a picture. The file itself stays — it may be in use elsewhere.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/applications.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "screenshotId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/applications/{appId}/listing/submit": {
+      "post": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Hand the page to the store for review.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/applications.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/applications/{appId}/listing/unpublish": {
+      "post": {
+        "tags": [
+          "Developer"
+        ],
+        "summary": "Take it down, or withdraw it from the queue. Back to a draft, never deleted.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/applications.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "appId",
             "in": "path",
             "required": true,
             "schema": {
@@ -6230,13 +3328,543 @@
         ]
       }
     },
-    "/assets/{id}/upload-direct": {
+    "/assets": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "List the user's files",
+        "description": "Paginated list of files owned by the authenticated user, including upload status, deduplication info (`sha256`), variants (thumbnails, resized renditions), and any entity links.\n",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated file list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "files": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/assets/batch-access": {
       "post": {
         "tags": [
           "Files"
         ],
-        "summary": "Direct upload via API (bypasses browser CORS for presigned PUT)",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
+        "summary": "Resolve access + a caller-scoped, variant-aware URL for many assets in",
+        "description": "ONE round trip. Body: `{ files: [{ fileId, variant? }], expiresIn?, context? }`.\n      A file-manager grid resolves each tile's own rendition (thumb/poster)\n      without one request per tile. One denied/missing file never fails the\n      batch (still 200); denied/missing ids are returned with `allowed:false`.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fileId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "variant": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "fileId"
+                      ]
+                    },
+                    "minItems": 1,
+                    "maxItems": 100
+                  },
+                  "expiresIn": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "context": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "files"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/assets/complete": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Complete a file upload",
+        "description": "Second call in the two-step upload flow. Call this after the client has finished PUTing the file to the pre-signed S3 URL returned by `/assets/init`. Commits the metadata, marks the file ready, and enqueues variant generation (thumbnails, image resizes) where applicable.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "fileId",
+                  "originalName",
+                  "size",
+                  "mime"
+                ],
+                "properties": {
+                  "fileId": {
+                    "type": "string"
+                  },
+                  "originalName": {
+                    "type": "string",
+                    "example": "profile.png"
+                  },
+                  "size": {
+                    "type": "integer",
+                    "example": 12345
+                  },
+                  "mime": {
+                    "type": "string",
+                    "example": "image/png"
+                  },
+                  "visibility": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "public",
+                      "unlisted"
+                    ],
+                    "default": "private"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "File committed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "assetId": {
+                      "type": "string"
+                    },
+                    "file": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/assets/init": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Initialise a file upload",
+        "description": "First call in the two-step upload flow. Submit the file's SHA-256, size, and MIME type and receive a `fileId` plus a pre-signed S3 upload URL. If a file with the same SHA-256 already exists for the caller, the server short-circuits and returns the existing record (de-duplication).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sha256",
+                  "size",
+                  "mime"
+                ],
+                "properties": {
+                  "sha256": {
+                    "type": "string",
+                    "minLength": 64,
+                    "maxLength": 64,
+                    "example": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                  },
+                  "size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "example": 12345
+                  },
+                  "mime": {
+                    "type": "string",
+                    "example": "image/png"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Upload initialised.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fileId": {
+                      "type": "string"
+                    },
+                    "uploadUrl": {
+                      "type": "string",
+                      "description": "Pre-signed S3 PUT URL."
+                    },
+                    "storageKey": {
+                      "type": "string"
+                    },
+                    "deduplicated": {
+                      "type": "boolean",
+                      "description": "True if the SHA-256 was already present."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/assets/service/by-ids": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Batch-resolve asset metadata for a service",
+        "description": "Service-token-only batch metadata read. Given up to 100 file ids, returns the content hash (`sha256`), `mime`, `size`, and `status` for each KNOWN, non-deleted file. This is a METADATA-ONLY surface — it never returns bytes, signed URLs, owner ids, links, or any other field, so a service token can map a file id to its content hash without being able to read private file contents. Unknown, invalid, or deleted ids are silently omitted from `data` (the batch never 404s as a whole).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "ids"
+                ],
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved asset metadata (order not guaranteed).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "sha256": {
+                            "type": "string"
+                          },
+                          "mime": {
+                            "type": "string"
+                          },
+                          "size": {
+                            "type": "integer"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "active",
+                              "trash"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed (empty array or more than 100 ids)."
+          },
+          "401": {
+            "description": "Missing or expired service token."
+          },
+          "403": {
+            "description": "Not a service token, or missing the files:read scope."
+          }
+        }
+      }
+    },
+    "/assets/service/by-sha256": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Reverse content-address resolve assets by SHA-256",
+        "description": "Service-token-only batch REVERSE lookup. Given up to 100 lowercase hex SHA-256 content hashes, resolves each to the live (non-deleted) Oxy asset holding that content: its file `id`, `mime`, byte `size`, `status`, and — for ACTIVE, PUBLIC, CDN-reachable assets only — a public `url` (`cloud.oxy.so`). This is the inverse of `POST /assets/service/by-ids`: callers (e.g. Mention's MTN materializer / node-blob sync) that hold a record's `blob.sha256` use it to find the servable asset for that content. Private/unlisted assets omit `url`. Unknown, invalid, or deleted hashes are silently omitted from `data` (the batch never 404s as a whole); the result may be shorter than the requested list — map by `sha256`.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sha256s"
+                ],
+                "properties": {
+                  "sha256s": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-f0-9]{64}$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Resolved asset metadata (order not guaranteed).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "sha256": {
+                            "type": "string"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "mime": {
+                            "type": "string"
+                          },
+                          "size": {
+                            "type": "integer"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "active",
+                              "trash"
+                            ]
+                          },
+                          "url": {
+                            "type": "string",
+                            "description": "Public CDN URL; present only for active, public, CDN-reachable assets."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed (empty array, > 100 hashes, or a non-hex digest)."
+          },
+          "401": {
+            "description": "Missing or expired service token."
+          },
+          "403": {
+            "description": "Not a service token, or missing the files:read scope."
+          }
+        }
+      }
+    },
+    "/assets/service/cache": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Stream-upload a remote/federated media file into the reserved cache",
+        "description": "namespace. The raw bytes are sent as the request body (NOT multipart)\n      so large video streams straight to S3 without buffering in RAM.\n      Content-Type must be image/*, video/*, or audio/*.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
+    "/assets/service/cache/{id}": {
+      "delete": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Evict a cached media asset by id. Rejects (403) anything that is not",
+        "description": "in the reserved cache namespace, so a service token can never delete\n      user-owned media.",
         "parameters": [
           {
             "name": "id",
@@ -6272,58 +3900,18 @@
               }
             }
           },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/assets/service/cache": {
-      "post": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Stream-upload a remote/federated media file into the reserved cache",
-        "description": "namespace. The raw bytes are sent as the request body (NOT multipart)\n      so large video streams straight to S3 without buffering in RAM.\n      Content-Type must be image/*, video/*, or audio/*.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
           "403": {
             "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -6450,13 +4038,223 @@
         ]
       }
     },
-    "/assets/service/cache/{id}": {
+    "/assets/upload": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Upload a file in a single request",
+        "description": "Convenience endpoint that wraps the init/PUT/complete flow into a single multipart upload. The backend computes the SHA-256 itself. Use this for small files where the round-trip cost outweighs the benefit of direct-to-S3 streaming.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "file"
+                ],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "visibility": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "public",
+                      "unlisted"
+                    ],
+                    "default": "private"
+                  },
+                  "metadata": {
+                    "type": "string",
+                    "description": "Optional JSON-encoded metadata object."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "File uploaded and committed."
+          },
+          "400": {
+            "description": "Missing file or malformed metadata."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/assets/{id}": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get file metadata",
+        "description": "Return metadata for the file (size, MIME, SHA-256, variants, links, usage count, status). Only the owner can fetch metadata; signed URLs (`/assets/:id/url` or `/assets/:id/stream`) are the public access path.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File metadata."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "File not found."
+          }
+        }
+      },
       "delete": {
         "tags": [
           "Files"
         ],
-        "summary": "Evict a cached media asset by id. Rejects (403) anything that is not",
-        "description": "in the reserved cache namespace, so a service token can never delete\n      user-owned media.",
+        "summary": "Delete file with impact summary",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/assets/{id}/download": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Redirect to the signed file URL (suitable for <img src> and direct downloads)",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          },
+          {}
+        ]
+      }
+    },
+    "/assets/{id}/exists": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Debug: return storageKey and existence of the underlying object",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
             "name": "id",
@@ -6492,16 +4290,6 @@
               }
             }
           },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Resource not found",
             "content": {
@@ -6525,7 +4313,7 @@
         },
         "security": [
           {
-            "serviceTokenAuth": []
+            "bearerAuth": []
           }
         ]
       }
@@ -6668,137 +4456,6 @@
         ]
       }
     },
-    "/assets/{id}/exists": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Debug: return storageKey and existence of the underlying object",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/assets/{id}/download": {
-      "get": {
-        "tags": [
-          "Files"
-        ],
-        "summary": "Redirect to the signed file URL (suitable for <img src> and direct downloads)",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          },
-          {}
-        ]
-      }
-    },
     "/assets/{id}/restore": {
       "post": {
         "tags": [
@@ -6867,6 +4524,199 @@
             "bearerAuth": []
           }
         ]
+      }
+    },
+    "/assets/{id}/stream": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Stream file bytes (with correct headers)",
+        "description": "Public endpoint that streams the raw file bytes back to the caller. Sends correct `Content-Type` and `Cache-Control` headers and falls back to a placeholder if the underlying object is missing (`?fallback=placeholder|placeholderVisible|icon`). For private files the caller must supply a bearer token.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fallback",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "placeholder",
+                "placeholderVisible",
+                "icon"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File bytes streamed (or placeholder if fallback requested)."
+          },
+          "302": {
+            "description": "Redirect to pre-signed S3 URL."
+          },
+          "403": {
+            "description": "Access denied."
+          },
+          "404": {
+            "description": "File not found (and no fallback requested)."
+          }
+        }
+      }
+    },
+    "/assets/{id}/upload-direct": {
+      "post": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Direct upload via API (bypasses browser CORS for presigned PUT)",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/assets.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/assets/{id}/url": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get a download URL for a file",
+        "description": "Return a CDN URL (for public files) or a pre-signed S3 URL (for private files) suitable for `<img src>` or direct download. The URL is valid for `expiresIn` seconds (default 3600).\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "variant",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Variant name (e.g. \"thumb-256\", \"medium\")."
+            }
+          },
+          {
+            "name": "expiresIn",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 3600,
+              "description": "Seconds the signed URL stays valid."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Signed URL.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "variant": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "expiresIn": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "File not found."
+          }
+        }
       }
     },
     "/assets/{id}/visibility": {
@@ -6938,96 +4788,113 @@
         ]
       }
     },
-    "/assets/batch-access": {
+    "/auth/challenge": {
       "post": {
         "tags": [
-          "Files"
+          "Authentication"
         ],
-        "summary": "Resolve access + a caller-scoped, variant-aware URL for many assets in",
-        "description": "ONE round trip. Body: `{ files: [{ fileId, variant? }], expiresIn?, context? }`.\n      A file-manager grid resolves each tile's own rendition (thumb/poster)\n      without one request per tile. One denied/missing file never fails the\n      batch (still 200); denied/missing ids are returned with `allowed:false`.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
+        "security": [],
+        "summary": "Request a sign-in challenge for a public key",
+        "description": "Step 1 of the passwordless public-key login. Returns a short-lived random challenge that the client must sign with the matching private key, then submit to `POST /auth/verify`.\n",
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "properties": {
-                  "files": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "fileId": {
-                          "type": "string",
-                          "minLength": 1
-                        },
-                        "variant": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      },
-                      "required": [
-                        "fileId"
-                      ]
-                    },
-                    "minItems": 1,
-                    "maxItems": 100
-                  },
-                  "expiresIn": {
-                    "type": "integer",
-                    "minimum": 0,
-                    "exclusiveMinimum": true
-                  },
-                  "context": {
-                    "type": "string"
-                  }
-                },
                 "required": [
-                  "files"
-                ]
+                  "publicKey"
+                ],
+                "properties": {
+                  "publicKey": {
+                    "type": "string",
+                    "description": "secp256k1 public key (hex)."
+                  }
+                }
               }
             }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Challenge issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "challenge": {
+                      "type": "string",
+                      "description": "Opaque challenge string to sign."
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No account registered for this public key."
+          },
+          "429": {
+            "description": "Rate limit exceeded (10 / minute / IP)."
+          }
+        }
+      }
+    },
+    "/auth/check-email/{email}": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Check email availability",
+        "description": "Check whether an email address is available for registration.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "email",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "email"
+            },
+            "example": "user@example.com"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Availability check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid email format",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded"
           }
         }
       }
@@ -7100,30 +4967,47 @@
         ]
       }
     },
-    "/auth/user/{publicKey}": {
+    "/auth/check-username/{username}": {
       "get": {
         "tags": [
           "Authentication"
         ],
-        "summary": "Get user by public key (public profile info)",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/auth.ts` to fill in summary, description, request/response examples.",
+        "summary": "Check username availability",
+        "description": "Check whether a username is available for registration.",
         "parameters": [
           {
-            "name": "publicKey",
             "in": "path",
+            "name": "username",
             "required": true,
             "schema": {
               "type": "string",
-              "minLength": 1
-            }
+              "minLength": 3,
+              "maxLength": 30
+            },
+            "example": "johndoe"
           }
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Availability check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "available": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
           },
           "400": {
-            "description": "Validation failed",
+            "description": "Invalid username format",
             "content": {
               "application/json": {
                 "schema": {
@@ -7132,702 +5016,64 @@
               }
             }
           },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+          "429": {
+            "description": "Rate limit exceeded"
           }
-        },
-        "security": [
-          {}
-        ]
+        }
       }
     },
-    "/auth/session/cancel/{sessionToken}": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Cancel an auth session. The `sessionToken` is a 128-bit secret held only by",
-        "description": "the originating client, so possessing it IS the ownership proof — no\nadditional identifier is required.",
-        "parameters": [
-          {
-            "name": "sessionToken",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/auth/session/approve-info/{authorizeCode}": {
+    "/auth/grants": {
       "get": {
         "tags": [
           "Authentication"
         ],
-        "summary": "PUBLIC. Returns the server-resolved, sanitized Application identity (never the",
-        "description": "QR's self-asserted strings) plus the bound origin, purpose, delegated subject\nand status, so the Commons approval screen renders the TRUE request. Never\nleaks the secret `sessionToken`, tokens, or the PKCE binding.",
-        "parameters": [
-          {
-            "name": "authorizeCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/auth/session/authorize-signed/{authorizeCode}": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "NO bearer auth — this is the gap-filler. The Commons vault approves with its",
-        "description": "local secp256k1 key: it proves key control with a single-use challenge\nsignature (`verifyChallengeResponse` + atomic burn), and the resolved signer\nbecomes the authorizing user. The session is bound by `authorizeCode`. The\nwaiting originator is notified over the socket on the row's `sessionToken`.",
-        "parameters": [
-          {
-            "name": "authorizeCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
+        "summary": "List the third-party apps the user has authorized (Connected apps)",
+        "description": "Returns the user's revocable OAuth grants joined with the application's name + logo + granted scopes + timestamps. Trusted (auto-approved) apps are never recorded as grants, so they never appear here.\n",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "publicKey": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "challenge": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "signature": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "timestamp": {
-                    "type": "number"
-                  },
-                  "deviceName": {
-                    "type": "string"
-                  },
-                  "deviceFingerprint": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "publicKey",
-                  "challenge",
-                  "signature",
-                  "timestamp"
-                ]
-              }
-            }
+        "responses": {
+          "200": {
+            "description": "The user's connected applications."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
           }
         }
       }
     },
-    "/auth/session/authorize-code/{authorizeCode}": {
-      "post": {
+    "/auth/grants/{applicationId}": {
+      "delete": {
         "tags": [
           "Authentication"
         ],
-        "summary": "Bearer-authed sibling of `POST /session/authorize/:sessionToken`, keyed on",
-        "description": "the PUBLIC `authorizeCode` instead of the secret `sessionToken` — for an\napprover that authenticates via bearer token (e.g. a passkey ceremony) but,\nunlike the Oxy Accounts app, never holds the secret. This lets the caller\ncarry ONLY the public code (safe in a URL); the secret `sessionToken` never\nhas to leave the originating client. The authenticated principal (bearer)\nis the sole source of \"who is authorising\" — mirrors `/session/authorize`.\n\nThe claim + mint live in `authorizeSessionWithBearer` (atomic, see its\ndoc) so two concurrent authorizes of the same code can't both mint a\nsession — the route only resolves the bearer identity and maps the\noutcome to a status code.",
-        "parameters": [
-          {
-            "name": "authorizeCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
+        "summary": "Revoke a connected app's OAuth grant",
+        "description": "Deletes the user's AppGrant for the application so the next OAuth authorize for this app prompts for consent again.\n",
         "security": [
           {
             "bearerAuth": []
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "deviceName": {
-                    "type": "string"
-                  },
-                  "deviceFingerprint": {
-                    "type": "string"
-                  }
-                }
-              }
+        "parameters": [
+          {
+            "in": "path",
+            "name": "applicationId",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Grant revoked. Idempotent, and total: an `applicationId` that names no application — or one the caller never granted — deletes nothing and answers the same way, so nothing here is an existence oracle.\n"
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
           }
         }
-      }
-    },
-    "/auth/session/deny/{authorizeCode}": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "The Commons vault denies a pending approval. It never holds the secret",
-        "description": "`sessionToken`, so it cannot use `/session/cancel/:sessionToken`; it cancels\nby the public `authorizeCode` instead. Only a PENDING session can be denied\n(so a knower of the code cannot cancel an already-authorized session).\n\nThe OPTIONAL `reason` comes from the closed `COMMONS_DENY_REASONS` set —\nthis endpoint is unauthenticated, so free-form text is rejected at the edge\nrather than persisted. Recording it makes \"This wasn't me\" (`not_me`) a\ndistinguishable, honest record instead of an ordinary cancel.",
-        "parameters": [
-          {
-            "name": "authorizeCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "reason": {
-                    "type": "string",
-                    "enum": [
-                      "declined",
-                      "not_me"
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/auth/session/deliver/{authorizeCode}": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Bearer REQUIRED — and the bearer is the SECURITY CONTROL, not a convenience.",
-        "description": "Delivery targets the AUTHENTICATED user's own approval-capable installs and\nnothing else: the target identity is never resolved from the request body, the\nQR payload, or the bound `AuthSession`. That makes it impossible to make Oxy\npush a sign-in prompt at someone by typing their username or email into an\nunauthenticated browser.\n\nEligible installs are those registered by an `Application` carrying the\nstaff-controlled `identity:approval` capability — a registry decision, never a\nhardcoded client id or bundle id.\n\nThe payload is exactly `{ type, approvalUrl }`: a type discriminator plus the\nPUBLIC approval handle. No application name, no origin, no scopes, no secrets\n— the vault re-fetches all authoritative display data from\n`GET /auth/session/approve-info/:authorizeCode`. The notification carries no\naction buttons, so it can only be opened or dismissed; approval always happens\ninside the vault, behind biometrics and a local-key signature.\n\nResponds with COUNTS only (`{ delivered, targets }`) — never device names,\nplatforms, or any other install detail. `targets: 0` is a normal outcome (no\nvault install on any device) and the client falls back to the QR surface; a\npush transport failure degrades to exactly the same shape and never fails the\nauth flow.",
-        "parameters": [
-          {
-            "name": "authorizeCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/auth/session/opened/{authorizeCode}": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "NO bearer — like `approve-info`, the PUBLIC single-use approval handle IS the",
-        "description": "credential. Records delivery progress only: `openedAt` is written at most once,\nonly while the request is still pending and unexpired, and NEVER touches\n`status`. The authoritative state machine stays exactly\n`pending -> authorized -> consumed` / `cancelled` / `expired`.",
-        "parameters": [
-          {
-            "name": "authorizeCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 256
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/auth/methods": {
-      "get": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Get the account DID and all linked authentication methods for the current",
-        "description": "user, shaped to the `authMethodsResponseSchema` contract. Identity methods\ncarry their DID verification-method id (`#key-1`); passkeys carry none.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/auth/rotate/challenge": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Mint a single-use `rotate_key` challenge for the current account. The client",
-        "description": "signs it with its CURRENT key to prove control before the swap.\n\nThe challenge is bound to the account's current `publicKey` and carries\n`purpose: 'rotate_key'`, so a signin challenge (default purpose) can never be\nspent here and vice-versa.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/auth/rotate/complete": {
-      "post": {
-        "tags": [
-          "Authentication"
-        ],
-        "summary": "Atomically REPLACE the account's identity key with `newPublicKey`.",
-        "description": "Rotation is a single atomic swap — never a remove-then-add — so it never\npasses through a zero-auth-method state and is independent of the unlink\nguards. Because control of the CURRENT key is proven (from SecureStore OR a\nrecovery-phrase re-derivation), even the LAST remaining credential can be\nreplaced.\n\nSecurity invariants:\n - `oldPublicKey` is ALWAYS derived from the authenticated user row, NEVER\n   from the request (prevents proving control of key X but rotating key Y).\n - control of the CURRENT key is proven (`signature`) AND possession of the\n   NEW key is proven (`newKeyProof`) — the latter stops an attacker rotating\n   their account to a re-encoding of a key they do not control.\n - the incoming key is canonicalized (uncompressed, lowercased) before the\n   uniqueness check and the write, so two encodings of the same point cannot\n   coexist across accounts.\n - the `rotate_key` challenge is burned ATOMICALLY (single-use) by one\n   conditional UPDATE; the timestamp is checked BEFORE the burn so a stale\n   request cannot self-burn a challenge.\n - the identity `user_auth_methods` row is UPDATED IN PLACE (never deleted and\n   re-inserted), so the account never passes through `total === 0`.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
       }
     },
     "/auth/link": {
@@ -8016,13 +5262,42 @@
         ]
       }
     },
-    "/billing/packages": {
+    "/auth/lookup/{username}": {
       "get": {
         "tags": [
-          "Billing"
+          "Authentication"
         ],
-        "summary": "List one-time credit packages available for purchase.",
-        "description": "Public endpoint, no auth needed.",
+        "summary": "Lookup user by username",
+        "description": "Lightweight lookup that returns minimal public info for the login flow. Returns whether the user exists along with their color preset, avatar, and display name.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "username",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 3
+            },
+            "example": "nate"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lookup result"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    },
+    "/auth/methods": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Get the account DID and all linked authentication methods for the current",
+        "description": "user, shaped to the `authMethodsResponseSchema` contract. Identity methods\ncarry their DID verification-method id (`#key-1`); passkeys carry none.",
         "parameters": [],
         "responses": {
           "200": {
@@ -8044,13 +5319,395 @@
         ]
       }
     },
-    "/billing/plans": {
+    "/auth/oauth/authorize": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Issue an OAuth2 authorization code (after user consent)",
+        "description": "Called by the Oxy auth UI after the user clicks \"Allow\" on a third-party app's consent screen. Requires the authenticated user's Bearer access token. Returns a short-lived single-use code that the client app exchanges for tokens via `POST /auth/oauth/token`.\nThe `redirectUri` MUST exactly match one of the Application's registered `redirectUris` — otherwise the request is rejected.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "clientId",
+                  "redirectUri"
+                ],
+                "properties": {
+                  "clientId": {
+                    "type": "string",
+                    "description": "ApplicationCredential publicKey (OAuth client_id)"
+                  },
+                  "redirectUri": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "Opaque CSRF token forwarded back to the client."
+                  },
+                  "codeChallenge": {
+                    "type": "string",
+                    "description": "PKCE code challenge (S256). Required for public clients."
+                  },
+                  "codeChallengeMethod": {
+                    "type": "string",
+                    "enum": [
+                      "S256"
+                    ]
+                  },
+                  "scope": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authorization code issued."
+          },
+          "400": {
+            "description": "Validation failed."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "403": {
+            "description": "Redirect URI is not registered for this client."
+          }
+        }
+      }
+    },
+    "/auth/oauth/client/{clientId}": {
       "get": {
         "tags": [
-          "Billing"
+          "Authentication"
         ],
-        "summary": "List subscription plans (free, pro, business).",
-        "description": "Public endpoint, no auth needed.",
+        "security": [],
+        "summary": "Public lookup of an application's consent-UI metadata",
+        "description": "Resolves an OAuth `client_id` (= ApplicationCredential public key) to the sanitized public metadata of its registered Application so the auth web consent screen can render the app's name, icon, official badge, and requested scopes. No bearer token is required. Secrets, webhook config, owner identity, and capabilities are never returned. Returns a generic 404 for unknown, revoked, expired, or inactive clients (no enumeration).\n",
+        "parameters": [
+          {
+            "name": "clientId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sanitized application metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "application": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "icon": {
+                          "type": "string"
+                        },
+                        "websiteUrl": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "first_party",
+                            "third_party",
+                            "internal",
+                            "system"
+                          ]
+                        },
+                        "isOfficial": {
+                          "type": "boolean"
+                        },
+                        "isInternal": {
+                          "type": "boolean"
+                        },
+                        "scopes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "developerName": {
+                          "type": "string",
+                          "description": "Best-effort owner display name (non-official apps only)."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Application not found."
+          }
+        }
+      }
+    },
+    "/auth/oauth/consent": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Server-authoritative decision on whether OAuth consent is needed",
+        "description": "Called by the auth UI before rendering the consent screen. Resolves the `clientId` to an Application (validating the `redirectUri` exactly like `POST /auth/oauth/authorize`) and decides whether the user must consent:\n- TRUSTED apps (first-party / internal / system / official) are\n  auto-approved → `consentRequired: false, reason: 'trusted'`.\n- A prior grant whose scopes cover the requested `scope` →\n  `consentRequired: false, reason: 'granted'`.\n- A prior grant missing some requested scope →\n  `consentRequired: true, reason: 'scope_changed'`.\n- No prior grant → `consentRequired: true, reason: 'new'`.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "clientId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "redirectUri",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scope",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Consent decision."
+          },
+          "400": {
+            "description": "Invalid client."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "403": {
+            "description": "Redirect URI is not registered for this client."
+          }
+        }
+      }
+    },
+    "/auth/oauth/token": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [],
+        "summary": "Exchange an OAuth2 authorization code for tokens (RFC 6749)",
+        "description": "Standards-compliant RFC 6749 §4.1.3 token endpoint. Single-use exchange of an authorization code (from `POST /auth/oauth/authorize`) for a bearer access token, rotating device credentials, and session ID.\nThe request MUST be `application/x-www-form-urlencoded` with `grant_type=authorization_code`. Confidential clients authenticate with `client_secret` — either in the body (`client_secret_post`) or via HTTP Basic (`client_secret_basic`), never both. Public clients send `client_id` plus the PKCE `code_verifier`.\nThe response is a FLAT JSON document (no `data` wrapper) sent with `Cache-Control: no-store`, as RFC 6749 §5.1 requires. Alongside the standard `access_token` / `token_type` / `expires_in` it carries Oxy's device-first extras (`session_id`, `deviceId`, `deviceSecret`, `user`), which §5.1 permits as additional parameters.\nErrors follow RFC 6749 §5.2 (`{ \"error\": ..., \"error_description\": ... }`). Replaying an already-used code, sending a code past its 60-second TTL, or mismatching the `redirect_uri` all return the same `400 invalid_grant` with no detail about which check failed.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "grant_type",
+                  "code",
+                  "redirect_uri"
+                ],
+                "properties": {
+                  "grant_type": {
+                    "type": "string",
+                    "enum": [
+                      "authorization_code"
+                    ]
+                  },
+                  "code": {
+                    "type": "string"
+                  },
+                  "redirect_uri": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "client_id": {
+                    "type": "string",
+                    "description": "Required unless supplied via HTTP Basic authentication."
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "description": "Confidential clients only. Mutually exclusive with HTTP Basic."
+                  },
+                  "code_verifier": {
+                    "type": "string",
+                    "description": "PKCE verifier. Required for public clients."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "access_token": {
+                      "type": "string"
+                    },
+                    "token_type": {
+                      "type": "string",
+                      "enum": [
+                        "Bearer"
+                      ]
+                    },
+                    "expires_in": {
+                      "type": "integer"
+                    },
+                    "scope": {
+                      "type": "string",
+                      "description": "Space-delimited granted scopes. Omitted when the grant carries none."
+                    },
+                    "session_id": {
+                      "type": "string"
+                    },
+                    "deviceId": {
+                      "type": "string"
+                    },
+                    "deviceSecret": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "RFC 6749 §5.2 error — `invalid_request`, `invalid_grant`, or `unsupported_grant_type`.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "`invalid_client` — unknown client, or client authentication failed. Carries a `WWW-Authenticate: Basic` challenge.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/oauth/userinfo": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "OpenID Connect userinfo for the bearer's account",
+        "description": "Returns the standard OpenID Connect claims for the account the access token belongs to. The response is a FLAT JSON document (no `data` wrapper) so any OIDC client can read it, and `sub` is the account's permanent id — NEVER the username, which is mutable and case-sensitive.\n`name` is omitted for accounts with no real name (the API never synthesizes one from the handle) and `picture` is omitted for accounts with no avatar. Also accepts POST, as OIDC Core §5.3.1 requires; the token is read only from the `Authorization` header.\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The bearer's claims.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "sub"
+                  ],
+                  "properties": {
+                    "sub": {
+                      "type": "string",
+                      "description": "Permanent, immutable account identifier."
+                    },
+                    "preferred_username": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "picture": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "`invalid_request` — the token was sent in the query string.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "`invalid_token` — missing, malformed, or expired bearer token. Carries a `WWW-Authenticate: Bearer` challenge.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OAuthError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "POST /auth/oauth/userinfo",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/auth.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -8070,6 +5727,1425 @@
         "security": [
           {}
         ]
+      }
+    },
+    "/auth/register": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [],
+        "summary": "Register a new account with a public key",
+        "description": "Create a passwordless account bound to a local secp256k1 identity. The client generates a key pair (see `KeyManager` in `@oxyhq/core`), signs `register:{publicKey}:{timestamp}`, and submits the signature. Username and email are optional but recommended for discoverability.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "publicKey",
+                  "signature",
+                  "timestamp"
+                ],
+                "properties": {
+                  "publicKey": {
+                    "type": "string",
+                    "description": "secp256k1 public key (hex)."
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Hex signature over `register:{publicKey}:{timestamp}`."
+                  },
+                  "timestamp": {
+                    "type": "integer",
+                    "description": "Unix ms when the signature was produced (max 5 minutes old)."
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "username": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 30,
+                    "pattern": "^[a-zA-Z0-9]{3,30}$"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account created and the first session issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSuccess"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid signature, malformed key, or duplicate username/email.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/rotate/challenge": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Mint a single-use `rotate_key` challenge for the current account. The client",
+        "description": "signs it with its CURRENT key to prove control before the swap.\n\nThe challenge is bound to the account's current `publicKey` and carries\n`purpose: 'rotate_key'`, so a signin challenge (default purpose) can never be\nspent here and vice-versa.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/auth/rotate/complete": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Atomically REPLACE the account's identity key with `newPublicKey`.",
+        "description": "Rotation is a single atomic swap — never a remove-then-add — so it never\npasses through a zero-auth-method state and is independent of the unlink\nguards. Because control of the CURRENT key is proven (from SecureStore OR a\nrecovery-phrase re-derivation), even the LAST remaining credential can be\nreplaced.\n\nSecurity invariants:\n - `oldPublicKey` is ALWAYS derived from the authenticated user row, NEVER\n   from the request (prevents proving control of key X but rotating key Y).\n - control of the CURRENT key is proven (`signature`) AND possession of the\n   NEW key is proven (`newKeyProof`) — the latter stops an attacker rotating\n   their account to a re-encoding of a key they do not control.\n - the incoming key is canonicalized (uncompressed, lowercased) before the\n   uniqueness check and the write, so two encodings of the same point cannot\n   coexist across accounts.\n - the `rotate_key` challenge is burned ATOMICALLY (single-use) by one\n   conditional UPDATE; the timestamp is checked BEFORE the burn so a stale\n   request cannot self-burn a challenge.\n - the identity `user_auth_methods` row is UPDATED IN PLACE (never deleted and\n   re-inserted), so the account never passes through `total === 0`.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/auth/service-token": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Exchange credentials for a service token",
+        "description": "Internal service-to-service authentication endpoint. Exchange ApplicationCredential credentials (apiKey = publicKey, apiSecret = plaintext secret) for a short-lived service JWT (1 hour). Requires a usable credential of type `service` on an active application: either `active`, or `deprecated` but still within its rotation grace window (a credential rotated within the last 7 days keeps minting tokens until its grace `expiresAt`). `revoked` and grace-expired credentials are rejected. The minted JWT carries `appId` (Application `_id`) and `credentialId` (the minting ApplicationCredential `_id`).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "apiKey",
+                  "apiSecret"
+                ],
+                "properties": {
+                  "apiKey": {
+                    "type": "string",
+                    "description": "ApplicationCredential publicKey",
+                    "example": "oxy_dk_abc123"
+                  },
+                  "apiSecret": {
+                    "type": "string",
+                    "description": "ApplicationCredential plaintext secret"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Service token issued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string",
+                      "description": "Short-lived JWT for service-to-service calls"
+                    },
+                    "expiresIn": {
+                      "type": "integer",
+                      "description": "Token lifetime in seconds",
+                      "example": 3600
+                    },
+                    "appName": {
+                      "type": "string",
+                      "description": "Name of the authenticated app"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing apiKey or apiSecret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Credential is not a service credential",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    },
+    "/auth/session/approve-info/{authorizeCode}": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "PUBLIC. Returns the server-resolved, sanitized Application identity (never the",
+        "description": "QR's self-asserted strings) plus the bound origin, purpose, delegated subject\nand status, so the Commons approval screen renders the TRUE request. Never\nleaks the secret `sessionToken`, tokens, or the PKCE binding.",
+        "parameters": [
+          {
+            "name": "authorizeCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/session/authorize-code/{authorizeCode}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Bearer-authed sibling of `POST /session/authorize/:sessionToken`, keyed on",
+        "description": "the PUBLIC `authorizeCode` instead of the secret `sessionToken` — for an\napprover that authenticates via bearer token (e.g. a passkey ceremony) but,\nunlike the Oxy Accounts app, never holds the secret. This lets the caller\ncarry ONLY the public code (safe in a URL); the secret `sessionToken` never\nhas to leave the originating client. The authenticated principal (bearer)\nis the sole source of \"who is authorising\" — mirrors `/session/authorize`.\n\nThe claim + mint live in `authorizeSessionWithBearer` (atomic, see its\ndoc) so two concurrent authorizes of the same code can't both mint a\nsession — the route only resolves the bearer identity and maps the\noutcome to a status code.",
+        "parameters": [
+          {
+            "name": "authorizeCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deviceName": {
+                    "type": "string"
+                  },
+                  "deviceFingerprint": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/session/authorize-signed/{authorizeCode}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "NO bearer auth — this is the gap-filler. The Commons vault approves with its",
+        "description": "local secp256k1 key: it proves key control with a single-use challenge\nsignature (`verifyChallengeResponse` + atomic burn), and the resolved signer\nbecomes the authorizing user. The session is bound by `authorizeCode`. The\nwaiting originator is notified over the socket on the row's `sessionToken`.",
+        "parameters": [
+          {
+            "name": "authorizeCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "publicKey": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "challenge": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "signature": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "timestamp": {
+                    "type": "number"
+                  },
+                  "deviceName": {
+                    "type": "string"
+                  },
+                  "deviceFingerprint": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "publicKey",
+                  "challenge",
+                  "signature",
+                  "timestamp"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/session/authorize/{sessionToken}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Authorise a pending cross-app auth session",
+        "description": "Called by the Oxy Accounts app (or any first-party UI) after the user accepts a cross-app sign-in prompt. Requires the authorising user's access token via the `Authorization: Bearer` header — the authenticated principal is the only valid source of \"who is authorising\". The previous `x-session-id`-based path has been removed (fixes C2).\n",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "sessionToken",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deviceName": {
+                    "type": "string"
+                  },
+                  "deviceFingerprint": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session authorised.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "sessionId": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Session expired, or malformed body."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Auth session not found or already processed."
+          }
+        }
+      }
+    },
+    "/auth/session/cancel/{sessionToken}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Cancel an auth session. The `sessionToken` is a 128-bit secret held only by",
+        "description": "the originating client, so possessing it IS the ownership proof — no\nadditional identifier is required.",
+        "parameters": [
+          {
+            "name": "sessionToken",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/auth/session/claim": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [],
+        "summary": "Exchange a sessionToken for the first access token (device flow)",
+        "description": "Final step of the QR-code / \"Open Oxy Auth\" device sign-in flow. After another authenticated device has approved this session via `POST /auth/session/authorize/{sessionToken}`, the originating client — which alone knows the secret `sessionToken` — calls this endpoint to atomically claim the resulting access token, refresh token, and session ID.\nNo `Authorization` header is required: the 128-bit `sessionToken` (held only by the originating client, never echoed back to observers) IS the credential, exactly as in RFC 8628 §3.4. The exchange is single-use: a successful claim transitions the AuthSession status from `authorized` -> `consumed`, so a replayed sessionToken is rejected. Time-bound by the AuthSession TTL (default 5 minutes). Status-bound: only `authorized` rows are claimable.\nThis endpoint is the only device-flow token handoff: the originating client starts with no bearer token, so it must claim exactly once with the secret sessionToken it created.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sessionToken"
+                ],
+                "properties": {
+                  "sessionToken": {
+                    "type": "string",
+                    "description": "The same 128-bit sessionToken issued by `POST /auth/session/create`."
+                  },
+                  "deviceFingerprint": {
+                    "type": "string",
+                    "description": "Optional fingerprint of the originating client device."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "First access token issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "accessToken": {
+                      "type": "string"
+                    },
+                    "deviceSecret": {
+                      "type": "string"
+                    },
+                    "sessionId": {
+                      "type": "string"
+                    },
+                    "deviceId": {
+                      "type": "string"
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "user": {
+                      "$ref": "#/components/schemas/User"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed."
+          },
+          "401": {
+            "description": "SessionToken is unknown, expired, cancelled, not yet authorized, or already consumed."
+          }
+        }
+      }
+    },
+    "/auth/session/create": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [],
+        "summary": "Open a cross-app auth session (OAuth-like flow)",
+        "description": "Begin a cross-app sign-in handshake. A third-party / first-party client generates a one-time `sessionToken` and opens this endpoint; the user is then directed to Oxy Accounts where they authorise the session via `POST /auth/session/authorize/{sessionToken}`. The client polls `GET /auth/session/status/{sessionToken}` until the session is authorised, cancelled, or expires (default 5 minutes).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sessionToken"
+                ],
+                "properties": {
+                  "sessionToken": {
+                    "type": "string",
+                    "description": "Random opaque token the client generates and keeps secret.",
+                    "example": "at_random_4e9c2a1b8e9d3f4a1c2b3d4"
+                  },
+                  "clientId": {
+                    "type": "string",
+                    "description": "OAuth client_id (ApplicationCredential public key) of the requesting application. Provide this OR `applicationId`.\n",
+                    "example": "oxy_dk_1a2b3c4d"
+                  },
+                  "applicationId": {
+                    "type": "string",
+                    "description": "Application _id of the requesting application. Provide this OR `clientId`.\n",
+                    "example": "64f7c2a1b8e9d3f4a1c2b3d4"
+                  },
+                  "expiresAt": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      {
+                        "type": "integer",
+                        "description": "Unix ms."
+                      }
+                    ],
+                    "description": "Optional explicit expiry (capped at 5 minutes)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Auth session pending.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sessionToken": {
+                      "type": "string"
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "authorized",
+                        "cancelled",
+                        "expired"
+                      ],
+                      "example": "pending"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing/invalid application reference or token already in use."
+          },
+          "403": {
+            "description": "Application is not available (suspended/deleted/pending review)."
+          }
+        }
+      }
+    },
+    "/auth/session/deliver/{authorizeCode}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Bearer REQUIRED — and the bearer is the SECURITY CONTROL, not a convenience.",
+        "description": "Delivery targets the AUTHENTICATED user's own approval-capable installs and\nnothing else: the target identity is never resolved from the request body, the\nQR payload, or the bound `AuthSession`. That makes it impossible to make Oxy\npush a sign-in prompt at someone by typing their username or email into an\nunauthenticated browser.\n\nEligible installs are those registered by an `Application` carrying the\nstaff-controlled `identity:approval` capability — a registry decision, never a\nhardcoded client id or bundle id.\n\nThe payload is exactly `{ type, approvalUrl }`: a type discriminator plus the\nPUBLIC approval handle. No application name, no origin, no scopes, no secrets\n— the vault re-fetches all authoritative display data from\n`GET /auth/session/approve-info/:authorizeCode`. The notification carries no\naction buttons, so it can only be opened or dismissed; approval always happens\ninside the vault, behind biometrics and a local-key signature.\n\nResponds with COUNTS only (`{ delivered, targets }`) — never device names,\nplatforms, or any other install detail. `targets: 0` is a normal outcome (no\nvault install on any device) and the client falls back to the QR surface; a\npush transport failure degrades to exactly the same shape and never fails the\nauth flow.",
+        "parameters": [
+          {
+            "name": "authorizeCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/auth/session/deny/{authorizeCode}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "The Commons vault denies a pending approval. It never holds the secret",
+        "description": "`sessionToken`, so it cannot use `/session/cancel/:sessionToken`; it cancels\nby the public `authorizeCode` instead. Only a PENDING session can be denied\n(so a knower of the code cannot cancel an already-authorized session).\n\nThe OPTIONAL `reason` comes from the closed `COMMONS_DENY_REASONS` set —\nthis endpoint is unauthenticated, so free-form text is rejected at the edge\nrather than persisted. Recording it makes \"This wasn't me\" (`not_me`) a\ndistinguishable, honest record instead of an ordinary cancel.",
+        "parameters": [
+          {
+            "name": "authorizeCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "enum": [
+                      "declined",
+                      "not_me"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/session/finalize/{sessionToken}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [],
+        "summary": "Finalize an approved OAuth-bound auth session into an authorization code",
+        "description": "Terminal step of an OAuth authorization request created with `POST /auth/session/create` + an `oauth` binding and approved through any delivery surface (popup, push, QR, verified app link). Mints the ONE single-use `AuthCode` the relying party redeems at `POST /auth/oauth/token` with its PKCE verifier.\nNo `Authorization` header: the 128-bit `sessionToken` — held only by the originating client, never echoed to observers — IS the credential, exactly as on `POST /auth/session/claim`. No access token is ever handed out here.\nAtomic and single-use: the authorization code's identity is reserved by the same update that spends the request, so a request can never mint a second code, even under concurrent calls. Every failure mode collapses to one generic `invalid_grant` (RFC 6749 §5.2) — nothing enumerates which precondition failed.\n",
+        "parameters": [
+          {
+            "name": "sessionToken",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authorization code issued.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "redirectUri": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "expiresIn": {
+                      "type": "integer",
+                      "example": 60
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unknown, not an OAuth request, not approved, expired, already finalized, no longer permitted, or its application/redirect binding is no longer valid.\n"
+          }
+        }
+      }
+    },
+    "/auth/session/opened/{authorizeCode}": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "NO bearer — like `approve-info`, the PUBLIC single-use approval handle IS the",
+        "description": "credential. Records delivery progress only: `openedAt` is written at most once,\nonly while the request is still pending and unexpired, and NEVER touches\n`status`. The authoritative state machine stays exactly\n`pending -> authorized -> consumed` / `cancelled` / `expired`.",
+        "parameters": [
+          {
+            "name": "authorizeCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/auth/session/status/{sessionToken}": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [],
+        "summary": "Poll the status of a cross-app auth session",
+        "description": "Polled by the client that opened a session via `POST /auth/session/create`. Returns the session's current `status` and, once authorised, the `sessionId` / `userId` that the client should now treat as its own session.\n",
+        "parameters": [
+          {
+            "name": "sessionToken",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current status of the auth session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "pending",
+                        "authorized",
+                        "cancelled",
+                        "expired"
+                      ]
+                    },
+                    "authorized": {
+                      "type": "boolean"
+                    },
+                    "sessionToken": {
+                      "type": "string"
+                    },
+                    "application": {
+                      "nullable": true,
+                      "description": "Sanitized public metadata of the registered Application bound to this session, for the consent UI. Null only if the app was hard-deleted after the session was created.\n",
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
+                        "icon": {
+                          "type": "string"
+                        },
+                        "websiteUrl": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "first_party",
+                            "third_party",
+                            "internal",
+                            "system"
+                          ]
+                        },
+                        "isOfficial": {
+                          "type": "boolean"
+                        },
+                        "isInternal": {
+                          "type": "boolean"
+                        },
+                        "scopes": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "developerName": {
+                          "type": "string",
+                          "description": "Best-effort owner display name (non-official apps only)."
+                        }
+                      }
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "pushSentAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Delivery progress, not a status: when the pending request was pushed to the approving identity's capable installs. Null when no push was delivered.\n"
+                    },
+                    "openedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Delivery progress, not a status: when the approval surface first opened the request. Written at most once.\n"
+                    },
+                    "sessionId": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "publicKey": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "userId": {
+                      "type": "string",
+                      "nullable": true
+                    }
+                  }
+                },
+                "examples": {
+                  "pending": {
+                    "value": {
+                      "status": "pending",
+                      "authorized": false,
+                      "sessionToken": "at_random_4e9c2a1b8e9d3f4a1c2b3d4",
+                      "application": {
+                        "id": "64f7c2a1b8e9d3f4a1c2b3d4",
+                        "name": "Oxy Accounts",
+                        "type": "first_party",
+                        "isOfficial": true,
+                        "isInternal": false,
+                        "scopes": [
+                          "user:read"
+                        ]
+                      },
+                      "expiresAt": "2025-05-25T12:39:56.000Z",
+                      "sessionId": null,
+                      "publicKey": null,
+                      "userId": null
+                    }
+                  },
+                  "authorized": {
+                    "value": {
+                      "status": "authorized",
+                      "authorized": true,
+                      "sessionToken": "at_random_4e9c2a1b8e9d3f4a1c2b3d4",
+                      "application": {
+                        "id": "64f7c2a1b8e9d3f4a1c2b3d4",
+                        "name": "Acme Widgets",
+                        "type": "third_party",
+                        "isOfficial": false,
+                        "isInternal": false,
+                        "scopes": [
+                          "files:read",
+                          "user:read"
+                        ],
+                        "websiteUrl": "https://acme.example",
+                        "developerName": "Ada Lovelace"
+                      },
+                      "expiresAt": "2025-05-25T12:39:56.000Z",
+                      "sessionId": "sess_64f7c2a1b8e9d3f4a1c2b3d4",
+                      "publicKey": "02a1b2c3d4e5f6...",
+                      "userId": "64f7c2a1b8e9d3f4a1c2b3d4"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Auth session not found."
+          }
+        }
+      }
+    },
+    "/auth/user/{publicKey}": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Get user by public key (public profile info)",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/auth.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "publicKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/auth/validate": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "summary": "Validate authentication status",
+        "description": "Check whether the current request carries valid authentication.",
+        "responses": {
+          "200": {
+            "description": "Authentication is valid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "valid": {
+                      "type": "boolean",
+                      "example": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/verify": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [],
+        "summary": "Verify a signed challenge and create a session",
+        "description": "Step 2 of the passwordless public-key login. Submit the challenge returned by `/auth/challenge` together with its signature; on success a new session is created and the standard `AuthSuccess` payload is returned.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "publicKey",
+                  "challenge",
+                  "signature",
+                  "timestamp"
+                ],
+                "properties": {
+                  "publicKey": {
+                    "type": "string"
+                  },
+                  "challenge": {
+                    "type": "string"
+                  },
+                  "signature": {
+                    "type": "string",
+                    "description": "Hex signature of the challenge."
+                  },
+                  "timestamp": {
+                    "type": "integer",
+                    "description": "Unix ms."
+                  },
+                  "deviceName": {
+                    "type": "string"
+                  },
+                  "deviceFingerprint": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Session created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthSuccess"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Signature invalid or challenge expired."
+          },
+          "429": {
+            "description": "Rate limit exceeded (5 / minute / IP)."
+          }
+        }
       }
     },
     "/billing/checkout/credits": {
@@ -8230,6 +7306,131 @@
         }
       }
     },
+    "/billing/packages": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "List one-time credit packages available for purchase.",
+        "description": "Public endpoint, no auth needed.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/billing/plans": {
+      "get": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "List subscription plans (free, pro, business).",
+        "description": "Public endpoint, no auth needed.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/billing/portal": {
+      "post": {
+        "tags": [
+          "Billing"
+        ],
+        "summary": "Open a Stripe customer portal session. Returns the portal URL — redirect",
+        "description": "the user there to manage payment methods, view invoices, or change their\nsubscription.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "returnUrl": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": [
+                  "returnUrl"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
     "/billing/subscription": {
       "get": {
         "tags": [
@@ -8379,75 +7580,6 @@
         ]
       }
     },
-    "/billing/portal": {
-      "post": {
-        "tags": [
-          "Billing"
-        ],
-        "summary": "Open a Stripe customer portal session. Returns the portal URL — redirect",
-        "description": "the user there to manage payment methods, view invoices, or change their\nsubscription.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "returnUrl": {
-                    "type": "string",
-                    "format": "uri"
-                  }
-                },
-                "required": [
-                  "returnUrl"
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
     "/billing/webhook": {
       "post": {
         "tags": [
@@ -8476,61 +7608,40 @@
         ]
       }
     },
-    "/civic/{userId}/card": {
+    "/cdn/{id}": {
       "get": {
+        "summary": "Resolve a public asset id to its cloud.oxy.so CDN URL (302).",
+        "description": "Public CDN origin endpoint (no auth). Redirects to the `cloud.oxy.so` CDN URL for a PUBLIC, CDN-backed asset. Private/unlisted assets, files that are not active, files with no public copy, and unknown ids all return 404 — this path never streams bytes and never exposes a non-public asset.\n",
         "tags": [
-          "Identity"
+          "Assets"
         ],
-        "summary": "Returns `{ card, attestation }`; `attestation` is `null` only when the Oxy",
-        "description": "signing key is unconfigured (dev). Unknown / invalid id → 404.",
         "parameters": [
           {
-            "name": "userId",
             "in": "path",
+            "name": "id",
             "required": true,
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "variant",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional variant (e.g. `thumb`, `w320`); omitted = original."
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+          "302": {
+            "description": "Redirect to the public cloud.oxy.so CDN URL."
           },
           "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "description": "No public CDN-backed asset for this id."
           }
-        },
-        "security": [
-          {}
-        ]
+        }
       }
     },
     "/civic/attestations": {
@@ -8573,63 +7684,13 @@
         ]
       }
     },
-    "/civic/validations": {
+    "/civic/credentials": {
       "post": {
         "tags": [
           "Identity"
         ],
-        "summary": "An internal service opens a request on behalf of a user action; the jury is",
-        "description": "selected server-side. Returns `{ requestId, selectedValidatorCount, expiresAt }`.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "serviceTokenAuth": []
-          }
-        ]
-      }
-    },
-    "/civic/validations/inbox": {
-      "get": {
-        "tags": [
-          "Identity"
-        ],
-        "summary": "Returns `{ requests: ValidationRequestSummary[] }`.",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/civic.ts` to fill in summary, description, request/response examples.",
+        "summary": "Body is the issuer's SELF-ISSUED, signed `credential` envelope (the holder is",
+        "description": "referenced by `record.about`). The server verifies the signature + the issuer\nVM + chain continuity, stores the signed record, and projects a queryable\ncredential row. All claim data comes from the SIGNED envelope — the issuer id\nis resolved server-side from the session, never from the body.",
         "parameters": [],
         "responses": {
           "200": {
@@ -8663,16 +7724,16 @@
         ]
       }
     },
-    "/civic/validations/{id}/vote": {
-      "post": {
+    "/civic/credentials/by-record/{recordId}/verify": {
+      "get": {
         "tags": [
           "Identity"
         ],
-        "summary": "juror's `validation_verdict` envelope. Returns `ValidationVoteResult`.",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/civic.ts` to fill in summary, description, request/response examples.",
+        "summary": "signed record id (public). Recomputes the canonical signing input and verifies",
+        "description": "the signature against the ISSUER DID's current verification method, then checks\nrevocation/expiry. Returns `{ valid, reason?, credential }`. Registered BEFORE\n`/:holderUserId` so `by-record` is never captured as a holder id.",
         "parameters": [
           {
-            "name": "id",
+            "name": "recordId",
             "in": "path",
             "required": true,
             "schema": {
@@ -8686,16 +7747,6 @@
           },
           "400": {
             "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
             "content": {
               "application/json": {
                 "schema": {
@@ -8726,18 +7777,73 @@
           }
         },
         "security": [
-          {
-            "bearerAuth": []
-          }
+          {}
         ]
       }
     },
-    "/civic/validations/{id}/deny": {
+    "/civic/credentials/{holderUserId}": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Optional `?status=active|revoked|expired` filters by stored status. Credentials",
+        "description": "are issuer-signed attestations a holder collects to SHOW, so the list is public\n(mirrors the card/personhood reads); an unknown holder yields an empty list.",
+        "parameters": [
+          {
+            "name": "holderUserId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/civic/credentials/{id}/revoke": {
       "post": {
         "tags": [
           "Identity"
         ],
-        "summary": "removed from the jury and the request is re-tallied.",
+        "summary": "Only the original user issuer may revoke. Flips the credential to `revoked`.",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/civic.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
@@ -9036,13 +8142,63 @@
         ]
       }
     },
-    "/civic/credentials": {
+    "/civic/validations": {
       "post": {
         "tags": [
           "Identity"
         ],
-        "summary": "Body is the issuer's SELF-ISSUED, signed `credential` envelope (the holder is",
-        "description": "referenced by `record.about`). The server verifies the signature + the issuer\nVM + chain continuity, stores the signed record, and projects a queryable\ncredential row. All claim data comes from the SIGNED envelope — the issuer id\nis resolved server-side from the session, never from the body.",
+        "summary": "An internal service opens a request on behalf of a user action; the jury is",
+        "description": "selected server-side. Returns `{ requestId, selectedValidatorCount, expiresAt }`.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
+    "/civic/validations/inbox": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Returns `{ requests: ValidationRequestSummary[] }`.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/civic.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -9076,126 +8232,12 @@
         ]
       }
     },
-    "/civic/credentials/by-record/{recordId}/verify": {
-      "get": {
-        "tags": [
-          "Identity"
-        ],
-        "summary": "signed record id (public). Recomputes the canonical signing input and verifies",
-        "description": "the signature against the ISSUER DID's current verification method, then checks\nrevocation/expiry. Returns `{ valid, reason?, credential }`. Registered BEFORE\n`/:holderUserId` so `by-record` is never captured as a holder id.",
-        "parameters": [
-          {
-            "name": "recordId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/civic/credentials/{holderUserId}": {
-      "get": {
-        "tags": [
-          "Identity"
-        ],
-        "summary": "Optional `?status=active|revoked|expired` filters by stored status. Credentials",
-        "description": "are issuer-signed attestations a holder collects to SHOW, so the list is public\n(mirrors the card/personhood reads); an unknown holder yields an empty list.",
-        "parameters": [
-          {
-            "name": "holderUserId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/civic/credentials/{id}/revoke": {
+    "/civic/validations/{id}/deny": {
       "post": {
         "tags": [
           "Identity"
         ],
-        "summary": "Only the original user issuer may revoke. Flips the credential to `revoked`.",
+        "summary": "removed from the jury and the request is re-tallied.",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/civic.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
@@ -9257,6 +8299,258 @@
             "bearerAuth": []
           }
         ]
+      }
+    },
+    "/civic/validations/{id}/vote": {
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "juror's `validation_verdict` envelope. Returns `ValidationVoteResult`.",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/civic.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/civic/{userId}/card": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Returns `{ card, attestation }`; `attestation` is `null` only when the Oxy",
+        "description": "signing key is unconfigured (dev). Unknown / invalid id → 404.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/contacts/discover": {
+      "post": {
+        "tags": [
+          "Contacts"
+        ],
+        "summary": "Discover which contacts are on Oxy",
+        "description": "Privacy-preserving contact-book matching. Clients SHA-256 hash each email and phone number locally (lowercased; phone numbers normalised to E.164 — see `utils/contactHash.ts` in `@oxyhq/core`) and upload only the resulting 64-character hex digests. The server intersects them against the indexed `users.hashed_email` / `users.hashed_phone` columns and returns matched Oxy user IDs only when the matched user has opted in to contact discovery for that identifier type.\nPrivacy invariants:\n  - Raw email / phone never traverses this endpoint.\n  - The response contains no PII — only Oxy user IDs and the hash the\n    caller supplied (so the client can map matches back to the local\n    contact that produced them).\n  - The endpoint never writes to the database. Discovery is stateless.\n\nRate limits: 5 requests per minute per authenticated user; up to 200 hashed identifiers per channel (~400 total) per request. Service tokens are explicitly rejected with 403.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "hashedEmails": {
+                    "type": "array",
+                    "maxItems": 200,
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-f0-9]{64}$",
+                      "description": "SHA-256 hex of `email.toLowerCase().trim()`."
+                    }
+                  },
+                  "hashedPhones": {
+                    "type": "array",
+                    "maxItems": 200,
+                    "items": {
+                      "type": "string",
+                      "pattern": "^[a-f0-9]{64}$",
+                      "description": "SHA-256 hex of the E.164-normalised phone number."
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "addressBook": {
+                  "summary": "Mixed email + phone request",
+                  "value": {
+                    "hashedEmails": [
+                      "7c211433f02071597741e6ff5a8ea34789abbf43b9c1abcdef0123456789abcd"
+                    ],
+                    "hashedPhones": [
+                      "9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Discovery completed. Empty `matches` means no overlap.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "matches": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "userId",
+                          "hashedIdentifier",
+                          "matchType"
+                        ],
+                        "properties": {
+                          "userId": {
+                            "type": "string",
+                            "example": "64f7c2a1b8e9d3f4a1c2b3d4"
+                          },
+                          "hashedIdentifier": {
+                            "type": "string",
+                            "example": "7c211433f02071597741e6ff5a8ea34789abbf43b9c1abcdef0123456789abcd"
+                          },
+                          "matchType": {
+                            "type": "string",
+                            "enum": [
+                              "email",
+                              "phone"
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "oneMatch": {
+                    "value": {
+                      "matches": [
+                        {
+                          "userId": "64f7c2a1b8e9d3f4a1c2b3d4",
+                          "hashedIdentifier": "7c211433f02071597741e6ff5a8ea34789abbf43b9c1abcdef0123456789abcd",
+                          "matchType": "email"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed (empty payload, malformed hash, oversized batch).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "403": {
+            "description": "Service token used — must use a user session token."
+          },
+          "429": {
+            "description": "Rate limit exceeded (5 requests / minute / user)."
+          }
+        }
       }
     },
     "/credits": {
@@ -9362,13 +8656,111 @@
         ]
       }
     },
-    "/.well-known/did.json": {
+    "/devices": {
       "get": {
         "tags": [
-          "Identity"
+          "Devices"
         ],
-        "summary": "GET /.well-known/did.json",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/did.ts` to fill in summary, description, request/response examples.",
+        "summary": "List the user's devices",
+        "description": "Return every device that has at least one active session for the authenticated user. Useful for \"Where am I signed in?\" screens.\n",
+        "responses": {
+          "200": {
+            "description": "List of devices.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Device"
+                  }
+                },
+                "examples": {
+                  "twoDevices": {
+                    "value": [
+                      {
+                        "id": "dev_64f7c2a1b8e9d3f4a1c2b3d4",
+                        "name": "MacBook Pro 16",
+                        "platform": "macOS",
+                        "firstSeenAt": "2024-01-15T12:34:56.789Z",
+                        "lastSeenAt": "2025-05-12T09:00:00.000Z",
+                        "sessionCount": 2
+                      },
+                      {
+                        "id": "dev_74f7c2a1b8e9d3f4a1c2b3d5",
+                        "name": "iPhone 15 Pro",
+                        "platform": "iOS",
+                        "firstSeenAt": "2024-02-01T08:00:00.000Z",
+                        "lastSeenAt": "2025-05-12T08:55:00.000Z",
+                        "sessionCount": 1
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/devices/security": {
+      "get": {
+        "tags": [
+          "Devices",
+          "Security"
+        ],
+        "summary": "Get aggregate security info for the user's devices",
+        "description": "Return high-level security signals across the user's devices (count of active sessions, unusual logins, last suspicious activity, etc.). Used to surface a security health summary on the account dashboard.\n",
+        "responses": {
+          "200": {
+            "description": "Security info payload."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/devices/{deviceId}": {
+      "delete": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Remove a device",
+        "description": "Revoke every active session attached to the given device. The user on that device will be signed out the next time their client tries to refresh its access token.\n",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "dev_64f7c2a1b8e9d3f4a1c2b3d4"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Device removed."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "Device not found."
+          }
+        }
+      }
+    },
+    "/email/bundles": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/bundles",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -9390,20 +8782,1094 @@
         ]
       }
     },
-    "/u/{userId}/did.json": {
-      "get": {
+    "/email/bundles/{bundleId}": {
+      "put": {
         "tags": [
-          "Identity"
+          "Email"
         ],
-        "summary": "GET /u/{userId}/did.json",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/did.ts` to fill in summary, description, request/response examples.",
+        "summary": "PUT /email/bundles/{bundleId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
-            "name": "userId",
+            "name": "bundleId",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "collapsed": {
+                    "type": "boolean"
+                  },
+                  "matchLabels": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "order": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email/contacts": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/contacts",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "POST /email/contacts",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "company": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "starred": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "name",
+                  "email"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email/contacts/suggest": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/contacts/suggest",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/email/contacts/{contactId}": {
+      "put": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "PUT /email/contacts/{contactId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "company": {
+                    "type": "string"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "starred": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "DELETE /email/contacts/{contactId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "contactId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/email/drafts": {
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "POST /email/drafts",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "to": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "maxLength": 255
+                        },
+                        "address": {
+                          "type": "string",
+                          "minLength": 3,
+                          "maxLength": 320,
+                          "format": "email"
+                        }
+                      },
+                      "required": [
+                        "address"
+                      ]
+                    },
+                    "maxItems": 100
+                  },
+                  "cc": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "maxLength": 255
+                        },
+                        "address": {
+                          "type": "string",
+                          "minLength": 3,
+                          "maxLength": 320,
+                          "format": "email"
+                        }
+                      },
+                      "required": [
+                        "address"
+                      ]
+                    },
+                    "maxItems": 100
+                  },
+                  "bcc": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "maxLength": 255
+                        },
+                        "address": {
+                          "type": "string",
+                          "minLength": 3,
+                          "maxLength": 320,
+                          "format": "email"
+                        }
+                      },
+                      "required": [
+                        "address"
+                      ]
+                    },
+                    "maxItems": 100
+                  },
+                  "subject": {
+                    "type": "string",
+                    "maxLength": 998
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "html": {
+                    "type": "string"
+                  },
+                  "inReplyTo": {
+                    "type": "string"
+                  },
+                  "references": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "existingDraftId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email/filters": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/filters",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "POST /email/filters",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "conditions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "field": {
+                          "type": "string",
+                          "enum": [
+                            "from",
+                            "to",
+                            "subject",
+                            "has-attachment",
+                            "size"
+                          ]
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "contains",
+                            "equals",
+                            "not-contains",
+                            "starts-with",
+                            "ends-with",
+                            "greater-than",
+                            "less-than"
+                          ]
+                        },
+                        "value": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "field",
+                        "operator",
+                        "value"
+                      ]
+                    },
+                    "minItems": 1
+                  },
+                  "matchAll": {
+                    "type": "boolean"
+                  },
+                  "actions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "move",
+                            "label",
+                            "star",
+                            "mark-read",
+                            "archive",
+                            "delete",
+                            "forward"
+                          ]
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "minItems": 1
+                  },
+                  "order": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "name",
+                  "conditions",
+                  "actions"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email/filters/{filterId}": {
+      "put": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "PUT /email/filters/{filterId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "filterId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "conditions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "field": {
+                          "type": "string",
+                          "enum": [
+                            "from",
+                            "to",
+                            "subject",
+                            "has-attachment",
+                            "size"
+                          ]
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "contains",
+                            "equals",
+                            "not-contains",
+                            "starts-with",
+                            "ends-with",
+                            "greater-than",
+                            "less-than"
+                          ]
+                        },
+                        "value": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "field",
+                        "operator",
+                        "value"
+                      ]
+                    },
+                    "minItems": 1
+                  },
+                  "matchAll": {
+                    "type": "boolean"
+                  },
+                  "actions": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "move",
+                            "label",
+                            "star",
+                            "mark-read",
+                            "archive",
+                            "delete",
+                            "forward"
+                          ]
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    },
+                    "minItems": 1
+                  },
+                  "order": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "DELETE /email/filters/{filterId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "filterId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/email/import": {
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "POST /email/import",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/email/inbound": {
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "Accepts raw RFC 5322 MIME email as the request body.",
+        "description": "Content-Type should be message/rfc822 or application/octet-stream.\n\nHeaders:\n  Authorization: Bearer <EMAIL_INBOUND_WEBHOOK_SECRET>\n  X-Envelope-From: sender@example.com (optional, from SMTP MAIL FROM)\n  X-Envelope-To: recipient@oxy.so (comma-separated if multiple)",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/email/labels": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/labels",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "POST /email/labels",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "color": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email/labels/{labelId}": {
+      "put": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "PUT /email/labels/{labelId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "labelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "color": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "DELETE /email/labels/{labelId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "labelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -9784,34 +10250,6 @@
         }
       }
     },
-    "/email/messages/bundled": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/messages/bundled",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
     "/email/messages/bulk/flags": {
       "post": {
         "tags": [
@@ -9965,6 +10403,34 @@
         }
       }
     },
+    "/email/messages/bundled": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/messages/bundled",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/email/messages/{messageId}": {
       "get": {
         "tags": [
@@ -10027,64 +10493,6 @@
           "Email"
         ],
         "summary": "DELETE /email/messages/{messageId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "messageId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/email/messages/{messageId}/thread": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/messages/{messageId}/thread",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
@@ -10529,6 +10937,64 @@
         }
       }
     },
+    "/email/messages/{messageId}/thread": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/messages/{messageId}/thread",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "messageId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/email/messages/{messageId}/unsnooze": {
       "post": {
         "tags": [
@@ -10587,637 +11053,13 @@
         ]
       }
     },
-    "/email/labels": {
+    "/email/proxy": {
       "get": {
         "tags": [
           "Email"
         ],
-        "summary": "GET /email/labels",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      },
-      "post": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "POST /email/labels",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "color": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "name"
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
-    "/email/labels/{labelId}": {
-      "put": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "PUT /email/labels/{labelId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "labelId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string"
-                  },
-                  "color": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "DELETE /email/labels/{labelId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "labelId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/email/contacts/suggest": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/contacts/suggest",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/email/contacts": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/contacts",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      },
-      "post": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "POST /email/contacts",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "email": {
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "company": {
-                    "type": "string"
-                  },
-                  "notes": {
-                    "type": "string"
-                  },
-                  "starred": {
-                    "type": "boolean"
-                  }
-                },
-                "required": [
-                  "name",
-                  "email"
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
-    "/email/contacts/{contactId}": {
-      "put": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "PUT /email/contacts/{contactId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "contactId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "email": {
-                    "type": "string",
-                    "format": "email"
-                  },
-                  "company": {
-                    "type": "string"
-                  },
-                  "notes": {
-                    "type": "string"
-                  },
-                  "starred": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "DELETE /email/contacts/{contactId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "contactId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/email/drafts": {
-      "post": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "POST /email/drafts",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "to": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "maxLength": 255
-                        },
-                        "address": {
-                          "type": "string",
-                          "minLength": 3,
-                          "maxLength": 320,
-                          "format": "email"
-                        }
-                      },
-                      "required": [
-                        "address"
-                      ]
-                    },
-                    "maxItems": 100
-                  },
-                  "cc": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "maxLength": 255
-                        },
-                        "address": {
-                          "type": "string",
-                          "minLength": 3,
-                          "maxLength": 320,
-                          "format": "email"
-                        }
-                      },
-                      "required": [
-                        "address"
-                      ]
-                    },
-                    "maxItems": 100
-                  },
-                  "bcc": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "maxLength": 255
-                        },
-                        "address": {
-                          "type": "string",
-                          "minLength": 3,
-                          "maxLength": 320,
-                          "format": "email"
-                        }
-                      },
-                      "required": [
-                        "address"
-                      ]
-                    },
-                    "maxItems": 100
-                  },
-                  "subject": {
-                    "type": "string",
-                    "maxLength": 998
-                  },
-                  "text": {
-                    "type": "string"
-                  },
-                  "html": {
-                    "type": "string"
-                  },
-                  "inReplyTo": {
-                    "type": "string"
-                  },
-                  "references": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "existingDraftId": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/email/search": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/search",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "summary": "GET /email/proxy",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/emailProxy.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -11265,239 +11107,6 @@
         "security": [
           {}
         ]
-      }
-    },
-    "/email/import": {
-      "post": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "POST /email/import",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/email/subscriptions": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/subscriptions",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/email/subscriptions/unsubscribe": {
-      "post": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "POST /email/subscriptions/unsubscribe",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "senderAddress": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "method": {
-                    "type": "string",
-                    "enum": [
-                      "list-unsubscribe",
-                      "block"
-                    ]
-                  }
-                },
-                "required": [
-                  "senderAddress"
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
-    "/email/bundles": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/bundles",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/email/bundles/{bundleId}": {
-      "put": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "PUT /email/bundles/{bundleId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "bundleId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean"
-                  },
-                  "collapsed": {
-                    "type": "boolean"
-                  },
-                  "matchLabels": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
-                  },
-                  "order": {
-                    "type": "number"
-                  }
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/email/reminders": {
@@ -11787,12 +11396,40 @@
         ]
       }
     },
-    "/email/filters": {
+    "/email/search": {
       "get": {
         "tags": [
           "Email"
         ],
-        "summary": "GET /email/filters",
+        "summary": "GET /email/search",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/email/settings": {
+      "get": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "GET /email/settings",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -11814,11 +11451,11 @@
           {}
         ]
       },
-      "post": {
+      "put": {
         "tags": [
           "Email"
         ],
-        "summary": "POST /email/filters",
+        "summary": "PUT /email/settings",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -11856,122 +11493,37 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "minLength": 1
+                  "signature": {
+                    "type": "string"
                   },
-                  "enabled": {
+                  "autoReply": {},
+                  "autoForwardTo": {
+                    "type": "string"
+                  },
+                  "autoForwardKeepCopy": {
                     "type": "boolean"
-                  },
-                  "conditions": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "type": "string",
-                          "enum": [
-                            "from",
-                            "to",
-                            "subject",
-                            "has-attachment",
-                            "size"
-                          ]
-                        },
-                        "operator": {
-                          "type": "string",
-                          "enum": [
-                            "contains",
-                            "equals",
-                            "not-contains",
-                            "starts-with",
-                            "ends-with",
-                            "greater-than",
-                            "less-than"
-                          ]
-                        },
-                        "value": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      },
-                      "required": [
-                        "field",
-                        "operator",
-                        "value"
-                      ]
-                    },
-                    "minItems": 1
-                  },
-                  "matchAll": {
-                    "type": "boolean"
-                  },
-                  "actions": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "move",
-                            "label",
-                            "star",
-                            "mark-read",
-                            "archive",
-                            "delete",
-                            "forward"
-                          ]
-                        },
-                        "value": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ]
-                    },
-                    "minItems": 1
-                  },
-                  "order": {
-                    "type": "number"
                   }
-                },
-                "required": [
-                  "name",
-                  "conditions",
-                  "actions"
-                ]
+                }
               }
             }
           }
         }
       }
     },
-    "/email/filters/{filterId}": {
-      "put": {
+    "/email/subscriptions": {
+      "get": {
         "tags": [
           "Email"
         ],
-        "summary": "PUT /email/filters/{filterId}",
+        "summary": "GET /email/subscriptions",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "filterId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "Success"
           },
-          "400": {
-            "description": "Validation failed",
+          "5XX": {
+            "description": "Server error",
             "content": {
               "application/json": {
                 "schema": {
@@ -11979,9 +11531,27 @@
                 }
               }
             }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/email/subscriptions/unsubscribe": {
+      "post": {
+        "tags": [
+          "Email"
+        ],
+        "summary": "POST /email/subscriptions/unsubscribe",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
           },
-          "404": {
-            "description": "Resource not found",
+          "400": {
+            "description": "Validation failed",
             "content": {
               "application/json": {
                 "schema": {
@@ -12011,146 +11581,25 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string"
+                  "senderAddress": {
+                    "type": "string",
+                    "minLength": 1
                   },
-                  "enabled": {
-                    "type": "boolean"
-                  },
-                  "conditions": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "field": {
-                          "type": "string",
-                          "enum": [
-                            "from",
-                            "to",
-                            "subject",
-                            "has-attachment",
-                            "size"
-                          ]
-                        },
-                        "operator": {
-                          "type": "string",
-                          "enum": [
-                            "contains",
-                            "equals",
-                            "not-contains",
-                            "starts-with",
-                            "ends-with",
-                            "greater-than",
-                            "less-than"
-                          ]
-                        },
-                        "value": {
-                          "type": "string",
-                          "minLength": 1
-                        }
-                      },
-                      "required": [
-                        "field",
-                        "operator",
-                        "value"
-                      ]
-                    },
-                    "minItems": 1
-                  },
-                  "matchAll": {
-                    "type": "boolean"
-                  },
-                  "actions": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string",
-                          "enum": [
-                            "move",
-                            "label",
-                            "star",
-                            "mark-read",
-                            "archive",
-                            "delete",
-                            "forward"
-                          ]
-                        },
-                        "value": {
-                          "type": "string"
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ]
-                    },
-                    "minItems": 1
-                  },
-                  "order": {
-                    "type": "number"
+                  "method": {
+                    "type": "string",
+                    "enum": [
+                      "list-unsubscribe",
+                      "block"
+                    ]
                   }
-                }
+                },
+                "required": [
+                  "senderAddress"
+                ]
               }
             }
           }
         }
-      },
-      "delete": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "DELETE /email/filters/{filterId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "filterId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
       }
     },
     "/email/templates": {
@@ -12381,103 +11830,37 @@
         ]
       }
     },
-    "/email/settings": {
-      "get": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "GET /email/settings",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      },
-      "put": {
-        "tags": [
-          "Email"
-        ],
-        "summary": "PUT /email/settings",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/email.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "signature": {
-                    "type": "string"
-                  },
-                  "autoReply": {},
-                  "autoForwardTo": {
-                    "type": "string"
-                  },
-                  "autoForwardKeepCopy": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/email/inbound": {
+    "/federation/actor-delete": {
       "post": {
         "tags": [
-          "Email"
+          "Federation"
         ],
-        "summary": "Accepts raw RFC 5322 MIME email as the request body.",
-        "description": "Content-Type should be message/rfc822 or application/octet-stream.\n\nHeaders:\n  Authorization: Bearer <EMAIL_INBOUND_WEBHOOK_SECRET>\n  X-Envelope-From: sender@example.com (optional, from SMTP MAIL FROM)\n  X-Envelope-To: recipient@oxy.so (comma-separated if multiple)",
+        "summary": "HARD-DELETES a dead remote fediverse identity and purges its Oxy follow-graph",
+        "description": "edges. Mention calls this after an actor is permanently removed upstream (HTTP\n410 Gone for a deleted/spam account) to erase the ghost identity and its\nsocial-graph residue from Oxy entirely — the irreversible counterpart to\n`actor-gone` (which only archives, keeping the row).\n\nANTI-FOOTGUN: only a `type:'federated'` user may be deleted here. The route\nloads the user and rejects a non-federated target with 409 BEFORE any\ndestructive write; `userService.deleteFederatedActor` additionally re-asserts\n`type = 'federated'` in the terminal `delete from users` predicate, so a real\naccount can never be hard-deleted through this bridge even under a race.\n\nIdempotent: an already-deleted (or never-known) id is a 200 no-op with\n`deleted:false` — NOT a 404 — so a retried delete after a partial success\nalways converges.",
         "parameters": [],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "5XX": {
             "description": "Server error",
@@ -12491,21 +11874,43 @@
           }
         },
         "security": [
-          {}
+          {
+            "serviceTokenAuth": []
+          }
         ]
       }
     },
-    "/email/proxy": {
-      "get": {
+    "/federation/actor-gone": {
+      "post": {
         "tags": [
-          "Email"
+          "Federation"
         ],
-        "summary": "GET /email/proxy",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/emailProxy.ts` to fill in summary, description, request/response examples.",
+        "summary": "Marks a dead remote fediverse identity gone. Mention is the only component",
+        "description": "that talks to the remote fediverse; when it receives an HTTP 410 Gone for an\nactor (the remote Mastodon/Bluesky account was deleted) it calls this to\narchive the corresponding Oxy user, so the dead identity leaves Oxy's\ndiscovery/search surfaces instead of lingering as a 0-post ghost profile.\n\nSAFETY: the user document is NEVER hard-deleted — archival mirrors\n`accountService.archiveAccount` (set `accountStatus: 'archived'`, invalidate\nthe user cache), so Oxy keeps the archived identity and Mention keeps its\nFederatedActor tombstone; the follow-graph edges survive intact.\n\nANTI-FOOTGUN: only a `type:'federated'` user may be archived here. Archiving a\nlocal/agent/automated account would silently disable a real account, so a\nnon-federated target is rejected with 409 and never written.\n\nIdempotent: an already-archived actor returns 200 with `alreadyArchived:true`\nand performs no write.",
         "parameters": [],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "5XX": {
             "description": "Server error",
@@ -12519,7 +11924,109 @@
           }
         },
         "security": [
-          {}
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
+    "/federation/domain-purge": {
+      "post": {
+        "tags": [
+          "Federation"
+        ],
+        "summary": "Removes what the Oxy PLATFORM holds for a fediverse instance the calling app",
+        "description": "has blocked: the app's mirrored media, the avatars Oxy fetched, and the\n`type:'federated'` user rows themselves with their social-graph edges.\n\nOxy holds NO blocklist and never will — the calling app owns that policy and\nnames one domain per call. The rationale, the ownership rules and the exact\nhost-matching semantics live in\n`services/federation/blockedDomainPurge.service.ts`; this route is only the\nauthenticated door to them.\n\nWHOSE DATA: files are deleted only when their recorded `serviceAppId` is the\ncaller's own application id, taken from the SERVICE CREDENTIAL\n(`req.serviceApp.appId`) and never from the request body — an app cannot ask\nOxy to delete another app's data. A user row shared with another application\nis archived and kept, and the response names the apps that kept it.\n\nSAFE BY DEFAULT: `dryRun` defaults to true, so a caller that omits it gets a\nplan. A real deletion needs `dryRun:false` AND\n`FEDERATION_DOMAIN_PURGE_ENABLED=true` on the deployment; otherwise 409.\n\nBOUNDED AND RESUMABLE: at most `limit` actors (default 200) per call. The\nresponse carries `done`, `nextCursor`, and `remaining` (informational only).\nLoop until `done`, echoing `nextCursor` as `afterId` on each subsequent call.\nRepeating a completed purge is a no-op, so a retry after a partial failure\nconverges.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
+    "/federation/follow": {
+      "post": {
+        "tags": [
+          "Federation"
+        ],
+        "summary": "Mirrors an inbound ActivityPub Follow/Undo-Follow into the Oxy follow graph on",
+        "description": "behalf of a FEDERATED actor: when a remote actor follows (or unfollows) a\nlocal user, Mention's backend calls this to create/remove the corresponding\nOxy edge. Idempotent — repeated calls never double-move the follower/following\ncounters.\n\nANTI-IMPERSONATION: `followerUserId` MUST resolve to a `type:'federated'`\nuser. A service credential must never be able to move a LOCAL user's follow\ngraph — only the user themselves (via their own session) may do that. The\ntarget must be a real, non-federated (local) user.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
         ]
       }
     },
@@ -12652,213 +12159,51 @@
         ]
       }
     },
-    "/federation/follow": {
-      "post": {
-        "tags": [
-          "Federation"
-        ],
-        "summary": "Mirrors an inbound ActivityPub Follow/Undo-Follow into the Oxy follow graph on",
-        "description": "behalf of a FEDERATED actor: when a remote actor follows (or unfollows) a\nlocal user, Mention's backend calls this to create/remove the corresponding\nOxy edge. Idempotent — repeated calls never double-move the follower/following\ncounters.\n\nANTI-IMPERSONATION: `followerUserId` MUST resolve to a `type:'federated'`\nuser. A service credential must never be able to move a LOCAL user's follow\ngraph — only the user themselves (via their own session) may do that. The\ntarget must be a real, non-federated (local) user.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "serviceTokenAuth": []
-          }
-        ]
-      }
-    },
-    "/federation/actor-gone": {
-      "post": {
-        "tags": [
-          "Federation"
-        ],
-        "summary": "Marks a dead remote fediverse identity gone. Mention is the only component",
-        "description": "that talks to the remote fediverse; when it receives an HTTP 410 Gone for an\nactor (the remote Mastodon/Bluesky account was deleted) it calls this to\narchive the corresponding Oxy user, so the dead identity leaves Oxy's\ndiscovery/search surfaces instead of lingering as a 0-post ghost profile.\n\nSAFETY: the user document is NEVER hard-deleted — archival mirrors\n`accountService.archiveAccount` (set `accountStatus: 'archived'`, invalidate\nthe user cache), so Oxy keeps the archived identity and Mention keeps its\nFederatedActor tombstone; the follow-graph edges survive intact.\n\nANTI-FOOTGUN: only a `type:'federated'` user may be archived here. Archiving a\nlocal/agent/automated account would silently disable a real account, so a\nnon-federated target is rejected with 409 and never written.\n\nIdempotent: an already-archived actor returns 200 with `alreadyArchived:true`\nand performs no write.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "serviceTokenAuth": []
-          }
-        ]
-      }
-    },
-    "/federation/actor-delete": {
-      "post": {
-        "tags": [
-          "Federation"
-        ],
-        "summary": "HARD-DELETES a dead remote fediverse identity and purges its Oxy follow-graph",
-        "description": "edges. Mention calls this after an actor is permanently removed upstream (HTTP\n410 Gone for a deleted/spam account) to erase the ghost identity and its\nsocial-graph residue from Oxy entirely — the irreversible counterpart to\n`actor-gone` (which only archives, keeping the row).\n\nANTI-FOOTGUN: only a `type:'federated'` user may be deleted here. The route\nloads the user and rejects a non-federated target with 409 BEFORE any\ndestructive write; `userService.deleteFederatedActor` additionally re-asserts\n`type = 'federated'` in the terminal `delete from users` predicate, so a real\naccount can never be hard-deleted through this bridge even under a race.\n\nIdempotent: an already-deleted (or never-known) id is a 200 no-op with\n`deleted:false` — NOT a 404 — so a retried delete after a partial success\nalways converges.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "serviceTokenAuth": []
-          }
-        ]
-      }
-    },
-    "/federation/domain-purge": {
-      "post": {
-        "tags": [
-          "Federation"
-        ],
-        "summary": "Removes what the Oxy PLATFORM holds for a fediverse instance the calling app",
-        "description": "has blocked: the app's mirrored media, the avatars Oxy fetched, and the\n`type:'federated'` user rows themselves with their social-graph edges.\n\nOxy holds NO blocklist and never will — the calling app owns that policy and\nnames one domain per call. The rationale, the ownership rules and the exact\nhost-matching semantics live in\n`services/federation/blockedDomainPurge.service.ts`; this route is only the\nauthenticated door to them.\n\nWHOSE DATA: files are deleted only when their recorded `serviceAppId` is the\ncaller's own application id, taken from the SERVICE CREDENTIAL\n(`req.serviceApp.appId`) and never from the request body — an app cannot ask\nOxy to delete another app's data. A user row shared with another application\nis archived and kept, and the response names the apps that kept it.\n\nSAFE BY DEFAULT: `dryRun` defaults to true, so a caller that omits it gets a\nplan. A real deletion needs `dryRun:false` AND\n`FEDERATION_DOMAIN_PURGE_ENABLED=true` on the deployment; otherwise 409.\n\nBOUNDED AND RESUMABLE: at most `limit` actors (default 200) per call. The\nresponse carries `done`, `nextCursor`, and `remaining` (informational only).\nLoop until `done`, echoing `nextCursor` as `afterId` on each subsequent call.\nRepeating a completed purge is a no-op, so a retry after a partial failure\nconverges.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "serviceTokenAuth": []
-          }
-        ]
-      }
-    },
-    "/identity/records": {
+    "/identity/domains": {
       "post": {
         "tags": [
           "Identity"
         ],
-        "summary": "The envelope's `subject` MUST be the caller's DID and its `publicKey` MUST be",
-        "description": "a current verification method; verification + storage is atomic.",
+        "summary": "POST /identity/domains",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "GET /identity/domains",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -12892,13 +12237,151 @@
         ]
       }
     },
-    "/identity/records/{userId}/chain/head": {
+    "/identity/domains/{domain}": {
+      "delete": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "DELETE /identity/domains/{domain}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/identity/domains/{domain}/verify": {
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "POST /identity/domains/{domain}/verify",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/identity/head/{userId}": {
       "get": {
         "tags": [
           "Identity"
         ],
-        "summary": "(public, cacheable, CORS-open). A client fetches this before signing the next",
-        "description": "v2 record so it knows the `prev` (head `recordId`) and `seq` (`head.seq + 1`)\nto sign over. Response shape (F0.2 contract — F1/client agents match this):\n - with a chain: `{ headRecordId: string, seq: number, recordCount: number }`\n - no chain yet: `{ headRecordId: null, seq: -1, recordCount: 0 }`\n\nRegistered BEFORE `/:type` so the literal `chain/head` path is unambiguous.\n\nThere is deliberately NO id-shape precheck: the one that used to stand here\n404'd every post-cutover account, which aborts client-side signing of every v2\nrecord (see the module header). An unknown account and a malformed id both\nresolve to the empty chain, which is what this route has always answered for\nan account that exists but has published nothing.",
+        "summary": "(O(1)): `{ seq, headRecordId, recordCount }`, or the empty form when the user",
+        "description": "has no chain yet. Node-facing alias of the chain head; public, CORS-open,\nshort-cached, never touches a node.",
         "parameters": [
           {
             "name": "userId",
@@ -13006,13 +12489,53 @@
         ]
       }
     },
-    "/identity/head/{userId}": {
+    "/identity/records": {
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "The envelope's `subject` MUST be the caller's DID and its `publicKey` MUST be",
+        "description": "a current verification method; verification + storage is atomic.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/identity/records/{userId}/chain/head": {
       "get": {
         "tags": [
           "Identity"
         ],
-        "summary": "(O(1)): `{ seq, headRecordId, recordCount }`, or the empty form when the user",
-        "description": "has no chain yet. Node-facing alias of the chain head; public, CORS-open,\nshort-cached, never touches a node.",
+        "summary": "(public, cacheable, CORS-open). A client fetches this before signing the next",
+        "description": "v2 record so it knows the `prev` (head `recordId`) and `seq` (`head.seq + 1`)\nto sign over. Response shape (F0.2 contract — F1/client agents match this):\n - with a chain: `{ headRecordId: string, seq: number, recordCount: number }`\n - no chain yet: `{ headRecordId: null, seq: -1, recordCount: 0 }`\n\nRegistered BEFORE `/:type` so the literal `chain/head` path is unambiguous.\n\nThere is deliberately NO id-shape precheck: the one that used to stand here\n404'd every post-cutover account, which aborts client-side signing of every v2\nrecord (see the module header). An unknown account and a malformed id both\nresolve to the empty chain, which is what this route has always answered for\nan account that exists but has published nothing.",
         "parameters": [
           {
             "name": "userId",
@@ -13193,222 +12716,6 @@
         ]
       }
     },
-    "/identity/domains": {
-      "post": {
-        "tags": [
-          "Identity"
-        ],
-        "summary": "POST /identity/domains",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      },
-      "get": {
-        "tags": [
-          "Identity"
-        ],
-        "summary": "GET /identity/domains",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/identity/domains/{domain}/verify": {
-      "post": {
-        "tags": [
-          "Identity"
-        ],
-        "summary": "POST /identity/domains/{domain}/verify",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/identity/domains/{domain}": {
-      "delete": {
-        "tags": [
-          "Identity"
-        ],
-        "summary": "DELETE /identity/domains/{domain}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/identity.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
     "/link-metadata/fetch-metadata": {
       "post": {
         "tags": [
@@ -13505,52 +12812,12 @@
         ]
       }
     },
-    "/location-search/search": {
-      "get": {
+    "/location-search/cache": {
+      "delete": {
         "tags": [
           "Misc"
         ],
-        "summary": "GET /location-search/search",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/locationSearch.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/location-search/details": {
-      "get": {
-        "tags": [
-          "Misc"
-        ],
-        "summary": "GET /location-search/details",
+        "summary": "DELETE /location-search/cache",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/locationSearch.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -13625,12 +12892,52 @@
         ]
       }
     },
-    "/location-search/cache": {
-      "delete": {
+    "/location-search/db-search": {
+      "get": {
         "tags": [
           "Misc"
         ],
-        "summary": "DELETE /location-search/cache",
+        "summary": "GET /location-search/db-search",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/locationSearch.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/location-search/details": {
+      "get": {
+        "tags": [
+          "Misc"
+        ],
+        "summary": "GET /location-search/details",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/locationSearch.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -13705,12 +13012,52 @@
         ]
       }
     },
-    "/location-search/db-search": {
+    "/location-search/performance": {
       "get": {
         "tags": [
           "Misc"
         ],
-        "summary": "GET /location-search/db-search",
+        "summary": "GET /location-search/performance",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/locationSearch.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/location-search/search": {
+      "get": {
+        "tags": [
+          "Misc"
+        ],
+        "summary": "GET /location-search/search",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/locationSearch.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -13785,13 +13132,98 @@
         ]
       }
     },
-    "/location-search/performance": {
+    "/models/stats": {
       "get": {
         "tags": [
-          "Misc"
+          "AI"
         ],
-        "summary": "GET /location-search/performance",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/locationSearch.ts` to fill in summary, description, request/response examples.",
+        "summary": "Returns model information and stats",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/models-stats.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/nodes/ingest/notify/{userId}": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "has new records. The target is resolved server-side from the path param ONLY;",
+        "description": "the request body is never read or trusted. If the named user has a registered\n(non-revoked) node, a background ingest is enqueued — deduped per user, then\nfully re-verified by the worker (a notify can never inject data). Always\nanswers 202: it is a fire-and-forget hint, not a probe.\n\nUnauthenticated by design (it only re-pulls the user's OWN node and changes\nnothing without cryptographic verification), but rate-limited hard by IP. The\nread path is untouched — this only schedules background work.\n\nThe `isValidObjectId` pre-filter is DELETED, not ported. It existed to keep a\nnon-ObjectId path param out of a Mongoose `CastError`; here `user_id` is\n`text`, so an unknown or malformed id simply selects no row. Keeping it would\nhave been worse than useless: every account minted since the cutover carries a\nuuid v7, which the 24-hex predicate rejects — the notify would have silently\nenqueued nothing for exactly those accounts, with a 202 either way. Same trap\nthe chain-head route hit (`routes/__tests__/chainHead.test.ts`).",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/nodes/managed": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "summary": "(F5c \"Create your vault\"). The owner id is resolved from the session ONLY (the",
+        "description": "request body is never read), Oxy custodial-signs the node registration onto the\ncaller's chain, and the materialized node is returned. Idempotent: an existing\nactive managed vault is refreshed in place, not duplicated.\n\nA missing Oxy custodial key or unconfigured managed-node fleet is server config,\nso it answers 503 (try later) — never a silent broken vault.",
         "parameters": [],
         "responses": {
           "200": {
@@ -13822,34 +13254,6 @@
           {
             "bearerAuth": []
           }
-        ]
-      }
-    },
-    "/models/stats": {
-      "get": {
-        "tags": [
-          "AI"
-        ],
-        "summary": "Returns model information and stats",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/models-stats.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
         ]
       }
     },
@@ -13928,103 +13332,6 @@
           {
             "bearerAuth": []
           }
-        ]
-      }
-    },
-    "/nodes/managed": {
-      "post": {
-        "tags": [
-          "System"
-        ],
-        "summary": "(F5c \"Create your vault\"). The owner id is resolved from the session ONLY (the",
-        "description": "request body is never read), Oxy custodial-signs the node registration onto the\ncaller's chain, and the materialized node is returned. Idempotent: an existing\nactive managed vault is refreshed in place, not duplicated.\n\nA missing Oxy custodial key or unconfigured managed-node fleet is server config,\nso it answers 503 (try later) — never a silent broken vault.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/nodes/ingest/notify/{userId}": {
-      "post": {
-        "tags": [
-          "System"
-        ],
-        "summary": "has new records. The target is resolved server-side from the path param ONLY;",
-        "description": "the request body is never read or trusted. If the named user has a registered\n(non-revoked) node, a background ingest is enqueued — deduped per user, then\nfully re-verified by the worker (a notify can never inject data). Always\nanswers 202: it is a fire-and-forget hint, not a probe.\n\nUnauthenticated by design (it only re-pulls the user's OWN node and changes\nnothing without cryptographic verification), but rate-limited hard by IP. The\nread path is untouched — this only schedules background work.\n\nThe `isValidObjectId` pre-filter is DELETED, not ported. It existed to keep a\nnon-ObjectId path param out of a Mongoose `CastError`; here `user_id` is\n`text`, so an unknown or malformed id simply selects no row. Keeping it would\nhave been worse than useless: every account minted since the cutover carries a\nuuid v7, which the 24-hex predicate rejects — the notify would have silently\nenqueued nothing for exactly those accounts, with a 202 either way. Same trap\nthe chain-head route hit (`routes/__tests__/chainHead.test.ts`).",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
         ]
       }
     },
@@ -14141,34 +13448,6 @@
           "Notifications"
         ],
         "summary": "GET /notifications",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/notifications.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/notifications/unread-count": {
-      "get": {
-        "tags": [
-          "Notifications"
-        ],
-        "summary": "GET /notifications/unread-count",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/notifications.routes.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -14324,12 +13603,68 @@
         }
       }
     },
-    "/notifications/{id}/read": {
+    "/notifications/read-all": {
       "put": {
         "tags": [
           "Notifications"
         ],
-        "summary": "PUT /notifications/{id}/read",
+        "summary": "PUT /notifications/read-all",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/notifications.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/notifications/unread-count": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "GET /notifications/unread-count",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/notifications.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/notifications/{id}": {
+      "delete": {
+        "tags": [
+          "Notifications"
+        ],
+        "summary": "DELETE /notifications/{id}",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/notifications.routes.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
@@ -14382,40 +13717,12 @@
         ]
       }
     },
-    "/notifications/read-all": {
+    "/notifications/{id}/read": {
       "put": {
         "tags": [
           "Notifications"
         ],
-        "summary": "PUT /notifications/read-all",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/notifications.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/notifications/{id}": {
-      "delete": {
-        "tags": [
-          "Notifications"
-        ],
-        "summary": "DELETE /notifications/{id}",
+        "summary": "PUT /notifications/{id}/read",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/notifications.routes.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
@@ -14552,6 +13859,318 @@
         ]
       }
     },
+    "/privacy/blocked": {
+      "get": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "List blocked users",
+        "description": "Return the users the authenticated caller has blocked.",
+        "responses": {
+          "200": {
+            "description": "List of blocked users."
+          }
+        }
+      }
+    },
+    "/privacy/blocked/{targetId}": {
+      "post": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "Block a user",
+        "description": "Block `targetId` for the authenticated caller. Blocking is symmetric — neither account can see the other's posts, profile, or reach the other in DMs.\n",
+        "parameters": [
+          {
+            "name": "targetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User blocked."
+          },
+          "400": {
+            "description": "The target is the caller, or an account the caller operates — an active member of a channel, or a member of an organization / project / bot holding `account:act_as`.\n"
+          },
+          "409": {
+            "description": "Already blocked."
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "Unblock a user",
+        "parameters": [
+          {
+            "name": "targetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User unblocked."
+          }
+        }
+      }
+    },
+    "/privacy/restricted": {
+      "get": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "List restricted users",
+        "description": "Return the users the authenticated caller has restricted.",
+        "responses": {
+          "200": {
+            "description": "List of restricted users."
+          }
+        }
+      }
+    },
+    "/privacy/restricted/{targetId}": {
+      "post": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "Restrict a user",
+        "description": "Restrict `targetId` — they can still see public content but their replies and DMs are silently filtered out of the caller's view.\n",
+        "parameters": [
+          {
+            "name": "targetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User restricted."
+          },
+          "400": {
+            "description": "The target is the caller, or an account the caller operates — same rule as `POST /privacy/blocked/{targetId}`.\n"
+          },
+          "409": {
+            "description": "Already restricted."
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "Unrestrict a user",
+        "parameters": [
+          {
+            "name": "targetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User unrestricted."
+          }
+        }
+      }
+    },
+    "/privacy/{id}/privacy": {
+      "get": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "Get a user's privacy settings",
+        "description": "Return the full privacy settings record for the user. Some fields are only visible to the owner; non-owner callers see a redacted projection.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Privacy settings.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                },
+                "examples": {
+                  "default": {
+                    "value": {
+                      "profileVisibility": "public",
+                      "showActivity": true,
+                      "allowDirectMessages": "contacts-only",
+                      "discoverableByEmail": false,
+                      "discoverableByPhone": false
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "404": {
+            "description": "User not found."
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Privacy"
+        ],
+        "summary": "Update a user's privacy settings (owner only)",
+        "description": "Partial update of the user's privacy settings. Only the owner of the account may patch their settings — other callers get 403. Invalidates the in-memory user cache so subsequent reads return fresh values.\n",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "examples": {
+                "tighten": {
+                  "summary": "Make profile private and disable email discovery",
+                  "value": {
+                    "profileVisibility": "private",
+                    "discoverableByEmail": false
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated privacy settings."
+          },
+          "400": {
+            "description": "Validation failed."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "403": {
+            "description": "Caller is not the owner."
+          }
+        }
+      }
+    },
+    "/profiles/recommendations": {
+      "get": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Get recommended user profiles. Maps the query string to the shared",
+        "description": "{@link buildRecommendations}, which runs the reputation-weighted scorer.\n\nOptional auth: when a valid session token is present the response is\npersonalized; when absent it returns popular public profiles. Private accounts\nare always excluded; `excludeTypes` filters federated/agent/automated users.\n\n  (federated, agent, automated)",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      },
+      "post": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Rich recommendation surface accepting a JSON body: per-app weight profile",
+        "description": "(`clientId`), explicit `excludeIds`, editorial `boosts`, and per-request\n`signalWeights`. Optional auth (same personalization rules as GET). Validates\nthe body against `recommendationRequestSchema`. Shares the exact builder/cache\nwith GET, so identical inputs yield identical output.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/profiles/resolve": {
+      "get": {
+        "tags": [
+          "Profiles"
+        ],
+        "summary": "Resolve a handle (e.g. @user@mastodon.social) to an Oxy user profile.",
+        "description": "LOCAL-FIRST: a handle that already maps to a known Oxy user is resolved\ndirectly from the DB — no network round-trip. This is essential for atproto\n(Bluesky) actors whose `user@bsky.social` username oxy-api's WebFinger can\nnever resolve: the user already exists, so remote discovery must NOT run (it\nwould fail and yield a false \"Profile not found\"). The local lookup runs\nregardless of `isFediverseHandle` because a stored `user@domain` username is a\nvalid lookup key even when the strict handle-format check would reject it.\n\nOnly when NO local user exists do we fall through to WebFinger/ActivityPub\ndiscovery (`resolveAndUpsert`) — genuine discovery of an unknown handle, which\nis where the `isFediverseHandle` format validation still applies.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/profiles/search": {
       "get": {
         "tags": [
@@ -14630,20 +14249,70 @@
         ]
       }
     },
-    "/profiles/resolve": {
+    "/profiles/username/{username}": {
       "get": {
         "tags": [
           "Profiles"
         ],
-        "summary": "Resolve a handle (e.g. @user@mastodon.social) to an Oxy user profile.",
-        "description": "LOCAL-FIRST: a handle that already maps to a known Oxy user is resolved\ndirectly from the DB — no network round-trip. This is essential for atproto\n(Bluesky) actors whose `user@bsky.social` username oxy-api's WebFinger can\nnever resolve: the user already exists, so remote discovery must NOT run (it\nwould fail and yield a false \"Profile not found\"). The local lookup runs\nregardless of `isFediverseHandle` because a stored `user@domain` username is a\nvalid lookup key even when the strict handle-format check would reject it.\n\nOnly when NO local user exists do we fall through to WebFinger/ActivityPub\ndiscovery (`resolveAndUpsert`) — genuine discovery of an unknown handle, which\nis where the `isFediverseHandle` format validation still applies.",
-        "parameters": [],
+        "security": [],
+        "summary": "Public profile lookup by username",
+        "description": "Resolve a username to a public profile, with follower/following counts. Federated handles (`user@domain`) are resolved on the fly via WebFinger + ActivityPub; if the actor has never been seen the endpoint will upsert it as a federated user before returning.\nThis endpoint is unauthenticated and may be cached by edge.\n",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Local username (alphanumeric, 3-30 chars) or fediverse handle.",
+              "examples": {
+                "local": "alice",
+                "federated": "alice@mastodon.social"
+              }
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Profile found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "local": {
+                    "value": {
+                      "id": "64f7c2a1b8e9d3f4a1c2b3d4",
+                      "username": "alice",
+                      "name": {
+                        "first": "Alice",
+                        "last": "Example"
+                      },
+                      "description": "Coffee, code, and open source.",
+                      "type": "local",
+                      "_count": {
+                        "followers": 42,
+                        "following": 17
+                      }
+                    }
+                  }
+                }
+              }
+            }
           },
-          "5XX": {
-            "description": "Server error",
+          "400": {
+            "description": "Malformed username.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Profile not found (and federation lookup failed).",
             "content": {
               "application/json": {
                 "schema": {
@@ -14652,10 +14321,7 @@
               }
             }
           }
-        },
-        "security": [
-          {}
-        ]
+        }
       }
     },
     "/profiles/{userId}/similar": {
@@ -14727,13 +14393,41 @@
         ]
       }
     },
-    "/profiles/recommendations": {
-      "get": {
+    "/reputation/award": {
+      "post": {
         "tags": [
-          "Profiles"
+          "Reputation"
         ],
-        "summary": "Get recommended user profiles. Maps the query string to the shared",
-        "description": "{@link buildRecommendations}, which runs the reputation-weighted scorer.\n\nOptional auth: when a valid session token is present the response is\npersonalized; when absent it returns popular public profiles. Private accounts\nare always excluded; `excludeTypes` filters federated/agent/automated users.\n\n  (federated, agent, automated)",
+        "summary": "Awarding is restricted to service tokens with the privileged",
+        "description": "`reputation:write` scope (the canonical path — a source app reports an\naction) and platform staff. Regular users may NOT award reputation\n(no self-award). When called with a service token the `applicationId` /\n`credentialId` are resolved from `req.serviceApp` and any client-supplied\nvalues for those fields are ignored.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/reputation/disputes": {
+      "post": {
+        "tags": [
+          "Reputation"
+        ],
+        "summary": "POST /reputation/disputes",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -14754,16 +14448,103 @@
           {}
         ]
       },
-      "post": {
+      "get": {
         "tags": [
-          "Profiles"
+          "Reputation"
         ],
-        "summary": "Rich recommendation surface accepting a JSON body: per-app weight profile",
-        "description": "(`clientId`), explicit `excludeIds`, editorial `boosts`, and per-request\n`signalWeights`. Optional auth (same personalization rules as GET). Validates\nthe body against `recommendationRequestSchema`. Shares the exact builder/cache\nwith GET, so identical inputs yield identical output.",
-        "parameters": [],
+        "summary": "GET /reputation/disputes",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/reputation/disputes/{id}/resolve": {
+      "post": {
+        "tags": [
+          "Reputation"
+        ],
+        "summary": "POST /reputation/disputes/{id}/resolve",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "5XX": {
             "description": "Server error",
@@ -14904,6 +14685,122 @@
         ]
       }
     },
+    "/reputation/transactions/{id}/reverse": {
+      "post": {
+        "tags": [
+          "Reputation"
+        ],
+        "summary": "POST /reputation/transactions/{id}/reverse",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/reputation/transactions/{id}/void": {
+      "post": {
+        "tags": [
+          "Reputation"
+        ],
+        "summary": "POST /reputation/transactions/{id}/void",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/reputation/{userId}/balance": {
       "get": {
         "tags": [
@@ -14965,41 +14862,13 @@
         ]
       }
     },
-    "/reputation/award": {
-      "post": {
-        "tags": [
-          "Reputation"
-        ],
-        "summary": "Awarding is restricted to service tokens with the privileged",
-        "description": "`reputation:write` scope (the canonical path — a source app reports an\naction) and platform staff. Regular users may NOT award reputation\n(no self-award). When called with a service token the `applicationId` /\n`credentialId` are resolved from `req.serviceApp` and any client-supplied\nvalues for those fields are ignored.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/reputation/{userId}/transactions": {
+    "/reputation/{userId}/disputes": {
       "get": {
         "tags": [
           "Reputation"
         ],
-        "summary": "A transaction's `metadata` names the THIRD PARTIES behind the award — the",
-        "description": "attestor who physically met the subject, the voucher who staked on them, the\njury that validated them — so the ledger is readable only by its own subject\nand platform staff, never by an arbitrary authenticated caller.",
+        "summary": "GET /reputation/{userId}/disputes",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
             "name": "userId",
@@ -15141,281 +15010,6 @@
         ]
       }
     },
-    "/reputation/{userId}/disputes": {
-      "get": {
-        "tags": [
-          "Reputation"
-        ],
-        "summary": "GET /reputation/{userId}/disputes",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/reputation/disputes": {
-      "post": {
-        "tags": [
-          "Reputation"
-        ],
-        "summary": "POST /reputation/disputes",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      },
-      "get": {
-        "tags": [
-          "Reputation"
-        ],
-        "summary": "GET /reputation/disputes",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 1
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/reputation/transactions/{id}/reverse": {
-      "post": {
-        "tags": [
-          "Reputation"
-        ],
-        "summary": "POST /reputation/transactions/{id}/reverse",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/reputation/transactions/{id}/void": {
-      "post": {
-        "tags": [
-          "Reputation"
-        ],
-        "summary": "POST /reputation/transactions/{id}/void",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
     "/reputation/{userId}/recalculate": {
       "post": {
         "tags": [
@@ -15474,21 +15068,39 @@
         ]
       }
     },
-    "/reputation/disputes/{id}/resolve": {
-      "post": {
+    "/reputation/{userId}/transactions": {
+      "get": {
         "tags": [
           "Reputation"
         ],
-        "summary": "POST /reputation/disputes/{id}/resolve",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/reputation.routes.ts` to fill in summary, description, request/response examples.",
+        "summary": "A transaction's `metadata` names the THIRD PARTIES behind the award — the",
+        "description": "attestor who physically met the subject, the voucher who staked on them, the\njury that validated them — so the ledger is readable only by its own subject\nand platform staff, never by an arbitrary authenticated caller.",
         "parameters": [
           {
-            "name": "id",
+            "name": "userId",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
               "minLength": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
             }
           }
         ],
@@ -15614,63 +15226,222 @@
         ]
       }
     },
-    "/session/device/token": {
-      "post": {
+    "/security/activity": {
+      "get": {
         "tags": [
-          "Sessions"
+          "Security"
         ],
-        "summary": "PUBLIC by design and mounted ABOVE the router-wide",
-        "description": "`requireSameSiteOrigin, authMiddleware` below: it carries NO bearer and NO\ncookies. The client presents the `deviceId` it stored first-party plus the\nopaque `deviceSecret`; possession of the secret IS the ownership proof, so the\nmint can be initiated from any registered cross-apex origin over normal CORS.\n\nOn a valid secret it mints a short access token for the device's active\naccount and ROTATES the secret in-use (returns `nextDeviceSecret`; the\npresented secret stays valid for a short grace so multi-tab races don't lock\nout). A dead/absent active session returns `no_active_session` WITHOUT rotating\n— the client must re-authenticate and keeps its still-valid secret. Per-device\nlockout + rate limiting blunt online secret-guessing.\n\nAn optional `accountId` PINS the mint to one account of that device instead of\nwhichever one is currently active. It exists for identity-bound clients\n(Commons), whose authenticated user is fixed by a local cryptographic key and\nmust not follow an account switch made by another app sharing the same\n`DeviceSession`. A pinned mint is READ-ONLY with respect to device state: it\nnever writes `activeAccountId`, never bumps `revision` and never broadcasts —\nthe returned `state` therefore still reports the device's TRUE active account.\nRotation is unchanged. A pin that names an account which is not on the device,\nor whose session is dead, answers `account_not_on_device` without rotating.",
-        "parameters": [],
+        "summary": "Account activity log with pagination",
+        "description": "Return security-relevant events for the authenticated user — sign-ins, email changes, device add/remove, private-key exports, backup creations, suspicious activity flags. Always scoped to the bearer's own account; there is no parameter that widens it to another user. Used to power the activity history screen.\n\nNo event carries an IP address, a country or any other network-derived location: the platform stores no user IPs at rest, in any form. Do not add such a field here or to the underlying table.\n",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Rows to skip. Offset/limit paging — there is no cursor.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "required": false,
+            "description": "Restrict to one event type. An unknown value is a 400.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "sign_in",
+                "sign_out",
+                "email_changed",
+                "profile_updated",
+                "device_added",
+                "device_removed",
+                "account_recovery",
+                "security_settings_changed",
+                "private_key_exported",
+                "backup_created",
+                "suspicious_activity"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "Activity events, newest first.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "userId": {
+                            "type": "string"
+                          },
+                          "eventType": {
+                            "type": "string",
+                            "example": "sign_in"
+                          },
+                          "eventDescription": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": true
+                          },
+                          "userAgent": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "deviceId": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "When the EVENT happened."
+                          },
+                          "severity": {
+                            "type": "string",
+                            "enum": [
+                              "low",
+                              "medium",
+                              "high",
+                              "critical"
+                            ]
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "When the row was written."
+                          }
+                        }
+                      }
+                    },
+                    "pagination": {
+                      "type": "object",
+                      "properties": {
+                        "total": {
+                          "type": "integer"
+                        },
+                        "limit": {
+                          "type": "integer"
+                        },
+                        "offset": {
+                          "type": "integer"
+                        },
+                        "hasMore": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Unknown eventType."
           },
           "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/security/activity/backup-created": {
+      "post": {
+        "tags": [
+          "Security"
+        ],
+        "summary": "Log a \"backup created\" event",
+        "description": "Record that the local identity wallet wrote a backup of its keys.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deviceId": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "bearerAuth": []
+        "responses": {
+          "200": {
+            "description": "Event recorded."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
           }
-        ]
+        }
       }
     },
-    "/session/device/background-token": {
+    "/security/activity/private-key-exported": {
+      "post": {
+        "tags": [
+          "Security"
+        ],
+        "summary": "Log a \"private key exported\" event",
+        "description": "Record that the local identity wallet exported its private key for backup. The event surfaces in the activity log and is used to remind the user to safely store the key.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "deviceId": {
+                    "type": "string",
+                    "description": "Device that performed the export. Optional."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Event recorded."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/session/device/add": {
       "post": {
         "tags": [
           "Sessions"
         ],
-        "summary": "code. Possession of the provisioned background secret IS the proof; the secret",
-        "description": "is NEVER rotated (unlike `POST /token`). Returns only the short access token,\nits expiry, and the account it belongs to — no device state.",
+        "summary": "POST /session/device/add",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/sessionDevice.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -15720,12 +15491,153 @@
         ]
       }
     },
-    "/session/device/state": {
-      "get": {
+    "/session/device/background-token": {
+      "post": {
         "tags": [
           "Sessions"
         ],
-        "summary": "GET /session/device/state",
+        "summary": "code. Possession of the provisioned background secret IS the proof; the secret",
+        "description": "is NEVER rotated (unlike `POST /token`). Returns only the short access token,\nits expiry, and the account it belongs to — no device state.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/session/device/logout-all/{sessionId}": {
+      "post": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Sign out every session on this device",
+        "description": "Revoke every session that shares the device fingerprint of the supplied session. Useful for a one-click \"sign out this device\" button.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Device sessions revoked."
+          },
+          "404": {
+            "description": "Session not found."
+          }
+        }
+      }
+    },
+    "/session/device/name/{sessionId}": {
+      "put": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "Rename the device for the given session",
+        "description": "Update the human-readable device label shown in the user's devices list. The change applies to every session sharing the device fingerprint.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "deviceName"
+                ],
+                "properties": {
+                  "deviceName": {
+                    "type": "string",
+                    "example": "Living room iPad"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Device renamed."
+          },
+          "400": {
+            "description": "Validation failed."
+          },
+          "404": {
+            "description": "Session not found."
+          }
+        }
+      }
+    },
+    "/session/device/sessions/{sessionId}": {
+      "get": {
+        "tags": [
+          "Devices"
+        ],
+        "summary": "List sessions on the same device as the given session",
+        "description": "Return every active session that shares the device fingerprint of the supplied session. Used to power \"this device has these accounts\" UI in the auth picker.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sessions on this device.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Session"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found."
+          }
+        }
+      }
+    },
+    "/session/device/signout": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "POST /session/device/signout",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/sessionDevice.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -15748,12 +15660,12 @@
         ]
       }
     },
-    "/session/device/add": {
-      "post": {
+    "/session/device/state": {
+      "get": {
         "tags": [
           "Sessions"
         ],
-        "summary": "POST /session/device/add",
+        "summary": "GET /session/device/state",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/sessionDevice.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
@@ -15804,17 +15716,37 @@
         ]
       }
     },
-    "/session/device/signout": {
+    "/session/device/token": {
       "post": {
         "tags": [
           "Sessions"
         ],
-        "summary": "POST /session/device/signout",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/sessionDevice.ts` to fill in summary, description, request/response examples.",
+        "summary": "PUBLIC by design and mounted ABOVE the router-wide",
+        "description": "`requireSameSiteOrigin, authMiddleware` below: it carries NO bearer and NO\ncookies. The client presents the `deviceId` it stored first-party plus the\nopaque `deviceSecret`; possession of the secret IS the ownership proof, so the\nmint can be initiated from any registered cross-apex origin over normal CORS.\n\nOn a valid secret it mints a short access token for the device's active\naccount. The successful response carries the same secret back as\n`nextDeviceSecret`: the secret is a stable device credential, so several\nofficial apps/origins sharing one device can refresh concurrently without\ninvalidating one another. A dead/absent active session returns\n`no_active_session` WITHOUT changing the credential — the client must\nre-authenticate and keeps its still-valid secret. Per-device lockout + rate\nlimiting blunt online secret-guessing.\n\nAn optional `accountId` PINS the mint to one account of that device instead of\nwhichever one is currently active. It exists for identity-bound clients\n(Commons), whose authenticated user is fixed by a local cryptographic key and\nmust not follow an account switch made by another app sharing the same\n`DeviceSession`. A pinned mint is READ-ONLY with respect to device state: it\nnever writes `activeAccountId`, never bumps `revision` and never broadcasts —\nthe returned `state` therefore still reports the device's TRUE active account.\nRotation is unchanged. A pin that names an account which is not on the device,\nor whose session is dead, answers `account_not_on_device` without rotating.",
         "parameters": [],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "5XX": {
             "description": "Server error",
@@ -15828,8 +15760,366 @@
           }
         },
         "security": [
-          {}
+          {
+            "bearerAuth": []
+          }
         ]
+      }
+    },
+    "/session/logout-all/{sessionId}": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Sign out every session for this user",
+        "description": "Revoke every session belonging to the user behind `sessionId`, including the calling session itself. Recommended after a password reset or suspected compromise.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All sessions revoked."
+          },
+          "404": {
+            "description": "Session not found."
+          }
+        }
+      }
+    },
+    "/session/logout/{sessionId}": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Sign out the given session",
+        "description": "Revoke the session identified by `sessionId`. After this call any bearer token tied to that session is rejected. Idempotent — calling twice is a no-op on the second call.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session revoked."
+          },
+          "404": {
+            "description": "Session not found."
+          }
+        }
+      }
+    },
+    "/session/logout/{sessionId}/{targetSessionId}": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Sign another session out via an authenticated session",
+        "description": "Use `sessionId` (which must be a valid active session) to revoke a different session identified by `targetSessionId`. This is how the \"sign out other devices\" flow works.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "targetSessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Target session revoked."
+          },
+          "401": {
+            "description": "The acting session is not valid."
+          },
+          "404": {
+            "description": "Target session not found."
+          }
+        }
+      }
+    },
+    "/session/sessions/{sessionId}": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "List all sessions for the user of the given session",
+        "description": "Return every active session the user has across all devices, with a flag marking the current session. Requires a valid access token whose user owns the referenced session.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Active sessions for the user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Session"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found or expired."
+          }
+        }
+      }
+    },
+    "/session/user/{sessionId}": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Resolve a session ID to the user it belongs to",
+        "description": "Look up the user record for a given session ID. Requires a valid access token whose user owns the referenced session — callers cannot look up sessions belonging to other users. Used by SDK clients (e.g. `@oxyhq/core`) to hydrate user state from a stored session reference. Expired, revoked, or non-owned sessions return 404.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "example": "sess_64f7c2a1b8e9d3f4a1c2b3d4"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User attached to this session.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed sessionId.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found or expired.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/session/users/batch": {
+      "post": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Resolve multiple session IDs in one call",
+        "description": "Batch counterpart of `/session/user/:sessionId`. Pass an array of session IDs and get back a map of user records — used by clients that need to render multiple connected accounts at once (e.g. the account switcher).\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "sessionIds"
+                ],
+                "properties": {
+                  "sessionIds": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "pair": {
+                  "value": {
+                    "sessionIds": [
+                      "sess_64f7c2a1b8e9d3f4a1c2b3d4",
+                      "sess_74f7c2a1b8e9d3f4a1c2b3d5"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User records keyed by session ID. Missing sessions are omitted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed."
+          }
+        }
+      }
+    },
+    "/session/validate-header/{sessionId}": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "summary": "Validate a session using a header-bound bearer token",
+        "description": "Like `/session/validate/:sessionId` but cross-checks the bearer token against the session — returns 200 only if the token still belongs to the session.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session and bearer token match."
+          },
+          "401": {
+            "description": "Token does not match the session."
+          },
+          "404": {
+            "description": "Session not found."
+          }
+        }
+      }
+    },
+    "/session/validate/{sessionId}": {
+      "get": {
+        "tags": [
+          "Sessions"
+        ],
+        "security": [],
+        "summary": "Validate a session ID",
+        "description": "Cheap liveness check — returns 200 with a small payload if the session is still active, 404 otherwise. Use this in lieu of the heavier `/session/user/:id` lookup when you only need a yes/no.\n",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session is active.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "valid": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "expiresAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Session not found or expired."
+          }
+        }
+      }
+    },
+    "/storage/usage": {
+      "get": {
+        "tags": [
+          "Files"
+        ],
+        "summary": "Get the authenticated user's storage usage",
+        "description": "Return the total bytes used and the user's storage quota for the file-storage feature. Used by the storage settings UI to render progress bars and quota warnings.\n",
+        "responses": {
+          "200": {
+            "description": "Storage usage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "used": {
+                      "type": "integer",
+                      "description": "Bytes consumed.",
+                      "example": 1073741824
+                    },
+                    "quota": {
+                      "type": "integer",
+                      "description": "Bytes available.",
+                      "example": 10737418240
+                    },
+                    "percent": {
+                      "type": "number",
+                      "description": "Percentage used (0-1).",
+                      "example": 0.1
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
       }
     },
     "/subscription/{userId}": {
@@ -16014,6 +16304,34 @@
         ]
       }
     },
+    "/topics/resolve": {
+      "post": {
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Batch resolve names to topics (upsert).",
+        "description": "Body: { names: Array<{ name: string; type: TopicType }> }",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/topics/search": {
       "get": {
         "tags": [
@@ -16154,17 +16472,46 @@
         ]
       }
     },
-    "/topics/resolve": {
-      "post": {
+    "/u/{userId}/did.json": {
+      "get": {
         "tags": [
-          "Misc"
+          "Identity"
         ],
-        "summary": "Batch resolve names to topics (upsert).",
-        "description": "Body: { names: Array<{ name: string; type: TopicType }> }",
-        "parameters": [],
+        "summary": "GET /u/{userId}/did.json",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/did.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "5XX": {
             "description": "Server error",
@@ -16179,126 +16526,6 @@
         },
         "security": [
           {}
-        ]
-      }
-    },
-    "/users/follow/bulk": {
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Follow many users in a single request. Follow-only and idempotent — users",
-        "description": "already followed stay followed and are never unfollowed. One bad/invalid id\nnever fails the whole batch; every supplied id gets a per-target result.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`follow` as a `:userId` value.\n\n  per-target list of `{ userId, success, alreadyFollowing }` and\n  `followedCount` counts only NEWLY created follows.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/users/unfollow/bulk": {
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Unfollow many users in a single request. Unfollow-only and idempotent — ids",
-        "description": "that are not currently followed are left untouched and reported as already in\nthe desired (not-following) state. One bad/invalid id never fails the whole\nbatch; every supplied id gets a per-target result.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`unfollow` as a `:userId` value.\n\n  per-target list of `{ userId, success, wasFollowing }` and `unfollowedCount`\n  counts only follows that were actually removed.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/users/follow-status/bulk": {
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Resolve the authenticated viewer's follow status for MANY target users in a",
-        "description": "single request. Built for list UIs (a page of N FollowButtons) that would\notherwise fire N `GET /users/:id/follow-status` calls — this collapses them\ninto one round-trip served by a single indexed query.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`follow-status` as a `:userId` value.\n\n  whether the viewer follows it; unknown/unfollowed ids are `false`.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
         ]
       }
     },
@@ -16364,17 +16591,27 @@
         }
       }
     },
-    "/users/mutual-ids": {
-      "get": {
+    "/users/follow-status/bulk": {
+      "post": {
         "tags": [
           "Users"
         ],
-        "summary": "The authenticated VIEWER's OWN mutual-follow user ids — the accounts the viewer",
-        "description": "follows that ALSO follow the viewer back. Lean, ids-only, bounded payload built\nto SEED Mention's \"Mutuals\" feed (which then hydrates and ranks the posts\nitself), so it returns bare ids rather than the hydrated DTOs of\n`GET /users/:userId/mutuals` (\"followers you know\" about ANOTHER profile).\n\nThe viewer is derived SERVER-SIDE from the auth token via `resolveViewerId`\n(the same dual-auth as `/mutuals` and `/by-ids`) — never a client-supplied id,\nand there is no `:userId` param to spoof (anti-IDOR). OPTIONAL semantics: an\nanonymous caller (or a service token with no user context) has no \"you follow\"\nset → `{ data: [] }`.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`mutual-ids` as a `:userId` value.",
+        "summary": "Resolve the authenticated viewer's follow status for MANY target users in a",
+        "description": "single request. Built for list UIs (a page of N FollowButtons) that would\notherwise fire N `GET /users/:id/follow-status` calls — this collapses them\ninto one round-trip served by a single indexed query.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`follow-status` as a `:userId` value.\n\n  whether the viewer follows it; unknown/unfollowed ids are `false`.",
         "parameters": [],
         "responses": {
           "200": {
             "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           },
           "5XX": {
             "description": "Server error",
@@ -16388,7 +16625,49 @@
           }
         },
         "security": [
-          {}
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/users/follow/bulk": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Follow many users in a single request. Follow-only and idempotent — users",
+        "description": "already followed stay followed and are never unfollowed. One bad/invalid id\nnever fails the whole batch; every supplied id gets a per-target result.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`follow` as a `:userId` value.\n\n  per-target list of `{ userId, success, alreadyFollowing }` and\n  `followedCount` counts only NEWLY created follows.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
         ]
       }
     },
@@ -16420,6 +16699,600 @@
         ]
       }
     },
+    "/users/me": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get the current authenticated user",
+        "description": "Returns the full profile for the bearer-token holder, including privacy settings, identity flags, and connected account types. This is the canonical \"who am I\" endpoint that every Oxy app calls on startup.\n",
+        "responses": {
+          "200": {
+            "description": "Current user profile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                },
+                "examples": {
+                  "success": {
+                    "value": {
+                      "id": "64f7c2a1b8e9d3f4a1c2b3d4",
+                      "username": "alice",
+                      "name": {
+                        "first": "Alice",
+                        "last": "Example"
+                      },
+                      "description": "Coffee, code, and open source.",
+                      "type": "local",
+                      "_count": {
+                        "followers": 42,
+                        "following": 17
+                      },
+                      "createdAt": "2024-01-15T12:34:56.789Z",
+                      "updatedAt": "2025-05-12T09:00:00.000Z"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Update the current authenticated user",
+        "description": "Partial profile update for the authenticated user. Only fields supplied in the body are touched — missing fields keep their existing values. The server enforces uniqueness on `email` and `username`; conflicts return 409. Always invalidates the in-memory user cache so the next read returns the updated record.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string",
+                    "minLength": 3,
+                    "maxLength": 30,
+                    "pattern": "^[a-zA-Z0-9]{3,30}$",
+                    "example": "alice"
+                  },
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "example": "alice@placeholder.example"
+                  },
+                  "name": {
+                    "type": "object",
+                    "properties": {
+                      "first": {
+                        "type": "string",
+                        "example": "Alice"
+                      },
+                      "last": {
+                        "type": "string",
+                        "example": "Example"
+                      }
+                    }
+                  },
+                  "description": {
+                    "type": "string",
+                    "example": "Updated bio."
+                  },
+                  "avatar": {
+                    "type": "string",
+                    "description": "Asset ID or absolute URL.",
+                    "example": "64f7c2a1b8e9d3f4a1c2b3d4"
+                  }
+                }
+              },
+              "examples": {
+                "rename": {
+                  "summary": "Update the display name",
+                  "value": {
+                    "name": {
+                      "first": "Alice",
+                      "last": "Example"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated user profile.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "409": {
+            "description": "Email or username conflict.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Permanently delete the current account",
+        "description": "Hard-delete the authenticated user's account. To prove identity at the time of deletion the client signs `delete:{publicKey}:{timestamp}` with the local secp256k1 private key (see `KeyManager.sign` in `@oxyhq/core`). The signature is rejected if it is older than 5 minutes, if the confirmation text does not match the account's username, or if the account has no associated public key.\nSuccessful deletion removes all mailboxes, messages, and S3 attachments owned by the user.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "signature",
+                  "timestamp",
+                  "confirmText"
+                ],
+                "properties": {
+                  "signature": {
+                    "type": "string",
+                    "description": "Hex-encoded secp256k1 signature over `delete:{publicKey}:{timestamp}`.",
+                    "example": "3045022100abcd...3045022100efgh"
+                  },
+                  "timestamp": {
+                    "type": "integer",
+                    "description": "Unix milliseconds when the signature was produced.",
+                    "example": 1714576800000
+                  },
+                  "confirmText": {
+                    "type": "string",
+                    "description": "Must equal the account's username.",
+                    "example": "alice"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Account deleted successfully"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing field, expired signature, or mismatched confirmText.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/me/app-data/{namespace}": {
+      "get": {
+        "tags": [
+          "UserAppData"
+        ],
+        "summary": "List every value in a namespace for the current user",
+        "description": "Returns `{ entries }` where `entries` is a `key -> value` map of everything stored under `namespace` for the authenticated user. The response is bounded by the 128-key namespace quota and by the 64 KB cap per individual value. If an older namespace exceeds the current quota, the endpoint refuses to materialize it in one response.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]{1,64}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map of every key in the namespace to its value.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "entries": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "description": "Stored JSON value."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      }
+    },
+    "/users/me/app-data/{namespace}/{key}": {
+      "get": {
+        "tags": [
+          "UserAppData"
+        ],
+        "summary": "Read a single per-user JSON value",
+        "description": "Returns the value stored under `(namespace, key)` for the authenticated user. The response body is always `{ value }`. If no value has ever been stored, `value` is `null` (the endpoint does not 404 on missing entries — a missing entry is semantically a `null` value).\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]{1,64}$"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]{1,64}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current value (or null when not stored).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "description": "Arbitrary JSON value previously stored, or null."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "UserAppData"
+        ],
+        "summary": "Upsert a single per-user JSON value",
+        "description": "Stores (or replaces) the value under `(namespace, key)` for the authenticated user. Body must be `{ value: <any JSON-serializable value> }`. Serialized JSON is capped at 64 KB.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]{1,64}$"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]{1,64}$"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "value"
+                ],
+                "properties": {
+                  "value": {
+                    "description": "Arbitrary JSON value to persist."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The stored value, echoed back.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "description": "The value that is now stored."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation failed (bad namespace/key, oversized value)."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "429": {
+            "description": "Per-user write rate limit exceeded."
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "UserAppData"
+        ],
+        "summary": "Delete a single per-user JSON value",
+        "description": "Removes the value under `(namespace, key)` for the authenticated user. Idempotent — succeeds with 204 whether or not the entry existed.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "namespace",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]{1,64}$"
+            }
+          },
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-z0-9_-]{1,64}$"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted (or was already absent)."
+          },
+          "401": {
+            "description": "Missing or invalid bearer token."
+          },
+          "429": {
+            "description": "Per-user write rate limit exceeded."
+          }
+        }
+      }
+    },
+    "/users/me/data": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Download account data export",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "csv"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/users/me/export": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Signed, open-format self-sovereign data export (\"credible exit\"). Returns the",
+        "description": "`ExportBundle` (DID document, profile, verified domains, auth methods, signed\nrecords, app data, social graph) sealed with an Oxy provenance attestation.\n`?format=ndjson` streams each section as newline-delimited JSON for large\naccounts.",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "ndjson"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
     "/users/me/graph": {
       "get": {
         "tags": [
@@ -16446,6 +17319,253 @@
         "security": [
           {}
         ]
+      }
+    },
+    "/users/mutual-ids": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "The authenticated VIEWER's OWN mutual-follow user ids — the accounts the viewer",
+        "description": "follows that ALSO follow the viewer back. Lean, ids-only, bounded payload built\nto SEED Mention's \"Mutuals\" feed (which then hydrates and ranks the posts\nitself), so it returns bare ids rather than the hydrated DTOs of\n`GET /users/:userId/mutuals` (\"followers you know\" about ANOTHER profile).\n\nThe viewer is derived SERVER-SIDE from the auth token via `resolveViewerId`\n(the same dual-auth as `/mutuals` and `/by-ids`) — never a client-supplied id,\nand there is no `:userId` param to spoof (anti-IDOR). OPTIONAL semantics: an\nanonymous caller (or a service token with no user context) has no \"you follow\"\nset → `{ data: [] }`.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`mutual-ids` as a `:userId` value.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/users/resolve": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "PUT /users/resolve",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient privileges",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "serviceTokenAuth": []
+          }
+        ]
+      }
+    },
+    "/users/search": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Search for users by username or name",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "query": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "query"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users/unfollow/bulk": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Unfollow many users in a single request. Unfollow-only and idempotent — ids",
+        "description": "that are not currently followed are left untouched and reported as already in\nthe desired (not-following) state. One bad/invalid id never fails the whole\nbatch; every supplied id gets a per-target result.\n\nRegistered BEFORE the `/:userId` param routes so Express never treats\n`unfollow` as a `:userId` value.\n\n  per-target list of `{ userId, success, wasFollowing }` and `unfollowedCount`\n  counts only follows that were actually removed.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/users/verify/request": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Request account verification",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "evidence": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          }
+        }
       }
     },
     "/users/{userId}": {
@@ -16502,246 +17622,6 @@
         },
         "security": [
           {}
-        ]
-      }
-    },
-    "/users/{userId}/followers": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Get user's followers with pagination",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/users/{userId}/following": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Get users that this user is following with pagination",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/users/{userId}/mutuals": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "\"Followers you know\" — the MUTUAL followers between the authenticated viewer",
-        "description": "and the target user: users U such that the VIEWER follows U AND U follows\n:userId.\n\nThe viewer is derived SERVER-SIDE from the auth token (never a client-supplied\nparam) via `resolveViewerId`, the same dual-auth viewer resolution the\nrecommendation surfaces use. OPTIONAL semantics — the request is never\nrejected: an anonymous caller (or a service token with no user context) has no\n\"you follow\" set, so the response is an empty page; a self-target\n(`:userId === viewer`) is likewise empty. The empty/self guards live in the\nservice so the route stays thin.",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/users/{userId}/follow-status": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Check if current user is following target user",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
         ]
       }
     },
@@ -16977,6 +17857,246 @@
         }
       }
     },
+    "/users/{userId}/follow-status": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Check if current user is following target user",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/users/{userId}/followers": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get user's followers with pagination",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/users/{userId}/following": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Get users that this user is following with pagination",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
+    "/users/{userId}/mutuals": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "\"Followers you know\" — the MUTUAL followers between the authenticated viewer",
+        "description": "and the target user: users U such that the VIEWER follows U AND U follows\n:userId.\n\nThe viewer is derived SERVER-SIDE from the auth token (never a client-supplied\nparam) via `resolveViewerId`, the same dual-auth viewer resolution the\nrecommendation surfaces use. OPTIONAL semantics — the request is never\nrejected: an anonymous caller (or a service token with no user context) has no\n\"you follow\" set, so the response is an empty page; a self-target\n(`:userId === viewer`) is likewise empty. The empty/self guards live in the\nservice so the route stays thin.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
+      }
+    },
     "/users/{userId}/privacy": {
       "put": {
         "tags": [
@@ -17142,13 +18262,13 @@
         }
       }
     },
-    "/users/search": {
+    "/wallet/purchase": {
       "post": {
         "tags": [
-          "Users"
+          "Wallet"
         ],
-        "summary": "Search for users by username or name",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
+        "summary": "POST /wallet/purchase",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/wallet.routes.ts` to fill in summary, description, request/response examples.",
         "parameters": [],
         "responses": {
           "200": {
@@ -17185,85 +18305,32 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "query": {
-                    "type": "string",
-                    "minLength": 1
-                  }
-                },
-                "required": [
-                  "query"
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
-    "/users/verify/request": {
-      "post": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Request account verification",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "reason": {
+                  "userId": {
                     "type": "string",
                     "minLength": 1
                   },
-                  "evidence": {
+                  "amount": {
+                    "type": "number",
+                    "minimum": 0,
+                    "exclusiveMinimum": true
+                  },
+                  "itemId": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "itemType": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "description": {
                     "type": "string"
                   }
                 },
                 "required": [
-                  "reason"
+                  "userId",
+                  "amount",
+                  "itemId",
+                  "itemType"
                 ]
               }
             }
@@ -17271,222 +18338,16 @@
         }
       }
     },
-    "/users/me/data": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Download account data export",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "format",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "json",
-                "csv"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ]
-      }
-    },
-    "/users/me/export": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "Signed, open-format self-sovereign data export (\"credible exit\"). Returns the",
-        "description": "`ExportBundle` (DID document, profile, verified domains, auth methods, signed\nrecords, app data, social graph) sealed with an Oxy provenance attestation.\n`?format=ndjson` streams each section as newline-delimited JSON for large\naccounts.",
-        "parameters": [
-          {
-            "name": "format",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "enum": [
-                "json",
-                "ndjson"
-              ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "429": {
-            "description": "Rate limit exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "serviceTokenAuth": []
-          }
-        ]
-      }
-    },
-    "/users/resolve": {
-      "put": {
-        "tags": [
-          "Users"
-        ],
-        "summary": "PUT /users/resolve",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/users.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient privileges",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "serviceTokenAuth": []
-          }
-        ]
-      }
-    },
-    "/wallet/{userId}": {
+    "/wallet/transaction/{transactionId}": {
       "get": {
         "tags": [
           "Wallet"
         ],
-        "summary": "GET /wallet/{userId}",
+        "summary": "GET /wallet/transaction/{transactionId}",
         "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/wallet.routes.ts` to fill in summary, description, request/response examples.",
         "parameters": [
           {
-            "name": "userId",
+            "name": "transactionId",
             "in": "path",
             "required": true,
             "schema": {
@@ -17545,64 +18406,6 @@
         "parameters": [
           {
             "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "minLength": 1
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Resource not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ]
-      }
-    },
-    "/wallet/transaction/{transactionId}": {
-      "get": {
-        "tags": [
-          "Wallet"
-        ],
-        "summary": "GET /wallet/transaction/{transactionId}",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/wallet.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [
-          {
-            "name": "transactionId",
             "in": "path",
             "required": true,
             "schema": {
@@ -17722,82 +18525,6 @@
         }
       }
     },
-    "/wallet/purchase": {
-      "post": {
-        "tags": [
-          "Wallet"
-        ],
-        "summary": "POST /wallet/purchase",
-        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/wallet.routes.ts` to fill in summary, description, request/response examples.",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "Success"
-          },
-          "400": {
-            "description": "Validation failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
-          "5XX": {
-            "description": "Server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {}
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "userId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "amount": {
-                    "type": "number",
-                    "minimum": 0,
-                    "exclusiveMinimum": true
-                  },
-                  "itemId": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "itemType": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "description": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "userId",
-                  "amount",
-                  "itemId",
-                  "itemType"
-                ]
-              }
-            }
-          }
-        }
-      }
-    },
     "/wallet/withdraw": {
       "post": {
         "tags": [
@@ -17864,6 +18591,64 @@
             }
           }
         }
+      }
+    },
+    "/wallet/{userId}": {
+      "get": {
+        "tags": [
+          "Wallet"
+        ],
+        "summary": "GET /wallet/{userId}",
+        "description": "No long-form description. Add a JSDoc block (or `@openapi` block) above this route in `src/routes/wallet.routes.ts` to fill in summary, description, request/response examples.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Validation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {}
+        ]
       }
     }
   },

--- a/packages/api/scripts/generate-openapi.ts
+++ b/packages/api/scripts/generate-openapi.ts
@@ -69,6 +69,22 @@ interface OpenApiDocument {
 // (`module: NodeNext`, no `"type": "module"`), where `import.meta` is a type
 // error. Bun populates `__dirname` identically when running this file.
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
+/**
+ * Schema modules that could not be imported.
+ *
+ * This exists because the generator used to log an import failure and CARRY ON,
+ * emitting a document with those schemas silently missing and exiting 0. That is
+ * the worst possible shape for a tool that writes a PUBLISHED contract: the
+ * output looks complete, nothing about the run says otherwise, and the drift is
+ * discovered later by whoever trusted it. Measured before this change —
+ * `@oxyhq/contracts` and `@oxyhq/db` unbuilt dropped `components.schemas` from
+ * 7 to 4, and the run still reported success.
+ *
+ * A generator that quietly emits a partial contract is worse than the drift it
+ * causes, so the run now refuses to write at all.
+ */
+const schemaImportFailures: Array<{ filename: string; error: unknown }> = [];
+
 const BASE_YAML = path.join(PACKAGE_ROOT, 'openapi.base.yaml');
 const OUTPUT_JSON = path.join(PACKAGE_ROOT, 'openapi.json');
 const ROUTES_DIR = path.join(PACKAGE_ROOT, 'src', 'routes');
@@ -80,7 +96,7 @@ const SCHEMAS_DIR = path.join(PACKAGE_ROOT, 'src', 'schemas');
  * conservative subset (scalars, lists, nested maps, single-line block strings).
  * We avoid a runtime dep so the build doesn't grow.
  */
-function parseYaml(input: string): OpenApiDocument {
+export function parseYaml(input: string): OpenApiDocument {
   const lines = input.split(/\r?\n/);
   let i = 0;
 
@@ -104,9 +120,30 @@ function parseYaml(input: string): OpenApiDocument {
       const key = line.slice(0, colonIdx).trim();
       const rest = line.slice(colonIdx + 1).trim();
       i += 1;
-      if (rest === '' || rest === '>' || rest === '|') {
+      // A block-scalar header, with its optional chomping indicator: `>`, `>-`,
+      // `>+`, `|`, `|-`, `|+`.
+      //
+      // `>-` used to fall through to `parseScalar`, which returned the literal
+      // string ">-" and then read the indented body as further KEYS — silently
+      // dropping every sibling schema after it. Measured: `components.schemas`
+      // went 7 -> 4 and `User.id.description` came back as ">-", and none of it
+      // surfaced until a regeneration was compared against the committed
+      // document. A parser that mis-reads standard YAML into plausible-looking
+      // garbage is the same failure as the generator writing a partial document,
+      // one layer down, so the unrecognised case now THROWS rather than guessing.
+      const blockHeader = /^([>|])([-+]?)$/.exec(rest);
+      if (!blockHeader && (rest.startsWith('>') || rest.startsWith('|'))) {
+        throw new Error(
+          `openapi.base.yaml: unsupported block scalar header "${rest}" for key "${key}". `
+          + 'This minimal parser understands >, >-, >+, |, |- and |+ only — an explicit '
+          + 'indentation indicator (e.g. ">2") is not supported. Rewrite the value or extend '
+          + 'parseYaml; do NOT leave it, because the fallback would read the header as a '
+          + 'string and silently swallow the keys that follow.',
+        );
+      }
+      if (rest === '' || blockHeader) {
         // Possibly a folded/block scalar.
-        if (rest === '>' || rest === '|') {
+        if (blockHeader) {
           const lines2: string[] = [];
           const childIndent = indent + 2;
           while (i < lines.length) {
@@ -125,7 +162,16 @@ function parseYaml(input: string): OpenApiDocument {
             lines2.push(ln.slice(childIndent));
             i += 1;
           }
-          obj[key] = rest === '>' ? lines2.join(' ').trim() : lines2.join('\n');
+          // Folded (`>`) joins with spaces, literal (`|`) keeps newlines. The
+          // folded branch keeps its existing `.trim()` so every description
+          // already in this file renders byte-identically; `-` (strip) on the
+          // literal branch removes the trailing newlines it would otherwise
+          // keep. `+` (keep) is accepted and treated as the default, which is
+          // exact for folded and near enough for literal — no value in this
+          // document relies on trailing blank lines.
+          obj[key] = blockHeader[1] === '>'
+            ? lines2.join(' ').trim()
+            : (blockHeader[2] === '-' ? lines2.join('\n').replace(/\n+$/, '') : lines2.join('\n'));
           continue;
         }
         // Either nested object or list follows.
@@ -350,7 +396,11 @@ async function loadSchemaModule(filename: string): Promise<Record<string, ZodTyp
     const mod = await import(full);
     return mod as Record<string, ZodTypeAny>;
   } catch (err) {
-    console.error(`[generate-openapi] failed to import ${filename}:`, err);
+    // Recorded rather than swallowed. Continuing past a failed import is
+    // deliberate — one run should name EVERY unimportable module rather than
+    // stopping at the first — but the run must not then write a document, and
+    // `schemaImportFailures` is what makes that impossible to forget.
+    schemaImportFailures.push({ filename, error: err });
     return {};
   }
 }
@@ -929,16 +979,59 @@ async function main(): Promise<void> {
     seen.add(key);
   }
 
+  // Paths sorted, so the output is DETERMINISTIC. They were previously emitted
+  // in route-walk order, which depends on directory listing and on where each
+  // handler sits in its file — so an unrelated edit reshuffled the document and
+  // produced a diff in the tens of thousands of lines with a few hundred lines
+  // of actual change inside it. Measured on the regeneration this commit ships:
+  // 15,403 textual diff lines against 803 semantic ones.
+  //
+  // That is not cosmetic. An unreviewable diff is precisely how contract drift
+  // accumulates unnoticed — nobody reads 15,000 lines to find the nine routes
+  // that appeared, so nobody notices the description that silently went wrong.
+  const sortedPaths: typeof documented = {};
+  for (const route of Object.keys(documented).sort()) {
+    sortedPaths[route] = documented[route] as (typeof documented)[string];
+  }
+
   const merged: OpenApiDocument = {
     openapi: baseDoc.openapi ?? '3.1.0',
     info: baseDoc.info,
     servers: baseDoc.servers ?? [],
     components: { ...(baseDoc.components ?? {}), ...(jsdocSpec.components ?? {}) },
-    paths: documented,
+    paths: sortedPaths,
     tags: baseDoc.tags ?? [],
   };
 
   if (baseDoc.security) merged.security = baseDoc.security;
+
+  // REFUSE TO WRITE on a partial read. Everything above this point succeeded,
+  // which is exactly why it has to be checked here: the merged document looks
+  // perfectly well-formed and is simply missing whatever those modules export.
+  if (schemaImportFailures.length > 0) {
+    console.error(
+      `\n[generate-openapi] REFUSING TO WRITE: ${schemaImportFailures.length} schema module(s) `
+      + 'could not be imported, so the document would be missing their schemas.\n',
+    );
+    for (const { filename, error } of schemaImportFailures) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error(`  ${filename}\n    ${detail.split('\n')[0]}\n`);
+    }
+    console.error(
+      '  The usual cause is unbuilt workspace dependencies — these modules import\n'
+      + '  `@oxyhq/contracts` and `@oxyhq/db`, which resolve through their build output.\n'
+      + '  Build them first, from the repository root (this is the same sequence\n'
+      + '  `ci.yml` runs before the api tests, for the same reason):\n\n'
+      + '      bun run --filter @oxyhq/contracts build\n'
+      + '      bun run --filter @oxyhq/protocol build\n'
+      + '      bun run --filter @oxyhq/core build\n'
+      + '      bun run --filter @oxyhq/db build\n\n'
+      + `  ${OUTPUT_JSON} is UNCHANGED. The previous document is still the committed\n`
+      + '  contract, which is the correct outcome: a stale document is recoverable,\n'
+      + '  a silently truncated one that ships to consumers is not.\n',
+    );
+    process.exit(1);
+  }
 
   await writeFile(OUTPUT_JSON, JSON.stringify(merged, null, 2));
   const totalOps = Object.values(merged.paths).reduce(
@@ -950,7 +1043,11 @@ async function main(): Promise<void> {
   );
 }
 
-main().catch((err) => {
-  console.error('[generate-openapi] fatal:', err);
-  process.exit(1);
-});
+// Guarded so the parser can be imported by a test without running a generation.
+// Bun/CommonJS: `require.main` is this module only when it was the entrypoint.
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[generate-openapi] fatal:', err);
+    process.exit(1);
+  });
+}

--- a/packages/api/src/__tests__/openapiBaseYaml.test.ts
+++ b/packages/api/src/__tests__/openapiBaseYaml.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { parseYaml } from '../../scripts/generate-openapi';
+
+/**
+ * The base document is parsed by a hand-rolled YAML reader, deliberately, to
+ * keep the generator dependency-free. That trade is only safe if the reader
+ * REFUSES what it cannot represent — its previous failure mode was to read an
+ * unrecognised block-scalar header as a plain string and then treat the
+ * indented body as further keys, silently dropping every sibling that followed.
+ *
+ * Measured when `>-` was introduced: `components.schemas` came back with 4 of
+ * its 7 entries and `User.id.description` was the literal string ">-", and
+ * nothing failed. The published contract was written from that.
+ */
+describe('openapi.base.yaml parses completely', () => {
+  const base = parseYaml(
+    readFileSync(path.resolve(__dirname, '../../openapi.base.yaml'), 'utf8'),
+  );
+
+  it('reads every component schema, not a prefix of them', () => {
+    // A floor, not an exact count: the point is that a mis-parse truncates the
+    // map, and a truncation deep enough to matter drops below this.
+    expect(Object.keys(base.components.schemas ?? {}).length).toBeGreaterThanOrEqual(7);
+    expect(Object.keys(base.components.schemas ?? {})).toEqual(
+      expect.arrayContaining(['User', 'Session', 'Device', 'AuthSuccess']),
+    );
+  });
+
+  it('folds a `>-` block scalar into text rather than the header string', () => {
+    const id = (base.components.schemas?.User as Record<string, Record<string, Record<string, unknown>>>)
+      ?.properties?.id;
+    expect(id?.description).not.toBe('>-');
+    expect(String(id?.description)).toContain('Stable Oxy user ID');
+    // The sibling keys that a mis-parse swallows.
+    expect(id?.pattern).toEqual(expect.any(String));
+    expect(id?.examples).toEqual(expect.any(Array));
+  });
+
+  it('THROWS on a block-scalar header it cannot represent, rather than guessing', () => {
+    expect(() => parseYaml('components:\n  description: >2\n    indented\n')).toThrow(
+      /unsupported block scalar header/,
+    );
+  });
+
+  // `|` CLIPS — it keeps exactly one trailing newline — while `|-` STRIPS it.
+  // That difference is the whole reason the chomping indicator has to be read
+  // rather than ignored, and asserting it here is what stops a future
+  // "simplification" from collapsing the two back into one branch.
+  it.each([
+    ['>', 'one two'],
+    ['>-', 'one two'],
+    ['|', 'one\ntwo\n'],
+    ['|-', 'one\ntwo'],
+  ])('supports the %s header', (header, expected) => {
+    const parsed = parseYaml(`root:\n  text: ${header}\n    one\n    two\n`) as unknown as {
+      root: { text: string };
+    };
+    expect(parsed.root.text).toBe(expected);
+  });
+});


### PR DESCRIPTION
Three silent failures, stacked, and the published document was written from all of them.

### 1. A schema module that failed to import was logged and skipped

The run emitted a document with those schemas missing and **exited 0**. Measured: `@oxyhq/contracts` and `@oxyhq/db` unbuilt takes `components.schemas` from **7 to 4**, and the run reports success.

A generator that quietly emits a partial *published* contract is worse than the drift it causes. Failures are now collected — one run names every unimportable module — and the generator **refuses to write**, leaving the previous document in place. A stale contract is recoverable; a silently truncated one that ships to consumers is not. The message names the exact build commands, which are the ones `ci.yml` already runs and which I ran to confirm they work.

### 2. The hand-rolled YAML reader mis-parsed `>-` into plausible garbage — and this one is mine

#892 introduced the first `>-` in this file. The reader tested for exactly `>` or `|`, so `>-` became the literal string `">-"`, and the indented body was then read as further **keys** — swallowing every sibling schema after it. `User.id.description` came back as `">-"` with its `pattern` and `examples` gone.

It now reads the chomping indicator (`>`, `>-`, `>+`, `|`, `|-`, `|+`) and **throws** on anything else rather than guessing — the same rule as (1), one layer down. Folded output is byte-identical, so no existing description moves.

### 3. Paths were emitted in route-walk order

Which depends on directory listing and where each handler sits in its file, so an unrelated edit reshuffled the document. This regeneration is **15,403 textual diff lines around 803 semantic ones**.

Not cosmetic: nobody reads 15,000 lines to find the nine routes that appeared, so nobody notices the description that went wrong. Paths are now sorted — this is the last reshuffle.

### What the regeneration actually contains

268 → 277 paths, 8 existing paths corrected. The one worth naming is **`/session/device/token`**, whose published description still said the device secret **rotates** on every mint — the code returns a stable secret so concurrent origins don't invalidate each other. A materially wrong statement about an auth endpoint, in the document consumers generate clients from.

`openapi.base.yaml` is untouched. Every `openapi.json` change comes from the generator reading sources already on `main`. Confirm the semantic diff independently:

```bash
diff <(git show origin/main:packages/api/openapi.json | jq -S .) \
     <(jq -S . packages/api/openapi.json)
```

### Tests

`src/__tests__/openapiBaseYaml.test.ts` pins the schema-count floor, the `>-` fold, the refusal, and each header's chomping — `|` clips one trailing newline where `|-` strips it, which is *why* the indicator must be read rather than ignored.

**Mutation-verified:** reverting the parser to bare `>`/`|` fails **5 of 7** cases; restored, 7 of 7. `parseYaml` is exported and the entrypoint guarded on `require.main`, so importing it runs no generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)