### PR TITLE
fix(api): constrain Homiio reputation awards

### DIFF
--- a/packages/api/drizzle/0021_narrow_homiio_reputation_scope.sql
+++ b/packages/api/drizzle/0021_narrow_homiio_reputation_scope.sql
@@ -1,0 +1,15 @@
+-- Homiio reports lease lifecycle events; it must not inherit the global ledger
+-- mutation authority used by trusted platform services.
+ALTER TABLE "account_credentials" DROP CONSTRAINT "account_credentials_scopes_check";--> statement-breakpoint
+ALTER TABLE "application_credentials" DROP CONSTRAINT "application_credentials_scopes_check";--> statement-breakpoint
+ALTER TABLE "applications" DROP CONSTRAINT "applications_scopes_check";--> statement-breakpoint
+
+UPDATE "applications"
+SET "scopes" = array_append(array_remove("scopes", 'reputation:write'), 'reputation:lease:write')
+WHERE lower(btrim("name")) = 'homiio'
+  AND "scopes" @> array['reputation:write']::text[]
+  AND NOT "scopes" @> array['reputation:lease:write']::text[];--> statement-breakpoint
+
+ALTER TABLE "account_credentials" ADD CONSTRAINT "account_credentials_scopes_check" CHECK ("account_credentials"."scopes" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:lease:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register']::text[]);--> statement-breakpoint
+ALTER TABLE "application_credentials" ADD CONSTRAINT "application_credentials_scopes_check" CHECK ("application_credentials"."scopes" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:lease:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register']::text[]);--> statement-breakpoint
+ALTER TABLE "applications" ADD CONSTRAINT "applications_scopes_check" CHECK ("applications"."scopes" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:lease:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register']::text[]);

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1785814925471,
       "tag": "0020_follow_events_claim",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1785859200000,
+      "tag": "0021_narrow_homiio_reputation_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/scripts/seed-oxy-applications.ts
+++ b/packages/api/scripts/seed-oxy-applications.ts
@@ -166,9 +166,9 @@ const SEED_APPS: SeedAppSpec[] = [
     websiteUrl: 'https://homiio.com',
     type: 'first_party',
     redirectUris: ['https://homiio.com'],
-    // Homiio awards Oxy Trust on lease lifecycle events via its service credential.
-    // `reputation:write` is staff-gated — the seed script grants it to official apps.
-    scopes: ['user:read', 'reputation:write'],
+    // Homiio may report only idempotent lease-lifecycle events; unlike the broad
+    // `reputation:write` authority this scope cannot invoke unrelated rules.
+    scopes: ['user:read', 'reputation:lease:write'],
   },
   {
     name: 'Allo',

--- a/packages/api/src/routes/__tests__/reputationAwardAuthz.test.ts
+++ b/packages/api/src/routes/__tests__/reputationAwardAuthz.test.ts
@@ -86,6 +86,7 @@ import { applications } from '../../db/schema/applications';
 import { reputationRules } from '../../db/schema/reputationRules';
 import { reputationTransactions } from '../../db/schema/reputationTransactions';
 import { users } from '../../db/schema/users';
+import { LEASE_SIGNED_ACTION } from '../../utils/reputation.constants';
 import { errorHandler } from '../../middleware/errorHandler';
 import reputationRouter from '../reputation.routes';
 
@@ -249,6 +250,56 @@ describe('POST /reputation/award — service-token scope gate', () => {
     expect(transaction.category).toBe('content');
     expect(transaction.status).toBe('active');
     expect(safeParseContract(reputationTransactionSchema, transaction)).not.toBeNull();
+  });
+
+  it('limits reputation:lease:write to lease actions', async () => {
+    const service = await serviceApplication();
+    const subject = await account();
+    const unrelatedAction = await awardableAction();
+    currentServiceApp = { ...service, scopes: ['reputation:lease:write'] };
+
+    const res = await award(
+      { userId: subject, actionType: unrelatedAction, sourceActionId: 'lease-123' },
+      'service',
+    );
+
+    expect(res.status).toBe(403);
+    expect(await storedTransactions(subject)).toHaveLength(0);
+  });
+
+  it('requires an idempotency key for reputation:lease:write', async () => {
+    const service = await serviceApplication();
+    const subject = await account();
+    currentServiceApp = { ...service, scopes: ['reputation:lease:write'] };
+
+    const res = await award({ userId: subject, actionType: LEASE_SIGNED_ACTION }, 'service');
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toMatch(/sourceActionId/);
+    expect(await storedTransactions(subject)).toHaveLength(0);
+  });
+
+  it('allows an idempotent lease action with reputation:lease:write', async () => {
+    const service = await serviceApplication();
+    const subject = await account();
+    await getDb()
+      .insert(reputationRules)
+      .values({
+        actionType: LEASE_SIGNED_ACTION,
+        points: 10,
+        category: 'trust',
+        description: 'Lease signed',
+      })
+      .onConflictDoNothing();
+    currentServiceApp = { ...service, scopes: ['reputation:lease:write'] };
+
+    const res = await award(
+      { userId: subject, actionType: LEASE_SIGNED_ACTION, sourceActionId: 'lease-456:signed' },
+      'service',
+    );
+
+    expect(res.status).toBe(201);
+    expect(await storedTransactions(subject)).toHaveLength(1);
   });
 
   it('attributes the stored row to the TOKEN, ignoring a spoofed body attribution', async () => {

--- a/packages/api/src/routes/reputation.routes.ts
+++ b/packages/api/src/routes/reputation.routes.ts
@@ -47,6 +47,10 @@ import {
   MAX_LEADERBOARD_LIMIT,
   DEFAULT_DISPUTE_LIMIT,
   MAX_DISPUTE_LIMIT,
+  LEASE_SIGNED_ACTION,
+  LEASE_COMPLETED_ACTION,
+  CLEAN_MOVEOUT_ACTION,
+  LEASE_DEFAULT_ACTION,
 } from '../utils/reputation.constants';
 import {
   reputationUserIdParams,
@@ -61,6 +65,13 @@ const router = express.Router();
 const WINDOW_15_MIN = 15 * 60 * 1000;
 const WINDOW_1_MIN = 60 * 1000;
 const REQUIRED_AWARD_SCOPE = 'reputation:write';
+const LEASE_AWARD_SCOPE = 'reputation:lease:write';
+const LEASE_ACTION_TYPES = new Set([
+  LEASE_SIGNED_ACTION,
+  LEASE_COMPLETED_ACTION,
+  CLEAN_MOVEOUT_ACTION,
+  LEASE_DEFAULT_ACTION,
+]);
 
 /** Read limiter for public/auth read endpoints. */
 const readLimiter = rateLimit({
@@ -102,10 +113,25 @@ interface UserOrServiceRequest extends AuthRequest, ServiceAuthRequest {}
  * token resolves `req.serviceApp`; anything else falls through to the regular
  * user `authMiddleware`.
  */
-function requireReputationWriteScope(req: ServiceAuthRequest): void {
+function authorizeServiceAward(
+  req: ServiceAuthRequest,
+  actionType: string,
+  sourceActionId: string | undefined
+): void {
   const scopes = req.serviceApp?.scopes ?? [];
-  if (!scopes.includes(REQUIRED_AWARD_SCOPE)) {
-    throw new ForbiddenError(`Missing required scope: ${REQUIRED_AWARD_SCOPE}`);
+  if (scopes.includes(REQUIRED_AWARD_SCOPE)) {
+    return;
+  }
+  if (!scopes.includes(LEASE_AWARD_SCOPE)) {
+    throw new ForbiddenError(
+      `Missing required scope: ${REQUIRED_AWARD_SCOPE} or ${LEASE_AWARD_SCOPE}`
+    );
+  }
+  if (!LEASE_ACTION_TYPES.has(actionType)) {
+    throw new ForbiddenError(`${LEASE_AWARD_SCOPE} cannot award this action type`);
+  }
+  if (!sourceActionId) {
+    throw new ForbiddenError(`${LEASE_AWARD_SCOPE} requires sourceActionId`);
   }
 }
 
@@ -472,7 +498,7 @@ router.post(
     let createdByUserId: string | undefined;
 
     if (serviceApp) {
-      requireReputationWriteScope(req);
+      authorizeServiceAward(req, req.body.actionType, req.body.sourceActionId);
 
       // Canonical service path — source app identity is the token's, not the
       // client body's.

--- a/packages/api/src/utils/applicationScopes.ts
+++ b/packages/api/src/utils/applicationScopes.ts
@@ -17,6 +17,8 @@
  * - `reputation:write` permits service credentials to create reputation ledger
  *   awards/penalties for arbitrary users. PRIVILEGED — only Oxy platform staff
  *   may grant it.
+ * - `reputation:lease:write` permits a service credential to report only the
+ *   allowlisted lease-lifecycle actions accepted by `/reputation/award`.
  * - `signals:write` permits trusted services to write cross-app ranking signals
  *   (endorsement/interest edges) that influence recommendation rankings and can
  *   trigger reputation awards. PRIVILEGED — only Oxy platform staff may grant it.
@@ -55,6 +57,7 @@ export const APPLICATION_SCOPES = [
   'federation:write',
   'signals:write',
   'reputation:write',
+  'reputation:lease:write',
   'reputation:moderation:apply',
   'reputation:binding:register',
   'notifications:write',
@@ -123,6 +126,7 @@ export type ApplicationScope = (typeof APPLICATION_SCOPES)[number];
 export const PRIVILEGED_APPLICATION_SCOPES = [
   'federation:write',
   'reputation:write',
+  'reputation:lease:write',
   'reputation:moderation:apply',
   'reputation:binding:register',
   'signals:write',


### PR DESCRIPTION
### Motivation

- Close an authorization-boundary gap introduced by granting Homiio the broad `reputation:write` application scope which allowed arbitrary ledger mutations. 
- Limit Homiio's authority to only the intended lease lifecycle events and enforce idempotency to prevent misuse by service credentials that inherit app-level scopes.

### Description

- Introduces a new privileged scope `reputation:lease:write` and documents it in `packages/api/src/utils/applicationScopes.ts`. 
- Replaces Homiio's seeded `reputation:write` grant with the narrower `reputation:lease:write` in `packages/api/scripts/seed-oxy-applications.ts` so new credentials do not receive global ledger-write authority. 
- Adds route-level authorization in `packages/api/src/routes/reputation.routes.ts` that: allows `reputation:write` callers to retain existing behavior, permits `reputation:lease:write` callers only for the four lease action types (`lease_signed`, `lease_completed`, `clean_moveout`, `lease_default`) and requires `sourceActionId` for idempotency. 
- Adds a migration `packages/api/drizzle/0021_narrow_homiio_reputation_scope.sql` to update existing Homiio app rows and to update DB scope CHECK constraints to include the new scope. 
- Adds regression tests in `packages/api/src/routes/__tests__/reputationAwardAuthz.test.ts` verifying that `reputation:lease:write` rejects unrelated actions, enforces the idempotency key, and permits valid idempotent lease awards.

### Testing

- Ran `git diff --check` and validated the repo diffs and new test additions; that check succeeded. 
- Verified `packages/api/drizzle/meta/_journal.json` is valid JSON after adding the migration entry. 
- Attempted to run the updated package test file with `bun run --filter @oxyhq/api test --runTestsByPath src/routes/__tests__/reputationAwardAuthz.test.ts --runInBand` but test execution could not run in this environment because `jest` / workspace dependencies are not installed, so the new tests were added but not executed here. 
- All changes are limited to authorization, seed data, migration, and tests to minimize behaviour changes for existing privileged callers holding the original `reputation:write` scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7175ae70c08323904cc46ffe104b75)