### PR TITLE
docs(auth): the device model gains people, and the wire contract to say so

### DIFF
--- a/docs/adr/0001-multi-principal-device-model.md
+++ b/docs/adr/0001-multi-principal-device-model.md
@@ -1,0 +1,121 @@
+# ADR 0001 — A device holds principals, and principals hold account contexts
+
+- Status: accepted
+- Date: 2026-08-10
+- Issue: #937
+- Supersedes: the flat `device_session_accounts` projection as the authority for "what is signed in on this device"
+
+## Context
+
+`device_sessions` today owns a flat set of rows in `device_session_accounts`:
+
+```
+device_session_id, account_id, session_id, authuser, operated_by_user_id?
+UNIQUE(device_session_id, account_id)
+```
+
+Four different facts are collapsed into that one row shape:
+
+1. a person who authenticated on this device;
+2. that person's personal account;
+3. an organization/project the person may act as;
+4. the person through whom a delegated account is being operated.
+
+Two consequences follow directly from the unique constraint, and neither is a bug
+in the code that can be fixed without changing the shape:
+
+- **`Nate → The Oxy Collective` and `Alice → The Oxy Collective` cannot both
+  exist on one device.** The second insert collides on
+  `UNIQUE(device_session_id, account_id)`. The same subject operated by two
+  different people is a legitimate, ordinary state — different sessions,
+  different permissions, different audit actor, different revocation path — and
+  the schema cannot hold it.
+- **`authuser` is allocated per account, not per person.** Adding an
+  organization consumes an `authuser` slot, so the Google-style "signed-in user
+  slot" number does not identify a human. Nothing downstream can rely on it to
+  mean what its name says.
+
+A third consequence is client-side: because the server hands out a flat list,
+every application has to rebuild the person→accounts tree itself by unioning the
+device rows with a separately fetched account graph. That reconstruction cannot
+be correct on a multi-person device — the client only ever holds *one* caller's
+graph, so it cannot enumerate what Alice may act as.
+
+## Decision
+
+Split the flat set into two tables and make the *context* — one principal acting
+as one account — the switchable unit.
+
+```
+device_principals
+  id, device_session_id, user_id, authuser,
+  personal_session_id, added_at, last_authenticated_at, revoked_at?
+  UNIQUE(device_session_id, user_id)
+  UNIQUE(device_session_id, authuser)
+
+device_account_contexts
+  id, device_session_id, principal_id, account_id, session_id?,
+  added_at, last_used_at, revoked_at?
+  UNIQUE(device_session_id, principal_id, account_id)
+```
+
+`session_id` is **nullable**, which is a change from the issue's sketch and is
+load-bearing. A context row exists for every account a principal may act as, so
+that the switcher has a stable id to activate — but the delegated session is
+minted on first activation, not eagerly for every organization the person
+belongs to. `session_id IS NULL` is therefore "reachable, never yet used here",
+and it is what the directory reports as `onDevice: false`. ADR 0002's activation
+step 5 already says "reuse or mint", so this only names when each happens.
+
+Invariants:
+
+- A **principal** is a human who authenticated onto this device. Never an
+  organization, project, channel, or bot.
+- `authuser` belongs to the principal. An organization never consumes one.
+- A **context** is `principal acting as account`. `principal.user_id ==
+  account_id` is the personal context; anything else is delegated and requires a
+  live `account:act_as` membership.
+- The principal's personal context must exist while the principal is live.
+- Removing a principal removes exactly its own contexts, and no other
+  principal's — including when another principal can independently operate the
+  same account.
+- Deleting an account removes every context pointing at it, under any principal.
+- Revoking `account:act_as` invalidates the delegated context and its session,
+  and leaves the principal's personal context untouched.
+
+`device_sessions.active_context_id` replaces `active_account_id` as the
+authority (see ADR 0002). `active_account_id` survives only as a compatibility
+projection for the length of the migration window.
+
+## Alternatives rejected
+
+**Widen the unique to `(device_session_id, account_id, operated_by_user_id)`.**
+Cheapest change, and it does make the two-operators case storable. It leaves
+`authuser` allocated per row, keeps the client rebuilding the tree, and keeps
+"is this row a person or a thing?" as a question you answer by checking whether
+a nullable column is null. The distinction we need is between two *kinds* of
+entity, so it belongs in two tables.
+
+**Keep one table, add a `kind` discriminator.** Flattening a discriminated union
+into one table invites a biconditional CHECK that is wrong in one direction —
+and the writers, not the columns, are what decide which implication actually
+holds. Two tables state the relationship in the schema instead of in a
+constraint comment.
+
+## Consequences
+
+- Backfill must map every existing row: an ordinary row becomes
+  `principal(user_id=account_id)` + a personal context; a row carrying
+  `operated_by_user_id` becomes `principal(user_id=operated_by_user_id)` + a
+  delegated context. `authuser` ordering is preserved where it maps to a
+  principal. Ambiguous rows are **reported, never dropped** — see ADR 0002's
+  migration section and the Phase 1 backfill audit list.
+- Row counts are part of the migration record: "this device set holds N rows,
+  and here is what happened to each" is a line in the PR, because its absence is
+  what lets silent data loss through.
+- Any code that inferred meaning from *absence* — "no row for this account, so
+  the account is not on this device" — must be re-read against the new shape,
+  where absence of a context and absence of a principal mean different things.
+- The old flat wire contract (`DeviceSessionState.accounts[]`) keeps working,
+  projected from the new tables, until every supported client has moved to the
+  directory contract in ADR 0002.

