### PR TITLE
fix(app-preset): require OTA code signing by default

### DIFF
--- a/packages/app-preset/README.md
+++ b/packages/app-preset/README.md
@@ -103,7 +103,7 @@ prebuild applies its config plugin automatically.
 | `clientId` | required | The registered `ApplicationCredential` publicKey |
 | `apiOrigin` | `https://api.oxy.so` | Origin serving `/updates/v1` |
 | `channel` | `production` | Release channel this binary polls |
-| `codeSigning` | `auto` | `require` to fail the build when the certificate is missing; `false` to skip signing |
+| `codeSigning` | `require` | Fails when the certificate is missing; `auto` warns and `false` skips signing (development only) |
 | `certificatePath` | bundled certificate | Only for a key-rotation overlap |
 | `runtimeVersionPolicy` | `appVersion` | `false` leaves whatever the app declared |
 
@@ -120,12 +120,11 @@ receive JS assuming native modules they do not have.
 **Code signing is one certificate for the whole ecosystem**, shipped in this
 package at `certs/oxy-updates-code-signing.pem` rather than copied into each app
 repo, so a rotation is one preset bump. See `certs/README.md` for how it is
-generated and rotated. Until that file exists, `withOxyUpdates` wires the update
-URL but not signature verification and warns on both platforms; because the
-certificate is baked into the native build, a binary shipped in that state can
-never verify a manifest for its lifetime, so **do not ship a store build of an
-OTA-enabled app before the certificate is committed.** Pass
-`{ codeSigning: 'require' }` to make that a build failure instead of a warning.
+generated and rotated. Until that file exists, `withOxyUpdates` fails the build
+by default rather than producing a binary that accepts unsigned manifests for
+its whole lifetime. Development builds may explicitly pass
+`{ codeSigning: 'auto' }` to receive platform warnings, or
+`{ codeSigning: false }` to opt out of verification.
 
 Publishing is `oxy-ship` (`@oxyhq/ship`); see that package's README and its
 `templates/publish-update.yml` CI workflow.

--- a/packages/app-preset/__tests__/withOxyUpdates.test.js
+++ b/packages/app-preset/__tests__/withOxyUpdates.test.js
@@ -26,6 +26,11 @@ function baseConfig(extra = {}) {
   return { name: 'Test', slug: 'test', _internal: { projectRoot: PROJECT_ROOT }, ...extra };
 }
 
+/** Options for tests whose behavior is unrelated to code signing. */
+function unsignedOptions(extra = {}) {
+  return { clientId: CLIENT_ID, codeSigning: false, ...extra };
+}
+
 /** Write a throwaway certificate file and hand its path to `fn`, always cleaning up. */
 function withTemporaryCertificate(fn) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'oxy-updates-cert-'));
