### PR TITLE
fix(api): prevent managed-account WebAuthn backdoors

### DIFF
--- a/packages/api/src/routes/__tests__/webauthnLogin.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnLogin.test.ts
@@ -147,9 +147,10 @@ async function accountWithPasskey(options?: {
   counter?: number;
   transports?: string[];
   userVerified?: boolean;
+  kind?: 'personal' | 'organization';
 }): Promise<{ userId: string; username: string; credentialID: string }> {
   const username = options?.username ?? freshUsername();
-  const [row] = await getDb().insert(users).values({ username }).returning({ id: users.id });
+  const [row] = await getDb().insert(users).values({ username, kind: options?.kind ?? 'personal' }).returning({ id: users.id });
   const credentialID = freshCredentialId();
   await getDb().insert(webauthnCredentials).values({
     userId: row.id,
@@ -248,6 +249,17 @@ interface AuthOptionsArg {
 }
 
 describe('POST /webauthn/login/options', () => {
+  it('treats a managed account like an account with no directly usable passkey', async () => {
+    const { username, credentialID } = await accountWithPasskey({ kind: 'organization' });
+
+    const res = await request(server, 'POST', '/webauthn/login/options', { username });
+
+    expect(res.status).toBe(200);
+    const opts = mockGenerateAuthOptions.mock.calls[0][0] as AuthOptionsArg;
+    expect(opts.allowCredentials.map((credential) => credential.id)).not.toContain(credentialID);
+    expect((await storedChallenge(currentChallenge)).used).toBe(true);
+  });
+
   it("username-first (KNOWN username with a passkey): returns that user's real allowCredentials and binds the challenge to the account", async () => {
     const { userId, username, credentialID } = await accountWithPasskey({ transports: ['usb', 'nfc'] });
 
@@ -396,6 +408,18 @@ describe('POST /webauthn/login/options', () => {
 });
 
 describe('POST /webauthn/login/verify', () => {
+  it('never mints a direct session for a managed account credential', async () => {
+    const { credentialID } = await accountWithPasskey({ kind: 'organization' });
+    presentedCredentialId = credentialID;
+    await request(server, 'POST', '/webauthn/login/options', {});
+
+    const res = await request(server, 'POST', '/webauthn/login/verify', { response: authenticationResponse() });
+
+    expect(res.status).toBe(401);
+    expect(mockCreateSession).not.toHaveBeenCalled();
+    expect(mockFinalizeDeviceLogin).not.toHaveBeenCalled();
+  });
+
   it('mints a session with the byte-identical AuthSuccess shape of /auth/verify', async () => {
     const { userId, username, credentialID } = await accountWithPasskey({ counter: 5 });
     presentedCredentialId = credentialID;

--- a/packages/api/src/routes/__tests__/webauthnRegister.test.ts
+++ b/packages/api/src/routes/__tests__/webauthnRegister.test.ts
@@ -148,10 +148,10 @@ function freshCredentialId(): string {
 }
 
 /** A real `users` row — every `user_id` in this suite carries a foreign key. */
-async function account(username?: string): Promise<string> {
+async function account(username?: string, kind: 'personal' | 'organization' = 'personal'): Promise<string> {
   const [row] = await getDb()
     .insert(users)
-    .values(username === undefined ? {} : { username })
+    .values({ ...(username === undefined ? {} : { username }), kind })
     .returning({ id: users.id });
   return row.id;
 }
@@ -349,6 +349,21 @@ describe('POST /webauthn/register/options', () => {
     const stored = await storedChallenge(currentChallenge);
     expect(stored.userId).toBe(userId);
     expect(stored.used).toBe(false);
+  });
+
+  it('rejects linking a passkey to a managed account bearer', async () => {
+    mockBearerUserId = await account(freshUsername(), 'organization');
+
+    const res = await request(
+      server,
+      'POST',
+      '/webauthn/register/options',
+      {},
+      { authorization: 'Bearer valid-token' },
+    );
+
+    expect(res.status).toBe(403);
+    expect(await storedChallenge(currentChallenge)).toBeUndefined();
   });
 
   it('offers residentKey:preferred + UV:preferred and does NOT pin authenticatorAttachment (roaming/hardware keys can enrol)', async () => {
@@ -561,6 +576,30 @@ describe('POST /webauthn/register/verify — signup branch', () => {
 });
 
 describe('POST /webauthn/register/verify — linking branch', () => {
+  it('rejects a managed account even if a linking challenge already exists', async () => {
+    const managedId = await account(freshUsername(), 'organization');
+    mockBearerUserId = managedId;
+    await getDb().insert(webauthnChallenges).values({
+      challenge: currentChallenge,
+      type: 'registration',
+      userId: managedId,
+      expiresAt: new Date(Date.now() + 60_000),
+      used: false,
+    });
+
+    const res = await request(
+      server,
+      'POST',
+      '/webauthn/register/verify',
+      { response: registrationResponse() },
+      { authorization: 'Bearer valid-token' },
+    );
+
+    expect(res.status).toBe(403);
+    expect(await storedCredential(currentCredentialId)).toBeUndefined();
+    expect(await storedAuthMethods(managedId)).toHaveLength(0);
+  });
+
   it('links the passkey to the bearer account (credential row + auth-method row + cache invalidate)', async () => {
     const userId = await account(freshUsername());
     mockBearerUserId = userId;

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -62,7 +62,7 @@ import { webauthnCredentials } from '../db/schema/webauthnCredentials';
 import { extractTokenFromRequest, decodeToken } from '../middleware/authUtils';
 import { rateLimit } from '../middleware/rateLimiter';
 import { asyncHandler } from '../utils/asyncHandler';
-import { BadRequestError, ConflictError, UnauthorizedError, InternalServerError } from '../utils/error';
+import { BadRequestError, ConflictError, ForbiddenError, UnauthorizedError, InternalServerError } from '../utils/error';
 import { logger } from '../utils/logger';
 import userCache from '../utils/userCache';
 import { isOxyApexOrigin } from '../utils/origin';
@@ -113,6 +113,11 @@ interface WebauthnAccount {
   id: string;
   username: string | null;
   avatar: string | null;
+}
+
+/** Managed accounts are operated only through the audited account-switch flow. */
+function isPersonalAccount(kind: string): boolean {
+  return kind === 'personal';
 }
 
 /**
@@ -475,12 +480,15 @@ router.post(
     if (bearerUserId) {
       // Linking branch: the signed-in account adds another passkey.
       const [account] = await db
-        .select({ id: users.id, username: users.username })
+        .select({ id: users.id, username: users.username, kind: users.kind })
         .from(users)
         .where(eq(users.id, bearerUserId))
         .limit(1);
       if (!account) {
         throw new UnauthorizedError('User not found');
+      }
+      if (!isPersonalAccount(account.kind)) {
+        throw new ForbiddenError('Passkeys can only be linked to personal accounts');
       }
       userName = account.username || bearerUserId;
       userHandle = bearerUserId;
@@ -630,12 +638,15 @@ router.post(
     if (bearerUserId) {
       // ---- Linking branch --------------------------------------------------
       const [account] = await db
-        .select({ id: users.id })
+        .select({ id: users.id, kind: users.kind })
         .from(users)
         .where(eq(users.id, bearerUserId))
         .limit(1);
       if (!account) {
         throw new UnauthorizedError('User not found');
+      }
+      if (!isPersonalAccount(account.kind)) {
+        throw new ForbiddenError('Passkeys can only be linked to personal accounts');
       }
 
       // The credential row and its `user_auth_methods` row describe ONE fact, so
@@ -809,7 +820,7 @@ router.post(
       // Always resolve the user (an unparseable/nonexistent username simply finds
       // nothing — never a distinct rejection that would leak "no such account").
       const [account] = await db
-        .select({ id: users.id })
+        .select({ id: users.id, kind: users.kind })
         .from(users)
         .where(usernameMatches(normalizedUsername))
         .limit(1);
@@ -818,20 +829,21 @@ router.post(
       const decoy = decoyAllowCredentials(normalizedUsername);
       // Always issue exactly one credential query. For a missing user a throwaway
       // id keeps the query shape/cost identical while returning no rows.
-      const probeUserId = account?.id ?? crypto.randomUUID();
+      const personalAccount = account && isPersonalAccount(account.kind) ? account : undefined;
+      const probeUserId = personalAccount?.id ?? crypto.randomUUID();
       const credentials = await db
         .select({ credentialID: webauthnCredentials.credentialID, transports: webauthnCredentials.transports })
         .from(webauthnCredentials)
         .where(eq(webauthnCredentials.userId, probeUserId));
 
-      if (account && credentials.length > 0) {
+      if (personalAccount && credentials.length > 0) {
         allowCredentials = credentials.map((cred) => ({
           id: cred.credentialID,
           transports: toTransports(cred.transports),
         }));
         // Bind the challenge to the resolved account — verify asserts the presented
         // credential's owner equals this id (user A's challenge ≠ user B's key).
-        challengeUserId = account.id;
+        challengeUserId = personalAccount.id;
       } else {
         // Unknown username OR an account with no passkey → decoy. Its challenge is
         // stored PRE-BURNED (`used: true`) instead of bound to a throwaway account
@@ -1005,12 +1017,18 @@ router.post(
       .where(eq(webauthnCredentials.id, credential.id));
 
     const [account] = await db
-      .select({ id: users.id, username: users.username, avatar: users.avatar })
+      .select({ id: users.id, username: users.username, avatar: users.avatar, kind: users.kind })
       .from(users)
       .where(eq(users.id, owner))
       .limit(1);
     if (!account) {
       throw new UnauthorizedError('User not found');
+    }
+    if (!isPersonalAccount(account.kind)) {
+      // Managed accounts must remain bound to an operator session whose
+      // `account:act_as` permission is revalidated; a passkey cannot encode that
+      // delegation, so direct authentication is deliberately unavailable.
+      throw new UnauthorizedError('Invalid passkey');
     }
 
     await mintWebauthnSession(req, res, account, envelope);


### PR DESCRIPTION
### Motivation
- Close a high-severity auth boundary gap where WebAuthn routes could link passkeys to managed (organization/project/bot) accounts or mint direct sessions for them, bypassing the `account:act_as` operator binding.
- Preserve the existing model where managed accounts are only operated via the audited account-switch flow and not directly authenticated by credentials owned by a switched-in bearer.

### Description
- Added a personal-account guard (`isPersonalAccount`) and reject linking when the resolved account `kind` is not `personal`, returning `403` from the register/options and register/verify linking branches in `packages/api/src/routes/webauthn.ts`.
- Adjusted username-first `login/options` to treat managed accounts as if they have no directly usable passkeys (issue the decoy allow-list and pre-burn the challenge) rather than returning real allowCredentials for managed-account credentials.
- Prevented direct WebAuthn session minting for managed-account credentials by rejecting authentication verify when the credential owner is not `personal`, so a passkey owned by a managed account cannot mint an ordinary session without the operator flow.
- Added regression tests covering rejection of linking to managed accounts, rejection of verify when a managed linking challenge exists, decoy behavior for managed-account login options, and refusal to mint direct sessions for managed-account credentials in `packages/api/src/routes/__tests__/webauthnRegister.test.ts` and `packages/api/src/routes/__tests__/webauthnLogin.test.ts`.

### Testing
- `git diff --check` passed locally against the working tree.
- Dependency installation and running the package test runner were blocked by external registry 403s, so `bun install` and `bun run test` could not complete; as a result the Jest suites could not be executed in this environment.
- New regression tests were added and committed; they exercise the new guards but could not be executed here due to the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7162f75634832388570279ae1bc6e2)