### PR TITLE
fix(api): block unauthenticated lazy MP4 transcoding

### DIFF
--- a/packages/api/src/services/__tests__/assetService.ensureVariantVideo.test.ts
+++ b/packages/api/src/services/__tests__/assetService.ensureVariantVideo.test.ts
@@ -1,9 +1,8 @@
 /**
- * AssetService.ensureVariant — video mp4 rendition routing (#759).
+ * AssetService.ensureVariant — safe video mp4 rendition routing.
  *
- * Upload-time generation can leave a video with poster/hls_master but no
- * `360p`/`720p`/`1080p`. `ensureVariant` must lazily regenerate those on
- * request instead of throwing "not supported for mime video/*".
+ * Public media routes reach ensureVariant, so missing MP4 renditions must not
+ * start expensive FFmpeg work on the request path.
  */
 
 import { AssetService } from '../assetService';
@@ -62,16 +61,15 @@ beforeEach(() => {
 });
 
 describe('AssetService.ensureVariant — video mp4 renditions', () => {
-  it('routes 720p to ensureVideoMp4Rendition', async () => {
-    mockEnsureVideoMp4Rendition.mockResolvedValue(RENDITION_ROW);
+  it('does not lazily generate a missing mp4 rendition', async () => {
     const service = buildService();
 
-    const result = await service.ensureVariant('file-video-1', '720p', VIDEO_FILE);
+    await expect(service.ensureVariant('file-video-1', '720p', VIDEO_FILE))
+      .rejects.toThrow('Video rendition 720p is not available');
 
     expect(mockIsVideoMp4Rendition).toHaveBeenCalledWith('720p');
-    expect(mockEnsureVideoMp4Rendition).toHaveBeenCalledWith(VIDEO_FILE, '720p');
+    expect(mockEnsureVideoMp4Rendition).not.toHaveBeenCalled();
     expect(mockEnsureVideoImageVariant).not.toHaveBeenCalled();
-    expect(result).toBe(RENDITION_ROW);
   });
 
   it('still routes poster to ensureVideoPoster', async () => {

--- a/packages/api/src/services/assetService.ts
+++ b/packages/api/src/services/assetService.ts
@@ -455,7 +455,11 @@ export class AssetService {
         return variant;
       }
       if (this.variantService.isVideoMp4Rendition(variantType)) {
-        return this.variantService.ensureVideoMp4Rendition(fileObj, variantType);
+        // MP4 renditions are generated during the trusted upload pipeline. Do
+        // not generate a missing rendition here: ensureVariant is also reached
+        // from unauthenticated public media routes, where transcoding on demand
+        // would let arbitrary callers consume unbounded FFmpeg CPU and memory.
+        throw new Error(`Video rendition ${variantType} is not available`);
       }
       // A SIZE name (`thumb`, `w320`, …) asked of a video means "an image of
       // this asset at that size", which for a video is a render of its poster


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated public media requests from triggering on-demand FFmpeg MP4 transcoding (360p/720p/1080p) via `ensureVariant`, which allowed unbounded CPU and memory use and concurrent ffmpeg spawns from attacker-controlled `variant` query values.

### Description
- Stop lazy-generation of MP4 bitrate renditions in `AssetService.ensureVariant` by throwing an explicit error for MP4 rendition names instead of calling `ensureVideoMp4Rendition`, preserving serving of already-ready variants and poster/thumb/image flows.
- Update the routing unit test `src/services/__tests__/assetService.ensureVariantVideo.test.ts` to assert that a missing MP4 rendition is rejected and that `ensureVideoMp4Rendition` is not invoked while poster/thumb behavior remains covered.
- This change keeps upload-time rendition generation and existing variant storage/serving logic intact while removing the expensive work from public request paths.

### Testing
- Ran `git diff --check` to validate the working tree changes and found no whitespace/patch issues (check passed). 
- Attempted to run the targeted unit test via `bun run test --runInBand src/services/__tests__/assetService.ensureVariantVideo.test.ts`, but the test runner failed to execute in this environment because `jest` is not available (`exit code 127`), so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71217fef748323a3a16863dd064677)