### PR TITLE
fix(accounts): isolate dev Android shared UID

### DIFF
--- a/packages/accounts/app.config.js
+++ b/packages/accounts/app.config.js
@@ -92,10 +92,10 @@ module.exports = {
       'expo-sharing',
       'expo-status-bar',
       'expo-web-browser',
-      // Adds android:sharedUserId="so.oxy.shared" so this app shares the same
-      // Android keychain namespace as every other Oxy app signed with the
-      // shared ecosystem cert — enables sign-in-once-use-everywhere.
-      './plugins/withSharedUserId',
+      // Production joins the shared Android UID for sign-in-once-use-everywhere.
+      // Development builds must stay outside that UID so a lower-trust build
+      // cannot access production apps' private data or identity credentials.
+      ...(!IS_DEV_VARIANT ? ['./plugins/withSharedUserId'] : []),
       // Requests the signature-level READ_IDENTITY permission + provider queries
       // so this app can READ the shared identity Commons hosts (the native
       // module now ships inside @oxyhq/services). Reader-only: it never hosts


### PR DESCRIPTION
### Motivation
- Prevent development builds from inheriting `android:sharedUserId="so.oxy.shared"` so lower-trust/dev apps cannot access production shared identity/keychain credentials while preserving the production sign-in-sharing behavior.

### Description
- Change `packages/accounts/app.config.js` to include the `./plugins/withSharedUserId` plugin only when `APP_VARIANT !== 'development'` (uses `...(!IS_DEV_VARIANT ? ['./plugins/withSharedUserId'] : [])`), keeping production unchanged and excluding the dev variant from the shared Android UID.

### Testing
- Ran a Node-based config validation that loads the app config for both the production and development variants (stubbing `@oxyhq/expo-splash/config`) and asserted the shared-UID plugin is present for production and absent for development, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a716dcc45e48323b053f6139dd66c72)