@@ -44,7 +49,7 @@ test('rejects a missing or blank clientId', () => {
 });
 
 test('builds the manifest URL from the client id and the default origin', () => {
-  const config = withOxyUpdates(baseConfig(), { clientId: CLIENT_ID });
+  const config = withOxyUpdates(baseConfig(), unsignedOptions());
   assert.equal(
     config.updates.url,
     `https://api.oxy.so/updates/v1/apps/${CLIENT_ID}/manifest`,
@@ -52,10 +57,9 @@ test('builds the manifest URL from the client id and the default origin', () => 
 });
 
 test('honours an explicit apiOrigin and strips its trailing slashes', () => {
-  const config = withOxyUpdates(baseConfig(), {
-    clientId: CLIENT_ID,
+  const config = withOxyUpdates(baseConfig(), unsignedOptions({
     apiOrigin: 'http://localhost:3001//',
-  });
+  }));
   assert.equal(
     config.updates.url,
     `http://localhost:3001/updates/v1/apps/${CLIENT_ID}/manifest`,
@@ -65,7 +69,7 @@ test('honours an explicit apiOrigin and strips its trailing slashes', () => {
 test('sets the channel request header without dropping existing headers', () => {
   const config = withOxyUpdates(
     baseConfig({ updates: { requestHeaders: { 'x-existing': 'kept' } } }),
-    { clientId: CLIENT_ID, channel: 'pr-42' },
+    unsignedOptions({ channel: 'pr-42' }),
   );
   assert.deepEqual(config.updates.requestHeaders, {
     'x-existing': 'kept',
@@ -74,21 +78,19 @@ test('sets the channel request header without dropping existing headers', () => 
 });
 
 test('defaults the runtime version to the appVersion policy', () => {
-  const config = withOxyUpdates(baseConfig(), { clientId: CLIENT_ID });
+  const config = withOxyUpdates(baseConfig(), unsignedOptions());
   assert.deepEqual(config.runtimeVersion, { policy: 'appVersion' });
 });
 
 test('honours another runtime version policy, and leaves the app value alone when false', () => {
-  const fingerprint = withOxyUpdates(baseConfig(), {
-    clientId: CLIENT_ID,
+  const fingerprint = withOxyUpdates(baseConfig(), unsignedOptions({
     runtimeVersionPolicy: 'fingerprint',
-  });
+  }));
   assert.deepEqual(fingerprint.runtimeVersion, { policy: 'fingerprint' });
 
-  const untouched = withOxyUpdates(baseConfig({ runtimeVersion: '9.9.9' }), {
-    clientId: CLIENT_ID,
+  const untouched = withOxyUpdates(baseConfig({ runtimeVersion: '9.9.9' }), unsignedOptions({
     runtimeVersionPolicy: false,
-  });
+  }));
   assert.equal(untouched.runtimeVersion, '9.9.9');
 });
 
@@ -128,13 +130,12 @@ test('skips signing entirely when codeSigning is false, even with a certificate 
   });
 });
 
-test('throws when the certificate is absent and codeSigning is require', () => {
+test('requires code signing by default and throws when the certificate is absent', () => {
   assert.throws(
     () =>
       withOxyUpdates(baseConfig(), {
         clientId: CLIENT_ID,
         certificatePath: path.join(os.tmpdir(), 'oxy-updates-absent.pem'),
-        codeSigning: 'require',
       }),
     /code signing is required but the Oxy Updates certificate is missing/,
   );
@@ -144,6 +145,7 @@ test('wires the URL but no signing when the certificate is absent and codeSignin
   const config = withOxyUpdates(baseConfig(), {
     clientId: CLIENT_ID,
     certificatePath: path.join(os.tmpdir(), 'oxy-updates-absent.pem'),
+    codeSigning: 'auto',
   });
   assert.ok(config.updates.url.includes(CLIENT_ID));
   assert.equal(config.updates.codeSigningCertificate, undefined);

--- a/packages/app-preset/certs/README.md
+++ b/packages/app-preset/certs/README.md
@@ -10,9 +10,10 @@ It is the **public** half of the Oxy Updates code-signing keypair. It is safe to
 commit, and it lives here rather than in each app repo so that a key rotation is
 one `@oxyhq/app-preset` bump instead of one edit per app.
 
-The file is absent until the ecosystem keypair is generated. While it is absent
-`withOxyUpdates` still wires the update URL, but the resulting binaries do **not**
-verify manifest signatures, and it emits a build warning saying so.
+The file is absent until the ecosystem keypair is generated. While it is absent,
+`withOxyUpdates` fails closed by default so an OTA-enabled production binary cannot
+be built without manifest signature verification. Development builds can explicitly
+select `codeSigning: 'auto'` (warning) or `codeSigning: false` (no verification).
 
 ## Provisioning (one time, by the platform owner)
 

--- a/packages/app-preset/plugin/withOxyUpdates.js
+++ b/packages/app-preset/plugin/withOxyUpdates.js
@@ -92,7 +92,7 @@ module.exports = function withOxyUpdates(config, options = {}) {
     clientId,
     apiOrigin = DEFAULT_API_ORIGIN,
     channel = DEFAULT_CHANNEL,
-    codeSigning = 'auto',
+    codeSigning = 'require',
     certificatePath = CERTIFICATE_PATH,
     runtimeVersionPolicy = 'appVersion',
   } = options;


### PR DESCRIPTION
### Motivation
- Prevent production OTA-enabled binaries from being built in a fail-open state that accepts unsigned manifests.  
- The previous default (`codeSigning: 'auto'`) wired `updates.url` even when the bundled certificate was absent, leaving clients unable to request signed manifests and enabling unsigned JS delivery if the update path is tampered with.  
- Make secure behavior the default while still allowing explicit development-only opt-outs.

### Description
- Change the `withOxyUpdates` config plugin default from `codeSigning: 'auto'` to `codeSigning: 'require'` in `packages/app-preset/plugin/withOxyUpdates.js` so builds fail when the certificate is missing.  
- Update tests in `packages/app-preset/__tests__/withOxyUpdates.test.js` to assert the new secure default and add a helper `unsignedOptions` for tests that intentionally exercise unsigned behavior.  
- Clarify the preset and certs documentation in `packages/app-preset/README.md` and `packages/app-preset/certs/README.md` to state the secure default and describe explicit development modes (`auto` for warnings, `false` to opt out).  
- Preserve explicit `codeSigning: 'auto'` and `codeSigning: false` modes for development/testing scenarios.

### Testing
- Attempted `bun run --cwd packages/app-preset test` initially failed due to a missing peer `expo/config-plugins` in the environment, which is expected in a minimal environment.  
- Ran the package tests with a temporary minimal `expo/config-plugins` stub via `NODE_PATH` and `bun run --cwd packages/app-preset test`, and all tests in `packages/app-preset` passed (11/11).  
- Ran `git diff --check` to validate whitespace/patch hygiene with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73febf1b6c83238cd3dd5ea802d731)