### PR TITLE
fix(chains): require subject consent for app writes

### DIFF
--- a/packages/api/src/routes/__tests__/chainsRecords.test.ts
+++ b/packages/api/src/routes/__tests__/chainsRecords.test.ts
@@ -35,6 +35,7 @@ import { randomUUID } from 'node:crypto';
 import { ec as EC } from 'elliptic';
 import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
 import { applications } from '../../db/schema/applications';
+import { appGrants } from '../../db/schema/appGrants';
 import { users } from '../../db/schema/users';
 import { errorHandler } from '../../middleware/errorHandler';
 import chainsRoutes from '../chains';
@@ -81,6 +82,12 @@ async function application(chainNamespaces: string[]): Promise<string> {
     .values({ name: `test-${randomUUID()}`, ownerAccountId, chainNamespaces })
     .returning({ id: applications.id });
   return row.id;
+}
+
+async function authorize(appId: string, userId: string): Promise<void> {
+  await getDb()
+    .insert(appGrants)
+    .values({ applicationId: appId, userId, scopes: ['chains:write'] });
 }
 
 function post(body: unknown): Promise<{ status: number; body: Record<string, unknown> }> {
@@ -150,10 +157,12 @@ describe('POST /chains/records', () => {
 
   it('appends when the scope and the namespace both allow it', async () => {
     const appId = await application(['app.mention.']);
+    const userId = await account();
+    await authorize(appId, userId);
     present(appId, ['chains:write']);
 
     const res = await post({
-      oxyUserId: await account(),
+      oxyUserId: userId,
       collection: 'app.mention.feed.post',
       rkey: 'r1',
       record: { text: 'hi' },
@@ -162,6 +171,20 @@ describe('POST /chains/records', () => {
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ seq: 0, verified: true });
     expect(typeof res.body.recordId).toBe('string');
+  });
+
+  it('refuses an authorized service credential when the subject did not consent', async () => {
+    const appId = await application(['app.mention.']);
+    present(appId, ['chains:write']);
+
+    const res = await post({
+      oxyUserId: await account(),
+      collection: 'app.mention.feed.post',
+      rkey: 'r1',
+      record: {},
+    });
+
+    expect(res.status).toBe(403);
   });
 
   it('refuses a collection outside the application’s namespace, with the scope present', async () => {

--- a/packages/api/src/routes/chains.ts
+++ b/packages/api/src/routes/chains.ts
@@ -36,8 +36,9 @@ function assertChainsScope(req: ServiceAuthRequest): void {
 /**
  * POST /chains/records — append a record to `oxyUserId`'s chain.
  *
- * Requires the `chains:write` scope AND that `collection` falls under one of the
- * calling application's `chainNamespaces`. Oxy issues and signs the envelope
+ * Requires the `chains:write` scope, a matching user OAuth grant, AND that
+ * `collection` falls under one of the calling application's `chainNamespaces`.
+ * Oxy issues and signs the envelope
  * (`issuer = OXY_DID`); the application never holds a chain signing key.
  *
  * 201 with the stored record on success. A namespace violation is 403 rather
@@ -79,6 +80,10 @@ router.post(
           throw new ForbiddenError('collection is not within this application’s chain namespaces');
         case 'unknown_application':
           throw new ForbiddenError('Service credential does not name a known application');
+        case 'subject_forbidden':
+          throw new ForbiddenError(
+            'The subject has not authorized this application to write chain records',
+          );
         case 'signing_disabled':
           res.status(503).json({ error: 'Chain signing is not configured on this deployment' });
           return;

--- a/packages/api/src/services/__tests__/appChainWrite.service.test.ts
+++ b/packages/api/src/services/__tests__/appChainWrite.service.test.ts
@@ -21,6 +21,7 @@ import { ec as EC } from 'elliptic';
 import { eq } from 'drizzle-orm';
 import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
 import { applications } from '../../db/schema/applications';
+import { appGrants } from '../../db/schema/appGrants';
 import { signedRecords } from '../../db/schema/signedRecords';
 import { users } from '../../db/schema/users';
 import { OXY_DID } from '../did.service';
@@ -57,6 +58,12 @@ async function application(chainNamespaces: string[]): Promise<string> {
     .values({ name: `test-${randomUUID()}`, ownerAccountId, chainNamespaces })
     .returning({ id: applications.id });
   return row.id;
+}
+
+async function authorize(appId: string, userId: string): Promise<void> {
+  await getDb()
+    .insert(appGrants)
+    .values({ applicationId: appId, userId, scopes: ['chains:write'] });
 }
 
 describe('collectionIsWithinNamespaces', () => {
@@ -96,6 +103,7 @@ describe('collectionIsWithinNamespaces', () => {
 describe('appendAppRecord', () => {
   it('appends under the subject’s chain, issued by Oxy', async () => {
     const [appId, userId] = [await application(['app.mention.']), await account()];
+    await authorize(appId, userId);
 
     const result = await appendAppRecord({
       appId,
@@ -123,6 +131,7 @@ describe('appendAppRecord', () => {
 
   it('chains a second record onto the first', async () => {
     const [appId, userId] = [await application(['app.mention.']), await account()];
+    await authorize(appId, userId);
     const first = await appendAppRecord({
       appId, oxyUserId: userId, collection: 'app.mention.feed.post', rkey: 'a', record: { text: '1' },
     });
@@ -144,6 +153,16 @@ describe('appendAppRecord', () => {
     });
 
     expect(result).toEqual({ ok: false, reason: 'namespace_forbidden', detail: 'app.syra.listen' });
+  });
+
+  it('refuses a subject who has not authorized the application', async () => {
+    const [appId, userId] = [await application(['app.mention.']), await account()];
+
+    const result = await appendAppRecord({
+      appId, oxyUserId: userId, collection: 'app.mention.feed.post', rkey: 'x', record: {},
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'subject_forbidden' });
   });
 
   it('refuses everything for an application with no grant', async () => {

--- a/packages/api/src/services/appChainWrite.service.ts
+++ b/packages/api/src/services/appChainWrite.service.ts
@@ -27,14 +27,15 @@
  * ## What authorizes the write
  *
  * A service credential proves which APP is calling. It does not prove the person
- * asked for anything, and nothing here pretends otherwise. Two independent gates
+ * asked for anything, and nothing here pretends otherwise. Three independent gates
  * stand between a credential and someone's chain:
  *
- *  1. the `chains:write` scope on the service token, and
- *  2. the collection falling under one of the application's own
+ *  1. the `chains:write` scope on the service token,
+ *  2. the subject's revocable OAuth grant of `chains:write` to the app, and
+ *  3. the collection falling under one of the application's own
  *     `chainNamespaces` prefixes.
  *
- * The second is the real boundary: it is what stops an app with a valid
+ * The third is the namespace boundary: it is what stops an app with a valid
  * credential writing `app.someoneelse.*` records into every account it can name.
  * An application with no granted namespace can write nothing — the empty list
  * authorizes nothing rather than everything.
@@ -50,10 +51,11 @@
  * environment that cannot sign must not accept writes it will silently drop.
  */
 
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type { SignedRecordEnvelope } from '@oxyhq/contracts';
 import { getDb } from '../config/postgres';
 import { applications } from '../db/schema/applications';
+import { appGrants } from '../db/schema/appGrants';
 import { buildUserDid, OXY_DID } from './did.service';
 import { oxyRecordStore } from './oxyRecordStore';
 import { signRecordEnvelope, verifyAndStoreRecord, type StoredRecordRef } from './signedRecord.service';
@@ -77,7 +79,16 @@ const MAX_APPEND_ATTEMPTS = 3;
 /** Outcomes a caller has to distinguish. Never thrown — every one maps to a status. */
 export type AppChainWriteResult =
   | { ok: true; record: StoredRecordRef }
-  | { ok: false; reason: 'namespace_forbidden' | 'signing_disabled' | 'unknown_application' | 'rejected'; detail?: string };
+  | {
+      ok: false;
+      reason:
+        | 'namespace_forbidden'
+        | 'subject_forbidden'
+        | 'signing_disabled'
+        | 'unknown_application'
+        | 'rejected';
+      detail?: string;
+    };
 
 /** The namespace prefixes an application may write under, or `null` if unknown. */
 export async function chainNamespacesForApplication(appId: string): Promise<string[] | null> {
@@ -131,6 +142,15 @@ export async function appendAppRecord(args: {
   }
   if (!collectionIsWithinNamespaces(args.collection, namespaces)) {
     return { ok: false, reason: 'namespace_forbidden', detail: args.collection };
+  }
+
+  const [grant] = await getDb()
+    .select({ scopes: appGrants.scopes })
+    .from(appGrants)
+    .where(and(eq(appGrants.applicationId, args.appId), eq(appGrants.userId, args.oxyUserId)))
+    .limit(1);
+  if (!grant?.scopes.includes(CHAINS_WRITE_SCOPE)) {
+    return { ok: false, reason: 'subject_forbidden' };
   }
 
   const subject = buildUserDid(args.oxyUserId);

--- a/packages/api/src/utils/__tests__/applicationScopes.test.ts
+++ b/packages/api/src/utils/__tests__/applicationScopes.test.ts
@@ -144,7 +144,7 @@ describe('payments:read / payments:write (F2.0)', () => {
   });
 });
 
-describe('follow scopes: the user grants them, the platform never assumes them', () => {
+describe('user-consent scopes: the user grants them, the platform never assumes them', () => {
   /*
    * Written out rather than derived from the constant. Iterating
    * `USER_CONSENT_REQUIRED_SCOPES` to check facts ABOUT it proves nothing:
@@ -158,9 +158,10 @@ describe('follow scopes: the user grants them, the platform never assumes them',
     'follows:manage',
     'follows:events',
     'follow-targets:register',
+    'chains:write',
   ] as const;
 
-  it('holds exactly the follow family, and loses none of it silently', () => {
+  it('holds exactly the user-authority scopes, and loses none of them silently', () => {
     expect([...USER_CONSENT_REQUIRED_SCOPES].sort()).toEqual([...MUST_BE_CONSENTED].sort());
   });
 
@@ -171,24 +172,29 @@ describe('follow scopes: the user grants them, the platform never assumes them',
     }
   });
 
-  it('recognises the whole family as valid application scopes', () => {
+  it('recognises every consent-required scope as a valid application scope', () => {
     for (const scope of MUST_BE_CONSENTED) {
       expect(isValidApplicationScope(scope)).toBe(true);
     }
   });
 
-  it('keeps them OUT of the privileged set', () => {
+  it('keeps follow scopes OUT of the privileged set', () => {
     // Privileged asks "may the app's owner grant this to themselves?" and its
     // answer is about platform staff. A follow scope's authority comes from the
     // subject user, so staff-gating it would be answering the wrong question —
     // and would block a third-party app the user genuinely authorized.
-    for (const scope of MUST_BE_CONSENTED) {
+    for (const scope of MUST_BE_CONSENTED.filter((scope) => scope !== 'chains:write')) {
       expect(isPrivilegedScope(scope)).toBe(false);
     }
   });
 
-  it('and the two sets do not overlap in the other direction either', () => {
-    for (const scope of PRIVILEGED_APPLICATION_SCOPES) {
+  it('requires both staff approval and user consent for chains:write', () => {
+    expect(isPrivilegedScope('chains:write')).toBe(true);
+    expect(isUserConsentRequiredScope('chains:write')).toBe(true);
+  });
+
+  it('does not require user consent for the other privileged scopes', () => {
+    for (const scope of PRIVILEGED_APPLICATION_SCOPES.filter((scope) => scope !== 'chains:write')) {
       expect(isUserConsentRequiredScope(scope)).toBe(false);
     }
   });

--- a/packages/api/src/utils/applicationScopes.ts
+++ b/packages/api/src/utils/applicationScopes.ts
@@ -173,6 +173,7 @@ export const USER_CONSENT_REQUIRED_SCOPES = [
   'follows:manage',
   'follows:events',
   'follow-targets:register',
+  'chains:write',
 ] as const satisfies readonly ApplicationScope[];
 
 const USER_CONSENT_REQUIRED_SCOPE_SET: ReadonlySet<string> = new Set<string>(


### PR DESCRIPTION
### Motivation
- Close an authorization gap where a service credential with `chains:write` plus a namespace grant could append Oxy-signed records to any named user's chain without proof the user authorized that application.
- Ensure app-authored writes are only allowed when the subject user has a revocable grant for that application in addition to the service scope and namespace check.

### Description
- Require per-subject consent in the app write path by verifying an `app_grants` row for `(applicationId, userId)` that includes `chains:write` before signing/storing a record, returning `subject_forbidden` when missing (`packages/api/src/services/appChainWrite.service.ts`).
- Map the new `subject_forbidden` outcome to HTTP 403 with a clear error message in the router (`packages/api/src/routes/chains.ts`).
- Mark `chains:write` as a user-consent-required scope so it must be explicitly granted by the subject (added to `USER_CONSENT_REQUIRED_SCOPES`) and update the scope-policy helper behavior (`packages/api/src/utils/applicationScopes.ts`).
- Add and adjust regression tests to cover the new gate and expected behavior: updated/added assertions in `packages/api/src/services/__tests__/appChainWrite.service.test.ts` and `packages/api/src/routes/__tests__/chainsRecords.test.ts`, and updated `packages/api/src/utils/__tests__/applicationScopes.test.ts` to assert the dual staff+user-consent nature of `chains:write`.

### Testing
- Added unit/integration tests exercising both the service layer and the HTTP route that verify: a consented subject+app pair can append, and a missing subject grant causes rejection (tests updated in `appChainWrite.service.test.ts` and `chainsRecords.test.ts`).
- Attempted to run the targeted test command `bun run --filter @oxyhq/api test --runInBand src/utils/__tests__/applicationScopes.test.ts src/services/__tests__/appChainWrite.service.test.ts src/routes/__tests__/chainsRecords.test.ts`, but the test runner was unavailable in this environment (`jest: command not found`), so tests could not be executed here; the tests are included and expected to run in CI where dependencies are present.
- Performed local repository checks to ensure the patch applied cleanly and static edits are present (no verification errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a742005da9c8323a9ff089cde21ce27)