### PR TITLE
refactor(services): one component named OxyProvider, and a missing one now says so

### DIFF
--- a/packages/accounts/app/_layout.tsx
+++ b/packages/accounts/app/_layout.tsx
@@ -8,7 +8,6 @@ import { Stack, ThemeProvider } from 'expo-router';
 import Head from 'expo-router/head';
 import { StatusBar } from 'expo-status-bar';
 import { Platform } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { configureReanimatedLogger, ReanimatedLogLevel } from 'react-native-reanimated';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -228,17 +227,18 @@ function AppStackContent() {
   // first non-redirecting sibling, so exactly one group is active at any time.
   const needsAuth = isAuthResolved ? !isAuthenticated : true;
 
+  // No `<SafeAreaProvider>` here: this subtree renders inside the provider
+  // above, which mounts one itself (on both the ready and the boot-shell
+  // path). A second, deeper one only re-measures the same full-screen frame.
   return (
-    <SafeAreaProvider>
-      <ScrollProvider>
-        <ThemeProvider value={navTheme}>
-          <Stack>
-            <Stack.Screen name="(tabs)" redirect={needsAuth} options={{ headerShown: false }} />
-            <Stack.Screen name="(auth)" redirect={!needsAuth} options={{ headerShown: false }} />
-          </Stack>
-          <StatusBar style="auto" />
-        </ThemeProvider>
-      </ScrollProvider>
-    </SafeAreaProvider>
+    <ScrollProvider>
+      <ThemeProvider value={navTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" redirect={needsAuth} options={{ headerShown: false }} />
+          <Stack.Screen name="(auth)" redirect={!needsAuth} options={{ headerShown: false }} />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </ScrollProvider>
   );
 }

--- a/packages/commons/app/_layout.tsx
+++ b/packages/commons/app/_layout.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from 'expo-router/react-navigation';
 import Head from 'expo-router/head';
 import { StatusBar } from 'expo-status-bar';
 import { Linking, Platform } from 'react-native';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useEffect, useRef, useState } from 'react';
 import 'react-native-reanimated';
 import { configureReanimatedLogger, ReanimatedLogLevel } from 'react-native-reanimated';
@@ -417,64 +416,65 @@ function AppStackContent() {
   // time `initialUrlResolved` flips) owns that window.
   useAuthRequestNotifications(initialUrlResolved && splashReady && !needsAuth);
 
+  // No `<SafeAreaProvider>` here: this subtree renders inside the provider
+  // above, which mounts one itself (on both the ready and the boot-shell
+  // path). A second, deeper one only re-measures the same full-screen frame.
   return (
-    <SafeAreaProvider>
-      <ScrollProvider>
-        <ThemeProvider value={navTheme}>
-          <Stack>
-            {/*
-              Bidirectional onboarding guard.
+    <ScrollProvider>
+      <ThemeProvider value={navTheme}>
+        <Stack>
+          {/*
+            Bidirectional onboarding guard.
 
-              Commons legitimately OWNS the `hasIdentity` gate — it is the
-              key vault. `needsAuth` is true when this device has no local
-              identity yet OR has one but no username/session. We must:
-                - Redirect AWAY from `(tabs)` (the post-auth tab shell) when
-                  onboarding is incomplete.
-                - Redirect AWAY from `(auth)` when onboarding is complete.
+            Commons legitimately OWNS the `hasIdentity` gate — it is the
+            key vault. `needsAuth` is true when this device has no local
+            identity yet OR has one but no username/session. We must:
+              - Redirect AWAY from `(tabs)` (the post-auth tab shell) when
+                onboarding is incomplete.
+              - Redirect AWAY from `(auth)` when onboarding is complete.
 
-              Expo Router resolves redirects to the first non-redirecting
-              sibling, so exactly one is true at any time. Commons is a
-              NATIVE-ONLY app (iOS/Android — see `platforms` in app.json):
-              `(auth)/index.tsx` is the create-identity welcome (Hello Human)
-              and there is no web build, because the key vault never leaves the
-              device.
-            */}
-            <Stack.Screen name="(tabs)" redirect={needsAuth} options={{ headerShown: false }} />
-            <Stack.Screen name="(auth)" redirect={!needsAuth} options={{ headerShown: false }} />
-            {/*
-              The QR scanner is an ACTION, not a tab. It lives at the root as a
-              full-screen presented modal (pushed from the ID landing FAB via
-              `router.push('/(scan)')`) so the CameraView covers the tab bar. It
-              holds the camera (`index`) + the real-life attestation confirmation
-              (`attest`). Guarded by the same `needsAuth` redirect as `(tabs)`:
-              only an authenticated user can open it, and an unauthenticated
-              `oxycommons://attest` deep link is bounced to onboarding.
-            */}
-            <Stack.Screen
-              name="(scan)"
-              redirect={needsAuth}
-              options={{ headerShown: false, presentation: 'fullScreenModal' }}
-            />
-            {/*
-              "Sign in with Oxy" approval — a Bloom bottom sheet. Registered at
-              the ROOT (not inside `(scan)`) as a TRANSPARENT modal so the sheet
-              rises over the real underlying context (the `(tabs)` anchor from
-              `unstable_settings`) instead of an opaque `fullScreenModal` group
-              card — otherwise it looks like a dedicated screen. `animation:
-              'none'` lets the sheet own the motion. Same `needsAuth` guard as
-              `(scan)`: an unauthenticated `oxycommons://approve` deep link is
-              bounced to onboarding (and the cold-start replay above re-navigates
-              here once the gate settles to an authenticated device).
-            */}
-            <Stack.Screen
-              name="approve"
-              redirect={needsAuth}
-              options={{ headerShown: false, presentation: 'transparentModal', animation: 'none' }}
-            />
-          </Stack>
-          <StatusBar style="auto" />
-        </ThemeProvider>
-      </ScrollProvider>
-    </SafeAreaProvider>
+            Expo Router resolves redirects to the first non-redirecting
+            sibling, so exactly one is true at any time. Commons is a
+            NATIVE-ONLY app (iOS/Android — see `platforms` in app.json):
+            `(auth)/index.tsx` is the create-identity welcome (Hello Human)
+            and there is no web build, because the key vault never leaves the
+            device.
+          */}
+          <Stack.Screen name="(tabs)" redirect={needsAuth} options={{ headerShown: false }} />
+          <Stack.Screen name="(auth)" redirect={!needsAuth} options={{ headerShown: false }} />
+          {/*
+            The QR scanner is an ACTION, not a tab. It lives at the root as a
+            full-screen presented modal (pushed from the ID landing FAB via
+            `router.push('/(scan)')`) so the CameraView covers the tab bar. It
+            holds the camera (`index`) + the real-life attestation confirmation
+            (`attest`). Guarded by the same `needsAuth` redirect as `(tabs)`:
+            only an authenticated user can open it, and an unauthenticated
+            `oxycommons://attest` deep link is bounced to onboarding.
+          */}
+          <Stack.Screen
+            name="(scan)"
+            redirect={needsAuth}
+            options={{ headerShown: false, presentation: 'fullScreenModal' }}
+          />
+          {/*
+            "Sign in with Oxy" approval — a Bloom bottom sheet. Registered at
+            the ROOT (not inside `(scan)`) as a TRANSPARENT modal so the sheet
+            rises over the real underlying context (the `(tabs)` anchor from
+            `unstable_settings`) instead of an opaque `fullScreenModal` group
+            card — otherwise it looks like a dedicated screen. `animation:
+            'none'` lets the sheet own the motion. Same `needsAuth` guard as
+            `(scan)`: an unauthenticated `oxycommons://approve` deep link is
+            bounced to onboarding (and the cold-start replay above re-navigates
+            here once the gate settles to an authenticated device).
+          */}
+          <Stack.Screen
+            name="approve"
+            redirect={needsAuth}
+            options={{ headerShown: false, presentation: 'transparentModal', animation: 'none' }}
+          />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </ScrollProvider>
   );
 }