--- a/docs/adr/0002-global-account-context.md
+++ b/docs/adr/0002-global-account-context.md
@@ -1,0 +1,119 @@
+# ADR 0002 — One globally active context per device, activated through one endpoint
+
+- Status: accepted
+- Date: 2026-08-10
+- Issue: #937
+- Builds on: ADR 0001
+
+## Context
+
+A device has one active account today (`device_sessions.active_account_id`), and
+switching it is `POST /session/device/switch` with an `accountId`. That works
+while an account identifies its own operator. Under ADR 0001 it no longer does:
+`The Oxy Collective` may be reachable through Nate *and* through Alice, and those
+are different sessions with different permissions and different audit actors.
+An `accountId` is therefore no longer sufficient to name what to switch to.
+
+Separately, each application currently assembles the switcher itself:
+
+```
+fetch device state + fetch account graph + fetch profiles
++ merge + dedupe + compute switchability + reconcile the current account
+```
+
+That is repeated per app, and on a multi-person device it cannot be correct —
+the client holds one caller's account graph and cannot enumerate the other
+principals' memberships.
+
+## Decision
+
+### One read model
+
+```http
+GET /session/device/directory
+```
+
+The server builds the whole tree — principals, their contexts, relationship and
+kind per context, which is active, and sanitized display metadata — from
+principals, live sessions, account graphs, memberships and permissions. It is
+deterministic and revision-bound. A managed account the principal cannot
+currently act as is omitted or explicitly marked unavailable; it is never
+silently rendered as available.
+
+The account dialog in `@oxyhq/services` and the `auth.oxy.so` chooser consume
+this one contract. The client does not reconstruct any principal's graph. The
+old flat projection remains only as a compatibility adapter.
+
+### One write
+
+```http
+POST /session/device/activate   { "contextId": "..." }
+```
+
+Server behaviour is one serialized state transition:
+
+1. resolve the DeviceSession from the caller's verified credential;
+2. resolve the target context and its principal;
+3. verify the principal's personal session is live;
+4. for a delegated subject, verify live `account:act_as`;
+5. reuse or mint the delegated session;
+6. bind the session to actor *and* subject;
+7. set `active_context_id`;
+8. increment `revision`;
+9. return the new directory plus an application-appropriate active token;
+10. broadcast token-free device state.
+
+Rules that fall out of this and are load-bearing:
+
+- **Activating the already-active context bumps nothing and broadcasts
+  nothing.** Idempotence is observable, so it is testable.
+- **A stale or revoked target fails closed** and heals the invalid context out
+  of the device rather than leaving it to be selected again.
+- **Concurrent activations produce one deterministic winning revision.**
+- `contextId`, not `accountId`, is the identifier on the wire. An `accountId`
+  cannot name a context on a multi-principal device.
+
+### Client ordering invariant
+
+For every local switch, socket push, cold boot, reconnect and cross-tab update:
+
+```
+resolve/mint bearer for the new context
+→ commit token
+→ reset account-scoped caches
+→ publish the new runtime snapshot
+→ notify React consumers
+```
+
+A component must never render Alice while sending Nate's bearer. This ordering
+already exists in `SessionClient` for account switches and is preserved verbatim
+for contexts — it is not re-derived.
+
+## Alternatives rejected
+
+**Keep `POST /session/device/switch { accountId }` and disambiguate
+server-side.** The server would have to guess which principal the caller meant
+whenever an account is reachable through two of them. A guess in an
+authorization path is not a default we are willing to ship, and "whichever one
+the caller's own bearer belongs to" is exactly the case that breaks when an
+admin device holds two people.
+
+**Let each app keep building the switcher and just add the missing fields.**
+It multiplies the number of places a permission decision is made by the number
+of apps, and every one of them is a client. Switchability is an authorization
+question; it belongs on the server.
+
+## Consequences
+
+- `@oxyhq/contracts` gains a typed `DeviceDirectory` and the activation
+  request/response. Server validates output, clients validate input.
+- `SessionClient` moves from `activeAccountId` to `activeContextId` and carries
+  actor/subject separately. Revision handling, last-writer-wins, and
+  token-before-notify are preserved unchanged.
+- `sessionMode: 'identity'` (Commons) is unaffected: it stays pinned to the
+  local key's owner and ignores `activeContextId` entirely. It receives device
+  updates only for management and progress display.
+- Same-origin tabs converge over `BroadcastChannel` in addition to the socket;
+  cross-origin official apps converge over the socket / rebootstrap.
+- Sockets join the room derived from the *verified* device, never a
+  client-supplied room id.

