### PR TITLE
fix(api): prevent service tokens from accessing other users' private viewer graph

### DIFF
--- a/packages/api/src/routes/__tests__/usersMeGraph.test.ts
+++ b/packages/api/src/routes/__tests__/usersMeGraph.test.ts
@@ -5,9 +5,11 @@
  * (the graph LOGIC outcomes are covered by
  * `services/__tests__/user.service.getViewerGraph.test.ts`).
  *
- *  - the viewer is taken from `resolveViewerId(req)` (server-derived from the
- *    auth token) and passed to the service — there is no `:userId` param and a
- *    client-supplied `?viewerId=` query is IGNORED (anti-IDOR / anti-impersonation)
+ *  - the viewer is taken from `resolveViewerId(req)` for user sessions and
+ *    passed to the service — there is no `:userId` param and a client-supplied
+ *    `?viewerId=` query is IGNORED (anti-IDOR / anti-impersonation)
+ *  - service-token delegation returns the empty graph even when a delegated
+ *    viewer resolves, because blocks and restrictions are private data
  *  - an anonymous caller (resolveViewerId → undefined) is NOT rejected: it returns
  *    the empty graph WITHOUT invoking the service or touching the cache
  *  - a cache HIT returns the cached graph and never recomputes from the service
@@ -32,6 +34,7 @@ const mockGraphCacheSet = jest.fn();
 // Mutable viewer the stubbed `resolveViewerId` returns — set per test to model
 // an authenticated viewer vs. an anonymous caller.
 let currentViewerId: string | undefined;
