### PR TITLE
Enforce exact federation authority host boundaries

### DIFF
--- a/packages/api/src/routes/__tests__/federation.test.ts
+++ b/packages/api/src/routes/__tests__/federation.test.ts
@@ -477,7 +477,7 @@ describe('POST /federation/sign', () => {
     expect(mockSignWithKeyId).not.toHaveBeenCalled();
   });
 
-  it('accepts a www. keyId host when the credential is registered for the bare domain', async () => {
+  it('rejects a www. keyId host when the credential is registered for the bare domain', async () => {
     const keyId = `https://www.${MENTION_DOMAIN}/ap/users/bob#main-key`;
 
     const res = await requestJson('POST', '/federation/sign', {
@@ -485,8 +485,8 @@ describe('POST /federation/sign', () => {
       signingString: SIGNING_STRING,
     });
 
-    expect(res.status).toBe(200);
-    expect(mockSignWithKeyId).toHaveBeenCalledWith(keyId, SIGNING_STRING);
+    expect(res.status).toBe(403);
+    expect(mockSignWithKeyId).not.toHaveBeenCalled();
   });
 });
 
@@ -527,13 +527,13 @@ describe('GET /federation/public-key/:username', () => {
     expect(mockGetUserPublicKey).not.toHaveBeenCalled();
   });
 
-  it('accepts a www. domain query when the credential is registered for the bare domain', async () => {
+  it('rejects a www. domain query when the credential is registered for the bare domain', async () => {
     const res = await requestJson(
       'GET',
       `/federation/public-key/bob?domain=www.${MENTION_DOMAIN}`,
     );
 
-    expect(res.status).toBe(200);
-    expect(mockGetUserPublicKey).toHaveBeenCalledWith('bob', `www.${MENTION_DOMAIN}`);
+    expect(res.status).toBe(403);
+    expect(mockGetUserPublicKey).not.toHaveBeenCalled();
   });
 });

--- a/packages/api/src/routes/__tests__/usersResolve.test.ts
+++ b/packages/api/src/routes/__tests__/usersResolve.test.ts
@@ -386,7 +386,7 @@ describe('PUT /users/resolve — actor-URI host binding', () => {
     expect(await storedByActorUri(actorUri)).toBeUndefined();
   });
 
-  it('accepts an actor on the www host of the asserted domain without a WebFinger probe', async () => {
+  it('rejects an actor on the www sibling of the asserted domain without a WebFinger binding', async () => {
     const handle = `alice${token()}`;
     const actorUri = `https://www.mastodon.social/users/${handle}`;
 
@@ -397,15 +397,12 @@ describe('PUT /users/resolve — actor-URI host binding', () => {
       domain: 'mastodon.social',
     });
 
-    expect(res.status).toBe(200);
-    expect(mockSafeFetch).not.toHaveBeenCalled();
-    const stored = await storedByActorUri(actorUri);
-    // The canonical handle is kept — the www host does not become the domain.
-    expect(stored.username).toBe(`${handle}@mastodon.social`);
-    expect(stored.federationDomain).toBe('mastodon.social');
+    expect(res.status).toBe(400);
+    expect(mockSafeFetch).toHaveBeenCalled();
+    expect(await storedByActorUri(actorUri)).toBeUndefined();
   });
 
-  it('accepts the SAME pair with www. on the domain side instead of the actor side', async () => {
+  it('rejects the reverse bare/www sibling pair without a WebFinger binding', async () => {
     const handle = `alice${token()}`;
     const actorUri = `https://mastodon.social/users/${handle}`;
 
@@ -416,16 +413,9 @@ describe('PUT /users/resolve — actor-URI host binding', () => {
       domain: 'www.mastodon.social',
     });
 
-    // The binding is a comparison, so it has to answer the same regardless of
-    // which side carries the `www.`. A rule applied to only one side (the shape
-    // this route shipped with) rejects this pair while accepting the mirrored
-    // one above — so the two cases have to be asserted together or the
-    // asymmetry reads as passing.
-    expect(res.status).toBe(200);
-    expect(mockSafeFetch).not.toHaveBeenCalled();
-    const stored = await storedByActorUri(actorUri);
-    expect(stored.username).toBe(`${handle}@mastodon.social`);
-    expect(stored.federationDomain).toBe('mastodon.social');
+    expect(res.status).toBe(400);
+    expect(mockSafeFetch).toHaveBeenCalled();
+    expect(await storedByActorUri(actorUri)).toBeUndefined();
   });
 
   it('accepts a foreign actor host when WebFinger loops the handle back to it', async () => {

--- a/packages/api/src/routes/federation.ts
+++ b/packages/api/src/routes/federation.ts
@@ -1,6 +1,5 @@
 import { Router, type Response } from 'express';
 import { and, eq } from 'drizzle-orm';
-import { canonicalFederationHost } from '@oxyhq/federation';
 import { serviceAuthMiddleware, type ServiceAuthRequest } from '../middleware/auth';
 import { asyncHandler, sendSuccess } from '../utils/asyncHandler';
 import { validate } from '../middleware/validate';
@@ -75,7 +74,7 @@ async function loadAllowedDomains(appId: string): Promise<string[]> {
   const hosts = new Set<string>();
   for (const uri of app.redirectUris) {
     try {
-      hosts.add(canonicalFederationHost(new URL(uri).hostname));
+      hosts.add(new URL(uri).hostname.toLowerCase());
     } catch {
       // A malformed redirect URI contributes no authorisation. `NOT NULL` on a
       // `text[]` constrains the array, not its elements, so a NULL element is
@@ -150,7 +149,7 @@ router.get(
     const { domain } = req.query as unknown as PublicKeyQuery;
 
     const allowed = await getAllowedDomainsForRequest(req);
-    if (!allowed.has(canonicalFederationHost(domain))) {
+    if (!allowed.has(domain.trim().toLowerCase())) {
       logger.warn('federation/public-key: domain not authorised for credential', {
         appId: req.serviceApp?.appId,
         credentialId: req.serviceApp?.credentialId,
@@ -195,7 +194,7 @@ router.post(
     // is unambiguous.
     let keyIdHost: string;
     try {
-      keyIdHost = canonicalFederationHost(new URL(keyId).hostname);
+      keyIdHost = new URL(keyId).hostname.toLowerCase();
     } catch {
       throw new ForbiddenError('keyId host is not authorised for this application');
     }

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -12,7 +12,6 @@
 import { Router, type Request, type Response, type NextFunction } from 'express';
 import { and, eq, inArray, sql, type SQL } from 'drizzle-orm';
 import { safeFetch, SsrfRejection } from '@oxyhq/core/server';
-import { canonicalFederationHost, isSameFederationHost } from '@oxyhq/federation';
 import { readBoundedBody } from '../services/linkPreview/boundedBody';
 import { getDb } from '../config/postgres';
 import { identityBackups } from '../db/schema/identityBackups';
@@ -1577,7 +1576,7 @@ function normalizeFederatedResolveUsername(username: string): string | null {
   if (atIndex <= 0 || atIndex === cleaned.length - 1) return null;
 
   const localPart = cleaned.substring(0, atIndex).toLowerCase();
-  const domain = canonicalFederationHost(cleaned.substring(atIndex + 1));
+  const domain = cleaned.substring(atIndex + 1).trim().toLowerCase();
   if (!localPart || !domain) return null;
 
   return `${localPart}@${domain}`;
@@ -1756,13 +1755,13 @@ router.put(
           throw new BadRequestError('actorUri must be a valid http(s) URL or a did: URI');
         }
       }
-      const normalisedDomain = canonicalFederationHost(domain);
+      const normalisedDomain = domain.trim().toLowerCase();
       const normalisedUsername = normalizeFederatedResolveUsername(username);
       if (!normalisedUsername) {
         throw new BadRequestError('username must be a valid federated handle');
       }
       const usernameDomain = normalisedUsername.substring(normalisedUsername.indexOf('@') + 1);
-      if (!isSameFederationHost(usernameDomain, normalisedDomain)) {
+      if (usernameDomain !== normalisedDomain) {
         throw new BadRequestError('username domain does not match domain');
       }
 
@@ -1802,7 +1801,7 @@ router.put(
       // lookup and that is a network round trip.
       if (
         actorHostname !== null
-        && !isSameFederationHost(actorHostname, normalisedDomain)
+        && actorHostname !== normalisedDomain
         && !bridgeVouchesForNetwork(actorHostname, normalisedDomain)
         && !(await verifyFederatedWebFingerBinding(normalisedUsername, actorUri))
       ) {


### PR DESCRIPTION
### Motivation

- Fix a security regression where `www.`-prefixed sibling hosts were treated as equivalent to their apex host for federation authorization, allowing a credential registered for `example.com` to mint or sign keys for `www.example.com` and broaden identity binding checks across sibling hosts.

### Description

- Change allowed-domain derivation in `packages/api/src/routes/federation.ts` to record the exact redirect-uri hostname lowercased via `new URL(uri).hostname.toLowerCase()` and to authorize requests using `domain.trim().toLowerCase()` instead of `canonicalFederationHost`.
- Require exact lowercased hostname equality for signing host checks by deriving `keyIdHost` with `new URL(keyId).hostname.toLowerCase()` before comparing to the credential allow-list.
- Preserve `www.` as a distinct authority in federated-user resolution by normalizing the asserted domain to `domain.trim().toLowerCase()` in `packages/api/src/routes/users.ts` and replacing `isSameFederationHost` comparisons with exact hostname equality for username↔domain and actor↔domain binding checks.
- Update regression tests in `packages/api/src/routes/__tests__/federation.test.ts` and `packages/api/src/routes/__tests__/usersResolve.test.ts` to assert that bare/`www.` sibling hosts are rejected unless authority is established via the existing bridge trust or WebFinger paths, and remove unused `canonicalFederationHost` imports where applicable.

### Testing

- Ran `git diff --check` and inspected diffs to ensure no whitespace/errors were introduced and the intended files were modified as expected.  
- Attempted to run the targeted Jest tests with `bun run --filter @oxyhq/api test -- --runInBand src/routes/__tests__/federation.test.ts src/routes/__tests__/usersResolve.test.ts`, but tests could not be executed because the environment did not have `jest` installed (command failed).  
- Attempted `bun install --frozen-lockfile` to install dependencies required to run the test suite, but dependency resolution failed due to HTTP 403 responses from the package registry.  
- Verified working-tree status with `git status --short --branch` and confirmed the modified files are present in the repository for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a712450cbac8323befd5a18a741c83b)