### PR TITLE
fix(api): tie OAuth origin verification to actual request origin

### DIFF
--- a/packages/api/src/routes/__tests__/authSessionOAuthRequest.test.ts
+++ b/packages/api/src/routes/__tests__/authSessionOAuthRequest.test.ts
@@ -376,6 +376,41 @@ describe('POST /auth/session/create — the OAuth binding', () => {
     );
 
     expect(res.status).toBe(200);
+    const row = await stored(sessionToken);
+    expect(row.boundOrigin).toBe('https://rp.example');
+    expect(row.originVerified).toBe(false);
+  });
+
+  it('does not verify a trusted OAuth app from an attacker origin', async () => {
+    const { clientId } = await client({ isOfficial: true, type: 'first_party' });
+    const sessionToken = token();
+
+    const res = await post(
+      '/auth/session/create',
+      { sessionToken, clientId, oauth: oauthBody() },
+      { origin: 'https://evil.example' },
+    );
+
+    expect(res.status).toBe(200);
+    const row = await stored(sessionToken);
+    // Keep showing the intended relying party, but do not turn its registered
+    // redirect URI into proof that this request actually came from that party.
+    expect(row.boundOrigin).toBe('https://rp.example');
+    expect(row.originVerified).toBe(false);
+  });
+
+  it('verifies a trusted OAuth app when the request origin is registered', async () => {
+    const { clientId } = await client({ isOfficial: true, type: 'first_party' });
+    const sessionToken = token();
+
+    const res = await post(
+      '/auth/session/create',
+      { sessionToken, clientId, oauth: oauthBody() },
+      { origin: 'https://rp.example' },
+    );
+
+    expect(res.status).toBe(200);
+    expect((await stored(sessionToken)).originVerified).toBe(true);
   });
 
   it('still rejects a trusted DEVICE sign-in from an unregistered browser origin', async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -830,16 +830,17 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
   }
 
   // Authoritative anti-phishing signal for the Commons approval UI. True ONLY
-  // when a platform-trusted Application proved it is running on one of its OWN
-  // registered redirect origins. Native callers (no Origin) and untrusted /
-  // third-party apps are `false` — Commons warns the approver in that case. The
-  // guard above already rejected a trusted browser caller on a NON-registered
-  // origin, so reaching here with a trusted app + allowed origin is the only way
-  // this is true. This flag is never a gate by itself.
+  // when a platform-trusted Application proved the REQUEST came from one of its
+  // own registered redirect origins. `boundOrigin` may intentionally name the
+  // OAuth relying party while the request itself came from the IdP shell, so it
+  // must never be used as that proof: client IDs, redirect URIs and PKCE
+  // challenges are all public / caller-controlled. Native callers (no Origin)
+  // and untrusted / third-party apps are `false` and Commons warns the approver.
+  // This flag is never a gate by itself.
   const originVerified =
     isTrustedApplication(resolvedApp) &&
-    !!boundOrigin &&
-    applicationAllowsOrigin(resolvedApp, boundOrigin);
+    !!requestOriginHeader &&
+    applicationAllowsOrigin(resolvedApp, requestOriginHeader);
 
   // COARSE requester descriptor for the approval screen ("Chrome on Windows"),
   // so the approver can see WHERE the request came from. It is derived


### PR DESCRIPTION
### Motivation
- Close a security gap where OAuth-bound session creation used the relying-party redirect URI to skip the trusted-app origin proof and mark requests as `originVerified`, enabling attacker-created OAuth sessions for trusted apps after victim approval.
- Preserve the UX requirement that the relying-party origin remains visible in the approval UI while ensuring it cannot be used as proof that the request actually originated from that origin.

### Description
- Change origin verification in `packages/api/src/routes/auth.ts` to compute `originVerified` from the actual request Origin (`requestOriginHeader`) rather than from the OAuth `boundOrigin` derived from the redirect URI, and update the explanatory comments accordingly.
- Keep `boundOrigin` (the relying-party redirect origin) recorded for display during approval but explicitly prevent it being treated as the requester proof.
- Add regression tests in `packages/api/src/routes/__tests__/authSessionOAuthRequest.test.ts` that assert IdP-originated requests keep the displayed RP but are unverified, attacker-originated OAuth requests are not verified, and genuine requests from a registered RP origin are verified.

### Testing
- Ran `git diff --check` to validate the patch formatting and it passed. 
- Attempted to run the modified test file with `bun run test --runInBand src/routes/__tests__/authSessionOAuthRequest.test.ts`, but execution was blocked in this environment because Jest and repository dependencies are not installed (environment limitation). 
- Attempted `bun install --frozen-lockfile` to install dependencies, but it failed due to the npm registry returning HTTP 403 from this environment (environment limitation). 
- Unit tests were added to cover the regressions, but full automated execution could not be completed here due to the dependency install limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71396f2d8c8323996b765e2af443a9)