### PR TITLE
Require privileged scope for service user-media uploads to prevent cross-tenant attribution

### DIFF
--- a/packages/api/src/routes/__tests__/assetsServiceCache.test.ts
+++ b/packages/api/src/routes/__tests__/assetsServiceCache.test.ts
@@ -476,6 +476,31 @@ describe('POST /assets/service/user-media', () => {
     expect(mockUploadUserMediaStream).not.toHaveBeenCalled();
   });
 
+  it('requires privileged act-as authority in addition to files:write', async () => {
+    mockServiceAuthMiddleware.mockImplementationOnce(
+      (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {
+        req.serviceApp = {
+          type: 'service',
+          appId: 'unprivileged-app',
+          appName: 'unprivileged',
+          scopes: ['files:write'],
+        };
+        next();
+      }
+    );
+
+    const res = await requestRaw(
+      server,
+      'POST',
+      '/assets/service/user-media',
+      { 'content-type': 'image/png', 'content-length': '4', 'x-owner-user-id': LOCAL_OWNER_ID },
+      Buffer.from('PNG!')
+    );
+
+    expect(res.status).toBe(403);
+    expect(mockUploadUserMediaStream).not.toHaveBeenCalled();
+  });
+
   it('requires the files:write service scope', async () => {
     mockServiceAuthMiddleware.mockImplementationOnce(
       (req: { serviceApp?: unknown }, _res: unknown, next: () => void) => {

--- a/packages/api/src/routes/assets.ts
+++ b/packages/api/src/routes/assets.ts
@@ -847,7 +847,7 @@ router.post(
  * @desc Stream-upload durable media into a normal public file owned by an
  *       existing local Oxy user. Used by Mention MCP intent-media when the
  *       caller authenticates with an MCP JWT (no Oxy session bearer).
- * @access Service token only (requires files:write)
+ * @access Privileged service token only (requires files:write and federation:write)
  */
 router.post(
   '/service/user-media',
@@ -855,6 +855,11 @@ router.post(
   cacheUploadLimiter,
   asyncHandler(async (req: ServiceAuthRequest, res: express.Response) => {
     requireServiceScope(req, 'files:write');
+    // Attributing a public file to a user is cross-tenant act-as authority, not
+    // ordinary application-owned file access. Require a staff-granted scope in
+    // addition to files:write so self-grantable service credentials cannot pick
+    // an arbitrary local user via x-owner-user-id.
+    requireServiceScope(req, 'federation:write');
 
     const ownerUserId = getSingleHeader(req, 'x-owner-user-id')?.trim();
     if (!ownerUserId) {


### PR DESCRIPTION
### Motivation
- Fix an authorization flaw where a service credential holding only the self-grantable `files:write` scope could choose any local user via `x-owner-user-id` and create a public user-owned asset, enabling cross-tenant attribution.

### Description
- Require the staff-granted privileged scope `federation:write` in addition to `files:write` for the `POST /api/assets/service/user-media` route in `packages/api/src/routes/assets.ts` by calling `requireServiceScope(req, 'federation:write')` before trusting the `x-owner-user-id` header.
- Add a regression test in `packages/api/src/routes/__tests__/assetsServiceCache.test.ts` that asserts a service credential with only `files:write` receives HTTP 403 and cannot invoke the upload path.
- Preserve existing behavior for callers that already hold both scopes (e.g. the Mention MCP credential used in production) while preventing ordinary self-grantable apps from acting as arbitrary users.

### Testing
- Ran repository pre-commit checks including `git diff --check` which reported no problems and inspected the modified files.
- Added a unit-level regression test that asserts unprivileged service credentials are rejected (the test is committed under `packages/api/src/routes/__tests__/assetsServiceCache.test.ts`).
- Attempted to run the package tests (`bun run test` / Jest) but the test runner was unavailable in this environment (`jest: command not found`), so the new test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7175b3d0548323b35cff9d2ec2a87c)