--- a/packages/console/src/routes/__root.tsx
+++ b/packages/console/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { Outlet, createRootRoute } from '@tanstack/react-router';
 import { Suspense, lazy } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { OxyProvider } from '@oxyhq/services';
 import { BloomThemeProvider } from '@oxyhq/bloom/theme';
 import { ConnectionStatusToasts } from '@oxyhq/bloom/connection-status';
@@ -36,25 +36,28 @@ export const Route = createRootRoute({
 });
 
 function RootComponent() {
+  // `OxyProvider` owns the one `QueryClientProvider` for the tree — handing it
+  // the app's client is what makes the SDK's account hooks and Console's own
+  // hooks share a single cache. Wrapping it in a second provider around the
+  // same instance added a layer and no behaviour; nothing outside `OxyProvider`
+  // here uses React Query.
   return (
-    <QueryClientProvider client={queryClient}>
-      <LocaleProvider>
-        <BloomThemeProvider mode="system" colorPreset="oxy">
-          <ConnectionStatusToasts />
-          <OxyProvider baseURL={config.oxyUrl} clientId={config.clientId} authRedirectUri={config.authRedirectUri} queryClient={queryClient}>
-            <AccountProvider>
-              <TooltipProvider delayDuration={300}>
-                <Outlet />
-              </TooltipProvider>
-            </AccountProvider>
-          </OxyProvider>
-        </BloomThemeProvider>
-      </LocaleProvider>
-      {import.meta.env.DEV && (
-        <Suspense fallback={null}>
-          <TanStackRouterDevtools position="bottom-right" />
-        </Suspense>
-      )}
-    </QueryClientProvider>
+    <LocaleProvider>
+      <BloomThemeProvider mode="system" colorPreset="oxy">
+        <ConnectionStatusToasts />
+        <OxyProvider baseURL={config.oxyUrl} clientId={config.clientId} authRedirectUri={config.authRedirectUri} queryClient={queryClient}>
+          <AccountProvider>
+            <TooltipProvider delayDuration={300}>
+              <Outlet />
+            </TooltipProvider>
+          </AccountProvider>
+          {import.meta.env.DEV && (
+            <Suspense fallback={null}>
+              <TanStackRouterDevtools position="bottom-right" />
+            </Suspense>
+          )}
+        </OxyProvider>
+      </BloomThemeProvider>
+    </LocaleProvider>
   );
 }

--- a/packages/inbox/app/_layout.tsx
+++ b/packages/inbox/app/_layout.tsx
@@ -5,7 +5,6 @@ import '../global.css';
 import { Stack, ThemeProvider } from 'expo-router';
 import Head from 'expo-router/head';
 import { StatusBar } from 'expo-status-bar';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Platform, View } from 'react-native';
