### PR TITLE
Fail closed when sign-in client lookup fails

### DIFF
--- a/packages/services/__tests__/components/OxySignInButton.test.tsx
+++ b/packages/services/__tests__/components/OxySignInButton.test.tsx
@@ -163,15 +163,18 @@ describe('OxySignInButton', () => {
     errorSpy.mockRestore();
   });
 
-  it('falls back to the dialog when the application cannot be resolved', async () => {
+  it('fails closed when the application cannot be resolved', async () => {
     const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
     getPublicApplication.mockRejectedValue(new Error('network'));
 
     render(<OxySignInButton oauthRedirectUri="https://rp.example/callback" />);
     fireEvent.click(screen.getByRole('button'));
 
-    await waitFor(() => expect(openAccountDialog).toHaveBeenCalledWith('signin'));
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    expect(openAccountDialog).not.toHaveBeenCalled();
+    expect(startWebOAuthSignIn).not.toHaveBeenCalled();
     expect(redirectToAuthorizeMock).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
 
     warnSpy.mockRestore();
   });

--- a/packages/services/src/ui/components/OxySignInButton.tsx
+++ b/packages/services/src/ui/components/OxySignInButton.tsx
@@ -303,10 +303,11 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
     );
 
     // Resolve the Application once, then route: third-party → OAuth; first-party
-    // / official / unresolved → the in-app dialog. Resolution failure NEVER
-    // breaks an official app's sign-in — it falls back to the dialog. Every path
-    // that does NOT reach the OAuth lane closes the pre-opened popup, so a
-    // mis-routed press can never leave an empty window on screen.
+    // / official → the in-app dialog. An unresolved client must fail closed:
+    // opening the privileged device-session dialog without a known first-party
+    // classification could downgrade a third-party OAuth + PKCE flow. Every path
+    // that does NOT reach the OAuth lane closes the pre-opened popup, so an
+    // aborted press can never leave an empty window on screen.
     const routeSignIn = useCallback(
         async (popup: OAuthPopupHandle | null): Promise<void> => {
             if (routingRef.current) {
@@ -327,11 +328,11 @@ export const OxySignInButton: React.FC<OxySignInButtonProps> = ({
                 } catch (error) {
                     closeOAuthPopup(popup);
                     logger.warn(
-                        'OxySignInButton: could not resolve the application; opening the sign-in dialog',
+                        'OxySignInButton: could not resolve the application; sign-in aborted',
                         { component: 'OxySignInButton', clientId },
                         error,
                     );
-                    startOfficialSignIn();
+                    notifyFailed();
                     return;
                 }
                 if (app.type === 'third_party' && !app.isOfficial) {


### PR DESCRIPTION
### Motivation

- Close a critical fail-open in the sign-in routing where an unresolved `clientId` could fall back to the privileged in-app device/QR session flow and thereby downgrade a third-party OAuth+PKCE flow into a direct device-session claim.

### Description

- Change `routeSignIn` routing in `OxySignInButton` to abort (fail closed) when `getPublicApplication(clientId)` rejects, close any pre-opened OAuth popup, log the abort, and surface the existing failure notification instead of opening the account dialog.
- Replace the previous fallback that opened the in-app `openAccountDialog('signin')` on resolution error with `notifyFailed()` so no privileged device-session flow is started for an unresolved client.
- Update the focused unit test in `packages/services/__tests__/components/OxySignInButton.test.tsx` to assert the new fail-closed behavior (verify the dialog is not opened, OAuth transport is not started, and the visible error toast is shown).
- Small comment clarifications describing the fail-closed rationale to prevent future regressions.

### Testing

- Ran `git diff --check` to validate no whitespace/diff issues; it passed.
- Attempted to run the focused Jest test `bun run test -- --runInBand __tests__/components/OxySignInButton.test.tsx`, but the test runner is not available in this environment (`jest: command not found`), so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71832b3e148323964480c87e77ad53)