### PR TITLE
fix(auth): isolate QR claim device credentials

### DIFF
--- a/packages/api/src/routes/__tests__/sessionClaim.test.ts
+++ b/packages/api/src/routes/__tests__/sessionClaim.test.ts
@@ -24,6 +24,7 @@ import { randomUUID } from 'node:crypto';
 
 const mockGetAccessToken = jest.fn();
 const mockIssueDeviceSecret = jest.fn();
+const mockAddDeviceAccount = jest.fn();
 
 jest.mock('../../middleware/auth', () => ({
   authMiddleware: (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -41,7 +42,10 @@ jest.mock('../../services/session.service', () => ({
   },
 }));
 jest.mock('../../services/deviceSession.service', () => {
-  const service = { issueDeviceSecret: (...args: unknown[]) => mockIssueDeviceSecret(...args) };
+  const service = {
+    addAccount: (...args: unknown[]) => mockAddDeviceAccount(...args),
+    issueDeviceSecret: (...args: unknown[]) => mockIssueDeviceSecret(...args),
+  };
   return { __esModule: true, default: service, deviceSessionService: service };
 });
 jest.mock('../../utils/authSessionSocket', () => ({
@@ -200,6 +204,7 @@ beforeEach(() => {
     accessToken: 'fresh-access-token',
     expiresAt: new Date(Date.now() + 15 * 60 * 1000),
   });
+  mockAddDeviceAccount.mockResolvedValue({ state: { accounts: [] }, changed: false });
   mockIssueDeviceSecret.mockResolvedValue(null);
 });
 
@@ -345,12 +350,17 @@ describe('POST /auth/session/claim — the happy path', () => {
   });
 
   it('includes a rotating deviceSecret when one could be minted', async () => {
-    const { sessionToken, deviceId } = await approvedRequest();
+    const { sessionToken, userId, sessionId, deviceId } = await approvedRequest();
     mockIssueDeviceSecret.mockResolvedValueOnce('rotating-device-secret');
 
     const res = await claim(sessionToken);
 
     expect(res.status).toBe(200);
+    expect(mockAddDeviceAccount).toHaveBeenCalledWith(
+      deviceId,
+      { accountId: userId, sessionId },
+      { activate: 'if-empty' },
+    );
     expect(mockIssueDeviceSecret).toHaveBeenCalledWith(deviceId);
     expect((res.body.data as { deviceSecret: string }).deviceSecret).toBe('rotating-device-secret');
   });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -1475,23 +1475,14 @@ router.post(
 
     const userData = formatUserResponse(user);
 
-    // Mint the `deviceSecret` the client persists first-party (with the response's
-    // `deviceId`) to restore the session via `POST /session/device/token`
-    // (zero-cookie transport). Best-effort — a mint failure never fails the claim,
-    // and a device with no doc simply omits the secret.
-    let deviceSecret: string | undefined;
-    try {
-      if (typeof session.deviceId === 'string' && session.deviceId.length > 0) {
-        const { deviceSessionService } = await import('../services/deviceSession.service.js');
-        const minted = await deviceSessionService.issueDeviceSecret(session.deviceId);
-        if (minted) deviceSecret = minted;
-      }
-    } catch (error) {
-      logger.warn('[AuthSession] deviceSecret mint failed on claim', {
-        sessionId: authSession.authorizedSessionId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    // Register the account on the fresh, claim-only device boundary created by
+    // the approval service, then mint its restore secret. `finalizeDeviceLogin`
+    // is best-effort, so an infrastructure failure still leaves the one-time
+    // access token usable without ever falling back to the approver's device.
+    const { deviceSecret } = await finalizeDeviceLogin({
+      session: { sessionId: authSession.authorizedSessionId, deviceId: session.deviceId },
+      userId: authSession.authorizedUserId,
+    });
 
     logger.info('[AuthSession] Claim succeeded', {
       sessionToken: sessionToken.substring(0, 8) + '...',

--- a/packages/api/src/services/__tests__/authSession.service.test.ts
+++ b/packages/api/src/services/__tests__/authSession.service.test.ts
@@ -680,17 +680,15 @@ describe('authorizeSessionWithSignedChallenge', () => {
     expect((await stored(id)).status).toBe('pending');
   });
 
-  it('mints onto the originating deviceId when the request carried one', async () => {
+  it('isolates the claimant from a requester-supplied deviceId', async () => {
     const { publicKey, challenge: value } = await signer();
     const { authorizeCode } = await authSession({ deviceId: 'device-xyz' });
 
     await authorizeSessionWithSignedChallenge(input({ authorizeCode, publicKey, challenge: value }));
 
-    expect(mockCreateSession).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.anything(),
-      expect.objectContaining({ deviceId: 'device-xyz' })
-    );
+    const options = mockCreateSession.mock.calls[0]?.[2] as { deviceId: string };
+    expect(options.deviceId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(options.deviceId).not.toBe('device-xyz');
   });
 
   it('labels the minted device with the bound application name', async () => {
@@ -855,17 +853,15 @@ describe('authorizeSessionWithBearer', () => {
     expect((await stored(id)).status).toBe('pending');
   });
 
-  it('mints onto the originating deviceId when the request carried one', async () => {
+  it('isolates the claimant from a requester-supplied deviceId', async () => {
     const userId = await account();
     const { authorizeCode } = await authSession({ deviceId: 'device-xyz' });
 
     await authorizeSessionWithBearer(input({ authorizeCode, authenticatedUserId: userId }));
 
-    expect(mockCreateSession).toHaveBeenCalledWith(
-      userId,
-      expect.anything(),
-      expect.objectContaining({ deviceId: 'device-xyz' })
-    );
+    const options = mockCreateSession.mock.calls[0]?.[2] as { deviceId: string };
+    expect(options.deviceId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(options.deviceId).not.toBe('device-xyz');
   });
 });
 

--- a/packages/api/src/services/authSession.service.ts
+++ b/packages/api/src/services/authSession.service.ts
@@ -435,10 +435,11 @@ export async function authorizeSessionWithSignedChallenge(
     return { ok: false, status: 403, message: 'Not authorized to act as the requested account' };
   }
 
-  // 5. Mint the session for the originating app, owned by the signer. When the
-  //    flow was started with a device binding (`deviceId` persisted at create
-  //    time), pass it as the explicit deviceId so the session lands on the
-  //    originating device set instead of sprawling a fresh device. An OAuth
+  // 5. Mint the session for the originating app, owned by the signer. Give the
+  //    claimant a NEW device boundary: neither its untrusted create payload nor
+  //    the approver request may select an existing DeviceSession. Claim later
+  //    returns a restore secret for this id, so reusing either device id would
+  //    disclose a durable credential for that device's other accounts. An OAuth
   //    authorization request mints nothing here — see `approvalMintsSession`.
   let sessionId: string | undefined;
   if (approvalMintsSession(authSession)) {
@@ -451,7 +452,7 @@ export async function authorizeSessionWithSignedChallenge(
     const newSession = await sessionService.createSession(userId, req, {
       deviceName: deviceName || `${appLabel} App`,
       deviceFingerprint,
-      ...(authSession.deviceId ? { deviceId: authSession.deviceId } : {}),
+      deviceId: uuidv7(),
     });
     sessionId = newSession.sessionId;
   }
@@ -608,7 +609,9 @@ export async function authorizeSessionWithBearer(
   const newSession = await sessionService.createSession(authenticatedUserId, req, {
     deviceName: deviceName || `${appLabel} App`,
     deviceFingerprint,
-    ...(claimed.deviceId ? { deviceId: claimed.deviceId } : {}),
+    // The unauthenticated requester must never choose an existing device whose
+    // durable restore secret it will receive from `/auth/session/claim`.
+    deviceId: uuidv7(),
   });
 
   // Only the winner of the atomic claim above ever reaches here, so this


### PR DESCRIPTION
### Motivation
- Close a security hole where an approving flow could mint and return a durable `deviceSecret` tied to an existing DeviceSession (the approver/requester-supplied deviceId), allowing a relying party to receive a restore credential for the approver's device and potentially mint tokens for other accounts on that device.

### Description
- Prevent the claimant from selecting or inheriting an existing `DeviceSession` by always creating a fresh server-generated device boundary for approval mints (`deviceId: uuidv7()`) in both signed-challenge and bearer approval paths. (`packages/api/src/services/authSession.service.ts`)
- Move claim finalization to register the authorized account on the isolated device and then mint the rotating restore secret via the device-first finalization helper instead of directly calling the device secret rotation routine; this registers the claimed account on the new device boundary before returning any secret. (`packages/api/src/routes/auth.ts`)
- Update and extend regression tests to assert that requester-supplied `deviceId` values are not used as the credential boundary and that claim finalization registers the account before issuing a device secret; add mocks for device-session registration where appropriate. (`packages/api/src/services/__tests__/authSession.service.test.ts`, `packages/api/src/routes/__tests__/sessionClaim.test.ts`)
- Small test and expectation updates to reflect the new isolation behavior and the best-effort device registration step. (`packages/api/src/services/__tests__/authSession.service.test.ts`, `packages/api/src/routes/__tests__/sessionClaim.test.ts`)

### Testing
- Ran repository static checks: `git diff --check` passed. 
- Updated unit tests and mocks for the auth session claim/authorize paths; assertions now confirm a server-generated `deviceId` is used and that the device registration helper is invoked during claim finalization. (`packages/api/src/services/__tests__/authSession.service.test.ts`, `packages/api/src/routes/__tests__/sessionClaim.test.ts`).
- Attempted to run the package's Jest test script for the modified service, but the environment lacks installed dependencies (Jest not available), so the full unit run could not be executed in this checkout (test run blocked by missing dev dependencies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7181838c888323a44e4117a404f0d0)