### PR TITLE
fix(ship): secure publish-update GitHub Actions template to prevent command injection

### DIFF
--- a/packages/ship/README.md
+++ b/packages/ship/README.md
@@ -61,4 +61,6 @@ oxy-ship update:list [--channel production] [--runtime-version 1.2.3] [--platfor
 ## CI
 
 Copy `templates/publish-update.yml` into an app repo. It publishes to
-`production` on push to `main` and to `pr-<n>` on pull requests.
+`production` on push to `main`. The workflow intentionally does not run for
+pull requests, so untrusted pull request code and metadata cannot access the
+OTA publishing credentials.

--- a/packages/ship/templates/publish-update.yml
+++ b/packages/ship/templates/publish-update.yml
@@ -3,7 +3,6 @@
 # Copy this into an app repo as `.github/workflows/publish-update.yml`. It runs
 # `expo export` and publishes the JS bundle + assets to the Oxy Updates service:
 #   - push to `main`  → channel `production`
-#   - pull request     → channel `pr-<number>` (a disposable preview track)
 #
 # Prerequisites:
 #   - Repo secrets OXY_SHIP_CLIENT_ID / OXY_SHIP_SECRET: a `service`-type
@@ -19,7 +18,6 @@ name: Publish OTA update
 on:
   push:
     branches: [main]
-  pull_request:
 
 concurrency:
   group: oxy-updates-${{ github.ref }}
@@ -42,21 +40,17 @@ jobs:
 
       - name: Resolve channel
         id: channel
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "name=pr-${{ github.event.number }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "name=production" >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "name=production" >> "$GITHUB_OUTPUT"
 
       - name: Run oxy-ship publish
         env:
           OXY_SHIP_CLIENT_ID: ${{ secrets.OXY_SHIP_CLIENT_ID }}
           OXY_SHIP_SECRET: ${{ secrets.OXY_SHIP_SECRET }}
           OXY_API_URL: https://api.oxy.so
+          SHIP_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           bunx oxy-ship publish \
             --channel "${{ steps.channel.outputs.name }}" \
             --platform all \
             --git-commit "${{ github.sha }}" \
-            --message "${{ github.event.head_commit.message || github.event.pull_request.title }}"
+            --message "$SHIP_MESSAGE"


### PR DESCRIPTION
### Motivation

- A workflow template interpolated attacker-controlled pull request metadata directly into a shell command in `packages/ship/templates/publish-update.yml`, creating a command-injection / secret-exfiltration primitive when step secrets are present. 
- The publishing step exported `OXY_SHIP_CLIENT_ID` / `OXY_SHIP_SECRET` into the shell environment and embedded `${{ github.event... }}` into a double-quoted `run:` script, which allows shell metacharacters in PR titles to become executable source. 
- The change reduces the attack surface by preventing untrusted pull-request data from executing with publish credentials while preserving safe publishes from `main` pushes.

### Description

- Removed the `pull_request` trigger and made the workflow run only on pushes to `main`, so untrusted PR metadata cannot run with publishing credentials. 
- Forced the deploy channel to `production` via `echo "name=production" >> "$GITHUB_OUTPUT"` and eliminated the branch/PR branching logic in `packages/ship/templates/publish-update.yml`. 
- Passed the commit message through an environment variable `SHIP_MESSAGE: ${{ github.event.head_commit.message }}` and used a quoted shell variable `--message "$SHIP_MESSAGE"` so GitHub expression content is never parsed as shell source. 
- Updated `packages/ship/README.md` to document that the workflow intentionally does not run for pull requests to protect OTA publishing credentials.

### Testing

- Ran `bun run test` in `packages/ship` and all tests passed (36 passed, 0 failed). 
- Validated the workflow YAML with `ruby -e "require 'yaml'; YAML.parse_file('templates/publish-update.yml')"`, which parsed successfully. 
- Performed a static grep that checks for untrusted `github.event*` interpolation into shell `run:` lines and confirmed no unsafe GitHub context is embedded in shell commands. 
- Ran `git diff --check` with no whitespace errors; `bun run typecheck` could not complete due to missing Node type definitions and a deprecated TypeScript option external to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a715ea514cc8323a744b25177cdce84)