### PR TITLE
fix(updates): verify content-addressed asset uploads

### DIFF
--- a/packages/api/src/services/s3Service.ts
+++ b/packages/api/src/services/s3Service.ts
@@ -338,7 +338,13 @@ export class S3Service {
     options: PresignedUrlOptions = {}
   ): Promise<string> {
     try {
-      const { expiresIn = 3600, contentType = 'application/octet-stream', metadata, cacheControl } = options;
+      const {
+        expiresIn = 3600,
+        contentType = 'application/octet-stream',
+        metadata,
+        cacheControl,
+        checksumSHA256,
+      } = options;
 
       // Sanitize metadata to ensure all values are strings
       const sanitizedMetadata: Record<string, string> = {};
@@ -355,6 +361,7 @@ export class S3Service {
         Key: key,
         ContentType: contentType,
         CacheControl: cacheControl,
+        ChecksumSHA256: checksumSHA256,
         Metadata: Object.keys(sanitizedMetadata).length > 0 ? sanitizedMetadata : undefined,
       });
 

--- a/packages/api/src/services/updates/__tests__/publish.service.test.ts
+++ b/packages/api/src/services/updates/__tests__/publish.service.test.ts
@@ -16,18 +16,20 @@
  *    descriptors behind.
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { and, asc, eq, sql } from 'drizzle-orm';
 import type { CreateUpdateRequest } from '@oxyhq/contracts';
 
 const mockPresign = jest.fn();
 const mockHeadObject = jest.fn();
+const mockDownloadBuffer = jest.fn();
 
 jest.mock('../../s3ServiceSingleton', () => ({
   __esModule: true,
   s3Service: {
     getPresignedUploadUrl: (...args: unknown[]) => mockPresign(...args),
     headObject: (...args: unknown[]) => mockHeadObject(...args),
+    downloadBuffer: (...args: unknown[]) => mockDownloadBuffer(...args),
   },
 }));
 jest.mock('../../../utils/logger', () => ({
@@ -192,8 +194,15 @@ describe('initAssets', () => {
         storageKey: updateAssetS3Key(fresh),
         contentType: 'image/png',
         cacheControl: 'public, max-age=31536000, immutable',
+        checksumSHA256: Buffer.from(fresh, 'hex').toString('base64'),
       },
     ]);
+    expect(mockPresign).toHaveBeenCalledWith(updateAssetS3Key(fresh), {
+      contentType: 'image/png',
+      cacheControl: 'public, max-age=31536000, immutable',
+      checksumSHA256: Buffer.from(fresh, 'hex').toString('base64'),
+      expiresIn: 3600,
+    });
     expect(mockPresign).toHaveBeenCalledTimes(1);
 
     // The pending record `completeAssets` will look for, with the S3 key derived
@@ -245,22 +254,49 @@ describe('initAssets', () => {
 describe('completeAssets', () => {
   test('flips a pending asset to uploaded with the size S3 reports', async () => {
     const applicationId = await application();
-    const sha256 = sha256Hex();
+    const bytes = Buffer.from('verified update asset');
+    const sha256 = createHash('sha256').update(bytes).digest('hex');
     await getDb()
       .insert(updateAssets)
-      .values({ sha256, contentType: 'image/png', size: 0, status: 'pending' });
-    mockHeadObject.mockResolvedValue({ size: 512, contentType: 'image/png' });
+      .values({ sha256, contentType: 'image/png', size: bytes.length, status: 'pending' });
+    mockHeadObject.mockResolvedValue({ size: bytes.length, contentType: 'image/png' });
+    mockDownloadBuffer.mockResolvedValue(bytes);
 
     const result = await publishService.completeAssets(applicationId, [sha256]);
 
     expect(mockHeadObject).toHaveBeenCalledWith(updateAssetS3Key(sha256));
-    expect(result.assets).toEqual([{ sha256, status: 'uploaded', size: 512 }]);
+    expect(mockDownloadBuffer).toHaveBeenCalledWith(updateAssetS3Key(sha256));
+    expect(result.assets).toEqual([{ sha256, status: 'uploaded', size: bytes.length }]);
 
     const [row] = await getDb()
       .select({ status: updateAssets.status, size: updateAssets.size })
       .from(updateAssets)
       .where(eq(updateAssets.sha256, sha256));
-    expect(row).toEqual({ status: 'uploaded', size: 512 });
+    expect(row).toEqual({ status: 'uploaded', size: bytes.length });
+  });
+
+  test('leaves an asset pending when its bytes do not match the claimed hash', async () => {
+    const applicationId = await application();
+    const expected = Buffer.from('legitimate asset');
+    const poisoned = Buffer.from('attacker content');
+    const sha256 = createHash('sha256').update(expected).digest('hex');
+    await getDb().insert(updateAssets).values({
+      sha256,
+      contentType: 'application/javascript',
+      size: poisoned.length,
+      status: 'pending',
+    });
+    mockHeadObject.mockResolvedValue({ size: poisoned.length });
+    mockDownloadBuffer.mockResolvedValue(poisoned);
+
+    const result = await publishService.completeAssets(applicationId, [sha256]);
+
+    expect(result.assets).toEqual([{ sha256, status: 'pending', size: 0 }]);
+    const [row] = await getDb()
+      .select({ status: updateAssets.status })
+      .from(updateAssets)
+      .where(eq(updateAssets.sha256, sha256));
+    expect(row.status).toBe('pending');
   });
 
   test('leaves an asset pending when the object is missing in S3', async () => {

--- a/packages/api/src/services/updates/publish.service.ts
+++ b/packages/api/src/services/updates/publish.service.ts
@@ -29,6 +29,7 @@
  */
 
 import { and, asc, desc, eq, inArray } from 'drizzle-orm';
+import { createHash } from 'node:crypto';
 import type {
   AssetInitItem,
   AssetInitResponse,
@@ -304,9 +305,11 @@ export async function initAssets(
       });
 
     const s3Key = updateAssetS3Key(asset.sha256);
+    const checksumSHA256 = Buffer.from(asset.sha256, 'hex').toString('base64');
     const uploadUrl = await s3Service.getPresignedUploadUrl(s3Key, {
       contentType: asset.contentType,
       cacheControl: ASSET_CACHE_CONTROL,
+      checksumSHA256,
       expiresIn: ASSET_UPLOAD_URL_EXPIRY_SECONDS,
     });
     missing.push({
@@ -315,6 +318,7 @@ export async function initAssets(
       storageKey: s3Key,
       contentType: asset.contentType,
       cacheControl: ASSET_CACHE_CONTROL,
+      checksumSHA256,
     });
   }
 
@@ -329,10 +333,9 @@ export async function initAssets(
 }
 
 /**
- * Verify each claimed-complete asset actually exists in S3 (HEAD) and flip it to
- * `uploaded`, recording the object's true byte size. An object that is absent or
- * empty stays `pending` and is reported as such — the caller must re-PUT it
- * before the assets can back a published update.
+ * Verify each claimed-complete asset's bytes and flip it to `uploaded`. Because
+ * assets are globally deduplicated by their content address, trusting only S3
+ * metadata here would let one publisher poison an asset used by every app.
  */
 export async function completeAssets(
   applicationId: string,
@@ -365,10 +368,27 @@ export async function completeAssets(
     }
 
     const head = await s3Service.headObject(asset.s3Key);
-    if (!head || head.size <= 0) {
-      logger.warn('Oxy Updates asset complete: object missing or empty', {
+    if (!head || head.size <= 0 || head.size !== asset.size) {
+      logger.warn('Oxy Updates asset complete: object missing or size mismatch', {
         applicationId,
         sha256,
+        s3Key: asset.s3Key,
+        expectedSize: asset.size,
+        actualSize: head?.size ?? 0,
+      });
+      results.push({ sha256, status: 'pending', size: 0 });
+      continue;
+    }
+
+    const bytes = await s3Service.downloadBuffer(asset.s3Key);
+    const actualSha256 = createHash('sha256').update(bytes).digest('hex');
+    if (bytes.length !== asset.size || actualSha256 !== sha256) {
+      logger.warn('Oxy Updates asset complete: content verification failed', {
+        applicationId,
+        sha256,
+        actualSha256,
+        expectedSize: asset.size,
+        actualSize: bytes.length,
         s3Key: asset.s3Key,
       });
       results.push({ sha256, status: 'pending', size: 0 });
@@ -377,9 +397,9 @@ export async function completeAssets(
 
     await db
       .update(updateAssets)
-      .set({ size: head.size, status: 'uploaded' })
+      .set({ status: 'uploaded' })
       .where(eq(updateAssets.sha256, sha256));
-    results.push({ sha256, status: 'uploaded', size: head.size });
+    results.push({ sha256, status: 'uploaded', size: asset.size });
   }
 
   return { assets: results };

--- a/packages/api/src/types/s3.types.ts
+++ b/packages/api/src/types/s3.types.ts
@@ -40,5 +40,6 @@ export interface PresignedUrlOptions {
    * SignatureDoesNotMatch. Used for immutable content-addressed assets.
    */
   cacheControl?: string;
+  /** Base64 SHA-256 checksum that S3 must validate before accepting the PUT. */
+  checksumSHA256?: string;
 }
-

--- a/packages/contracts/src/updates.ts
+++ b/packages/contracts/src/updates.ts
@@ -106,6 +106,8 @@ export const assetUploadTicketSchema = z.object({
    * carries the long immutable cache header (assets are content-addressed).
    */
   cacheControl: z.string(),
+  /** Base64 SHA-256 value required in the presigned PUT's checksum header. */
+  checksumSHA256: z.string(),
 });
 export type AssetUploadTicket = z.infer<typeof assetUploadTicketSchema>;
 

--- a/packages/ship/src/__tests__/client.test.ts
+++ b/packages/ship/src/__tests__/client.test.ts
@@ -107,6 +107,7 @@ describe('ShipClient', () => {
         'http://s3/put',
         'image/png',
         'public, max-age=31536000, immutable',
+        'AQIDBA==',
         tmp
       );
     } finally {
@@ -116,6 +117,7 @@ describe('ShipClient', () => {
     expect(calls[0].method).toBe('PUT');
     expect(calls[0].headers['content-type']).toBe('image/png');
     expect(calls[0].headers['cache-control']).toBe('public, max-age=31536000, immutable');
+    expect(calls[0].headers['x-amz-checksum-sha256']).toBe('AQIDBA==');
     expect(calls[0].headers.authorization).toBeUndefined();
     expect(calls[0].isBytes).toBe(true);
   });

--- a/packages/ship/src/__tests__/publish.command.test.ts
+++ b/packages/ship/src/__tests__/publish.command.test.ts
@@ -29,11 +29,17 @@ const fakeClient = {
         storageKey: `public/updates/assets/${item.sha256}`,
         contentType: item.contentType,
         cacheControl: CACHE_CONTROL,
+        checksumSHA256: Buffer.from(item.sha256, 'hex').toString('base64'),
       })),
       existing: [],
     };
   },
-  uploadAsset: async (url: string, _contentType: string, cacheControl: string) => {
+  uploadAsset: async (
+    url: string,
+    _contentType: string,
+    cacheControl: string,
+    _checksumSHA256: string
+  ) => {
     uploadCalls.push({ url, cacheControl });
   },
   completeAssets: async (sha256s: string[]) => {

--- a/packages/ship/src/client.ts
+++ b/packages/ship/src/client.ts
@@ -116,12 +116,17 @@ export class ShipClient {
     uploadUrl: string,
     contentType: string,
     cacheControl: string,
+    checksumSHA256: string,
     absPath: string
   ): Promise<void> {
     const bytes = fs.readFileSync(absPath);
     const response = await this.fetchFn(uploadUrl, {
       method: 'PUT',
-      headers: { 'content-type': contentType, 'cache-control': cacheControl },
+      headers: {
+        'content-type': contentType,
+        'cache-control': cacheControl,
+        'x-amz-checksum-sha256': checksumSHA256,
+      },
       body: bytes,
     });
     if (!response.ok) {

--- a/packages/ship/src/commands.ts
+++ b/packages/ship/src/commands.ts
@@ -102,7 +102,13 @@ export async function publishCommand(flags: ShipFlags): Promise<void> {
     if (!asset) {
       throw new Error(`Server asked for an asset we did not offer: ${ticket.sha256}`);
     }
-    await client.uploadAsset(ticket.uploadUrl, ticket.contentType, ticket.cacheControl, asset.absPath);
+    await client.uploadAsset(
+      ticket.uploadUrl,
+      ticket.contentType,
+      ticket.cacheControl,
+      ticket.checksumSHA256,
+      asset.absPath
+    );
   }
 
   const complete = await client.completeAssets([...bySha.keys()]);


### PR DESCRIPTION
### Motivation

- Prevent cross-tenant asset poisoning by ensuring content-addressed update assets are verified before being marked `uploaded` and reused across applications.

### Description

- During `initAssets` the server now includes a base64 `checksumSHA256` (derived from the declared hex sha256) in the presigned upload ticket and passes it through to the S3 presign options. 
- The S3 helper (`getPresignedUploadUrl`) accepts a `checksumSHA256` option and injects `ChecksumSHA256` into the presigned `PutObjectCommand` parameters. 
- `completeAssets` now verifies S3 metadata against the declared size, downloads the object, recomputes the SHA-256, and leaves the asset `pending` when size or content mismatches occur instead of flipping it to `uploaded`. 
- Contracts, types, and clients were updated so the upload ticket carries `checksumSHA256` and the `ship` client sends the `x-amz-checksum-sha256` header when PUTing the asset; relevant tests were extended to cover verified uploads and poisoned-byte rejection. 

### Testing

- Ran `git diff --check` which reported a clean diff (no whitespace errors). 
- Attempted to run the package tests for the publish service (`bun run --filter @oxyhq/api test ...`) but `jest` was not available in the current environment so the test run exited (command not found). 
- Attempted to build affected workspace packages (`@oxyhq/contracts` / `@oxyhq/ship`) but TypeScript/compiler configuration errors in this environment prevented a successful compile. 
- Added/updated unit tests that mock `s3Service` for `headObject`/`downloadBuffer` and assert checksum propagation and verification logic, but full automated execution of the updated suites could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a715f0de98c8323b98cf6be49af130c)