### PR TITLE
fix(api): prevent WebFinger actor relabelling

### DIFF
--- a/packages/api/src/services/__tests__/federation.service.test.ts
+++ b/packages/api/src/services/__tests__/federation.service.test.ts
@@ -538,35 +538,34 @@ describe('FederationService.resolveAndUpsert (fast + eventually-fresh)', () => {
     expect(result?.avatar).toBe('new-file-id');
   });
 
-  it('upserts onto the EXISTING row when the actor URI is already known', async () => {
-    const fx = nextFixture();
-    // Seeded under a DIFFERENT username/domain, so the cached-user lookup
-    // misses and the insert path is taken — it must then collide on
-    // `users_federation_actor_uri_key` and update rather than duplicate.
-    const userId = await seedFederatedUser(fx, STALE_AGE_MS, {
-      username: `stale-${actorCounter}@elsewhere.example`,
-      federationDomain: 'elsewhere.example',
-    });
+  it('does not let a WebFinger alias relabel an existing actor URI', async () => {
+    const victim = nextFixture('victim.example');
+    const attackerHandle = `attacker${actorCounter}@evil.example`;
+    const userId = await seedFederatedUser(victim, STALE_AGE_MS);
 
-    webfingerSpy.mockResolvedValue({ actorUri: fx.actorUri, subjectAcct: fx.handle });
+    // The attacker's server points its self link at an already-cached victim.
+    webfingerSpy.mockResolvedValue({
+      actorUri: victim.actorUri,
+      subjectAcct: attackerHandle,
+    });
     actorSpy.mockResolvedValue({
-      actorUri: fx.actorUri,
-      domain: fx.domain,
-      username: fx.handle,
-      displayName: 'Alice Moved',
+      actorUri: victim.actorUri,
+      domain: 'evil.example',
+      username: attackerHandle,
+      displayName: 'Attacker',
       avatarUrl: undefined,
       bio: undefined,
     });
 
-    const result = await federationService.resolveAndUpsert(fx.handle);
+    const result = await federationService.resolveAndUpsert(attackerHandle);
 
-    // One row, updated — never a second row for the same actor.
     expect(result?._id).toBe(userId);
-    expect(await storedByActorUri(fx.actorUri)).toMatchObject({
+    expect(result?.username).toBe(victim.handle);
+    expect(actorSpy).not.toHaveBeenCalled();
+    expect(await storedByActorUri(victim.actorUri)).toMatchObject({
       id: userId,
-      username: fx.handle,
-      domain: fx.domain,
-      nameFirst: 'Alice Moved',
+      username: victim.handle,
+      domain: victim.domain,
     });
   });
 

--- a/packages/api/src/services/federation.service.ts
+++ b/packages/api/src/services/federation.service.ts
@@ -22,7 +22,6 @@ import userCache from '../utils/userCache';
 import { composeDisplayName } from '../utils/displayName';
 import { cleanDisplayName } from '../utils/displayNameSanitize';
 import { sanitizePlainText, decodeHtmlEntities } from '../utils/sanitize';
-import { bridgeVouchesForNetwork } from '../config/federationBridgeTrust';
 
 /** The `users.kind` closed value set, derived from the column itself. */
 type AccountKind = (typeof ACCOUNT_KINDS)[number];
@@ -1228,28 +1227,13 @@ class FederationService {
       ? await userService.readAccountDocument(existingByActorUriRow.id)
       : null;
 
+    // The actor URI is the stable identity key. Never let a different
+    // WebFinger resource relabel an existing actor: a malicious domain can
+    // point its self link at any known actor URI, while the upsert below keys on
+    // that URI and would otherwise overwrite the victim's username/domain.
+    // This also preserves intentionally relabelled bridge identities.
     if (existingByActorUri) {
-      const storedDomain = existingByActorUri.federation?.domain;
-      let actorHost: string | null = null;
-      try {
-        actorHost = canonicalFederationHost(new URL(webfinger.actorUri).hostname);
-      } catch {
-        actorHost = null;
-      }
-
-      // A relabelled bridge identity (e.g. `nasa@x.com` on a bird.makeup actor)
-      // shares the bridge actor URI but not the bridge handle. Returning cached
-      // here preserves the derived identity; falling through would clobber it
-      // back to the bridge copy. A stale row on a NON-bridge actor (wrong domain
-      // stored beside a canonical actor URI) must fall through to the upsert.
-      if (
-        actorHost
-        && typeof storedDomain === 'string'
-        && storedDomain.length > 0
-        && bridgeVouchesForNetwork(actorHost, storedDomain)
-      ) {
-        return this.returnCachedFederatedRow(existingByActorUri, cleaned);
-      }
+      return this.returnCachedFederatedRow(existingByActorUri, cleaned);
     }
 
     const verifiedAcct = await this.verifiedAccountForResolution(cleaned, webfinger);


### PR DESCRIPTION
### Motivation

- Prevent a high-impact integrity vulnerability where an attacker-controlled WebFinger resource could point its self-link at an already-cached actor URI and cause the upsert path to overwrite that actor's stored username and federation domain.

### Description

- Treat an existing `federationActorUri` as the stable identity key and immediately return the cached federated row instead of falling through to the fetch/upsert path in `packages/api/src/services/federation.service.ts`.
- Remove the previous conditional that allowed non-bridge actor rows to be re-attributed via WebFinger and preserve intentionally relabelled bridge identities by returning the cached row unconditionally when present.
- Replace the prior upsert-focused test with a regression test in `packages/api/src/services/__tests__/federation.service.test.ts` that simulates a malicious WebFinger alias targeting an existing actor and asserts the cached victim remains unchanged and the attacker profile is not fetched.
- Files changed: `packages/api/src/services/federation.service.ts` and `packages/api/src/services/__tests__/federation.service.test.ts`.

### Testing

- Ran `git diff --check`, which reported no whitespace/patch problems and completed successfully.
- Attempted `bun run test --runTestsByPath src/services/__tests__/federation.service.test.ts --runInBand`, but the test run failed in this environment because `jest` is not available (repository dependencies are not installed), so the unit test could not be executed here.
- The change is covered by the new regression test added to `packages/api/src/services/__tests__/federation.service.test.ts`, which should be executed in CI or a developer environment with dependencies installed to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a713ce545308323834df874bc85d0d5)