### PR TITLE
chore(api): delete monitorDatabaseQuery, which nothing calls

### DIFF
--- a/packages/api/src/middleware/performance.ts
+++ b/packages/api/src/middleware/performance.ts
@@ -37,33 +37,6 @@ export const performanceMiddleware = (req: Request, res: Response, next: NextFun
 };
 
 /**
- * Times any promise-returning function under a `db:<operation>` label.
- *
- * Not middleware, and nothing to do with mongoose despite what this said until
- * the Postgres cutover was tidied up: it takes an arbitrary `queryFn`, so it
- * works for a drizzle query, a raw `postgres.js` call or anything else that
- * returns a promise. The label is whatever the caller passes.
- *
- * A rejection is timed as `success: false` and RETHROWN, so wrapping a call
- * changes its timing metadata and never its outcome.
- */
-export const monitorDatabaseQuery = async <T>(
-  operation: string,
-  queryFn: () => Promise<T>
-): Promise<T> => {
-  const endTimer = performanceMonitor.startTimer(`db:${operation}`);
-  
-  try {
-    const result = await queryFn();
-    endTimer({ success: true });
-    return result;
-  } catch (error) {
-    endTimer({ success: false, error: error instanceof Error ? error.message : String(error) });
-    throw error;
-  }
-};
-
-/**
  * Get memory usage statistics
  */
 export const getMemoryStats = () => {


### PR DESCRIPTION
**Zero callers repo-wide** — the only occurrence was its own definition, confirmed against current `main` with a positive control (its neighbour `getMemoryStats` is found in `server.ts`, so the search does locate callers).

### Deleting rather than wiring, deliberately

Wiring it would mean choosing which queries to instrument and accepting the overhead — a design decision about the metrics path, not something to make as a side effect of tidying. Meanwhile an exported timer nobody calls is an invitation to *"just use this"* without anyone deciding instrumentation was wanted.

**Nothing is lost.** It was a five-line wrapper over `performanceMonitor.startTimer`, which stays and is still used by `performanceMiddleware` in the same file. Anyone wanting query timing calls it directly, or reintroduces a wrapper as part of a change that has callers.

### Why it survived this long

Until #893 its docblock described it as *"Database query monitoring middleware / Wraps mongoose queries"* — so it read as **dead Mongo code that would break something if touched**, and got left alone by everyone who saw it. Once the comment was corrected to what it actually does (time any promise), there was nothing left to justify keeping it.

A wrong comment kept dead code alive. That's the same failure mode as the rest of this batch, pointing the other way.

`tsc --noEmit` clean with workspace deps built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)