### PR TITLE
fix(services): revoke all user sessions on logoutAll (global + device)

### DIFF
--- a/packages/services/__tests__/context/useAuthOperations.test.tsx
+++ b/packages/services/__tests__/context/useAuthOperations.test.tsx
@@ -11,10 +11,11 @@
  * so the test exercises the orchestration logic only — actual network, crypto,
  * and persistence belong to `@oxyhq/core` and are covered by its own tests.
  *
- * `logout` / `logoutAll` route SERVER-side revocation through a mocked
- * `SessionClient` (device-first) rather than the bearer/cookie logout
- * endpoints. A genuine FULL sign-out additionally clears the persisted refresh
- * family via `store.clear()` (`clearPersistedAuthSafe`).
+ * `logout` routes server-side revocation through a mocked `SessionClient`.
+ * `logoutAll` first uses the global bearer endpoint to revoke other devices and
+ * refresh-token families, then uses SessionClient for the current device. A
+ * genuine full sign-out additionally clears persisted auth state via
+ * `store.clear()` (`clearPersistedAuthSafe`).
  */
 
 import { renderHook, act } from '@testing-library/react';
@@ -61,6 +62,7 @@ interface FakeServices {
   setTokens: jest.Mock;
   getCurrentUser: jest.Mock;
   logoutSession: jest.Mock;
+  logoutAllSessions: jest.Mock;
 }
 
 const makeOxyServices = (overrides: Partial<FakeServices> = {}): FakeServices => ({
@@ -91,6 +93,7 @@ const makeOxyServices = (overrides: Partial<FakeServices> = {}): FakeServices =>
   // Still used by `performSignIn`'s same-user duplicate-session dedup path —
   // unrelated to the SessionClient-routed `logout`/`logoutAll`.
   logoutSession: jest.fn(async () => undefined),
+  logoutAllSessions: jest.fn(async () => undefined),
   ...overrides,
 });
 
@@ -555,7 +558,7 @@ describe('useAuthOperations.logoutAll', () => {
     }));
   });
 
