### PR TITLE
fix(api): revoke stale background credentials on session replacement

### DIFF
--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -246,6 +246,25 @@ describe('addAccount', () => {
     expect(rows.find((r) => r.accountId === a1)?.sessionId).toBe('s-new');
   });
 
+  it('revokes a background credential when its account session is replaced', async () => {
+    const device = deviceId();
+    const a1 = await account();
+    await deviceSessionService.addAccount(device, { accountId: a1, sessionId: 's-old' });
+    mockGetAccessToken.mockResolvedValue({ accessToken: 'jwt-old', expiresAt: new Date() });
+    const credential = await deviceSessionService.issueBackgroundCredential(device, a1);
+
+    await deviceSessionService.addAccount(device, { accountId: a1, sessionId: 's-new' });
+
+    const stored = await storedDevice(device);
+    expect(stored.backgroundSecretHash).toBeNull();
+    expect(stored.backgroundSecretAccountId).toBeNull();
+    expect(stored.backgroundSecretExpiresAt).toBeNull();
+    expect(
+      await deviceSessionService.mintFromBackgroundSecret(device, credential?.secret as string)
+    ).toEqual({ ok: false, reason: 'background_credential_invalid' });
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+  });
+
   it('idempotent re-register with the SAME sessionId is a pure no-op (no deactivate, no revision bump)', async () => {
     const device = deviceId();
     const a1 = await account();

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -292,6 +292,12 @@ class DeviceSessionService {
         .set({
           activeAccountId: nextActiveAccountId,
           revision: sql`${deviceSessions.revision} + 1`,
+          // A background credential authorizes the session that was present
+          // when it was provisioned. Do not let it follow the same account
+          // across a re-authentication (or a change of delegated operator).
+          ...(existing && current.backgroundSecretAccountId === input.accountId
+            ? this.clearedBackgroundCredentialFields()
+            : {}),
         })
         .where(eq(deviceSessions.id, current.id));
 


### PR DESCRIPTION
### Motivation

- Close an authorization gap where a background credential bound to an account could still mint tokens after that account's session was replaced on the same device.
- Ensure background credentials are scoped to the session state that provisioned them so delegated/managed accounts on shared devices cannot be hijacked by stale credentials.

### Description

- When re-adding/replacing an account in `addAccount`, clear the stored background credential fields so a credential issued under the previous session cannot follow the account into a new session by account id match in `packages/api/src/services/deviceSession.service.ts`.
- Add a regression test that provisions a background credential, replaces the account's session, asserts the stored background fields are cleared, and verifies `mintFromBackgroundSecret` returns `background_credential_invalid` in `packages/api/src/services/__tests__/deviceSession.service.test.ts`.
- Preserve existing behaviour for unrelated accounts and idempotent same-session re-registers; only the case that replaces an account's `sessionId` triggers clearing the background credential.

### Testing

- Ran `git diff --check` and repository status checks to validate the patch applied cleanly and the working tree is updated (success).
- Added a focused regression test in `deviceSession.service` suite, but running the repo's test script (`bun run test` / `jest`) failed in this environment because test dependencies are not installed and the `jest` binary was not available (could not execute unit test runner here).
- CI or a developer machine with node deps installed should run `bun run test -- --runInBand src/services/__tests__/deviceSession.service.test.ts` to verify the new test and the full service suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7130c5575083238342e766954fb45c)