### PR TITLE
Require application administrators for follow registry writes

### DIFF
--- a/packages/api/src/routes/__tests__/followsV2.test.ts
+++ b/packages/api/src/routes/__tests__/followsV2.test.ts
@@ -93,12 +93,20 @@ async function request(
 }
 
 /** Mint a user, an application, an authorization and a grant with these scopes. */
-async function signIn(scopes: string[]): Promise<{ userId: string; applicationId: string }> {
+async function signIn(
+  scopes: string[],
+  options: { ownedByUser?: boolean } = {}
+): Promise<{ userId: string; applicationId: string }> {
   const db = getDb();
   const [user] = await db.insert(users).values({}).returning({ id: users.id });
+  let ownerId = user.id;
+  if (options.ownedByUser === false) {
+    const [owner] = await db.insert(users).values({}).returning({ id: users.id });
+    ownerId = owner.id;
+  }
   const [app] = await db
     .insert(applications)
-    .values({ name: unique('App '), status: 'active', ownerAccountId: user.id })
+    .values({ name: unique('App '), status: 'active', ownerAccountId: ownerId })
     .returning({ id: applications.id });
 
   const sessionId = unique('session-');
@@ -360,6 +368,17 @@ describe('the central list', () => {
 });
 
 describe('the registry, over the wire', () => {
+  it('does not treat a user OAuth grant as application administration', async () => {
+    await signIn(ALL_SCOPES, { ownedByUser: false });
+
+    const res = await request('POST', '/v2/follow-targets/namespaces', {
+      namespace: unique('unowned'),
+    });
+
+    expect(res.status).toBe(403);
+    expect(String(res.body.message ?? res.body.error)).toMatch(/owner or administrator/i);
+  });
+
   it('refuses a namespace another application already holds, as a conflict', async () => {
     await signIn(ALL_SCOPES);
     const ns = unique('rt');

--- a/packages/api/src/routes/followRegistry.v2.routes.ts
+++ b/packages/api/src/routes/followRegistry.v2.routes.ts
@@ -12,7 +12,11 @@
  */
 
 import express, { type Response } from 'express';
+import { eq } from 'drizzle-orm';
+import { getDb } from '../config/postgres';
+import { applications } from '../db/schema';
 import { authMiddleware, type AuthRequest } from '../middleware/auth';
+import { accountService } from '../services/account.service';
 import {
   assertFollowScopes,
   missingFollowScope,
@@ -57,6 +61,23 @@ async function requireRegistrar(req: AuthRequest): Promise<FollowCapability> {
 
   const missing = missingFollowScope(result.capability, REGISTER);
   if (missing) throw new ForbiddenError(`Missing scope: ${missing}`);
+
+  // A user's OAuth grant delegates follow operations; it does not make that
+  // user an administrator of the application-global registry. Resolve the
+  // application's owning account independently and require an administrative
+  // role before treating the application id in the capability as write
+  // authority for namespaces, kinds, or provider metadata.
+  const [application] = await getDb()
+    .select({ ownerAccountId: applications.ownerAccountId })
+    .from(applications)
+    .where(eq(applications.id, result.capability.applicationId))
+    .limit(1);
+  const access = application
+    ? await accountService.resolveEffectiveAccess(userId, application.ownerAccountId)
+    : null;
+  if (!access || (access.role !== 'owner' && access.role !== 'admin')) {
+    throw new ForbiddenError('Application owner or administrator access is required');
+  }
 
   return result.capability;
 }


### PR DESCRIPTION
### Motivation
- The follow-registry routes treated a user-delegated `follow-targets:register` grant as sufficient authority to mutate application-global registry state, letting ordinary OAuth grantees claim namespaces and change kinds for an application they do not administer.
- The intent is to keep `follow-targets:register` as a necessary consent for follow-related operations while preventing user-scoped grants from becoming application-administration authority.

### Description
- Harden `requireRegistrar` in `packages/api/src/routes/followRegistry.v2.routes.ts` to, after verifying `follow-targets:register`, load the target application's `ownerAccountId` and require the caller to have `owner` or `admin` effective access via `accountService.resolveEffectiveAccess` before permitting registry writes.
- Add imports and a small DB lookup (`getDb()` + `applications.ownerAccountId`) to determine the owning account for the application referenced by the capability.
- Update the test helper `signIn` in `packages/api/src/routes/__tests__/followsV2.test.ts` to support creating an application not owned by the token-holder and add an HTTP regression test asserting a fully scoped but non-administrative user receives `403` when attempting to claim a namespace.

### Testing
- Ran `git diff --check` with no whitespace or trivial patch errors reported. 
- Added an automated Jest regression test in `packages/api/src/routes/__tests__/followsV2.test.ts`, but running `bun run test -- --runInBand src/routes/__tests__/followsV2.test.ts` could not be completed in this environment because repository dependencies (Jest/Bun toolchain) are not installed and `jest: command not found` was returned. The new test is present and ready to run in CI where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71652d05c483239b4c4c5dd354a88e)