### PR TITLE
fix(api): retain shared actors during domain purge

### DIFF
--- a/packages/api/src/routes/__tests__/federationDomainPurge.test.ts
+++ b/packages/api/src/routes/__tests__/federationDomainPurge.test.ts
@@ -265,6 +265,15 @@ async function follow(followerId: string, followedId: string): Promise<void> {
   await getDb().insert(userFollows).values({ followerId, followedId });
 }
 
+async function followExists(followerId: string, followedId: string): Promise<boolean> {
+  const [row] = await getDb()
+    .select({ id: userFollows.id })
+    .from(userFollows)
+    .where(and(eq(userFollows.followerId, followerId), eq(userFollows.followedId, followedId)))
+    .limit(1);
+  return row !== undefined;
+}
+
 async function userExists(id: string): Promise<boolean> {
   const [row] = await getDb().select({ id: users.id }).from(users).where(eq(users.id, id)).limit(1);
   return row !== undefined;
@@ -423,10 +432,10 @@ describe('POST /federation/domain-purge — dry run writes nothing', () => {
     // The plan is non-empty: "wrote nothing" cannot be satisfied by "did nothing".
     expect(data.actorsMatched).toBe(2);
     expect(data.actorsProcessed).toBe(2);
-    expect(data.actorsDeleted).toBe(2);
+    expect(data.actorsDeleted).toBe(0);
     expect(data.filesDeleted).toBe(2);
-    expect(data.avatarsDeleted).toBe(2);
-    expect(data.bytesDeleted).toBe(500 + 20 + 700 + 30);
+    expect(data.avatarsDeleted).toBe(0);
+    expect(data.bytesDeleted).toBe(500 + 700);
     expect(data.dryRun).toBe(true);
 
     await expectStoreUnchanged(before);
@@ -439,7 +448,7 @@ describe('POST /federation/domain-purge — dry run writes nothing', () => {
     const data = planOf(await purge({ domain: corpus.domain }));
 
     expect(data.dryRun).toBe(true);
-    expect(data.actorsDeleted).toBe(2);
+    expect(data.actorsDeleted).toBe(0);
     await expectStoreUnchanged(before);
   });
 
@@ -454,12 +463,12 @@ describe('POST /federation/domain-purge — dry run writes nothing', () => {
     expect(applied.avatarsDeleted).toBe(planned.avatarsDeleted);
     expect(applied.bytesDeleted).toBe(planned.bytesDeleted);
 
-    // And the applied numbers describe the store: both actors gone, and their
-    // files with them (`files.owner_user_id` cascades).
-    expect(await userExists(corpus.actors[0])).toBe(false);
-    expect(await userExists(corpus.actors[1])).toBe(false);
-    expect(await fileState(corpus.fileA)).toBe('gone');
-    expect(await fileState(corpus.avatarB)).toBe('gone');
+    // Caller-owned files are tombstoned, while globally shared actors and
+    // unattributed avatars remain available to other applications.
+    expect(await userExists(corpus.actors[0])).toBe(true);
+    expect(await userExists(corpus.actors[1])).toBe(true);
+    expect(await fileState(corpus.fileA)).toBe('deleted');
+    expect(await fileState(corpus.avatarB)).toBe('active');
   });
 });
 
@@ -475,11 +484,11 @@ describe('POST /federation/domain-purge — a non-blocked domain is never touche
 
     const data = planOf(await purge({ domain, dryRun: false }));
 
-    expect(data.actorsDeleted).toBe(1);
+    expect(data.actorsDeleted).toBe(0);
     // The subdomain actor and its file survive: the engine still federates with it.
     expect(await userExists(subdomainActor)).toBe(true);
     expect(await fileState(subdomainFile)).toBe('active');
-    expect(await userExists(blockedActor)).toBe(false);
+    expect(await userExists(blockedActor)).toBe(true);
   });
 
   it('leaves an unrelated domain untouched', async () => {
@@ -493,7 +502,7 @@ describe('POST /federation/domain-purge — a non-blocked domain is never touche
 
     planOf(await purge({ domain, dryRun: false }));
 
-    expect(await userExists(blockedActor)).toBe(false);
+    expect(await userExists(blockedActor)).toBe(true);
     expect(await userExists(otherActor)).toBe(true);
     expect(await fileState(otherFile)).toBe('active');
   });
@@ -534,10 +543,10 @@ describe('POST /federation/domain-purge — canonical host matching', () => {
 
     const data = planOf(await purge({ domain, dryRun: false }));
 
-    expect(data.actorsDeleted).toBe(1);
+    expect(data.actorsDeleted).toBe(0);
     expect(data.candidatesRejected).toBe(0);
-    expect(await userExists(actor)).toBe(false);
-    expect(await fileState(file)).toBe('gone');
+    expect(await userExists(actor)).toBe(true);
+    expect(await fileState(file)).toBe('deleted');
   });
 
   it('matches when the CALLER spells the domain with www. and the store does not', async () => {
@@ -547,7 +556,7 @@ describe('POST /federation/domain-purge — canonical host matching', () => {
     const data = planOf(await purge({ domain: `www.${domain}`, dryRun: false }));
 
     expect(data.canonicalDomain).toBe(domain);
-    expect(await userExists(actor)).toBe(false);
+    expect(await userExists(actor)).toBe(true);
   });
 
   /**
@@ -599,6 +608,32 @@ describe('POST /federation/domain-purge — canonical host matching', () => {
 });
 
 describe('POST /federation/domain-purge — multi-tenancy', () => {
+  it('retains an actor when another application may reference it without owning a file', async () => {
+    const domain = freshDomain();
+    const actor = await seedFederatedUser(domain);
+    const localFollower = await seedLocalUser();
+    await follow(localFollower, actor);
+    const mine = await seedFile(actor, {
+      source: 'federation',
+      serviceAppId: CALLER_APP_ID,
+    });
+
+    const data = planOf(await purge({ domain, dryRun: false }));
+
+    expect(data.actorsDeleted).toBe(0);
+    expect(data.followEdgesRemoved).toBe(0);
+    expect(data.actorsRetained).toEqual([
+      expect.objectContaining({
+        oxyUserId: actor,
+        referencedByAppIds: [],
+        retentionReason: 'application_references_unknown',
+      }),
+    ]);
+    expect(await userExists(actor)).toBe(true);
+    expect(await fileState(mine)).toBe('deleted');
+    expect(await followExists(localFollower, actor)).toBe(true);
+  });
+
   it("never deletes another application's files, and RETAINS the shared row", async () => {
     const domain = freshDomain();
     const actor = await seedFederatedUser(domain);
@@ -682,7 +717,7 @@ describe('POST /federation/domain-purge — multi-tenancy', () => {
 
     expect(data.filesDeleted).toBe(1);
     expect(data.bytesDeleted).toBe(100);
-    expect(await userExists(actor)).toBe(false);
+    expect(await userExists(actor)).toBe(true);
   });
 });
 
@@ -726,7 +761,7 @@ describe('POST /federation/domain-purge — authorisation and arming', () => {
 
     const data = planOf(await purge({ domain: corpus.domain, dryRun: true }));
 
-    expect(data.actorsDeleted).toBe(2);
+    expect(data.actorsDeleted).toBe(0);
     await expectStoreUnchanged(before);
   });
 });
@@ -739,10 +774,10 @@ describe('POST /federation/domain-purge — bounded, resumable, idempotent', () 
     const first = planOf(await purge({ domain: corpus.domain, dryRun: false, limit: 1 }));
 
     expect(first.actorsProcessed).toBe(1);
-    expect(first.actorsDeleted).toBe(1);
+    expect(first.actorsDeleted).toBe(0);
     expect(first.done).toBe(false);
     expect(first.nextCursor).toBe(actorA);
-    expect(await userExists(actorA)).toBe(false);
+    expect(await userExists(actorA)).toBe(true);
     expect(await userExists(actorB)).toBe(true);
 
     const second = planOf(
@@ -755,11 +790,14 @@ describe('POST /federation/domain-purge — bounded, resumable, idempotent', () 
     );
 
     expect(second.actorsProcessed).toBe(1);
-    expect(second.remaining).toBe(0);
-    expect(await userExists(actorB)).toBe(false);
-    // Every file of both actors went with them.
-    for (const fileId of [corpus.fileA, corpus.avatarA, corpus.fileB, corpus.avatarB]) {
-      expect(await fileState(fileId)).toBe('gone');
+    expect(second.remaining).toBe(2);
+    expect(await userExists(actorB)).toBe(true);
+    // Only caller-owned files are removed; shared rows and avatars survive.
+    for (const fileId of [corpus.fileA, corpus.fileB]) {
+      expect(await fileState(fileId)).toBe('deleted');
+    }
+    for (const fileId of [corpus.avatarA, corpus.avatarB]) {
+      expect(await fileState(fileId)).toBe('active');
     }
   });
 
@@ -800,11 +838,11 @@ describe('POST /federation/domain-purge — bounded, resumable, idempotent', () 
 
     const repeat = planOf(await purge({ domain: corpus.domain, dryRun: false }));
 
-    expect(repeat.actorsMatched).toBe(0);
-    expect(repeat.actorsProcessed).toBe(0);
+    expect(repeat.actorsMatched).toBe(2);
+    expect(repeat.actorsProcessed).toBe(2);
     expect(repeat.actorsDeleted).toBe(0);
     expect(repeat.done).toBe(true);
-    expect(repeat.nextCursor).toBeNull();
+    expect(repeat.nextCursor).not.toBeNull();
     await expectStoreUnchanged(before);
   });
 
@@ -836,9 +874,9 @@ describe('POST /federation/domain-purge — bounded, resumable, idempotent', () 
     );
 
     // The cursor moved past the retained row onto the next actor.
-    expect(pass2.actorsDeleted).toBe(1);
-    expect(await userExists(deletable)).toBe(false);
-    expect(await fileState(mine)).toBe('gone');
+    expect(pass2.actorsDeleted).toBe(0);
+    expect(await userExists(deletable)).toBe(true);
+    expect(await fileState(mine)).toBe('deleted');
     expect(await userExists(retained)).toBe(true);
     expect(await fileState(theirs)).toBe('active');
   });

--- a/packages/api/src/routes/federation.ts
+++ b/packages/api/src/routes/federation.ts
@@ -427,9 +427,9 @@ function isDomainPurgeArmed(): boolean {
 /**
  * POST /federation/domain-purge
  *
- * Removes what the Oxy PLATFORM holds for a fediverse instance the calling app
- * has blocked: the app's mirrored media, the avatars Oxy fetched, and the
- * `type:'federated'` user rows themselves with their social-graph edges.
+ * Removes caller-owned mirrored media for a fediverse instance the calling app
+ * has blocked. Shared actor rows, platform avatars, and graph edges are retained
+ * because file ownership cannot prove that another app does not use an actor.
  *
  * Oxy holds NO blocklist and never will — the calling app owns that policy and
  * names one domain per call. The rationale, the ownership rules and the exact
@@ -440,8 +440,9 @@ function isDomainPurgeArmed(): boolean {
  * WHOSE DATA: files are deleted only when their recorded `serviceAppId` is the
  * caller's own application id, taken from the SERVICE CREDENTIAL
  * (`req.serviceApp.appId`) and never from the request body — an app cannot ask
- * Oxy to delete another app's data. A user row shared with another application
- * is archived and kept, and the response names the apps that kept it.
+ * Oxy to delete another app's data. Every globally shared actor row is archived
+ * and kept; tagged files can identify known app references, but their absence
+ * is not proof that no untagged application reference exists.
  *
  * SAFE BY DEFAULT: `dryRun` defaults to true, so a caller that omits it gets a
  * plan. A real deletion needs `dryRun:false` AND

--- a/packages/api/src/services/federation/blockedDomainPurge.service.ts
+++ b/packages/api/src/services/federation/blockedDomainPurge.service.ts
@@ -30,24 +30,13 @@
  * remote actor they get the SAME row — and deleting it because one app blocked
  * the instance would destroy data the other app legitimately holds.
  *
- * Today exactly one app federates, and federated rows were measured to carry no
- * sessions, reputation, wallets, grants or app data — so deleting the row is in
- * fact safe right now. That is a fact about the current DEPLOYMENT, not about
- * the data model, and it stops being true silently the day a second app
- * federates. So the rule is evaluated per actor from what is actually there:
- *
  *   - Files are deleted only when their `metadata.serviceAppId` is the
  *     AUTHENTICATED caller's application id (resolved from the service
- *     credential — never a value the caller supplies), plus the actor's own
- *     Oxy-fetched avatars, which belong to the row rather than to any app.
- *   - The row itself is deleted only when nothing ANOTHER app owns still
- *     references it. If something does, the row is archived and RETAINED, and
- *     the result names the app that caused the retention.
- *
- * The retention branch is unreachable in the current deployment. It is here
- * deliberately, because it is the thing that stops this from quietly becoming
- * "one app deletes another app's data" later, and it costs one query the plan
- * already needs.
+ *     credential — never a value the caller supplies).
+ *   - Federated actor rows are retained. Oxy does not currently keep a complete
+ *     per-application reference ledger for these globally shared rows, so the
+ *     absence of another app's file is not proof that no other app references
+ *     the actor. Hard deletion would cross the caller's authorization boundary.
  *
  * MATCHING
  * --------
@@ -83,7 +72,6 @@ import { logger } from '../../utils/logger';
 import userCache from '../../utils/userCache';
 import { assetService } from '../assetServiceSingleton';
 import { isOwnFederationDomain } from '../federation.service';
-import { userService } from '../user.service';
 
 const COMPONENT = 'blockedDomainPurge';
 
@@ -133,6 +121,8 @@ export interface RetainedActor {
   username: string;
   /** Application ids, other than the caller, still holding files for this row. */
   referencedByAppIds: string[];
+  /** Why the shared actor row could not safely be hard-deleted. */
+  retentionReason: 'other_application_files' | 'application_references_unknown';
 }
 
 export interface BlockedDomainPurgeResult {
@@ -393,16 +383,12 @@ export async function purgeBlockedDomain(
     const username = candidate.username ?? '';
     result.actorsProcessed += 1;
 
-    const { callerOwned, unattributed, otherAppIds } = await classifyActorFiles(
+    const { callerOwned, otherAppIds } = await classifyActorFiles(
       oxyUserId,
       callerAppId,
     );
 
     result.localFollowersAffected += await countLocalFollowers(oxyUserId);
-
-    // The row is shared with another application: delete only what the caller
-    // owns, archive the row, and report who kept it alive.
-    const retainRow = otherAppIds.length > 0;
 
     for (const file of callerOwned) {
       if (dryRun || (await deleteFileBestEffort(file.id, { oxyUserId, canonicalDomain }))) {
@@ -411,57 +397,32 @@ export async function purgeBlockedDomain(
       }
     }
 
-    if (retainRow) {
-      if (!dryRun) {
-        // Same semantics as `POST /federation/actor-gone`: single whitelisted
-        // column, with `type = 'federated'` re-asserted in the predicate so a
-        // concurrent type change can never let this touch a real account.
-        await getDb()
-          .update(users)
-          .set({ accountStatus: 'archived' })
-          .where(and(eq(users.id, oxyUserId), eq(users.type, 'federated')));
-        userCache.invalidate(oxyUserId);
-      }
-      result.actorsRetained.push({ oxyUserId, username, referencedByAppIds: otherAppIds });
-      logger.info('blockedDomainPurge: actor retained, referenced by another application', {
-        component: COMPONENT,
-        oxyUserId,
-        canonicalDomain,
-        referencedByAppIds: otherAppIds,
-        dryRun,
-      });
-      continue;
+    // File attribution is not an actor-reference ledger. Another application
+    // can resolve and use this globally keyed actor without uploading a file,
+    // so an empty `otherAppIds` cannot authorize deleting the actor or graph.
+    if (!dryRun) {
+      await getDb()
+        .update(users)
+        .set({ accountStatus: 'archived' })
+        .where(and(eq(users.id, oxyUserId), eq(users.type, 'federated')));
+      userCache.invalidate(oxyUserId);
     }
-
-    // Nothing else holds this row: the platform-level avatars go too, then the
-    // row and its whole social graph.
-    for (const file of unattributed) {
-      if (dryRun || (await deleteFileBestEffort(file.id, { oxyUserId, canonicalDomain }))) {
-        result.avatarsDeleted += 1;
-        result.bytesDeleted += file.size;
-      }
-    }
-
-    if (dryRun) {
-      result.actorsDeleted += 1;
-      continue;
-    }
-
-    // Reuses the shared teardown so edge deletion, counterparty `_count` repair
-    // and block/restrict/graph cache invalidation stay in ONE place. Its caller
-    // contract requires `type:'federated'`, which the query filter and the
-    // re-verification above both established, and which its own terminal
-    // `deleteOne` filter re-asserts atomically.
-    const { followEdgesRemoved } = await userService.deleteFederatedActor(oxyUserId);
-    result.followEdgesRemoved += followEdgesRemoved;
-    result.actorsDeleted += 1;
-
-    logger.info('blockedDomainPurge: federated actor purged', {
-      component: COMPONENT,
+    const retentionReason = otherAppIds.length > 0
+      ? 'other_application_files'
+      : 'application_references_unknown';
+    result.actorsRetained.push({
       oxyUserId,
       username,
+      referencedByAppIds: otherAppIds,
+      retentionReason,
+    });
+    logger.info('blockedDomainPurge: shared actor retained', {
+      component: COMPONENT,
+      oxyUserId,
       canonicalDomain,
-      followEdgesRemoved,
+      referencedByAppIds: otherAppIds,
+      retentionReason,
+      dryRun,
     });
   }
 


### PR DESCRIPTION
### Motivation

- A vulnerability allowed a federation-enabled app to hard-delete globally shared federated actor rows when no other app-tagged files existed, which can destroy another tenant's social graph when that tenant referenced the actor but did not upload files. The change closes this authorization/retention gap by treating file attribution as insufficient proof of exclusive ownership.

### Description

- Change purge semantics to only remove files owned by the caller and to always retain/archive the globally keyed federated actor row and its platform avatars/graph instead of hard-deleting them. (`packages/api/src/services/federation/blockedDomainPurge.service.ts`)
- Add a `retentionReason` discriminator to `RetainedActor` so responses distinguish known other-app file references from unknown potential references. (`blockedDomainPurge.service.ts`) 
- Stop reusing the actor hard-delete path from the purge; actor teardown is no longer invoked by domain purge (actor rows are archived instead). (`blockedDomainPurge.service.ts`) 
- Update the route documentation to explain the conservative authorization boundary (caller-owned files only; shared actors retained). (`packages/api/src/routes/federation.ts`) 
- Update tests to reflect the conservative behavior and add a regression test ensuring an actor + local follow survive a real purge even when no other application-tagged file exists, while the caller's own file is deleted; adjust expectations for avatars and pagination/resumption. (`packages/api/src/routes/__tests__/federationDomainPurge.test.ts`)

### Testing

- Ran repository checks and committed the change as `fix(api): retain shared actors during domain purge` (commit present in the working tree). (`git diff --check`, `git commit`) — succeeded.
- Attempted dependency install with `bun install --frozen-lockfile`, but registry artifact fetches returned HTTP 403 in this environment, so install failed and test runners could not be executed end-to-end (environment limitation). — failed to install dependencies.
- Attempted to run the single-test invocation via the test script, but `jest`/test tooling was unavailable due to the failed install, so tests could not be executed here. — could not run Jest.
- All changes are covered by updated/added tests under `packages/api/src/routes/__tests__/federationDomainPurge.test.ts`; CI should run the full suite (including the updated Jest tests) after dependencies are available and will verify behavior in a real Postgres-backed environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7121fff4748323962c7b963eee8fd4)