### PR TITLE
fix(api): isolate OAuth sessions from shared devices

### DIFF
--- a/packages/api/src/routes/__tests__/oauthToken.test.ts
+++ b/packages/api/src/routes/__tests__/oauthToken.test.ts
@@ -383,7 +383,7 @@ describe('POST /auth/oauth/token — RFC 6749 §5.1 success response', () => {
     expect(app.lastUsedAt).toBeInstanceOf(Date);
   });
 
-  it('threads the originating device and the delegated operator onto the session', async () => {
+  it('isolates the OAuth session from the originating device while preserving delegation', async () => {
     const org = await subject({ kind: 'organization' });
     const operator = await subject();
     mockExchangeAuthCode.mockResolvedValueOnce(
@@ -395,8 +395,9 @@ describe('POST /auth/oauth/token — RFC 6749 §5.1 success response', () => {
     expect(mockCreateSession).toHaveBeenCalledWith(
       org,
       expect.anything(),
-      expect.objectContaining({ deviceId: 'dev-shared', operatedByUserId: operator }),
+      expect.objectContaining({ operatedByUserId: operator }),
     );
+    expect(mockCreateSession.mock.calls[0]?.[2]).not.toHaveProperty('deviceId');
   });
 
   it('never serializes a protected user column into the token response', async () => {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -3070,11 +3070,6 @@ router.post(
       throw OAuthError.invalidGrant(INVALID_GRANT_DESCRIPTION);
     }
 
-    const sharedDeviceId =
-      typeof exchange.code.deviceId === 'string' && exchange.code.deviceId.trim()
-        ? exchange.code.deviceId.trim()
-        : undefined;
-
     // A DELEGATED code authorises the app to act as `userId` on behalf of the
     // approving identity. Carry that operator onto the session so its validity
     // stays bound to their live `account:act_as` membership — revoking the
@@ -3089,7 +3084,10 @@ router.post(
       req,
       {
         deviceName: `${app.name} OAuth`,
-        ...(sharedDeviceId ? { deviceId: sharedDeviceId } : {}),
+        // OAuth clients are an authorization boundary, so their bearer must
+        // live on an isolated device session. Reusing the authorizing app's
+        // central deviceId would let the client operate every account already
+        // registered on that shared device through /session/device/*.
         ...(operatedByUserId ? { operatedByUserId } : {}),
       },
     );


### PR DESCRIPTION
### Motivation

- Close an authorization-boundary vulnerability where an OAuth token grant could be attributed to a user's shared central `DeviceSession` and thereby allow an OAuth client to operate or disrupt other accounts registered on that device.
- Ensure OAuth-issued sessions are isolated from the authorizing app's multi-account device state while preserving delegated-operator binding semantics.

### Description

- Stop threading the authorizing `deviceId` from the redeemed auth code into `sessionService.createSession` by removing the use of `exchange.code.deviceId` in the token exchange code path (`packages/api/src/routes/auth.ts`).
- Preserve delegation metadata by continuing to pass `operatedByUserId` into the newly-created OAuth session so managed-account semantics remain intact.
- Add a regression assertion in the token-exchange unit test (`packages/api/src/routes/__tests__/oauthToken.test.ts`) that the created OAuth session object does not receive a `deviceId` while still containing `operatedByUserId`.
- Commit message: `fix(api): isolate OAuth device sessions` (changes to `auth.ts` and the related test file).

### Testing

- Ran `git diff --check` which reported no whitespace or simple-diff issues.
- Updated and committed the test `packages/api/src/routes/__tests__/oauthToken.test.ts` to assert the absence of `deviceId`, but executing the test runner failed because `jest` is not installed in the execution environment (`jest: command not found`), so the modified test was not executed here.
- Manual inspection and local static checks confirm the removed device attribution and the new test assertion are present in the diff; runtime verification should be performed in CI or a developer environment with project test dependencies installed (`bun install` / `npm install` and `npm test` / `bun run test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a718450bcb48323acc147f871f1e134)