### PR TITLE
fix(inbox): restore secure Android release signing

### DIFF
--- a/packages/inbox/android/app/build.gradle
+++ b/packages/inbox/android/app/build.gradle
@@ -81,6 +81,12 @@ def enableMinifyInReleaseBuilds = (findProperty('android.enableMinifyInReleaseBu
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+def releaseStoreFile = findProperty('MYAPP_RELEASE_STORE_FILE') ?: System.getenv('MYAPP_RELEASE_STORE_FILE')
+def releaseStorePassword = findProperty('MYAPP_RELEASE_STORE_PASSWORD') ?: System.getenv('MYAPP_RELEASE_STORE_PASSWORD')
+def releaseKeyAlias = findProperty('MYAPP_RELEASE_KEY_ALIAS') ?: System.getenv('MYAPP_RELEASE_KEY_ALIAS')
+def releaseKeyPassword = findProperty('MYAPP_RELEASE_KEY_PASSWORD') ?: System.getenv('MYAPP_RELEASE_KEY_PASSWORD')
+def hasReleaseSigningConfig = releaseStoreFile && releaseStorePassword && releaseKeyAlias && releaseKeyPassword
+
 android {
     ndkVersion rootProject.ext.ndkVersion
 
@@ -104,6 +110,14 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+        if (hasReleaseSigningConfig) {
+            release {
+                storeFile file(releaseStoreFile)
+                storePassword releaseStorePassword
+                keyAlias releaseKeyAlias
+                keyPassword releaseKeyPassword
+            }
+        }
     }
     buildTypes {
         debug {
@@ -112,7 +126,9 @@ android {
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.
-            signingConfig signingConfigs.debug
+            if (hasReleaseSigningConfig) {
+                signingConfig signingConfigs.release
+            }
             def enableShrinkResources = findProperty('android.enableShrinkResourcesInReleaseBuilds') ?: 'false'
             shrinkResources enableShrinkResources.toBoolean()
             minifyEnabled enableMinifyInReleaseBuilds


### PR DESCRIPTION
### Motivation

- The inbox Android `release` build was configured to use the repository `debug` signing config, which uses the committed `debug.keystore` and public debug credentials, allowing malicious APKs to be signed as the official app.
- Restore a safer signing flow that requires explicit release keystore credentials to be present before any release signing config is applied.

### Description

- Added Gradle properties / env var lookups for `MYAPP_RELEASE_STORE_FILE`, `MYAPP_RELEASE_STORE_PASSWORD`, `MYAPP_RELEASE_KEY_ALIAS`, and `MYAPP_RELEASE_KEY_PASSWORD` and computed a `hasReleaseSigningConfig` guard.
- Conditionally create a `signingConfigs.release` entry from the provided release keystore values only when `hasReleaseSigningConfig` is truthy.
- Updated `buildTypes.release` to apply `signingConfigs.release` only when the guarded release signing config exists, and left `debug` builds using the existing `signingConfigs.debug`.
- This ensures release artifacts will not fall back to the repository debug keystore and require explicit CI or developer-provided secrets to sign releases.

### Testing

- Ran `git diff --check` to ensure no whitespace or patch issues and it passed.
- Executed a Python assertion script that inspects `packages/inbox/android/app/build.gradle` to verify the `hasReleaseSigningConfig` guard is present and that `release` no longer references `signingConfigs.debug`, which succeeded.
- Attempted `./gradlew --offline :app:tasks` to exercise Gradle configuration, but the Gradle distribution download was blocked by the environment proxy (HTTP 403), so this step could not complete.
- Verified working tree status was clean after the change via `git status --short --branch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71740155c4832396b16e450bcfeb18)