@@ -99,12 +98,14 @@ function RootLayoutContent() {
         <InboxCacheRestoreGate>
           <BloomImageResolver>
             <LocaleProvider>
-              <SafeAreaProvider>
-                <PortalProvider>
-                  <ThemeProvider value={navTheme}>
-                    <ConnectionStatusToasts />
-                    <RootEffects />
-                    {/*
+              {/* No `<SafeAreaProvider>` here: `OxyProvider` above mounts one
+                  (on both the ready and the boot-shell path), so a second,
+                  deeper one only re-measures the same full-screen frame. */}
+              <PortalProvider>
+                <ThemeProvider value={navTheme}>
+                  <ConnectionStatusToasts />
+                  <RootEffects />
+                  {/*
                     The whole app is gated behind the shared SDK signed-out wall
                     (`RequireOxyAuth prompt="hard"`). It replaces the former
                     hand-rolled sign-in gate: it blocks the navigator until the
@@ -113,12 +114,11 @@ function RootLayoutContent() {
                     primary CTA opens the ONE shared account dialog. See
                     `GatedNavigator` for the localized copy.
                   */}
-                    <GatedNavigator />
-                    <StatusBar style="auto" />
-                  </ThemeProvider>
-                  <PortalOutlet />
-                </PortalProvider>
-              </SafeAreaProvider>
+                  <GatedNavigator />
+                  <StatusBar style="auto" />
+                </ThemeProvider>
+                <PortalOutlet />
+              </PortalProvider>
             </LocaleProvider>
           </BloomImageResolver>
         </InboxCacheRestoreGate>

--- a/packages/services/README.md
+++ b/packages/services/README.md
@@ -681,7 +681,7 @@ const metadata = getLanguageMetadata('es-ES');
 
 ### Common Issues
 
-#### 1. "useOxy must be used within an OxyContextProvider"
+#### 1. "useOxy() was called outside &lt;OxyProvider&gt;"
 
 **Solution**: Wrap your app with `OxyProvider`
 

--- a/packages/services/__tests__/__mocks__/bloom.ts
+++ b/packages/services/__tests__/__mocks__/bloom.ts
@@ -206,20 +206,27 @@ const passthrough =
 export const BloomDialogProvider = ({ children }: { children?: ReactNode }) =>
   createElement(Fragment, null, children);
 
-export const ToastOutlet = () => null;
+/**
+ * Renders an empty marker node rather than `null` so a test can COUNT the
+ * outlets in a rendered tree. Both Bloom outlets read a module-level store, so
+ * two of either would render every toast / every surface twice — the marker is
+ * what lets `oxyProviderComposition.test.tsx` assert exactly one.
+ */
+export const ToastOutlet = () => createElement('div', { 'data-testid': 'bloom-toast-outlet' });
 
 /**
  * `@oxyhq/bloom/surfaces` stubs. The real stack renders each presented surface as
  * a stacked `<Dialog>`; here we only need the module surface so the SDK's
  * `navigation/surfaces.ts` + `OxyProvider` resolve. `present` returns a
  * never-settling promise (unit tests do not await surface dismissals) and
- * `SurfaceHost` renders nothing. The SDK's own surface behaviour is covered by
- * the browser-verification harness, not jsdom.
+ * `SurfaceHost` renders only a countable marker. The SDK's own surface behaviour
+ * is covered by the browser-verification harness, not jsdom.
  */
-export const SurfaceProvider = ({ children }: { children?: ReactNode }) =>
-  createElement(Fragment, null, children);
+export const SurfaceHost = () => createElement('div', { 'data-testid': 'bloom-surface-host' });
 
-export const SurfaceHost = () => null;
+// Mirrors the real provider, which renders `[children, <SurfaceHost/>]`.
+export const SurfaceProvider = ({ children }: { children?: ReactNode }) =>
+  createElement(Fragment, null, children, createElement(SurfaceHost));
 
 export const useSurface = (): { dismiss: (result?: unknown) => void; present: () => Promise<unknown> } => ({
   dismiss: () => {},

--- a/packages/services/__tests__/components/OxySignInButton.test.tsx
+++ b/packages/services/__tests__/components/OxySignInButton.test.tsx
@@ -42,15 +42,21 @@ const startWebOAuthSignIn = jest.fn<Promise<WebOAuthSignInResult>, [StartWebOAut
 let clientId: string | null = 'oxy_dk_test';
 let webAuthMode: WebAuthMode = 'popup';
 
+const mockRuntime = () => ({
+  openAccountDialog,
+  oxyServices: { getPublicApplication },
+  clientId,
+  webAuthMode,
+  startWebOAuthSignIn,
+  currentLanguage: 'en-US',
+});
+
 jest.mock('../../src/ui/context/OxyContext', () => ({
   __esModule: true,
-  useOxy: () => ({
-    openAccountDialog,
-    oxyServices: { getPublicApplication },
-    clientId,
-    webAuthMode,
-    startWebOAuthSignIn,
-  }),
+  useOxy: () => mockRuntime(),
+  // The button's label goes through `useI18n()`, the one hook that reads the
+  // runtime optionally.
+  useOptionalOxy: () => mockRuntime(),
 }));
 
 jest.mock('../../src/ui/stores/authStore', () => ({

--- a/packages/services/__tests__/components/oxyProviderComposition.test.tsx
+++ b/packages/services/__tests__/components/oxyProviderComposition.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * `OxyProvider` — the ONE public composition root (ADR 0004).
+ *
+ * These cases pin the two composition invariants a future edit is most likely
+ * to break silently, because neither produces an error when it regresses:
+ *
+ *  - **One QueryClient.** A consumer-supplied client must become *the* client
+ *    for the whole subtree. If the provider ever created its own alongside it,
+ *    the SDK's account hooks and the app's own hooks would read two different
+ *    caches — an invalidation on one would simply not reach the other, and the
+ *    UI would just show stale data.
+ *  - **Outlets mount exactly once.** Bloom's `ToastOutlet` and `SurfaceHost`
+ *    both render from a MODULE-LEVEL store, so a second mount of either renders
+ *    every toast and every surface twice, in two stacked copies.
+ *
+ * The session runtime is stubbed out: this is a test of the composition root's
+ * wiring, and booting the real state machine would only add network seams that
+ * say nothing about it. `__tests__/context/*` cover the runtime itself.
+ */
+import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClient, useQueryClient } from '@tanstack/react-query';
+
+jest.mock('react-native-gesture-handler', () => ({
+  __esModule: true,
+  GestureHandlerRootView: ({ children }: { children?: ReactNode }) => children,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  __esModule: true,
+  SafeAreaProvider: ({ children }: { children?: ReactNode }) => children,
+}));
+
+// The runtime provider is exercised by the context suites; here it is a
+// pass-through so the composition around it is what the assertions see.
+jest.mock('../../src/ui/context/OxyContext', () => ({
+  __esModule: true,
+  OxyRuntimeProvider: ({ children }: { children?: ReactNode }) => children,
+  useOxy: () => ({ currentLanguage: 'en-US' }),
+  useOptionalOxy: () => ({ currentLanguage: 'en-US' }),
+}));
+
+const createQueryClientMock = jest.fn(() => new QueryClient());
+const attachQueryPersistenceMock = jest.fn(() => ({
+  restored: Promise.resolve(),
+  unsubscribe: () => {},
+}));
+
+jest.mock('../../src/ui/hooks/queryClient', () => ({
+  __esModule: true,
+  createQueryClient: () => createQueryClientMock(),
+  attachQueryPersistence: () => attachQueryPersistenceMock(),
+}));
+
+import OxyProvider from '../../src/ui/components/OxyProvider';
+
+let observedClient: QueryClient | null = null;
+
+function ClientProbe() {
+  observedClient = useQueryClient();
+  return <div data-testid="probe" />;
+}
+
+beforeEach(() => {
+  observedClient = null;
+  createQueryClientMock.mockClear();
+  attachQueryPersistenceMock.mockClear();
+});
+
+describe('OxyProvider — one QueryClient', () => {
+  it('uses a supplied QueryClient as THE client and creates none of its own', async () => {
+    const supplied = new QueryClient();
+
+    const { findByTestId } = render(
+      <OxyProvider baseURL="https://api.oxy.so" queryClient={supplied}>
+        <ClientProbe />
+      </OxyProvider>,
+    );
+
+    await findByTestId('probe');
+
+    expect(observedClient).toBe(supplied);
+    expect(createQueryClientMock).not.toHaveBeenCalled();
+    // Persistence is the host app's lifecycle when it owns the client.
+    expect(attachQueryPersistenceMock).not.toHaveBeenCalled();
+  });
+
+  it('creates exactly one client when the consumer supplies none', async () => {
+    const { findByTestId } = render(
+      <OxyProvider baseURL="https://api.oxy.so">
+        <ClientProbe />
+      </OxyProvider>,
+    );
+
+    await findByTestId('probe');
+
+    expect(createQueryClientMock).toHaveBeenCalledTimes(1);
+    expect(observedClient).not.toBeNull();
+  });
+});
+
+describe('OxyProvider — outlets mount exactly once', () => {
+  it('renders one toast outlet and one surface host', async () => {
+    const { findByTestId, queryAllByTestId } = render(
+      <OxyProvider baseURL="https://api.oxy.so" queryClient={new QueryClient()}>
+        <ClientProbe />
+      </OxyProvider>,
+    );
+
+    await findByTestId('probe');
+
+    expect(queryAllByTestId('bloom-toast-outlet')).toHaveLength(1);
+    expect(queryAllByTestId('bloom-surface-host')).toHaveLength(1);
+  });
+
+  it('mounts no outlets at all while the boot shell is up', async () => {
+    // No supplied client + persistence still resolving => the boot shell path.
+    // It must not render a second copy of either outlet when the real tree
+    // takes over, which is exactly what a copy in the shell would cause.
+    let releaseRestore: () => void = () => {};
+    attachQueryPersistenceMock.mockImplementationOnce(() => ({
+      restored: new Promise<void>((resolve) => {
+        releaseRestore = () => resolve();
+      }),
+      unsubscribe: () => {},
+    }));
+
+    const { queryAllByTestId, findByTestId } = render(
+      <OxyProvider baseURL="https://api.oxy.so">
+        <ClientProbe />
+      </OxyProvider>,
+    );
+
+    expect(queryAllByTestId('bloom-toast-outlet')).toHaveLength(0);
+    expect(queryAllByTestId('bloom-surface-host')).toHaveLength(0);
+
+    // Storage init is async, so the persistence attach (and with it the
+    // `releaseRestore` handle) only exists once the bootstrap effect gets there.
+    await waitFor(() => {
+      expect(attachQueryPersistenceMock).toHaveBeenCalledTimes(1);
+    });
+    expect(queryAllByTestId('bloom-toast-outlet')).toHaveLength(0);
+
+    releaseRestore();
+
+    await findByTestId('probe');
+    await waitFor(() => {
+      expect(queryAllByTestId('bloom-toast-outlet')).toHaveLength(1);
+    });
+    expect(queryAllByTestId('bloom-surface-host')).toHaveLength(1);
+  });
+});

--- a/packages/services/__tests__/context/coldBoot.test.tsx
+++ b/packages/services/__tests__/context/coldBoot.test.tsx
@@ -56,7 +56,7 @@ jest.mock('../../src/ui/session', () => {
   };
 });
 
-import { OxyContextProvider, useOxy } from '../../src/ui/context/OxyContext';
+import { OxyRuntimeProvider, useOxy } from '../../src/ui/context/OxyContext';
 import type { OxyContextState } from '../../src/ui/context/OxyContext';
 import { useAuthStore } from '../../src/ui/stores/authStore';
 
@@ -124,9 +124,9 @@ function renderProvider(oxyServices: unknown): RenderResult {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <OxyContextProvider oxyServices={oxyServices as never} baseURL={API_BASE_URL} clientId="oxy_test_client">
+      <OxyRuntimeProvider oxyServices={oxyServices as never} baseURL={API_BASE_URL} clientId="oxy_test_client">
         <Capture />
-      </OxyContextProvider>
+      </OxyRuntimeProvider>
     </QueryClientProvider>,
   );
 }

--- a/packages/services/__tests__/context/identitySessionMode.test.tsx
+++ b/packages/services/__tests__/context/identitySessionMode.test.tsx
@@ -83,7 +83,7 @@ jest.mock('../../src/ui/session', () => {
   };
 });
 
-import { OxyContextProvider, useOxy } from '../../src/ui/context/OxyContext';
+import { OxyRuntimeProvider, useOxy } from '../../src/ui/context/OxyContext';
 import type { OxyContextState } from '../../src/ui/context/OxyContext';
 import { IdentityBoundSessionError } from '../../src/ui/session';
 import { useAuthStore } from '../../src/ui/stores/authStore';
@@ -217,14 +217,14 @@ function renderProvider(oxyServices: unknown, sessionMode?: 'account' | 'identit
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <OxyContextProvider
+      <OxyRuntimeProvider
         oxyServices={oxyServices as never}
         baseURL={API_BASE_URL}
         clientId="oxy_test_client"
         sessionMode={sessionMode}
       >
         <Capture />
-      </OxyContextProvider>
+      </OxyRuntimeProvider>
     </QueryClientProvider>,
   );
 }

--- a/packages/services/__tests__/context/mutationsSessionClient.test.tsx
+++ b/packages/services/__tests__/context/mutationsSessionClient.test.tsx
@@ -30,7 +30,7 @@ jest.mock('../../src/ui/session', () => {
   };
 });
 
-import { OxyContextProvider, useOxy } from '../../src/ui/context/OxyContext';
+import { OxyRuntimeProvider, useOxy } from '../../src/ui/context/OxyContext';
 import type { OxyContextState } from '../../src/ui/context/OxyContext';
 import { useAuthStore } from '../../src/ui/stores/authStore';
 import { createSessionClient } from '../../src/ui/session';
@@ -241,9 +241,9 @@ function renderProvider(oxyServices: unknown, baseURL: string) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <OxyContextProvider oxyServices={oxyServices as never} baseURL={baseURL}>
+      <OxyRuntimeProvider oxyServices={oxyServices as never} baseURL={baseURL}>
         <Capture />
-      </OxyContextProvider>
+      </OxyRuntimeProvider>
     </QueryClientProvider>,
   );
 }

