### PR TITLE
fix(federation): bound remote ActivityPub response bodies

### DIFF
--- a/packages/federation/src/__tests__/actorResolver.test.ts
+++ b/packages/federation/src/__tests__/actorResolver.test.ts
@@ -23,6 +23,7 @@ function makeResolver(
     cached?: TestActor | null;
     cachedKey?: Pick<TestActor, 'uri' | 'publicKeyPem'> | null;
     blockedHosts?: string[];
+    signedFetch?: (url: string) => Promise<Response>;
   } = {},
 ) {
   const blockedHosts = overrides.blockedHosts ?? ['spam.example'];
@@ -37,6 +38,7 @@ function makeResolver(
     federationEnabled: true,
     signedFetch: async (url) => {
       signedFetchCalls.push(url);
+      if (overrides.signedFetch) return overrides.signedFetch(url);
       // A 404 ends `fetchRemoteActor` without exercising the parse/upsert path;
       // these tests only care about WHETHER the fetch was attempted.
       return new Response(null, { status: 404 });
@@ -70,6 +72,22 @@ function makeResolver(
   };
 
   return { resolver: createActorResolver(config), findActorByUriCalls, signedFetchCalls };
+}
+
+function streamedResponse(chunks: string[], init?: ResponseInit): { response: Response; cancelled: () => boolean } {
+  let cancelled = false;
+  const encoder = new TextEncoder();
+  const response = new Response(new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const chunk = chunks.shift();
+      if (chunk === undefined) controller.close();
+      else controller.enqueue(encoder.encode(chunk));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  }), init);
+  return { response, cancelled: () => cancelled };
 }
 
 describe('getOrFetchActor — instance domain policy', () => {
@@ -135,5 +153,57 @@ describe('fetchPublicKey — signature lookups stay honest', () => {
     const rig = makeResolver({ cachedKey: null, cached: null });
     await expect(rig.resolver.fetchPublicKey(`${BLOCKED_ACTOR}#main-key`)).resolves.toBeNull();
     expect(rig.signedFetchCalls).toHaveLength(0);
+  });
+});
+
+describe('fetchRemoteActor — bounded remote bodies', () => {
+  it('rejects and cancels an actor body that exceeds the decompressed-size cap', async () => {
+    const oversized = streamedResponse(['x'.repeat(1024 * 1024), 'x']);
+    const rig = makeResolver({ signedFetch: async () => oversized.response });
+
+    await expect(rig.resolver.fetchRemoteActor(ALLOWED_ACTOR)).resolves.toBeNull();
+    expect(oversized.cancelled()).toBe(true);
+  });
+
+  it('rejects an oversized actor from Content-Length without consuming its stream', async () => {
+    let cancelled = false;
+    const response = new Response(new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array([123]));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    }), { headers: { 'content-length': String(1024 * 1024 + 1) } });
+    const rig = makeResolver({ signedFetch: async () => response });
+
+    await expect(rig.resolver.fetchRemoteActor(ALLOWED_ACTOR)).resolves.toBeNull();
+    expect(cancelled).toBe(true);
+  });
+
+  it('bounds actor-advertised collection responses and fails the count soft', async () => {
+    const actor = JSON.stringify({
+      id: ALLOWED_ACTOR,
+      inbox: 'https://remote.example/inbox',
+      preferredUsername: 'bob',
+      followers: 'https://remote.example/followers',
+    });
+    const oversizedCollection = streamedResponse(['x'.repeat(64 * 1024), 'x']);
+    const rig = makeResolver({
+      signedFetch: async (url) => url === ALLOWED_ACTOR
+        ? new Response(actor)
+        : oversizedCollection.response,
+    });
+
+    await expect(rig.resolver.fetchRemoteActor(ALLOWED_ACTOR)).resolves.toBeNull();
+    expect(oversizedCollection.cancelled()).toBe(true);
+  });
+
+  it('caps an error body before attempting the WebFinger fallback', async () => {
+    const oversized = streamedResponse(['x'.repeat(4096), 'x'], { status: 500 });
+    const rig = makeResolver({ signedFetch: async () => oversized.response });
+
+    await expect(rig.resolver.fetchRemoteActor(ALLOWED_ACTOR)).resolves.toBeNull();
+    expect(oversized.cancelled()).toBe(true);
   });
 });

--- a/packages/federation/src/node/actorResolver.ts
+++ b/packages/federation/src/node/actorResolver.ts
@@ -42,6 +42,51 @@ const ACTOR_STALE_MS = 24 * 60 * 60 * 1000; // 24 hours
 /** The AP content type asked for on signed actor/collection fetches. */
 const AP_CONTENT_TYPE = 'application/activity+json';
 
