### PR TITLE
feat(core): the client learns who is here, not just which account is active

### DIFF
--- a/packages/contracts/src/__tests__/deviceDirectory.test.ts
+++ b/packages/contracts/src/__tests__/deviceDirectory.test.ts
@@ -3,7 +3,9 @@ import {
   deviceActivateRequestSchema,
   deviceActivateResponseSchema,
   deviceDirectorySchema,
+  deviceDirectorySyncSchema,
   devicePrincipalSchema,
+  deviceSessionSyncSchema,
   safeParseContract,
 } from '../index';
 
@@ -165,5 +167,50 @@ describe('device activation contracts', () => {
 
   it('rejects a response with no activeToken key at all', () => {
     expect(safeParseContract(deviceActivateResponseSchema, { directory })).toBeNull();
+  });
+});
+
+describe('deviceDirectorySyncSchema — the context-aware removal response', () => {
+  const state = {
+    deviceId: 'device_x',
+    accounts: [{ accountId: 'nate', sessionId: 'sess_nate', authuser: 0 }],
+    activeAccountId: 'nate',
+    revision: 43,
+    updatedAt: 1720000003000,
+  };
+  const removal = {
+    directory,
+    state,
+    activeToken: { accessToken: 'tok', expiresAt: '2026-08-10T10:00:00.000Z' },
+  };
+
+  it('parses both halves plus the token', () => {
+    expect(safeParseContract(deviceDirectorySyncSchema, removal)).toEqual(removal);
+  });
+
+  it('accepts activeToken=null, including "the removal left no active context"', () => {
+    expect(safeParseContract(deviceDirectorySyncSchema, { ...removal, activeToken: null })?.activeToken).toBeNull();
+  });
+
+  /**
+   * The reason this is a SECOND schema rather than a widened first one.
+   *
+   * Zod strips unknown keys, so the removal response parses cleanly as a
+   * `deviceSessionSync` — silently dropping the directory. That direction is
+   * lossy and gives no signal, which is why the removal lane must never be
+   * routed through `applySync`. The reverse direction is the one that has to
+   * fail, and does: `directory` is required, so a directory-less payload is
+   * refused instead of being read as "this device has no principals".
+   */
+  it('is not interchangeable with deviceSessionSyncSchema', () => {
+    expect(safeParseContract(deviceSessionSyncSchema, removal)).toEqual({
+      state,
+      activeToken: removal.activeToken,
+    });
+    expect(safeParseContract(deviceDirectorySyncSchema, { state, activeToken: removal.activeToken })).toBeNull();
+  });
+
+  it('rejects a payload missing the flat state', () => {
+    expect(safeParseContract(deviceDirectorySyncSchema, { directory, activeToken: null })).toBeNull();
   });
 });

--- a/packages/contracts/src/deviceDirectory.ts
+++ b/packages/contracts/src/deviceDirectory.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { accountKindSchema } from './accountGraph';
+import { activeTokenSchema, deviceSessionStateSchema } from './deviceSession';
 import { userNameSchema } from './userResponse';
 
 /**
@@ -145,15 +146,41 @@ export const deviceActivateRequestSchema = z.object({
  */
 export const deviceActivateResponseSchema = z.object({
   directory: deviceDirectorySchema,
-  activeToken: z
-    .object({
-      accessToken: z.string(),
-      expiresAt: z.string(),
-    })
-    .nullable(),
+  activeToken: activeTokenSchema.nullable(),
+});
+
+/**
+ * Response of the CONTEXT-aware removals — `POST /session/device/signout` with
+ * `{ contextId }` (one `principal → account` pair) or `{ principalId }` (one
+ * person and every context they reach, and nobody else's).
+ *
+ * It carries BOTH halves because a removal elects a replacement active context,
+ * so both the directory and the flat compatibility projection move in the same
+ * transition — and a client that learned only one of them would render one
+ * half of a device that no longer exists.
+ *
+ * This is deliberately NOT {@link deviceSessionSyncSchema} and must never be
+ * merged into it. A zod object strips unknown keys, so `{directory, state,
+ * activeToken}` parses cleanly as `{state, activeToken}` — silently dropping the
+ * directory. One schema covering both shapes would therefore make "the server
+ * stopped sending the directory" and "this endpoint never sends one"
+ * indistinguishable at the parse, on the exact path that decides which identity
+ * the app is running as. Two schemas fail closed instead: `directory` is
+ * required here, so a directory-less payload is refused outright.
+ *
+ * `activeToken` is null on the same terms as everywhere else — an identity-
+ * pinned caller, or one not entitled to a bearer for the newly-elected context —
+ * and null is also the honest answer when the removal left the device with no
+ * active context at all.
+ */
+export const deviceDirectorySyncSchema = z.object({
+  directory: deviceDirectorySchema,
+  state: deviceSessionStateSchema,
+  activeToken: activeTokenSchema.nullable(),
 });
 
 export type DeviceContextRelationship = z.infer<typeof deviceContextRelationshipSchema>;
+export type DeviceDirectorySync = z.infer<typeof deviceDirectorySyncSchema>;
 export type DeviceDirectoryProfile = z.infer<typeof deviceDirectoryProfileSchema>;
 export type DeviceAccountContext = z.infer<typeof deviceAccountContextSchema>;
 export type DevicePrincipal = z.infer<typeof devicePrincipalSchema>;