--- a/packages/services/__tests__/context/oxyClientTokenSync.test.tsx
+++ b/packages/services/__tests__/context/oxyClientTokenSync.test.tsx
@@ -1,22 +1,22 @@
 /**
- * OxyProvider ↔ exported `oxyClient` singleton token-sync integration test.
+ * OxyRuntimeProvider ↔ exported `oxyClient` singleton token-sync integration test.
  *
  * THE BUG THIS GUARDS AGAINST
  * ---------------------------
  * @oxyhq/core exports a module-level `oxyClient` singleton. Apps commonly build
  * their imperative api clients against it (reading `oxyClient.getAccessToken()`
  * to construct `Authorization` headers) while passing ONLY `baseURL` to
- * OxyProvider. In that configuration OxyProvider constructs its OWN OxyServices
+ * OxyProvider. In that configuration the runtime constructs its OWN OxyServices
  * instance and plants the session token on THAT instance — so the singleton
  * never received it and imperative consumers sent `Authorization: Bearer null`,
  * which backends reject. (Homiio + Allo both hit this.)
  *
- * OxyProvider now subscribes to its instance's `onTokensChanged` and mirrors
+ * OxyRuntimeProvider now subscribes to its instance's `onTokensChanged` and mirrors
  * every token mutation onto the exported `oxyClient` singleton — on sign-in,
  * restore, refresh, AND sign-out/clear — so any imperative consumer reading the
  * singleton always observes the live token (or null when logged out).
  *
- * This test renders the REAL OxyProvider against the REAL @oxyhq/core and
+ * This test renders the REAL OxyRuntimeProvider against the REAL @oxyhq/core and
  * asserts the singleton tracks the provider instance's token. Only the
  * network/socket seams that fire at mount (web SSO, session socket) are stubbed
  * so the test is deterministic offline; the token-mirroring wiring under test
@@ -62,7 +62,7 @@ jest.mock('../../src/ui/session', () => {
   };
 });
 
-import { OxyProvider, useOxy, type OxyContextState } from '../../src/ui/context/OxyContext';
+import { OxyRuntimeProvider, useOxy, type OxyContextState } from '../../src/ui/context/OxyContext';
 import { useAuthStore } from '../../src/ui/stores/authStore';
 
 const SIGNED_OUT_TOKEN_VALUE = oxyClient.getAccessToken();
@@ -96,14 +96,14 @@ const renderProvider = (sink: { current: OxyContextState | null }): RenderResult
     <QueryClientProvider client={queryClient}>
       {/* Only baseURL is passed — the reproduction case. The provider builds
           its own instance distinct from the exported singleton. */}
