### PR TITLE
Restrict seed-oxy-applications workflow to protected main

### DIFF
--- a/.github/workflows/seed-oxy-applications.yml
+++ b/.github/workflows/seed-oxy-applications.yml
@@ -39,11 +39,6 @@ name: Seed Oxy applications
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: 'Branch or SHA to build the seeder image from'
-        required: true
-        type: string
-        default: 'main'
       only_apps:
         description: "Comma-separated application names this run may touch (e.g. 'CrowdSource')"
         required: true
@@ -72,13 +67,16 @@ permissions:
 
 jobs:
   seed:
+    # This job receives production credentials and secrets. Only the protected
+    # main branch may select the code that runs in the production VPC.
+    if: github.ref == 'refs/heads/main'
     # Same arch as the deployed image — the service runs linux/arm64.
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: main
 
       - name: Refuse an empty application list
         env:


### PR DESCRIPTION
### Motivation

- The manual `seed-oxy-applications` workflow accepted an arbitrary `ref` and built/pushed that code, then ran it in the production ECS environment reusing live secrets and task roles, which allowed a dispatcher-selected branch to execute arbitrary code in the production VPC.
- The change removes the untrusted code-selection primitive so only reviewed, protected `main` code can be built and run with production credentials.

### Description

- Removed the `ref` `workflow_dispatch` input from `.github/workflows/seed-oxy-applications.yml` so the dispatcher can no longer select an arbitrary branch or SHA. 
- Added a job-level guard `if: github.ref == 'refs/heads/main'` to the `seed` job so the job only runs when the workflow is dispatched from the protected `main` ref. 
- Fixed the checkout step to `ref: main` so the job always builds the trusted `main` tree while preserving the existing `only_apps` and `dry_run` inputs and the one-shot ECS execution logic.

### Testing

- Verified the workflow YAML parses with `ruby -e "require 'yaml'; YAML.parse_file('.github/workflows/seed-oxy-applications.yml')"` and reported no parse errors. (success)
- Ran `git diff --check` and `git status` to ensure no lint or workspace issues remained and the working tree was clean after the change. (success)
- Searched the workflows for stale patterns with `rg -n "inputs\.ref|^\s+ref:\s*$|Branch or SHA" .github/workflows` to confirm no dispatcher-controlled `ref` remains, and `rg -n "if: github.ref == 'refs/heads/main'|ref: main" .github/workflows/seed-oxy-applications.yml` to confirm the guard and fixed checkout are present; both checks succeeded. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a711e1abd0c8323a5886d07adea8030)