### PR TITLE
fix(auth): rotate device secret after token mint

### DIFF
--- a/docs/SESSION-ARCHITECTURE.md
+++ b/docs/SESSION-ARCHITECTURE.md
@@ -50,7 +50,7 @@ from the request body.
 
 | Method | Route | Body | Behavior |
 |--------|-------|------|----------|
-| POST | `/session/device/token` | `{ deviceId, deviceSecret }` | **The zero-cookie mint** — PUBLIC (no bearer, no cookies): possession of the secret is the device-ownership proof. Verifies `sha256(deviceSecret)` (constant-time) against the device's `secretHash`, mints a short access token for the active account, and returns the proven secret unchanged as `nextDeviceSecret`. Keeping the credential stable lets multiple official apps/origins sharing one device refresh concurrently. Per-device lockout + rate limit blunt online guessing. |
+| POST | `/session/device/token` | `{ deviceId, deviceSecret }` | **The zero-cookie mint** — PUBLIC (no bearer, no cookies): possession of the secret is the device-ownership proof. Verifies `sha256(deviceSecret)` (constant-time) against the device's `secretHash`, mints a short access token for the active account, and rotates the secret in-use (`nextDeviceSecret`; the presented secret stays valid for a short grace). Per-device lockout + rate limit blunt online guessing. |
 | GET | `/session/device/state` | — | Returns current state for the caller's JWT device. |
 | POST | `/session/device/add` | — | Registers the caller's account into the device set. Account + session ids come from the bearer (IDOR-safe); `operatedByUserId` is resolved from the session document. Idempotent — an unchanged re-register does not broadcast. |
 | POST | `/session/device/switch` | `{ accountId }` | Sets `activeAccountId`, bumps `revision`, broadcasts. If the target session was revoked, heals the device set (drops the dead account), broadcasts the healed state, and returns 403. |
