### PR TITLE
fix(services): revoke remote sessions on sign out all

### DIFF
--- a/packages/services/__tests__/context/useAuthOperations.test.tsx
+++ b/packages/services/__tests__/context/useAuthOperations.test.tsx
@@ -11,10 +11,10 @@
  * so the test exercises the orchestration logic only — actual network, crypto,
  * and persistence belong to `@oxyhq/core` and are covered by its own tests.
  *
- * `logout` / `logoutAll` route SERVER-side revocation through a mocked
- * `SessionClient` (device-first) rather than the bearer/cookie logout
- * endpoints. A genuine FULL sign-out additionally clears the persisted refresh
- * family via `store.clear()` (`clearPersistedAuthSafe`).
+ * `logout` routes server-side revocation through a mocked `SessionClient`.
+ * `logoutAll` combines user-wide revocation with device-set removal. A genuine
+ * full sign-out additionally clears the persisted device credential via
+ * `store.clear()` (`clearPersistedAuthSafe`).
  */
 
 import { renderHook, act } from '@testing-library/react';
@@ -61,6 +61,7 @@ interface FakeServices {
   setTokens: jest.Mock;
   getCurrentUser: jest.Mock;
   logoutSession: jest.Mock;
+  logoutAllSessions: jest.Mock;
 }
 
 const makeOxyServices = (overrides: Partial<FakeServices> = {}): FakeServices => ({
@@ -91,6 +92,7 @@ const makeOxyServices = (overrides: Partial<FakeServices> = {}): FakeServices =>
   // Still used by `performSignIn`'s same-user duplicate-session dedup path —
   // unrelated to the SessionClient-routed `logout`/`logoutAll`.
   logoutSession: jest.fn(async () => undefined),
+  logoutAllSessions: jest.fn(async () => undefined),
   ...overrides,
 });
 
@@ -555,7 +557,7 @@ describe('useAuthOperations.logoutAll', () => {
     }));
   });
 
-  it('revokes every device account via SessionClient and clears local state + the persisted store on success', async () => {
+  it('revokes remote sessions before every device account and clears local state + the persisted store on success', async () => {
     const sessionClient = buildFakeSessionClient([
       { accountId: 'acc-1', sessionId: 'session-1', authuser: 0 },
       { accountId: 'acc-2', sessionId: 'session-2', authuser: 1 },
@@ -564,11 +566,29 @@ describe('useAuthOperations.logoutAll', () => {
     await act(async () => {
       await helpers.result.current.logoutAll();
     });
+    expect(helpers.oxyServices.logoutAllSessions).toHaveBeenCalledWith('session-1');
     expect(sessionClient.signOut).toHaveBeenCalledWith({ all: true });
     expect(helpers.clearSessionState).toHaveBeenCalledTimes(1);
     // logoutAll is ALWAYS a full sign-out → the persisted device credential is
     // cleared so the next cold boot finds nothing to restore.
     expect(helpers.store.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not perform device sign-out when all-device revocation fails', async () => {
+    const sessionClient = buildFakeSessionClient([{ accountId: 'acc-1', sessionId: 'session-1', authuser: 0 }]);
+    const helpers = setup({
+      activeSessionId: 'session-1',
+      sessionClient,
+      oxyServices: { logoutAllSessions: jest.fn(async () => { throw new Error('global revoke failed'); }) },
+    });
+
+    await expect(act(async () => {
+      await helpers.result.current.logoutAll();
+    })).rejects.toThrow('global revoke failed');
+
+    expect(sessionClient.signOut).not.toHaveBeenCalled();
+    expect(helpers.clearSessionState).not.toHaveBeenCalled();
+    expect(helpers.store.clear).not.toHaveBeenCalled();
   });
 
   it('re-throws and reports when SessionClient.signOut({ all: true }) fails', async () => {

--- a/packages/services/src/ui/context/hooks/useAuthOperations.ts
+++ b/packages/services/src/ui/context/hooks/useAuthOperations.ts
@@ -29,9 +29,9 @@ export interface UseAuthOperationsOptions {
   switchSession: (sessionId: string) => Promise<User>;
   /**
    * The Fase 3-A/3-B `SessionClient` (server-authoritative device account
-   * set). `logout` / `logoutAll` route SERVER-side revocation through
-   * `sessionClient.signOut(...)` instead of the bearer/cookie logout
-   * endpoints.
+   * set). `logout` routes revocation through `sessionClient.signOut(...)`;
+   * `logoutAll` first uses the user-wide endpoint, then removes the accounts
+   * from this device through the client.
    */
   sessionClient: SessionClient;
   /** Reprojects `sessionClient.getState()` onto sessions/activeSessionId/user (Task 1's callback). Awaited after a partial `signOut` so the exposed state reflects the server truth before the call resolves. */
@@ -372,10 +372,10 @@ export const useAuthOperations = ({
     }
 
     try {
-      // Server-side revocation of every account on this device now flows
-      // through the SessionClient (`POST /session/device/signout` with
-      // `{ all: true }`) — replaces the bearer `logoutAllSessions` +
-      // web-cookie `logoutAllSessionsViaCookie` pair.
+      // Revoke the active account's sessions on every device before removing
+      // this device's complete account set. The device-scoped sign-out alone
+      // cannot satisfy signOutAll's public all-device revocation contract.
+      await oxyServices.logoutAllSessions(activeSessionId);
       await sessionClient.signOut({ all: true });
       // logoutAll is ALWAYS a full sign-out: clear the persisted device
       // credential so the next cold boot finds no session to restore, then tear
@@ -392,7 +392,7 @@ export const useAuthOperations = ({
       });
       throw error instanceof Error ? error : new Error('Logout all failed');
     }
-  }, [activeSessionId, clearSessionState, store, logger, onError, sessionClient, setAuthState]);
+  }, [activeSessionId, clearSessionState, store, logger, onError, oxyServices, sessionClient, setAuthState]);
 
   return {
     signIn,


### PR DESCRIPTION
### Motivation

- The public `signOutAll`/`logoutAll` contract must revoke sessions across all devices, but recent changes routed it to the device-scoped signout only, leaving remote/stolen sessions active.
- Restore the prior global revocation behavior while preserving the device-local cleanup and device-session projection semantics.

### Description

- Call the user-wide revocation endpoint via `oxyServices.logoutAllSessions(activeSessionId)` before performing the device-scoped removal `sessionClient.signOut({ all: true })` in `useAuthOperations.logoutAll`.
- Update the hook documentation to clarify that `logoutAll` combines a user-wide revoke with device-set removal, while `logout` remains device-scoped.
- Add/adjust unit-test mocks to include `logoutAllSessions` and enhance `packages/services/__tests__/context/useAuthOperations.test.tsx` with assertions that global revocation is invoked and that device teardown is skipped if the global revoke fails.
- Include `oxyServices` in the `useCallback` dependency list to satisfy React hook dependencies.

### Testing

- Ran `git diff --check` and committed the changes (local pre-commit checks passed).
- Added/updated unit tests in `packages/services/__tests__/context/useAuthOperations.test.tsx` that verify successful flow (global revoke then device sign-out) and failure flow (global revoke error prevents device sign-out and teardown).
- Attempted to install dependencies and run the package test harness (`bun install` / package tests), but dependency resolution failed due to external registry 403s so Jest tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7190973ee4832386f51b52f640997d)