### PR TITLE
Prevent role-based permission escalation in account member management

### DIFF
--- a/packages/api/src/routes/__tests__/accountsMemberPermissions.test.ts
+++ b/packages/api/src/routes/__tests__/accountsMemberPermissions.test.ts
@@ -156,6 +156,43 @@ function patchMember(
   });
 }
 
+function inviteMember(
+  accountId: string,
+  payload: Record<string, unknown>
+): Promise<JsonResponse> {
+  const address = server.address() as AddressInfo;
+  const body = JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: address.port,
+        path: `/accounts/${accountId}/members`,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+          Authorization: 'Bearer user-token',
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: raw ? (JSON.parse(raw) as JsonResponse['body']) : {},
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
 async function rowById(memberId: string) {
   const [row] = await getDb()
     .select()
@@ -267,6 +304,37 @@ describe('per-member permission editing', () => {
 
     expect(res.status).toBe(403);
     expect((await rowById(targetMemberId)).permissionGrants).toEqual([]);
+  });
+
+  test('a role change may not restore a permission revoked from the actor', async () => {
+    const { org, adminUserId, adminMemberId, targetMemberId } = await seedOrg();
+    await getDb()
+      .update(accountMembers)
+      .set({ permissionRevokes: ['credentials:create'] })
+      .where(eq(accountMembers.id, adminMemberId));
+    actingUserId = adminUserId;
+
+    const res = await patchMember(org, targetMemberId, { role: 'developer' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('credentials:create');
+    expect((await rowById(targetMemberId)).role).toBe('viewer');
+  });
+
+  test('an invite may not restore a permission revoked from the actor', async () => {
+    const { org, adminUserId, adminMemberId } = await seedOrg();
+    const invitee = uniqueUsername('invitee');
+    await getDb().insert(users).values({ color: 'teal', username: invitee, kind: 'personal' });
+    await getDb()
+      .update(accountMembers)
+      .set({ permissionRevokes: ['account:act_as'] })
+      .where(eq(accountMembers.id, adminMemberId));
+    actingUserId = adminUserId;
+
+    const res = await inviteMember(org, { usernameOrEmail: invitee, role: 'editor' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('account:act_as');
   });
 
   test('a grant BEYOND the actor is refused even when bundled with a legal one', async () => {
@@ -420,10 +488,10 @@ describe('per-member permission editing', () => {
     expect(permissionsForAccountRole('developer')).not.toContain('members:update');
     actingUserId = targetUserId;
 
-    const res = await patchMember(org, victimMemberId, { role: 'billing' });
+    const res = await patchMember(org, victimMemberId, { role: 'developer' });
 
     expect(res.status).toBe(200);
-    expect(res.body.member?.role).toBe('billing');
+    expect(res.body.member?.role).toBe('developer');
   });
 
   test('an INHERITED actor is bound by the same rules as a direct one', async () => {

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -42,6 +42,7 @@ import { stripSensitiveUrlQueryParams } from '../utils/sanitizeUrl';
 import { formatUserResponse } from '../utils/userTransform';
 import {
   effectivePermissionsForMember,
+  resolveEffectivePermissions,
   type AccountPermission,
   type AccountRole,
 } from '../utils/accountRoles';
@@ -69,6 +70,21 @@ import {
 interface AccountContextRequest extends AuthRequest {
   account?: AccountRow;
   access?: EffectiveAccess;
+}
+
+/** Refuse any permission conferral outside the actor's effective permission set. */
+function requireConferredPermissions(
+  actorPermissions: readonly AccountPermission[],
+  conferredPermissions: readonly AccountPermission[]
+): void {
+  const beyondActor = [...new Set(conferredPermissions)].filter(
+    (permission) => !actorPermissions.includes(permission)
+  );
+  if (beyondActor.length > 0) {
+    throw new ForbiddenError(
+      `You cannot grant permissions you do not hold: ${beyondActor.join(', ')}`
+    );
+  }
 }
 
 const router = express.Router();
@@ -991,7 +1007,8 @@ router.post(
   requireAccountPermission('members:invite'),
   asyncHandler(async (req: AccountContextRequest, res) => {
     const account = req.account;
-    if (!account) {
+    const access = req.access;
+    if (!account || !access) {
       throw new NotFoundError('Account not found');
     }
     const { usernameOrEmail, role, inherit } = req.body as {
@@ -999,6 +1016,14 @@ router.post(
       role: Exclude<AccountRole, 'owner'>;
       inherit?: boolean;
     };
+
+    // A role is itself a bundle of grants. Checking only `members:invite`
+    // would let a narrowed admin restore one of their revoked permissions on a
+    // confederate by choosing a role whose baseline contains it.
+    requireConferredPermissions(
+      access.permissions,
+      resolveEffectivePermissions(role, [], [])
+    );
 
     const targetUser = await resolveUserByIdentifier(usernameOrEmail);
     if (!targetUser) {
@@ -1084,17 +1109,23 @@ router.patch(
       throw new ForbiddenError('You cannot change your own membership');
     }
 
-    // Rule 1.
-    if (permissionGrants && permissionGrants.length > 0) {
-      const beyondActor = permissionGrants.filter(
-        (permission) => !access.permissions.includes(permission)
-      );
-      if (beyondActor.length > 0) {
-        throw new ForbiddenError(
-          `You cannot grant permissions you do not hold: ${beyondActor.join(', ')}`
-        );
-      }
-    }
+    // Rule 1. Role baselines are grants too. Compare the target's current and
+    // prospective effective sets so an actor may still revoke or otherwise
+    // edit a member who already holds a permission beyond the actor. Explicit
+    // grants remain checked even when a baseline currently makes them a no-op.
+    const currentPermissions = effectivePermissionsForMember(target);
+    const prospectivePermissions = resolveEffectivePermissions(
+      role ?? target.role,
+      permissionGrants ?? target.permissionGrants,
+      permissionRevokes ?? target.permissionRevokes
+    );
+    const newlyConferred = prospectivePermissions.filter(
+      (permission) => !currentPermissions.includes(permission)
+    );
+    requireConferredPermissions(access.permissions, [
+      ...newlyConferred,
+      ...(permissionGrants ?? []),
+    ]);
 
     const member = await accountService.updateMember(account.id, req.params.memberId, {
       ...(role !== undefined ? { role } : {}),


### PR DESCRIPTION
### Motivation

- Close a security hole where assigning a role (via invite or PATCH) could re-grant permissions that an actor had explicitly revoked.  
- Ensure per-member revokes are honored even when a role baseline includes the revoked permission.  

### Description

- Add a shared guard `requireConferredPermissions` that rejects any permission conferral outside the actor's effective permission set.  
- Validate role-baseline grants at the invite path (`POST /accounts/:id/members`) so an invited role cannot restore a permission the inviter has been revoked.  
- Harden the member update path (`PATCH /accounts/:id/members/:memberId`) to compute the target's current and prospective effective permissions (role baseline + grants - revokes) and block any newly-conferred permissions that the actor does not hold.  
- Add regression tests covering role-change and invite scenarios that previously allowed escalation, and a helper for exercising the invite path in tests.  

### Testing

- Ran static checks (`git diff --check` and repository diff inspection) which passed.  
- Attempted to run the package test suite for the affected tests (`bun run test -- --runInBand src/routes/__tests__/accountsMemberPermissions.test.ts` / `jest`), but test execution was blocked because installing project dependencies failed due to outbound registry access returning HTTP 403 in this environment.  
- Updated/added Jest tests exercising the invite and role-change cases; they should run green once dependencies are available and the test runner is executed in an environment with network access to the package registry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a711738b5bc8323b24d18a36ab3ff6b)