### PR TITLE
Revoke shared device secret on account signout

### DIFF
--- a/packages/api/src/services/__tests__/deviceSession.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceSession.service.test.ts
@@ -549,19 +549,23 @@ describe('signout — device-secret cleanup', () => {
     expect(after.backgroundSecretExpiresAt).toBeNull();
   });
 
-  it('single-account signout does NOT clear the device secret (other accounts still mint with it)', async () => {
+  it('single-account signout revokes the shared device secret', async () => {
     const device = deviceId();
     const a1 = await account();
     const a2 = await account();
     await deviceSessionService.addAccount(device, { accountId: a1, sessionId: 's1' });
     await deviceSessionService.addAccount(device, { accountId: a2, sessionId: 's2' });
-    await deviceSessionService.issueDeviceSecret(device);
-    const before = await storedDevice(device);
+    const previousRetainedSecret = await deviceSessionService.issueDeviceSecret(device);
+    const retainedSecret = await deviceSessionService.issueDeviceSecret(device);
 
     await deviceSessionService.signout(device, { accountId: a1 });
 
     const after = await storedDevice(device);
-    expect(after.secretHash).toBe(before.secretHash);
+    expect(after.secretHash).toBeNull();
+    expect(after.prevSecretHash).toBeNull();
+    expect(after.prevSecretExpiresAt).toBeNull();
+    expect(await deviceSessionService.getStateBySecret(device, retainedSecret as string)).toBeNull();
+    expect(await deviceSessionService.getStateBySecret(device, previousRetainedSecret as string)).toBeNull();
   });
 
   it('single-account signout DOES clear a background credential bound to the removed account', async () => {
@@ -579,8 +583,8 @@ describe('signout — device-secret cleanup', () => {
     const after = await storedDevice(device);
     expect(after.backgroundSecretHash).toBeNull();
     expect(after.backgroundSecretAccountId).toBeNull();
-    // The DEVICE secret survives — a2 is still here and legitimately mints.
-    expect(after.secretHash).not.toBeNull();
+    // The device secret is shared, so removing any account must revoke it too.
+    expect(after.secretHash).toBeNull();
   });
 
   it('single-account signout leaves a background credential bound to a DIFFERENT account alone', async () => {

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -424,10 +424,9 @@ class DeviceSessionService {
       'all' in target ||
       (boundBackgroundAccountId !== null && removingIds.has(boundBackgroundAccountId));
 
-    // Signout-ALL also revokes the device's `deviceSecret`: clear the secret
-    // hashes so a retained secret can never later mint a token for the now-empty
-    // set. Single-account signout leaves the secret alone — other accounts on the
-    // SAME device still legitimately mint with it.
+    // Every signout revokes the device's shared `deviceSecret`. The credential is
+    // not account-scoped, so retaining it after removing one account would let
+    // that signed-out account mint a token for whichever account remains active.
     //
     // Cleared to NULL, never `''`. Mongo used `$unset`; the Postgres analogue of
     // "absent" is NULL. An empty string is a VALUE — it would collide on
@@ -435,9 +434,9 @@ class DeviceSessionService {
     // guards on a non-empty hash, so `''` would also read as "no secret" while
     // occupying the unique slot.
     const clearedSecrets = {
-      ...('all' in target
-        ? { secretHash: null, prevSecretHash: null, prevSecretExpiresAt: null }
-        : {}),
+      secretHash: null,
+      prevSecretHash: null,
+      prevSecretExpiresAt: null,
       ...(shouldClearBackground ? this.clearedBackgroundCredentialFields() : {}),
     };
 


### PR DESCRIPTION
### Motivation

- Prevent a retained device-wide `deviceSecret` from being used to mint tokens for another account after one account signs out on a multi-account device.

### Description

- Always clear the device's rotating secret material (`secretHash`, `prevSecretHash`, `prevSecretExpiresAt`) when any account is removed from a device so the shared credential cannot be reused after signout (change in `packages/api/src/services/deviceSession.service.ts`).
- Update tests to assert single-account signout now revokes both the current and grace-window secrets and that `getStateBySecret` rejects previously issued secrets (changes in `packages/api/src/services/__tests__/deviceSession.service.test.ts`).
- Preserve existing background-credential behavior while ensuring its removal also clears the shared device secret as appropriate.

### Testing

- Ran static check `git diff --check`, which reported no whitespace/patch issues.
- Added/updated regression tests in `packages/api/src/services/__tests__/deviceSession.service.test.ts` covering signout behavior and `getStateBySecret` rejection of retained secrets; they cannot be executed end-to-end here because the environment is missing test dependencies (`jest`/workspace install), so test execution was not completed (`jest: command not found`).
- Verified repository diffs and local TypeScript/JS edits for syntactic consistency via `git status`/`git diff --stat` in the working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a717fda290c832384da4c1b457c283b)