### PR TITLE
fix(api): preserve explicit OAuth redirect allowlists

### DIFF
--- a/packages/api/src/config/reconcileOfficialRedirectUris.ts
+++ b/packages/api/src/config/reconcileOfficialRedirectUris.ts
@@ -1,10 +1,10 @@
 /**
- * Self-heal official Application redirect URIs when missing or drifted.
+ * Seed official Application redirect URIs when their allowlist is empty.
  *
  * Production drift blocks `POST /auth/oauth/authorize` with
  * "redirect_uri is not registered for this client", breaking password sign-in
- * hand-offs from every first-party app. Official apps declare a `websiteUrl`
- * whose origin is the canonical OAuth redirect surface.
+ * hand-offs from every first-party app. Explicitly configured allowlists are
+ * never modified because each exact callback URI is a security boundary.
  */
 
 import { eq } from 'drizzle-orm';

--- a/packages/api/src/utils/__tests__/redirectUris.test.ts
+++ b/packages/api/src/utils/__tests__/redirectUris.test.ts
@@ -20,7 +20,7 @@ describe('unionRedirectUris', () => {
 });
 
 describe('computeOfficialRedirectUriRepair', () => {
-  it('returns null when the website origin is already registered', () => {
+  it('does not modify an existing allowlist when the website origin is registered', () => {
     expect(
       computeOfficialRedirectUriRepair(
         ['https://oxy.so', 'https://fairco.in'],
@@ -29,13 +29,25 @@ describe('computeOfficialRedirectUriRepair', () => {
     ).toBeNull();
   });
 
-  it('UNIONs the website origin instead of replacing the allowlist', () => {
+  it('does not broaden an existing allowlist with the website origin', () => {
     expect(
       computeOfficialRedirectUriRepair(
         ['https://fairco.in'],
         'https://oxy.so',
       ),
-    ).toEqual(['https://fairco.in', 'https://oxy.so']);
+    ).toBeNull();
+  });
+
+  it('preserves path-specific callbacks instead of adding their bare origin', () => {
+    expect(
+      computeOfficialRedirectUriRepair(
+        [
+          'https://app.example.com/oauth/callback',
+          'https://staging.example.com/oauth/callback',
+        ],
+        'https://app.example.com',
+      ),
+    ).toBeNull();
   });
 
   it('seeds the origin when redirectUris is empty', () => {

--- a/packages/api/src/utils/redirectUris.ts
+++ b/packages/api/src/utils/redirectUris.ts
@@ -1,6 +1,6 @@
 /**
- * Non-destructive redirect-uri helpers. Official-app reconciliation must never
- * replace an existing allowlist — only append missing canonical entries.
+ * Redirect-uri helpers. Official-app reconciliation may seed an empty
+ * allowlist, but must never broaden an explicitly configured allowlist.
  */
 
 /** Union preserving order: existing entries first, then additions, de-duplicated. */
@@ -29,20 +29,20 @@ export function originOfWebsiteUrl(websiteUrl: string): string | null {
 }
 
 /**
- * When a trusted app's `websiteUrl` origin is missing from `redirectUris`,
- * return the unioned allowlist that repairs it. Returns `null` when no change
- * is needed or the website URL is unusable.
+ * Seed an empty trusted-app allowlist from its `websiteUrl` origin. Existing
+ * entries are security-sensitive exact callback URIs and must never be changed
+ * or supplemented by this background repair.
  */
 export function computeOfficialRedirectUriRepair(
   redirectUris: readonly string[] | null | undefined,
   websiteUrl: string | null | undefined,
 ): string[] | null {
+  if (redirectUris?.length) return null;
+
   const trimmed = websiteUrl?.trim();
   if (!trimmed) return null;
 
   const origin = originOfWebsiteUrl(trimmed);
   if (!origin) return null;
-  if (includesRedirectUri(redirectUris, origin)) return null;
-
-  return unionRedirectUris(redirectUris, [origin]);
+  return [origin];
 }


### PR DESCRIPTION
### Motivation

- A background reconciler was broadening trusted applications' OAuth `redirectUris` by replacing path-specific callbacks with the bare `websiteUrl` origin, weakening the exact-match security boundary for OAuth redirects. 
- The change restores the intended behavior: seed empty allowlists only, and never modify an explicitly configured callback allowlist.

### Description

- Restrict the repair logic in `computeOfficialRedirectUriRepair` so it only seeds a redirect allowlist when `redirectUris` is empty and returns `null` otherwise. 
- Update the reconciler's documentation to emphasise that explicit allowlists are a security boundary and must not be modified by the background job. 
- Extend `src/utils/__tests__/redirectUris.test.ts` with regression coverage proving that path-specific callback URIs are preserved and that empty allowlists are still seeded.

### Testing

- Ran a targeted runtime assertion with `bun -e` that verifies existing path-specific allowlists are not broadened and that empty allowlists are seeded; the check passed. 
- Updated unit tests in `packages/api/src/utils/__tests__/redirectUris.test.ts` were added, but running the full Jest suite in this environment failed because workspace dependencies were unavailable. 
- Attempted `bun install --frozen-lockfile` to install deps but the registry requests were blocked (HTTP 403), preventing a complete CI test run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717db397888323a4bc5867e44f4d8a)