+let currentServiceApp: { appId: string; scopes: string[] } | undefined;
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -42,7 +45,14 @@ jest.mock('../../middleware/auth', () => ({
 // stubbed `resolveViewerId` (server-side derivation), never from the request
 // query/body.
 jest.mock('../../middleware/optionalAuth', () => ({
-  optionalUserOrServiceAuth: (_req: unknown, _res: unknown, next: () => void) => next(),
+  optionalUserOrServiceAuth: (
+    req: { serviceApp?: typeof currentServiceApp },
+    _res: unknown,
+    next: () => void
+  ) => {
+    req.serviceApp = currentServiceApp;
+    next();
+  },
   resolveViewerId: () => currentViewerId,
 }));
 
@@ -149,6 +159,7 @@ afterAll((done) => {
 beforeEach(() => {
   jest.clearAllMocks();
   currentViewerId = undefined;
+  currentServiceApp = undefined;
   mockGetViewerGraph.mockReset();
   mockGraphCacheGet.mockReset();
   mockGraphCacheSet.mockReset();
@@ -206,7 +217,30 @@ describe('GET /users/me/graph', () => {
     const res = await getJson(server, '/users/me/graph');
 
     expect(res.status).toBe(200);
-    expect(res.body.data).toEqual({ followingIds: [], mutualIds: [], blockedIds: [], restrictedIds: [] });
+    expect(res.body.data).toEqual({
+      followingIds: [],
+      mutualIds: [],
+      blockedIds: [],
+      restrictedIds: [],
+    });
+    expect(mockGraphCacheGet).not.toHaveBeenCalled();
+    expect(mockGetViewerGraph).not.toHaveBeenCalled();
+    expect(mockGraphCacheSet).not.toHaveBeenCalled();
+  });
+
+  it('does not expose a delegated user graph to a service token', async () => {
+    currentViewerId = VIEWER;
+    currentServiceApp = { appId: 'mention', scopes: ['user:read'] };
+
+    const res = await getJson(server, '/users/me/graph');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual({
+      followingIds: [],
+      mutualIds: [],
+      blockedIds: [],
+      restrictedIds: [],
+    });
     expect(mockGraphCacheGet).not.toHaveBeenCalled();
     expect(mockGetViewerGraph).not.toHaveBeenCalled();
     expect(mockGraphCacheSet).not.toHaveBeenCalled();

--- a/packages/api/src/routes/users.ts
+++ b/packages/api/src/routes/users.ts
@@ -750,11 +750,12 @@ router.get(
  * three per-viewer graph reads consuming apps (Mention, Allo, Homiio) otherwise
  * make as separate round trips on nearly every feed request.
  *
- * The viewer is derived SERVER-SIDE from the auth token via `resolveViewerId`
- * (the same dual-auth as `/mutual-ids` and `/follows-of-follows-ids`) — never a
- * client-supplied id, and there is no `:userId` param to spoof (anti-IDOR).
- * OPTIONAL semantics: an anonymous caller (or a service token with no user
- * context) has no graph → every list is empty.
+ * The viewer is derived SERVER-SIDE from the authenticated user session via
+ * `resolveViewerId` — never a client-supplied id, and there is no `:userId`
+ * param to spoof (anti-IDOR). Service-token delegation is intentionally not
+ * accepted because blocks and restrictions are private relationship data.
+ * OPTIONAL semantics: an anonymous or service-token caller has no graph →
+ * every list is empty.
  *
  * Backed by a short-TTL Redis cache (`graphCache`) filled on miss and busted by
  * the follow/unfollow/block/unblock write paths; degrades to a straight Mongo
@@ -769,8 +770,11 @@ router.get(
   '/me/graph',
   optionalUserOrServiceAuth,
   asyncHandler(async (req: OptionalUserOrServiceRequest, res: Response) => {
-    // Viewer is always the authenticated principal — never a client param.
-    const viewerId = resolveViewerId(req);
+    // This endpoint returns private relationship data (blocks/restrictions), so
+    // only a user session may select its viewer. Service delegation is limited
+    // to public personalization and must not turn X-Oxy-User-Id into access to
+    // another user's private graph.
+    const viewerId = req.serviceApp ? undefined : resolveViewerId(req);
 
     // Anonymous / no-user-context callers have no graph. Short-circuit with the
     // empty graph and never touch the cache (its keys are strictly per-viewer).


### PR DESCRIPTION
### Motivation

- A newly-added `/users/me/graph` endpoint could accept a delegated viewer id from a service token holding the non-privileged `user:read` scope and return private relationship data (`blockedIds`), creating an exposure/IDOR-like privacy bug.
- Blocks/restrictions are private relationship data and must never be readable via an ordinary public `user:read` delegation path.

### Description

- Restrict the `/users/me/graph` route to only accept a server-derived viewer from an authenticated user session and explicitly refuse to honor service-token delegation for this endpoint by treating service-token callers as anonymous; implement by changing the viewer selection to `const viewerId = req.serviceApp ? undefined : resolveViewerId(req);` in `packages/api/src/routes/users.ts` and updating the route JSDoc to document the policy.
- Add a regression test that models a service principal with `user:read` delegation and asserts the endpoint returns the empty graph and never touches the cache or `userService.getViewerGraph`; tests updated in `packages/api/src/routes/__tests__/usersMeGraph.test.ts` to inject `currentServiceApp` into the mocked `optionalUserOrServiceAuth` shim.
- Preserve existing behaviors for authenticated user sessions, anonymous callers, cache-hit/cache-miss flows, and the anti-impersonation guarantees already covered by the route tests.

### Testing

- Ran repository checks: `git diff --check` and `git show --check` and committed the change as `fix(api): protect private viewer graph from service tokens`, which succeeded.
- Added unit test coverage in `packages/api/src/routes/__tests__/usersMeGraph.test.ts` that asserts service-token callers do not receive blocked/restricted IDs, but execution of the test runner failed in this environment because `jest` is not installed; attempting `bun run test -- --runInBand src/routes/__tests__/usersMeGraph.test.ts` exited with `jest: command not found` so the new test was not executed here.
- No other automated test suites were run due to missing repository dependencies in the execution environment. Please run the package tests (`bun run test` from `packages/api` or the monorepo-appropriate runner) in CI to validate the new regression test in a complete environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a716a34392483239bc7440ba14c949f)