### PR TITLE
fix(api): prevent cross-account token disclosure

### DIFF
--- a/packages/api/src/routes/__tests__/sessionDevice.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDevice.test.ts
@@ -561,7 +561,7 @@ describe('POST /session/device/add', () => {
 });
 
 describe('GET /session/device/state', () => {
-  it('returns the device subset with a live active token', async () => {
+  it('returns the device subset without minting an active-account token', async () => {
     const { deviceId, accountId } = await deviceWithSecret();
     callerDeviceId = deviceId;
     callerAccountId = accountId;
@@ -571,12 +571,13 @@ describe('GET /session/device/state', () => {
     expect(res.status).toBe(200);
     const data = res.body.data as {
       state: { deviceId: string; activeAccountId: string; accounts: unknown[] };
-      activeToken: { accessToken: string };
+      activeToken: null;
     };
     expect(data.state.deviceId).toBe(deviceId);
     expect(data.state.activeAccountId).toBe(accountId);
     expect(data.state.accounts).toHaveLength(1);
-    expect(data.activeToken.accessToken).toBe('jwt-active');
+    expect(data.activeToken).toBeNull();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
   });
 });
 
@@ -593,6 +594,8 @@ describe('POST /session/device/switch', () => {
     const res = await requestJson('POST', '/session/device/switch', { accountId: first });
 
     expect(res.status).toBe(200);
+    expect(res.body.data.activeToken).toBeNull();
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
     const after = await storedDevice(deviceId);
     expect(after.activeAccountId).toBe(first);
     expect(after.revision).toBeGreaterThan(before.revision);

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -181,9 +181,13 @@ router.post(
   }),
 );
 
-async function withActiveToken(state: DeviceSessionState) {
-  const activeToken = await deviceSessionService.resolveActiveToken(state);
-  return { state, activeToken };
+function withoutActiveToken(state: DeviceSessionState) {
+  // Bearer-authenticated device routes authorize the device, not every account
+  // registered on it. Returning another account's token here would let any
+  // account on the device disclose that token after changing activeAccountId.
+  // Token minting remains available only through /token, where the caller must
+  // prove possession of the device secret.
+  return { state, activeToken: null };
 }
 
 function resolveCallerDeviceId(req: AuthRequest): string | null {
@@ -259,7 +263,7 @@ router.get('/state', asyncHandler(async (req: AuthRequest, res: Response) => {
   const deviceId = resolveCallerDeviceId(req);
   if (!deviceId) { res.status(401).json({ error: 'No device' }); return; }
 
-  res.json({ data: await withActiveToken(await deviceSessionService.getState(deviceId)) });
+  res.json({ data: withoutActiveToken(await deviceSessionService.getState(deviceId)) });
 }));
 
 router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -291,7 +295,7 @@ router.post('/add', asyncHandler(async (req: AuthRequest, res: Response) => {
     // Also signal the added account's user across their other apps/devices.
     broadcastSessionAccountsChanged(accountId, state.revision, 'add');
   }
-  res.json({ data: await withActiveToken(state) });
+  res.json({ data: withoutActiveToken(state) });
 }));
 
 router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -316,7 +320,7 @@ router.post('/switch', asyncHandler(async (req: AuthRequest, res: Response) => {
   }
   broadcastDeviceState(outcome.state);
   broadcastSessionAccountsChanged(accountId, outcome.state.revision, 'switch');
-  res.json({ data: await withActiveToken(outcome.state) });
+  res.json({ data: withoutActiveToken(outcome.state) });
 }));
 
 router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => {
@@ -336,7 +340,7 @@ router.post('/signout', asyncHandler(async (req: AuthRequest, res: Response) => 
     .map((a) => a.accountId)
     .filter((id) => !remaining.has(id));
   broadcastSessionAccountsChanged(removedUserIds, state.revision, 'signout');
-  res.json({ data: await withActiveToken(state) });
+  res.json({ data: withoutActiveToken(state) });
 }));
 
 export default router;


### PR DESCRIPTION
### Motivation
- The device routes (`GET /state`, `POST /add`, `POST /switch`, `POST /signout`) were returning an access token for the device's active account based only on bearer-authenticated `deviceId`, enabling any session on that device to obtain another account's token.
- Token minting must require proof of the device secret (the existing `POST /session/device/token` path) so bearer-authenticated device-state endpoints remain state-only and cannot disclose other accounts' tokens.

### Description
- Replaced the helper that resolved and returned an active-account token with a safe response that preserves the original response shape but always returns `activeToken: null` for bearer-authenticated device routes. (`packages/api/src/routes/sessionDevice.ts`).
- Updated `GET /state`, `POST /add`, `POST /switch`, and `POST /signout` to return the device state with `activeToken: null` instead of minting/returning an access token. (`packages/api/src/routes/sessionDevice.ts`).
- Added/adjusted regression assertions to the device route tests to assert `activeToken` is null and that the session token minting collaborator is not called by these routes. (`packages/api/src/routes/__tests__/sessionDevice.test.ts`).
- Kept the existing device-secret mint (`POST /session/device/token`) as the only path that mints access tokens, preserving intended functionality for clients that present device secrets.

### Testing
- Ran `git diff --check` to validate formatting and patch hygiene, which passed. 
- Updated unit tests in `packages/api/src/routes/__tests__/sessionDevice.test.ts` to cover the regression assertions verifying no token mint occurs from state/switch routes, and the tests were committed. 
- Attempted to run the package tests (`bun run test` / `jest`) but the test runner (`jest`) is not available in the execution environment (dependencies are not installed), so the test invocation could not be executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7193a970048323b6398b1f8417f317)