### PR TITLE
fix(api): require WebAuthn user verification

### DIFF
--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -258,7 +258,7 @@ describe('POST /webauthn/login/options', () => {
     // The user's real credential id is surfaced so a non-discoverable hardware key
     // can be invoked by the browser.
     expect(opts.allowCredentials).toEqual([{ id: credentialID, transports: ['usb', 'nfc'] }]);
-    expect(opts.userVerification).toBe('preferred');
+    expect(opts.userVerification).toBe('required');
 
     // The stored challenge is bound to the resolved account and is SPENDABLE.
     const stored = await storedChallenge(currentChallenge);
@@ -422,9 +422,8 @@ describe('POST /webauthn/login/verify', () => {
       deviceType: 'web',
       platform: 'web',
     });
-    // Possession-only assertions are accepted — UV is not required at verify.
     const verifyArg = mockVerifyAuthentication.mock.calls[0][0] as { requireUserVerification: boolean };
-    expect(verifyArg.requireUserVerification).toBe(false);
+    expect(verifyArg.requireUserVerification).toBe(true);
   });
 
   it('feeds the verifier the STORED public key, counter and transports', async () => {
@@ -453,20 +452,6 @@ describe('POST /webauthn/login/verify', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.user).toMatchObject({ id: userId });
-  });
-
-  it('accepts a possession-only (userVerified:false) assertion and records the flag', async () => {
-    // A stored credential that had verified previously authenticates presence-only
-    // now (e.g. a U2F key with no PIN) → still succeeds, flag refreshed to false.
-    const { username, credentialID } = await accountWithPasskey({ userVerified: true });
-    presentedCredentialId = credentialID;
-    await request(server, 'POST', '/webauthn/login/options', { username });
-    mockVerifyAuthentication.mockResolvedValue({ verified: true, authenticationInfo: { newCounter: 6, userVerified: false } });
-
-    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
-
-    expect(res.status).toBe(200);
-    expect((await storedCredential(credentialID)).userVerified).toBe(false);
   });
 
   it('accepts a platform authenticator that never increments (newCounter === 0, stored 0)', async () => {

--- a/packages/api/src/routes/__tests__/webauthnRegister.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnRegister.test.ts
@@ -351,7 +351,7 @@ describe('POST /webauthn/register/options', () => {
     expect(stored.used).toBe(false);
   });
 
-  it('offers residentKey:preferred + UV:preferred and does NOT pin authenticatorAttachment (roaming/hardware keys can enrol)', async () => {
+  it('offers residentKey:preferred + UV:required and does NOT pin authenticatorAttachment (roaming/hardware keys can enrol)', async () => {
     const res = await request(server, 'POST', '/webauthn/register/options', { username: freshUsername() });
     expect(res.status).toBe(200);
     const opts = mockGenerateRegistration.mock.calls[0][0] as {
@@ -364,9 +364,7 @@ describe('POST /webauthn/register/options', () => {
     // `preferred` (not `required`) is what lets a Google Titan / roaming key with no
     // resident-key support still register a non-discoverable credential.
     expect(opts.authenticatorSelection.residentKey).toBe('preferred');
-    // UV is `preferred` (owner possession-credential policy): UV-capable keys still
-    // verify; a UV-incapable U2F key falls back to presence-only.
-    expect(opts.authenticatorSelection.userVerification).toBe('preferred');
+    expect(opts.authenticatorSelection.userVerification).toBe('required');
     // Attachment is unpinned so both platform and cross-platform authenticators show.
     expect(opts.authenticatorSelection.authenticatorAttachment).toBeUndefined();
   });
@@ -425,9 +423,8 @@ describe('POST /webauthn/register/verify — signup branch', () => {
       deviceType: 'web',
       platform: 'web',
     });
-    // Possession-only credentials are accepted — UV is not required at verify.
     const verifyArg = mockVerifyRegistration.mock.calls[0][0] as { requireUserVerification: boolean };
-    expect(verifyArg.requireUserVerification).toBe(false);
+    expect(verifyArg.requireUserVerification).toBe(true);
   });
 
   it('defaults the credential name when the client sends none', async () => {
@@ -436,23 +433,6 @@ describe('POST /webauthn/register/verify — signup branch', () => {
     await request(server, 'POST', '/webauthn/register/verify', { username, response: registrationResponse() });
 
     expect((await storedCredential(currentCredentialId)).name).toBe('Passkey');
-  });
-
-  it('records userVerified:false for a possession-only (no-UV) enrollment and still creates the account', async () => {
-    mockRegisterUserVerified = false;
-    const username = freshUsername();
-    await request(server, 'POST', '/webauthn/register/options', { username });
-
-    const res = await request(server, 'POST', '/webauthn/register/verify', {
-      username,
-      deviceName: 'Titan Key',
-      response: registrationResponse(),
-    });
-
-    expect(res.status).toBe(200);
-    // Presence-only assertion → recorded as an unverified (possession-only) credential.
-    expect((await storedCredential(currentCredentialId)).userVerified).toBe(false);
-    expect(await storedUserByUsername(username)).toBeDefined();
   });
 
   it('leaves NO account behind when the credential collides — the whole signup rolls back (409)', async () => {

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -535,13 +535,9 @@ router.post(
         // serves via an explicit allow-list. `required` here is exactly what made a
         // Google Titan fail Chrome's "device can't be used with this site" gate.
         residentKey: 'preferred',
-        // `preferred`, not `required` (owner possession-credential policy): a
-        // UV-capable authenticator (platform Face ID / Windows Hello, FIDO2-with-PIN)
-        // STILL performs user verification unchanged; only a UV-incapable key (a
-        // U2F/CTAP1 Titan with no PIN) falls back to presence-only. The assurance
-        // level of each ceremony is captured on the credential's `userVerified` flag
-        // (see register/verify) so a future step-up can gate on UV-backed credentials.
-        userVerification: 'preferred',
+        // Account authentication must prove local user verification (PIN,
+        // biometric, or equivalent), not mere possession of an authenticator.
+        userVerification: 'required',
         // `authenticatorAttachment` is deliberately UNPINNED so both platform (Face ID /
         // Touch ID / Windows Hello) and cross-platform/roaming (USB-C / NFC security key)
         // authenticators are offered.
@@ -599,10 +595,7 @@ router.post(
         expectedChallenge: challenge,
         expectedOrigin: origin,
         expectedRPID: rpID,
-        // Possession-only credentials are accepted (owner policy): a presence-only
-        // U2F/CTAP1 key would fail here if UV were required. The actual assurance
-        // level is recorded per-credential via `registrationInfo.userVerified`.
-        requireUserVerification: false,
+        requireUserVerification: true,
       });
     } catch (error) {
       logger.warn('webauthn register verification threw', {
@@ -617,8 +610,7 @@ router.post(
     }
 
     // CAVEAT — `userVerified` is authenticator-SELF-ASSERTED, not attestation-proven.
-    // We register with `attestationType: 'none'` and verify with
-    // `requireUserVerification: false`, so this flag is only the UV bit the
+    // We register with `attestationType: 'none'`, so this flag is only the UV bit the
     // authenticator reported for THIS ceremony; nothing cryptographically attests the
     // authenticator's UV capability or that UV actually happened. Treat it as an
     // assurance/telemetry marker ONLY — it must NOT be used as a hard security
@@ -853,11 +845,8 @@ router.post(
     const options = await generateAuthenticationOptions({
       rpID,
       allowCredentials,
-      // `preferred` (owner possession-credential policy): UV-capable authenticators
-      // still verify; a UV-incapable U2F key authenticates presence-only. The
-      // ceremony's real assurance level is refreshed onto the credential's
-      // `userVerified` flag at verify time.
-      userVerification: 'preferred',
+      // Require local user verification rather than authenticator possession alone.
+      userVerification: 'required',
     });
 
     await db.insert(webauthnChallenges).values({
@@ -944,9 +933,7 @@ router.post(
         expectedChallenge: challenge,
         expectedOrigin: origin,
         expectedRPID: rpID,
-        // Possession-only assertions are accepted (owner policy); the actual
-        // assurance level is refreshed onto `credential.userVerified` below.
-        requireUserVerification: false,
+        requireUserVerification: true,
         credential: {
           id: credential.credentialID,
           publicKey: new Uint8Array(credential.credentialPublicKey),
@@ -993,11 +980,9 @@ router.post(
       .set({
         counter: newCounter,
         lastUsedAt: new Date(),
-        // Refresh the assurance level: a credential that enrolled UV-capable but
-        // authenticated presence-only (or vice versa) reflects its most recent ceremony.
+        // Refresh the assurance telemetry from the successfully verified ceremony.
         // CAVEAT (same as register/verify): `userVerified` is authenticator-SELF-ASSERTED
-        // — verify runs with `requireUserVerification: false` and no attestation, so this
-        // is only the UV bit the authenticator reported for this assertion. It is an
+        // — this is only the UV bit the authenticator reported for this assertion. It is an
         // assurance/telemetry marker, NOT an attestation-proven fact, and must NOT gate a
         // hard step-up boundary without attestation.
         userVerified,


### PR DESCRIPTION
### Motivation

- A recent change downgraded WebAuthn flows to allow possession-only ceremonies and then minted full sessions unconditionally, which made credentials usable without PIN/biometric verification and opened a high-severity authentication risk.

### Description

- Enforce local user verification in registration and authentication options by setting `userVerification: 'required'` in the WebAuthn option generation paths in `packages/api/src/routes/webauthn.ts`.
- Require user verification server-side by passing `requireUserVerification: true` to `verifyRegistrationResponse` and `verifyAuthenticationResponse` in `packages/api/src/routes/webauthn.ts` so assertions without UV are rejected.
- Update regression tests to reflect the new policy by asserting `userVerification: 'required'` in `packages/api/src/routes/__tests__/webauthnRegister.test.ts` and `packages/api/src/routes/__tests__/webauthnLogin.test.ts`, and remove tests that expected possession-only enrollments/logins to succeed.
- Tidy a couple of comments to reflect that `userVerified` remains a telemetry/assurance bit and is not a cryptographic attestation.

### Testing

- Ran `git diff --check` and repository text searches for `userVerification` / `requireUserVerification` to validate the edits, which succeeded.
- Updated tests were validated by static inspection (`rg`), but running the package's Jest suites with `bun run test` could not be executed in this environment because the test runner/dependencies are not installed, so full automated test execution was not performed.
- Changes were committed locally with message `fix(api): require WebAuthn user verification`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a715ccec35083239539565b1dba1c45)