### PR TITLE
Preserve application membership boundaries during account migration (Phase 4 audit-only)

### DIFF
--- a/packages/api/scripts/account-migration-lib.ts
+++ b/packages/api/scripts/account-migration-lib.ts
@@ -66,26 +66,6 @@ export function mapWorkspaceRole(role: string): AccountRole {
   }
 }
 
-/** Legacy ApplicationMember role → unified AccountRole on the owning account. */
-export function mapAppRole(role: string): AccountRole {
-  switch (role) {
-    case 'owner':
-      // An app owner becomes an admin of the owning account (account ownership
-      // is a stronger grant reserved for the account's true owner).
-      return 'admin';
-    case 'admin':
-      return 'admin';
-    case 'developer':
-      return 'developer';
-    case 'billing':
-      return 'billing';
-    case 'viewer':
-      return 'viewer';
-    default:
-      return 'viewer';
-  }
-}
-
 /** Connect to MongoDB using `MONGODB_URI`, or exit. */
 export async function connect(): Promise<void> {
   const uri = process.env.MONGODB_URI;

--- a/packages/api/scripts/migrate-accounts-40-app-members.ts
+++ b/packages/api/scripts/migrate-accounts-40-app-members.ts
@@ -1,21 +1,15 @@
 #!/usr/bin/env bun
 /**
- * Account migration — Phase 4: application members → account members.
+ * Account migration — Phase 4: audit legacy application members.
  *
- * Reads the legacy `applicationmembers` collection. Each active membership is
- * folded into an `AccountMember` on the application's owning account
- * (`app.ownerAccountId`) with the mapped role (app owner → account admin;
- * developer/billing/viewer unchanged).
+ * Reads the legacy `applicationmembers` collection and identifies memberships
+ * that cannot be represented by the unified account-wide authorization model.
  *
- * `ensureMember` never downgrades a stronger existing role (e.g. an account
- * owner from Phase 2), so folding is safe and idempotent.
- *
- * FLAG: an app-only `developer`/`viewer` who, under the old model, could only
- * see ONE application now gains that role across the WHOLE owning account. Those
- * are reported (`OXY_ACCOUNTS_BROADENED_MEMBERS=`) so an operator can, if
- * desired, move the single app into a `kind:'project'` sub-account and scope the
- * member there instead. This script does NOT auto-move (that is a judgement
- * call); it only surfaces the list.
+ * A per-application grant must never be converted to an AccountMember on the
+ * application's current owner: doing so grants access to every sibling app (and
+ * potentially descendant accounts). Existing account members need no migration;
+ * app-only members are reported for explicit project-account scoping and fail
+ * closed in the meantime.
  *
  * NOTHING is deleted. Run Phases 0–3 first.
  *
@@ -27,19 +21,17 @@ import mongoose from 'mongoose';
 import {
   connect,
   disconnect,
-  ensureMember,
   isDryRun,
-  mapAppRole,
   rawDb,
 } from './account-migration-lib';
+import AccountMember from '../src/models/AccountMember';
 import { logger } from '../src/utils/logger';
 
-interface BroadenedMember {
+interface UnscopedMember {
   applicationId: string;
   ownerAccountId: string;
   memberUserId: string;
   appRole: string;
-  accountRole: string;
 }
 
 async function migrate(): Promise<void> {
@@ -54,9 +46,9 @@ async function migrate(): Promise<void> {
 
   // Cache app → ownerAccountId.
   const ownerByApp = new Map<string, mongoose.Types.ObjectId>();
-  const broadened: BroadenedMember[] = [];
+  const unscoped: UnscopedMember[] = [];
 
-  let foldedMembers = 0;
+  let existingAccountMembers = 0;
   let skippedNoOwner = 0;
 
   for (const member of memberships) {
@@ -84,31 +76,33 @@ async function migrate(): Promise<void> {
       continue;
     }
 
-    const accountRole = mapAppRole(appRole);
-    const wrote = await ensureMember(ownerAccountId, memberUserId, accountRole, undefined, dryRun);
-    if (wrote) foldedMembers += 1;
-
-    // An app-only member that is not an owner now reaches the whole account.
-    if (appRole !== 'owner') {
-      broadened.push({
-        applicationId: appKey,
-        ownerAccountId: ownerAccountId.toString(),
-        memberUserId: memberUserId.toString(),
-        appRole,
-        accountRole,
-      });
+    const existingAccountMember = await AccountMember.exists({
+      accountId: ownerAccountId,
+      memberUserId,
+      status: 'active',
+    });
+    if (existingAccountMember) {
+      existingAccountMembers += 1;
+      continue;
     }
+
+    unscoped.push({
+      applicationId: appKey,
+      ownerAccountId: ownerAccountId.toString(),
+      memberUserId: memberUserId.toString(),
+      appRole,
+    });
   }
 
   logger.info('Phase 4 summary', {
     dryRun,
     memberships: memberships.length,
-    foldedMembers,
+    existingAccountMembers,
     skippedNoOwner,
-    broadenedCount: broadened.length,
+    unscopedCount: unscoped.length,
   });
   // eslint-disable-next-line no-console
-  console.log('OXY_ACCOUNTS_BROADENED_MEMBERS=' + JSON.stringify(broadened));
+  console.log('OXY_ACCOUNTS_UNSCOPED_APP_MEMBERS=' + JSON.stringify(unscoped));
 }
 
 async function main(): Promise<void> {
@@ -123,10 +117,10 @@ async function main(): Promise<void> {
 main()
   .then(() => process.exit(0))
   .catch((error) => {
-  logger.error(
-    'Phase 4 (app members → account members) failed',
-    error instanceof Error ? error : new Error(String(error)),
-    { component: 'migrate-accounts-40' }
-  );
-  process.exit(1);
-});
+    logger.error(
+      'Phase 4 (app-member audit) failed',
+      error instanceof Error ? error : new Error(String(error)),
+      { component: 'migrate-accounts-40' }
+    );
+    process.exit(1);
+  });

--- a/packages/api/src/scripts/__tests__/accountAppMemberMigration.test.ts
+++ b/packages/api/src/scripts/__tests__/accountAppMemberMigration.test.ts
@@ -1,0 +1,15 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('legacy application-member migration authorization boundary', () => {
+  test('never converts an application-scoped grant into an account-wide membership', () => {
+    const migrationSource = fs.readFileSync(
+      path.resolve(__dirname, '../../../scripts/migrate-accounts-40-app-members.ts'),
+      'utf8'
+    );
+
+    expect(migrationSource).not.toMatch(/\bensureMember\s*\(/);
+    expect(migrationSource).not.toMatch(/AccountMember\.(?:create|updateOne|findOneAndUpdate)\s*\(/);
+    expect(migrationSource).toContain('OXY_ACCOUNTS_UNSCOPED_APP_MEMBERS=');
+  });
+});


### PR DESCRIPTION
### Motivation

- A migration folded legacy per-application memberships into account-wide AccountMember rows, which broadened legacy app-scoped grants to every application on the owning account and created an authorization boundary regression. 
- The goal is to prevent accidental escalation of app-only roles (notably credential-management rights) while surfacing unresolved legacy memberships for an operator to remediate explicitly.

### Description

- Change Phase 4 migration to audit-only: it no longer calls `ensureMember` or writes `AccountMember` rows for migrated application members and instead collects unscoped app-only memberships for operator review in `OXY_ACCOUNTS_UNSCOPED_APP_MEMBERS` (file: `packages/api/scripts/migrate-accounts-40-app-members.ts`).
- Skip migration when an equivalent active `AccountMember` already exists by checking `AccountMember.exists(...)` so existing account members remain unaffected (file: `packages/api/scripts/migrate-accounts-40-app-members.ts`).
- Remove the legacy app-role → account-role mapper to avoid accidental reuse of the unsafe mapping (file: `packages/api/scripts/account-migration-lib.ts`).
- Add a regression test that ensures the migration source does not call `ensureMember`, does not write `AccountMember`, and emits the unresolved-members report (file: `packages/api/src/scripts/__tests__/accountAppMemberMigration.test.ts`).

### Testing

- Ran a dependency-free source guard script that scans the migration and confirmed it does not call `ensureMember` or write `AccountMember` and contains the `OXY_ACCOUNTS_UNSCOPED_APP_MEMBERS=` report, and that check passed. 
- Attempted to run the added Jest test but the environment lacked installed test tooling/dependencies so the suite could not be executed here (test runner not available). 
- Attempted TypeScript script typecheck which was blocked by missing type dependencies and a global TypeScript deprecation check in this environment, so a full `tsc` verification did not complete. 
- Performed repository static checks (diff/check) and the modified files pass local formatting/linting checks in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a719c80eedc83238dbd01aa0877b6ac)