@@ -79,9 +79,10 @@ The transport that carries "which device is this?" across reloads is **`deviceId
    nothing about any other device.
 2. **Mint** — to restore or refresh, the client POSTs `{ deviceId, deviceSecret }` to
    `POST /session/device/token` (no bearer, no cookies). The server verifies the secret
-   (constant-time) and returns a short access token for the active account plus the same
-   proven secret as `nextDeviceSecret`. The credential is intentionally stable: several
-   official apps/origins can share a `DeviceSession` without rotating one another out.
+   (constant-time) and returns a short access token for the active account plus a
+   rotated `nextDeviceSecret`. **Rotation-in-use:** the presented secret stays valid for
+   a short grace window (60s) so a multi-tab race is not locked out; the client persists
+   the next secret BEFORE planting the minted token.
 3. **Revocation** — sign-out-all (`POST /session/device/signout { all: true }`) clears
    `secretHash` so a retained secret can never mint again. A theft divergence is detected
    at the next mint (the loser's secret no longer matches → `invalid_device_secret`).

--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -228,7 +228,7 @@ beforeEach(() => {
 });
 
 describe('POST /session/device/token — the public deviceSecret mint', () => {
-  it('mints an access token, preserves the shared device secret, and returns the wire shape the SDK parses', async () => {
+  it('mints an access token, rotates the stored secret, and returns the wire shape the SDK parses', async () => {
     const { deviceId, accountId, secret } = await deviceWithSecret();
     const hashBefore = (await storedDevice(deviceId)).secretHash;
 
@@ -242,12 +242,14 @@ describe('POST /session/device/token — the public deviceSecret mint', () => {
     expect((data as { accessToken: string }).accessToken).toBe('jwt-active');
     expect((data as { state: { activeAccountId: string } }).state.activeAccountId).toBe(accountId);
 
-    // The credential is stable: separate official app origins can mint
-    // concurrently without invalidating one another.
+    // The rotation is real, not a returned string: the fresh secret's hash is
+    // now current and the presented one moved into the grace slot.
     const nextSecret = (data as { nextDeviceSecret: string }).nextDeviceSecret;
     const after = await storedDevice(deviceId);
     expect(after.secretHash).toBe(sha256(nextSecret));
-    expect(after.secretHash).toBe(hashBefore);
+    expect(after.secretHash).not.toBe(hashBefore);
+    expect(after.prevSecretHash).toBe(hashBefore);
+    expect(after.prevSecretExpiresAt?.getTime()).toBeGreaterThan(Date.now());
 
     // The raw secret is never logged — only the lane and the device id.
     expect(logger.info).toHaveBeenCalledWith('device.token.mint', {
@@ -301,7 +303,7 @@ describe('POST /session/device/token — the public deviceSecret mint', () => {
     expect((second.body.data as { accessToken: string }).accessToken).toBe('jwt-active');
   });
 
-  it('continues accepting the stable secret after the legacy grace window has passed', async () => {
+  it('REFUSES the superseded secret once the grace window has passed', async () => {
     const { deviceId, secret } = await deviceWithSecret();
 
     const first = await requestJson('POST', '/session/device/token', { deviceId, deviceSecret: secret });
@@ -315,7 +317,8 @@ describe('POST /session/device/token — the public deviceSecret mint', () => {
       .where(eq(deviceSessions.deviceId, deviceId));
 
     const late = await requestJson('POST', '/session/device/token', { deviceId, deviceSecret: secret });
-    expect(late.status).toBe(200);
+    expect(late.status).toBe(401);
+    expect(late.body.error).toBe('invalid_device_secret');
   });
 
   it('401 no_active_session WITHOUT rotating when the secret is valid but the session is dead', async () => {

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -47,13 +47,11 @@ const BACKGROUND_TOKEN_LOCKOUT_SCOPE = 'background-token';
  * mint can be initiated from any registered cross-apex origin over normal CORS.
  *
  * On a valid secret it mints a short access token for the device's active
- * account. The successful response carries the same secret back as
- * `nextDeviceSecret`: the secret is a stable device credential, so several
- * official apps/origins sharing one device can refresh concurrently without
- * invalidating one another. A dead/absent active session returns
- * `no_active_session` WITHOUT changing the credential — the client must
- * re-authenticate and keeps its still-valid secret. Per-device lockout + rate
- * limiting blunt online secret-guessing.
+ * account and ROTATES the secret in-use (returns `nextDeviceSecret`; the
+ * presented secret stays valid for a short grace so multi-tab races don't lock
+ * out). A dead/absent active session returns `no_active_session` WITHOUT rotating
+ * — the client must re-authenticate and keeps its still-valid secret. Per-device
+ * lockout + rate limiting blunt online secret-guessing.
  *
  * An optional `accountId` PINS the mint to one account of that device instead of
  * whichever one is currently active. It exists for identity-bound clients
@@ -111,6 +109,15 @@ router.post(
       return;
     }
 
+    const nextDeviceSecret = await deviceSessionService.issueDeviceSecret(deviceId);
+    if (!nextDeviceSecret) {
+      // The device row vanished between resolve and rotate (should not happen for
+      // a live session). Fail closed rather than return a secret-less response.
+      logger.error('device.token.mint could not rotate the device secret', new Error('rotation failed'), { deviceId });
+      res.status(500).json({ error: 'Internal server error' });
+      return;
+    }
+
     // Telemetry carries the lane and the pin discriminator only — never the
     // pinned accountId, the secret, or any other user-identifying value.
     logger.info('device.token.mint', { mint_source: 'secret', deviceId, ...(accountId ? { pinned: true } : {}) });
@@ -118,10 +125,7 @@ router.post(
       data: {
         accessToken: mintedToken.accessToken,
         expiresAt: mintedToken.expiresAt,
-        // Keep the proven credential stable. Rotating here makes separate
-        // first-party origins race over one DeviceSession secret and causes
-        // otherwise healthy sessions to disappear after the grace window.
-        nextDeviceSecret: deviceSecret,
+        nextDeviceSecret,
         // The device's TRUE state — a pin never rewrites `activeAccountId`, and
         // the response must not pretend otherwise.
         state,


### PR DESCRIPTION
### Motivation

- A recent change stopped rotating the device credential in the public `POST /session/device/token` mint, leaving a captured `deviceSecret` usable indefinitely and enabling replayed mints that prolong session lifetime.

### Description

- Re-enabled in-place rotation in the mint handler by calling `deviceSessionService.issueDeviceSecret(deviceId)` after a successful token resolution and returning the fresh `nextDeviceSecret` in the response.
- The handler now fails closed with `500` if rotation cannot be completed for a live mint, while unchanged behavior remains for unsuccessful mints (they keep the existing credential).
- Updated unit tests in `packages/api/src/routes/__tests__/sessionDevice.test.ts` to assert the new rotation behavior, that the previous secret moves to the grace slot, and that the superseded secret is rejected after the grace window.
- Updated documentation in `docs/SESSION-ARCHITECTURE.md` to describe rotation-in-use and the concurrency grace window semantics (60s) so the transport contract matches implementation.

### Testing

- Ran repository checks via `git diff --check` which reported no whitespace errors and the working tree is consistent with the change set.
- Attempted to install dependencies with `bun install --frozen-lockfile`, but the environment could not fetch registry packages (HTTP 403), preventing a full test run.
- Attempted to run the package tests with `bun run --filter @oxyhq/api test`, but `jest` was unavailable because dependencies were not installed, so unit suites could not be executed here.
- The modified test cases were updated to reflect the intended secure behavior (rotation + grace semantics) and are ready to run in CI or a local environment with dependencies available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71192854c88323b60feebc94e23d8e)