--- a/packages/contracts/src/deviceDirectory.ts
+++ b/packages/contracts/src/deviceDirectory.ts
@@ -57,11 +57,22 @@ export const deviceDirectoryProfileSchema = z.object({
  * its delegated session is minted on first activation rather than eagerly for
  * every organization the principal belongs to.
  *
- * `available` is the live `account:act_as` verdict at read time. A managed
- * account whose membership was revoked is returned with `available: false`
- * rather than silently omitted, so the UI can explain a row disappearing
- * instead of just dropping it. A personal context is always available while its
- * principal is live.
+ * `available` is `principalLive && (personal || live account:act_as)`, and the
+ * principal clause is not decoration: a principal whose own personal session
+ * has died makes EVERY context of theirs unavailable, including delegated ones
+ * whose sessions are perfectly alive. Activation verifies the principal's
+ * personal session (ADR 0002 step 3), so a client that models availability as
+ * "delegated context has a live session ⇒ activatable" will be refused by the
+ * server and the context healed away.
+ *
+ * A managed account whose membership was revoked is returned with
+ * `available: false` rather than silently omitted, so the UI can explain a row
+ * disappearing instead of just dropping it.
+ *
+ * (An earlier version of this comment described `available` as the
+ * `account:act_as` verdict alone. It was written before the server existed and
+ * was weaker than the code that shipped — the kind of wrong statement nothing
+ * recomputes, so it is spelled out here in full.)
  */
 export const deviceAccountContextSchema = z.object({
   id: z.string().min(1),

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -468,6 +468,7 @@ export {
     deviceDirectorySchema,
     deviceActivateRequestSchema,
     deviceActivateResponseSchema,
+    deviceDirectorySyncSchema,
 } from './deviceDirectory';
 
 export type {
@@ -478,6 +479,7 @@ export type {
     DeviceDirectory,
     DeviceActivateRequest,
     DeviceActivateResponse,
+    DeviceDirectorySync,
 } from './deviceDirectory';
 
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -686,7 +686,9 @@ export {
 // `DeviceSessionState` collapses them into one row, so it can neither tell
 // "signed in as an org" from "a person operating that org" nor hold two people
 // reaching the same org on one device.
-export { resolveActiveContext, resolveDeviceContext } from './session/deviceDirectory';
+// `canActivateContext` is the switchability question — `available` alone, never
+// composed with `onDevice`, which is a different fact in both directions.
+export { canActivateContext, resolveActiveContext, resolveDeviceContext } from './session/deviceDirectory';
 export type {
     DeviceContext,
     DeviceContextActor,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -680,6 +680,19 @@ export {
     accountIdsOf,
 } from './session/projectSessionState';
 
+// Pure projections over the device DIRECTORY (`GET /session/device/directory`,
+// ADR 0002) — the read model that keeps the actor (the human who authenticated)
+// and the subject (the account being acted as) apart. The flat
+// `DeviceSessionState` collapses them into one row, so it can neither tell
+// "signed in as an org" from "a person operating that org" nor hold two people
+// reaching the same org on one device.
+export { resolveActiveContext, resolveDeviceContext } from './session/deviceDirectory';
+export type {
+    DeviceContext,
+    DeviceContextActor,
+    DeviceContextSubject,
+} from './session/deviceDirectory';
+
 // Unified account-list projection (THE single source of truth for the account
 // chooser: device sign-ins ∪ account graph, deduped by accountId). Pure +
 // I/O-free — the caller hydrates profiles via `getUsersByIds`. Shared by

--- a/packages/core/src/models/session.ts
+++ b/packages/core/src/models/session.ts
@@ -14,6 +14,17 @@ export interface ClientSession {
    * account-chooser ordering, not for any token-refresh mechanism.
    */
   authuser?: number;
+  /**
+   * The HUMAN operating this account, when it is a delegated session — the
+   * audit actor behind "The Oxy Collective". Absent when the session belongs to
+   * the account itself.
+   *
+   * The flat wire shape has carried it since the multi-account model shipped and
+   * nothing read it, so an operated org rendered exactly like a directly
+   * signed-in one. `SessionClient.getActiveContext()` is the richer answer
+   * (ADR 0002); this is the same fact on the compatibility lane.
+   */
+  operatedByUserId?: string;
 }
 
 export interface StorageKeys {

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -1,13 +1,17 @@
 import {
+  deviceActivateResponseSchema,
+  deviceDirectorySchema,
   deviceSessionStateSchema,
   deviceSessionSyncSchema,
   safeParseContract,
   SESSION_ACCOUNTS_CHANGED_EVENT,
   sessionAccountsChangedEventSchema,
+  type DeviceDirectory,
   type DeviceSessionState,
 } from '@oxyhq/contracts';
 import { logger } from '../logger';
 import { computeIdentityTag } from '../utils/cacheKey';
+import { resolveActiveContext, type DeviceContext } from './deviceDirectory';
 import { getSocketIO } from './socketLoader';
 import type { MinimalSocket, SocketIOFactory } from './socketLoader';
 
@@ -98,6 +102,7 @@ export interface SessionClientOptions {
 }
 
 type StateListener = (state: DeviceSessionState | null) => void;
+type DirectoryListener = (directory: DeviceDirectory | null) => void;
 
 /**
  * Same-origin `BroadcastChannel` name for instant, network-free session-state
@@ -118,7 +123,20 @@ interface SessionBroadcastChannel {
 
 export class SessionClient {
   private state: DeviceSessionState | null = null;
+  /**
+   * The device DIRECTORY (ADR 0002) — principals, the contexts each may act as,
+   * and which context is active. Held BESIDE `state` rather than replacing it:
+   * `state` is the flat compatibility projection every app renders until Phase 7
+   * moves it, and the two describe the same device at the same `revision`.
+   *
+   * `null` until something asks for it. A client that never calls
+   * {@link refreshDirectory} has no consumer for a directory and never pays for
+   * the round trip — which is also what keeps the whole account lane's request
+   * count unchanged.
+   */
+  private directory: DeviceDirectory | null = null;
   private readonly listeners = new Set<StateListener>();
+  private readonly directoryListeners = new Set<DirectoryListener>();
   protected socket: MinimalSocket | null = null;
   private tokenUnsub: (() => void) | null = null;
   private started = false;
@@ -139,6 +157,27 @@ export class SessionClient {
   }
 
   /**
+   * The device directory, or `null` when this client has never read one.
+   * Populated by {@link refreshDirectory} / {@link activateContext} and kept
+   * fresh from there on.
+   */
+  getDirectory(): DeviceDirectory | null {
+    return this.directory;
+  }
+
+  /**
+   * The active `principal acting as account` pair, with the actor and the
+   * subject kept apart. `null` when no directory has been read, or when the
+   * device genuinely has no active context.
+   *
+   * This is the answer `getState()` cannot give: `activeAccountId` names the
+   * subject and says nothing about whose authentication is behind it.
+   */
+  getActiveContext(): DeviceContext | null {
+    return resolveActiveContext(this.directory);
+  }
+
+  /**
    * The account this client's bearer is pinned to, or `null` when it follows the
    * device's active account (the default). Resolvers are expected to be a plain
    * synchronous read of already-resolved state (see
@@ -152,6 +191,20 @@ export class SessionClient {
     this.listeners.add(listener);
     return () => {
       this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Subscribe to the directory half. Fires from the SAME {@link notify} as
+   * {@link subscribe}, so the flat state and the directory are never published
+   * at two different points of the ordering sequence — a directory subscriber
+   * and a state subscriber woken by one transition always see the same device
+   * revision under the same bearer.
+   */
+  subscribeDirectory(listener: DirectoryListener): () => void {
+    this.directoryListeners.add(listener);
+    return () => {
+      this.directoryListeners.delete(listener);
     };
   }
 
@@ -195,6 +248,13 @@ export class SessionClient {
         listener(this.state);
       } catch (error) {
         logger.error('[SessionClient] subscriber threw', error);
+      }
+    }
+    for (const listener of this.directoryListeners) {
+      try {
+        listener(this.directory);
+      } catch (error) {
+        logger.error('[SessionClient] directory subscriber threw', error);
       }
     }
   }
@@ -271,7 +331,7 @@ export class SessionClient {
       next.accounts.length > 0 &&
       (activeAccountId === null || computeIdentityTag(this.host.getAccessToken()) !== activeAccountId);
 
-    const finishApply = (): void => {
+    const publish = (): void => {
       this.notify();
       if (next.accounts.length === 0 && this.options.onUnauthenticated) {
         try {
@@ -280,6 +340,22 @@ export class SessionClient {
           logger.error('[SessionClient] onUnauthenticated threw', error);
         }
       }
+    };
+
+    // The directory half of the same ordering invariant: when this client holds
+    // a directory and the flat state has just moved past it, re-read the
+    // directory BEFORE anyone is notified — otherwise a directory-rendering
+    // consumer observes the PREVIOUS subject under the new subject's bearer,
+    // which is the account-switch race mirrored. `settleDirectory` returns null
+    // (and this stays synchronous) for every client that never read a
+    // directory, i.e. the whole account lane.
+    const finishApply = (): void => {
+      const settling = this.settleDirectory(next);
+      if (settling === null) {
+        publish();
+        return;
+      }
+      void settling.then(publish);
     };
 
     if (needsMintBeforeNotify) {
@@ -351,9 +427,212 @@ export class SessionClient {
     }
   }
 
+  /**
+   * Validate + last-writer-wins by revision, exactly as {@link applyState} does
+   * for the flat half — including the part that is easy to get wrong: the guard
+   * is `deviceId`-SCOPED. A directory belonging to a DIFFERENT device resets the
+   * baseline and is accepted at any revision, so a freshly-converged device
+   * cannot lose to a retired device's higher number.
+   *
+   * Notifies nothing. Every caller decides where in its own ordering sequence
+   * the publish belongs.
+   */
+  private applyDirectory(raw: unknown): boolean {
+    const next = safeParseContract(deviceDirectorySchema, raw);
+    if (!next) {
+      logger.warn('[SessionClient] discarded invalid device directory');
+      return false;
+    }
+    if (
+      this.directory &&
+      next.deviceId === this.directory.deviceId &&
+      next.revision <= this.directory.revision
+    ) {
+      return false;
+    }
+    this.directory = next;
+    return true;
+  }
+
+  /** `GET /session/device/directory` → {@link applyDirectory}. No notify. */
+  private async fetchDirectory(): Promise<boolean> {
+    const res = await this.host.makeRequest<unknown>('GET', '/session/device/directory', undefined, { cache: false });
+    return this.applyDirectory(res);
+  }
+
+  /**
+   * Re-read the directory when the flat state has moved past it, returning the
+   * in-flight work so the caller can hold its notify until both halves describe
+   * the same revision.
+   *
+   * `null` — meaning "nothing to settle, stay synchronous" — when this client
+   * holds no directory (nobody reads one), when the directory is already at or
+   * ahead of the state, or when there is no bearer to make the call with.
+   * Never rejects: a failed refresh leaves the previous directory in place and
+   * the next transition tries again; it must not swallow the flat state's
+   * notify.
+   */
+  private settleDirectory(state: DeviceSessionState): Promise<void> | null {
+    const held = this.directory;
+    if (held === null) {
+      return null;
+    }
+    if (held.deviceId === state.deviceId && held.revision >= state.revision) {
+      return null;
+    }
+    if (!this.host.getAccessToken()) {
+      return null;
+    }
+    return this.fetchDirectory().then(
+      () => undefined,
+      (error: unknown) => {
+        logger.warn('[SessionClient] directory refresh failed', { component: 'SessionClient' }, error);
+      },
+    );
+  }
+
+  /**
+   * The highest device revision this client currently knows for `deviceId`,
+   * across BOTH halves, or `null` when it knows nothing about that device.
+   *
+   * Used to read the server's `changed` flag, which
+   * `POST /session/device/activate` deliberately does not carry: the revision
+   * already says whether the device moved, and a second field saying the same
+   * thing is a second field that can disagree with the first.
+   */
+  private knownRevisionFor(deviceId: string): number | null {
+    const fromDirectory = this.directory?.deviceId === deviceId ? this.directory.revision : null;
+    const fromState = this.state?.deviceId === deviceId ? this.state.revision : null;
+    if (fromDirectory === null) return fromState;
+    if (fromState === null) return fromDirectory;
+    return Math.max(fromDirectory, fromState);
+  }
+
+  /**
+   * Plant the bearer `POST /session/device/activate` returned for the newly
+   * active context, under the same guards {@link applyState} applies to a
+   * sync-supplied `activeToken`: never for a null active context, never a
+   * foreign account's token while pinned, and never a redundant re-plant of the
+   * token already held.
+   *
+   * `activeToken: null` is not an error — it is an identity-pinned client, or a
+   * caller whose application is not entitled to a bearer for the new context.
+   */
+  private plantActiveContextToken(directory: DeviceDirectory, accessToken: string | undefined): void {
+    if (!accessToken) {
+      return;
+    }
+    const subjectAccountId = resolveActiveContext(directory)?.subject.accountId ?? null;
+    if (subjectAccountId === null) {
+      return;
+    }
+    const pinnedAccountId = this.pinnedAccountId();
+    if (pinnedAccountId !== null && subjectAccountId !== pinnedAccountId) {
+      return;
+    }
+    if (accessToken === this.host.getAccessToken()) {
+      return;
+    }
+    this.host.setTokens(accessToken);
+  }
+
+  /**
+   * Bring the FLAT projection back in step after a context activation.
+   *
+   * The activation response answers with the directory and a bearer and
+   * deliberately not with `DeviceSessionState` (ADR 0002) — but every app that
+   * has not moved to the directory still renders from `getState()`, and leaving
+   * it a revision behind would show the PREVIOUS subject under the new
+   * subject's bearer. So it is settled BEFORE the notify, not after.
+   *
+   * This is also what converges the bearer when the activation returned no
+   * token: `GET /session/device/state` mints one for the active account, and
+   * `applyState`'s own mint-before-notify gate holds its notify until it lands.
+   *
+   * Non-fatal on failure — the directory is applied and (usually) the bearer is
+   * planted; the socket push or the next bootstrap catches the flat half up. A
+   * network blip must not turn a completed activation into a thrown error.
+   */
+  private async reconcileFlatState(directory: DeviceDirectory): Promise<void> {
+    if (
+      this.state &&
+      this.state.deviceId === directory.deviceId &&
+      this.state.revision >= directory.revision
+    ) {
+      return;
+    }
+    if (!this.host.getAccessToken()) {
+      return;
+    }
+    try {
+      await this.bootstrap();
+    } catch (error) {
+      logger.warn('[SessionClient] flat-state reconcile after activation failed', { component: 'SessionClient' }, error);
+    }
+  }
+
   async bootstrap(): Promise<void> {
     const res = await this.host.makeRequest<unknown>('GET', '/session/device/state', undefined, { cache: false });
     this.applySync(res);
+  }
+
+  /**
+   * Read `GET /session/device/directory` and publish it.
+   *
+   * Calling this is what opts a client into the directory: from here on every
+   * applied device state re-reads it (see {@link settleDirectory}), so the two
+   * halves stay at one revision without the caller polling.
+   */
+  async refreshDirectory(): Promise<void> {
+    if (await this.fetchDirectory()) {
+      this.notify();
+    }
+  }
+
+  /**
+   * `POST /session/device/activate` — make one `principal acting as account`
+   * context active (ADR 0002).
+   *
+   * The body is `{ contextId }` and nothing else: an `accountId` cannot name
+   * what to activate on a device where two people can both reach the same
+   * organization, and the server refuses a body carrying one rather than
+   * guessing inside an authorization path.
+   *
+   * The sequence is the ADR's ordering invariant, in order — commit the bearer
+   * for the new context, publish the new snapshot, notify — with the flat
+   * projection reconciled in the middle so no consumer can observe the two
+   * halves disagreeing.
+   *
+   * An IDEMPOTENT activation (the target was already active) moves no revision,
+   * so it reconciles nothing and wakes no sibling tab, mirroring the server's
+   * "bumps nothing and broadcasts nothing". `switchAccount` remains the
+   * compatibility path for callers still keyed on account ids.
+   */
+  async activateContext(contextId: string): Promise<void> {
+    const res = await this.host.makeRequest<unknown>('POST', '/session/device/activate', { contextId }, { cache: false });
+    const activation = safeParseContract(deviceActivateResponseSchema, res);
+    if (!activation) {
+      logger.warn('[SessionClient] discarded invalid activation response');
+      return;
+    }
+    const known = this.knownRevisionFor(activation.directory.deviceId);
+    const moved = known === null || activation.directory.revision > known;
+    this.plantActiveContextToken(activation.directory, activation.activeToken?.accessToken);
+    // Applied BEFORE the reconcile, and only then: the reconcile's own
+    // `GET /session/device/state` runs the full apply path, whose
+    // `settleDirectory` would otherwise see a stale directory and issue a
+    // second, redundant `GET /session/device/directory` for the revision we are
+    // already holding in hand.
+    const applied = this.applyDirectory(activation.directory);
+    if (moved) {
+      await this.reconcileFlatState(activation.directory);
+    }
+    if (applied) {
+      this.notify();
+    }
+    if (moved) {
+      this.postCommitPing();
+    }
   }
 
   async switchAccount(accountId: string): Promise<void> {

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -428,11 +428,26 @@ export class SessionClient {
   }
 
   /**
-   * Validate + last-writer-wins by revision, exactly as {@link applyState} does
-   * for the flat half — including the part that is easy to get wrong: the guard
-   * is `deviceId`-SCOPED. A directory belonging to a DIFFERENT device resets the
+   * Validate + last-writer-wins, `deviceId`-SCOPED exactly as {@link applyState}
+   * is for the flat half: a directory belonging to a DIFFERENT device resets the
    * baseline and is accepted at any revision, so a freshly-converged device
    * cannot lose to a retired device's higher number.
+   *
+   * The comparison itself is deliberately WEAKER than the flat state's. There it
+   * is `revision <= current` — correct, because a `DeviceSessionState` arrives
+   * out of band over a socket, so a straggler can genuinely land after a newer
+   * one. A directory only ever arrives as the response to a request THIS client
+   * just made, so the newest response is the freshest answer and only a strictly
+   * LOWER revision can be a straggler (two GETs racing).
+   *
+   * Equal-revision reads are not redundant, and rejecting them was a bug: the
+   * directory includes rows projected from the account GRAPH, and the server
+   * materializes a context for every account a principal may act as WITHOUT
+   * bumping `revision` — deliberately, since `revision` tracks what the device
+   * holds and must never advance on a read. So a newly-granted `account:act_as`,
+   * and a removed-then-rematerialized context under its NEW id, both appear at
+   * an unchanged revision. Under `<=` neither would ever be seen until some
+   * unrelated device mutation happened to move the number.
    *
    * Notifies nothing. Every caller decides where in its own ordering sequence
    * the publish belongs.
@@ -446,7 +461,7 @@ export class SessionClient {
     if (
       this.directory &&
       next.deviceId === this.directory.deviceId &&
-      next.revision <= this.directory.revision
+      next.revision < this.directory.revision
     ) {
       return false;
     }

--- a/packages/core/src/session/SessionClient.ts
+++ b/packages/core/src/session/SessionClient.ts
@@ -1,6 +1,7 @@
 import {
   deviceActivateResponseSchema,
   deviceDirectorySchema,
+  deviceDirectorySyncSchema,
   deviceSessionStateSchema,
   deviceSessionSyncSchema,
   safeParseContract,
@@ -8,6 +9,7 @@ import {
   sessionAccountsChangedEventSchema,
   type DeviceDirectory,
   type DeviceSessionState,
+  type DeviceSessionSync,
 } from '@oxyhq/contracts';
 import { logger } from '../logger';
 import { computeIdentityTag } from '../utils/cacheKey';
@@ -401,6 +403,20 @@ export class SessionClient {
       logger.warn('[SessionClient] discarded invalid session sync', { component: 'SessionClient', issues, keys });
       return;
     }
+    this.commitSync(sync);
+  }
+
+  /**
+   * The apply + token-plant half of {@link applySync}, on an ALREADY-VALIDATED
+   * sync. Split out so the context-aware removal lane — whose response is a
+   * different wire shape and therefore a different parse — reuses this ordering
+   * verbatim instead of re-deriving it. Two implementations of
+   * "plant before notify" is two chances to get it wrong once.
+   *
+   * Returns whether `applyState` applied, so a caller holding a second half
+   * (the directory) can decide whether anything still needs publishing.
+   */
+  private commitSync(sync: DeviceSessionSync): boolean {
     // A `sync` is always the response to a direct REST call this client made
     // (bootstrap / switch / signOut / add) → a `request`-origin, authoritative
     // verdict. Hand the active token to `applyState`: in the applied path it is
@@ -425,6 +441,7 @@ export class SessionClient {
     ) {
       this.host.setTokens(sync.activeToken.accessToken);
     }
+    return applied;
   }
 
   /**
@@ -656,9 +673,76 @@ export class SessionClient {
     this.postCommitPing();
   }
 
+  /**
+   * The FLAT removal meanings, unchanged: `{ accountId }` removes that account
+   * however it is reached — plus the operator cascade — and `{ all: true }`
+   * removes the whole device including its credentials.
+   *
+   * `{ accountId }` is deliberately still account-grained. On a device holding
+   * two people it removes BOTH of their routes to that account, which is the
+   * right meaning for "sign this account out of this device" and the wrong one
+   * for "this person is done here" — see {@link signOutContext} and
+   * {@link signOutPrincipal} for the two that can tell those apart.
+   */
   async signOut(target: { accountId: string } | { all: true }): Promise<void> {
     const res = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
     this.applySync(res);
+    this.postCommitPing();
+  }
+
+  /**
+   * Remove ONE `principal → account` pair, and only that pair.
+   *
+   * Never the account across the device: the same organization reached through
+   * a second person is a different session, a different audit actor and a
+   * different revocation path, and it stays. That distinction is unreachable
+   * through {@link signOut}, whose `accountId` cannot name which route to drop.
+   *
+   * Removal is not permanent while the membership lives — the server offers the
+   * pair again on the next directory read, as `onDevice: false` under a NEW id.
+   */
+  async signOutContext(contextId: string): Promise<void> {
+    await this.removeFromDevice({ contextId });
+  }
+
+  /**
+   * Remove ONE PERSON and every context they reach — and nobody else's,
+   * including when another principal independently operates the same account.
+   */
+  async signOutPrincipal(principalId: string): Promise<void> {
+    await this.removeFromDevice({ principalId });
+  }
+
+  /**
+   * The shared apply path for both context-aware removals.
+   *
+   * The response is `{directory, state, activeToken}` — its own contract, never
+   * `deviceSessionSyncSchema`, which would strip the directory silently. Both
+   * halves move in one server transition (a removal elects a replacement active
+   * context), so both are applied before anything is published: the directory
+   * first, so the flat apply's own `settleDirectory` sees a current directory
+   * and does not issue a redundant `GET /session/device/directory` for the
+   * revision already in hand.
+   *
+   * Token-before-notify is `commitSync`'s, reused verbatim rather than
+   * re-derived — including the equal-revision plant when a socket push already
+   * applied this revision.
+   */
+  private async removeFromDevice(target: { contextId: string } | { principalId: string }): Promise<void> {
+    const res = await this.host.makeRequest<unknown>('POST', '/session/device/signout', target, { cache: false });
+    const removal = safeParseContract(deviceDirectorySyncSchema, res);
+    if (!removal) {
+      logger.warn('[SessionClient] discarded invalid device removal response');
+      return;
+    }
+    const directoryApplied = this.applyDirectory(removal.directory);
+    const stateApplied = this.commitSync({ state: removal.state, activeToken: removal.activeToken });
+    // `commitSync` publishes whenever the flat state moved. When only the
+    // directory did — a socket push already applied this revision — the
+    // directory half would otherwise never reach a subscriber.
+    if (directoryApplied && !stateApplied) {
+      this.notify();
+    }
     this.postCommitPing();
   }
 

--- a/packages/core/src/session/__tests__/SessionClient.directory.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.directory.test.ts
@@ -445,6 +445,164 @@ describe('SessionClient — device directory', () => {
     expect(countOf(host.urls, '/session/device/state')).toBe(0);
   });
 
+  describe('context-aware removals', () => {
+    const removalResponse = (revision: number, activeContextId: string | null) => ({
+      directory: directoryAt(revision, activeContextId),
+      state: stateAt(revision, activeContextId === 'ctx-org' ? 'org' : 'nate'),
+      activeToken: { accessToken: jwtFor(activeContextId === 'ctx-org' ? 'org' : 'nate'), expiresAt: 'x' },
+    });
+
+    it('signOutContext POSTs { contextId } and applies BOTH halves from one response', async () => {
+      const host = makeHost(
+        { '/session/device/signout': () => removalResponse(6, 'ctx-nate') },
+        jwtFor('org'),
+      );
+      const client = new TestClient(host);
+      client.apply(stateAt(5, 'org'));
+
+      await client.signOutContext('ctx-org');
+
+      expect(host.makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { contextId: 'ctx-org' }, { cache: false });
+      expect(client.getActiveContext()?.contextId).toBe('ctx-nate');
+      expect(client.getState()?.activeAccountId).toBe('nate');
+      expect(client.getState()?.revision).toBe(6);
+      // Both halves arrived together, so nothing had to be fetched back.
+      expect(countOf(host.urls, '/session/device/state')).toBe(0);
+      expect(countOf(host.urls, '/session/device/directory')).toBe(0);
+    });
+
+    it('signOutPrincipal POSTs { principalId }', async () => {
+      const host = makeHost(
+        { '/session/device/signout': () => removalResponse(7, 'ctx-nate') },
+        jwtFor('nate'),
+      );
+      const client = new SessionClient(host);
+
+      await client.signOutPrincipal('p-alice');
+
+      expect(host.makeRequest).toHaveBeenCalledWith('POST', '/session/device/signout', { principalId: 'p-alice' }, { cache: false });
+    });
+
+    it('commits the replacement context bearer before any subscriber observes it', async () => {
+      const host = makeHost(
+        { '/session/device/signout': () => removalResponse(6, 'ctx-nate') },
+        jwtFor('org'),
+      );
+      const client = new TestClient(host);
+      client.apply(stateAt(5, 'org'));
+
+      const observations: Array<{ active: string | null; bearer: string }> = [];
+      client.subscribe((state) => {
+        observations.push({
+          active: state?.activeAccountId ?? null,
+          bearer: computeIdentityTag(host.getAccessToken()),
+        });
+      });
+
+      await client.signOutContext('ctx-org');
+
+      expect(observations.length).toBeGreaterThan(0);
+      for (const observation of observations) {
+        expect(observation.bearer).toBe(observation.active);
+      }
+    });
+
+    /**
+     * The removal response is `{directory, state, activeToken}` and must never
+     * be routed through the flat parser, which would strip the directory. The
+     * client-side half of that rule is that a directory-LESS payload on this
+     * lane is refused outright rather than half-applied.
+     */
+    it('discards a response missing the directory instead of applying the flat half', async () => {
+      const host = makeHost(
+        {
+          '/session/device/signout': () => ({
+            state: stateAt(6, 'nate'),
+            activeToken: { accessToken: jwtFor('nate'), expiresAt: 'x' },
+          }),
+        },
+        jwtFor('org'),
+      );
+      const client = new TestClient(host);
+      client.apply(stateAt(5, 'org'));
+
+      await client.signOutContext('ctx-org');
+
+      expect(client.getState()?.revision).toBe(5);
+      expect(client.getState()?.activeAccountId).toBe('org');
+    });
+
+    it('reports a device emptied by the removal as an authoritative sign-out', async () => {
+      const origins: string[] = [];
+      const host = makeHost(
+        {
+          '/session/device/signout': () => ({
+            directory: {
+              ...directoryAt(6, null),
+              principals: [],
+            },
+            state: { ...stateAt(6, 'nate'), accounts: [], activeAccountId: null },
+            activeToken: null,
+          }),
+        },
+        jwtFor('nate'),
+      );
+      const client = new TestClient(host, { onUnauthenticated: (origin) => origins.push(origin) });
+      client.apply(stateAt(5, 'nate'));
+
+      await client.signOutPrincipal('p-nate');
+
+      // `request` origin, not `push`: a REST removal this client asked for is
+      // authoritative enough to erase the durable device credential.
+      expect(origins).toEqual(['request']);
+      expect(client.getActiveContext()).toBeNull();
+    });
+
+    /**
+     * A socket push already applied this revision, so the flat half no-ops and
+     * publishes nothing. The directory half still moved — the push carries no
+     * directory — and without its own publish the switcher would keep rendering
+     * a context the removal deleted.
+     */
+    it('publishes the directory when only the directory half moved', async () => {
+      const host = makeHost(
+        { '/session/device/signout': () => removalResponse(6, 'ctx-nate') },
+        jwtFor('nate'),
+      );
+      const client = new TestClient(host);
+      // The push landed first: the flat state is already at revision 6.
+      client.apply(stateAt(6, 'nate'));
+
+      const seen: Array<string | null | undefined> = [];
+      client.subscribeDirectory((directory) => seen.push(directory?.activeContextId));
+
+      await client.signOutContext('ctx-org');
+
+      expect(seen).toEqual(['ctx-nate']);
+      expect(client.getActiveContext()?.contextId).toBe('ctx-nate');
+    });
+
+    it('leaves signOut({accountId}) on the flat lane untouched', async () => {
+      const host = makeHost(
+        {
+          '/session/device/signout': () => ({
+            state: stateAt(6, 'nate'),
+            activeToken: { accessToken: jwtFor('nate'), expiresAt: 'x' },
+          }),
+        },
+        jwtFor('org'),
+      );
+      const client = new TestClient(host);
+      client.apply(stateAt(5, 'org'));
+
+      await client.signOut({ accountId: 'org' });
+
+      // The flat response has no directory and is still accepted here.
+      expect(client.getState()?.revision).toBe(6);
+      expect(client.getState()?.activeAccountId).toBe('nate');
+    });
+  });
+
   describe('under an identity pin', () => {
     it('tracks an activation truthfully but never adopts the foreign bearer', async () => {
       const host = makeHost(

--- a/packages/core/src/session/__tests__/SessionClient.directory.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.directory.test.ts
@@ -13,6 +13,7 @@
  */
 import type { DeviceDirectory, DeviceSessionState } from '@oxyhq/contracts';
 import { SessionClient, type SessionClientHost } from '../SessionClient';
+import { resolveDeviceContext } from '../deviceDirectory';
 import { computeIdentityTag } from '../../utils/cacheKey';
 
 /** A minimal jwt-decode-able token whose `userId` claim is `accountId`. */
@@ -184,16 +185,14 @@ describe('SessionClient — device directory', () => {
     expect(seen.at(-1)?.revision).toBe(3);
   });
 
-  it('applies last-writer-wins by revision WITHIN one device', async () => {
+  it('rejects a STRICTLY LOWER revision from the same device', async () => {
     let next = directoryAt(5, 'ctx-nate');
     const host = makeHost({ '/session/device/directory': () => next }, jwtFor('nate'));
     const client = new SessionClient(host);
 
     await client.refreshDirectory();
-    next = directoryAt(5, 'ctx-org');
-    await client.refreshDirectory();
-    expect(client.getActiveContext()?.subject.accountId).toBe('nate');
 
+    // Two GETs racing: the older response landing second must not win.
     next = directoryAt(4, 'ctx-org');
     await client.refreshDirectory();
     expect(client.getActiveContext()?.subject.accountId).toBe('nate');
@@ -201,6 +200,50 @@ describe('SessionClient — device directory', () => {
     next = directoryAt(6, 'ctx-org');
     await client.refreshDirectory();
     expect(client.getActiveContext()?.subject.accountId).toBe('org');
+  });
+
+  /**
+   * The equal-revision read is NOT redundant, and rejecting it was a bug.
+   *
+   * The directory carries rows projected from the account graph, and the server
+   * materializes a context for every account a principal may act as WITHOUT
+   * bumping `revision` — deliberately, because `revision` tracks what the DEVICE
+   * holds and must never advance on a read. So a removed-then-rematerialized
+   * context comes back under a NEW id at an unchanged revision, as does a
+   * newly-granted `account:act_as`. Under a `<=` guard neither would ever be
+   * seen until some unrelated device mutation happened to move the number.
+   */
+  it('applies a re-read at the SAME revision, so a rematerialized context id lands', async () => {
+    const withOrgContextId = (contextId: string): DeviceDirectory => {
+      const base = directoryAt(5, 'ctx-nate');
+      const principal = base.principals[0];
+      return {
+        ...base,
+        principals: [
+          {
+            ...principal,
+            contexts: principal.contexts.map((context) =>
+              context.accountId === 'org' ? { ...context, id: contextId, onDevice: false } : context,
+            ),
+          },
+        ],
+      };
+    };
+
+    let next = withOrgContextId('ctx-org-first');
+    const host = makeHost({ '/session/device/directory': () => next }, jwtFor('nate'));
+    const client = new SessionClient(host);
+    await client.refreshDirectory();
+    expect(resolveDeviceContext(client.getDirectory(), 'ctx-org-first')).not.toBeNull();
+
+    // Same device, same revision — the pair is back under a fresh id.
+    next = withOrgContextId('ctx-org-rematerialized');
+    await client.refreshDirectory();
+
+    expect(resolveDeviceContext(client.getDirectory(), 'ctx-org-rematerialized')).not.toBeNull();
+    // And the id that is gone stays gone: it must read as absent, not as an
+    // error, and nothing may still be holding it.
+    expect(resolveDeviceContext(client.getDirectory(), 'ctx-org-first')).toBeNull();
   });
 
   it('accepts a LOWER-revision directory from a DIFFERENT device', async () => {

--- a/packages/core/src/session/__tests__/SessionClient.directory.test.ts
+++ b/packages/core/src/session/__tests__/SessionClient.directory.test.ts
@@ -1,0 +1,443 @@
+/**
+ * `SessionClient` on the device DIRECTORY (issue #937, ADR 0002).
+ *
+ * The four properties the account lane already holds are re-asserted here for
+ * the context lane, because none of them transfers for free:
+ *   1. last-writer-wins is `deviceId`-SCOPED, not global;
+ *   2. the bearer for the new context is committed BEFORE any subscriber is
+ *      notified;
+ *   3. an identity-pinned client tracks the device truthfully and never adopts
+ *      a foreign bearer;
+ *   4. an idempotent activation moves nothing, so it reconciles nothing and
+ *      wakes nobody — the client-side reading of the server's `changed: false`.
+ */
+import type { DeviceDirectory, DeviceSessionState } from '@oxyhq/contracts';
+import { SessionClient, type SessionClientHost } from '../SessionClient';
+import { computeIdentityTag } from '../../utils/cacheKey';
+
+/** A minimal jwt-decode-able token whose `userId` claim is `accountId`. */
+function jwtFor(accountId: string): string {
+  const payload = Buffer.from(JSON.stringify({ userId: accountId })).toString('base64url');
+  return `h.${payload}.s`;
+}
+
+/**
+ * Nate (personal) plus `org`, reached through Nate. `activeContextId` picks
+ * which one is live.
+ */
+function directoryAt(
+  revision: number,
+  activeContextId: string | null,
+  deviceId = 'd1',
+): DeviceDirectory {
+  return {
+    deviceId,
+    revision,
+    activeContextId,
+    updatedAt: 1_720_000_000_000,
+    principals: [
+      {
+        id: 'p-nate',
+        userId: 'nate',
+        authuser: 0,
+        user: { id: 'nate', username: 'nate' },
+        contexts: [
+          {
+            id: 'ctx-nate',
+            accountId: 'nate',
+            kind: 'personal',
+            relationship: 'self',
+            account: { id: 'nate', username: 'nate' },
+            onDevice: true,
+            available: true,
+            active: activeContextId === 'ctx-nate',
+            lastUsedAt: null,
+          },
+          {
+            id: 'ctx-org',
+            accountId: 'org',
+            kind: 'organization',
+            relationship: 'owner',
+            account: { id: 'org', username: 'oxy' },
+            onDevice: true,
+            available: true,
+            active: activeContextId === 'ctx-org',
+            lastUsedAt: null,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function stateAt(revision: number, activeAccountId: string, deviceId = 'd1'): DeviceSessionState {
+  return {
+    deviceId,
+    accounts: [
+      { accountId: 'nate', sessionId: 's-nate', authuser: 0 },
+      { accountId: 'org', sessionId: 's-org', authuser: 1, operatedByUserId: 'nate' },
+    ],
+    activeAccountId,
+    revision,
+    updatedAt: 1_720_000_000_000,
+  };
+}
+
+type Route = () => unknown;
+
+interface TestHost extends SessionClientHost {
+  urls: string[];
+  bodies: unknown[];
+  planted(): string | null;
+}
+
+function makeHost(routes: Record<string, Route>, initialToken: string | null): TestHost {
+  const urls: string[] = [];
+  const bodies: unknown[] = [];
+  let planted = initialToken;
+  return {
+    makeRequest: jest.fn(async (_method: string, url: string, data?: unknown) => {
+      urls.push(url);
+      bodies.push(data);
+      const route = routes[url];
+      if (!route) {
+        throw new Error(`unexpected request: ${url}`);
+      }
+      return route();
+    }),
+    getBaseURL: () => 'http://test.invalid',
+    getAccessToken: () => planted,
+    getDeviceCredential: () => null,
+    onTokensChanged: () => () => undefined,
+    setTokens: (token: string) => {
+      planted = token;
+    },
+    getCurrentAccountId: () => null,
+    urls,
+    bodies,
+    planted: () => planted,
+  };
+}
+
+/** `applyState` is protected; a tiny subclass exposes it for the unit tests. */
+class TestClient extends SessionClient {
+  public apply(raw: unknown): boolean {
+    return this.applyState(raw);
+  }
+}
+
+const countOf = (urls: string[], url: string): number => urls.filter((seen) => seen === url).length;
+
+/**
+ * A recording stand-in for `BroadcastChannel`.
+ *
+ * Node's real one is ref'd and would keep the Jest event loop alive forever, but
+ * simply feature-detecting it away would ALSO make the cross-tab wake
+ * unobservable — and "an idempotent activation wakes nobody" is one of the
+ * properties under test, so it has to be a fake rather than an absence.
+ */
+const posted: unknown[] = [];
+class RecordingBroadcastChannel {
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  postMessage(message: unknown): void {
+    posted.push(message);
+  }
+  close(): void {
+    /* nothing to release */
+  }
+}
+
+describe('SessionClient — device directory', () => {
+  const realBroadcastChannel = (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+  beforeAll(() => {
+    (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = RecordingBroadcastChannel;
+  });
+  afterAll(() => {
+    (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = realBroadcastChannel;
+  });
+  beforeEach(() => {
+    posted.length = 0;
+  });
+
+  it('holds no directory until one is read', () => {
+    const client = new SessionClient(makeHost({}, jwtFor('nate')));
+
+    expect(client.getDirectory()).toBeNull();
+    expect(client.getActiveContext()).toBeNull();
+  });
+
+  it('refreshDirectory GETs the directory, applies it and notifies', async () => {
+    const host = makeHost(
+      { '/session/device/directory': () => directoryAt(3, 'ctx-org') },
+      jwtFor('nate'),
+    );
+    const client = new SessionClient(host);
+    const seen: Array<DeviceDirectory | null> = [];
+    client.subscribeDirectory((directory) => seen.push(directory));
+
+    await client.refreshDirectory();
+
+    expect(host.makeRequest).toHaveBeenCalledWith('GET', '/session/device/directory', undefined, { cache: false });
+    expect(client.getDirectory()?.revision).toBe(3);
+    expect(client.getActiveContext()?.subject.accountId).toBe('org');
+    expect(client.getActiveContext()?.actor.userId).toBe('nate');
+    expect(seen.at(-1)?.revision).toBe(3);
+  });
+
+  it('applies last-writer-wins by revision WITHIN one device', async () => {
+    let next = directoryAt(5, 'ctx-nate');
+    const host = makeHost({ '/session/device/directory': () => next }, jwtFor('nate'));
+    const client = new SessionClient(host);
+
+    await client.refreshDirectory();
+    next = directoryAt(5, 'ctx-org');
+    await client.refreshDirectory();
+    expect(client.getActiveContext()?.subject.accountId).toBe('nate');
+
+    next = directoryAt(4, 'ctx-org');
+    await client.refreshDirectory();
+    expect(client.getActiveContext()?.subject.accountId).toBe('nate');
+
+    next = directoryAt(6, 'ctx-org');
+    await client.refreshDirectory();
+    expect(client.getActiveContext()?.subject.accountId).toBe('org');
+  });
+
+  it('accepts a LOWER-revision directory from a DIFFERENT device', async () => {
+    let next = directoryAt(10, 'ctx-nate', 'A');
+    const host = makeHost({ '/session/device/directory': () => next }, jwtFor('nate'));
+    const client = new SessionClient(host);
+
+    await client.refreshDirectory();
+    expect(client.getDirectory()?.deviceId).toBe('A');
+
+    // Device B is freshly converged at revision 1. The revision is monotone only
+    // WITHIN a device, so B must win over A's stale-but-higher number.
+    next = directoryAt(1, 'ctx-org', 'B');
+    await client.refreshDirectory();
+    expect(client.getDirectory()?.deviceId).toBe('B');
+    expect(client.getDirectory()?.revision).toBe(1);
+  });
+
+  it('discards an invalid directory and keeps the one it holds', async () => {
+    let next: unknown = directoryAt(2, 'ctx-nate');
+    const host = makeHost({ '/session/device/directory': () => next }, jwtFor('nate'));
+    const client = new SessionClient(host);
+
+    await client.refreshDirectory();
+    next = { deviceId: 'd1', revision: 9, principals: 'nope' };
+    await client.refreshDirectory();
+
+    expect(client.getDirectory()?.revision).toBe(2);
+  });
+
+  it('never fetches a directory for a client that has not asked for one', () => {
+    const host = makeHost({}, jwtFor('nate'));
+    const client = new TestClient(host);
+
+    client.apply(stateAt(1, 'nate'));
+    client.apply(stateAt(2, 'org'));
+
+    expect(countOf(host.urls, '/session/device/directory')).toBe(0);
+  });
+
+  it('re-reads the directory BEFORE notifying once the flat state moves past it', async () => {
+    let releaseDirectory: (() => void) | null = null;
+    const host = makeHost(
+      {
+        '/session/device/directory': () => {
+          if (releaseDirectory === null) {
+            return directoryAt(2, 'ctx-nate');
+          }
+          return new Promise((resolve) => {
+            releaseDirectory = () => resolve(directoryAt(3, 'ctx-org'));
+          });
+        },
+      },
+      jwtFor('nate'),
+    );
+    const client = new TestClient(host);
+    await client.refreshDirectory();
+
+    // Positive control for the previous test: this client HAS a directory, so
+    // an advancing state does fetch one.
+    const observed: Array<number | undefined> = [];
+    client.subscribe(() => observed.push(client.getDirectory()?.revision));
+    releaseDirectory = () => undefined;
+
+    client.apply(stateAt(3, 'org'));
+    // The directory is still at 2 and the fetch is in flight — nobody has been
+    // told about revision 3 yet.
+    expect(observed).toEqual([]);
+    expect(countOf(host.urls, '/session/device/directory')).toBe(2);
+
+    releaseDirectory();
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+
+    // The one notify observed BOTH halves at revision 3.
+    expect(observed).toEqual([3]);
+    expect(client.getActiveContext()?.subject.accountId).toBe('org');
+  });
+
+  it('activateContext POSTs { contextId } and nothing else', async () => {
+    const host = makeHost(
+      {
+        '/session/device/activate': () => ({
+          directory: directoryAt(4, 'ctx-org'),
+          activeToken: { accessToken: jwtFor('org'), expiresAt: 'x' },
+        }),
+        '/session/device/state': () => ({ state: stateAt(4, 'org'), activeToken: null }),
+      },
+      jwtFor('nate'),
+    );
+    const client = new SessionClient(host);
+
+    await client.activateContext('ctx-org');
+
+    expect(host.makeRequest).toHaveBeenCalledWith('POST', '/session/device/activate', { contextId: 'ctx-org' }, { cache: false });
+    expect(client.getActiveContext()?.contextId).toBe('ctx-org');
+  });
+
+  it('commits the new context bearer BEFORE any subscriber observes the new subject', async () => {
+    const host = makeHost(
+      {
+        '/session/device/activate': () => ({
+          directory: directoryAt(4, 'ctx-org'),
+          activeToken: { accessToken: jwtFor('org'), expiresAt: 'x' },
+        }),
+        '/session/device/state': () => ({ state: stateAt(4, 'org'), activeToken: null }),
+      },
+      jwtFor('nate'),
+    );
+    const client = new SessionClient(host);
+
+    const observations: Array<{ subject: string | null; bearer: string }> = [];
+    client.subscribeDirectory((directory) => {
+      observations.push({
+        subject: directory?.activeContextId === 'ctx-org' ? 'org' : 'nate',
+        bearer: computeIdentityTag(host.getAccessToken()),
+      });
+    });
+
+    await client.activateContext('ctx-org');
+
+    expect(observations.length).toBeGreaterThan(0);
+    for (const observation of observations) {
+      expect(observation.bearer).toBe(observation.subject);
+    }
+  });
+
+  it('reconciles the flat projection so it cannot lag the directory', async () => {
+    const host = makeHost(
+      {
+        '/session/device/activate': () => ({
+          directory: directoryAt(4, 'ctx-org'),
+          activeToken: { accessToken: jwtFor('org'), expiresAt: 'x' },
+        }),
+        '/session/device/state': () => ({ state: stateAt(4, 'org'), activeToken: null }),
+      },
+      jwtFor('nate'),
+    );
+    const client = new TestClient(host);
+    client.apply(stateAt(3, 'nate'));
+
+    await client.activateContext('ctx-org');
+
+    expect(countOf(host.urls, '/session/device/state')).toBe(1);
+    expect(client.getState()?.activeAccountId).toBe('org');
+    expect(client.getState()?.revision).toBe(4);
+  });
+
+  it('an idempotent activation reconciles nothing and wakes nobody', async () => {
+    let directory = directoryAt(4, 'ctx-org');
+    const host = makeHost(
+      {
+        '/session/device/activate': () => ({
+          directory,
+          activeToken: { accessToken: jwtFor('org'), expiresAt: 'x' },
+        }),
+        '/session/device/state': () => ({ state: stateAt(directory.revision, 'org'), activeToken: null }),
+      },
+      jwtFor('nate'),
+    );
+    const client = new TestClient(host);
+    client.apply(stateAt(4, 'org'));
+    await client.activateContext('ctx-org');
+
+    const before = host.urls.length;
+    // The server answers the SAME revision: nothing was written, nothing
+    // broadcast. The client must read that off the revision, not re-fetch —
+    // and must not wake the origin's other tabs to converge on a change that
+    // did not happen.
+    await client.activateContext('ctx-org');
+    expect(host.urls.slice(before)).toEqual(['/session/device/activate']);
+    expect(posted).toEqual([]);
+
+    // Vacuity floor: a real transition from the same starting point DOES
+    // reconcile and DOES wake the siblings, so the assertions above are
+    // measuring idempotence and not a client that simply never does either.
+    directory = directoryAt(5, 'ctx-nate');
+    const beforeReal = host.urls.length;
+    await client.activateContext('ctx-nate');
+    expect(host.urls.slice(beforeReal)).toEqual(['/session/device/activate', '/session/device/state']);
+    expect(posted).toEqual([{ type: 'commit', at: expect.any(Number) }]);
+  });
+
+  it('discards an invalid activation response without touching the directory', async () => {
+    const host = makeHost(
+      {
+        '/session/device/directory': () => directoryAt(4, 'ctx-nate'),
+        '/session/device/activate': () => ({ directory: { deviceId: 'd1' }, activeToken: null }),
+      },
+      jwtFor('nate'),
+    );
+    const client = new SessionClient(host);
+    await client.refreshDirectory();
+
+    await client.activateContext('ctx-org');
+
+    expect(client.getActiveContext()?.contextId).toBe('ctx-nate');
+    expect(countOf(host.urls, '/session/device/state')).toBe(0);
+  });
+
+  describe('under an identity pin', () => {
+    it('tracks an activation truthfully but never adopts the foreign bearer', async () => {
+      const host = makeHost(
+        {
+          '/session/device/activate': () => ({
+            directory: directoryAt(4, 'ctx-org'),
+            activeToken: { accessToken: jwtFor('org'), expiresAt: 'x' },
+          }),
+          '/session/device/state': () => ({ state: stateAt(4, 'org'), activeToken: null }),
+        },
+        jwtFor('nate'),
+      );
+      const client = new SessionClient(host, { getPinnedAccountId: () => 'nate' });
+
+      await client.activateContext('ctx-org');
+
+      expect(client.getActiveContext()?.subject.accountId).toBe('org');
+      expect(host.planted()).toBe(jwtFor('nate'));
+    });
+
+    it('DOES adopt the bearer when the new subject IS the pinned account', async () => {
+      const host = makeHost(
+        {
+          '/session/device/activate': () => ({
+            directory: directoryAt(4, 'ctx-nate'),
+            activeToken: { accessToken: jwtFor('nate'), expiresAt: 'x' },
+          }),
+          '/session/device/state': () => ({ state: stateAt(4, 'nate'), activeToken: null }),
+        },
+        null,
+      );
+      const client = new SessionClient(host, { getPinnedAccountId: () => 'nate' });
+
+      await client.activateContext('ctx-nate');
+
+      expect(host.planted()).toBe(jwtFor('nate'));
+    });
+  });
+});

--- a/packages/core/src/session/__tests__/accountDialogController.test.ts
+++ b/packages/core/src/session/__tests__/accountDialogController.test.ts
@@ -20,9 +20,31 @@ class TestSessionClient extends SessionClient {
   }
 }
 
+/**
+ * A valid, empty directory for the host below.
+ *
+ * `refresh()` reads `GET /session/device/directory` now, so the shared host has
+ * to answer it with something the contract accepts — otherwise every test in
+ * this file logs "discarded invalid device directory" and the ones asserting on
+ * the logger fail for a reason that has nothing to do with their subject.
+ *
+ * Its `revision` sits deliberately ahead of every state revision these tests
+ * use, so the directory-settle re-read (which has its own suite) never fires
+ * here and each test's request count stays about the thing it is testing.
+ */
+const EMPTY_DIRECTORY = {
+  deviceId: 'device-1',
+  revision: 9_000,
+  activeContextId: null,
+  principals: [],
+  updatedAt: 1_720_000_000_000,
+};
+
 function host(): SessionClientHost {
   return {
-    makeRequest: jest.fn(),
+    makeRequest: jest.fn(async (_method: string, url: string) =>
+      (url === '/session/device/directory' ? EMPTY_DIRECTORY : undefined),
+    ),
     getBaseURL: () => 'http://test.invalid',
     getAccessToken: () => 'token',
     getDeviceCredential: () => null,
@@ -79,7 +101,6 @@ interface OxyMock {
   startCommonsSignIn: jest.Mock;
   deliverCommonsSignIn: jest.Mock;
   pollCommonsSignIn: jest.Mock;
-  deliverCommonsSignIn: jest.Mock;
   denyCommonsSignIn: jest.Mock;
   claimSessionByToken: jest.Mock;
   signInWithSharedIdentity: jest.Mock;
@@ -107,7 +128,6 @@ function makeOxy(): OxyMock {
     getFileDownloadUrl: jest.fn((id: string) => `https://cdn/${id}`),
     switchToAccount: jest.fn(),
     startCommonsSignIn: jest.fn(),
-    deliverCommonsSignIn: jest.fn().mockResolvedValue({ delivered: false, targets: 0 }),
     pollCommonsSignIn: jest.fn(),
     // Default: no capable Commons installation is registered. A NORMAL outcome
     // that resolves the primary route to QR — never an error.
@@ -1810,6 +1830,196 @@ describe('AccountDialogController — lifecycle', () => {
     // destroy clears all listeners; a subsequent state push notifies nobody.
     sc.set(state([{ accountId: 'a1', sessionId: 's1' }], 'a1'));
     expect(seen).toEqual([]);
+  });
+});
+
+describe('AccountDialogController — the directory (ADR 0002)', () => {
+  /** A two-principal device where `org` is reachable through BOTH people. */
+  const sharedDirectory = (revision: number, activeContextId: string | null) => ({
+    deviceId: 'device-1',
+    revision,
+    activeContextId,
+    updatedAt: 1_720_000_000_000,
+    principals: [
+      {
+        id: 'p-nate',
+        userId: 'nate',
+        authuser: 0,
+        user: { id: 'nate', username: 'nate' },
+        contexts: [
+          {
+            id: 'ctx-nate-org',
+            accountId: 'org',
+            kind: 'organization' as const,
+            relationship: 'owner' as const,
+            account: { id: 'org', username: 'oxy' },
+            onDevice: true,
+            available: true,
+            active: activeContextId === 'ctx-nate-org',
+            lastUsedAt: null,
+          },
+        ],
+      },
+      {
+        id: 'p-alice',
+        userId: 'alice',
+        authuser: 1,
+        user: { id: 'alice', username: 'alice' },
+        contexts: [
+          {
+            id: 'ctx-alice-org',
+            accountId: 'org',
+            kind: 'organization' as const,
+            relationship: 'member' as const,
+            account: { id: 'org', username: 'oxy' },
+            onDevice: true,
+            available: true,
+            active: activeContextId === 'ctx-alice-org',
+            lastUsedAt: null,
+          },
+        ],
+      },
+    ],
+  });
+
+  function directoryHarness(activeContextId: string | null) {
+    const oxy = makeOxy();
+    const urls: string[] = [];
+    const bodies: unknown[] = [];
+    const sc = new TestSessionClient({
+      makeRequest: jest.fn(async (_method: string, url: string, data?: unknown) => {
+        urls.push(url);
+        bodies.push(data);
+        if (url === '/session/device/directory') return sharedDirectory(5, activeContextId);
+        if (url === '/session/device/activate') {
+          return { directory: sharedDirectory(6, 'ctx-alice-org'), activeToken: null };
+        }
+        return undefined;
+      }),
+      getBaseURL: () => 'http://test.invalid',
+      getAccessToken: () => 'token',
+      getDeviceCredential: () => null,
+      onTokensChanged: () => () => undefined,
+      setTokens: jest.fn(),
+      getCurrentAccountId: () => null,
+    });
+    const controller = createAccountDialogController({
+      oxyServices: oxy as unknown as OxyServices,
+      sessionClient: sc,
+      clientId: 'oxy_dk_test',
+      commitSession: jest.fn().mockResolvedValue(undefined),
+      onSignedIn: jest.fn(),
+    });
+    return { controller, oxy, sc, urls, bodies };
+  }
+
+  it('publishes the directory and the active context on the snapshot', async () => {
+    const { controller, oxy } = directoryHarness('ctx-alice-org');
+    oxy.listAccounts.mockResolvedValue([]);
+    oxy.getUsersByIds.mockResolvedValue([]);
+
+    await controller.refresh();
+
+    const snap = controller.getSnapshot();
+    expect(snap.directory?.revision).toBe(5);
+    // The flat `accounts` list cannot express this: it is keyed by account id,
+    // so ONE of these two routes to `org` would be all a consumer ever saw.
+    expect(snap.directory?.principals.map((p) => p.userId)).toEqual(['nate', 'alice']);
+    expect(snap.activeContext?.contextId).toBe('ctx-alice-org');
+    expect(snap.activeContext?.actor.userId).toBe('alice');
+    expect(snap.activeContext?.subject.accountId).toBe('org');
+    expect(snap.activeContext?.isDelegated).toBe(true);
+  });
+
+  it('activateContext POSTs the contextId and reports the switch in flight', async () => {
+    const { controller, oxy, urls, bodies } = directoryHarness('ctx-nate-org');
+    oxy.listAccounts.mockResolvedValue([]);
+    oxy.getUsersByIds.mockResolvedValue([]);
+    await controller.refresh();
+
+    const inFlight: Array<string | null> = [];
+    controller.subscribe((s) => inFlight.push(s.activatingContextId));
+
+    expect(await controller.activateContext('ctx-alice-org')).toBe(true);
+
+    expect(urls).toContain('/session/device/activate');
+    expect(bodies[urls.indexOf('/session/device/activate')]).toEqual({ contextId: 'ctx-alice-org' });
+    // Reported while running, cleared after — a row can show a spinner.
+    expect(inFlight).toContain('ctx-alice-org');
+    expect(controller.getSnapshot().activatingContextId).toBeNull();
+    expect(controller.getSnapshot().activeContext?.actor.userId).toBe('alice');
+  });
+
+  it('refuses a second activation while one is in flight', async () => {
+    const { controller, oxy } = directoryHarness('ctx-nate-org');
+    oxy.listAccounts.mockResolvedValue([]);
+    oxy.getUsersByIds.mockResolvedValue([]);
+    await controller.refresh();
+
+    const first = controller.activateContext('ctx-alice-org');
+    expect(await controller.activateContext('ctx-nate-org')).toBe(false);
+    expect(await first).toBe(true);
+  });
+
+  it('surfaces an activation failure as a dialog error without wedging the flag', async () => {
+    const { controller, oxy, sc } = directoryHarness('ctx-nate-org');
+    oxy.listAccounts.mockResolvedValue([]);
+    oxy.getUsersByIds.mockResolvedValue([]);
+    await controller.refresh();
+    // A stale context id is an ordinary outcome, not a bug: the server 404s and
+    // heals the row away.
+    jest.spyOn(sc, 'activateContext').mockRejectedValue(new Error('Context not on this device'));
+
+    expect(await controller.activateContext('ctx-gone')).toBe(false);
+
+    expect(controller.getSnapshot().error).toBe('Context not on this device');
+    expect(controller.getSnapshot().activatingContextId).toBeNull();
+  });
+
+  it('keeps rendering the flat list when the directory read fails', async () => {
+    const oxy = makeOxy();
+    const sc = new TestSessionClient({
+      makeRequest: jest.fn(async (_method: string, url: string) => {
+        if (url === '/session/device/directory') throw new Error('boom');
+        return undefined;
+      }),
+      getBaseURL: () => 'http://test.invalid',
+      getAccessToken: () => 'token',
+      getDeviceCredential: () => null,
+      onTokensChanged: () => () => undefined,
+      setTokens: jest.fn(),
+      getCurrentAccountId: () => null,
+    });
+    const controller = createAccountDialogController({
+      oxyServices: oxy as unknown as OxyServices,
+      sessionClient: sc,
+      clientId: 'oxy_dk_test',
+      commitSession: jest.fn().mockResolvedValue(undefined),
+      onSignedIn: jest.fn(),
+    });
+    sc.set(state([{ accountId: 'a1', sessionId: 's1' }], 'a1'));
+    oxy.listAccounts.mockResolvedValue([]);
+    oxy.getUsersByIds.mockResolvedValue([user('a1')]);
+
+    await controller.refresh();
+
+    // Degraded, not blank: a directory outage must not take the switcher down
+    // while the compatibility lane can still answer.
+    const snap = controller.getSnapshot();
+    expect(snap.directory).toBeNull();
+    expect(snap.accounts.map((r) => r.accountId)).toEqual(['a1']);
+    expect(snap.error).toBeNull();
+  });
+
+  it('makes no directory call while signed out', async () => {
+    const { controller, oxy, urls } = directoryHarness(null);
+    oxy.getAccessToken.mockReturnValue(null);
+    oxy.listAccounts.mockResolvedValue([]);
+
+    await controller.refresh();
+
+    expect(urls).not.toContain('/session/device/directory');
+    expect(controller.getSnapshot().directory).toBeNull();
   });
 });
 

--- a/packages/core/src/session/__tests__/accountProjection.test.ts
+++ b/packages/core/src/session/__tests__/accountProjection.test.ts
@@ -20,12 +20,17 @@ function user(id: string, over: Partial<User> = {}): User {
 }
 
 function state(
-  accounts: Array<{ accountId: string; sessionId: string; authuser?: number }>,
+  accounts: Array<{ accountId: string; sessionId: string; authuser?: number; operatedByUserId?: string }>,
   activeAccountId: string | null,
 ): DeviceSessionState {
   return {
     deviceId: 'device-1',
-    accounts: accounts.map((a) => ({ accountId: a.accountId, sessionId: a.sessionId, authuser: a.authuser ?? 0 })),
+    accounts: accounts.map((a) => ({
+      accountId: a.accountId,
+      sessionId: a.sessionId,
+      authuser: a.authuser ?? 0,
+      operatedByUserId: a.operatedByUserId,
+    })),
     activeAccountId,
     revision: 1,
     updatedAt: 1_720_000_000_000,
@@ -411,6 +416,80 @@ describe('projectSwitchableAccounts', () => {
     // Graph-only siblings (operable but not yet on this device) still appear.
     expect(rows.find((r) => r.accountId === 'oxy')?.onDevice).toBe(false);
     expect(rows.find((r) => r.accountId === 'faircoin')?.onDevice).toBe(false);
+  });
+
+  /**
+   * The pin, which this projection did not take until #937.
+   *
+   * Reading `state.activeAccountId` directly was correct only for as long as an
+   * identity-bound client never built a switcher — a coupling to what happens to
+   * be reachable from where, not a property anything checks. Every projection in
+   * `projectSessionState.ts` already took the pin; this one now answers through
+   * the same `boundAccountIdOf`, so the switcher and the session projection can
+   * never disagree about which row is current.
+   */
+  it('marks the PINNED row current rather than the device’s active account', () => {
+    const rows = projectSwitchableAccounts({
+      state: state([{ accountId: 'vault', sessionId: 's-vault' }, { accountId: 'other', sessionId: 's-other' }], 'other'),
+      graph: [],
+      profilesById: mapOf(user('vault'), user('other')),
+      pinnedAccountId: 'vault',
+      resolveAvatarUrl: noAvatar,
+    });
+
+    expect(rows.find((r) => r.accountId === 'vault')?.isCurrent).toBe(true);
+    expect(rows.find((r) => r.accountId === 'other')?.isCurrent).toBe(false);
+  });
+
+  it('treats an empty-string pin as no pin at all', () => {
+    const rows = projectSwitchableAccounts({
+      state: state([{ accountId: 'vault', sessionId: 's-vault' }, { accountId: 'other', sessionId: 's-other' }], 'other'),
+      graph: [],
+      profilesById: mapOf(user('vault'), user('other')),
+      pinnedAccountId: '',
+      resolveAvatarUrl: noAvatar,
+    });
+
+    expect(rows.find((r) => r.accountId === 'other')?.isCurrent).toBe(true);
+  });
+
+  it('prefers activeUser for the PINNED row, not for the device’s active one', () => {
+    const fresh = user('vault', { name: { displayName: 'Freshly Renamed' } });
+    const rows = projectSwitchableAccounts({
+      state: state([{ accountId: 'vault', sessionId: 's-vault' }, { accountId: 'other', sessionId: 's-other' }], 'other'),
+      graph: [],
+      profilesById: mapOf(user('vault'), user('other')),
+      activeUser: fresh,
+      pinnedAccountId: 'vault',
+      resolveAvatarUrl: noAvatar,
+    });
+
+    expect(rows.find((r) => r.accountId === 'vault')?.displayName).toBe('Freshly Renamed');
+  });
+
+  /**
+   * `operatedByUserId` has ridden the wire since the multi-account model shipped
+   * and no client has ever read it, so an org somebody is OPERATING has rendered
+   * identically to one signed in directly — different audit actor, same row.
+   * The directory is the full answer; this is the same fact on the flat lane.
+   */
+  it('surfaces the human operating a delegated device row', () => {
+    const rows = projectSwitchableAccounts({
+      state: state(
+        [
+          { accountId: 'nate', sessionId: 's-nate' },
+          { accountId: 'org', sessionId: 's-org', authuser: 1, operatedByUserId: 'nate' },
+        ],
+        'org',
+      ),
+      graph: [],
+      profilesById: mapOf(user('nate'), user('org')),
+      resolveAvatarUrl: noAvatar,
+    });
+
+    expect(rows.find((r) => r.accountId === 'org')?.operatedByUserId).toBe('nate');
+    // A directly signed-in account carries no operator — absence is the signal.
+    expect(rows.find((r) => r.accountId === 'nate')?.operatedByUserId).toBeUndefined();
   });
 });
 

--- a/packages/core/src/session/__tests__/deviceDirectory.test.ts
+++ b/packages/core/src/session/__tests__/deviceDirectory.test.ts
@@ -8,7 +8,7 @@
  * that is the wrong human.
  */
 import type { DeviceDirectory, DeviceDirectoryProfile } from '@oxyhq/contracts';
-import { resolveActiveContext, resolveDeviceContext } from '../deviceDirectory';
+import { canActivateContext, resolveActiveContext, resolveDeviceContext } from '../deviceDirectory';
 
 const profileFor = (id: string): DeviceDirectoryProfile => ({ id, username: id });
 
@@ -161,5 +161,104 @@ describe('resolveDeviceContext', () => {
   it('is null for an unknown context id and a null directory', () => {
     expect(resolveDeviceContext(sharedDeviceDirectory(null), 'nope')).toBeNull();
     expect(resolveDeviceContext(null, 'ctx-nate-self')).toBeNull();
+  });
+});
+
+describe('canActivateContext', () => {
+  /**
+   * A principal whose OWN personal session has died. Their delegated context
+   * still holds a live delegated session, so `onDevice` is true — and it is
+   * still not activatable, because activation has no proof of who is acting
+   * once the human's session is gone. The server answers such a request with a
+   * 403 and heals the row away, so a switcher that offered it would be offering
+   * a button that deletes the row it sits on.
+   */
+  function deadPrincipalDirectory(): DeviceDirectory {
+    return {
+      deviceId: 'd1',
+      revision: 3,
+      activeContextId: null,
+      updatedAt: 1_720_000_000_000,
+      principals: [
+        {
+          id: 'p-nate',
+          userId: 'nate',
+          authuser: 0,
+          user: NATE,
+          contexts: [
+            {
+              id: 'ctx-nate-self',
+              accountId: 'nate',
+              kind: 'personal',
+              relationship: 'self',
+              account: NATE,
+              onDevice: true,
+              available: false,
+              active: false,
+              lastUsedAt: null,
+            },
+            {
+              id: 'ctx-nate-org',
+              accountId: 'org',
+              kind: 'organization',
+              relationship: 'owner',
+              account: ORG,
+              // A LIVE delegated session, under a dead principal.
+              onDevice: true,
+              available: false,
+              active: false,
+              lastUsedAt: null,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it('refuses every context of a principal whose own session died', () => {
+    const directory = deadPrincipalDirectory();
+    const personal = resolveDeviceContext(directory, 'ctx-nate-self');
+    const delegated = resolveDeviceContext(directory, 'ctx-nate-org');
+
+    expect(delegated?.subject.onDevice).toBe(true);
+    expect(canActivateContext(delegated?.subject ?? { available: true })).toBe(false);
+    expect(canActivateContext(personal?.subject ?? { available: true })).toBe(false);
+  });
+
+  it('admits a reachable context that has never been activated here', () => {
+    // `onDevice: false` is the ordinary "reachable, session minted on first
+    // activation" row. Requiring `onDevice` would hide every organization the
+    // person has not used on this device yet.
+    const directory: DeviceDirectory = {
+      deviceId: 'd1',
+      revision: 3,
+      activeContextId: null,
+      updatedAt: 1_720_000_000_000,
+      principals: [
+        {
+          id: 'p-nate',
+          userId: 'nate',
+          authuser: 0,
+          user: NATE,
+          contexts: [
+            {
+              id: 'ctx-nate-org',
+              accountId: 'org',
+              kind: 'organization',
+              relationship: 'owner',
+              account: ORG,
+              onDevice: false,
+              available: true,
+              active: false,
+              lastUsedAt: null,
+            },
+          ],
+        },
+      ],
+    };
+    const context = resolveDeviceContext(directory, 'ctx-nate-org');
+
+    expect(context?.subject.onDevice).toBe(false);
+    expect(canActivateContext(context?.subject ?? { available: false })).toBe(true);
   });
 });

--- a/packages/core/src/session/__tests__/deviceDirectory.test.ts
+++ b/packages/core/src/session/__tests__/deviceDirectory.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The device directory's two halves, kept apart.
+ *
+ * Every fixture here puts the SAME organization under TWO principals, because
+ * that is the shape the flat projection cannot hold and the shape where a loose
+ * reading of "find the active context" and the correct one disagree: matching on
+ * `accountId` finds whichever person is enumerated first, and on this device
+ * that is the wrong human.
+ */
+import type { DeviceDirectory, DeviceDirectoryProfile } from '@oxyhq/contracts';
+import { resolveActiveContext, resolveDeviceContext } from '../deviceDirectory';
+
+const profileFor = (id: string): DeviceDirectoryProfile => ({ id, username: id });
+
+const NATE = profileFor('nate');
+const ALICE = profileFor('alice');
+const ORG = profileFor('org');
+
+/**
+ * `The Oxy Collective` reachable through Nate (who owns it) AND through Alice
+ * (a member). Nate's route is enumerated FIRST; Alice's is the active one.
+ */
+function sharedDeviceDirectory(activeContextId: string | null): DeviceDirectory {
+  return {
+    deviceId: 'd1',
+    revision: 7,
+    activeContextId,
+    updatedAt: 1_720_000_000_000,
+    principals: [
+      {
+        id: 'p-nate',
+        userId: 'nate',
+        authuser: 0,
+        user: NATE,
+        contexts: [
+          {
+            id: 'ctx-nate-self',
+            accountId: 'nate',
+            kind: 'personal',
+            relationship: 'self',
+            account: NATE,
+            onDevice: true,
+            available: true,
+            active: false,
+            lastUsedAt: 1_719_000_000_000,
+          },
+          {
+            id: 'ctx-nate-org',
+            accountId: 'org',
+            kind: 'organization',
+            relationship: 'owner',
+            account: ORG,
+            onDevice: true,
+            available: true,
+            active: false,
+            lastUsedAt: 1_719_500_000_000,
+          },
+        ],
+      },
+      {
+        id: 'p-alice',
+        userId: 'alice',
+        authuser: 1,
+        user: ALICE,
+        contexts: [
+          {
+            id: 'ctx-alice-self',
+            accountId: 'alice',
+            kind: 'personal',
+            relationship: 'self',
+            account: ALICE,
+            onDevice: true,
+            available: true,
+            active: false,
+            lastUsedAt: null,
+          },
+          {
+            id: 'ctx-alice-org',
+            accountId: 'org',
+            kind: 'organization',
+            relationship: 'member',
+            account: ORG,
+            onDevice: false,
+            available: false,
+            active: true,
+            lastUsedAt: null,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('resolveActiveContext', () => {
+  it('resolves the actor through the CONTEXT, not through the account', () => {
+    const context = resolveActiveContext(sharedDeviceDirectory('ctx-alice-org'));
+
+    // Both principals reach `org`; only one of them is the active context's.
+    expect(context?.actor).toEqual({
+      principalId: 'p-alice',
+      userId: 'alice',
+      authuser: 1,
+      profile: ALICE,
+    });
+    expect(context?.subject.accountId).toBe('org');
+    expect(context?.contextId).toBe('ctx-alice-org');
+  });
+
+  it('marks a delegated context delegated and a personal one not', () => {
+    expect(resolveActiveContext(sharedDeviceDirectory('ctx-alice-org'))?.isDelegated).toBe(true);
+    expect(resolveActiveContext(sharedDeviceDirectory('ctx-nate-self'))?.isDelegated).toBe(false);
+  });
+
+  it('carries the subject facts a switcher renders verbatim', () => {
+    const context = resolveActiveContext(sharedDeviceDirectory('ctx-alice-org'));
+
+    // `available: false` is a membership that was revoked. It is returned as a
+    // row, not omitted, so the UI can explain it instead of silently dropping it.
+    expect(context?.subject).toEqual({
+      accountId: 'org',
+      kind: 'organization',
+      relationship: 'member',
+      profile: ORG,
+      onDevice: false,
+      available: false,
+      lastUsedAt: null,
+    });
+  });
+
+  it('is null for no directory, no active context, and an active id nobody holds', () => {
+    expect(resolveActiveContext(null)).toBeNull();
+    expect(resolveActiveContext(sharedDeviceDirectory(null))).toBeNull();
+    // A directory that disagrees with itself resolves to "nothing active",
+    // never to whichever context happened to look closest.
+    expect(resolveActiveContext(sharedDeviceDirectory('ctx-healed-away'))).toBeNull();
+  });
+
+  it('refuses to read an ACCOUNT id as if it named a context', () => {
+    // `org` is a real account on this device, reachable through both people. A
+    // resolver that fell back to matching on `accountId` would answer with one
+    // of them — a guess about WHICH HUMAN is signed in, made inside the path
+    // that decides what the app renders and which bearer it holds. The whole
+    // reason activation takes a `contextId` is that this guess is not ours to
+    // make, so it resolves to nothing instead.
+    expect(resolveActiveContext(sharedDeviceDirectory('org'))).toBeNull();
+    expect(resolveDeviceContext(sharedDeviceDirectory(null), 'org')).toBeNull();
+  });
+});
+
+describe('resolveDeviceContext', () => {
+  it('resolves each route to the same account under its own principal', () => {
+    const directory = sharedDeviceDirectory('ctx-alice-org');
+
+    expect(resolveDeviceContext(directory, 'ctx-nate-org')?.actor.userId).toBe('nate');
+    expect(resolveDeviceContext(directory, 'ctx-alice-org')?.actor.userId).toBe('alice');
+    expect(resolveDeviceContext(directory, 'ctx-nate-org')?.subject.accountId).toBe(
+      resolveDeviceContext(directory, 'ctx-alice-org')?.subject.accountId,
+    );
+  });
+
+  it('is null for an unknown context id and a null directory', () => {
+    expect(resolveDeviceContext(sharedDeviceDirectory(null), 'nope')).toBeNull();
+    expect(resolveDeviceContext(null, 'ctx-nate-self')).toBeNull();
+  });
+});

--- a/packages/core/src/session/__tests__/projectSessionState.test.ts
+++ b/packages/core/src/session/__tests__/projectSessionState.test.ts
@@ -86,3 +86,20 @@ describe('projections — pinned', () => {
     expect(accountIdsOf(STATE)).toEqual([PINNED, OTHER]);
   });
 });
+
+describe('the operator behind a delegated session', () => {
+  it('carries operatedByUserId through instead of dropping it', () => {
+    const operated: DeviceSessionState = {
+      ...STATE,
+      accounts: [
+        { accountId: PINNED, sessionId: 'sess-vault', authuser: 0 },
+        { accountId: OTHER, sessionId: 'sess-other', authuser: 1, operatedByUserId: PINNED },
+      ],
+    };
+
+    const sessions = deviceStateToClientSessions(operated, USERS);
+
+    // The delegated row names the human behind it; the direct one has nobody.
+    expect(sessions.map((session) => session.operatedByUserId)).toEqual([undefined, PINNED]);
+  });
+});

--- a/packages/core/src/session/accountDialogController.ts
+++ b/packages/core/src/session/accountDialogController.ts
@@ -55,6 +55,7 @@
  * teardown), never an `open` / `close` / `visible`.
  */
 
+import type { DeviceDirectory } from '@oxyhq/contracts';
 import type { OxyServices } from '../OxyServices';
 import type { SessionLoginResponse, MinimalUserData } from '../models/session';
 import type { User } from '../models/interfaces';
@@ -68,6 +69,7 @@ import {
   switchableAccountIds,
   type SwitchableAccount,
 } from './accountProjection';
+import { resolveActiveContext, type DeviceContext } from './deviceDirectory';
 import type { AccountNode } from '../mixins/OxyServices.accounts';
 import type { CommonsSignInHandle } from '../mixins/OxyServices.auth';
 import {
@@ -262,7 +264,26 @@ function deriveSignInProgress(facts: SignInFlowFacts): SignInProgress {
 export interface AccountDialogSnapshot {
   /** The current view. */
   view: AccountDialogView;
-  /** The unified, deduped account list (device sign-ins ∪ graph accounts). */
+  /**
+   * The server-authoritative device directory — principals and the contexts
+   * each may act as (ADR 0002) — or `null` before the first read.
+   *
+   * This is the read model a switcher should render. {@link accounts} below is
+   * the compatibility adapter it replaces, and the two are NOT redundant: the
+   * flat list is keyed by account id, so on a device holding two people it can
+   * show one route to a shared organization and never both.
+   */
+  directory: DeviceDirectory | null;
+  /** The active `principal acting as account` pair, actor and subject apart. */
+  activeContext: DeviceContext | null;
+  /**
+   * The unified, deduped account list (device sign-ins ∪ graph accounts).
+   *
+   * The COMPATIBILITY projection, kept while consumers move to
+   * {@link directory}. It is the one place this controller still reconstructs a
+   * caller's account graph — which ADR 0002 removes precisely because a client
+   * holds one caller's graph and cannot enumerate the other principals'.
+   */
   accounts: SwitchableAccount[];
   /** The currently-active account id, or `null` when signed out. */
   activeAccountId: string | null;
@@ -272,6 +293,8 @@ export interface AccountDialogSnapshot {
   error: string | null;
   /** The `accountId` of an in-flight switch, or `null`. */
   switchingAccountId: string | null;
+  /** The `contextId` of an in-flight activation, or `null`. */
+  activatingContextId: string | null;
   /** The "Sign in with Oxy" device-flow state. */
   signIn: SignInFlowState;
   /** Whether Commons is installed on this device. See {@link CommonsAvailability}. */
@@ -457,6 +480,7 @@ export class AccountDialogController {
   private loading = false;
   private error: string | null = null;
   private switchingAccountId: string | null = null;
+  private activatingContextId: string | null = null;
   private signIn: SignInFlowState = IDLE_SIGN_IN;
   private commonsAvailability: CommonsAvailability = 'unknown';
 
@@ -691,6 +715,22 @@ export class AccountDialogController {
     this.error = null;
     this.emit();
 
+    // The directory (ADR 0002) — the read model that replaces the union below.
+    // Both lanes run while consumers migrate, which is the cost of not breaking
+    // every switcher in one commit; the flat half goes when they have moved.
+    // A failure here is never fatal: the compatibility projection still renders
+    // from device state, so a directory outage degrades rather than blanks.
+    try {
+      await this.sessionClient.refreshDirectory();
+    } catch (error) {
+      if (extractErrorStatus(error) === 401) {
+        logger.debug('[AccountDialogController] directory unauthorized (signed out)', { component: 'AccountDialogController' }, error);
+      } else {
+        logger.warn('[AccountDialogController] directory refresh failed', { component: 'AccountDialogController' }, error);
+      }
+    }
+    if (seq !== this.refreshSeq) return; // superseded by a newer refresh
+
     let graph: AccountNode[] = this.graph;
     try {
       graph = await this.oxyServices.listAccounts();
@@ -821,6 +861,40 @@ export class AccountDialogController {
       return false;
     } finally {
       this.switchingAccountId = null;
+      this.emit();
+    }
+  }
+
+  /**
+   * Activate one `principal acting as account` context — the ADR 0002 switch,
+   * and the one that can express what {@link switchTo} cannot: WHICH person's
+   * route to a shared organization to become.
+   *
+   * There is no on-device/graph fork here. That fork exists in `switchTo`
+   * because the flat model has no row for an account the caller may act as but
+   * has never entered, so the first entry has to mint through a different
+   * endpoint. The directory has a row for both, and `POST /session/device/
+   * activate` reuses or mints the delegated session server-side, so one call
+   * covers both cases.
+   *
+   * A context id is not stable across a removal, so a stale one is an ordinary
+   * outcome rather than a bug: the server answers 404 or 403, heals the row, and
+   * the refresh below re-reads a directory that no longer offers it.
+   */
+  async activateContext(contextId: string): Promise<boolean> {
+    if (this.activatingContextId) return false;
+    this.activatingContextId = contextId;
+    this.error = null;
+    this.emit();
+    try {
+      await this.sessionClient.activateContext(contextId);
+      await this.refresh();
+      return true;
+    } catch (error) {
+      this.error = errorMessage(error);
+      return false;
+    } finally {
+      this.activatingContextId = null;
       this.emit();
     }
   }
@@ -1491,8 +1565,11 @@ export class AccountDialogController {
 
   private computeSnapshot(): AccountDialogSnapshot {
     const state = this.sessionClient.getState();
+    const directory = this.sessionClient.getDirectory();
     return {
       view: this.view,
+      directory,
+      activeContext: resolveActiveContext(directory),
       accounts: projectSwitchableAccounts({
         state,
         graph: this.graph,
@@ -1505,6 +1582,7 @@ export class AccountDialogController {
       loading: this.loading,
       error: this.error,
       switchingAccountId: this.switchingAccountId,
+      activatingContextId: this.activatingContextId,
       signIn: this.signIn,
       commonsAvailability: this.commonsAvailability,
     };

--- a/packages/core/src/session/accountProjection.ts
+++ b/packages/core/src/session/accountProjection.ts
@@ -28,6 +28,7 @@ import type {
 } from '../mixins/OxyServices.accounts';
 import { getAccountDisplayName, getAccountFallbackHandle } from '../utils/accountUtils';
 import { getNormalizedUserHandle } from '../utils/userHandle';
+import { boundAccountIdOf } from './projectSessionState';
 
 /**
  * The per-account user shape carried by a {@link SwitchableAccount}. The SDK's
@@ -66,7 +67,23 @@ export interface SwitchableAccount {
    * `SessionAccount`. Absent for graph-only rows.
    */
   authuser?: number;
-  /** Whether this account is the currently-active one (`accountId === activeAccountId`). */
+  /**
+   * The HUMAN this account is being operated by, for a delegated device session.
+   * Absent for a row the account itself signed into, and for every graph-only
+   * row (nobody operates an account that has no session here yet).
+   *
+   * Lets a switcher say "The Oxy Collective — operated by Nate" instead of
+   * rendering a delegated session identically to a direct one. On a device
+   * holding two people the flat lane still cannot show BOTH routes to one
+   * account — the unique key is the account id — which is exactly the limit
+   * `SessionClient.getDirectory()` exists to lift.
+   */
+  operatedByUserId?: string;
+  /**
+   * Whether this account is the currently-active one — `accountId` equals the
+   * BOUND account, i.e. the pin when {@link ProjectSwitchableAccountsInput.pinnedAccountId}
+   * is supplied and the device's `activeAccountId` otherwise.
+   */
   isCurrent: boolean;
   /** Whether this account is signed in on THIS device (has a `sessionId`). */
   onDevice: boolean;
@@ -189,6 +206,21 @@ export interface ProjectSwitchableAccountsInput {
    * `profilesById` alone when omitted.
    */
   activeUser?: User | null;
+  /**
+   * The PINNED account id for an identity-bound client, or `null`/omitted for
+   * every ordinary one — the same parameter every projection in
+   * `projectSessionState.ts` takes, resolved through the same
+   * `boundAccountIdOf`.
+   *
+   * It exists here because the alternative was a structural coupling, not a
+   * guarantee: reading `state.activeAccountId` directly is correct only while
+   * identity mode never builds a switcher, and "this projection happens not to
+   * be reachable from that mode today" is not a property anything checks. With
+   * the pin threaded, a pinned client that DID render a switcher marks its own
+   * identity current instead of whichever account another app on the device
+   * last activated.
+   */
+  pinnedAccountId?: string | null;
   /** Locale for display-name resolution (passed to `getAccountDisplayName`). */
   locale?: string;
   /**
@@ -210,16 +242,23 @@ export interface ProjectSwitchableAccountsInput {
  * Graph nodes the caller cannot switch into — a `channel`, or a managed account
  * whose membership lacks `account:act_as` — are omitted.
  * {@link canSwitchIntoAccount} is the rule; see the filter below.
+ *
+ * `isCurrent` marks the BOUND account — the pin when
+ * {@link ProjectSwitchableAccountsInput.pinnedAccountId} is supplied, the
+ * device's `activeAccountId` otherwise — through the same `boundAccountIdOf`
+ * every projection in `projectSessionState.ts` uses, so the two can never
+ * disagree about which row is current for one pin.
  */
 export function projectSwitchableAccounts(input: ProjectSwitchableAccountsInput): SwitchableAccount[] {
-  const { state, graph, profilesById, activeUser, locale, resolveAvatarUrl } = input;
-  const activeAccountId = state?.activeAccountId ?? null;
+  const { state, graph, profilesById, activeUser, pinnedAccountId, locale, resolveAvatarUrl } = input;
+  const boundAccountId = boundAccountIdOf(state, pinnedAccountId);
 
   const toRow = (
     accountUser: User,
     opts: {
       sessionId?: string;
       authuser?: number;
+      operatedByUserId?: string;
       relationship?: AccountRelationship;
       kind?: AccountKind;
       parentAccountId?: string | null;
@@ -233,7 +272,8 @@ export function projectSwitchableAccounts(input: ProjectSwitchableAccountsInput)
       accountId,
       sessionId: opts.sessionId,
       authuser: opts.authuser,
-      isCurrent: Boolean(accountId) && accountId === activeAccountId,
+      operatedByUserId: opts.operatedByUserId,
+      isCurrent: Boolean(accountId) && accountId === boundAccountId,
       onDevice: Boolean(opts.sessionId),
       relationship: opts.relationship,
       kind: opts.kind,
@@ -253,7 +293,7 @@ export function projectSwitchableAccounts(input: ProjectSwitchableAccountsInput)
 
   // --- Device rows (from the server-authoritative session set) ---
   const deviceRows = (state?.accounts ?? []).flatMap((account): SwitchableAccount[] => {
-    const isActive = account.accountId === activeAccountId;
+    const isActive = account.accountId === boundAccountId;
     // The active row prefers the freshest `activeUser` (when supplied), then the
     // batch-resolved profile; every other row uses the batch-resolved profile.
     const accountUser: User | undefined = isActive && activeUser
@@ -262,7 +302,11 @@ export function projectSwitchableAccounts(input: ProjectSwitchableAccountsInput)
     if (!accountUser) {
       return [];
     }
-    return [toRow(accountUser, { sessionId: account.sessionId, authuser: account.authuser })];
+    return [toRow(accountUser, {
+      sessionId: account.sessionId,
+      authuser: account.authuser,
+      operatedByUserId: account.operatedByUserId,
+    })];
   });
 
   // --- Merge graph nodes, deduping by account id ---

--- a/packages/core/src/session/deviceDirectory.ts
+++ b/packages/core/src/session/deviceDirectory.ts
@@ -1,0 +1,126 @@
+import type {
+  AccountKind,
+  DeviceContextRelationship,
+  DeviceDirectory,
+  DeviceDirectoryProfile,
+} from '@oxyhq/contracts';
+
+/**
+ * Pure projections over the device directory (`GET /session/device/directory`,
+ * ADR 0002). No I/O — the caller holds the directory `SessionClient` fetched.
+ *
+ * These exist to say the one thing the flat `DeviceSessionState` projection
+ * structurally cannot: WHO an account is being reached through.
+ * `DeviceSessionState.accounts[]` has carried `operatedByUserId` on the wire all
+ * along and nothing in this SDK ever read it, so "signed in as The Oxy
+ * Collective" and "Nate operating The Oxy Collective" render identically today —
+ * two different audit actors, two different revocation paths, one row. The
+ * directory keeps the two facts apart, and so does everything below.
+ */
+
+/**
+ * The human whose authentication backs a context — the audit actor.
+ *
+ * Always a person (ADR 0001: a principal is never an organization, project,
+ * channel or bot) and the owner of the `authuser` slot. An organization in the
+ * switcher consumes no slot of its own; it is a SUBJECT under some principal.
+ */
+export interface DeviceContextActor {
+  /** Identifies the principal row — the id `POST /session/device/signout { principalId }` takes. */
+  principalId: string;
+  /** The person's own account id. */
+  userId: string;
+  /** Google-style signed-in-human slot, allocated per person. */
+  authuser: number;
+  profile: DeviceDirectoryProfile;
+}
+
+/** The account a context acts AS — what a profile header renders. */
+export interface DeviceContextSubject {
+  accountId: string;
+  kind: AccountKind;
+  relationship: DeviceContextRelationship;
+  profile: DeviceDirectoryProfile;
+  /** `false` for a context the principal may act as but has never activated here. */
+  onDevice: boolean;
+  /** The live `account:act_as` verdict at read time — a revoked row is returned, not omitted. */
+  available: boolean;
+  lastUsedAt: number | null;
+}
+
+/**
+ * One resolved `principal acting as account` pair — the globally switchable
+ * unit, with its two halves named.
+ */
+export interface DeviceContext {
+  /** The identifier `POST /session/device/activate` takes. Names the PAIR, never the account. */
+  contextId: string;
+  actor: DeviceContextActor;
+  subject: DeviceContextSubject;
+  /**
+   * Whether the actor and the subject are different accounts — "Nate operating
+   * The Oxy Collective" rather than "Nate". Compared by id rather than read off
+   * `relationship`, so it stays true if the vocabulary ever grows a fourth term.
+   */
+  isDelegated: boolean;
+}
+
+/**
+ * Resolve one context by its id.
+ *
+ * The search is over `(principal, context)` PAIRS, not over accounts: the same
+ * `accountId` legitimately appears under two principals on a shared device, and
+ * matching on the account would hand back whichever person happened to be
+ * enumerated first.
+ */
+export function resolveDeviceContext(
+  directory: DeviceDirectory | null,
+  contextId: string,
+): DeviceContext | null {
+  if (directory === null) {
+    return null;
+  }
+  for (const principal of directory.principals) {
+    for (const context of principal.contexts) {
+      if (context.id !== contextId) {
+        continue;
+      }
+      return {
+        contextId: context.id,
+        actor: {
+          principalId: principal.id,
+          userId: principal.userId,
+          authuser: principal.authuser,
+          profile: principal.user,
+        },
+        subject: {
+          accountId: context.accountId,
+          kind: context.kind,
+          relationship: context.relationship,
+          profile: context.account,
+          onDevice: context.onDevice,
+          available: context.available,
+          lastUsedAt: context.lastUsedAt,
+        },
+        isDelegated: context.accountId !== principal.userId,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * The device's active context, or `null`.
+ *
+ * `null` is a real state, not an error: a device with every context removed, or
+ * one whose active context was healed away, has none. It is also the answer when
+ * `activeContextId` names a row no principal holds — a directory that
+ * disagreed with itself, which resolves to "nothing is active" rather than to a
+ * guess.
+ */
+export function resolveActiveContext(directory: DeviceDirectory | null): DeviceContext | null {
+  if (directory === null || directory.activeContextId === null) {
+    return null;
+  }
+  return resolveDeviceContext(directory, directory.activeContextId);
+}

--- a/packages/core/src/session/deviceDirectory.ts
+++ b/packages/core/src/session/deviceDirectory.ts
@@ -41,9 +41,24 @@ export interface DeviceContextSubject {
   kind: AccountKind;
   relationship: DeviceContextRelationship;
   profile: DeviceDirectoryProfile;
-  /** `false` for a context the principal may act as but has never activated here. */
+  /**
+   * `false` for a context the principal may act as but has never activated here.
+   *
+   * NOT a synonym for activatable, in either direction — see
+   * {@link canActivateContext}.
+   */
   onDevice: boolean;
-  /** The live `account:act_as` verdict at read time — a revoked row is returned, not omitted. */
+  /**
+   * Whether this context can be activated right now — the server's whole verdict,
+   * returned as a row rather than omitted so the UI can explain a row going away.
+   *
+   * It is STRICTER than the old `/switch` gate, and stricter than the name
+   * suggests: it is the live `account:act_as` check AND the PRINCIPAL's own
+   * personal session being live. Activation has no proof of who is acting once
+   * the human's own session is gone, so a dead principal makes every one of
+   * their contexts unavailable — the delegated ones whose own sessions are
+   * perfectly alive included.
+   */
   available: boolean;
   lastUsedAt: number | null;
 }
@@ -53,7 +68,18 @@ export interface DeviceContextSubject {
  * unit, with its two halves named.
  */
 export interface DeviceContext {
-  /** The identifier `POST /session/device/activate` takes. Names the PAIR, never the account. */
+  /**
+   * The identifier `POST /session/device/activate` takes. Names the PAIR, never
+   * the account.
+   *
+   * NOT STABLE ACROSS A REMOVAL, and therefore never something to persist or to
+   * hold across a read. Removing a delegated context is not permanent while the
+   * membership lives: the server rematerializes the pair on the next directory
+   * read, as `onDevice: false` under a NEW id — and it does so WITHOUT bumping
+   * `revision`, so "the device has not changed" is not evidence the id has not.
+   * Re-resolve from the directory in hand every time, and read an id that no
+   * longer resolves as gone rather than as an error.
+   */
   contextId: string;
   actor: DeviceContextActor;
   subject: DeviceContextSubject;
@@ -123,4 +149,29 @@ export function resolveActiveContext(directory: DeviceDirectory | null): DeviceC
     return null;
   }
   return resolveDeviceContext(directory, directory.activeContextId);
+}
+
+/**
+ * Whether a switcher may offer this row — the one question it asks, answered
+ * here so no surface has to re-derive it.
+ *
+ * It is deliberately a single field. `available` is the server's complete
+ * verdict (see {@link DeviceContextSubject.available}), and switchability is an
+ * authorization question the client must READ, never recompute; this exists to
+ * name the field that answers it, not to combine several.
+ *
+ * `onDevice` is NOT part of the question and composing the two is the mistake
+ * this function exists to prevent, in both directions. `onDevice: false` is an
+ * ordinary reachable context whose session is minted on first activation, so
+ * requiring it hides every organization the person has not used here yet.
+ * `onDevice: true` does not imply activatable either: when a principal's own
+ * personal session dies, their delegated contexts keep live sessions of their
+ * own and still cannot be activated, so `available || onDevice` would render a
+ * row the server answers with 403 and then heals away.
+ *
+ * Takes a structural subset so a caller holding a raw `DeviceAccountContext`
+ * from the wire can ask it without resolving the pair first.
+ */
+export function canActivateContext(context: { available: boolean }): boolean {
+  return context.available;
 }

--- a/packages/core/src/session/projectSessionState.ts
+++ b/packages/core/src/session/projectSessionState.ts
@@ -25,15 +25,20 @@ import type { User } from '../models/interfaces';
  * The account a projection should resolve: the pin when one is supplied and
  * non-empty, else the device's active account. An empty-string pin is treated as
  * "not pinned" rather than as an account that can never match.
+ *
+ * Exported for `accountProjection.ts`, which asks the same question of the same
+ * state and must not answer it a second, subtly different way. A null state with
+ * a pin still resolves to the pin: the pinned identity is bound by a local key,
+ * not by device membership.
  */
-function boundAccountIdOf(
-  state: DeviceSessionState,
+export function boundAccountIdOf(
+  state: DeviceSessionState | null,
   pinnedAccountId?: string | null,
 ): string | null {
   if (typeof pinnedAccountId === 'string' && pinnedAccountId.length > 0) {
     return pinnedAccountId;
   }
-  return state.activeAccountId;
+  return state?.activeAccountId ?? null;
 }
 
 /**
@@ -68,6 +73,7 @@ export function deviceStateToClientSessions(
     userId: account.accountId,
     isCurrent: account.accountId === boundAccountId,
     authuser: account.authuser,
+    operatedByUserId: account.operatedByUserId,
   }));
 }
 

--- a/packages/services/__tests__/context/coldBoot.test.tsx
+++ b/packages/services/__tests__/context/coldBoot.test.tsx
@@ -37,6 +37,12 @@ const fakeSessionClientHost = {
 };
 const fakeSessionClient = {
   getState: jest.fn(() => null),
+  // The dialog controller reads the directory on every snapshot build, so a
+  // stand-in that omits these is not a SessionClient. Null is the honest
+  // answer for a fake that was never given one.
+  getDirectory: jest.fn(() => null),
+  refreshDirectory: jest.fn(async () => null),
+  activateContext: jest.fn(async () => null),
   subscribe: jest.fn(() => () => undefined),
   start: jest.fn(async () => undefined),
   bootstrap: jest.fn(async () => undefined),

--- a/packages/services/__tests__/context/identitySessionMode.test.tsx
+++ b/packages/services/__tests__/context/identitySessionMode.test.tsx
@@ -58,6 +58,12 @@ const fakeSessionClientHost = {
 };
 const fakeSessionClient = {
   getState: () => deviceState,
+  // The dialog controller reads the directory on every snapshot build, so a
+  // stand-in that omits these is not a SessionClient. Null is the honest
+  // answer for a fake that was never given one.
+  getDirectory: () => null,
+  refreshDirectory: async () => null,
+  activateContext: async () => null,
   subscribe: (listener: StateListener) => {
     stateListeners.add(listener);
     return () => stateListeners.delete(listener);

--- a/packages/services/__tests__/context/mutationsSessionClient.test.tsx
+++ b/packages/services/__tests__/context/mutationsSessionClient.test.tsx
@@ -132,8 +132,20 @@ function buildFakeClient(initial: DeviceSessionState) {
     switchAccount,
     signOut,
     getState: () => state,
+    // The dialog controller reads the directory on every snapshot build, so a
+    // stand-in that omits these is not a SessionClient. Null is the honest
+    // answer for a fake that was never given one.
+    getDirectory: () => null,
+    refreshDirectory: async () => null,
+    activateContext: async () => null,
     fakeClient: {
       getState: () => state,
+      // The dialog controller reads the directory on every snapshot build, so a
+      // stand-in that omits these is not a SessionClient. Null is the honest
+      // answer for a fake that was never given one.
+      getDirectory: () => null,
+      refreshDirectory: async () => null,
+      activateContext: async () => null,
       subscribe: (listener: StateListener) => {
         listeners.add(listener);
         return () => listeners.delete(listener);

--- a/packages/services/__tests__/context/oxyClientTokenSync.test.tsx
+++ b/packages/services/__tests__/context/oxyClientTokenSync.test.tsx
@@ -53,6 +53,12 @@ jest.mock('../../src/ui/session', () => {
     createSessionClient: jest.fn(() => ({
       client: {
         getState: () => null,
+        // The dialog controller reads the directory on every snapshot build, so a
+        // stand-in that omits these is not a SessionClient. Null is the honest
+        // answer for a fake that was never given one.
+        getDirectory: () => null,
+        refreshDirectory: async () => null,
+        activateContext: async () => null,
         subscribe: () => () => undefined,
         addCurrentAccount: jest.fn(async () => undefined),
         start: jest.fn(async () => undefined),

--- a/packages/services/__tests__/context/sessionClientProjection.test.tsx
+++ b/packages/services/__tests__/context/sessionClientProjection.test.tsx
@@ -74,6 +74,12 @@ function buildFakeClient(initialState: DeviceSessionState | null) {
   return {
     fakeClient: {
       getState: () => state,
+      // The dialog controller reads the directory on every snapshot build, so a
+      // stand-in that omits these is not a SessionClient. Null is the honest
+      // answer for a fake that was never given one.
+      getDirectory: () => null,
+      refreshDirectory: async () => null,
+      activateContext: async () => null,
       subscribe: (listener: StateListener) => {
         listeners.add(listener);
         return () => listeners.delete(listener);

--- a/packages/services/__tests__/context/sessionClientSocket.test.tsx
+++ b/packages/services/__tests__/context/sessionClientSocket.test.tsx
@@ -122,8 +122,20 @@ function buildFakeClient(initial: DeviceSessionState) {
     bootstrap,
     push,
     getState: () => state,
+    // The dialog controller reads the directory on every snapshot build, so a
+    // stand-in that omits these is not a SessionClient. Null is the honest
+    // answer for a fake that was never given one.
+    getDirectory: () => null,
+    refreshDirectory: async () => null,
+    activateContext: async () => null,
     fakeClient: {
       getState: () => state,
+      // The dialog controller reads the directory on every snapshot build, so a
+      // stand-in that omits these is not a SessionClient. Null is the honest
+      // answer for a fake that was never given one.
+      getDirectory: () => null,
+      refreshDirectory: async () => null,
+      activateContext: async () => null,
       subscribe: (listener: StateListener) => {
         listeners.add(listener);
         return () => listeners.delete(listener);

--- a/packages/services/src/ui/components/OxyAccountDialogScreen.tsx
+++ b/packages/services/src/ui/components/OxyAccountDialogScreen.tsx
@@ -161,6 +161,11 @@ function headerCopy(
 
 const EMPTY_SNAPSHOT: AccountDialogSnapshot = {
   view: 'accounts',
+  // The no-provider snapshot predates the directory. These three are null here
+  // for the same reason the rest of it is empty: nothing has been resolved yet.
+  directory: null,
+  activeContext: null,
+  activatingContextId: null,
   accounts: [],
   activeAccountId: null,
   loading: false,

--- a/packages/services/src/ui/components/OxyAuthChooser.tsx
+++ b/packages/services/src/ui/components/OxyAuthChooser.tsx
@@ -432,6 +432,11 @@ const OxyAuthChooser: React.FC<OxyAuthChooserProps> = ({
 
 const EMPTY_SNAPSHOT: AccountDialogSnapshot = {
   view: 'accounts',
+  // The no-provider snapshot predates the directory. These three are null here
+  // for the same reason the rest of it is empty: nothing has been resolved yet.
+  directory: null,
+  activeContext: null,
+  activatingContextId: null,
   accounts: [],
   activeAccountId: null,
   loading: false,

--- a/packages/services/src/ui/hooks/useSwitchableAccounts.ts
+++ b/packages/services/src/ui/hooks/useSwitchableAccounts.ts
@@ -17,6 +17,11 @@ export interface UseSwitchableAccountsResult {
  */
 const EMPTY_SNAPSHOT: AccountDialogSnapshot = {
     view: 'accounts',
+    // The no-provider snapshot predates the directory. These three are null here
+    // for the same reason the rest of it is empty: nothing has been resolved yet.
+    directory: null,
+    activeContext: null,
+    activatingContextId: null,
     accounts: [],
     activeAccountId: null,
     loading: false,


### PR DESCRIPTION
Phase 2b of #937 — the client half of the device directory, in `@oxyhq/core` only. The server half is #946, already merged. `@oxyhq/services` is untouched (Phase 3b).

## What shipped

A pure `session/deviceDirectory.ts` (`resolveActiveContext` / `resolveDeviceContext` → `DeviceContext {contextId, actor, subject, isDelegated}`), and `SessionClient` now holds `directory` beside `state`, with `getDirectory` / `getActiveContext` / `subscribeDirectory` / `refreshDirectory` / `activateContext(contextId)`.

`subscribe` keeps its signature — changing it would break `@oxyhq/services` — and **both listener sets fire from one `notify()`**, so the two halves can never publish at different points in the ordering sequence.

The directory is **opt-in**: nothing fetches one until asked, and after that every applied state re-reads it *before* the notify. `activateContext` reconciles the flat `getState()` **inside** the sequence rather than after, because `/activate` returns no `DeviceSessionState` and leaving it a revision behind is the account-switch race in the other direction.

## The four load-bearing properties

Device-scoped last-writer-wins, token-before-notify with revert-on-failed-mint, the `'request'` vs `'push'` credential-destruction gate, and identity-mode pinning were all extended to contexts rather than re-derived, and each was mutation-proved.

**A 10-mutation harness, anchor-verified, diffed after each edit, restored from a pristine copy — never `git checkout`, which would have taken other work with it. Baseline and restored runs both green.**

First pass left **two survivors**, and both were the same fault — fixtures too tidy:

1. `>=` vs `>` on "did this move" survived **because the fixture had stubbed `BroadcastChannel` away**, which made "an idempotent activation wakes nobody" unobservable. Replaced with a recording fake.
2. "Resolve a context by `accountId` as a fallback" survived until a fixture existed where `activeContextId` carries an account id reachable through **two** principals — the one shape where strict (return null) and loose (guess a human) disagree.

Second pass: all 10 killed.

## Two smaller things

`projectSwitchableAccounts` is **parameterized, not excused** — it takes `pinnedAccountId` and resolves through the same `boundAccountIdOf` as `projectSessionState`. It previously read `state?.activeAccountId` directly, correct only because identity mode never builds the dialog controller: a structural coupling, not a guarantee. `isCurrent` and the freshest-`activeUser` preference both follow the pin now. Mutation killed.

`operatedByUserId` had **zero client-side readers** (grep-confirmed on main, outside the schema and its own contract test) — the client could not tell "signed in as org X" from "human H operating org X". It is now on `ClientSession` and on `SwitchableAccount` device rows. It remains the poorer answer, and the commit says so: the flat lane still cannot represent two routes to one account.

## Verification

- **core 114 suites / 1596 tests → 116 / 1622**, green. Baseline reproduced *before* the first edit; final run reproduced independently by me from a separate checkout using the exact `core-test` job command.
- `tsc --noEmit` clean. Rebuilt `dist`: **zero `\p{`** (Hermes), the only `require(` in `dist/esm` is the pre-existing guarded one in `crypto/polyfill.js`, no react/react-native/expo imports.

## Not done, and deliberately

**`signout {contextId}` / `{principalId}` from #946 are not wired.** The brief named only the activation path, so I did not widen scope — but it is a real gap: `signOut({accountId})` still means "that account however reached, plus the operator cascade", which on a multi-principal device can remove another principal's independently-held route to the same account. It is also a third response shape (`{data: {directory, state, activeToken}}`). Tracked for Phase 3b/7; it must land before any UI exposes per-person removal.

## Not verified

- No integration test against a live server — all unit-level against a mocked `makeRequest`, with endpoint behaviour read from `gh pr diff 946`.
- No typed client errors for the 403-heal / 404 / 400 activation cases.
- `createSessionClient.ts` untouched: it still cannot pass `onUnauthenticated`/`getPinnedAccountId` and has zero callers in this monorepo.
- The extra directory GET per applied state was not measured against the server's per-device rate budget.
- Pre-existing: `SessionClient.rest.test.ts` leaves a real `BroadcastChannel` open, so a narrow jest selection hangs after reporting. The full package run force-exits and is fine.

Refs #937