### PR TITLE
Fix managed-account session privilege escalation

### DIFF
--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -553,7 +553,9 @@ async function loadAccountContext(req: AccountContextRequest): Promise<{
   account: AccountRow;
   access: EffectiveAccess;
 }> {
-  const userId = requireUserId(req);
+  // An operated session authenticates as the managed account, but its RBAC
+  // remains that of the human operator recorded on the server-side session.
+  const userId = await resolveOperatorId(req);
   const id = req.params.id;
 
   // The `isValidObjectId` guard is gone: it only ever prevented a Mongoose

--- a/packages/api/src/services/__tests__/account.service.test.ts
+++ b/packages/api/src/services/__tests__/account.service.test.ts
@@ -695,6 +695,13 @@ describe('membership inheritance + verifyActingAs', () => {
     expect(access?.membership).toBeNull();
   });
 
+  test('a managed account is not its own implicit owner', async () => {
+    const org = await seedAccount({ kind: 'organization' });
+
+    expect(await accountService.resolveEffectiveAccess(org.id, org.id)).toBeNull();
+    expect(await accountService.effectiveAccessForAccount(org.id, org)).toBeNull();
+  });
+
   test('a per-member GRANT reaches resolveEffectiveAccess', async () => {
     const org = await seedAccount({ kind: 'organization' });
     const bob = await seedAccount();

--- a/packages/api/src/services/account.service.ts
+++ b/packages/api/src/services/account.service.ts
@@ -724,26 +724,16 @@ export class AccountService {
     userId: string,
     accountId: string
   ): Promise<EffectiveAccess | null> {
-    if (userId === accountId) {
-      // A user is the implicit owner of their own (personal) account.
-      return {
-        role: 'owner',
-        permissions: permissionsForAccountRole('owner'),
-        source: 'self',
-        membership: null,
-      };
-    }
-
     const db = getDb();
     const [account] = await db
-      .select({ id: users.id, accountStatus: users.accountStatus })
+      .select({ id: users.id, kind: users.kind, accountStatus: users.accountStatus })
       .from(users)
       .where(eq(users.id, accountId))
       .limit(1);
     if (!account || account.accountStatus === 'archived') {
       return null;
     }
-    return this.effectiveAccessForAccount(userId, { id: account.id });
+    return this.effectiveAccessForAccount(userId, account);
   }
 
   /**
@@ -755,7 +745,7 @@ export class AccountService {
    */
   async effectiveAccessForAccount(
     userId: string,
-    account: { id?: unknown; _id?: unknown }
+    account: { id?: unknown; _id?: unknown; kind?: unknown }
   ): Promise<EffectiveAccess | null> {
     const raw = account.id ?? account._id;
     const accountId = typeof raw === 'string' ? raw : String(raw ?? '');
@@ -763,7 +753,7 @@ export class AccountService {
       return null;
     }
 
-    if (accountId === userId) {
+    if (accountId === userId && account.kind === 'personal') {
       return {
         role: 'owner',
         permissions: permissionsForAccountRole('owner'),


### PR DESCRIPTION
### Motivation
- A new real-session-based account switch allowed sessions whose `userId` equals a managed account id to be treated as the account owner because `resolveEffectiveAccess` / `effectiveAccessForAccount` returned owner when `userId === accountId`, which is only safe for personal accounts.
- That shortcut permitted any role that can `account:act_as` (e.g. editor) to switch into a managed account and gain owner-equivalent permissions, enabling privilege escalation.

### Description
- Resolve account route authorization against the recorded human operator for operated (managed) sessions by calling `resolveOperatorId(req)` in `loadAccountContext` so RBAC checks use the operator, not the active managed-account identity (`packages/api/src/routes/accounts.ts`).
- Restrict the implicit self-owner shortcut to personal accounts by passing the loaded account object (including `kind`) into `effectiveAccessForAccount` and requiring `account.kind === 'personal'` before returning owner permissions (`packages/api/src/services/account.service.ts`).
- Adjust function signatures to accept an account object with `kind` and update callers accordingly (`packages/api/src/services/account.service.ts`).
- Add a regression test asserting that a managed account is not considered its own implicit owner (`a managed account is not its own implicit owner`) to `packages/api/src/services/__tests__/account.service.test.ts`.

### Testing
- Ran `git diff --check` which passed locally. 
- Attempted to run the package tests with `bun run --filter @oxyhq/api test -- --runInBand src/services/__tests__/account.service.test.ts` but the environment lacked installed dependencies / `jest`, so the test run could not be executed (failed due to missing tooling). 
- Attempted to bring up local Postgres via `docker compose -f docker-compose.dev.yml up -d postgres` but Docker is unavailable in the execution environment, so integration DB-backed tests were not run.
- A focused unit regression test was added to the account service tests to guard this behavior; it should pass when run in the normal dev environment with dependencies installed and Postgres available (`bun run --filter @oxyhq/api test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a719a74a3408323b91792271d4bc490)