### PR TITLE
Restrict production migration workflow to protected main

### DIFF
--- a/.github/workflows/run-postgres-migrations.yml
+++ b/.github/workflows/run-postgres-migrations.yml
@@ -32,11 +32,12 @@ name: Run PostgreSQL migrations
 #    out of it. drizzle-kit depends on esbuild directly, so shipping the CLI
 #    would drag it back in.
 #
-# 3. It builds its own image from `ref` rather than reusing whatever `latest`
-#    happens to be, so the migrations applied are exactly the ones at the ref you
-#    chose, and a fix can be tried from a branch before it merges. The image
-#    differs from the live one only by tag; the throwaway task definition differs
-#    from the live one only by image.
+# 3. It builds its own image from the exact commit on protected `main` that
+#    dispatched the workflow rather than reusing whatever `latest` happens to
+#    be. The image differs from the live one only by tag; the throwaway task
+#    definition differs from the live one only by image. Never allow a caller to
+#    select an unreviewed ref here: this image runs with the live task's secrets
+#    and IAM role.
 #
 # ALWAYS run dry FIRST (`dry_run=true`, the default). A dry run reads the
 # journal and the `drizzle.__drizzle_migrations` ledger, prints which migrations
@@ -53,11 +54,6 @@ name: Run PostgreSQL migrations
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Branch or SHA to build the migration image from'
-        required: true
-        type: string
-        default: 'main'
       dry_run:
         description: 'Report which migrations WOULD be applied, write nothing'
         required: true
@@ -92,13 +88,17 @@ permissions:
 
 jobs:
   migrate:
+    # A dispatch against another ref must never reach the production-privileged
+    # task. Pinning checkout to github.sha below then gives us the immutable
+    # reviewed commit from protected main, not caller-selected source.
+    if: github.ref == 'refs/heads/main'
     # Same arch as the deployed image — the service runs linux/arm64.
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.sha }}
 
       - name: Configure AWS credentials (OIDC, no stored keys)
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
### Motivation

- Close a workflow provenance vulnerability where dispatchers could supply an arbitrary `ref`/branch and build an image that runs with the live API task's production secrets and IAM role.

### Description

- Remove the free-form `inputs.ref` from `.github/workflows/run-postgres-migrations.yml` so callers cannot select an arbitrary branch or SHA.
- Require the migration job only run when dispatched against protected `main` via `if: github.ref == 'refs/heads/main'` to enforce provenance at job level.
- Pin the checkout to the immutable dispatch commit by using `ref: ${{ github.sha }}` so the built image is the reviewed artifact associated with the dispatch.
- Update workflow comments to document the security invariant that images run with the live task's secrets and must not be built from unreviewed source.

### Testing

- Parsed the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file(...)"` and it succeeded.
- Verified the `inputs.ref` removal and presence of the `if: github.ref == 'refs/heads/main'` guard and `ref: ${{ github.sha }}` via `rg` assertions, which passed.
- Ran `git diff --check` to ensure no whitespace or patch issues, which reported no problems.
- `actionlint` was not available in the environment, so an `actionlint` validation was not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a712af4b2a08323b343732b3907c0d8)