-      <OxyProvider baseURL="https://api.oxy.so">
+      <OxyRuntimeProvider baseURL="https://api.oxy.so">
         <Capture sink={sink} />
-      </OxyProvider>
+      </OxyRuntimeProvider>
     </QueryClientProvider>,
   );
 };
 
-describe('OxyProvider mirrors the session token onto the exported oxyClient singleton', () => {
+describe('OxyRuntimeProvider mirrors the session token onto the exported oxyClient singleton', () => {
   afterEach(() => {
     // Leave the shared singleton in its original (signed-out) state for any
     // sibling suite that imports it.

--- a/packages/services/__tests__/context/providerMissing.test.tsx
+++ b/packages/services/__tests__/context/providerMissing.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * A missing `<OxyProvider>` must FAIL FAST (ADR 0004).
+ *
+ * `useOxy()` used to return a fabricated runtime — `isLoading: true`,
+ * `isPrivateApiPending: true`, `sessionClient: null`, every async method a
+ * rejecting no-op — so an app that forgot the provider rendered a spinner that
+ * never resolved, with nothing in the console and every gate (`canUsePrivateApi`
+ * false, `isAuthResolved` false) reading exactly like a slow cold boot. The
+ * failure surfaced as "auth is broken in production", not as "you forgot a
+ * provider".
+ *
+ * These cases also pin the naming half of the same ADR: `OxyProvider` is the ONE
+ * exported component with that name, and the runtime provider is
+ * `OxyRuntimeProvider`. Two exported components called `OxyProvider` made every
+ * stack frame and doc reference ambiguous.
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { renderHook } from '@testing-library/react';
+
+import {
+  useOxy,
+  useOptionalOxy,
+  OxyProviderMissingError,
+} from '../../src/ui/context/OxyContext';
+import * as oxyContextModule from '../../src/ui/context/OxyContext';
+import { useI18n } from '../../src/ui/hooks/useI18n';
+
+const SRC = path.join(__dirname, '..', '..', 'src');
+const readSource = (relative: string) => readFileSync(path.join(SRC, relative), 'utf8');
+
+describe('useOxy outside a provider', () => {
+  it('throws OxyProviderMissingError instead of fabricating a runtime', () => {
+    // React logs the thrown render error; silence it so the expected failure
+    // does not read as a broken suite.
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => renderHook(() => useOxy())).toThrow(OxyProviderMissingError);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('names the fix in the message', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => renderHook(() => useOxy())).toThrow(/<OxyProvider>/);
+      expect(() => renderHook(() => useOxy())).toThrow(/useOptionalOxy/);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  it('carries a stable code so callers can branch on it', () => {
+    expect(new OxyProviderMissingError().code).toBe('oxy_provider_missing');
+  });
+});
+
+describe('useOptionalOxy outside a provider', () => {
+  it('returns null rather than a stand-in runtime', () => {
+    const { result } = renderHook(() => useOptionalOxy());
+    expect(result.current).toBeNull();
+  });
+
+  // The ONE sanctioned optional caller. `packages/auth`'s production-bundle
+  // probe renders `OxySignInRequestSurface` standalone to prove every element
+  // beneath it links; a throw there would report a linkage failure that is not
+  // one. The locale is display metadata, never a session gate.
+  it('lets useI18n resolve copy from the fallback locale', () => {
+    const { result } = renderHook(() => useI18n());
+    expect(result.current.locale).toBe('en-US');
+    expect(typeof result.current.t('anything.at.all')).toBe('string');
+  });
+});
+
+describe('one component named OxyProvider', () => {
+  it('the runtime module exports OxyRuntimeProvider and nothing called OxyProvider', () => {
+    expect(typeof oxyContextModule.OxyRuntimeProvider).toBe('function');
+    expect(Object.keys(oxyContextModule)).not.toContain('OxyProvider');
+    // The pre-ADR alias. Its removal is a clean cut, not a deprecation: it was
+    // never reachable through any published export subpath.
+    expect(Object.keys(oxyContextModule)).not.toContain('OxyContextProvider');
+  });
+
+  // `src/ui/server.ts` is deliberately absent: the `@oxyhq/services/ui/server`
+  // subpath is an SSR shim that replaces every export with a render-null / empty
+  // no-op, `OxyProvider` and `useOxy` included. It is its own published subpath
+  // and its own fabricated runtime; retiring it is a public API removal.
+  it.each([
+    ['index.ts', 'index.ts'],
+    ['ui/index.ts', 'ui/index.ts'],
+    ['ui/client.ts', 'ui/client.ts'],
+  ])('%s exports OxyProvider only from the composition root', (_label, file) => {
+    const source = readSource(file);
+    const exportsOfOxyProvider = source
+      .split('\n')
+      .filter((line) => /\bOxyProvider\b/.test(line) && line.trimStart().startsWith('export'));
+
+    expect(exportsOfOxyProvider).toHaveLength(1);
+    expect(exportsOfOxyProvider[0]).toMatch(/components\/OxyProvider/);
+  });
+});

--- a/packages/services/__tests__/context/sessionClientProjection.test.tsx
+++ b/packages/services/__tests__/context/sessionClientProjection.test.tsx
@@ -2,7 +2,7 @@
  * Task 1 (Fase 3-B): `SessionClient` wiring into `OxyContext` is ADDITIVE and
  * INERT until Task 2 calls `client.start()`.
  *
- * `OxyProvider` now builds a `SessionClient` (via the Fase 3-A
+ * `OxyRuntimeProvider` now builds a `SessionClient` (via the Fase 3-A
  * `createSessionClient` factory) once per `oxyServices` instance and
  * subscribes to it, projecting `client.getState()` onto the exposed
  * `sessions` / `activeSessionId` / `user` through the SAME setters the
@@ -56,7 +56,7 @@ jest.mock('../../src/ui/session', () => {
   };
 });
 
-import { OxyProvider, useOxy, type OxyContextState } from '../../src/ui/context/OxyContext';
+import { OxyRuntimeProvider, useOxy, type OxyContextState } from '../../src/ui/context/OxyContext';
 import { useAuthStore } from '../../src/ui/stores/authStore';
 import { createSessionClient } from '../../src/ui/session';
 
@@ -129,9 +129,9 @@ function renderProvider(sink: { current: OxyContextState | null }): RenderResult
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <OxyProvider baseURL="https://api.oxy.so">
+      <OxyRuntimeProvider baseURL="https://api.oxy.so">
         <Capture sink={sink} />
-      </OxyProvider>
+      </OxyRuntimeProvider>
     </QueryClientProvider>,
   );
 }

--- a/packages/services/__tests__/context/sessionClientSocket.test.tsx
+++ b/packages/services/__tests__/context/sessionClientSocket.test.tsx
@@ -44,7 +44,7 @@ jest.mock('../../src/ui/session', () => {
   };
 });
 
-import { OxyContextProvider, useOxy } from '../../src/ui/context/OxyContext';
+import { OxyRuntimeProvider, useOxy } from '../../src/ui/context/OxyContext';
 import type { OxyContextState } from '../../src/ui/context/OxyContext';
 import { useAuthStore } from '../../src/ui/stores/authStore';
 import { createSessionClient } from '../../src/ui/session';
@@ -214,9 +214,9 @@ function renderProvider(oxyServices: unknown, baseURL: string) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
-      <OxyContextProvider oxyServices={oxyServices as never} baseURL={baseURL}>
+      <OxyRuntimeProvider oxyServices={oxyServices as never} baseURL={baseURL}>
         <Capture />
-      </OxyContextProvider>
+      </OxyRuntimeProvider>
     </QueryClientProvider>,
   );
 }

--- a/packages/services/docs/ARCHITECTURE.md
+++ b/packages/services/docs/ARCHITECTURE.md
@@ -23,7 +23,8 @@ Related docs:
 
 `OxyProvider` ([src/ui/components/OxyProvider.tsx](../src/ui/components/OxyProvider.tsx)) is the app root. It mounts:
 
-`OxyContextProvider` — auth/session state machine. Implementation split across:
+`OxyRuntimeProvider` — the internal auth/session state machine (never mounted by
+consumers; `OxyProvider` is the only public provider). Implementation split across:
 
 | Module | Role |
 |--------|------|

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -33,6 +33,10 @@ setPlatformOS(Platform.OS as PlatformOS);
 // ---------------------------------------------------------------------------
 export { default as OxyProvider } from './ui/components/OxyProvider';
 export { useOxy } from './ui/context/OxyContext';
+// `useOxy()` THROWS when no provider is mounted. `useOptionalOxy()` returns
+// `null` instead, for the rare component that renders on both sides of the
+// provider boundary; there is no fabricated forever-loading runtime.
+export { useOptionalOxy, OxyProviderMissingError } from './ui/context/OxyContext';
 export type { OxyContextState } from './ui/context/OxyContext';
 export { useAuth } from './ui/hooks/useAuth';
 export type { AuthState, AuthActions, UseAuthReturn } from './ui/hooks/useAuth';

--- a/packages/services/src/ui/client.ts
+++ b/packages/services/src/ui/client.ts
@@ -19,7 +19,7 @@ export { default as FollowButton } from './components/FollowButton';
 export { default as OxyPayButton } from './components/OxyPayButton';
 
 // Context
-export { useOxy } from './context/OxyContext';
+export { useOxy, useOptionalOxy, OxyProviderMissingError } from './context/OxyContext';
 
 // Hooks
 export { useAuth } from './hooks/useAuth';

--- a/packages/services/src/ui/components/OxyProvider.tsx
+++ b/packages/services/src/ui/components/OxyProvider.tsx
@@ -3,7 +3,7 @@ import { AppState, Platform, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import type { OxyProviderProps } from '../types/navigation';
-import { OxyContextProvider, type OxyContextProviderProps } from '../context/OxyContext';
+import { OxyRuntimeProvider, type OxyRuntimeProviderProps } from '../context/OxyContext';
 import { QueryClientProvider, focusManager, onlineManager } from '@tanstack/react-query';
 import { BloomDialogProvider } from '@oxyhq/bloom/dialog';
 import { SurfaceProvider } from '@oxyhq/bloom/surfaces';
@@ -284,8 +284,8 @@ const OxyProvider: FC<OxyProviderProps> = ({
     const coreContent = (
         <QueryClientProvider client={queryClient}>
             <BloomDialogProvider>
-                <OxyContextProvider
-                    oxyServices={oxyServices as OxyContextProviderProps['oxyServices']}
+                <OxyRuntimeProvider
+                    oxyServices={oxyServices as OxyRuntimeProviderProps['oxyServices']}
                     baseURL={baseURL}
                     authWebUrl={authWebUrl}
                     authRedirectUri={authRedirectUri}
@@ -295,7 +295,7 @@ const OxyProvider: FC<OxyProviderProps> = ({
                     sessionMode={sessionMode}
                     webAuthMode={webAuthMode}
                     backgroundSession={backgroundSession}
-                    onAuthStateChange={onAuthStateChange as OxyContextProviderProps['onAuthStateChange']}
+                    onAuthStateChange={onAuthStateChange as OxyRuntimeProviderProps['onAuthStateChange']}
                 >
                     <SurfaceProvider>
                         {requireAuth === 'off' ? (
@@ -305,7 +305,7 @@ const OxyProvider: FC<OxyProviderProps> = ({
                         )}
                     </SurfaceProvider>
                     <ToastOutlet />
-                </OxyContextProvider>
+                </OxyRuntimeProvider>
             </BloomDialogProvider>
         </QueryClientProvider>
     );

--- a/packages/services/src/ui/context/OxyContext.tsx
+++ b/packages/services/src/ui/context/OxyContext.tsx
@@ -75,7 +75,7 @@ import {
 } from '../session';
 import type {
   OxyContextState,
-  OxyContextProviderProps,
+  OxyRuntimeProviderProps,
   CommitInput,
 } from './oxyContextTypes';
 import { DEFAULT_SESSION_VALIDITY_MS } from './oxyContextHelpers';
@@ -93,11 +93,22 @@ import {
 import { queryKeys } from '../hooks/queries/queryKeys';
 import { useOxyAccountGraph } from './useOxyAccountGraph';
 
-export type { OxyContextState, OxyContextProviderProps } from './oxyContextTypes';
+export type { OxyContextState, OxyRuntimeProviderProps } from './oxyContextTypes';
 
-const OxyContext = createContext<OxyContextState | null>(null);
+const OxyRuntimeContext = createContext<OxyContextState | null>(null);
 
-export const OxyProvider: React.FC<OxyContextProviderProps> = ({
+/**
+ * The SDK's internal runtime provider — the session/account state machine that
+ * backs `useOxy()`.
+ *
+ * This is NOT the component consumers mount. The one public composition root is
+ * `OxyProvider` (`../components/OxyProvider`), which mounts this alongside the
+ * QueryClient, Bloom's dialog/surface/toast hosts, safe areas, the gesture root
+ * and the keyboard provider. Naming both of them `OxyProvider` (as this file
+ * used to) made every error message, stack frame and doc reference ambiguous —
+ * see ADR 0004.
+ */
+export const OxyRuntimeProvider: React.FC<OxyRuntimeProviderProps> = ({
   children,
   oxyServices: providedOxyServices,
   baseURL,
@@ -121,7 +132,7 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
       // link builder at the central auth host; there is no cold-boot redirect.
       oxyServicesRef.current = new OxyServices({ baseURL, authWebUrl, authRedirectUri });
     } else {
-      throw new Error('Either oxyServices or baseURL must be provided to OxyContextProvider');
+      throw new Error('Either oxyServices or baseURL must be provided to OxyProvider');
     }
   }
   const oxyServices = oxyServicesRef.current;
@@ -1327,83 +1338,44 @@ export const OxyProvider: React.FC<OxyContextProviderProps> = ({
     ],
   );
 
-  return <OxyContext.Provider value={contextValue}>{children}</OxyContext.Provider>;
+  return <OxyRuntimeContext.Provider value={contextValue}>{children}</OxyRuntimeContext.Provider>;
 };
 
-export const OxyContextProvider = OxyProvider;
+const PROVIDER_MISSING_ERROR_MESSAGE =
+  'useOxy() was called outside <OxyProvider>. Mount <OxyProvider clientId="…"> above this component, ' +
+  'or use useOptionalOxy() if this component legitimately renders both inside and outside the provider.';
+
+export class OxyProviderMissingError extends Error {
+  readonly code = 'oxy_provider_missing';
+
+  constructor() {
+    super(PROVIDER_MISSING_ERROR_MESSAGE);
+    this.name = 'OxyProviderMissingError';
+  }
+}
 
 /**
- * Loading-state stub used when `useOxy()` is called outside an OxyProvider.
- * All async methods reject with a clear error so misuse is caught early.
+ * The base runtime hook. THROWS when no `<OxyProvider>` is mounted.
+ *
+ * It used to return a fabricated forever-loading runtime — `isLoading: true`,
+ * `isPrivateApiPending: true`, every method a rejecting no-op — which turned a
+ * missing provider into a UI that spins forever with nothing in the console.
+ * Failing here names the mistake at the exact component that made it (ADR 0004).
+ *
+ * A component that legitimately renders both inside and outside the provider
+ * uses {@link useOptionalOxy} instead.
  */
-const PROVIDER_MISSING_ERROR_MESSAGE =
-  'OxyProvider is not mounted. Wrap your app in <OxyProvider> before calling useOxy() methods.';
-
-const rejectMissingProvider = <T,>(): Promise<T> =>
-  Promise.reject(new Error(PROVIDER_MISSING_ERROR_MESSAGE));
-
-const LOADING_STATE_OXY_SERVICES = new OxyServices({ baseURL: 'about:blank' });
-
-const LOADING_STATE: OxyContextState = {
-  user: null,
-  sessions: [],
-  activeSessionId: null,
-  isAuthenticated: false,
-  isLoading: true,
-  isTokenReady: false,
-  hasAccessToken: false,
-  canUsePrivateApi: false,
-  isPrivateApiPending: true,
-  isAuthResolved: false,
-  isStorageReady: false,
-  sessionMode: 'account',
-  webAuthMode: 'popup',
-  error: null,
-  currentLanguage: 'en-US',
-  currentLanguages: [],
-  currentLanguageMetadata: null,
-  currentLanguageName: 'English (United States)',
-  currentNativeLanguageName: 'English (United States)',
-  hasIdentity: () => Promise.resolve(false),
-  getPublicKey: () => Promise.resolve(null),
-  signIn: () => rejectMissingProvider<User>(),
-  signInWithPasskey: () => rejectMissingProvider<void>(),
-  registerWithPasskey: () => rejectMissingProvider<void>(),
-  addPasskey: () => rejectMissingProvider<void>(),
-  removePasskey: () => rejectMissingProvider<void>(),
-  revokeSuspiciousSignIn: () => rejectMissingProvider<void>(),
-  handleWebSession: () => rejectMissingProvider<void>(),
-  startWebOAuthSignIn: () => rejectMissingProvider<WebOAuthSignInResult>(),
-  logout: () => rejectMissingProvider<void>(),
-  logoutAll: () => rejectMissingProvider<void>(),
-  switchSession: () => rejectMissingProvider<User>(),
-  removeSession: () => rejectMissingProvider<void>(),
-  refreshSessions: () => rejectMissingProvider<void>(),
-  setLanguage: () => rejectMissingProvider<void>(),
-  getDeviceSessions: () => Promise.resolve([]),
-  logoutAllDeviceSessions: () => rejectMissingProvider<void>(),
-  updateDeviceName: () => rejectMissingProvider<void>(),
-  clearSessionState: () => rejectMissingProvider<void>(),
-  clearAllAccountData: () => rejectMissingProvider<void>(),
-  storageKeyPrefix: 'oxy_session',
-  clientId: null,
-  oxyServices: LOADING_STATE_OXY_SERVICES,
-  sessionClient: null,
-  openAvatarPicker: () => {},
-  accountDialogController: null,
-  isAccountDialogOpen: false,
-  openAccountDialog: () => {},
-  closeAccountDialog: () => {},
-  accounts: [],
-  switchToAccount: () => rejectMissingProvider<void>(),
-  refreshAccounts: () => rejectMissingProvider<void>(),
-  createAccount: () => rejectMissingProvider<import('@oxyhq/core').AccountNode>(),
-};
-
 export const useOxy = (): OxyContextState => {
-  const context = useContext(OxyContext);
+  const context = useContext(OxyRuntimeContext);
   if (!context) {
-    return LOADING_STATE;
+    throw new OxyProviderMissingError();
   }
   return context;
 };
+
+/**
+ * `useOxy()` for the rare component that renders both inside and outside the
+ * provider — returns `null` instead of throwing. Callers must handle `null`;
+ * there is no fabricated runtime to fall back on.
+ */
+export const useOptionalOxy = (): OxyContextState | null => useContext(OxyRuntimeContext);

--- a/packages/services/src/ui/context/oxyContextTypes.ts
+++ b/packages/services/src/ui/context/oxyContextTypes.ts
@@ -151,7 +151,7 @@ export interface OxyContextState {
   createAccount: (data: CreateAccountInput) => Promise<AccountNode>;
 }
 
-export interface OxyContextProviderProps {
+export interface OxyRuntimeProviderProps {
   children: ReactNode;
   oxyServices?: OxyServices;
   baseURL?: string;

--- a/packages/services/src/ui/hooks/useI18n.ts
+++ b/packages/services/src/ui/hooks/useI18n.ts
@@ -1,12 +1,32 @@
 import { useMemo } from 'react';
-import { useOxy } from '../context/OxyContext';
+import { useOptionalOxy } from '../context/OxyContext';
 import { translate } from '@oxyhq/core';
 
+/**
+ * The locale `@oxyhq/core`'s translator falls back to. Mirrors its own
+ * `FALLBACK`, so a surface rendered without a provider reads the same strings
+ * an unrecognised locale would.
+ */
+const FALLBACK_LOCALE = 'en-US';
+
+/**
+ * Display copy for SDK surfaces.
+ *
+ * This is the ONE hook that reads the runtime optionally. The locale is display
+ * metadata, not session state — ADR 0004 lists it among the things that come off
+ * the central value entirely — and purely presentational surfaces
+ * (`OxyConsentScreen`, `OxySignInRequestSurface`) are rendered outside a
+ * provider on purpose: `packages/auth`'s production-bundle probe builds the real
+ * Vite bundle and renders the surface standalone to prove every element beneath
+ * it links. Throwing there would report a linkage failure that is not one.
+ *
+ * Anything that reads or mutates session state uses `useOxy()`, which throws.
+ */
 export function useI18n() {
-  const { currentLanguage } = useOxy();
+  const oxy = useOptionalOxy();
+  const currentLanguage = oxy?.currentLanguage ?? FALLBACK_LOCALE;
   const t = useMemo(() => {
     return (key: string, vars?: Record<string, string | number>) => translate(currentLanguage, key, vars);
   }, [currentLanguage]);
   return { t, locale: currentLanguage };
 }
-

--- a/packages/services/src/ui/index.ts
+++ b/packages/services/src/ui/index.ts
@@ -29,7 +29,7 @@ export { default as OxyPayButton } from './components/OxyPayButton';
 export { default as ProfileButton } from './components/ProfileButton';
 
 // Context + hooks
-export { useOxy } from './context/OxyContext';
+export { useOxy, useOptionalOxy, OxyProviderMissingError } from './context/OxyContext';
 export { useAuth } from './hooks/useAuth';
 export { useFollow, useSeedFollowStatuses } from './hooks/useFollow';
 export { useStorage } from './hooks/useStorage';


### PR DESCRIPTION
Phase 3a of #937 — provider **composition** only. The headless `createOxyRuntime` and `OxyRuntimeSnapshot` from [ADR 0004](../blob/main/docs/adr/0004-single-oxy-runtime-provider.md) are Phase 3b and wait for the device directory, because shaping the snapshot around `activeAccountId` now would mean reworking it immediately after. Nothing here touches the wire model, `SessionClient`, cold boot, the identity pin, or `packages/api`.

## Two components were called `OxyProvider`

The public composition root and the internal context provider. A stack frame, an error message or a doc line naming "OxyProvider" was ambiguous. The internal one is now `OxyRuntimeProvider` over `OxyRuntimeContext`.

`OxyContextProvider` was deleted rather than deprecated: `packages/services`'s `exports` publishes `.`, `./ui`, `./ui/client`, `./ui/server`, `./notifications`, `./plugins/*` and two JSON files, with no wildcard reaching `src/ui/context/*` — no consumer could ever have imported it, so a deprecated alias would only preserve the ambiguity.

## A missing provider said nothing; now it says something

`useOxy()` returned a fabricated ~60-field forever-loading object full of no-op and rejecting methods, so forgetting the provider surfaced later as a mysterious permanent spinner. It now throws `OxyProviderMissingError` (`code: 'oxy_provider_missing'`).

That change found the one genuine optional caller. `packages/auth`'s `authorize-surface-bundle.test.ts` builds the real production Vite bundle and renders `OxySignInRequestSurface` standalone to prove every element beneath it links; six cases went red. Those surfaces are correct to render without a provider, and the thing they needed was the locale — display metadata, which ADR 0004 lists among what comes off the central value anyway. `useI18n` now reads through the new `useOptionalOxy()` and falls back to `en-US`. Everything session-bearing still throws.

## Guards for two things that were already right

- **One QueryClient.** A supplied client was already used as-is. Now pinned: the child's `useQueryClient()` is identity-equal to the supplied instance, `createQueryClient` is never called, persistence is not attached. Mutation-checked.
- **Outlets mount once.** No app double-mounts one today, so nothing was "fixed" — but both Bloom outlets render from a module-level store and neither self-guards, so a second mount would silently double every toast and every surface. The test asserts exactly one of each. Mutation-checked with a second `<ToastOutlet />`.

## Redundant providers removed

Each was strictly nested *inside* `OxyProvider`'s own copy, so removal is provably a no-op: `SafeAreaProvider` in accounts, commons and inbox, and console's outer `QueryClientProvider` wrapping `OxyProvider` around the same client instance already passed as its `queryClient` prop.

**Left alone deliberately**, because they are the OUTER copies and removing them re-roots the native view tree and moves `ConnectionStatusToasts` out from under them: app-root `GestureHandlerRootView` + `KeyboardProvider` in accounts/commons, `KeyboardProvider` in inbox (`InboxTabBar.tsx:88` already comments that it depends on the root one), and test-app-expo's `SafeAreaProvider`. `OxyProvider` loads the keyboard controller by async dynamic import and skips it on web, so those are real behaviour changes that cannot be demonstrated without a device build.

## Verification

Each package's own `bun run test`, which is the command CI runs:

| package | baseline | final |
|---|---|---|
| services | 73 suites / 641 tests | **75 / 654** green |
| accounts | 16 / 140 | 16 / 140 green |
| commons | 64 / 570 | 64 / 570 green |
| inbox | 3 / 26 | 3 / 26 green |
| auth (bun test) | 133 pass / 0 fail | 133 / 0 green |

`tsc --noEmit` clean for `packages/services` and `packages/auth`.

## Not verified

- **No browser or device run** — jsdom + jest + tsc only. The `SafeAreaProvider` removals are the only change with native-layout surface, and the argument for them is structural (the SDK's provider is already an ancestor on both render paths), not measured on a device.
- Pre-existing and untouched, each confirmed not-mine with a revert-and-recompare control: one `useExhaustiveDependencies` lint error in `TrustLeaderboardScreen.tsx:72`, and `tsc --noEmit` reds in accounts (1), commons (27), inbox (3), console (1) from NativeWind `className` augmentation and a console test fixture. No CI job runs lint or tsc for those packages.
- `src/ui/server.ts` still ships a third fabricated runtime (`OxyProvider = () => null`, `useOxy = () => ({})`) on the published `./ui/server` subpath. Retiring it is a public API removal — flagged for Phase 8 in a comment so the next reader does not think it was missed.
- The file `OxyContext.tsx` keeps its name (≈60 import sites); only the component, context and props type were renamed. Phase 3b restructures the module anyway.

Refs #937