### PR TITLE
fix(api): scope moderation reversals to emitter credential

### DIFF
--- a/packages/api/src/routes/__tests__/moderationReputationAuthz.test.ts
+++ b/packages/api/src/routes/__tests__/moderationReputationAuthz.test.ts
@@ -347,7 +347,12 @@ describe('POST /reputation/moderation/effects/reverse', () => {
       points: 9999,
     });
     expect(res.status).toBe(200);
-    expect(mockReverse).toHaveBeenCalledWith('dec_1', 1, 'Appeal accepted');
+    expect(mockReverse).toHaveBeenCalledWith(
+      'dec_1',
+      1,
+      'Appeal accepted',
+      '64bbbbbbbbbbbbbbbbbbbbbb'
+    );
   });
 
   it('requires a reason — a reversal without one is unexplainable', async () => {

--- a/packages/api/src/routes/moderationReputation.routes.ts
+++ b/packages/api/src/routes/moderationReputation.routes.ts
@@ -257,7 +257,8 @@ router.post(
     const result = await moderationReputationService.reverseModerationDecision(
       req.body.decisionId,
       req.body.decisionRevision,
-      req.body.reason
+      req.body.reason,
+      req.serviceApp!.credentialId
     );
 
     const dto: ReverseModerationEffectResult = {

--- a/packages/api/src/services/__tests__/moderationReputation.service.test.ts
+++ b/packages/api/src/services/__tests__/moderationReputation.service.test.ts
@@ -210,6 +210,16 @@ async function makeWorld(options: { globalEffects?: boolean } = {}): Promise<Wor
   const bindingId = await makeBinding(applicationId, subjectId);
   const policyVersion = await makePolicy();
   const emitterApplicationId = await makeApplication();
+  const [credential] = await getDb()
+    .insert(applicationCredentials)
+    .values({
+      applicationId: emitterApplicationId,
+      name: 'emitter credential',
+      publicKey: `oxy_dk_${uniqueId()}`,
+      type: 'service',
+      environment: 'development',
+    })
+    .returning({ id: applicationCredentials.id });
 
   mockResolveBindingProof.mockResolvedValue({ ok: true, binding: { id: bindingId } });
 
@@ -219,7 +229,7 @@ async function makeWorld(options: { globalEffects?: boolean } = {}): Promise<Wor
     bindingId,
     policyVersion,
     emitterApplicationId,
-    context: { emitterApplicationId },
+    context: { emitterApplicationId, emitterCredentialId: credential.id },
   };
 }
 
@@ -568,7 +578,8 @@ describe('DoD: an accepted appeal compensates the points and removes the active 
     const result = await moderationReputationService.reverseModerationDecision(
       event.decisionId,
       1,
-      'Appeal accepted: the material was quoted criticism, not abuse'
+      'Appeal accepted: the material was quoted criticism, not abuse',
+      world.context.emitterCredentialId!
     );
 
     expect(result.idempotent).toBe(false);
@@ -609,13 +620,15 @@ describe('DoD: an accepted appeal compensates the points and removes the active 
     await moderationReputationService.reverseModerationDecision(
       event.decisionId,
       1,
-      'Appeal accepted'
+      'Appeal accepted',
+      world.context.emitterCredentialId!
     );
 
     const again = await moderationReputationService.reverseModerationDecision(
       event.decisionId,
       1,
-      'Appeal accepted'
+      'Appeal accepted',
+      world.context.emitterCredentialId!
     );
 
     expect(again.idempotent).toBe(true);
@@ -623,12 +636,35 @@ describe('DoD: an accepted appeal compensates the points and removes the active 
     expect((await reputationService.getBalance(world.subjectId)).total).toBe(0);
   });
 
+  it('cannot reverse another service credential\'s colliding decision id', async () => {
+    const owner = await makeWorld();
+    const other = await makeWorld();
+    const decisionId = `dec_shared_${uniqueId().slice(0, 8)}`;
+    const ownerEvent = makeEvent(owner, { decisionId });
+    const otherEvent = makeEvent(other, { decisionId });
+    await moderationReputationService.applyModerationDecision(ownerEvent, owner.context);
+    await moderationReputationService.applyModerationDecision(otherEvent, other.context);
+
+    const result = await moderationReputationService.reverseModerationDecision(
+      decisionId,
+      1,
+      'Appeal accepted',
+      owner.context.emitterCredentialId!
+    );
+
+    expect(result.reversed).toHaveLength(1);
+    expect(result.reversed[0].credentialId).toBe(owner.context.emitterCredentialId);
+    expect((await effectRows(otherEvent.incidentId))[0].status).toBe('applied');
+    expect(await ledgerRows(other.subjectId)).toHaveLength(1);
+  });
+
   it('reversing a decision that produced no effect is an error, not a silent success', async () => {
     await expect(
       moderationReputationService.reverseModerationDecision(
         `dec_never_${uniqueId().slice(0, 8)}`,
         1,
-        'Appeal accepted'
+        'Appeal accepted',
+        world.context.emitterCredentialId!
       )
     ).rejects.toThrow(/No moderation effect/);
   });
@@ -986,7 +1022,8 @@ describe('the service does not trust its caller', () => {
       moderationReputationService.reverseModerationDecision(
         { toString: () => 'anything' } as never,
         1,
-        'Appeal accepted'
+        'Appeal accepted',
+        world.context.emitterCredentialId!
       )
     ).rejects.toThrow(/No moderation effect/);
 
@@ -1065,7 +1102,8 @@ describe('repetition and multi-finding caps', () => {
     await moderationReputationService.reverseModerationDecision(
       first.decisionId,
       1,
-      'Appeal accepted'
+      'Appeal accepted',
+      world.context.emitterCredentialId!
     );
 
     const next = await moderationReputationService.applyModerationDecision(
@@ -1296,7 +1334,8 @@ describe('expireConductStrikes', () => {
     await moderationReputationService.reverseModerationDecision(
       event.decisionId,
       1,
-      'Appeal accepted'
+      'Appeal accepted',
+      world.context.emitterCredentialId!
     );
     await getDb()
       .update(conductStrikes)

--- a/packages/api/src/services/moderationReputation.service.ts
+++ b/packages/api/src/services/moderationReputation.service.ts
@@ -579,16 +579,24 @@ class ModerationReputationService {
    * someone whose appeal SUCCEEDED still carrying active risk, which is the
    * failure this operation exists to prevent. Every step is idempotent, so a
    * retry completes the rest.
+   *
+   * The credential is part of the lookup key: decision ids are chosen by the
+   * emitter and are neither globally unique nor authority-bearing.
    */
   async reverseModerationDecision(
     decisionId: string,
     decisionRevision: number,
-    reason: string
+    reason: string,
+    emitterCredentialId: string
   ): Promise<ReverseResult> {
     // Coerced before it reaches the filter: reversing on an operator object
     // would compensate an unrelated decision's consequence, which is the worst
     // failure available on this path.
-    const effects = await this.findEffectsByDecision(decisionId, decisionRevision);
+    const effects = await this.findEffectsByDecisionForCredential(
+      decisionId,
+      decisionRevision,
+      emitterCredentialId
+    );
     if (effects.length === 0) {
       throw new NotFoundError('No moderation effect exists for that decision revision');
     }
@@ -667,7 +675,8 @@ class ModerationReputationService {
         await this.reverseModerationDecision(
           effect.decisionId,
           effect.decisionRevision,
-          `Superseded by revision ${latestRevision}`
+          `Superseded by revision ${latestRevision}`,
+          effect.credentialId ?? ''
         );
         supersededReversed += 1;
         touched.add(effect.principalId);
@@ -1196,6 +1205,24 @@ class ModerationReputationService {
         and(
           eq(moderationEffects.decisionId, String(decisionId)),
           eq(moderationEffects.decisionRevision, toDecisionRevision(decisionRevision))
+        )
+      );
+  }
+
+  /** Effects owned by the service credential requesting a reversal. */
+  private async findEffectsByDecisionForCredential(
+    decisionId: string,
+    decisionRevision: number,
+    emitterCredentialId: string
+  ): Promise<ModerationEffectRow[]> {
+    return getDb()
+      .select()
+      .from(moderationEffects)
+      .where(
+        and(
+          eq(moderationEffects.decisionId, String(decisionId)),
+          eq(moderationEffects.decisionRevision, toDecisionRevision(decisionRevision)),
+          eq(moderationEffects.credentialId, String(emitterCredentialId))
         )
       );
   }


### PR DESCRIPTION
### Motivation
- Prevent a service credential from reversing moderation effects produced by another credential when `decisionId` values collide by ensuring reversals are scoped to the verified emitter credential.

### Description
- Forward the authenticated service credential id from the route into the reversal operation by passing `req.serviceApp!.credentialId` to `reverseModerationDecision` in `packages/api/src/routes/moderationReputation.routes.ts`.
- Restrict the reversal lookup to effects owned by the requesting credential by adding `findEffectsByDecisionForCredential(decisionId, decisionRevision, emitterCredentialId)` and using it in `reverseModerationDecision` in `packages/api/src/services/moderationReputation.service.ts`.
- Propagate credential scoping into reconciliation calls that call `reverseModerationDecision` so superseded revisions are reversed only for their emitter credential in `packages/api/src/services/moderationReputation.service.ts`.
- Update tests and test fixtures in `packages/api/src/services/__tests__/moderationReputation.service.test.ts` and `packages/api/src/routes/__tests__/moderationReputationAuthz.test.ts` to create a service credential, pass `emitterCredentialId` through world context, and add a regression asserting a credential cannot reverse another credential's colliding `decisionId`.

### Testing
- Attempted to run the package tests via `bun run test --runInBand` for the modified suites, but the test runner (`jest`) was not present in the execution environment and the test command failed; no test suites were executed successfully.
- Static checks performed: `git diff --check` produced no whitespace errors on the working tree changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a713076b4e08323b22d69b676040452)