+/** Maximum decompressed response sizes accepted from untrusted federation hosts. */
+const ACTOR_BODY_MAX_BYTES = 1024 * 1024;
+const COLLECTION_BODY_MAX_BYTES = 64 * 1024;
+const ERROR_BODY_MAX_BYTES = 4 * 1024;
+
+async function readBoundedResponseBody(res: Response, maxBytes: number): Promise<string> {
+  const contentLength = res.headers.get('content-length');
+  if (contentLength) {
+    const declaredBytes = Number(contentLength);
+    if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
+      await res.body?.cancel().catch(() => {});
+      throw new Error(`Remote response exceeds ${maxBytes} byte limit`);
+    }
+  }
+
+  if (!res.body) return '';
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+  let bytesRead = 0;
+  let text = '';
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.byteLength;
+      if (bytesRead > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new Error(`Remote response exceeds ${maxBytes} byte limit`);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function readBoundedJson(res: Response, maxBytes: number): Promise<Record<string, unknown>> {
+  const value: unknown = JSON.parse(await readBoundedResponseBody(res, maxBytes));
+  const record = asRecord(value);
+  if (!record) throw new Error('Remote response is not a JSON object');
+  return record;
+}
+
 function isApActorContentType(type: string | undefined): boolean {
   if (!type) return false;
   const base = type.split(';')[0]?.trim().toLowerCase();
@@ -357,7 +402,7 @@ export class ActorResolver<TActor extends FederatedActorRecordBase> {
           await this.tombstoneGoneActor(currentUri);
           return null;
         }
-        const body = await res.text().catch(() => '');
+        const body = await readBoundedResponseBody(res, ERROR_BODY_MAX_BYTES).catch(() => '');
         this.config.logger.info(`[FedSync] fetchRemoteActor HTTP ${res.status} ${res.statusText} for ${currentUri} body=${body.slice(0, 500)}`);
 
         // If direct fetch failed, try WebFinger to resolve the canonical actor URI.
@@ -383,7 +428,7 @@ export class ActorResolver<TActor extends FederatedActorRecordBase> {
                 await this.tombstoneGoneActor(currentUri);
                 return null;
               }
-              const body2 = await res.text().catch(() => '');
+              const body2 = await readBoundedResponseBody(res, ERROR_BODY_MAX_BYTES).catch(() => '');
               this.config.logger.info(`[FedSync] fetchRemoteActor HTTP ${res.status} for resolved ${resolved} body=${body2.slice(0, 500)}`);
               return null;
             }
@@ -396,7 +441,7 @@ export class ActorResolver<TActor extends FederatedActorRecordBase> {
         }
       }
 
-      const actor = (await res.json()) as Record<string, unknown>;
+      const actor = await readBoundedJson(res, ACTOR_BODY_MAX_BYTES);
       const actorId = asString(actor.id);
       const actorInbox = asString(actor.inbox);
       if (!actorId || !actorInbox) {
@@ -672,7 +717,7 @@ export class ActorResolver<TActor extends FederatedActorRecordBase> {
     try {
       const res = await this.config.signedFetch(url, AP_CONTENT_TYPE);
       if (!res.ok) return 0;
-      const col = (await res.json()) as Record<string, unknown>;
+      const col = await readBoundedJson(res, COLLECTION_BODY_MAX_BYTES);
       return typeof col.totalItems === 'number' ? col.totalItems : 0;
     } catch {
       return 0;


### PR DESCRIPTION
### Motivation
- Prevent an unauthenticated remote federated server from exhausting memory/CPU by returning extremely large actor, collection, or error responses during actor resolution.

### Description
- Add bounded read helpers `readBoundedResponseBody` and `readBoundedJson` that check `Content-Length`, stream the response via `ReadableStream` readers, enforce separate decompressed-size caps, cancel streams that exceed limits, and validate JSON shapes.
- Apply bounded reads to actor error logging and WebFinger-fallback error logging, replace unbounded `res.json()` for the actor document with `readBoundedJson(res, ACTOR_BODY_MAX_BYTES)`, and replace collection `res.json()` with `readBoundedJson(res, COLLECTION_BODY_MAX_BYTES)` so collection counts cannot trigger unbounded parsing.
- Introduce size caps constants (`ACTOR_BODY_MAX_BYTES`, `COLLECTION_BODY_MAX_BYTES`, `ERROR_BODY_MAX_BYTES`) and ensure oversized collection responses preserve the existing fail-soft behavior by returning zero counts.
- Add regression tests in `packages/federation/src/__tests__/actorResolver.test.ts` that simulate streaming responses to verify stream cancellation, early `Content-Length` rejection, oversized actor bodies, oversized collection responses, and bounded error-body handling.

### Testing
- Built the updated resolver with `bun build packages/federation/src/node/actorResolver.ts --target=node --outfile=/tmp/actorResolver.js` which completed successfully. 
- Ran `git diff --check` to validate the working tree and file changes with no whitespace/errors reported. 
- Added Jest unit tests for the new behaviour but `bun run test --runInBand` could not be executed in this environment because the package test runner (`jest`) and other dependencies are not installed. 
- Attempted `bun install --frozen-lockfile` to populate dependencies but the environment's registry access returned HTTP 403, preventing automated test execution here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7153ffcf9483238864e8f66ad16250)