### PR TITLE
fix(api): restrict OAuth device restore credentials to trusted apps

### DIFF
--- a/packages/api/src/routes/__tests__/oauthToken.test.ts
+++ b/packages/api/src/routes/__tests__/oauthToken.test.ts
@@ -300,7 +300,7 @@ beforeEach(() => {
 });
 
 describe('POST /auth/oauth/token — RFC 6749 §5.1 success response', () => {
-  it('returns a FLAT token document (no `data` wrapper) for a PKCE public client', async () => {
+  it('returns a FLAT token document without device credentials for a third-party client', async () => {
     const res = await requestForm(pkceParams());
 
     expect(res.status).toBe(200);
@@ -310,9 +310,10 @@ describe('POST /auth/oauth/token — RFC 6749 §5.1 success response', () => {
       token_type: 'Bearer',
       expires_in: 900,
       session_id: 'sess-1',
-      deviceId: 'device-1',
-      deviceSecret: 'device-secret-1',
     });
+    expect(res.body).not.toHaveProperty('deviceId');
+    expect(res.body).not.toHaveProperty('deviceSecret');
+    expect(mockFinalizeDeviceLogin).not.toHaveBeenCalled();
     expect(res.body).not.toHaveProperty('data');
     // The zero-cookie transport hands out no refresh token.
     expect(res.body).not.toHaveProperty('refresh_token');
@@ -320,6 +321,22 @@ describe('POST /auth/oauth/token — RFC 6749 §5.1 success response', () => {
     const user = res.body.user as { id: string; name: { displayName?: string } };
     expect(user.id).toBe(defaultSubjectId);
     expect(user.name.displayName).toBe('Ada Lovelace');
+  });
+
+  it('returns device restore credentials only for a trusted first-party client', async () => {
+    const { clientId } = await client({}, { type: 'first_party' });
+
+    const res = await requestForm(pkceParams({ client_id: clientId }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      deviceId: 'device-1',
+      deviceSecret: 'device-secret-1',
+    });
+    expect(mockFinalizeDeviceLogin).toHaveBeenCalledWith({
+      session: { sessionId: 'sess-1', deviceId: 'device-1' },
+      userId: defaultSubjectId,
+    });
   });
 
   it('sends the credentials with `Cache-Control: no-store` (§5.1)', async () => {
@@ -697,9 +714,10 @@ describe('POST /auth/oauth/token — security properties', () => {
   });
 
   it('fails closed with server_error when deviceSecret minting fails', async () => {
+    const { clientId } = await client({}, { type: 'first_party' });
     mockFinalizeDeviceLogin.mockResolvedValueOnce({});
 
-    const res = await requestForm(pkceParams());
+    const res = await requestForm(pkceParams({ client_id: clientId }));
 
     expect(res.status).toBe(500);
     // Still RFC-shaped, and still says nothing about what broke internally.

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -3094,17 +3094,21 @@ router.post(
       },
     );
 
-    const deviceExtras = await finalizeDeviceLogin({
-      session: { sessionId: session.sessionId, deviceId: session.deviceId },
-      userId,
-    });
-    if (!deviceExtras.deviceSecret) {
-      logger.error('[OAuth] Token exchange succeeded but deviceSecret mint failed', {
+    let deviceExtras: { deviceSecret: string } | undefined;
+    if (isTrustedApplication(app)) {
+      const finalized = await finalizeDeviceLogin({
+        session: { sessionId: session.sessionId, deviceId: session.deviceId },
         userId,
-        sessionId: session.sessionId,
-        deviceId: session.deviceId,
       });
-      throw OAuthError.serverError('Failed to finalize the device session.');
+      if (!finalized.deviceSecret) {
+        logger.error('[OAuth] Token exchange succeeded but deviceSecret mint failed', {
+          userId,
+          sessionId: session.sessionId,
+          deviceId: session.deviceId,
+        });
+        throw OAuthError.serverError('Failed to finalize the device session.');
+      }
+      deviceExtras = { deviceSecret: finalized.deviceSecret };
     }
 
     await getDb()
@@ -3125,10 +3129,12 @@ router.post(
       // requested one, which it can (the authorize step intersects the request
       // with the app's registered scopes). Omitted when the grant carries none.
       ...(grantedScopes.length > 0 ? { scope: grantedScopes.join(' ') } : {}),
-      // Oxy's device-first extras, permitted by §5.1 as additional parameters.
+      // The session id identifies this OAuth grant. Device restore credentials
+      // are first-party credentials and must never cross into third-party apps.
       session_id: session.sessionId,
-      deviceId: session.deviceId,
-      deviceSecret: deviceExtras.deviceSecret,
+      ...(deviceExtras
+        ? { deviceId: session.deviceId, deviceSecret: deviceExtras.deviceSecret }
+        : {}),
       user: userData,
     });
   })


### PR DESCRIPTION
### Motivation

- Prevent third-party OAuth clients from receiving a device-level restore credential (`deviceSecret`) that would allow cross-app device token minting.
- Preserve the existing first-party password handoff flow for trusted platform apps while closing the newly-introduced privilege escalation vector.

### Description

- Gate `finalizeDeviceLogin` in the OAuth token exchange behind the existing `isTrustedApplication(app)` predicate so only trusted/first-party apps receive device-first credentials.【F:packages/api/src/routes/auth.ts†L3097-L3112】
- Omit `deviceId` and `deviceSecret` from token responses for third-party clients and only include them when the app is trusted.【F:packages/api/src/routes/auth.ts†L3122-L3139】
- Add regression tests that assert third-party clients do not trigger device finalization and trusted first-party clients still receive restore credentials.【F:packages/api/src/routes/__tests__/oauthToken.test.ts†L302-L340】
- Keep the existing fail-closed behavior by exercising the device-secret mint failure path for the trusted-app route.【F:packages/api/src/routes/__tests__/oauthToken.test.ts†L716-L729】

### Testing

- ✅ Ran `git diff --check` to validate patch whitespace and basic diffs and confirmed no conflicts.
- ⚠️ Attempted to run the modified OAuth unit test via `bun run test -- --runInBand src/routes/__tests__/oauthToken.test.ts`, but the environment lacks Jest (`jest: command not found`), so the test run could not be executed here.【F:packages/api/src/routes/__tests__/oauthToken.test.ts†L300-L340】
- ✅ Added and committed the test coverage that verifies behavior for both third-party and trusted first-party clients, but full test execution must be run in CI or a developer environment with the project test dependencies installed (`npm install`/`bun install` + `npm run test` / `bun run test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717d1b63f0832393531c43ab0698d0)