-  it('revokes every device account via SessionClient and clears local state + the persisted store on success', async () => {
+  it('revokes global sessions before every current-device account and clears local state on success', async () => {
     const sessionClient = buildFakeSessionClient([
       { accountId: 'acc-1', sessionId: 'session-1', authuser: 0 },
       { accountId: 'acc-2', sessionId: 'session-2', authuser: 1 },
@@ -564,11 +567,34 @@ describe('useAuthOperations.logoutAll', () => {
     await act(async () => {
       await helpers.result.current.logoutAll();
     });
+    expect(helpers.oxyServices.logoutAllSessions).toHaveBeenCalledWith('session-1');
+    expect(helpers.oxyServices.logoutAllSessions.mock.invocationCallOrder[0]).toBeLessThan(
+      sessionClient.signOut.mock.invocationCallOrder[0],
+    );
     expect(sessionClient.signOut).toHaveBeenCalledWith({ all: true });
     expect(helpers.clearSessionState).toHaveBeenCalledTimes(1);
     // logoutAll is ALWAYS a full sign-out → the persisted device credential is
     // cleared so the next cold boot finds nothing to restore.
     expect(helpers.store.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not perform device or local teardown when global revocation fails', async () => {
+    const helpers = setup({
+      activeSessionId: 'session-1',
+      oxyServices: {
+        logoutAllSessions: jest.fn(async () => {
+          throw new Error('global revoke failed');
+        }),
+      },
+    });
+
+    await expect(
+      act(async () => helpers.result.current.logoutAll()),
+    ).rejects.toThrow('global revoke failed');
+
+    expect(helpers.sessionClient.signOut).not.toHaveBeenCalled();
+    expect(helpers.clearSessionState).not.toHaveBeenCalled();
+    expect(helpers.store.clear).not.toHaveBeenCalled();
   });
 
   it('re-throws and reports when SessionClient.signOut({ all: true }) fails', async () => {

--- a/packages/services/src/ui/context/hooks/useAuthOperations.ts
+++ b/packages/services/src/ui/context/hooks/useAuthOperations.ts
@@ -28,10 +28,10 @@ export interface UseAuthOperationsOptions {
   /** Used only by `performSignIn`'s same-user duplicate-session dedup (legacy session-validate path; unrelated to the SessionClient device-account set). */
   switchSession: (sessionId: string) => Promise<User>;
   /**
-   * The Fase 3-A/3-B `SessionClient` (server-authoritative device account
-   * set). `logout` / `logoutAll` route SERVER-side revocation through
-   * `sessionClient.signOut(...)` instead of the bearer/cookie logout
-   * endpoints.
+   * The Phase 3-A/3-B `SessionClient` (server-authoritative device account
+   * set). Device-scoped sign-out routes through `sessionClient.signOut(...)`.
+   * `logoutAll` additionally uses the global bearer endpoint so sessions on
+   * other devices and their refresh-token families are revoked.
    */
   sessionClient: SessionClient;
   /** Reprojects `sessionClient.getState()` onto sessions/activeSessionId/user (Task 1's callback). Awaited after a partial `signOut` so the exposed state reflects the server truth before the call resolves. */
@@ -372,10 +372,12 @@ export const useAuthOperations = ({
     }
 
     try {
-      // Server-side revocation of every account on this device now flows
-      // through the SessionClient (`POST /session/device/signout` with
-      // `{ all: true }`) — replaces the bearer `logoutAllSessions` +
-      // web-cookie `logoutAllSessionsViaCookie` pair.
+      // Revoke the user's sessions on every other device and every refresh-
+      // token family first. SessionClient's `{ all: true }` operation is only
+      // device-scoped and therefore cannot implement "sign out everywhere" by
+      // itself. The global endpoint deliberately preserves the current
+      // session long enough for the device-scoped cleanup below to authenticate.
+      await oxyServices.logoutAllSessions(activeSessionId);
       await sessionClient.signOut({ all: true });
       // logoutAll is ALWAYS a full sign-out: clear the persisted device
       // credential so the next cold boot finds no session to restore, then tear
@@ -392,7 +394,7 @@ export const useAuthOperations = ({
       });
       throw error instanceof Error ? error : new Error('Logout all failed');
     }
-  }, [activeSessionId, clearSessionState, store, logger, onError, sessionClient, setAuthState]);
+  }, [activeSessionId, clearSessionState, store, logger, onError, oxyServices, sessionClient, setAuthState]);
 
   return {
     signIn,


### PR DESCRIPTION
### Motivation

- Close a security regression where `logoutAll()` only used the device-scoped `SessionClient` path and left other-device sessions and refresh-token families active.

### Description

- Update `logoutAll()` in `packages/services/src/ui/context/hooks/useAuthOperations.ts` to call the global bearer endpoint `oxyServices.logoutAllSessions(activeSessionId)` before the device-scoped `sessionClient.signOut({ all: true })` so that sessions on other devices and refresh-token families are revoked.
- Adjust `useAuthOperations`'s dependency list to include `oxyServices` and document the distinction between device-scoped and global revocation in comments.
- Extend `packages/services/__tests__/context/useAuthOperations.test.tsx` to assert the global revoke is called before the device cleanup and to add a failure test ensuring no local teardown runs if the global revoke fails.

### Testing

- Updated unit tests: `packages/services/__tests__/context/useAuthOperations.test.tsx` was modified to cover ordering and failure behavior of `logoutAll()` and existing `logoutAll` scenarios were preserved.
- Ran repository checks: `git diff --check` and local diff/status validations passed; changes committed locally.
- Attempted to run the package test command `bun run test -- --runInBand __tests__/context/useAuthOperations.test.tsx`, but test execution could not run in this environment because the test runner (`jest`) / workspace dependencies are not available, so tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a718f5dd8e8832383050026576a8184)