### PR TITLE
Fix(auth): prevent public auth from binding to unproved device sessions

### DIFF
--- a/packages/api/src/controllers/__tests__/session.controller.test.ts
+++ b/packages/api/src/controllers/__tests__/session.controller.test.ts
@@ -77,7 +77,22 @@ import { userAuthMethods } from '../../db/schema/userAuthMethods';
 import { userLinkMetadata } from '../../db/schema/userLinkMetadata';
 import { users } from '../../db/schema/users';
 import type { AuthRequest } from '../../middleware/auth';
-import { SessionController } from '../session.controller';
+import { SessionController, sessionCreateOptionsFromBody } from '../session.controller';
+
+describe('sessionCreateOptionsFromBody', () => {
+  it('does not trust a public authentication body to select an existing device', () => {
+    const body = {
+      deviceName: 'Browser',
+      deviceFingerprint: 'metadata-only',
+      deviceId: 'victim-device',
+    };
+
+    expect(sessionCreateOptionsFromBody(body)).toEqual({
+      deviceName: 'Browser',
+      deviceFingerprint: 'metadata-only',
+    });
+  });
+});
 
 /** A captured `res` — the status and body the handler actually produced. */
 interface CapturedResponse {

--- a/packages/api/src/controllers/session.controller.ts
+++ b/packages/api/src/controllers/session.controller.ts
@@ -29,16 +29,11 @@ import type { SessionCreateOptions } from '../types/session.types';
 export function sessionCreateOptionsFromBody(body: {
   deviceName?: string;
   deviceFingerprint?: string;
-  deviceId?: string;
 }): SessionCreateOptions {
-  const opts: SessionCreateOptions = {
+  return {
     deviceName: body.deviceName,
     deviceFingerprint: body.deviceFingerprint,
   };
-  if (typeof body.deviceId === 'string' && body.deviceId.trim()) {
-    opts.deviceId = body.deviceId.trim();
-  }
-  return opts;
 }
 
 /**
@@ -337,7 +332,7 @@ export class SessionController {
    */
   static async verifyChallenge(req: Request, res: Response) {
     try {
-      const { publicKey, challenge, signature, timestamp, deviceName, deviceFingerprint, deviceId } = req.body;
+      const { publicKey, challenge, signature, timestamp, deviceName, deviceFingerprint } = req.body;
       const db = getDb();
 
       if (!publicKey || !challenge || !signature || !timestamp) {
@@ -416,7 +411,7 @@ export class SessionController {
       const session = await sessionService.createSession(
         user.id,
         req,
-        sessionCreateOptionsFromBody({ deviceName, deviceFingerprint, deviceId }),
+        sessionCreateOptionsFromBody({ deviceName, deviceFingerprint }),
       );
       const sessionAfterCreate = Date.now();
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -687,12 +687,11 @@ router.get('/user/:publicKey', validate({ params: getUserByPublicKeyParams }), S
  *         description: Application is not available (suspended/deleted/pending review).
  */
 router.post('/session/create', validate({ body: authSessionCreateSchema }), asyncHandler(async (req, res) => {
-  const { sessionToken, expiresAt, clientId, applicationId, deviceId, oauth } = req.body as {
+  const { sessionToken, expiresAt, clientId, applicationId, oauth } = req.body as {
     sessionToken: string;
     clientId?: string;
     applicationId?: string;
     expiresAt?: string | number;
-    deviceId?: string;
     oauth?: {
       redirectUri: string;
       codeChallenge: string;
@@ -893,7 +892,6 @@ router.post('/session/create', validate({ body: authSessionCreateSchema }), asyn
       oauthCodeChallengeMethod: oauthContext ? oauthContext.codeChallengeMethod : null,
       oauthScopes: oauthContext ? oauthContext.scopes : null,
       oauthSubjectAccountId: oauthContext?.subjectAccountId ?? null,
-      deviceId: typeof deviceId === 'string' && deviceId.trim() ? deviceId.trim() : null,
     })
     .onConflictDoNothing({ target: authSessions.sessionToken })
     .returning({
@@ -1260,16 +1258,15 @@ router.post('/session/authorize/:sessionToken', authMiddleware, validate({ param
     const appLabel = app ? app.name : 'App';
 
     // Create a new session for the third-party app, owned by the
-    // authenticated user identified via the bearer token. When the flow was
-    // started with a device binding (`deviceId` persisted at create time), pass it
-    // as the explicit deviceId so the session lands on the originating device.
+    // authenticated user identified via the bearer token. The server derives a
+    // fresh device id because the public session-creation request has not proved
+    // ownership of an existing device session.
     const newSession = await sessionService.createSession(
       authenticatedUserId,
       req,
       {
         deviceName: deviceName || `${appLabel} App`,
         deviceFingerprint,
-        ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
       }
     );
     newSessionId = newSession.sessionId;

--- a/packages/api/src/routes/webauthn.ts
+++ b/packages/api/src/routes/webauthn.ts
@@ -99,7 +99,6 @@ const loginVerifyLimiter = rateLimit({ prefix: 'rl:webauthn:login-verify:', wind
 interface DeviceEnvelope {
   deviceName?: string;
   deviceFingerprint?: string;
-  deviceId?: string;
 }
 
 /**

--- a/packages/api/src/schemas/__tests__/auth.schemas.test.ts
+++ b/packages/api/src/schemas/__tests__/auth.schemas.test.ts
@@ -1,0 +1,25 @@
+import { authSessionCreateSchema, verifyChallengeSchema } from '../auth.schemas';
+
+describe('public authentication device binding', () => {
+  it('strips deviceId from signed-challenge verification input', () => {
+    const parsed = verifyChallengeSchema.parse({
+      publicKey: 'public-key',
+      challenge: 'challenge',
+      signature: 'signature',
+      timestamp: Date.now(),
+      deviceId: 'victim-device',
+    });
+
+    expect(parsed).not.toHaveProperty('deviceId');
+  });
+
+  it('strips deviceId from unauthenticated QR session creation input', () => {
+    const parsed = authSessionCreateSchema.parse({
+      sessionToken: 'secret-session-token',
+      clientId: 'client-id',
+      deviceId: 'victim-device',
+    });
+
+    expect(parsed).not.toHaveProperty('deviceId');
+  });
+});

--- a/packages/api/src/schemas/auth.schemas.ts
+++ b/packages/api/src/schemas/auth.schemas.ts
@@ -2,8 +2,6 @@ import { commonsDenyReasonSchema } from '@oxyhq/contracts';
 import { z } from 'zod';
 import { INVALID_USERNAME_MESSAGE, USERNAME_PATTERN } from '../utils/username';
 
-const deviceIdField = z.string().trim().min(1).max(128).optional();
-
 /**
  * A username is a routing key (`/@alice`, `acct:alice@…`), not prose. The length
  * bounds alone accepted `"al ice"` — the pattern is what actually rejects
@@ -39,7 +37,6 @@ export const verifyChallengeSchema = z.object({
   timestamp: z.number(),
   deviceName: z.string().trim().optional(),
   deviceFingerprint: z.string().trim().optional(),
-  deviceId: deviceIdField,
 });
 
 // GET /auth/check-username/:username
@@ -92,8 +89,6 @@ export const authSessionCreateSchema = z.object({
   clientId: z.string().trim().min(1).optional(),
   applicationId: z.string().trim().min(1).optional(),
   expiresAt: z.union([z.string(), z.number()]).optional(),
-  /** Originating RP device id — converges QR sign-in onto the same DeviceSession. */
-  deviceId: deviceIdField,
   oauth: authSessionOAuthContextSchema.optional(),
 }).refine(
   (data) => Boolean(data.clientId) || Boolean(data.applicationId),

--- a/packages/contracts/src/__tests__/webauthn.test.ts
+++ b/packages/contracts/src/__tests__/webauthn.test.ts
@@ -1,0 +1,15 @@
+import {
+  webauthnLoginVerifyRequestSchema,
+  webauthnRegisterVerifyRequestSchema,
+} from '../webauthn';
+
+describe('WebAuthn device metadata', () => {
+  it.each([
+    webauthnLoginVerifyRequestSchema,
+    webauthnRegisterVerifyRequestSchema,
+  ])('strips an untrusted deviceId from public verification input', (schema) => {
+    expect(schema.parse({ deviceName: 'Browser', deviceId: 'victim-device' })).toEqual({
+      deviceName: 'Browser',
+    });
+  });
+});

--- a/packages/contracts/src/webauthn.ts
+++ b/packages/contracts/src/webauthn.ts
@@ -3,7 +3,7 @@
  *
  * These schemas describe ONLY the outer Oxy envelope that wraps a WebAuthn
  * ceremony request — the username the client is registering/authenticating as,
- * plus the device-session options every first-party sign-in accepts. The browser
+ * plus non-authoritative device metadata. The browser
  * `RegistrationResponseJSON` / `AuthenticationResponseJSON` payloads are NOT
  * mirrored here: they are validated by `@simplewebauthn/server` inside the route
  * (`verifyRegistrationResponse` / `verifyAuthenticationResponse`), which is the
@@ -14,15 +14,16 @@
 import { z } from 'zod';
 
 /**
- * Device-session options shared by every first-party sign-in body
- * (`deviceName`/`deviceFingerprint`/`deviceId`). Mirrors what
+ * Device metadata shared by every first-party sign-in body
+ * (`deviceName`/`deviceFingerprint`). Mirrors what
  * `sessionCreateOptionsFromBody` reads in the API so a WebAuthn login/verify can
- * name and pin its resulting session exactly like `/auth/login` or `/auth/verify`.
+ * name its resulting session exactly like `/auth/verify`. A caller-supplied
+ * `deviceId` is deliberately not accepted: possession of an id is not proof of
+ * ownership of an existing device session.
  */
 const deviceSessionEnvelope = {
   deviceName: z.string().trim().min(1).max(120).optional(),
   deviceFingerprint: z.string().trim().min(1).max(256).optional(),
-  deviceId: z.string().trim().min(1).max(256).optional(),
 } as const;
 
 /**


### PR DESCRIPTION
### Motivation
- A public authentication path accepted a client-supplied `deviceId` and stamped it onto newly-created sessions, allowing an attacker who knows another device's `deviceId` to have their sign-in mint the victim's device secret and subsequently obtain bearer tokens for the victim's active account.
- The intended security model requires proof of possession of the existing `deviceSecret` (or a bearer-authenticated caller) before reusing or rotating an existing device's secret; public bodies must not be able to select an authoritative `deviceId`.

### Description
- Stop trusting caller-provided `deviceId` in public auth paths by making `sessionCreateOptionsFromBody` ignore `deviceId` and only return non-authoritative device metadata (`deviceName`, `deviceFingerprint`).
- Remove `deviceId` from public request schemas and contracts so validation strips unproved device identifiers, including `packages/api/src/schemas/auth.schemas.ts` and `packages/contracts/src/webauthn.ts`.
- Update handlers to stop persisting or passing an untrusted `deviceId` during session creation and WebAuthn/challenge verify flows, including `packages/api/src/controllers/session.controller.ts`, `packages/api/src/routes/auth.ts`, and `packages/api/src/routes/webauthn.ts`.
- Add regression tests that assert public auth schema parsing and the session-options boundary no longer accept `deviceId` (`packages/api/src/schemas/__tests__/auth.schemas.test.ts`, `packages/contracts/src/__tests__/webauthn.test.ts`) and a unit test for `sessionCreateOptionsFromBody` in the session controller test file.
- Commit recorded as `fix(auth): reject unproved device session binding` with the implemented changes across the files above.

### Testing
- Ran `git diff --check` to validate no obvious whitespace/conflict issues; it passed.
- Added unit/contract tests covering the new validation behavior (files under `packages/api/src/schemas/__tests__` and `packages/contracts/src/__tests__`), but running the full test suite was blocked in this environment because the workspace dependencies / `jest` are not installed (attempted `bun run test` / `jest` produced `command not found`).
- Verified code edits with local repository checks (`git status`, diff/commit) and grepped code paths to ensure all public auth entry points no longer accept a caller `deviceId` at the handler/schema boundary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717c0111048323b564eb44093fe60e)