### PR TITLE
fix(api): revoke stale official redirect URIs

### DIFF
--- a/packages/api/src/scripts/__tests__/seedOxyApplicationsPlan.test.ts
+++ b/packages/api/src/scripts/__tests__/seedOxyApplicationsPlan.test.ts
@@ -78,6 +78,19 @@ describe('computeSeedApplicationPlan', () => {
     expect(plan.changes).toEqual([]);
   });
 
+  it('revokes redirect URIs which are absent from the canonical seed', () => {
+    const current = {
+      ...commonsMissingCapability(),
+      redirectUris: ['commons://', 'oxycommons://', 'https://stale.example/callback'],
+      capabilities: ['identity:approval'],
+    };
+
+    const plan = computeSeedApplicationPlan(current, COMMONS_TARGET);
+
+    expect(plan.changes.map((change) => change.field)).toEqual(['redirectUris']);
+    expect(plan.desired.redirectUris).toEqual(['commons://', 'oxycommons://']);
+  });
+
   it('applySeedApplicationPlan writes exactly the fields the plan reported', () => {
     const plan = computeSeedApplicationPlan(commonsMissingCapability(), COMMONS_TARGET);
     const record = mutableRecord(commonsMissingCapability());

--- a/packages/api/src/scripts/seedOxyApplicationsPlan.ts
+++ b/packages/api/src/scripts/seedOxyApplicationsPlan.ts
@@ -119,7 +119,10 @@ export function computeSeedApplicationPlan(
     isOfficial: true,
     isInternal: target.type === 'internal',
     ownerAccountId: target.ownerAccountId,
-    redirectUris: union(current?.redirectUris ?? [], target.redirectUris),
+    // Redirect URIs are an OAuth authorization boundary. Unlike scopes and
+    // capabilities, the seed allowlist is authoritative so retired callbacks
+    // are revoked on every reconciliation.
+    redirectUris: [...target.redirectUris],
     scopes: union(current?.scopes ?? [], target.scopes),
     capabilities: union(current?.capabilities ?? [], target.capabilities),
   };

--- a/packages/api/src/utils/__tests__/redirectUris.test.ts
+++ b/packages/api/src/utils/__tests__/redirectUris.test.ts
@@ -2,40 +2,34 @@ import {
   computeOfficialRedirectUriRepair,
   includesRedirectUri,
   originOfWebsiteUrl,
-  unionRedirectUris,
 } from '../redirectUris';
 
-describe('unionRedirectUris', () => {
-  it('preserves existing entries and appends new ones without duplicates', () => {
-    expect(unionRedirectUris(['https://a.example', 'https://b.example'], ['https://b.example', 'https://c.example'])).toEqual([
-      'https://a.example',
-      'https://b.example',
-      'https://c.example',
-    ]);
-  });
-
-  it('treats null/undefined current as empty', () => {
-    expect(unionRedirectUris(null, ['https://a.example'])).toEqual(['https://a.example']);
-  });
-});
-
 describe('computeOfficialRedirectUriRepair', () => {
-  it('returns null when the website origin is already registered', () => {
+  it('returns null when the website origin is the complete allowlist', () => {
     expect(
       computeOfficialRedirectUriRepair(
-        ['https://oxy.so', 'https://fairco.in'],
+        ['https://oxy.so'],
         'https://oxy.so/about',
       ),
     ).toBeNull();
   });
 
-  it('UNIONs the website origin instead of replacing the allowlist', () => {
+  it('replaces stale entries with the canonical website origin', () => {
     expect(
       computeOfficialRedirectUriRepair(
         ['https://fairco.in'],
         'https://oxy.so',
       ),
-    ).toEqual(['https://fairco.in', 'https://oxy.so']);
+    ).toEqual(['https://oxy.so']);
+  });
+
+  it('removes extra entries even when the website origin is already present', () => {
+    expect(
+      computeOfficialRedirectUriRepair(
+        ['https://oxy.so', 'https://stale.example/callback'],
+        'https://oxy.so/about',
+      ),
+    ).toEqual(['https://oxy.so']);
   });
 
   it('seeds the origin when redirectUris is empty', () => {

--- a/packages/api/src/utils/redirectUris.ts
+++ b/packages/api/src/utils/redirectUris.ts
@@ -1,15 +1,4 @@
-/**
- * Non-destructive redirect-uri helpers. Official-app reconciliation must never
- * replace an existing allowlist — only append missing canonical entries.
- */
-
-/** Union preserving order: existing entries first, then additions, de-duplicated. */
-export function unionRedirectUris(
-  current: readonly string[] | null | undefined,
-  additions: readonly string[],
-): string[] {
-  return Array.from(new Set([...(current ?? []), ...additions]));
-}
+/** Redirect-uri helpers for converging official apps to canonical origins. */
 
 /** Exact-match helper — redirect URIs are compared literally, not by prefix. */
 export function includesRedirectUri(
@@ -29,9 +18,9 @@ export function originOfWebsiteUrl(websiteUrl: string): string | null {
 }
 
 /**
- * When a trusted app's `websiteUrl` origin is missing from `redirectUris`,
- * return the unioned allowlist that repairs it. Returns `null` when no change
- * is needed or the website URL is unusable.
+ * Converge a trusted web app's redirect allowlist to its declared website
+ * origin. Redirect URIs are an authorization boundary, so entries which are
+ * no longer canonical must be revoked rather than retained indefinitely.
  */
 export function computeOfficialRedirectUriRepair(
   redirectUris: readonly string[] | null | undefined,
@@ -42,7 +31,7 @@ export function computeOfficialRedirectUriRepair(
 
   const origin = originOfWebsiteUrl(trimmed);
   if (!origin) return null;
-  if (includesRedirectUri(redirectUris, origin)) return null;
+  if (redirectUris?.length === 1 && includesRedirectUri(redirectUris, origin)) return null;
 
-  return unionRedirectUris(redirectUris, [origin]);
+  return [origin];
 }


### PR DESCRIPTION
### Motivation

- A security regression made official-app reconciliation and seeding preserve existing redirect URIs (union), which keeps stale or attacker-controlled callbacks trusted for first-party apps and expands credentialed CORS trust.
- The change restores the authoritative/converging behavior for redirect allowlists so non-canonical callbacks are revoked and the OAuth/CORS trust boundary is tightened.

### Description

- Change `computeOfficialRedirectUriRepair` in `packages/api/src/utils/redirectUris.ts` to converge the allowlist to the canonical `websiteUrl` origin (return the single canonical origin) and to treat a single-origin allowlist that already equals the canonical origin as a no-op.  
- Make the seed plan authoritative for redirect URIs in `packages/api/src/scripts/seedOxyApplicationsPlan.ts` by using the seed's `redirectUris` (replace instead of union) while keeping additive unions for `scopes` and `capabilities`.  
- Update unit tests to cover the new behavior and add a regression test that stale redirect URIs are revoked in the seed plan (`packages/api/src/utils/__tests__/redirectUris.test.ts` and `packages/api/src/scripts/__tests__/seedOxyApplicationsPlan.test.ts`).  
- Small test and helper cleanup: removed the non-authoritative `unionRedirectUris` usage for the seed/official-repair paths and adapted expectations accordingly.

### Testing

- Attempted to run the updated unit tests `src/utils/__tests__/redirectUris.test.ts` and `src/scripts/__tests__/seedOxyApplicationsPlan.test.ts`, but the package `test` script could not execute in this environment because `jest` was not available (`command not found`), so the tests were not executed here.  
- Performed repository checks (`git diff --check`) and validated the working tree and diffs locally; the changes were committed in the workspace.  
- Recommend running the package tests locally or in CI with `bun run test` (or `yarn/npm run test`) inside `packages/api` to verify all tests pass in a fully provisioned dev environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71357176e08323a9497c7806d336f2)