### PR TITLE
fix(create-oxy-app): isolate generated AWS deploy roles

### DIFF
--- a/packages/create-oxy-app/README.md
+++ b/packages/create-oxy-app/README.md
@@ -50,6 +50,14 @@ BloomThemeProvider → OxyProvider → ImageResolver → LocaleProvider`) with t
 `Stack` as the sole `(auth)`↔`(app)` authority, keyed on the device-first
 session.
 
+### AWS deployment setup
+
+Before enabling the generated workflow, provision its app-specific IAM role
+(`oxy-<slug>-github-deploy`). Its OIDC trust policy must match the generated
+GitHub repository exactly, and its permissions must be limited to that app's
+`/oxy/<slug>/*` SSM parameters, `oxy/<slug>` ECR repository, and `<slug>` ECS
+service. Do not share a deploy role between generated repositories.
+
 ## Oxy client registration
 
 By default the CLI offers to register an `Application` + public credential with

--- a/packages/create-oxy-app/src/__tests__/render.test.ts
+++ b/packages/create-oxy-app/src/__tests__/render.test.ts
@@ -121,3 +121,25 @@ describe('base template bunfig.toml', () => {
     expect(renderString(raw, ctx, 'bunfig.toml.tpl')).toContain('linker = "hoisted"');
   });
 });
+
+describe('AWS deploy template', () => {
+  test('uses an app-specific role and cannot overwrite shared secrets', async () => {
+    const templateFile = path.join(
+      __dirname,
+      '..',
+      '..',
+      'templates',
+      'deploy',
+      'DOT_github',
+      'workflows',
+      'deploy-aws.yml',
+    );
+    const rendered = renderString(await fs.readFile(templateFile, 'utf8'), ctx, templateFile);
+
+    expect(rendered).toContain('role/oxy-my-app-github-deploy');
+    expect(rendered).not.toContain('role/oxy-github-deploy');
+    expect(rendered).not.toContain('/oxy/_shared/');
+    expect(rendered).not.toContain('AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY');
+    expect(rendered).toContain('path="/oxy/$APP/$k"');
+  });
+});

--- a/packages/create-oxy-app/templates/deploy/DOT_github/workflows/deploy-aws.yml
+++ b/packages/create-oxy-app/templates/deploy/DOT_github/workflows/deploy-aws.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Configure AWS credentials (OIDC, no stored keys)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::237343248947:role/oxy-github-deploy
+          # This role must trust only this repository and grant access only to
+          # this app's SSM path, ECR repository, and ECS service. Never replace
+          # it with a role shared by generated repositories.
+          role-to-assume: arn:aws:iam::237343248947:role/oxy-{{APP_SLUG}}-github-deploy
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Sync GitHub secrets -> SSM (GitHub is the source of truth)
@@ -42,11 +45,8 @@ jobs:
           SECRETS_JSON: ${{ toJSON(secrets) }}
           # Explicit backend runtime allowlist — do not sync unrelated CI tokens.
           SSM_SECRET_ALLOWLIST: >-
-            MONGODB_URI REDIS_URL
-            OXY_SERVICE_API_KEY OXY_SERVICE_API_SECRET
-            AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+            MONGODB_URI OXY_SERVICE_API_KEY OXY_SERVICE_API_SECRET
         run: |
-          SHARED="AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY REDIS_URL"
           echo "$SECRETS_JSON" | jq -r --arg allowlist "$SSM_SECRET_ALLOWLIST" '
             ($allowlist | split(" ")) as $allowed
             | to_entries[]
@@ -59,7 +59,7 @@ jobs:
               echo "::warning::skip empty/placeholder secret $k; SSM unchanged"
               continue
             fi
-            case " $SHARED " in *" $k "*) path="/oxy/_shared/$k";; *) path="/oxy/$APP/$k";; esac
+            path="/oxy/$APP/$k"
             aws ssm put-parameter --name "$path" --value "$v" --type SecureString --overwrite >/dev/null && echo "synced -> $path"
           done
 


### PR DESCRIPTION
### Motivation

- The generated GitHub Actions deploy workflow used a shared OIDC role and a user-controlled `APP` slug, allowing a generated repo to overwrite another app's SSM parameters, push to its ECR repo, or trigger its ECS service when the shared role was assumable.
- Reduce blast radius by enforcing per-app authorization boundaries in the scaffolded workflow and documenting least-privilege provisioning requirements.

### Description

- Updated the deploy workflow template to assume an app-scoped role name `arn:aws:iam::237343248947:role/oxy-{{APP_SLUG}}-github-deploy` instead of the shared `oxy-github-deploy` role and added a comment describing the trust/permission requirements in the template (`packages/create-oxy-app/templates/deploy/DOT_github/workflows/deploy-aws.yml`).
- Removed writes to the shared SSM namespace and long-lived AWS credential allowlist from the template by always writing secrets to the app-specific path `/oxy/$APP/$k` and removing `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/shared SSM sync behavior in the workflow.
- Added a regression test in `packages/create-oxy-app/src/__tests__/render.test.ts` that renders the workflow template and asserts the generated content uses the app-specific role and no longer references shared secrets or `/oxy/_shared/`.
- Documented the requirement to provision an app-specific OIDC role with limited permissions in the scaffolder `README` (`packages/create-oxy-app/README.md`).

### Testing

- Ran `bun run test` in `packages/create-oxy-app` and all tests passed (`18` tests total).
- Ran `git diff --check` and inspected the diff to confirm only intended changes were introduced, with no whitespace/errors reported.
- Attempted `bun run typecheck` but it is blocked in this environment due to missing Node type definitions and a TypeScript `moduleResolution=node10` deprecation error, so full typecheck was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a715ea4dbd8832382ca2aea15b09086)