### PR TITLE
fix(ci): restrict manual DNS workflow to main + production environment

### DIFF
--- a/.github/workflows/setup-mention-mcp-dns.yml
+++ b/.github/workflows/setup-mention-mcp-dns.yml
@@ -8,6 +8,10 @@ permissions:
 
 jobs:
   dns:
+    # workflow_dispatch can target arbitrary refs. Keep the DNS-editing token
+    # behind both the protected main ref and the production environment.
+    if: github.ref == 'refs/heads/main'
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - name: Create mcp.mention.earth DNS + ACM validation


### PR DESCRIPTION
### Motivation
- A manually-dispatched workflow (`.github/workflows/setup-mention-mcp-dns.yml`) exposed `secrets.CLOUDFLARE_API_TOKEN` to runs on arbitrary refs, allowing branch-controlled workflow code to mutate production DNS and ACM records.

### Description
- Added a job-level guard `if: github.ref == 'refs/heads/main'` to the `dns` job in `setup-mention-mcp-dns.yml` to ensure the DNS-editing step only runs for the protected `main` branch.
- Assigned the `dns` job to the `production` GitHub environment via `environment: production` so environment protection rules and environment-scoped secrets can gate access to the Cloudflare token.
- Preserved the existing DNS upsert logic and environment variables (`CF_TOKEN`, `ZONE_ID`, `ALB_DNS`) so functionality is unchanged when run from the protected ref/environment.

### Testing
- Validated the workflow YAML parses with `ruby -e "require 'yaml'; YAML.parse_file('.github/workflows/setup-mention-mcp-dns.yml')"` and the job-level guards are present via a targeted `python3` assertion script, both of which succeeded. 
- Ran `git diff --check` to ensure no whitespace/YAML issues, which reported clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717dfb543083238415f13acbc2e8b5)