--- a/docs/adr/0003-browser-device-session-hub.md
+++ b/docs/adr/0003-browser-device-session-hub.md
@@ -1,0 +1,132 @@
+# ADR 0003 — `auth.oxy.so` becomes the browser's first-party DeviceSession hub
+
+- Status: accepted
+- Date: 2026-08-10
+- Issue: #937
+- Amends: the zero-cookie posture recorded in `AGENTS.md` and
+  `docs/SESSION-ARCHITECTURE.md` — read "What this changes about zero-cookie"
+  below before touching either.
+
+## Context
+
+Session transport is device-first and, as of the zero-cookie cutover, carries no
+cookie of any kind: each origin persists its own `{deviceId, deviceSecret}` and
+mints a short access token at `POST /session/device/token`.
+
+That is per **origin**, and deliberately so — it was the accepted trade for
+deleting third-party cookies, FedCM, hidden-iframe detection and the `#oxy_boot`
+bootstrap hop. The consequence is equally deliberate and now unacceptable at the
+product level: **a browser that authenticated on `mention.example` starts signed
+out on `mercaria.example`**, because the second origin has no credential of its
+own and nothing may read the first one's. Today the user answers that with
+another Commons QR scan, per origin.
+
+`auth.oxy.so` cannot close the gap in its current form. It is a static Vite SPA
+that authenticates a user, emits the authorization code for the relying party,
+and retains nothing — so a later origin arriving at the IdP finds no session
+there either and the ceremony repeats.
+
+## Decision
+
+`auth.oxy.so` keeps a **first-party** DeviceSession for the browser profile, and
+later official origins join it over ordinary Authorization Code + PKCE.
+
+### The handle
+
+```http
+Set-Cookie: __Host-oxy-device=<opaque random handle>; Secure; HttpOnly; SameSite=Lax; Path=/
+```
+
+- `__Host-` prefix, therefore **no `Domain` attribute** — the cookie is bound to
+  `auth.oxy.so` alone and is not sent to any other `oxy.so` host. This is a
+  host-only first-party cookie, not a shared-domain one.
+- The value is an **opaque handle and nothing else**: no token, no user id, no
+  device id, no account id, no serialized state. The server stores only a
+  hash/verifier.
+- `HttpOnly`, so no script on the IdP origin can read it; `SameSite=Lax`, so it
+  is not sent on cross-site subrequests. **It is never required in a
+  third-party context** — every flow that depends on it is a top-level visit or
+  a user-opened popup.
+- Rotated on sensitive transitions, revocable from the Accounts/Commons security
+  UI, and revoked with the DeviceSession.
+
+### Joining a later origin
+
+A new official web app runs Authorization Code + PKCE against the IdP. When the
+hub session exists, the IdP resolves the active `DeviceAccountContext`, applies
+the existing registry-based trust decision for skipping consent, and issues a
+code bound to application, redirect URI, PKCE challenge, scopes, actor, subject
+and device context. No QR, no password, no passkey ceremony. When it does not
+exist, one Commons-first authentication establishes it, over the same
+`AuthSession` model every other delivery surface uses.
+
+### What stays forbidden
+
+Unchanged from the zero-cookie cutover, and not reopened by this ADR:
+
+- third-party cookies;
+- hidden or silent iframes for session detection;
+- cross-origin `localStorage`;
+- Storage Access API as the primary architecture;
+- popups created without a user gesture;
+- silent `prompt=none` loops (`'none'` stays absent from the `prompt` union);
+- FedCM;
+- automatic redirect chains across every Oxy origin.
+
+Public/guest-capable apps must not destroy the user's route or unsaved state on
+cold boot: they stay guest until the user chooses "Continue with Oxy", or use a
+product-approved top-level redirect policy. Popup remains the preferred
+interactive transport where the mounted page matters.
+
+### What this changes about zero-cookie
+
+The rule as written — "there is NO cookie, NO refresh-token family, NO bootstrap
+hop; never reintroduce any of it" — was one rule covering several mechanisms.
+This ADR reopens exactly one of them, at exactly one origin, and the rest stay
+deleted. Restated:
+
+- **Relying-party origins remain zero-cookie.** Mention, Mercaria, Syra,
+  Console, Accounts, Inbox and every scaffolded app keep
+  `{deviceId, deviceSecret}` + `POST /session/device/token` and set no cookie.
+- **`auth.oxy.so` alone holds a host-only, HttpOnly, opaque handle**, and only
+  in a first-party context.
+- **No refresh-token family and no bootstrap hop return.** The cookie is a
+  pointer to a server-side DeviceSession, not a credential the browser can
+  spend against the resource API.
+
+`AGENTS.md` must be amended in the same PR that lands this, or the repository
+will carry a rule that forbids what it also ships. A source-level guard is not
+enough: sweep comments, prose and log strings, since nothing recomputes them.
+
+## Alternatives rejected
+
+**A `Domain=.oxy.so` cookie shared across Oxy origins.** It is the smallest
+change and it is the one thing the `__Host-` prefix exists to prevent: any
+subdomain — including one delegated to a third party — could then read or
+overwrite the browser's device handle.
+
+**Per-origin device credentials plus a "sign in again" prompt.** The status quo.
+Rejected at product level: the repeated QR scan per origin is the specific
+failure this epic exists to remove.
+
+**Storage Access API.** Prompts the user, is implemented inconsistently, and
+makes the architecture depend on a permission that can be denied. Available as a
+future optimization, never as the mechanism.
+
+## Consequences
+
+- The IdP stops being purely static. It gains the **smallest** server/edge layer
+  that can read/set/rotate/revoke the handle, resolve the DeviceSession, run
+  authorize/callback/session endpoints, and enforce CSRF/origin/redirect
+  constraints. No account management moves there — `accounts.oxy.so` keeps it.
+- If that layer is a Cloudflare Pages Function it MUST be a Functions
+  *directory*, never an advanced-mode `dist/_worker.js`, and it deploys via
+  `bunx wrangler` (npm's Arborist rejects the repo-root `overrides`). That is a
+  recorded deploy failure, not a preference.
+- CSRF matters again for the cookie-bearing endpoints. Bearer-authenticated
+  writes elsewhere are unaffected.
+- Test coverage must include: third-party cookies blocked; no hidden iframe
+  present; the cookie's exact attribute set; the value being an opaque handle;
+  revocation invalidating joined apps per policy; Chrome/Safari/Firefox plus
+  private windows; popup success, blocked popup, manual close, timeout,
+  malformed message, wrong source/origin/state, and the redirect fallback.

--- a/docs/adr/0004-single-oxy-runtime-provider.md
+++ b/docs/adr/0004-single-oxy-runtime-provider.md
@@ -1,0 +1,152 @@
+# ADR 0004 — One headless `OxyRuntime` behind one public `OxyProvider`
+
+- Status: accepted
+- Date: 2026-08-10
+- Issue: #937
+
+## Context
+
+There are effectively two components named `OxyProvider`: the public composition
+root (`packages/services/src/ui/components/OxyProvider.tsx`, 324 lines) and the
+internal context provider it wraps (`packages/services/src/ui/context/
+OxyContext.tsx`, 1409 lines). Consumers cannot tell which one an error, a stack
+frame, or a piece of documentation is talking about.
+
+The internal one is where the concerns collected. Its context value
+(`oxyContextTypes.ts`) currently exposes, in one object:
+
+- session state — `user`, `sessions`, `activeSessionId`, `isAuthenticated`,
+  `isLoading`, `isTokenReady`, `hasAccessToken`, `canUsePrivateApi`,
+  `isPrivateApiPending`, `isAuthResolved`, `isStorageReady`, `error`;
+- session operations — `signIn`, `handleWebSession`, `startWebOAuthSignIn`,
+  `logout`, `logoutAll`, `switchSession`, `removeSession`, `refreshSessions`,
+  `clearSessionState`, `clearAllAccountData`;
+- the account graph — `accounts`, `switchToAccount`, `refreshAccounts`,
+  `createAccount`;
+- the dialog — `accountDialogController`, `isAccountDialogOpen`,
+  `openAccountDialog`, `closeAccountDialog`;
+- **passkey management** — `signInWithPasskey`, `registerWithPasskey`,
+  `addPasskey`, `removePasskey`, `revokeSuspiciousSignIn`;
+- **device management** — `getDeviceSessions`, `logoutAllDeviceSessions`,
+  `updateDeviceName`;
+- **language state** — `currentLanguage`, `currentLanguages`,
+  `currentLanguageMetadata`, `currentLanguageName`, `currentNativeLanguageName`,
+  `setLanguage`;
+- **unrelated domain/UI** — `useFollow`, `showBottomSheet`, `openAvatarPicker`;
+- plumbing — `storageKeyPrefix`, `clientId`, `oxyServices`, `sessionClient`,
+  `hasIdentity`, `getPublicKey`.
+
+Two problems follow. First, **any** change to any of those rebuilds the context
+value, so a language change rerenders every auth consumer. Second, session truth
+is spread across overlapping owners — `SessionClient` state, session-management
+React state, zustand stores, the `OxyServices` token store, the persisted auth
+state store, component state, and the Query cache — with implicit `useEffect`
+chains synchronising them. When two owners disagree, which one is right is not
+answerable from the code.
+
+## Decision
+
+**One headless runtime owns the truth; React is an adapter over it.**
+
+```ts
+const runtime = createOxyRuntime({ clientId, sessionMode, platform, services, queryClient });
+```
+
+The runtime owns `OxyServices`, `SessionClient`, auth-state persistence, the
+device transport adapter, cold boot and refresh, the active
+`DeviceAccountContext`, the account directory, the OAuth/Commons sign-in
+controller, the account-dialog controller, application session/token state, the
+account-scoped cache transition hooks, and reconnect/focus/socket/cross-tab
+convergence.
+
+**One snapshot** is the observable state:
+
+```ts
+interface OxyRuntimeSnapshot {
+  status: 'booting' | 'authenticated' | 'signed_out' | 'error';
+  device: DeviceDirectory | null;
+  activeContext: DeviceAccountContext | null;
+  principal: User | null;
+  account: User | null;
+  tokenStatus: 'missing' | 'refreshing' | 'ready' | 'error';
+  authResolved: boolean;
+  switching: boolean;
+  error: OxyRuntimeError | null;
+}
+```
+
+Everything else is a **derived selector**, not a second writable store.
+
+**One stable context**: the provider's value is the runtime reference itself, so
+it never changes identity. Hooks (`useAuth`, `useOxy`, `useActiveAccount`,
+`useDeviceDirectory`, `useOxyClient`, `useAccountSwitcher`) subscribe with
+selectors through `useSyncExternalStore`. They are hooks over one context, not
+additional providers.
+
+**One public provider.** The normal integration stays exactly:
+
+```tsx
+<OxyProvider clientId={OXY_CLIENT_ID}><App /></OxyProvider>
+```
+
+and Commons stays `<OxyProvider clientId={…} sessionMode="identity">`. There is
+no `<AuthProvider><SessionProvider><AccountsProvider>…` stack, now or later.
+The internal provider stops being a second exported component called
+`OxyProvider`; the target names are `OxyRuntime`, `OxyRuntimeContext`, and the
+public `OxyProvider` composition root.
+
+**Internal technical providers stay internal.** React Query, Bloom, safe areas,
+gesture handler, keyboard, surface host and toast outlets are mounted once by
+`OxyProvider` and are implementation details, not session authorities. A
+consumer-supplied QueryClient becomes *the* QueryClient — never nested under
+another. Outlets that render rows or surfaces mount exactly once.
+
+**Off the central value**, available as focused hooks or ordinary exports from
+`@oxyhq/services`: `useFollow`, avatar-picker presentation, arbitrary
+bottom-sheet navigation, detailed passkey management, detailed device
+management, payments/files/social APIs, and locale metadata that does not
+determine session behaviour. They remain available; they are not fields on the
+authentication context.
+
+**Missing provider fails fast.** The base hook throws a clear error. Optional
+use, if genuinely needed, is an explicit `useOptionalOxy()`. No fabricated
+forever-loading runtime with no-op methods.
+
+**Platform differences are explicit files** — `platformAdapter.{web,native}.ts`,
+`authStore.{web,native}.ts`, `OxyProvider.{web,native}.tsx` — not
+runtime-computed module names or bundler-analysis tricks. Business logic stays
+in the shared runtime.
+
+## Alternatives rejected
+
+**Split the context into several providers.** It fixes the rerender problem and
+creates the provider stack this ADR exists to prevent, while leaving the
+"which owner is right" question untouched — it would have more owners, not
+fewer.
+
+**Keep the context and memoize harder.** The value would still be rebuilt by
+unrelated state, and the duplicate state owners would remain. Memoization treats
+the symptom.
+
+**Move everything into zustand.** Swaps one store technology for another without
+answering ordering: the token-before-notify invariant (ADR 0002) is a sequencing
+property of a transition, which a store does not express.
+
+## Consequences
+
+- `packages/services/src/` is React-Compiler-compiled inside the `commons` and
+  `accounts` apps, so the runtime's external mutable state must be read through
+  `useSyncExternalStore` and never out-of-band in a memoizable position.
+- Public hooks keep working as compatibility selectors during the migration,
+  with deprecated fields marked. Compatibility APIs are removed in an
+  intentional major — but duplicate state machines are *not* preserved merely to
+  preserve implementation details.
+- Cleanup is deterministic: sockets, timers, listeners, popups and subscriptions
+  are owned by the runtime and released with it.
+- Tests must prove: one public provider mounts; a missing provider throws; a
+  supplied QueryClient is not duplicated; outlets mount once; unrelated state
+  changes do not rerender auth consumers; cold boot resolves exactly once; one
+  switch causes one ordered transition; no token mirror into a global
+  `oxyClient` and no app-local `setTokenGetter` or switch-reset gate is
+  required; both platform adapters build without pulling unavailable native
+  modules.

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -20,6 +20,8 @@ It does **not** own account management: every `/settings/*` path permanently red
 
 Session authority and transport live entirely in `api.oxy.so`: zero-cookie `deviceId` + `deviceSecret` persisted first-party by the client, minted/refreshed via `POST /session/device/token` (no bearer, no cookies — possession of the secret is the proof). The server-side model is `DeviceSession` (`/session/device/*` + the `session_state` socket event) — see [device-session.md](./device-session.md). There is no cookie and no refresh-token family. FedCM and the legacy silent/cross-domain restore machinery were deleted from the IdP and the SDK.
 
+The multi-person evolution of that model — principals, account contexts, one globally active context, and the browser DeviceSession hub this IdP is becoming — is specified in [principals-and-account-contexts.md](./principals-and-account-contexts.md) and the records under [`docs/adr/`](../adr/). Where the two disagree, the ADRs describe the target and this page describes what is deployed.
+
 ## Provider mount — `OxyProvider`, device-first like every app
 
 The IdP mounts the single UI SDK, `@oxyhq/services`, with NO special props — it is a device-first origin exactly like accounts.oxy.so (`packages/auth/src/main.tsx`). The previous separate web SDK package no longer exists in the monorepo.

--- a/docs/auth/principals-and-account-contexts.md
+++ b/docs/auth/principals-and-account-contexts.md
@@ -1,0 +1,114 @@
+# Principals and account contexts
+
+The vocabulary the device model, the API contracts, the SDK and the account
+switcher all use. If a term here disagrees with a term in code, the code is
+wrong — these names are the ones `@oxyhq/contracts` ships.
+
+Design rationale: [ADR 0001](../adr/0001-multi-principal-device-model.md) and
+[ADR 0002](../adr/0002-global-account-context.md).
+
+## The five nouns
+
+### Identity
+
+The cryptographic human identity controlled by a Commons key. Stable inside one
+Commons vault. Used for signed approvals, credentials, identity records,
+recovery and proof.
+
+An identity is **not** a session and **not** an account. Commons is bound to one
+and never follows the account switcher.
+
+### Principal
+
+A human who has authenticated onto one device or browser profile.
+
+Never an organization, project, channel or bot. `authuser` — the Google-style
+signed-in-human slot number — belongs to the principal: adding an organization
+never consumes one.
+
+### Account
+
+The subject an application acts as: personal, organization, project, bot, or any
+future kind that supports `account:act_as`.
+
+### Device session
+
+The server-authoritative representation of one physical device, one native
+shared installation group, or one browser profile. It owns the principals added
+to the device, the contexts available through them, the single active context,
+the monotonic `revision`, and device-scoped revocation.
+
+It does **not** own the Commons private key.
+
+### Device account context
+
+One principal acting as one account:
+
+```
+principal = Nate
+account   = The Oxy Collective
+```
+
+This is the globally switchable unit, and the thing `contextId` names. A context
+is **personal** when `principal.userId === accountId` and **delegated**
+otherwise; a delegated context requires a live `account:act_as` membership,
+re-checked at activation, never assumed from the row's existence.
+
+## Why the pair, and not the account
+
+The same managed account can be reachable through two different people on one
+device:
+
+```
+Nate  → The Oxy Collective
+Alice → The Oxy Collective
+```
+
+Those are different sessions, different permissions, different audit actors and
+different revocation paths. An `accountId` cannot tell them apart, so the wire
+identifier is the context id, and the server never guesses which principal a
+caller meant.
+
+## Application session
+
+The credential an individual application uses to reach its permitted APIs while
+following the device's active context.
+
+The active context is shared across official apps. The application's token is
+not: it is bound to the application, audience, scopes, actor and subject, and a
+third-party application never receives a device-wide credential.
+
+## What follows the switch, and what does not
+
+| Surface | Follows `activeContextId`? |
+|---|---|
+| Official app in `sessionMode: 'account'` | yes |
+| `auth.oxy.so` chooser | yes |
+| Commons (`sessionMode: 'identity'`) | **no** — pinned to the local key's owner |
+| Third-party OAuth client | **no** — isolated grant, no device context |
+
+Commons still receives device updates, for management and progress display
+only. `switchToAccount` / `switchSession` throw `IdentityBoundSessionError`
+there; they are never silent no-ops.
+
+## Sign-out has five distinct meanings
+
+Each is a separate operation, and conflating any two of them is a bug:
+
+1. **Sign out of this application** — revokes that application's session only.
+   The principal stays on the device; a later SSO join can recreate it.
+2. **Remove one context** — drops one `principal → account` pair. If it was
+   active, elect a deterministic replacement: that principal's personal context,
+   then another of that principal's contexts, then the next principal's personal
+   context, then no active context.
+3. **Remove one principal** — drops the person and all their contexts, and
+   nobody else's — including when another principal can independently operate
+   the same account.
+4. **Sign out every Oxy app on this device/browser profile** — revokes the
+   DeviceSession with its credentials, application sessions, principals,
+   contexts, sockets and browser hub session.
+5. **Sign out everywhere** — every DeviceSession, native installation and
+   browser session belonging to the user.
+
+Revoking an application's grant is separate again, and revoking an
+`account:act_as` membership invalidates only the delegated contexts it granted.

--- a/packages/contracts/src/__tests__/deviceDirectory.test.ts
+++ b/packages/contracts/src/__tests__/deviceDirectory.test.ts
@@ -1,0 +1,169 @@
+import {
+  deviceAccountContextSchema,
+  deviceActivateRequestSchema,
+  deviceActivateResponseSchema,
+  deviceDirectorySchema,
+  devicePrincipalSchema,
+  safeParseContract,
+} from '../index';
+
+const natePersonal = {
+  id: 'ctx_nate_personal',
+  accountId: 'nate',
+  kind: 'personal' as const,
+  relationship: 'self' as const,
+  account: { id: 'nate', username: 'nate' },
+  onDevice: true,
+  available: true,
+  active: false,
+  lastUsedAt: 1720000000000,
+};
+
+const nateOxy = {
+  id: 'ctx_nate_oxy',
+  accountId: 'oxy_collective',
+  kind: 'organization' as const,
+  relationship: 'owner' as const,
+  account: { id: 'oxy_collective', username: 'oxy' },
+  onDevice: true,
+  available: true,
+  active: true,
+  lastUsedAt: 1720000001000,
+};
+
+const aliceOxy = {
+  ...nateOxy,
+  id: 'ctx_alice_oxy',
+  relationship: 'member' as const,
+  active: false,
+};
+
+const nate = {
+  id: 'principal_nate',
+  userId: 'nate',
+  authuser: 0,
+  user: { id: 'nate', username: 'nate' },
+  contexts: [natePersonal, nateOxy],
+};
+
+const alice = {
+  id: 'principal_alice',
+  userId: 'alice',
+  authuser: 1,
+  user: { id: 'alice', username: 'alice' },
+  contexts: [
+    { ...natePersonal, id: 'ctx_alice_personal', accountId: 'alice', account: { id: 'alice', username: 'alice' } },
+    aliceOxy,
+  ],
+};
+
+const directory = {
+  deviceId: 'device_x',
+  revision: 42,
+  activeContextId: 'ctx_nate_oxy',
+  principals: [nate, alice],
+  updatedAt: 1720000002000,
+};
+
+describe('deviceDirectorySchema', () => {
+  it('parses a two-principal directory', () => {
+    expect(safeParseContract(deviceDirectorySchema, directory)).toEqual(directory);
+  });
+
+  it('carries the same account under two principals as two distinct contexts', () => {
+    const parsed = safeParseContract(deviceDirectorySchema, directory);
+    const contexts = parsed?.principals.flatMap((p) => p.contexts) ?? [];
+    const oxy = contexts.filter((c) => c.accountId === 'oxy_collective');
+    // The shape this whole model exists for: one account id, two context ids.
+    expect(oxy).toHaveLength(2);
+    expect(new Set(oxy.map((c) => c.id)).size).toBe(2);
+  });
+
+  it('accepts activeContextId=null (no active context on this device)', () => {
+    const parsed = safeParseContract(deviceDirectorySchema, { ...directory, activeContextId: null });
+    expect(parsed?.activeContextId).toBeNull();
+  });
+
+  it('rejects a negative authuser', () => {
+    expect(safeParseContract(devicePrincipalSchema, { ...nate, authuser: -1 })).toBeNull();
+  });
+
+  it('rejects a non-integer authuser', () => {
+    expect(safeParseContract(devicePrincipalSchema, { ...nate, authuser: 1.5 })).toBeNull();
+  });
+
+  it('rejects a directory missing revision', () => {
+    const { revision, ...noRevision } = directory;
+    expect(safeParseContract(deviceDirectorySchema, noRevision)).toBeNull();
+  });
+
+  it('rejects an unknown account kind', () => {
+    expect(safeParseContract(deviceAccountContextSchema, { ...nateOxy, kind: 'team' })).toBeNull();
+  });
+
+  it('rejects an unknown relationship', () => {
+    expect(safeParseContract(deviceAccountContextSchema, { ...nateOxy, relationship: 'admin' })).toBeNull();
+  });
+
+  it('accepts a reachable-but-unused context (onDevice=false)', () => {
+    const parsed = safeParseContract(deviceAccountContextSchema, {
+      ...nateOxy,
+      onDevice: false,
+      active: false,
+      lastUsedAt: null,
+    });
+    expect(parsed?.onDevice).toBe(false);
+    expect(parsed?.lastUsedAt).toBeNull();
+  });
+
+  it('accepts a revoked-membership context as available=false rather than omitting it', () => {
+    const parsed = safeParseContract(deviceAccountContextSchema, { ...nateOxy, available: false, active: false });
+    expect(parsed?.available).toBe(false);
+  });
+
+  it('keeps displayName optional on a directory profile', () => {
+    const parsed = safeParseContract(devicePrincipalSchema, {
+      ...nate,
+      user: { id: 'nate', username: 'nate', name: { first: 'Nate' } },
+    });
+    expect(parsed?.user.name?.displayName).toBeUndefined();
+  });
+
+  it('rejects a profile without an id', () => {
+    expect(safeParseContract(devicePrincipalSchema, { ...nate, user: { username: 'nate' } })).toBeNull();
+  });
+});
+
+describe('device activation contracts', () => {
+  it('parses an activate request', () => {
+    expect(safeParseContract(deviceActivateRequestSchema, { contextId: 'ctx_nate_oxy' })).toEqual({
+      contextId: 'ctx_nate_oxy',
+    });
+  });
+
+  it('rejects an empty contextId', () => {
+    expect(safeParseContract(deviceActivateRequestSchema, { contextId: '' })).toBeNull();
+  });
+
+  it('rejects an accountId in place of a contextId', () => {
+    // An account id cannot name a context on a multi-principal device.
+    expect(safeParseContract(deviceActivateRequestSchema, { accountId: 'oxy_collective' })).toBeNull();
+  });
+
+  it('parses a response carrying directory + token', () => {
+    const response = {
+      directory,
+      activeToken: { accessToken: 'tok', expiresAt: '2026-08-10T10:00:00.000Z' },
+    };
+    expect(safeParseContract(deviceActivateResponseSchema, response)).toEqual(response);
+  });
+
+  it('accepts activeToken=null (identity-pinned or non-entitled caller)', () => {
+    const parsed = safeParseContract(deviceActivateResponseSchema, { directory, activeToken: null });
+    expect(parsed?.activeToken).toBeNull();
+  });
+
+  it('rejects a response with no activeToken key at all', () => {
+    expect(safeParseContract(deviceActivateResponseSchema, { directory })).toBeNull();
+  });
+});

--- a/packages/contracts/src/deviceDirectory.ts
+++ b/packages/contracts/src/deviceDirectory.ts
@@ -1,0 +1,151 @@
+import { z } from 'zod';
+import { accountKindSchema } from './accountGraph';
+import { userNameSchema } from './userResponse';
+
+/**
+ * The canonical device directory — the ONE server-authoritative read model an
+ * account switcher renders (issue #937, ADR 0002).
+ *
+ * It replaces the client-side union of `DeviceSessionState.accounts[]` with a
+ * separately fetched `AccountNode[]` graph. That union cannot be correct on a
+ * device holding more than one person: the client only ever holds ONE caller's
+ * account graph, so it cannot enumerate what the OTHER principals may act as.
+ * Switchability is an authorization question, so the server answers it.
+ *
+ * The directory is deterministic and revision-bound: two reads at the same
+ * `revision` describe the same device state, and `revision` only advances on a
+ * real mutation (an idempotent activation advances nothing — ADR 0002).
+ */
+
+/**
+ * How a principal reaches an account.
+ *
+ * Mirrors `AccountRelationship` in `@oxyhq/core`'s account graph rather than
+ * inventing a second vocabulary for the same fact:
+ *  - `self`   — the principal's own personal account (`principal.userId === accountId`)
+ *  - `owner`  — the principal owns this account
+ *  - `member` — the principal holds a membership granting `account:act_as`
+ */
+export const deviceContextRelationshipSchema = z.enum(['self', 'owner', 'member']);
+
+/**
+ * Sanitized display metadata for a principal or an account context.
+ *
+ * Deliberately NOT `userResponseSchema`: a switcher needs a handle, a name and
+ * an avatar, and the directory is read by every app on the device — so it
+ * carries the minimum that renders a row and nothing that would make it a
+ * general profile feed. `name.displayName` stays OPTIONAL; consumers fall back
+ * to the handle (`getNormalizedUserHandle`), never to a synthesized name.
+ */
+export const deviceDirectoryProfileSchema = z.object({
+  id: z.string().min(1),
+  username: z.string(),
+  name: userNameSchema.optional(),
+  avatar: z.string().nullable().optional(),
+});
+
+/**
+ * One `principal acting as account` pair — the globally switchable unit.
+ *
+ * `id` is the identifier `POST /session/device/activate` takes. It names the
+ * PAIR, not the account: the same `accountId` legitimately appears under two
+ * principals on a shared device, and those are different sessions, permissions,
+ * audit actors and revocation paths.
+ *
+ * `onDevice` is `false` for a context the principal may act as but has never
+ * activated here — it exists as a row so it has a stable id to activate, and
+ * its delegated session is minted on first activation rather than eagerly for
+ * every organization the principal belongs to.
+ *
+ * `available` is the live `account:act_as` verdict at read time. A managed
+ * account whose membership was revoked is returned with `available: false`
+ * rather than silently omitted, so the UI can explain a row disappearing
+ * instead of just dropping it. A personal context is always available while its
+ * principal is live.
+ */
+export const deviceAccountContextSchema = z.object({
+  id: z.string().min(1),
+  accountId: z.string().min(1),
+  kind: accountKindSchema,
+  relationship: deviceContextRelationshipSchema,
+  account: deviceDirectoryProfileSchema,
+  onDevice: z.boolean(),
+  available: z.boolean(),
+  active: z.boolean(),
+  lastUsedAt: z.number().nullable(),
+});
+
+/**
+ * A human who authenticated onto this device.
+ *
+ * Never an organization, project, channel or bot — those are subjects a
+ * principal acts as, and they appear only in `contexts`. `authuser` is the
+ * Google-style signed-in-human slot and belongs HERE, not to an account: adding
+ * an organization must never consume one.
+ */
+export const devicePrincipalSchema = z.object({
+  id: z.string().min(1),
+  userId: z.string().min(1),
+  authuser: z.number().int().nonnegative(),
+  user: deviceDirectoryProfileSchema,
+  contexts: z.array(deviceAccountContextSchema),
+});
+
+/**
+ * Response of `GET /session/device/directory`.
+ *
+ * `activeContextId` is the authority for what every official app in
+ * `sessionMode: 'account'` renders. It is null when the device has no active
+ * context — a real state (every context removed, or an active context healed
+ * away), not an error.
+ */
+export const deviceDirectorySchema = z.object({
+  deviceId: z.string().min(1),
+  revision: z.number().int().nonnegative(),
+  activeContextId: z.string().nullable(),
+  principals: z.array(devicePrincipalSchema),
+  updatedAt: z.number(),
+});
+
+/**
+ * Request body of `POST /session/device/activate`.
+ *
+ * `contextId`, never `accountId`: an account id cannot name a context on a
+ * device where two people can both reach the same organization, and resolving
+ * that ambiguity server-side would mean guessing inside an authorization path.
+ */
+export const deviceActivateRequestSchema = z.object({
+  contextId: z.string().min(1),
+});
+
+/**
+ * Response of `POST /session/device/activate`.
+ *
+ * Carries the post-transition directory AND the bearer for the newly active
+ * context, because the client's ordering invariant is
+ * `commit token → reset caches → publish snapshot → notify` (ADR 0002). Handing
+ * the directory back without the token would force a second round trip in the
+ * middle of that sequence, which is exactly where a component would render the
+ * new subject while still holding the previous subject's bearer.
+ *
+ * `activeToken` is null when the activation legitimately produced no bearer for
+ * THIS caller — an identity-pinned client, or a caller whose application is not
+ * entitled to a token for the new context. It is never an error signal.
+ */
+export const deviceActivateResponseSchema = z.object({
+  directory: deviceDirectorySchema,
+  activeToken: z
+    .object({
+      accessToken: z.string(),
+      expiresAt: z.string(),
+    })
+    .nullable(),
+});
+
+export type DeviceContextRelationship = z.infer<typeof deviceContextRelationshipSchema>;
+export type DeviceDirectoryProfile = z.infer<typeof deviceDirectoryProfileSchema>;
+export type DeviceAccountContext = z.infer<typeof deviceAccountContextSchema>;
+export type DevicePrincipal = z.infer<typeof devicePrincipalSchema>;
+export type DeviceDirectory = z.infer<typeof deviceDirectorySchema>;
+export type DeviceActivateRequest = z.infer<typeof deviceActivateRequestSchema>;
+export type DeviceActivateResponse = z.infer<typeof deviceActivateResponseSchema>;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -461,6 +461,26 @@ export type {
 } from './deviceSession';
 
 export {
+    deviceContextRelationshipSchema,
+    deviceDirectoryProfileSchema,
+    deviceAccountContextSchema,
+    devicePrincipalSchema,
+    deviceDirectorySchema,
+    deviceActivateRequestSchema,
+    deviceActivateResponseSchema,
+} from './deviceDirectory';
+
+export type {
+    DeviceContextRelationship,
+    DeviceDirectoryProfile,
+    DeviceAccountContext,
+    DevicePrincipal,
+    DeviceDirectory,
+    DeviceActivateRequest,
+    DeviceActivateResponse,
+} from './deviceDirectory';
+
+export {
     // Schemas
     loginResultSchema,
 } from './deviceBoot';


### PR DESCRIPTION
Phase 0 of #937. Design records and the wire contract only — no runtime behaviour changes, nothing deleted.

## Why

A device row today conflates four facts: a person who authenticated, their personal account, an organization they may act as, and the person through whom it is operated. `UNIQUE(device_session_id, account_id)` on `device_session_accounts` then makes the interesting case unstorable — Nate and Alice cannot both reach The Oxy Collective on one device — and `authuser`, which is supposed to number the signed-in human, is allocated per account, so adding an organization consumes a slot.

## What is here

**Four ADRs** (`docs/adr/`), each recording what was rejected and why, not just the decision:

- `0001` two tables (`device_principals`, `device_account_contexts`) rather than a wider unique or a `kind` discriminator on the existing table.
- `0002` `GET /session/device/directory` + `POST /session/device/activate`, keyed on `contextId` rather than `accountId` — an account id cannot name a context on a device where two people reach the same organization, and resolving that server-side means guessing inside an authorization path.
- `0003` a host-only `__Host-oxy-device` HttpOnly handle at `auth.oxy.so` **alone**. This reopens exactly one mechanism from the zero-cookie cutover and leaves the rest deleted; the ADR states the amended rule explicitly, and `AGENTS.md` must be updated in the PR that lands Phase 5, not this one.
- `0004` one headless `OxyRuntime` behind the one public `OxyProvider`, with the current 40-plus-field context value enumerated as the evidence.

**The `DeviceDirectory` contract** (`@oxyhq/contracts`), so Phase 1 has something to validate against.

**`docs/auth/principals-and-account-contexts.md`** — the terminology the contracts, API and SDK will share, including the five distinct meanings of "sign out".

## One deviation from the issue's sketch

`device_account_contexts.session_id` is **nullable**. A context row exists for every account a principal may act as, so the switcher has a stable id to activate, and the delegated session is minted on first activation rather than eagerly for every organization the person belongs to. `onDevice: false` on the wire is that state. ADR 0002's activation step already says "reuse or mint"; this only names when each happens.

## Verification

- `packages/contracts`: **17 suites / 259 tests** green (19 new), `bun run build` clean.
- Baselines captured on `eeca7d41` before any change: api **311 suites / 4522 tests**, core **114 suites / 1596 tests**, both green.

Refs #937
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/oxyhq/oxy/pull/938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->