### PR TITLE
feat(api): a third party gets a session of its own, and nothing of the device

### DIFF
--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -88,3 +88,5 @@ The code→token exchange (`POST /auth/oauth/token`, RFC 6749 §4.1.3) happens o
 - [oxy-auth-platform.md](../architecture/oxy-auth-platform.md) — master plan and decisions
 - [integration-guide.md](./integration-guide.md) — third-party "Sign in with Oxy" (OAuth + PKCE)
 - [device-session.md](./device-session.md) — `DeviceSession` API, socket sync, multi-account
+- [principals-and-account-contexts.md](./principals-and-account-contexts.md) — the vocabulary: identity, principal, account, device session, context
+- [tokens-and-credentials.md](./tokens-and-credentials.md) — access token v2 claims, resource-server validation, third-party isolation, the v1 window

--- a/docs/auth/principals-and-account-contexts.md
+++ b/docs/auth/principals-and-account-contexts.md
@@ -7,6 +7,9 @@ wrong — these names are the ones `@oxyhq/contracts` ships.
 Design rationale: [ADR 0001](../adr/0001-multi-principal-device-model.md) and
 [ADR 0002](../adr/0002-global-account-context.md).
 
+What a token says about a principal and an account, and what the resource server
+checks: [tokens-and-credentials.md](./tokens-and-credentials.md).
+
 ## The five nouns
 
 ### Identity

--- a/docs/auth/tokens-and-credentials.md
+++ b/docs/auth/tokens-and-credentials.md
@@ -1,0 +1,199 @@
+# Tokens and credentials
+
+What an Oxy access token says, what the resource server checks before believing
+it, and why a third-party OAuth client cannot reach the device.
+
+Vocabulary: [principals-and-account-contexts.md](./principals-and-account-contexts.md).
+Transport: [device-session.md](./device-session.md).
+Design rationale: [ADR 0001](../adr/0001-multi-principal-device-model.md),
+[ADR 0002](../adr/0002-global-account-context.md).
+
+Owner: `packages/api/src/utils/sessionUtils.ts`. Everything below is minted and
+checked there; `session.service.ts` supplies the row it is checked against.
+
+## Access token v2
+
+```jsonc
+{
+  "ver": 2,
+  "iss": "oxy-auth",
+  "sub": "account-being-acted-as",
+  "act": { "sub": "the-human-acting" },
+  "aud": ["oxy-api"],
+  "azp": "oxy_dk_…",              // present only on an application's own session
+  "scope": "profile:read",         // ditto
+  "sid": "session-uuid",
+  "device_session_id": "…",        // present once the device has registered it
+  "device_context_id": "…",
+  "jti": "unique-per-mint",
+  "iat": 0,
+  "exp": 0,
+
+  // v1 claims, retained — see "The v1 window" below
+  "userId": "account-being-acted-as",
+  "sessionId": "session-uuid",
+  "deviceId": "…",
+  "type": "access"
+}
+```
+
+Lifetime is 15 minutes (`ACCESS_TOKEN_TTL_SECONDS`); the refresh half lives 7
+days.
+
+### `iss` and `aud` are `oxy-auth` / `oxy-api`, not URLs
+
+Issue #937 sketches `https://auth.oxy.so`. The service-token mint has used
+`oxy-auth` / `oxy-api` since it existed, and `@oxyhq/core`'s SDK verifies
+service tokens against exactly those by default — so the access token joins the
+vocabulary that is already there rather than introducing a second spelling of
+one issuer with nothing able to tell them apart.
+
+`aud` is a constant today because there is one resource server. When a second
+appears it becomes per-session state (a column), not a second constant.
+
+### `sub` and `act.sub` are never the same fact
+
+`sub` is the account the token acts **as**; `act.sub` is the human acting. On an
+ordinary first-party session they hold the same value; on a delegated session —
+Nate acting as The Oxy Collective — they do not, and the audit actor, the
+revocation path and the `account:act_as` re-check all key off `act.sub`.
+Collapsing them would make an organization authorise itself.
+
+### `azp` and `scope` are absent on a shared device session
+
+A shared device session belongs to no single application — every official Oxy
+app on the device uses it — so naming one of them as the authorized party would
+be false for the others. `azp` appears exactly when the session is one
+application's and nothing else can reach it, which today means an untrusted
+OAuth client. Per-application sessions for official apps are the BFF end state,
+not this phase.
+
+### Every mint is unique
+
+`jti` is a fresh UUID per mint. Before it, the payload was
+`{userId, sessionId, deviceId, type}` with no nonce and `iat`/`exp` carry
+one-second resolution, so a same-second re-mint produced a **byte-identical**
+token — which meant a refresh rotation that fast left
+`previous_refresh_token === refresh_token` and did not invalidate the token it
+had just been handed. (`sessions.access_token` and `refresh_token` are also
+UNIQUE, so the collision could fail a concurrent mint outright.)
+
+The refresh half carries `jti` and nothing else from the binding: it is
+presented to one endpoint, which reads the whole binding off the row, so a copy
+on the token could only ever drift from it.
+
+## The row is the authority
+
+The claims are derived from `sessions` and never the reverse:
+
+| Column | Claim |
+|---|---|
+| `user_id` | `sub` |
+| `operated_by_user_id ?? user_id` | `act.sub` |
+| `session_id` | `sid` |
+| `application_id` | — (row state; the device lane reads it) |
+| `client_id` | `azp` |
+| `scopes` | `scope` |
+| `device_session_id` | `device_session_id` |
+| `device_context_id` | `device_context_id` |
+
+`checkAccessTokenBinding` compares every claim back against the row on each
+request, after the signature and expiry have already been proven. A mismatch is
+not a difference of opinion — it is a token that no longer describes its
+session, and it is refused. The failure reasons are a closed set
+(`issuer_mismatch`, `audience_mismatch`, `session_mismatch`, `subject_mismatch`,
+`actor_mismatch`, `client_mismatch`, `device_session_mismatch`,
+`device_context_mismatch`, `scope_not_granted`, `wrong_token_type`,
+`legacy_window_closed`).
+
+Scopes are checked as a **subset**: the row is a ceiling. A token asking for
+more than its session was granted is refused, not trimmed.
+
+`validateSession` returns the resolved identity as `req.oxyToken`
+(`AuthRequest`). That, not the raw claims, is what a route may act on —
+`req.user` answers *who*, `req.oxyToken` answers *as whom, through what, with
+which scopes*. Only the blocking `authMiddleware` lane populates it.
+
+### What a switch does NOT do
+
+Activating a different context does not revoke the previous context's token.
+That is deliberate and matches the pinned-mint behaviour a `sessionMode:
+'identity'` client depends on: a token for a non-active account stays valid
+**for its own context**. What it can never do is pass as the active one — the
+`device_context_id` claim names the context it was minted for, and it is checked
+against the row.
+
+## Third-party isolation
+
+A third-party OAuth exchange yields an **isolated** session. Three consequences
+of one decision, and they only hold together:
+
+1. **Bound to the application.** `application_id`, `client_id` and `scopes` are
+   written to the row, so `azp`/`scope` are real claims and the device lane can
+   recognise the bearer. Binding also narrows reuse: a bound mint may only reuse
+   a session already bound to the *same* application.
+2. **Off the shared device.** It does not inherit the authorization code's
+   `deviceId`. A stable per-`(user, client)` device key keeps the client reusing
+   its own session across exchanges without ever landing where the reuse lookup
+   would find the device's first-party session.
+3. **No device credential.** It is not registered into the device's account set
+   and the token response carries no `deviceId` and no `deviceSecret`. That
+   secret is the device-wide restore credential: handing it to a third party
+   would let one leaked token mint bearers for every account on the device.
+
+Everything under `/session/device/*` that requires a bearer then refuses a
+third-party token with `403 third_party_device_access_denied` — the directory,
+`activate`, `add`, `switch`, `signout`, `state`, and the background-credential
+mint.
+
+The trust decision is the **registry's**, re-read per request rather than frozen
+into the token (`isTrustedApplication`, plus `status === 'active'`). Flipping an
+application out of official status locks it out immediately, and a missing
+application row fails closed. `application_id` is NULL on every shared device
+session, so the ordinary path does no lookup at all.
+
+A **trusted** application is an official Oxy app joining the shared device
+session and keeps all of the above unchanged.
+
+## The v1 window
+
+**A token is v2 if and only if it carries `ver: 2`.** Anything else is v1. The
+discriminator is deliberately not `jti` — every mint now carries one, and `jti`
+says a token is not replayable, not that the binding claims were minted and are
+enforceable.
+
+A v1 token asserted none of the binding, so it resolves to the **row's** own
+binding. That is what keeps the third-party device guard working for a legacy
+bearer: the guard reads `sessions.application_id`, which the token never
+claimed either way.
+
+**How the window closes.** Every mint after this change is v2, and every path
+that hands out a token re-mints when the stored one does not match its row
+(`getAccessToken`) or rotates (`refreshTokens`). An access token lives 15
+minutes and a refresh token 7 days, so the last possible v1 token expires one
+refresh-token lifetime after deploy with nobody doing anything.
+
+`ACCESS_TOKEN_V1_WINDOW=closed` then makes that enforceable rather than merely
+true: every remaining v1 bearer is refused, and from that point the v2
+guarantees hold for *every* authenticated request rather than for every request
+that happens to carry a new enough token. Set it after the window has elapsed.
+
+### What the migration could not backfill
+
+No existing row records which application obtained it. The OAuth exchange left
+only a cosmetic `device_name` of `'<App> OAuth'`, and a string a later session
+reuse can rewrite is not something to make an authorization decision from — so
+every pre-existing session is `application_id IS NULL` and the device lane
+treats it as first-party. The bound is the same one above: a third-party client
+must re-exchange to get a v2 token, and that exchange lands on the isolated
+path.
+
+## Not in this phase
+
+- **Per-route scope enforcement.** Scopes are *validated* (claim ⊆ row) and
+  exposed on `req.oxyToken.scopes`; no route yet declares a required scope.
+  That is per-route policy work, not token work.
+- **Per-application sessions for official apps.** They share the device session,
+  which is why their tokens carry no `azp`. The BFF/session-gateway direction in
+  issue #937 is where that changes.
+- **`aud` as per-session state.** One resource server, one constant.

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -42,6 +42,13 @@ DATABASE_URL=postgres://oxy:oxy@127.0.0.1:5432/oxy_dev
 ACCESS_TOKEN_SECRET=
 REFRESH_TOKEN_SECRET=
 
+# [OPTIONAL] Access token v2 migration window (issue #937, Phase 6).
+# A token is v2 iff it carries `ver: 2`. Set to `closed` to refuse every
+# remaining v1 bearer — safe once 7 days (one refresh-token lifetime) have
+# passed since the deploy that introduced v2, since no v1 token can be live by
+# then. Unset = window open.
+# ACCESS_TOKEN_V1_WINDOW=closed
+
 # [REQUIRED in production] Scopes the derived deviceId hash (see deviceUtils.ts).
 # Without it, two users behind the same NAT on the same browser can collide on
 # the same deviceId. Generate with: openssl rand -base64 48

--- a/packages/api/drizzle/0029_session_token_binding.sql
+++ b/packages/api/drizzle/0029_session_token_binding.sql
@@ -1,0 +1,80 @@
+-- oxy:deploy-phase=pre
+--
+-- PRE: five nullable-or-defaulted columns and three foreign keys on `sessions`.
+-- Nothing is dropped, renamed or narrowed, no existing statement changes shape,
+-- and no value is written — so the image still serving goes on reading and
+-- writing `sessions` exactly as it does today while this lands.
+--
+-- ISSUE #937, PHASE 6. An access token stops being a bare `{userId, sessionId,
+-- deviceId}` and starts saying WHO it acts as, WHO is acting, THROUGH which
+-- application and device context, and WITH which scopes — and every one of
+-- those claims is checked back against the row on each request. The claims are
+-- derived from these columns and never the reverse, which is what lets a
+-- re-mint of a live session reproduce the same token and lets a claim that
+-- disagrees with the row be recognised as a token that no longer describes its
+-- session.
+--
+-- WHY THE BINDING IS A COLUMN AND NOT A CLAIM WE SIMPLY TRUST. A token is
+-- signed by us, so its claims are authentic — but authenticity is not currency:
+-- a token minted for an application says nothing about whether that grant still
+-- stands, and the whole point of the isolation below is that the answer can
+-- change without the token changing. The row is the authority; the token is a
+-- copy with an expiry.
+--
+-- WHAT NULL MEANS, PER COLUMN, BECAUSE ALL FIVE ARE NULLABLE AND NONE MEANS
+-- "missing data":
+--
+--   application_id / client_id / scopes
+--     NULL is the ordinary SHARED device session — the one every official Oxy
+--     app on a device uses. It belongs to no single application, so its token
+--     carries no `azp`: naming one of those apps would be false for the others.
+--     A value means the session is exactly one application's and nothing else
+--     may reach it, which today is an untrusted OAuth client's exchange.
+--     `scopes` defaults to the empty array rather than NULL because "granted
+--     nothing" and "not an application's session" are different facts and only
+--     the first is a scope set.
+--
+--   device_session_id / device_context_id
+--     NULL is a session whose device has not registered it yet. The device
+--     login lane creates the context AFTER the session exists, so there is a
+--     real interval where the ids are unknowable; the token picks them up on
+--     its next mint.
+--
+-- THE TWO OPPOSITE DELETE RULES, both deliberate:
+--
+--   application_id  ON DELETE CASCADE. NOT `SET NULL`, for the same reason
+--     `operated_by_user_id` is not: NULL here means "not an application's
+--     session", so `SET NULL` would silently PROMOTE a third-party session into
+--     a first-party one the moment its application row went away — laundering
+--     exactly the isolation the column exists to enforce. Deleting the
+--     application must kill its sessions.
+--
+--   device_session_id / device_context_id  ON DELETE SET NULL. Losing the
+--     device context must not delete a live session; it must only stop the
+--     token claiming a context that no longer exists. The next mint then omits
+--     the claim, and the binding check agrees with it.
+--
+-- NO BACKFILL, AND THAT IS THE HONEST STATE. Nothing in an existing row records
+-- which application obtained it: the OAuth exchange left only a cosmetic
+-- `device_name` of `'<App> OAuth'`, and a string that a later session reuse can
+-- rewrite is not something to make an authorization decision from. So every
+-- pre-existing session is `application_id IS NULL` and is treated as
+-- first-party by the device lane. The bound is the token lifetime, not this
+-- migration: every mint after deploy is v2, an access token lives 15 minutes
+-- and a refresh token 7 days, and the sessions that matter here are third-party
+-- OAuth sessions whose clients must re-exchange to get a v2 token — at which
+-- point they land on the isolated path and become bound.
+--
+-- NO INDEX. `application_id` is read in exactly one query, the session-reuse
+-- lookup, which already leads with `(user_id, device_id)` and resolves to a
+-- handful of rows before this predicate is applied. An index here would serve
+-- nothing and cost every session write.
+--
+ALTER TABLE "sessions" ADD COLUMN "application_id" text;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "client_id" text;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "scopes" text[] DEFAULT '{}'::text[] NOT NULL;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "device_session_id" text;--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "device_context_id" text;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_application_id_applications_id_fk" FOREIGN KEY ("application_id") REFERENCES "public"."applications"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_device_session_id_device_sessions_id_fk" FOREIGN KEY ("device_session_id") REFERENCES "public"."device_sessions"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_device_context_id_device_account_contexts_id_fk" FOREIGN KEY ("device_context_id") REFERENCES "public"."device_account_contexts"("id") ON DELETE set null ON UPDATE no action;

--- a/packages/api/drizzle/meta/0029_snapshot.json
+++ b/packages/api/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,18066 @@
+{
+  "id": "18b5629a-415e-4e67-b4a1-a1c2e40f8d23",
+  "prevId": "ed1b1f43-2d3f-41b4-86ad-d8ff9b17ef3b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_credentials": {
+      "name": "account_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'service'"
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_credential_id": {
+          "name": "rotated_from_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "account_credentials_account_id_status_idx": {
+          "name": "account_credentials_account_id_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_credentials_account_id_users_id_fk": {
+          "name": "account_credentials_account_id_users_id_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_credentials_created_by_user_id_users_id_fk": {
+          "name": "account_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "account_credentials_rotated_from_fk": {
+          "name": "account_credentials_rotated_from_fk",
+          "tableFrom": "account_credentials",
+          "tableTo": "account_credentials",
+          "columnsFrom": [
+            "rotated_from_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_credentials_public_key_key": {
+          "name": "account_credentials_public_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_credentials_type_check": {
+          "name": "account_credentials_type_check",
+          "value": "\"account_credentials\".\"type\" in ('service')"
+        },
+        "account_credentials_environment_check": {
+          "name": "account_credentials_environment_check",
+          "value": "\"account_credentials\".\"environment\" in ('development', 'staging', 'production')"
+        },
+        "account_credentials_status_check": {
+          "name": "account_credentials_status_check",
+          "value": "\"account_credentials\".\"status\" in ('active', 'deprecated', 'revoked')"
+        },
+        "account_credentials_scopes_check": {
+          "name": "account_credentials_scopes_check",
+          "value": "\"account_credentials\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register', 'chains:write', 'chains:read']::text[]"
+        },
+        "account_credentials_rotated_from_not_self_check": {
+          "name": "account_credentials_rotated_from_not_self_check",
+          "value": "\"account_credentials\".\"rotated_from_credential_id\" <> \"account_credentials\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.account_members": {
+      "name": "account_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_user_id": {
+          "name": "member_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission_grants": {
+          "name": "permission_grants",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "permission_revokes": {
+          "name": "permission_revokes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "inherit": {
+          "name": "inherit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "account_members_member_user_id_status_idx": {
+          "name": "account_members_member_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "member_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_members_account_id_users_id_fk": {
+          "name": "account_members_account_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_members_member_user_id_users_id_fk": {
+          "name": "account_members_member_user_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_members_invited_by_user_id_users_id_fk": {
+          "name": "account_members_invited_by_user_id_users_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_members_account_id_member_user_id_key": {
+          "name": "account_members_account_id_member_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_id",
+            "member_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "account_members_role_check": {
+          "name": "account_members_role_check",
+          "value": "\"account_members\".\"role\" in ('owner', 'admin', 'editor', 'developer', 'billing', 'viewer')"
+        },
+        "account_members_status_check": {
+          "name": "account_members_status_check",
+          "value": "\"account_members\".\"status\" in ('active', 'invited', 'removed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.api_key_usage_events": {
+      "name": "api_key_usage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "response_time": {
+          "name": "response_time",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'api_key'"
+        },
+        "service_app": {
+          "name": "service_app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "api_key_usage_events_application_id_created_at_idx": {
+          "name": "api_key_usage_events_application_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_user_id_created_at_idx": {
+          "name": "api_key_usage_events_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_api_key_id_created_at_idx": {
+          "name": "api_key_usage_events_api_key_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_key_usage_events_created_at_idx": {
+          "name": "api_key_usage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_key_usage_events_api_key_id_developer_api_keys_id_fk": {
+          "name": "api_key_usage_events_api_key_id_developer_api_keys_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "developer_api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_usage_events_user_id_users_id_fk": {
+          "name": "api_key_usage_events_user_id_users_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_key_usage_events_application_id_applications_id_fk": {
+          "name": "api_key_usage_events_application_id_applications_id_fk",
+          "tableFrom": "api_key_usage_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "api_key_usage_events_method_check": {
+          "name": "api_key_usage_events_method_check",
+          "value": "\"api_key_usage_events\".\"method\" in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')"
+        },
+        "api_key_usage_events_auth_type_check": {
+          "name": "api_key_usage_events_auth_type_check",
+          "value": "\"api_key_usage_events\".\"auth_type\" in ('api_key', 'session', 'internal')"
+        },
+        "api_key_usage_events_status_code_check": {
+          "name": "api_key_usage_events_status_code_check",
+          "value": "\"api_key_usage_events\".\"status_code\" >= 100 and \"api_key_usage_events\".\"status_code\" < 600"
+        },
+        "api_key_usage_events_consumption_check": {
+          "name": "api_key_usage_events_consumption_check",
+          "value": "\"api_key_usage_events\".\"tokens_used\" >= 0 and \"api_key_usage_events\".\"credits_used\" >= 0\n        and (\"api_key_usage_events\".\"response_time\" is null or \"api_key_usage_events\".\"response_time\" >= 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_affinity_edges": {
+      "name": "app_affinity_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affinity": {
+          "name": "affinity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_event_at": {
+          "name": "last_event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_affinity_edges_application_id_from_user_id_affinity_idx": {
+          "name": "app_affinity_edges_application_id_from_user_id_affinity_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affinity",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_affinity_edges_application_id_to_user_id_idx": {
+          "name": "app_affinity_edges_application_id_to_user_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_affinity_edges_application_id_applications_id_fk": {
+          "name": "app_affinity_edges_application_id_applications_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_affinity_edges_from_user_id_users_id_fk": {
+          "name": "app_affinity_edges_from_user_id_users_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_affinity_edges_to_user_id_users_id_fk": {
+          "name": "app_affinity_edges_to_user_id_users_id_fk",
+          "tableFrom": "app_affinity_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_affinity_edges_directed_edge_key": {
+          "name": "app_affinity_edges_directed_edge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "from_user_id",
+            "to_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_affinity_edges_not_self_check": {
+          "name": "app_affinity_edges_not_self_check",
+          "value": "\"app_affinity_edges\".\"from_user_id\" <> \"app_affinity_edges\".\"to_user_id\""
+        },
+        "app_affinity_edges_affinity_check": {
+          "name": "app_affinity_edges_affinity_check",
+          "value": "\"app_affinity_edges\".\"affinity\" >= 0 and \"app_affinity_edges\".\"event_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_affinity_seen_events": {
+      "name": "app_affinity_seen_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_affinity_seen_events_created_at_idx": {
+          "name": "app_affinity_seen_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_affinity_seen_events_application_id_applications_id_fk": {
+          "name": "app_affinity_seen_events_application_id_applications_id_fk",
+          "tableFrom": "app_affinity_seen_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_affinity_seen_events_application_id_event_id_key": {
+          "name": "app_affinity_seen_events_application_id_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_categories": {
+      "name": "app_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_categories_order_idx": {
+          "name": "app_categories_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_categories_slug_unique": {
+          "name": "app_categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_endorsement_edges": {
+      "name": "app_endorsement_edges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_endorsement_edges_application_id_member_id_idx": {
+          "name": "app_endorsement_edges_application_id_member_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_endorsement_edges_application_id_applications_id_fk": {
+          "name": "app_endorsement_edges_application_id_applications_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_endorsement_edges_owner_id_users_id_fk": {
+          "name": "app_endorsement_edges_owner_id_users_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_endorsement_edges_member_id_users_id_fk": {
+          "name": "app_endorsement_edges_member_id_users_id_fk",
+          "tableFrom": "app_endorsement_edges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_endorsement_edges_idempotency_key": {
+          "name": "app_endorsement_edges_idempotency_key",
+          "nullsNotDistinct": true,
+          "columns": [
+            "application_id",
+            "owner_id",
+            "member_id",
+            "source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_endorsement_edges_not_self_check": {
+          "name": "app_endorsement_edges_not_self_check",
+          "value": "\"app_endorsement_edges\".\"owner_id\" <> \"app_endorsement_edges\".\"member_id\""
+        },
+        "app_endorsement_edges_source_id_check": {
+          "name": "app_endorsement_edges_source_id_check",
+          "value": "\"app_endorsement_edges\".\"source_id\" <> ''"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_grants": {
+      "name": "app_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "first_granted_at": {
+          "name": "first_granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_grants_application_id_idx": {
+          "name": "app_grants_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_grants_user_id_users_id_fk": {
+          "name": "app_grants_user_id_users_id_fk",
+          "tableFrom": "app_grants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_grants_application_id_applications_id_fk": {
+          "name": "app_grants_application_id_applications_id_fk",
+          "tableFrom": "app_grants",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_grants_user_id_application_id_key": {
+          "name": "app_grants_user_id_application_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_listing_screenshots": {
+      "name": "app_listing_screenshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "listing_id": {
+          "name": "listing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'desktop'"
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_listing_screenshots_listing_id_position_idx": {
+          "name": "app_listing_screenshots_listing_id_position_idx",
+          "columns": [
+            {
+              "expression": "listing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_listing_screenshots_file_id_idx": {
+          "name": "app_listing_screenshots_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_listing_screenshots_listing_id_app_listings_id_fk": {
+          "name": "app_listing_screenshots_listing_id_app_listings_id_fk",
+          "tableFrom": "app_listing_screenshots",
+          "tableTo": "app_listings",
+          "columnsFrom": [
+            "listing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_listing_screenshots_file_id_files_id_fk": {
+          "name": "app_listing_screenshots_file_id_files_id_fk",
+          "tableFrom": "app_listing_screenshots",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_listings": {
+      "name": "app_listings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_url": {
+          "name": "support_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "support_email": {
+          "name": "support_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_listings_category_id_idx": {
+          "name": "app_listings_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_listings_status_published_at_idx": {
+          "name": "app_listings_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_listings_application_id_applications_id_fk": {
+          "name": "app_listings_application_id_applications_id_fk",
+          "tableFrom": "app_listings",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_listings_category_id_app_categories_id_fk": {
+          "name": "app_listings_category_id_app_categories_id_fk",
+          "tableFrom": "app_listings",
+          "tableTo": "app_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_listings_slug_unique": {
+          "name": "app_listings_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "app_listings_application_id_key": {
+          "name": "app_listings_application_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_review_replies": {
+      "name": "app_review_replies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "review_id": {
+          "name": "review_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "app_review_replies_review_id_app_reviews_id_fk": {
+          "name": "app_review_replies_review_id_app_reviews_id_fk",
+          "tableFrom": "app_review_replies",
+          "tableTo": "app_reviews",
+          "columnsFrom": [
+            "review_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_review_replies_author_user_id_users_id_fk": {
+          "name": "app_review_replies_author_user_id_users_id_fk",
+          "tableFrom": "app_review_replies",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_review_replies_review_id_key": {
+          "name": "app_review_replies_review_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "review_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_reviews": {
+      "name": "app_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'visible'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_reviews_application_id_status_created_at_idx": {
+          "name": "app_reviews_application_id_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_reviews_user_id_idx": {
+          "name": "app_reviews_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_reviews_application_id_applications_id_fk": {
+          "name": "app_reviews_application_id_applications_id_fk",
+          "tableFrom": "app_reviews",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_reviews_user_id_users_id_fk": {
+          "name": "app_reviews_user_id_users_id_fk",
+          "tableFrom": "app_reviews",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_reviews_application_id_user_id_key": {
+          "name": "app_reviews_application_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_reviews_rating_range": {
+          "name": "app_reviews_rating_range",
+          "value": "\"app_reviews\".\"rating\" between 1 and 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_update_assets": {
+      "name": "app_update_assets",
+      "schema": "",
+      "columns": {
+        "app_update_id": {
+          "name": "app_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_extension": {
+          "name": "file_extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "app_update_assets_sha256_idx": {
+          "name": "app_update_assets_sha256_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_update_assets_app_update_id_app_updates_id_fk": {
+          "name": "app_update_assets_app_update_id_app_updates_id_fk",
+          "tableFrom": "app_update_assets",
+          "tableTo": "app_updates",
+          "columnsFrom": [
+            "app_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_update_assets_sha256_update_assets_sha256_fk": {
+          "name": "app_update_assets_sha256_update_assets_sha256_fk",
+          "tableFrom": "app_update_assets",
+          "tableTo": "update_assets",
+          "columnsFrom": [
+            "sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "app_update_assets_pkey": {
+          "name": "app_update_assets_pkey",
+          "columns": [
+            "app_update_id",
+            "ordinal"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "app_update_assets_ordinal_check": {
+          "name": "app_update_assets_ordinal_check",
+          "value": "\"app_update_assets\".\"ordinal\" >= 0"
+        },
+        "app_update_assets_sha256_check": {
+          "name": "app_update_assets_sha256_check",
+          "value": "\"app_update_assets\".\"sha256\" ~ '^[a-f0-9]{64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_updates": {
+      "name": "app_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "update_id": {
+          "name": "update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "launch_asset_sha256": {
+          "name": "launch_asset_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_key": {
+          "name": "launch_asset_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_content_type": {
+          "name": "launch_asset_content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "launch_asset_file_extension": {
+          "name": "launch_asset_file_extension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extra": {
+          "name": "extra",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rollout_percent": {
+          "name": "rollout_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "git_commit": {
+          "name": "git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_branch": {
+          "name": "git_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promoted_from_update_id": {
+          "name": "promoted_from_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_updates_head_idx": {
+          "name": "app_updates_head_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_updates_channel_id_idx": {
+          "name": "app_updates_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_updates_application_id_applications_id_fk": {
+          "name": "app_updates_application_id_applications_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_updates_channel_id_update_channels_id_fk": {
+          "name": "app_updates_channel_id_update_channels_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "update_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_updates_launch_asset_sha256_update_assets_sha256_fk": {
+          "name": "app_updates_launch_asset_sha256_update_assets_sha256_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "update_assets",
+          "columnsFrom": [
+            "launch_asset_sha256"
+          ],
+          "columnsTo": [
+            "sha256"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "app_updates_promoted_from_update_id_app_updates_update_id_fk": {
+          "name": "app_updates_promoted_from_update_id_app_updates_update_id_fk",
+          "tableFrom": "app_updates",
+          "tableTo": "app_updates",
+          "columnsFrom": [
+            "promoted_from_update_id"
+          ],
+          "columnsTo": [
+            "update_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_updates_update_id_key": {
+          "name": "app_updates_update_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "update_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_updates_platform_check": {
+          "name": "app_updates_platform_check",
+          "value": "\"app_updates\".\"platform\" in ('ios', 'android')"
+        },
+        "app_updates_status_check": {
+          "name": "app_updates_status_check",
+          "value": "\"app_updates\".\"status\" in ('published', 'superseded', 'rolled_back')"
+        },
+        "app_updates_update_id_check": {
+          "name": "app_updates_update_id_check",
+          "value": "\"app_updates\".\"update_id\" ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'"
+        },
+        "app_updates_launch_asset_sha256_check": {
+          "name": "app_updates_launch_asset_sha256_check",
+          "value": "\"app_updates\".\"launch_asset_sha256\" ~ '^[a-f0-9]{64}$'"
+        },
+        "app_updates_rollout_percent_check": {
+          "name": "app_updates_rollout_percent_check",
+          "value": "\"app_updates\".\"rollout_percent\" >= 0 and \"app_updates\".\"rollout_percent\" <= 100"
+        },
+        "app_updates_extra_expo_client_check": {
+          "name": "app_updates_extra_expo_client_check",
+          "value": "jsonb_typeof(\"app_updates\".\"extra\" -> 'expoClient') is not distinct from 'object'"
+        },
+        "app_updates_metadata_check": {
+          "name": "app_updates_metadata_check",
+          "value": "jsonb_typeof(\"app_updates\".\"metadata\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.app_user_signals": {
+      "name": "app_user_signals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endorsement_score": {
+          "name": "endorsement_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "interest_score": {
+          "name": "interest_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_endorsed_at": {
+          "name": "last_endorsed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "app_user_signals_application_id_endorsement_score_idx": {
+          "name": "app_user_signals_application_id_endorsement_score_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endorsement_score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_user_signals_user_id_idx": {
+          "name": "app_user_signals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_user_signals_application_id_applications_id_fk": {
+          "name": "app_user_signals_application_id_applications_id_fk",
+          "tableFrom": "app_user_signals",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "app_user_signals_user_id_users_id_fk": {
+          "name": "app_user_signals_user_id_users_id_fk",
+          "tableFrom": "app_user_signals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_user_signals_application_id_user_id_key": {
+          "name": "app_user_signals_application_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "app_user_signals_interest_score_check": {
+          "name": "app_user_signals_interest_score_check",
+          "value": "\"app_user_signals\".\"interest_score\" >= 0 and \"app_user_signals\".\"interest_score\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_credentials": {
+      "name": "application_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_credential_id": {
+          "name": "rotated_from_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "application_credentials_application_id_status_idx": {
+          "name": "application_credentials_application_id_status_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_credentials_application_id_applications_id_fk": {
+          "name": "application_credentials_application_id_applications_id_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_credentials_created_by_user_id_users_id_fk": {
+          "name": "application_credentials_created_by_user_id_users_id_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "application_credentials_rotated_from_fk": {
+          "name": "application_credentials_rotated_from_fk",
+          "tableFrom": "application_credentials",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "rotated_from_credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_credentials_public_key_key": {
+          "name": "application_credentials_public_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "application_credentials_type_check": {
+          "name": "application_credentials_type_check",
+          "value": "\"application_credentials\".\"type\" in ('public', 'confidential', 'service')"
+        },
+        "application_credentials_environment_check": {
+          "name": "application_credentials_environment_check",
+          "value": "\"application_credentials\".\"environment\" in ('development', 'staging', 'production')"
+        },
+        "application_credentials_status_check": {
+          "name": "application_credentials_status_check",
+          "value": "\"application_credentials\".\"status\" in ('active', 'deprecated', 'revoked')"
+        },
+        "application_credentials_scopes_check": {
+          "name": "application_credentials_scopes_check",
+          "value": "\"application_credentials\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register', 'chains:write', 'chains:read']::text[]"
+        },
+        "application_credentials_rotated_from_not_self_check": {
+          "name": "application_credentials_rotated_from_not_self_check",
+          "value": "\"application_credentials\".\"rotated_from_credential_id\" <> \"application_credentials\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_moderation_trust": {
+      "name": "application_moderation_trust",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standing": {
+          "name": "standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sandbox'"
+        },
+        "evidence_integrity": {
+          "name": "evidence_integrity",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "identity_binding_reliability": {
+          "name": "identity_binding_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "decision_overturn_rate": {
+          "name": "decision_overturn_rate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "policy_quality": {
+          "name": "policy_quality",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "global_reputation_effects_allowed": {
+          "name": "global_reputation_effects_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_note": {
+          "name": "review_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "application_moderation_trust_standing_idx": {
+          "name": "application_moderation_trust_standing_idx",
+          "columns": [
+            {
+              "expression": "standing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_moderation_trust_application_id_applications_id_fk": {
+          "name": "application_moderation_trust_application_id_applications_id_fk",
+          "tableFrom": "application_moderation_trust",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_moderation_trust_reviewed_by_user_id_users_id_fk": {
+          "name": "application_moderation_trust_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "application_moderation_trust",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "application_moderation_trust_application_id_key": {
+          "name": "application_moderation_trust_application_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "application_moderation_trust_standing_check": {
+          "name": "application_moderation_trust_standing_check",
+          "value": "\"application_moderation_trust\".\"standing\" in ('sandbox', 'trusted', 'restricted')"
+        },
+        "application_moderation_trust_scores_check": {
+          "name": "application_moderation_trust_scores_check",
+          "value": "\"application_moderation_trust\".\"evidence_integrity\" between 0 and 1\n        and \"application_moderation_trust\".\"identity_binding_reliability\" between 0 and 1\n        and \"application_moderation_trust\".\"decision_overturn_rate\" between 0 and 1\n        and \"application_moderation_trust\".\"policy_quality\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_policy_url": {
+          "name": "privacy_policy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms_url": {
+          "name": "terms_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'third_party'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "is_official": {
+          "name": "is_official",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_internal": {
+          "name": "is_internal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "chain_namespaces": {
+          "name": "chain_namespaces",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dev_webhook_url": {
+          "name": "dev_webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "applications_owner_account_id_created_at_idx": {
+          "name": "applications_owner_account_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "owner_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "applications_capabilities_idx": {
+          "name": "applications_capabilities_idx",
+          "columns": [
+            {
+              "expression": "capabilities",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_owner_account_id_users_id_fk": {
+          "name": "applications_owner_account_id_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_user_id_users_id_fk": {
+          "name": "applications_created_by_user_id_users_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "applications_type_check": {
+          "name": "applications_type_check",
+          "value": "\"applications\".\"type\" in ('first_party', 'third_party', 'internal', 'system')"
+        },
+        "applications_status_check": {
+          "name": "applications_status_check",
+          "value": "\"applications\".\"status\" in ('active', 'suspended', 'deleted', 'pending_review')"
+        },
+        "applications_scopes_check": {
+          "name": "applications_scopes_check",
+          "value": "\"applications\".\"scopes\" <@ array['files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive', 'chat:completions', 'models:read', 'updates:publish', 'federation:write', 'signals:write', 'reputation:write', 'reputation:moderation:apply', 'reputation:binding:register', 'notifications:write', 'payments:read', 'payments:write', 'accounts:provision', 'follows:read', 'follows:write', 'follows:context:write', 'follows:manage', 'follows:events', 'follow-targets:register', 'chains:write', 'chains:read']::text[]"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_challenges": {
+      "name": "auth_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signin'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "auth_challenges_expires_at_idx": {
+          "name": "auth_challenges_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_challenges_challenge_key": {
+          "name": "auth_challenges_challenge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_challenges_purpose_check": {
+          "name": "auth_challenges_purpose_check",
+          "value": "\"auth_challenges\".\"purpose\" in ('signin', 'rotate_key')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_codes": {
+      "name": "auth_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "auth_codes_user_id_idx": {
+          "name": "auth_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_codes_application_id_idx": {
+          "name": "auth_codes_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_codes_expires_at_idx": {
+          "name": "auth_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_codes_user_id_users_id_fk": {
+          "name": "auth_codes_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_operated_by_user_id_users_id_fk": {
+          "name": "auth_codes_operated_by_user_id_users_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_codes_application_id_applications_id_fk": {
+          "name": "auth_codes_application_id_applications_id_fk",
+          "tableFrom": "auth_codes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_codes_code_hash_key": {
+          "name": "auth_codes_code_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_codes_code_challenge_method_check": {
+          "name": "auth_codes_code_challenge_method_check",
+          "value": "\"auth_codes\".\"code_challenge_method\" in ('S256')"
+        },
+        "auth_codes_pkce_pair_check": {
+          "name": "auth_codes_pkce_pair_check",
+          "value": "(\"auth_codes\".\"code_challenge\" is null) = (\"auth_codes\".\"code_challenge_method\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_sessions": {
+      "name": "auth_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorize_code": {
+          "name": "authorize_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bound_origin": {
+          "name": "bound_origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_verified": {
+          "name": "origin_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requester_label": {
+          "name": "requester_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge_nonce": {
+          "name": "challenge_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device_sign_in'"
+        },
+        "oauth_redirect_uri": {
+          "name": "oauth_redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_code_challenge": {
+          "name": "oauth_code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_code_challenge_method": {
+          "name": "oauth_code_challenge_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scopes": {
+          "name": "oauth_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_subject_account_id": {
+          "name": "oauth_subject_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_auth_code_id": {
+          "name": "finalized_auth_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_reason": {
+          "name": "denied_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_by": {
+          "name": "authorized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_user_id": {
+          "name": "authorized_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorized_session_id": {
+          "name": "authorized_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "push_sent_at": {
+          "name": "push_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "auth_sessions_application_id_idx": {
+          "name": "auth_sessions_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_sessions_expires_at_idx": {
+          "name": "auth_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_sessions_application_id_applications_id_fk": {
+          "name": "auth_sessions_application_id_applications_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_sessions_oauth_subject_account_id_users_id_fk": {
+          "name": "auth_sessions_oauth_subject_account_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "oauth_subject_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_sessions_authorized_user_id_users_id_fk": {
+          "name": "auth_sessions_authorized_user_id_users_id_fk",
+          "tableFrom": "auth_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorized_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "auth_sessions_session_token_key": {
+          "name": "auth_sessions_session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        },
+        "auth_sessions_authorize_code_key": {
+          "name": "auth_sessions_authorize_code_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "authorize_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "auth_sessions_status_check": {
+          "name": "auth_sessions_status_check",
+          "value": "\"auth_sessions\".\"status\" in ('pending', 'authorized', 'consumed', 'expired', 'cancelled')"
+        },
+        "auth_sessions_purpose_check": {
+          "name": "auth_sessions_purpose_check",
+          "value": "\"auth_sessions\".\"purpose\" in ('device_sign_in', 'oauth_authorization')"
+        },
+        "auth_sessions_denied_reason_check": {
+          "name": "auth_sessions_denied_reason_check",
+          "value": "\"auth_sessions\".\"denied_reason\" in ('declined', 'not_me')"
+        },
+        "auth_sessions_oauth_code_challenge_method_check": {
+          "name": "auth_sessions_oauth_code_challenge_method_check",
+          "value": "\"auth_sessions\".\"oauth_code_challenge_method\" in ('S256')"
+        },
+        "auth_sessions_oauth_binding_check": {
+          "name": "auth_sessions_oauth_binding_check",
+          "value": "(\"auth_sessions\".\"oauth_redirect_uri\" is null and \"auth_sessions\".\"oauth_code_challenge\" is null and \"auth_sessions\".\"oauth_code_challenge_method\" is null and \"auth_sessions\".\"oauth_scopes\" is null)\n        or (\"auth_sessions\".\"oauth_redirect_uri\" is not null and \"auth_sessions\".\"oauth_code_challenge\" is not null and \"auth_sessions\".\"oauth_code_challenge_method\" is not null and \"auth_sessions\".\"oauth_scopes\" is not null)"
+        },
+        "auth_sessions_oauth_purpose_check": {
+          "name": "auth_sessions_oauth_purpose_check",
+          "value": "(\"auth_sessions\".\"purpose\" = 'oauth_authorization') = (\"auth_sessions\".\"oauth_redirect_uri\" is not null)"
+        },
+        "auth_sessions_oauth_subject_requires_binding_check": {
+          "name": "auth_sessions_oauth_subject_requires_binding_check",
+          "value": "\"auth_sessions\".\"oauth_subject_account_id\" is null or \"auth_sessions\".\"oauth_redirect_uri\" is not null"
+        },
+        "auth_sessions_requester_label_length_check": {
+          "name": "auth_sessions_requester_label_length_check",
+          "value": "\"auth_sessions\".\"requester_label\" is null or char_length(\"auth_sessions\".\"requester_label\") <= 64"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_subscriptions": {
+      "name": "billing_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "plan_name": {
+          "name": "plan_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_credits_per_month": {
+          "name": "plan_credits_per_month",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_price_minor_units": {
+          "name": "plan_price_minor_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_currency": {
+          "name": "plan_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_subscriptions_user_id_status_idx": {
+          "name": "billing_subscriptions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_subscriptions_user_id_users_id_fk": {
+          "name": "billing_subscriptions_user_id_users_id_fk",
+          "tableFrom": "billing_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "billing_subscriptions_stripe_subscription_id_key": {
+          "name": "billing_subscriptions_stripe_subscription_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "billing_subscriptions_status_check": {
+          "name": "billing_subscriptions_status_check",
+          "value": "\"billing_subscriptions\".\"status\" in ('active', 'canceled', 'incomplete', 'incomplete_expired', 'past_due', 'paused', 'trialing', 'unpaid')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.billing_transactions": {
+      "name": "billing_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_period_start": {
+          "name": "stripe_subscription_period_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_minor_units": {
+          "name": "amount_minor_units",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "credits": {
+          "name": "credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "billing_transactions_subscription_period_key": {
+          "name": "billing_transactions_subscription_period_key",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stripe_subscription_period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing_transactions\".\"type\" = 'subscription_payment' and \"billing_transactions\".\"stripe_subscription_id\" is not null and \"billing_transactions\".\"stripe_subscription_period_start\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_transactions_payment_intent_key": {
+          "name": "billing_transactions_payment_intent_key",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"billing_transactions\".\"type\" = 'credit_purchase' and \"billing_transactions\".\"stripe_payment_intent_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "billing_transactions_user_id_created_at_idx": {
+          "name": "billing_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "billing_transactions_user_id_users_id_fk": {
+          "name": "billing_transactions_user_id_users_id_fk",
+          "tableFrom": "billing_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "billing_transactions_type_check": {
+          "name": "billing_transactions_type_check",
+          "value": "\"billing_transactions\".\"type\" in ('credit_purchase', 'subscription_payment', 'refund')"
+        },
+        "billing_transactions_status_check": {
+          "name": "billing_transactions_status_check",
+          "value": "\"billing_transactions\".\"status\" in ('pending', 'completed', 'failed', 'refunded')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_id": {
+          "name": "blocked_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "blocks_blocked_id_idx": {
+          "name": "blocks_blocked_id_idx",
+          "columns": [
+            {
+              "expression": "blocked_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_user_id_users_id_fk": {
+          "name": "blocks_user_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocks_blocked_id_users_id_fk": {
+          "name": "blocks_blocked_id_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blocked_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocks_user_id_blocked_id_key": {
+          "name": "blocks_user_id_blocked_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "blocked_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_id_idx": {
+          "name": "bookmarks_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bundles": {
+      "name": "bundles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'folder-outline'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#5F6368'"
+        },
+        "match_labels": {
+          "name": "match_labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "bundles_user_id_lower_name_key": {
+          "name": "bundles_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bundles_user_id_users_id_fk": {
+          "name": "bundles_user_id_users_id_fk",
+          "tableFrom": "bundles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.civic_nonces": {
+      "name": "civic_nonces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nonce_hash": {
+          "name": "nonce_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "civic_nonces_expires_at_idx": {
+          "name": "civic_nonces_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "civic_nonces_subject_user_id_users_id_fk": {
+          "name": "civic_nonces_subject_user_id_users_id_fk",
+          "tableFrom": "civic_nonces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "civic_nonces_nonce_hash_key": {
+          "name": "civic_nonces_nonce_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nonce_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conduct_strikes": {
+      "name": "conduct_strikes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_points": {
+          "name": "risk_points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "conduct_strikes_user_id_status_idx": {
+          "name": "conduct_strikes_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_user_id_family_created_at_idx": {
+          "name": "conduct_strikes_user_id_family_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "family",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_decision_id_decision_revision_idx": {
+          "name": "conduct_strikes_decision_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conduct_strikes_expires_at_idx": {
+          "name": "conduct_strikes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conduct_strikes\".\"status\" = 'active' and \"conduct_strikes\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conduct_strikes_user_id_users_id_fk": {
+          "name": "conduct_strikes_user_id_users_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_application_id_applications_id_fk": {
+          "name": "conduct_strikes_application_id_applications_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_transaction_id_reputation_transactions_id_fk": {
+          "name": "conduct_strikes_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "conduct_strikes_policy_version_fk": {
+          "name": "conduct_strikes_policy_version_fk",
+          "tableFrom": "conduct_strikes",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_version"
+          ],
+          "columnsTo": [
+            "policy_version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conduct_strikes_incident_id_user_id_effect_type_revision_key": {
+          "name": "conduct_strikes_incident_id_user_id_effect_type_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "incident_id",
+            "user_id",
+            "effect_type",
+            "decision_revision"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conduct_strikes_effect_type_check": {
+          "name": "conduct_strikes_effect_type_check",
+          "value": "\"conduct_strikes\".\"effect_type\" in ('conduct_penalty', 'report_abuse_penalty', 'review_abuse_penalty')"
+        },
+        "conduct_strikes_severity_check": {
+          "name": "conduct_strikes_severity_check",
+          "value": "\"conduct_strikes\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "conduct_strikes_status_check": {
+          "name": "conduct_strikes_status_check",
+          "value": "\"conduct_strikes\".\"status\" in ('active', 'expired', 'reversed')"
+        },
+        "conduct_strikes_decision_revision_check": {
+          "name": "conduct_strikes_decision_revision_check",
+          "value": "\"conduct_strikes\".\"decision_revision\" >= 0"
+        },
+        "conduct_strikes_resolution_complete_check": {
+          "name": "conduct_strikes_resolution_complete_check",
+          "value": "(\"conduct_strikes\".\"status\" = 'active') = (\"conduct_strikes\".\"resolved_at\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_collected": {
+          "name": "auto_collected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_contacted_at": {
+          "name": "last_contacted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(name, '') || ' ' || coalesce(email, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "contacts_user_id_email_key": {
+          "name": "contacts_user_id_email_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_search_vector_idx": {
+          "name": "contacts_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "contacts_starred_idx": {
+          "name": "contacts_starred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"contacts\".\"starred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_user_id_users_id_fk": {
+          "name": "contacts_user_id_users_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.developer_api_keys": {
+      "name": "developer_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"chat:completions\",\"models:read\"}'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "rate_limit_requests_per_minute": {
+          "name": "rate_limit_requests_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_requests_per_day": {
+          "name": "rate_limit_requests_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1000
+        },
+        "rate_limit_tokens_per_minute": {
+          "name": "rate_limit_tokens_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit_tokens_per_day": {
+          "name": "rate_limit_tokens_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "developer_api_keys_user_id_is_active_idx": {
+          "name": "developer_api_keys_user_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "developer_api_keys_application_id_is_active_idx": {
+          "name": "developer_api_keys_application_id_is_active_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "developer_api_keys_user_id_users_id_fk": {
+          "name": "developer_api_keys_user_id_users_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "developer_api_keys_application_id_applications_id_fk": {
+          "name": "developer_api_keys_application_id_applications_id_fk",
+          "tableFrom": "developer_api_keys",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "developer_api_keys_key_hash_key": {
+          "name": "developer_api_keys_key_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "developer_api_keys_scopes_check": {
+          "name": "developer_api_keys_scopes_check",
+          "value": "\"developer_api_keys\".\"scopes\" <@ array['chat:completions', 'models:read', 'files:read', 'files:write', 'files:delete', 'user:read', 'webhooks:receive']::text[]"
+        },
+        "developer_api_keys_rate_limit_check": {
+          "name": "developer_api_keys_rate_limit_check",
+          "value": "(\"developer_api_keys\".\"rate_limit_requests_per_minute\" is null or \"developer_api_keys\".\"rate_limit_requests_per_minute\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_requests_per_day\" is null or \"developer_api_keys\".\"rate_limit_requests_per_day\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_tokens_per_minute\" is null or \"developer_api_keys\".\"rate_limit_tokens_per_minute\" > 0)\n        and (\"developer_api_keys\".\"rate_limit_tokens_per_day\" is null or \"developer_api_keys\".\"rate_limit_tokens_per_day\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_account_contexts": {
+      "name": "device_account_contexts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_session_id": {
+          "name": "device_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_account_contexts_account_id_idx": {
+          "name": "device_account_contexts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_account_contexts_principal_id_idx": {
+          "name": "device_account_contexts_principal_id_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_account_contexts_device_session_id_device_sessions_id_fk": {
+          "name": "device_account_contexts_device_session_id_device_sessions_id_fk",
+          "tableFrom": "device_account_contexts",
+          "tableTo": "device_sessions",
+          "columnsFrom": [
+            "device_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_account_contexts_principal_id_device_principals_id_fk": {
+          "name": "device_account_contexts_principal_id_device_principals_id_fk",
+          "tableFrom": "device_account_contexts",
+          "tableTo": "device_principals",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_account_contexts_account_id_users_id_fk": {
+          "name": "device_account_contexts_account_id_users_id_fk",
+          "tableFrom": "device_account_contexts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_account_contexts_device_principal_account_key": {
+          "name": "device_account_contexts_device_principal_account_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_session_id",
+            "principal_id",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_pairing_sessions": {
+      "name": "device_pairing_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pairing_id": {
+          "name": "pairing_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_device_ephemeral_public_key": {
+          "name": "new_device_ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_device_label": {
+          "name": "new_device_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "old_device_ephemeral_public_key": {
+          "name": "old_device_ephemeral_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "approved_by_user_id": {
+          "name": "approved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "device_pairing_sessions_expires_at_idx": {
+          "name": "device_pairing_sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_pairing_sessions_approved_by_user_id_users_id_fk": {
+          "name": "device_pairing_sessions_approved_by_user_id_users_id_fk",
+          "tableFrom": "device_pairing_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "approved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_pairing_sessions_pairing_id_key": {
+          "name": "device_pairing_sessions_pairing_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pairing_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_pairing_sessions_status_check": {
+          "name": "device_pairing_sessions_status_check",
+          "value": "\"device_pairing_sessions\".\"status\" in ('pending', 'approved', 'denied', 'expired')"
+        },
+        "device_pairing_sessions_sealed_payload_check": {
+          "name": "device_pairing_sessions_sealed_payload_check",
+          "value": "(\"device_pairing_sessions\".\"old_device_ephemeral_public_key\" is null and \"device_pairing_sessions\".\"ciphertext\" is null and \"device_pairing_sessions\".\"nonce\" is null)\n        or (\"device_pairing_sessions\".\"old_device_ephemeral_public_key\" is not null and \"device_pairing_sessions\".\"ciphertext\" is not null and \"device_pairing_sessions\".\"nonce\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_principal_backfill_conflicts": {
+      "name": "device_principal_backfill_conflicts",
+      "schema": "",
+      "columns": {
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conflict": {
+          "name": "conflict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "device_principal_backfill_conflicts_pkey": {
+          "name": "device_principal_backfill_conflicts_pkey",
+          "columns": [
+            "device_id",
+            "conflict",
+            "subject_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "device_principal_backfill_conflicts_conflict_check": {
+          "name": "device_principal_backfill_conflicts_conflict_check",
+          "value": "\"device_principal_backfill_conflicts\".\"conflict\" in ('authuser_collapsed', 'principal_without_personal_context', 'active_account_without_context', 'non_personal_principal', 'duplicate_principal_account', 'orphan_operator')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_principals": {
+      "name": "device_principals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_session_id": {
+          "name": "device_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authuser": {
+          "name": "authuser",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personal_session_id": {
+          "name": "personal_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_authenticated_at": {
+          "name": "last_authenticated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_principals_user_id_idx": {
+          "name": "device_principals_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_principals_device_session_id_device_sessions_id_fk": {
+          "name": "device_principals_device_session_id_device_sessions_id_fk",
+          "tableFrom": "device_principals",
+          "tableTo": "device_sessions",
+          "columnsFrom": [
+            "device_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_principals_user_id_users_id_fk": {
+          "name": "device_principals_user_id_users_id_fk",
+          "tableFrom": "device_principals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_principals_device_session_id_user_id_key": {
+          "name": "device_principals_device_session_id_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_session_id",
+            "user_id"
+          ]
+        },
+        "device_principals_device_session_id_authuser_key": {
+          "name": "device_principals_device_session_id_authuser_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_session_id",
+            "authuser"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_principals_authuser_check": {
+          "name": "device_principals_authuser_check",
+          "value": "\"device_principals\".\"authuser\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_session_accounts": {
+      "name": "device_session_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_session_id": {
+          "name": "device_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authuser": {
+          "name": "authuser",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_session_accounts_account_id_idx": {
+          "name": "device_session_accounts_account_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_session_accounts_operated_by_user_id_idx": {
+          "name": "device_session_accounts_operated_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "operated_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"device_session_accounts\".\"operated_by_user_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_session_accounts_device_session_id_device_sessions_id_fk": {
+          "name": "device_session_accounts_device_session_id_device_sessions_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "device_sessions",
+          "columnsFrom": [
+            "device_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_session_accounts_account_id_users_id_fk": {
+          "name": "device_session_accounts_account_id_users_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_session_accounts_operated_by_user_id_users_id_fk": {
+          "name": "device_session_accounts_operated_by_user_id_users_id_fk",
+          "tableFrom": "device_session_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_session_accounts_device_session_id_account_id_key": {
+          "name": "device_session_accounts_device_session_id_account_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_session_id",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "device_session_accounts_authuser_check": {
+          "name": "device_session_accounts_authuser_check",
+          "value": "\"device_session_accounts\".\"authuser\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device_sessions": {
+      "name": "device_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_account_id": {
+          "name": "active_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_context_id": {
+          "name": "active_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_hash": {
+          "name": "secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_hash": {
+          "name": "prev_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_expires_at": {
+          "name": "prev_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_hash": {
+          "name": "background_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_account_id": {
+          "name": "background_secret_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "background_secret_expires_at": {
+          "name": "background_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_sessions_active_account_id_users_id_fk": {
+          "name": "device_sessions_active_account_id_users_id_fk",
+          "tableFrom": "device_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "active_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "device_sessions_active_context_id_device_account_contexts_id_fk": {
+          "name": "device_sessions_active_context_id_device_account_contexts_id_fk",
+          "tableFrom": "device_sessions",
+          "tableTo": "device_account_contexts",
+          "columnsFrom": [
+            "active_context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "device_sessions_background_secret_account_id_users_id_fk": {
+          "name": "device_sessions_background_secret_account_id_users_id_fk",
+          "tableFrom": "device_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "background_secret_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_sessions_device_id_key": {
+          "name": "device_sessions_device_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_id"
+          ]
+        },
+        "device_sessions_secret_hash_key": {
+          "name": "device_sessions_secret_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "secret_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domain_verifications": {
+      "name": "domain_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "domain_verifications_user_id_lower_domain_key": {
+          "name": "domain_verifications_user_id_lower_domain_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "domain_verifications_expires_at_idx": {
+          "name": "domain_verifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domain_verifications_user_id_users_id_fk": {
+          "name": "domain_verifications_user_id_users_id_fk",
+          "tableFrom": "domain_verifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_filter_actions": {
+      "name": "email_filter_actions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filter_id": {
+          "name": "filter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_filter_actions_filter_id_email_filters_id_fk": {
+          "name": "email_filter_actions_filter_id_email_filters_id_fk",
+          "tableFrom": "email_filter_actions",
+          "tableTo": "email_filters",
+          "columnsFrom": [
+            "filter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_filter_actions_filter_id_ord_key": {
+          "name": "email_filter_actions_filter_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filter_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_filter_actions_type_check": {
+          "name": "email_filter_actions_type_check",
+          "value": "\"email_filter_actions\".\"type\" in ('move', 'label', 'star', 'mark-read', 'archive', 'delete', 'forward')"
+        },
+        "email_filter_actions_ord_check": {
+          "name": "email_filter_actions_ord_check",
+          "value": "\"email_filter_actions\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_filter_conditions": {
+      "name": "email_filter_conditions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "filter_id": {
+          "name": "filter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field": {
+          "name": "field",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_filter_conditions_filter_id_email_filters_id_fk": {
+          "name": "email_filter_conditions_filter_id_email_filters_id_fk",
+          "tableFrom": "email_filter_conditions",
+          "tableTo": "email_filters",
+          "columnsFrom": [
+            "filter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_filter_conditions_filter_id_ord_key": {
+          "name": "email_filter_conditions_filter_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "filter_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_filter_conditions_field_check": {
+          "name": "email_filter_conditions_field_check",
+          "value": "\"email_filter_conditions\".\"field\" in ('from', 'to', 'subject', 'has-attachment', 'size')"
+        },
+        "email_filter_conditions_operator_check": {
+          "name": "email_filter_conditions_operator_check",
+          "value": "\"email_filter_conditions\".\"operator\" in ('contains', 'equals', 'not-contains', 'starts-with', 'ends-with', 'greater-than', 'less-than')"
+        },
+        "email_filter_conditions_ord_check": {
+          "name": "email_filter_conditions_ord_check",
+          "value": "\"email_filter_conditions\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_filters": {
+      "name": "email_filters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "match_all": {
+          "name": "match_all",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "email_filters_user_id_enabled_order_idx": {
+          "name": "email_filters_user_id_enabled_order_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_filters_user_id_users_id_fk": {
+          "name": "email_filters_user_id_users_id_fk",
+          "tableFrom": "email_filters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_templates": {
+      "name": "email_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "email_templates_user_id_lower_name_key": {
+          "name": "email_templates_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_templates_user_id_users_id_fk": {
+          "name": "email_templates_user_id_users_id_fk",
+          "tableFrom": "email_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.federation_key_pairs": {
+      "name": "federation_key_pairs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key_id": {
+          "name": "key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_pem": {
+          "name": "public_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key_pem": {
+          "name": "private_key_pem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_key_pairs_key_id_key": {
+          "name": "federation_key_pairs_key_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_links": {
+      "name": "file_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_url": {
+          "name": "webhook_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "file_links_app_entity_type_entity_id_created_by_idx": {
+          "name": "file_links_app_entity_type_entity_id_created_by_idx",
+          "columns": [
+            {
+              "expression": "app",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_links_created_by_idx": {
+          "name": "file_links_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_links_file_id_files_id_fk": {
+          "name": "file_links_file_id_files_id_fk",
+          "tableFrom": "file_links",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_links_created_by_users_id_fk": {
+          "name": "file_links_created_by_users_id_fk",
+          "tableFrom": "file_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "file_links_file_id_app_entity_key": {
+          "name": "file_links_file_id_app_entity_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "file_id",
+            "app",
+            "entity_type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.file_variants": {
+      "name": "file_variants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_variants_file_id_type_idx": {
+          "name": "file_variants_file_id_type_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_variants_file_id_files_id_fk": {
+          "name": "file_variants_file_id_files_id_fk",
+          "tableFrom": "file_variants",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "file_variants_size_check": {
+          "name": "file_variants_size_check",
+          "value": "\"file_variants\".\"size\" is null or \"file_variants\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_owner": {
+          "name": "system_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "files_sha256_live_key": {
+          "name": "files_sha256_live_key",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"files\".\"status\" in ('active', 'trash')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_owner_user_id_status_idx": {
+          "name": "files_owner_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_owner_user_id_visibility_status_idx": {
+          "name": "files_owner_user_id_visibility_status_idx",
+          "columns": [
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_visibility_status_idx": {
+          "name": "files_visibility_status_idx",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_sha256_status_idx": {
+          "name": "files_sha256_status_idx",
+          "columns": [
+            {
+              "expression": "sha256",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_purpose_owner_user_id_status_idx": {
+          "name": "files_purpose_owner_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "purpose",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "files_created_at_idx": {
+          "name": "files_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_owner_user_id_users_id_fk": {
+          "name": "files_owner_user_id_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "files_status_check": {
+          "name": "files_status_check",
+          "value": "\"files\".\"status\" in ('active', 'trash', 'deleted')"
+        },
+        "files_visibility_check": {
+          "name": "files_visibility_check",
+          "value": "\"files\".\"visibility\" in ('private', 'public', 'unlisted')"
+        },
+        "files_purpose_check": {
+          "name": "files_purpose_check",
+          "value": "\"files\".\"purpose\" in ('user', 'federation-media-cache', 'link-preview')"
+        },
+        "files_system_owner_check": {
+          "name": "files_system_owner_check",
+          "value": "\"files\".\"system_owner\" is null or \"files\".\"system_owner\" in ('__federation__', '__federation_media_cache__', '__link_preview_cache__')"
+        },
+        "files_owner_exclusive_check": {
+          "name": "files_owner_exclusive_check",
+          "value": "(\"files\".\"owner_user_id\" is null) <> (\"files\".\"system_owner\" is null)"
+        },
+        "files_size_check": {
+          "name": "files_size_check",
+          "value": "\"files\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_namespaces": {
+      "name": "follow_namespaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "follow_namespaces_application_idx": {
+          "name": "follow_namespaces_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_namespaces_application_id_applications_id_fk": {
+          "name": "follow_namespaces_application_id_applications_id_fk",
+          "tableFrom": "follow_namespaces",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_namespaces_namespace_key": {
+          "name": "follow_namespaces_namespace_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "namespace"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_namespaces_shape_check": {
+          "name": "follow_namespaces_shape_check",
+          "value": "\"follow_namespaces\".\"namespace\" ~ '^[a-z][a-z0-9_]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_target_kinds": {
+      "name": "follow_target_kinds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "follow_target_kinds_namespace_idx": {
+          "name": "follow_target_kinds_namespace_idx",
+          "columns": [
+            {
+              "expression": "namespace",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_target_kinds_namespace_follow_namespaces_namespace_fk": {
+          "name": "follow_target_kinds_namespace_follow_namespaces_namespace_fk",
+          "tableFrom": "follow_target_kinds",
+          "tableTo": "follow_namespaces",
+          "columnsFrom": [
+            "namespace"
+          ],
+          "columnsTo": [
+            "namespace"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "follow_target_kinds_application_id_applications_id_fk": {
+          "name": "follow_target_kinds_application_id_applications_id_fk",
+          "tableFrom": "follow_target_kinds",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_target_kinds_kind_key": {
+          "name": "follow_target_kinds_kind_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "kind"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_target_kinds_namespace_prefix_check": {
+          "name": "follow_target_kinds_namespace_prefix_check",
+          "value": "\"follow_target_kinds\".\"kind\" like \"follow_target_kinds\".\"namespace\" || '.%'"
+        },
+        "follow_target_kinds_namespace_shape_check": {
+          "name": "follow_target_kinds_namespace_shape_check",
+          "value": "\"follow_target_kinds\".\"namespace\" ~ '^[a-z][a-z0-9_]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_targets": {
+      "name": "follow_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "canonical_uri": {
+          "name": "canonical_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_application_id": {
+          "name": "provider_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_reference": {
+          "name": "provider_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_user_id": {
+          "name": "local_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_snapshot": {
+          "name": "metadata_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "follow_targets_kind_idx": {
+          "name": "follow_targets_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_targets_provider_application_id_idx": {
+          "name": "follow_targets_provider_application_id_idx",
+          "columns": [
+            {
+              "expression": "provider_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_targets_kind_follow_target_kinds_kind_fk": {
+          "name": "follow_targets_kind_follow_target_kinds_kind_fk",
+          "tableFrom": "follow_targets",
+          "tableTo": "follow_target_kinds",
+          "columnsFrom": [
+            "kind"
+          ],
+          "columnsTo": [
+            "kind"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "follow_targets_provider_application_id_applications_id_fk": {
+          "name": "follow_targets_provider_application_id_applications_id_fk",
+          "tableFrom": "follow_targets",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "provider_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_targets_local_user_id_users_id_fk": {
+          "name": "follow_targets_local_user_id_users_id_fk",
+          "tableFrom": "follow_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "local_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_targets_canonical_uri_key": {
+          "name": "follow_targets_canonical_uri_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "canonical_uri"
+          ]
+        },
+        "follow_targets_local_user_id_key": {
+          "name": "follow_targets_local_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "local_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow_relationships": {
+      "name": "follow_relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_user_id": {
+          "name": "follower_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follow_target_id": {
+          "name": "follow_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "origin_application_id": {
+          "name": "origin_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_grant_id": {
+          "name": "created_by_grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'app'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "follow_relationships_follower_created_idx": {
+          "name": "follow_relationships_follower_created_idx",
+          "columns": [
+            {
+              "expression": "follower_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_relationships_target_idx": {
+          "name": "follow_relationships_target_idx",
+          "columns": [
+            {
+              "expression": "follow_target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_relationships_origin_application_id_idx": {
+          "name": "follow_relationships_origin_application_id_idx",
+          "columns": [
+            {
+              "expression": "origin_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_relationships_expires_at_idx": {
+          "name": "follow_relationships_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"follow_relationships\".\"expires_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_relationships_follower_user_id_users_id_fk": {
+          "name": "follow_relationships_follower_user_id_users_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_relationships_follow_target_id_follow_targets_id_fk": {
+          "name": "follow_relationships_follow_target_id_follow_targets_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "follow_targets",
+          "columnsFrom": [
+            "follow_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_relationships_origin_application_id_applications_id_fk": {
+          "name": "follow_relationships_origin_application_id_applications_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "origin_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_relationships_created_by_grant_id_app_grants_id_fk": {
+          "name": "follow_relationships_created_by_grant_id_app_grants_id_fk",
+          "tableFrom": "follow_relationships",
+          "tableTo": "app_grants",
+          "columnsFrom": [
+            "created_by_grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_relationships_follower_target_key": {
+          "name": "follow_relationships_follower_target_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_user_id",
+            "follow_target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_relationships_state_check": {
+          "name": "follow_relationships_state_check",
+          "value": "\"follow_relationships\".\"state\" in ('requested', 'active', 'rejected')"
+        },
+        "follow_relationships_source_check": {
+          "name": "follow_relationships_source_check",
+          "value": "\"follow_relationships\".\"source\" in ('app', 'federation_inbound', 'migration', 'system')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_application_overrides": {
+      "name": "follow_application_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "relationship_id": {
+          "name": "relationship_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "follow_application_overrides_application_idx": {
+          "name": "follow_application_overrides_application_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_application_overrides_relationship_id_follow_relationships_id_fk": {
+          "name": "follow_application_overrides_relationship_id_follow_relationships_id_fk",
+          "tableFrom": "follow_application_overrides",
+          "tableTo": "follow_relationships",
+          "columnsFrom": [
+            "relationship_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_application_overrides_application_id_applications_id_fk": {
+          "name": "follow_application_overrides_application_id_applications_id_fk",
+          "tableFrom": "follow_application_overrides",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_application_overrides_relationship_application_key": {
+          "name": "follow_application_overrides_relationship_application_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "relationship_id",
+            "application_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_application_overrides_mode_check": {
+          "name": "follow_application_overrides_mode_check",
+          "value": "\"follow_application_overrides\".\"mode\" in ('enabled', 'disabled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.follow_events": {
+      "name": "follow_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cause": {
+          "name": "cause",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationship_id": {
+          "name": "relationship_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_uri": {
+          "name": "target_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_application_id": {
+          "name": "origin_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_application_id": {
+          "name": "context_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "follow_events_pending_idx": {
+          "name": "follow_events_pending_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"follow_events\".\"processed_at\" is null and \"follow_events\".\"failed_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_events_dead_letter_idx": {
+          "name": "follow_events_dead_letter_idx",
+          "columns": [
+            {
+              "expression": "failed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"follow_events\".\"failed_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_events_relationship_idx": {
+          "name": "follow_events_relationship_idx",
+          "columns": [
+            {
+              "expression": "relationship_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_events_actor_idx": {
+          "name": "follow_events_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_events_actor_user_id_users_id_fk": {
+          "name": "follow_events_actor_user_id_users_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follow_events_origin_application_id_applications_id_fk": {
+          "name": "follow_events_origin_application_id_applications_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "origin_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_events_grant_id_app_grants_id_fk": {
+          "name": "follow_events_grant_id_app_grants_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "app_grants",
+          "columnsFrom": [
+            "grant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "follow_events_context_application_id_applications_id_fk": {
+          "name": "follow_events_context_application_id_applications_id_fk",
+          "tableFrom": "follow_events",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "context_application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "follow_events_event_id_key": {
+          "name": "follow_events_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "follow_events_type_check": {
+          "name": "follow_events_type_check",
+          "value": "\"follow_events\".\"type\" in ('follow.created', 'follow.removed', 'follow.requested', 'follow.accepted', 'follow.rejected', 'follow.context_enabled', 'follow.context_disabled')"
+        },
+        "follow_events_cause_check": {
+          "name": "follow_events_cause_check",
+          "value": "\"follow_events\".\"cause\" in ('user_action', 'expired', 'federation_inbound', 'reconciliation', 'migration')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.identity_backups": {
+      "name": "identity_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lookup_id_hash": {
+          "name": "lookup_id_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_hint": {
+          "name": "public_key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kdf_info": {
+          "name": "kdf_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_created_at": {
+          "name": "client_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "identity_backups_user_id_users_id_fk": {
+          "name": "identity_backups_user_id_users_id_fk",
+          "tableFrom": "identity_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "identity_backups_user_id_key": {
+          "name": "identity_backups_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "identity_backups_lookup_id_hash_key": {
+          "name": "identity_backups_lookup_id_hash_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lookup_id_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_bindings": {
+      "name": "identity_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_principal_id": {
+          "name": "local_principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_type": {
+          "name": "binding_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "identity_bindings_application_id_local_principal_id_active_key": {
+          "name": "identity_bindings_application_id_local_principal_id_active_key",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "local_principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"identity_bindings\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_bindings_application_id_user_id_status_idx": {
+          "name": "identity_bindings_application_id_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_bindings_user_id_idx": {
+          "name": "identity_bindings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_bindings_application_id_applications_id_fk": {
+          "name": "identity_bindings_application_id_applications_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "identity_bindings_user_id_users_id_fk": {
+          "name": "identity_bindings_user_id_users_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "identity_bindings_credential_id_application_credentials_id_fk": {
+          "name": "identity_bindings_credential_id_application_credentials_id_fk",
+          "tableFrom": "identity_bindings",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "identity_bindings_binding_type_check": {
+          "name": "identity_bindings_binding_type_check",
+          "value": "\"identity_bindings\".\"binding_type\" in ('oauth_grant', 'session_proof', 'commons_signature', 'federated_actor')"
+        },
+        "identity_bindings_status_check": {
+          "name": "identity_bindings_status_check",
+          "value": "\"identity_bindings\".\"status\" in ('active', 'revoked')"
+        },
+        "identity_bindings_revoked_at_check": {
+          "name": "identity_bindings_revoked_at_check",
+          "value": "(\"identity_bindings\".\"status\" = 'revoked') = (\"identity_bindings\".\"revoked_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#4285f4'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "labels_user_id_lower_name_key": {
+          "name": "labels_user_id_lower_name_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "labels_user_id_users_id_fk": {
+          "name": "labels_user_id_users_id_fk",
+          "tableFrom": "labels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.link_previews": {
+      "name": "link_previews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_url": {
+          "name": "requested_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "site_name": {
+          "name": "site_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_image_url": {
+          "name": "origin_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_favicon_url": {
+          "name": "origin_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "link_previews_status_idx": {
+          "name": "link_previews_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "link_previews_updated_at_idx": {
+          "name": "link_previews_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "link_previews_status_check": {
+          "name": "link_previews_status_check",
+          "value": "\"link_previews\".\"status\" in ('resolved', 'pending', 'empty')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.mailboxes": {
+      "name": "mailboxes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "special_use": {
+          "name": "special_use",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "mailboxes_user_id_path_key": {
+          "name": "mailboxes_user_id_path_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mailboxes_user_id_special_use_idx": {
+          "name": "mailboxes_user_id_special_use_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "special_use",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mailboxes_user_id_users_id_fk": {
+          "name": "mailboxes_user_id_users_id_fk",
+          "tableFrom": "mailboxes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_attachments": {
+      "name": "message_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_inline": {
+          "name": "is_inline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "message_attachments_file_id_idx": {
+          "name": "message_attachments_file_id_idx",
+          "columns": [
+            {
+              "expression": "file_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_attachments_message_id_messages_id_fk": {
+          "name": "message_attachments_message_id_messages_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_attachments_file_id_files_id_fk": {
+          "name": "message_attachments_file_id_files_id_fk",
+          "tableFrom": "message_attachments",
+          "tableTo": "files",
+          "columnsFrom": [
+            "file_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_attachments_message_id_ord_key": {
+          "name": "message_attachments_message_id_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "message_attachments_size_check": {
+          "name": "message_attachments_size_check",
+          "value": "\"message_attachments\".\"size\" >= 0"
+        },
+        "message_attachments_ord_check": {
+          "name": "message_attachments_ord_check",
+          "value": "\"message_attachments\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.message_recipients": {
+      "name": "message_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ord": {
+          "name": "ord",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_recipients_address_idx": {
+          "name": "message_recipients_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_recipients_message_id_messages_id_fk": {
+          "name": "message_recipients_message_id_messages_id_fk",
+          "tableFrom": "message_recipients",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_recipients_message_id_kind_ord_key": {
+          "name": "message_recipients_message_id_kind_ord_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "kind",
+            "ord"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "message_recipients_kind_check": {
+          "name": "message_recipients_kind_check",
+          "value": "\"message_recipients\".\"kind\" in ('to', 'cc', 'bcc')"
+        },
+        "message_recipients_ord_check": {
+          "name": "message_recipients_ord_check",
+          "value": "\"message_recipients\".\"ord\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mailbox_id": {
+          "name": "mailbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_to_name": {
+          "name": "reply_to_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to_address": {
+          "name": "reply_to_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "encrypted_body": {
+          "name": "encrypted_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seen": {
+          "name": "seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "starred": {
+          "name": "starred",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "answered": {
+          "name": "answered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "forwarded": {
+          "name": "forwarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "draft": {
+          "name": "draft",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "card_type": {
+          "name": "card_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_data": {
+          "name": "card_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_confidence": {
+          "name": "card_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_extracted_at": {
+          "name": "card_extracted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "spam_score": {
+          "name": "spam_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spam_action": {
+          "name": "spam_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "references": {
+          "name": "references",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "alias_tag": {
+          "name": "alias_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snoozed_from_mailbox": {
+          "name": "snoozed_from_mailbox",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_receipt_requested": {
+          "name": "read_receipt_requested",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_receipt_sent": {
+          "name": "read_receipt_sent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(subject, '')), 'A') || setweight(to_tsvector('english', coalesce(\"text\", '')), 'D')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "messages_user_id_mailbox_id_pinned_date_idx": {
+          "name": "messages_user_id_mailbox_id_pinned_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_message_id_idx": {
+          "name": "messages_user_id_message_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_in_reply_to_idx": {
+          "name": "messages_user_id_in_reply_to_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "in_reply_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_references_idx": {
+          "name": "messages_references_idx",
+          "columns": [
+            {
+              "expression": "references",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_unseen_idx": {
+          "name": "messages_unseen_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"messages\".\"seen\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_starred_idx": {
+          "name": "messages_starred_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"starred\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_search_vector_idx": {
+          "name": "messages_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_labels_idx": {
+          "name": "messages_labels_idx",
+          "columns": [
+            {
+              "expression": "labels",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "messages_user_id_alias_tag_idx": {
+          "name": "messages_user_id_alias_tag_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias_tag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_from_address_date_idx": {
+          "name": "messages_user_id_from_address_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "from_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_pinned_date_idx": {
+          "name": "messages_user_id_pinned_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_snoozed_until_idx": {
+          "name": "messages_snoozed_until_idx",
+          "columns": [
+            {
+              "expression": "snoozed_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"snoozed_until\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_scheduled_at_idx": {
+          "name": "messages_scheduled_at_idx",
+          "columns": [
+            {
+              "expression": "scheduled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"scheduled_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_mailbox_id_received_at_idx": {
+          "name": "messages_mailbox_id_received_at_idx",
+          "columns": [
+            {
+              "expression": "mailbox_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_user_id_users_id_fk": {
+          "name": "messages_user_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_mailbox_id_mailboxes_id_fk": {
+          "name": "messages_mailbox_id_mailboxes_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "mailboxes",
+          "columnsFrom": [
+            "mailbox_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_snoozed_from_mailbox_mailboxes_id_fk": {
+          "name": "messages_snoozed_from_mailbox_mailboxes_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "mailboxes",
+          "columnsFrom": [
+            "snoozed_from_mailbox"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "messages_card_type_check": {
+          "name": "messages_card_type_check",
+          "value": "\"messages\".\"card_type\" is null or \"messages\".\"card_type\" in ('trip', 'purchase', 'event', 'bill', 'package')"
+        },
+        "messages_card_complete_check": {
+          "name": "messages_card_complete_check",
+          "value": "\"messages\".\"card_type\" is not null or (\"messages\".\"card_data\" is null and \"messages\".\"card_confidence\" is null and \"messages\".\"card_extracted_at\" is null)"
+        },
+        "messages_size_check": {
+          "name": "messages_size_check",
+          "value": "\"messages\".\"size\" >= 0"
+        },
+        "messages_reply_to_complete_check": {
+          "name": "messages_reply_to_complete_check",
+          "value": "\"messages\".\"reply_to_address\" is not null or \"messages\".\"reply_to_name\" is null"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_effects": {
+      "name": "moderation_effects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "incident_id": {
+          "name": "incident_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_id": {
+          "name": "decision_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decision_revision": {
+          "name": "decision_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "principal_id": {
+          "name": "principal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_id": {
+          "name": "binding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effect_type": {
+          "name": "effect_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_risk": {
+          "name": "active_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family": {
+          "name": "family",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_multiplier": {
+          "name": "repetition_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_multiplier": {
+          "name": "multi_finding_multiplier",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strike_id": {
+          "name": "strike_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_transaction_id": {
+          "name": "reversal_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version_universal": {
+          "name": "policy_version_universal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version_application": {
+          "name": "policy_version_application",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "policy_version_oxy_conduct": {
+          "name": "policy_version_oxy_conduct",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_hash": {
+          "name": "proof_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reversed_at": {
+          "name": "reversed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reversal_reason": {
+          "name": "reversal_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_effects_decision_id_decision_revision_idx": {
+          "name": "moderation_effects_decision_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "decision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_effects_incident_id_decision_revision_idx": {
+          "name": "moderation_effects_incident_id_decision_revision_idx",
+          "columns": [
+            {
+              "expression": "incident_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "decision_revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "moderation_effects_principal_id_applied_at_idx": {
+          "name": "moderation_effects_principal_id_applied_at_idx",
+          "columns": [
+            {
+              "expression": "principal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "applied_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "moderation_effects_principal_id_users_id_fk": {
+          "name": "moderation_effects_principal_id_users_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "principal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_binding_id_identity_bindings_id_fk": {
+          "name": "moderation_effects_binding_id_identity_bindings_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "identity_bindings",
+          "columnsFrom": [
+            "binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_application_id_applications_id_fk": {
+          "name": "moderation_effects_application_id_applications_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_credential_id_application_credentials_id_fk": {
+          "name": "moderation_effects_credential_id_application_credentials_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_transaction_id_reputation_transactions_id_fk": {
+          "name": "moderation_effects_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_strike_id_conduct_strikes_id_fk": {
+          "name": "moderation_effects_strike_id_conduct_strikes_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "conduct_strikes",
+          "columnsFrom": [
+            "strike_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_reversal_transaction_id_reputation_transactions_id_fk": {
+          "name": "moderation_effects_reversal_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "reversal_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "moderation_effects_policy_version_oxy_conduct_fk": {
+          "name": "moderation_effects_policy_version_oxy_conduct_fk",
+          "tableFrom": "moderation_effects",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_version_oxy_conduct"
+          ],
+          "columnsTo": [
+            "policy_version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_effects_incident_principal_type_revision_key": {
+          "name": "moderation_effects_incident_principal_type_revision_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "incident_id",
+            "principal_id",
+            "effect_type",
+            "decision_revision"
+          ]
+        },
+        "moderation_effects_event_id_key": {
+          "name": "moderation_effects_event_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_effects_effect_type_check": {
+          "name": "moderation_effects_effect_type_check",
+          "value": "\"moderation_effects\".\"effect_type\" in ('conduct_penalty', 'report_abuse_penalty', 'review_abuse_penalty')"
+        },
+        "moderation_effects_status_check": {
+          "name": "moderation_effects_status_check",
+          "value": "\"moderation_effects\".\"status\" in ('applied', 'reversed')"
+        },
+        "moderation_effects_severity_check": {
+          "name": "moderation_effects_severity_check",
+          "value": "\"moderation_effects\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "moderation_effects_decision_revision_check": {
+          "name": "moderation_effects_decision_revision_check",
+          "value": "\"moderation_effects\".\"decision_revision\" >= 0"
+        },
+        "moderation_effects_reversal_complete_check": {
+          "name": "moderation_effects_reversal_complete_check",
+          "value": "(\"moderation_effects\".\"status\" = 'reversed') = (\"moderation_effects\".\"reversed_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policies": {
+      "name": "moderation_policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "conduct_families": {
+          "name": "conduct_families",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_multipliers": {
+          "name": "repetition_multipliers",
+          "type": "double precision[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repetition_window_days": {
+          "name": "repetition_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_secondary_share": {
+          "name": "multi_finding_secondary_share",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_finding_cap": {
+          "name": "multi_finding_cap",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provisional_effects_allowed": {
+          "name": "provisional_effects_allowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "moderation_policies_status_idx": {
+          "name": "moderation_policies_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policies_policy_version_key": {
+          "name": "moderation_policies_policy_version_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policies_status_check": {
+          "name": "moderation_policies_status_check",
+          "value": "\"moderation_policies\".\"status\" in ('active', 'retired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policy_severity_rules": {
+      "name": "moderation_policy_severity_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_points": {
+          "name": "risk_points",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_expiry_days": {
+          "name": "risk_expiry_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderation_policy_severity_rules_policy_id_fk": {
+          "name": "moderation_policy_severity_rules_policy_id_fk",
+          "tableFrom": "moderation_policy_severity_rules",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policy_severity_rules_policy_id_severity_key": {
+          "name": "moderation_policy_severity_rules_policy_id_severity_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_id",
+            "severity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policy_severity_rules_severity_check": {
+          "name": "moderation_policy_severity_rules_severity_check",
+          "value": "\"moderation_policy_severity_rules\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        },
+        "moderation_policy_severity_rules_risk_expiry_days_check": {
+          "name": "moderation_policy_severity_rules_risk_expiry_days_check",
+          "value": "\"moderation_policy_severity_rules\".\"risk_expiry_days\" is null or \"moderation_policy_severity_rules\".\"risk_expiry_days\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.moderation_policy_standing_thresholds": {
+      "name": "moderation_policy_standing_thresholds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standing": {
+          "name": "standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_risk": {
+          "name": "min_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "moderation_policy_standing_thresholds_policy_id_fk": {
+          "name": "moderation_policy_standing_thresholds_policy_id_fk",
+          "tableFrom": "moderation_policy_standing_thresholds",
+          "tableTo": "moderation_policies",
+          "columnsFrom": [
+            "policy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "moderation_policy_standing_thresholds_policy_id_standing_key": {
+          "name": "moderation_policy_standing_thresholds_policy_id_standing_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "policy_id",
+            "standing"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "moderation_policy_standing_thresholds_standing_check": {
+          "name": "moderation_policy_standing_thresholds_standing_check",
+          "value": "\"moderation_policy_standing_thresholds\".\"standing\" in ('good', 'watch', 'limited', 'restricted')"
+        },
+        "moderation_policy_standing_thresholds_min_risk_check": {
+          "name": "moderation_policy_standing_thresholds_min_risk_check",
+          "value": "\"moderation_policy_standing_thresholds\".\"min_risk\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.node_ingest_witnesses": {
+      "name": "node_ingest_witnesses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "witness_signature": {
+          "name": "witness_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingested_at": {
+          "name": "ingested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "node_ingest_witnesses_user_id_created_at_idx": {
+          "name": "node_ingest_witnesses_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "node_ingest_witnesses_user_id_users_id_fk": {
+          "name": "node_ingest_witnesses_user_id_users_id_fk",
+          "tableFrom": "node_ingest_witnesses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "node_ingest_witnesses_record_id_signed_records_record_id_fk": {
+          "name": "node_ingest_witnesses_record_id_signed_records_record_id_fk",
+          "tableFrom": "node_ingest_witnesses",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "node_ingest_witnesses_recordId_unique": {
+          "name": "node_ingest_witnesses_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "notifications_recipient_id_created_at_idx": {
+          "name": "notifications_recipient_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_recipient_id_users_id_fk": {
+          "name": "notifications_recipient_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_actor_id_users_id_fk": {
+          "name": "notifications_actor_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notifications_recipient_id_actor_id_type_entity_id_key": {
+          "name": "notifications_recipient_id_actor_id_type_entity_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "recipient_id",
+            "actor_id",
+            "type",
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "notifications_type_check": {
+          "name": "notifications_type_check",
+          "value": "\"notifications\".\"type\" in ('like', 'reply', 'mention', 'follow', 'repost', 'quote', 'welcome')"
+        },
+        "notifications_entity_type_check": {
+          "name": "notifications_entity_type_check",
+          "value": "\"notifications\".\"entity_type\" in ('post', 'reply', 'profile')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personhood_statuses": {
+      "name": "personhood_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_real_person": {
+          "name": "is_real_person",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vouch_count": {
+          "name": "vouch_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "real_life_count": {
+          "name": "real_life_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "biometric_bound": {
+          "name": "biometric_bound",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sybil_penalty": {
+          "name": "sybil_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_vouch_signal": {
+          "name": "breakdown_vouch_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_real_life_signal": {
+          "name": "breakdown_real_life_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_biometric_signal": {
+          "name": "breakdown_biometric_signal",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_evidence": {
+          "name": "breakdown_evidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_sybil_penalty": {
+          "name": "breakdown_sybil_penalty",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_seed": {
+          "name": "breakdown_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "personhood_statuses_score_idx": {
+          "name": "personhood_statuses_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personhood_statuses_is_real_person_idx": {
+          "name": "personhood_statuses_is_real_person_idx",
+          "columns": [
+            {
+              "expression": "is_real_person",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personhood_statuses_user_id_users_id_fk": {
+          "name": "personhood_statuses_user_id_users_id_fk",
+          "tableFrom": "personhood_statuses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "personhood_statuses_userId_unique": {
+          "name": "personhood_statuses_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "personhood_statuses_counts_check": {
+          "name": "personhood_statuses_counts_check",
+          "value": "\"personhood_statuses\".\"vouch_count\" >= 0 and \"personhood_statuses\".\"real_life_count\" >= 0"
+        },
+        "personhood_statuses_signals_check": {
+          "name": "personhood_statuses_signals_check",
+          "value": "\"personhood_statuses\".\"score\" between 0 and 1 and \"personhood_statuses\".\"sybil_penalty\" between 0 and 1 and \"personhood_statuses\".\"breakdown_vouch_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_real_life_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_biometric_signal\" between 0 and 1 and \"personhood_statuses\".\"breakdown_evidence\" between 0 and 1 and \"personhood_statuses\".\"breakdown_sybil_penalty\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.personhood_vouches": {
+      "name": "personhood_vouches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "voucher_user_id": {
+          "name": "voucher_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake_amount": {
+          "name": "stake_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "personhood_vouches_active_pair_key": {
+          "name": "personhood_vouches_active_pair_key",
+          "columns": [
+            {
+              "expression": "voucher_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"personhood_vouches\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "personhood_vouches_subject_id_status_idx": {
+          "name": "personhood_vouches_subject_id_status_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "personhood_vouches_voucher_user_id_users_id_fk": {
+          "name": "personhood_vouches_voucher_user_id_users_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "voucher_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personhood_vouches_subject_user_id_users_id_fk": {
+          "name": "personhood_vouches_subject_user_id_users_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "personhood_vouches_record_id_signed_records_record_id_fk": {
+          "name": "personhood_vouches_record_id_signed_records_record_id_fk",
+          "tableFrom": "personhood_vouches",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "personhood_vouches_status_check": {
+          "name": "personhood_vouches_status_check",
+          "value": "\"personhood_vouches\".\"status\" in ('active', 'slashed', 'withdrawn')"
+        },
+        "personhood_vouches_stake_check": {
+          "name": "personhood_vouches_stake_check",
+          "value": "\"personhood_vouches\".\"stake_amount\" >= 0"
+        },
+        "personhood_vouches_not_self_check": {
+          "name": "personhood_vouches_not_self_check",
+          "value": "\"personhood_vouches\".\"voucher_user_id\" <> \"personhood_vouches\".\"subject_user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "push_tokens_user_id_application_id_idx": {
+          "name": "push_tokens_user_id_application_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_tokens_user_id_users_id_fk": {
+          "name": "push_tokens_user_id_users_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "push_tokens_application_id_applications_id_fk": {
+          "name": "push_tokens_application_id_applications_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_tokens_user_id_token_key": {
+          "name": "push_tokens_user_id_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "push_tokens_platform_check": {
+          "name": "push_tokens_platform_check",
+          "value": "\"push_tokens\".\"platform\" in ('ios', 'android', 'web')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reminders": {
+      "name": "reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "remind_at": {
+          "name": "remind_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "snoozed_until": {
+          "name": "snoozed_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "related_message_id": {
+          "name": "related_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reminders_user_id_completed_remind_at_idx": {
+          "name": "reminders_user_id_completed_remind_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "remind_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reminders_due_idx": {
+          "name": "reminders_due_idx",
+          "columns": [
+            {
+              "expression": "remind_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "not \"reminders\".\"completed\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reminders_user_id_users_id_fk": {
+          "name": "reminders_user_id_users_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reminders_related_message_id_messages_id_fk": {
+          "name": "reminders_related_message_id_messages_id_fk",
+          "tableFrom": "reminders",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "related_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_heads": {
+      "name": "repo_heads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "repo_heads_user_id_users_id_fk": {
+          "name": "repo_heads_user_id_users_id_fk",
+          "tableFrom": "repo_heads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "repo_heads_head_record_id_signed_records_record_id_fk": {
+          "name": "repo_heads_head_record_id_signed_records_record_id_fk",
+          "tableFrom": "repo_heads",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "head_record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repo_heads_userId_unique": {
+          "name": "repo_heads_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repo_heads_seq_check": {
+          "name": "repo_heads_seq_check",
+          "value": "\"repo_heads\".\"seq\" >= 0"
+        },
+        "repo_heads_record_count_check": {
+          "name": "repo_heads_record_count_check",
+          "value": "\"repo_heads\".\"record_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reporter_reputation_profiles": {
+      "name": "reporter_reputation_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmed": {
+          "name": "confirmed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rejected": {
+          "name": "rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duplicate": {
+          "name": "duplicate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "malicious": {
+          "name": "malicious",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "confirmed_by_family": {
+          "name": "confirmed_by_family",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "rejected_by_family": {
+          "name": "rejected_by_family",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "reliability": {
+          "name": "reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_outcome_at": {
+          "name": "last_outcome_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reporter_reputation_profiles_user_id_users_id_fk": {
+          "name": "reporter_reputation_profiles_user_id_users_id_fk",
+          "tableFrom": "reporter_reputation_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reporter_reputation_profiles_user_id_key": {
+          "name": "reporter_reputation_profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reporter_reputation_profiles_confirmed_by_family_object_check": {
+          "name": "reporter_reputation_profiles_confirmed_by_family_object_check",
+          "value": "jsonb_typeof(\"reporter_reputation_profiles\".\"confirmed_by_family\") = 'object'"
+        },
+        "reporter_reputation_profiles_rejected_by_family_object_check": {
+          "name": "reporter_reputation_profiles_rejected_by_family_object_check",
+          "value": "jsonb_typeof(\"reporter_reputation_profiles\".\"rejected_by_family\") = 'object'"
+        },
+        "reporter_reputation_profiles_counts_check": {
+          "name": "reporter_reputation_profiles_counts_check",
+          "value": "\"reporter_reputation_profiles\".\"confirmed\" >= 0 and \"reporter_reputation_profiles\".\"rejected\" >= 0 and \"reporter_reputation_profiles\".\"duplicate\" >= 0 and \"reporter_reputation_profiles\".\"malicious\" >= 0"
+        },
+        "reporter_reputation_profiles_reliability_check": {
+          "name": "reporter_reputation_profiles_reliability_check",
+          "value": "\"reporter_reputation_profiles\".\"reliability\" >= 0 and \"reporter_reputation_profiles\".\"reliability\" <= 1"
+        },
+        "reporter_reputation_profiles_confidence_check": {
+          "name": "reporter_reputation_profiles_confidence_check",
+          "value": "\"reporter_reputation_profiles\".\"confidence\" >= 0 and \"reporter_reputation_profiles\".\"confidence\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_balances": {
+      "name": "reputation_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "positive": {
+          "name": "positive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "negative": {
+          "name": "negative",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_content": {
+          "name": "breakdown_content",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_social": {
+          "name": "breakdown_social",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_trust": {
+          "name": "breakdown_trust",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_moderation": {
+          "name": "breakdown_moderation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_physical": {
+          "name": "breakdown_physical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "breakdown_penalties": {
+          "name": "breakdown_penalties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "trust_tier": {
+          "name": "trust_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "influence_default_weight": {
+          "name": "influence_default_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_report_weight": {
+          "name": "influence_report_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_moderation_weight": {
+          "name": "influence_moderation_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "influence_ranking_feedback_weight": {
+          "name": "influence_ranking_feedback_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_accurate_reports": {
+          "name": "reliability_accurate_reports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_rejected_reports": {
+          "name": "reliability_rejected_reports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_report_accuracy_score": {
+          "name": "reliability_report_accuracy_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reliability_abuse_score": {
+          "name": "reliability_abuse_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "personhood_status": {
+          "name": "personhood_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "personhood_score": {
+          "name": "personhood_score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contribution_points": {
+          "name": "contribution_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contribution_tier": {
+          "name": "contribution_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "conduct_standing": {
+          "name": "conduct_standing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'good'"
+        },
+        "conduct_active_risk": {
+          "name": "conduct_active_risk",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conduct_active_strikes": {
+          "name": "conduct_active_strikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "conduct_next_expiry_at": {
+          "name": "conduct_next_expiry_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reporting_reliability": {
+          "name": "reporting_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "reporting_confidence": {
+          "name": "reporting_confidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_confirmed": {
+          "name": "reporting_confirmed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_rejected": {
+          "name": "reporting_rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reporting_malicious": {
+          "name": "reporting_malicious",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviewing_global_reliability": {
+          "name": "reviewing_global_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "contextual_report_priority_weight": {
+          "name": "contextual_report_priority_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contextual_review_selection_weight": {
+          "name": "contextual_review_selection_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "contextual_ranking_weight": {
+          "name": "contextual_ranking_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_transaction_id": {
+          "name": "last_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recalculated_at": {
+          "name": "recalculated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reputation_balances_total_idx": {
+          "name": "reputation_balances_total_idx",
+          "columns": [
+            {
+              "expression": "total",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_balances_trust_tier_idx": {
+          "name": "reputation_balances_trust_tier_idx",
+          "columns": [
+            {
+              "expression": "trust_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_balances_conduct_standing_idx": {
+          "name": "reputation_balances_conduct_standing_idx",
+          "columns": [
+            {
+              "expression": "conduct_standing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_balances_user_id_users_id_fk": {
+          "name": "reputation_balances_user_id_users_id_fk",
+          "tableFrom": "reputation_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_balances_last_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_balances_last_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_balances",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "last_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reputation_balances_userId_unique": {
+          "name": "reputation_balances_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reputation_balances_trust_tier_check": {
+          "name": "reputation_balances_trust_tier_check",
+          "value": "\"reputation_balances\".\"trust_tier\" in ('restricted', 'new', 'trusted', 'high_trust', 'verified')"
+        },
+        "reputation_balances_personhood_status_check": {
+          "name": "reputation_balances_personhood_status_check",
+          "value": "\"reputation_balances\".\"personhood_status\" in ('unknown', 'probable', 'verified')"
+        },
+        "reputation_balances_contribution_tier_check": {
+          "name": "reputation_balances_contribution_tier_check",
+          "value": "\"reputation_balances\".\"contribution_tier\" in ('new', 'trusted', 'high_trust')"
+        },
+        "reputation_balances_conduct_standing_check": {
+          "name": "reputation_balances_conduct_standing_check",
+          "value": "\"reputation_balances\".\"conduct_standing\" in ('good', 'watch', 'limited', 'restricted')"
+        },
+        "reputation_balances_positive_check": {
+          "name": "reputation_balances_positive_check",
+          "value": "\"reputation_balances\".\"positive\" >= 0"
+        },
+        "reputation_balances_negative_check": {
+          "name": "reputation_balances_negative_check",
+          "value": "\"reputation_balances\".\"negative\" <= 0"
+        },
+        "reputation_balances_penalties_check": {
+          "name": "reputation_balances_penalties_check",
+          "value": "\"reputation_balances\".\"breakdown_penalties\" >= 0"
+        },
+        "reputation_balances_contribution_points_check": {
+          "name": "reputation_balances_contribution_points_check",
+          "value": "\"reputation_balances\".\"contribution_points\" >= 0"
+        },
+        "reputation_balances_reliability_counts_check": {
+          "name": "reputation_balances_reliability_counts_check",
+          "value": "\"reputation_balances\".\"reliability_accurate_reports\" >= 0 and \"reputation_balances\".\"reliability_rejected_reports\" >= 0"
+        },
+        "reputation_balances_reporting_counts_check": {
+          "name": "reputation_balances_reporting_counts_check",
+          "value": "\"reputation_balances\".\"reporting_confirmed\" >= 0 and \"reputation_balances\".\"reporting_rejected\" >= 0 and \"reputation_balances\".\"reporting_malicious\" >= 0"
+        },
+        "reputation_balances_conduct_check": {
+          "name": "reputation_balances_conduct_check",
+          "value": "\"reputation_balances\".\"conduct_active_risk\" >= 0 and \"reputation_balances\".\"conduct_active_strikes\" >= 0"
+        },
+        "reputation_balances_scores_check": {
+          "name": "reputation_balances_scores_check",
+          "value": "\"reputation_balances\".\"reliability_report_accuracy_score\" between 0 and 1 and \"reputation_balances\".\"reliability_abuse_score\" between 0 and 1 and \"reputation_balances\".\"personhood_score\" between 0 and 1 and \"reputation_balances\".\"reporting_reliability\" between 0 and 1 and \"reputation_balances\".\"reporting_confidence\" between 0 and 1 and \"reputation_balances\".\"reviewing_global_reliability\" between 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_reviewing_reliability": {
+      "name": "reputation_reviewing_reliability",
+      "schema": "",
+      "columns": {
+        "balance_id": {
+          "name": "balance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reliability": {
+          "name": "reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reputation_reviewing_reliability_balance_id_reputation_balances_id_fk": {
+          "name": "reputation_reviewing_reliability_balance_id_reputation_balances_id_fk",
+          "tableFrom": "reputation_reviewing_reliability",
+          "tableTo": "reputation_balances",
+          "columnsFrom": [
+            "balance_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reputation_reviewing_reliability_pkey": {
+          "name": "reputation_reviewing_reliability_pkey",
+          "columns": [
+            "balance_id",
+            "scope",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_reviewing_reliability_scope_check": {
+          "name": "reputation_reviewing_reliability_scope_check",
+          "value": "\"reputation_reviewing_reliability\".\"scope\" in ('category', 'language')"
+        },
+        "reputation_reviewing_reliability_value_check": {
+          "name": "reputation_reviewing_reliability_value_check",
+          "value": "\"reputation_reviewing_reliability\".\"reliability\" between 0 and 1"
+        },
+        "reputation_reviewing_reliability_key_check": {
+          "name": "reputation_reviewing_reliability_key_check",
+          "value": "length(\"reputation_reviewing_reliability\".\"key\") > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_disputes": {
+      "name": "reputation_disputes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reputation_disputes_user_id_status_idx": {
+          "name": "reputation_disputes_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_disputes_status_idx": {
+          "name": "reputation_disputes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_disputes_transaction_id_idx": {
+          "name": "reputation_disputes_transaction_id_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_disputes_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_disputes_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_disputes_user_id_users_id_fk": {
+          "name": "reputation_disputes_user_id_users_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_disputes_resolved_by_user_id_users_id_fk": {
+          "name": "reputation_disputes_resolved_by_user_id_users_id_fk",
+          "tableFrom": "reputation_disputes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_disputes_status_check": {
+          "name": "reputation_disputes_status_check",
+          "value": "\"reputation_disputes\".\"status\" in ('open', 'accepted', 'rejected', 'needs_review')"
+        },
+        "reputation_disputes_resolution_check": {
+          "name": "reputation_disputes_resolution_check",
+          "value": "(\"reputation_disputes\".\"status\" in ('open', 'needs_review') and \"reputation_disputes\".\"resolved_at\" is null) or (\"reputation_disputes\".\"status\" in ('accepted', 'rejected') and \"reputation_disputes\".\"resolved_at\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_rules": {
+      "name": "reputation_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooldown_in_minutes": {
+          "name": "cooldown_in_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reputation_rules_actionType_unique": {
+          "name": "reputation_rules_actionType_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "action_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reputation_rules_category_check": {
+          "name": "reputation_rules_category_check",
+          "value": "\"reputation_rules\".\"category\" in ('content', 'social', 'trust', 'moderation', 'physical', 'penalty', 'other')"
+        },
+        "reputation_rules_cooldown_check": {
+          "name": "reputation_rules_cooldown_check",
+          "value": "\"reputation_rules\".\"cooldown_in_minutes\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reputation_transactions": {
+      "name": "reputation_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_id": {
+          "name": "source_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_type": {
+          "name": "source_action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_entity_id": {
+          "name": "target_entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_entity_type": {
+          "name": "target_entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "reversed_transaction_id": {
+          "name": "reversed_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reputation_transactions_user_id_status_idx": {
+          "name": "reputation_transactions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_user_id_created_at_idx": {
+          "name": "reputation_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_application_id_idx": {
+          "name": "reputation_transactions_application_id_idx",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"reputation_transactions\".\"application_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_source_action_key": {
+          "name": "reputation_transactions_source_action_key",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reputation_transactions_status_idx": {
+          "name": "reputation_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reputation_transactions_user_id_users_id_fk": {
+          "name": "reputation_transactions_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_application_id_applications_id_fk": {
+          "name": "reputation_transactions_application_id_applications_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_credential_id_application_credentials_id_fk": {
+          "name": "reputation_transactions_credential_id_application_credentials_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "application_credentials",
+          "columnsFrom": [
+            "credential_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_reversed_transaction_id_reputation_transactions_id_fk": {
+          "name": "reputation_transactions_reversed_transaction_id_reputation_transactions_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "reversed_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_created_by_user_id_users_id_fk": {
+          "name": "reputation_transactions_created_by_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "reputation_transactions_reviewed_by_user_id_users_id_fk": {
+          "name": "reputation_transactions_reviewed_by_user_id_users_id_fk",
+          "tableFrom": "reputation_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "reputation_transactions_category_check": {
+          "name": "reputation_transactions_category_check",
+          "value": "\"reputation_transactions\".\"category\" in ('content', 'social', 'trust', 'moderation', 'physical', 'penalty', 'other')"
+        },
+        "reputation_transactions_status_check": {
+          "name": "reputation_transactions_status_check",
+          "value": "\"reputation_transactions\".\"status\" in ('active', 'disputed', 'reversed', 'voided')"
+        },
+        "reputation_transactions_target_entity_type_check": {
+          "name": "reputation_transactions_target_entity_type_check",
+          "value": "\"reputation_transactions\".\"target_entity_type\" is null or \"reputation_transactions\".\"target_entity_type\" in ('post', 'comment', 'report', 'purchase', 'event', 'check_in', 'manual_review', 'user', 'other')"
+        },
+        "reputation_transactions_reversal_not_self_check": {
+          "name": "reputation_transactions_reversal_not_self_check",
+          "value": "\"reputation_transactions\".\"reversed_transaction_id\" is null or \"reputation_transactions\".\"reversed_transaction_id\" <> \"reputation_transactions\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.restrictions": {
+      "name": "restrictions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "restricted_id": {
+          "name": "restricted_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "restrictions_user_id_users_id_fk": {
+          "name": "restrictions_user_id_users_id_fk",
+          "tableFrom": "restrictions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "restrictions_restricted_id_users_id_fk": {
+          "name": "restrictions_restricted_id_users_id_fk",
+          "tableFrom": "restrictions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "restricted_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "restrictions_user_id_restricted_id_key": {
+          "name": "restrictions_user_id_restricted_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "restricted_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reviewer_reputation_profiles": {
+      "name": "reviewer_reputation_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "agreements": {
+          "name": "agreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "disagreements": {
+          "name": "disagreements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gold_passed": {
+          "name": "gold_passed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gold_failed": {
+          "name": "gold_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "overturned": {
+          "name": "overturned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "global_reliability": {
+          "name": "global_reliability",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "category_reliability": {
+          "name": "category_reliability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "language_reliability": {
+          "name": "language_reliability",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "unlocked_categories": {
+          "name": "unlocked_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "seed_weight": {
+          "name": "seed_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "reviewer_reputation_profiles_status_idx": {
+          "name": "reviewer_reputation_profiles_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviewer_reputation_profiles_user_id_users_id_fk": {
+          "name": "reviewer_reputation_profiles_user_id_users_id_fk",
+          "tableFrom": "reviewer_reputation_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviewer_reputation_profiles_user_id_key": {
+          "name": "reviewer_reputation_profiles_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "reviewer_reputation_profiles_status_check": {
+          "name": "reviewer_reputation_profiles_status_check",
+          "value": "\"reviewer_reputation_profiles\".\"status\" in ('active', 'probation', 'suspended')"
+        },
+        "reviewer_reputation_profiles_category_reliability_object_check": {
+          "name": "reviewer_reputation_profiles_category_reliability_object_check",
+          "value": "jsonb_typeof(\"reviewer_reputation_profiles\".\"category_reliability\") = 'object'"
+        },
+        "reviewer_reputation_profiles_language_reliability_object_check": {
+          "name": "reviewer_reputation_profiles_language_reliability_object_check",
+          "value": "jsonb_typeof(\"reviewer_reputation_profiles\".\"language_reliability\") = 'object'"
+        },
+        "reviewer_reputation_profiles_counts_check": {
+          "name": "reviewer_reputation_profiles_counts_check",
+          "value": "\"reviewer_reputation_profiles\".\"agreements\" >= 0 and \"reviewer_reputation_profiles\".\"disagreements\" >= 0 and \"reviewer_reputation_profiles\".\"gold_passed\" >= 0 and \"reviewer_reputation_profiles\".\"gold_failed\" >= 0 and \"reviewer_reputation_profiles\".\"overturned\" >= 0"
+        },
+        "reviewer_reputation_profiles_global_reliability_check": {
+          "name": "reviewer_reputation_profiles_global_reliability_check",
+          "value": "\"reviewer_reputation_profiles\".\"global_reliability\" >= 0 and \"reviewer_reputation_profiles\".\"global_reliability\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.security_activities": {
+      "name": "security_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_description": {
+          "name": "event_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'low'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "security_activities_user_id_occurred_at_idx": {
+          "name": "security_activities_user_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_user_id_event_type_occurred_at_idx": {
+          "name": "security_activities_user_id_event_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_user_id_device_id_occurred_at_idx": {
+          "name": "security_activities_user_id_device_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "security_activities_occurred_at_idx": {
+          "name": "security_activities_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_activities_user_id_users_id_fk": {
+          "name": "security_activities_user_id_users_id_fk",
+          "tableFrom": "security_activities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "security_activities_event_type_check": {
+          "name": "security_activities_event_type_check",
+          "value": "\"security_activities\".\"event_type\" in ('sign_in', 'sign_out', 'email_changed', 'profile_updated', 'device_added', 'device_removed', 'account_recovery', 'security_settings_changed', 'private_key_exported', 'backup_created', 'suspicious_activity')"
+        },
+        "security_activities_severity_check": {
+          "name": "security_activities_severity_check",
+          "value": "\"security_activities\".\"severity\" in ('low', 'medium', 'high', 'critical')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sender_avatars": {
+      "name": "sender_avatars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "sender_avatars_email_key": {
+          "name": "sender_avatars_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sender_avatars_expires_at_idx": {
+          "name": "sender_avatars_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sender_avatars_source_check": {
+          "name": "sender_avatars_source_check",
+          "value": "\"sender_avatars\".\"source\" in ('oxy', 'bimi', 'gravatar', 'favicon', 'none')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "os": {
+          "name": "os",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_fingerprint": {
+          "name": "device_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_refresh_token": {
+          "name": "previous_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_rotated_at": {
+          "name": "token_rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operated_by_user_id": {
+          "name": "operated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "device_session_id": {
+          "name": "device_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_context_id": {
+          "name": "device_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_refresh": {
+          "name": "last_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_device_id_idx": {
+          "name": "sessions_user_id_device_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_id_is_active_expires_at_idx": {
+          "name": "sessions_user_id_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_device_id_is_active_expires_at_idx": {
+          "name": "sessions_device_id_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_previous_refresh_token_rotated_at_idx": {
+          "name": "sessions_previous_refresh_token_rotated_at_idx",
+          "columns": [
+            {
+              "expression": "previous_refresh_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token_rotated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"previous_refresh_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_device_fingerprint_is_active_expires_at_idx": {
+          "name": "sessions_device_fingerprint_is_active_expires_at_idx",
+          "columns": [
+            {
+              "expression": "device_fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"sessions\".\"device_fingerprint\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_operated_by_user_id_users_id_fk": {
+          "name": "sessions_operated_by_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "operated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_application_id_applications_id_fk": {
+          "name": "sessions_application_id_applications_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_device_session_id_device_sessions_id_fk": {
+          "name": "sessions_device_session_id_device_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "device_sessions",
+          "columnsFrom": [
+            "device_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sessions_device_context_id_device_account_contexts_id_fk": {
+          "name": "sessions_device_context_id_device_account_contexts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "device_account_contexts",
+          "columnsFrom": [
+            "device_context_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_id_key": {
+          "name": "sessions_session_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        },
+        "sessions_access_token_key": {
+          "name": "sessions_access_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "access_token"
+          ]
+        },
+        "sessions_refresh_token_key": {
+          "name": "sessions_refresh_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refresh_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.signed_records": {
+      "name": "signed_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev": {
+          "name": "prev",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nsid": {
+          "name": "nsid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rkey": {
+          "name": "rkey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "signed_records_subject_did_idx": {
+          "name": "signed_records_subject_did_idx",
+          "columns": [
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_type_created_at_idx": {
+          "name": "signed_records_user_id_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_seq_key": {
+          "name": "signed_records_user_id_seq_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_user_id_nsid_rkey_created_at_idx": {
+          "name": "signed_records_user_id_nsid_rkey_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nsid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rkey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"signed_records\".\"nsid\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "signed_records_authors_created_at_id_idx": {
+          "name": "signed_records_authors_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"signed_records\".\"nsid\" is not null and \"signed_records\".\"verified\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "signed_records_user_id_users_id_fk": {
+          "name": "signed_records_user_id_users_id_fk",
+          "tableFrom": "signed_records",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "signed_records_prev_signed_records_record_id_fk": {
+          "name": "signed_records_prev_signed_records_record_id_fk",
+          "tableFrom": "signed_records",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "prev"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "signed_records_recordId_unique": {
+          "name": "signed_records_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "signed_records_type_check": {
+          "name": "signed_records_type_check",
+          "value": "\"signed_records\".\"type\" in ('identity', 'profile', 'reputation_attestation', 'real_life_attestation', 'validation_verdict', 'personhood_vouch', 'credential', 'node', 'app_record')"
+        },
+        "signed_records_seq_check": {
+          "name": "signed_records_seq_check",
+          "value": "\"signed_records\".\"seq\" is null or \"signed_records\".\"seq\" >= 0"
+        },
+        "signed_records_chain_completeness_check": {
+          "name": "signed_records_chain_completeness_check",
+          "value": "(\"signed_records\".\"seq\" is null and \"signed_records\".\"record_id\" is null and \"signed_records\".\"nsid\" is null and \"signed_records\".\"rkey\" is null) or (\"signed_records\".\"record_id\" is not null and \"signed_records\".\"nsid\" is not null and \"signed_records\".\"rkey\" is not null)"
+        },
+        "signed_records_prev_not_self_check": {
+          "name": "signed_records_prev_not_self_check",
+          "value": "\"signed_records\".\"prev\" is null or \"signed_records\".\"prev\" <> \"signed_records\".\"record_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'basic'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_renew": {
+          "name": "auto_renew",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_invoice": {
+          "name": "latest_invoice",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature_analytics": {
+          "name": "feature_analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_premium_badge": {
+          "name": "feature_premium_badge",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_unlimited_following": {
+          "name": "feature_unlimited_following",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_higher_upload_limits": {
+          "name": "feature_higher_upload_limits",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_promoted_posts": {
+          "name": "feature_promoted_posts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feature_business_tools": {
+          "name": "feature_business_tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_status_idx": {
+          "name": "subscriptions_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_active_end_date_idx": {
+          "name": "subscriptions_active_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"subscriptions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_user_id_users_id_fk": {
+          "name": "subscriptions_user_id_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "subscriptions_plan_check": {
+          "name": "subscriptions_plan_check",
+          "value": "\"subscriptions\".\"plan\" in ('basic', 'pro', 'business')"
+        },
+        "subscriptions_status_check": {
+          "name": "subscriptions_status_check",
+          "value": "\"subscriptions\".\"status\" in ('active', 'canceled', 'expired')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "parent_topic_id": {
+          "name": "parent_topic_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "translations": {
+          "name": "translations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "setweight(to_tsvector('english', coalesce(name, '')), 'A') || setweight(to_tsvector('english', coalesce(display_name, '')), 'B') || setweight(to_tsvector('english', replace(array_to_tsvector(coalesce(aliases, '{}'::text[]))::text, '''', ' ')), 'C') || setweight(to_tsvector('english', coalesce(description, '')), 'D')",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "topics_is_active_type_idx": {
+          "name": "topics_is_active_type_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_parent_topic_id_idx": {
+          "name": "topics_parent_topic_id_idx",
+          "columns": [
+            {
+              "expression": "parent_topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"topics\".\"parent_topic_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "topics_search_vector_idx": {
+          "name": "topics_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_parent_topic_id_topics_id_fk": {
+          "name": "topics_parent_topic_id_topics_id_fk",
+          "tableFrom": "topics",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "parent_topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topics_name_key": {
+          "name": "topics_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topics_slug_key": {
+          "name": "topics_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "topics_type_check": {
+          "name": "topics_type_check",
+          "value": "\"topics\".\"type\" in ('category', 'topic', 'entity')"
+        },
+        "topics_source_check": {
+          "name": "topics_source_check",
+          "value": "\"topics\".\"source\" in ('seed', 'ai', 'manual', 'system')"
+        },
+        "topics_translations_object_check": {
+          "name": "topics_translations_object_check",
+          "value": "\"topics\".\"translations\" is null or jsonb_typeof(\"topics\".\"translations\") = 'object'"
+        },
+        "topics_parent_topic_id_not_self_check": {
+          "name": "topics_parent_topic_id_not_self_check",
+          "value": "\"topics\".\"parent_topic_id\" <> \"topics\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(38, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_reference": {
+          "name": "external_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "transactions_user_id_created_at_idx": {
+          "name": "transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transactions_recipient_id_created_at_idx": {
+          "name": "transactions_recipient_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"transactions\".\"recipient_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_user_id_users_id_fk": {
+          "name": "transactions_user_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "transactions_recipient_id_users_id_fk": {
+          "name": "transactions_recipient_id_users_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transactions_type_check": {
+          "name": "transactions_type_check",
+          "value": "\"transactions\".\"type\" in ('deposit', 'withdrawal', 'transfer', 'purchase')"
+        },
+        "transactions_status_check": {
+          "name": "transactions_status_check",
+          "value": "\"transactions\".\"status\" in ('pending', 'completed', 'failed', 'cancelled')"
+        },
+        "transactions_amount_check": {
+          "name": "transactions_amount_check",
+          "value": "\"transactions\".\"amount\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_anchors": {
+      "name": "transparency_checkpoint_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "network": {
+          "name": "network",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txid": {
+          "name": "txid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confirmations": {
+          "name": "confirmations",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "anchored_at": {
+          "name": "anchored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_anchors_txid_key": {
+          "name": "transparency_checkpoint_anchors_txid_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "network",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "txid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_anchors_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_anchors_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_anchors",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_anchors_confirmations_check": {
+          "name": "transparency_checkpoint_anchors_confirmations_check",
+          "value": "\"transparency_checkpoint_anchors\".\"confirmations\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_signatures": {
+      "name": "transparency_checkpoint_signatures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_signatures_position_key": {
+          "name": "transparency_checkpoint_signatures_position_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "transparency_checkpoint_signatures_signer_key": {
+          "name": "transparency_checkpoint_signatures_signer_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_signatures_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_signatures_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_signatures",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_signatures_alg_check": {
+          "name": "transparency_checkpoint_signatures_alg_check",
+          "value": "\"transparency_checkpoint_signatures\".\"alg\" in ('ES256K-DER-SHA256')"
+        },
+        "transparency_checkpoint_signatures_position_check": {
+          "name": "transparency_checkpoint_signatures_position_check",
+          "value": "\"transparency_checkpoint_signatures\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoint_snapshot_entries": {
+      "name": "transparency_checkpoint_snapshot_entries",
+      "schema": "",
+      "columns": {
+        "checkpoint_id": {
+          "name": "checkpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leaf_index": {
+          "name": "leaf_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_did": {
+          "name": "subject_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_record_id": {
+          "name": "head_record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "transparency_checkpoint_snapshot_entries_subject_key": {
+          "name": "transparency_checkpoint_snapshot_entries_subject_key",
+          "columns": [
+            {
+              "expression": "checkpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transparency_checkpoint_snapshot_entries_checkpoint_id_transparency_checkpoints_id_fk": {
+          "name": "transparency_checkpoint_snapshot_entries_checkpoint_id_transparency_checkpoints_id_fk",
+          "tableFrom": "transparency_checkpoint_snapshot_entries",
+          "tableTo": "transparency_checkpoints",
+          "columnsFrom": [
+            "checkpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "transparency_checkpoint_snapshot_entries_pkey": {
+          "name": "transparency_checkpoint_snapshot_entries_pkey",
+          "columns": [
+            "checkpoint_id",
+            "leaf_index"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoint_snapshot_entries_leaf_index_check": {
+          "name": "transparency_checkpoint_snapshot_entries_leaf_index_check",
+          "value": "\"transparency_checkpoint_snapshot_entries\".\"leaf_index\" >= 0"
+        },
+        "transparency_checkpoint_snapshot_entries_seq_check": {
+          "name": "transparency_checkpoint_snapshot_entries_seq_check",
+          "value": "\"transparency_checkpoint_snapshot_entries\".\"seq\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.transparency_checkpoints": {
+      "name": "transparency_checkpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tree_size": {
+          "name": "tree_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "root": {
+          "name": "root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_checkpoint_hash": {
+          "name": "prev_checkpoint_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "transparency_checkpoints_index_unique": {
+          "name": "transparency_checkpoints_index_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "transparency_checkpoints_index_check": {
+          "name": "transparency_checkpoints_index_check",
+          "value": "\"transparency_checkpoints\".\"index\" >= 0"
+        },
+        "transparency_checkpoints_tree_size_check": {
+          "name": "transparency_checkpoints_tree_size_check",
+          "value": "\"transparency_checkpoints\".\"tree_size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_assets": {
+      "name": "update_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "'public/updates/assets/' || sha256",
+            "type": "stored"
+          }
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "update_assets_sha256_key": {
+          "name": "update_assets_sha256_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sha256"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "update_assets_status_check": {
+          "name": "update_assets_status_check",
+          "value": "\"update_assets\".\"status\" in ('pending', 'uploaded')"
+        },
+        "update_assets_sha256_check": {
+          "name": "update_assets_sha256_check",
+          "value": "\"update_assets\".\"sha256\" ~ '^[a-f0-9]{64}$'"
+        },
+        "update_assets_size_check": {
+          "name": "update_assets_size_check",
+          "value": "\"update_assets\".\"size\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_channel_rollbacks": {
+      "name": "update_channel_rollbacks",
+      "schema": "",
+      "columns": {
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_version": {
+          "name": "runtime_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit_time": {
+          "name": "commit_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "update_channel_rollbacks_channel_id_update_channels_id_fk": {
+          "name": "update_channel_rollbacks_channel_id_update_channels_id_fk",
+          "tableFrom": "update_channel_rollbacks",
+          "tableTo": "update_channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "update_channel_rollbacks_pkey": {
+          "name": "update_channel_rollbacks_pkey",
+          "columns": [
+            "channel_id",
+            "runtime_version",
+            "platform"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "update_channel_rollbacks_platform_check": {
+          "name": "update_channel_rollbacks_platform_check",
+          "value": "\"update_channel_rollbacks\".\"platform\" in ('ios', 'android')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.update_channels": {
+      "name": "update_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "update_channels_application_id_applications_id_fk": {
+          "name": "update_channels_application_id_applications_id_fk",
+          "tableFrom": "update_channels",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "update_channels_application_id_name_key": {
+          "name": "update_channels_application_id_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "application_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_analytics": {
+      "name": "user_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_views": {
+          "name": "post_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "profile_views": {
+          "name": "profile_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_likes": {
+          "name": "engagement_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_replies": {
+          "name": "engagement_replies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_reposts": {
+          "name": "engagement_reposts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_quotes": {
+          "name": "engagement_quotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "engagement_bookmarks": {
+          "name": "engagement_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reach_impressions": {
+          "name": "reach_impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reach_unique_viewers": {
+          "name": "reach_unique_viewers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "demographics_countries": {
+          "name": "demographics_countries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "demographics_languages": {
+          "name": "demographics_languages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "peak_activity_hour": {
+          "name": "peak_activity_hour",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "peak_activity_count": {
+          "name": "peak_activity_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_analytics_user_id_users_id_fk": {
+          "name": "user_analytics_user_id_users_id_fk",
+          "tableFrom": "user_analytics",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_analytics_user_id_period_date_key": {
+          "name": "user_analytics_user_id_period_date_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "period",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_analytics_period_check": {
+          "name": "user_analytics_period_check",
+          "value": "\"user_analytics\".\"period\" in ('daily', 'weekly', 'monthly', 'yearly')"
+        },
+        "user_analytics_peak_activity_hour_check": {
+          "name": "user_analytics_peak_activity_hour_check",
+          "value": "\"user_analytics\".\"peak_activity_hour\" >= 0 and \"user_analytics\".\"peak_activity_hour\" < 24"
+        },
+        "user_analytics_demographics_countries_object_check": {
+          "name": "user_analytics_demographics_countries_object_check",
+          "value": "jsonb_typeof(\"user_analytics\".\"demographics_countries\") = 'object'"
+        },
+        "user_analytics_demographics_languages_object_check": {
+          "name": "user_analytics_demographics_languages_object_check",
+          "value": "jsonb_typeof(\"user_analytics\".\"demographics_languages\") = 'object'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_ancestors": {
+      "name": "user_ancestors",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ancestor_id": {
+          "name": "ancestor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_ancestors_ancestor_id_idx": {
+          "name": "user_ancestors_ancestor_id_idx",
+          "columns": [
+            {
+              "expression": "ancestor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_ancestors_user_id_users_id_fk": {
+          "name": "user_ancestors_user_id_users_id_fk",
+          "tableFrom": "user_ancestors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_ancestors_ancestor_id_users_id_fk": {
+          "name": "user_ancestors_ancestor_id_users_id_fk",
+          "tableFrom": "user_ancestors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ancestor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_ancestors_pkey": {
+          "name": "user_ancestors_pkey",
+          "columns": [
+            "user_id",
+            "depth"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_ancestors_depth_check": {
+          "name": "user_ancestors_depth_check",
+          "value": "\"user_ancestors\".\"depth\" >= 0 and \"user_ancestors\".\"depth\" < 8"
+        },
+        "user_ancestors_not_self_check": {
+          "name": "user_ancestors_not_self_check",
+          "value": "\"user_ancestors\".\"ancestor_id\" <> \"user_ancestors\".\"user_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_app_data": {
+      "name": "user_app_data",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_app_data_user_id_users_id_fk": {
+          "name": "user_app_data_user_id_users_id_fk",
+          "tableFrom": "user_app_data",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_app_data_user_id_namespace_key_key": {
+          "name": "user_app_data_user_id_namespace_key_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "namespace",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_app_data_namespace_check": {
+          "name": "user_app_data_namespace_check",
+          "value": "\"user_app_data\".\"namespace\" ~ '^[a-z0-9_-]{1,64}$'"
+        },
+        "user_app_data_key_check": {
+          "name": "user_app_data_key_check",
+          "value": "\"user_app_data\".\"key\" ~ '^[a-z0-9_-]{1,64}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_auth_methods": {
+      "name": "user_auth_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "method_public_key": {
+          "name": "method_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_email": {
+          "name": "method_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_credential_id": {
+          "name": "method_credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_name": {
+          "name": "method_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "user_auth_methods_user_id_idx": {
+          "name": "user_auth_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_auth_methods_lower_method_public_key_key": {
+          "name": "user_auth_methods_lower_method_public_key_key",
+          "columns": [
+            {
+              "expression": "lower(\"method_public_key\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_auth_methods\".\"method_public_key\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_auth_methods_method_credential_id_key": {
+          "name": "user_auth_methods_method_credential_id_key",
+          "columns": [
+            {
+              "expression": "method_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_auth_methods\".\"method_credential_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_auth_methods_user_id_users_id_fk": {
+          "name": "user_auth_methods_user_id_users_id_fk",
+          "tableFrom": "user_auth_methods",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_auth_methods_type_check": {
+          "name": "user_auth_methods_type_check",
+          "value": "\"user_auth_methods\".\"type\" in ('identity', 'webauthn')"
+        },
+        "user_auth_methods_identifier_check": {
+          "name": "user_auth_methods_identifier_check",
+          "value": "(\"user_auth_methods\".\"type\" = 'identity' and \"user_auth_methods\".\"method_public_key\" is not null) or (\"user_auth_methods\".\"type\" = 'webauthn' and \"user_auth_methods\".\"method_credential_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_credits": {
+      "name": "user_credits",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "credits_free": {
+          "name": "credits_free",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "credits_free_limit": {
+          "name": "credits_free_limit",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "credits_daily_refresh": {
+          "name": "credits_daily_refresh",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 300
+        },
+        "credits_last_refresh": {
+          "name": "credits_last_refresh",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "credits_paid": {
+          "name": "credits_paid",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "user_credits_stripe_customer_id_key": {
+          "name": "user_credits_stripe_customer_id_key",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_credits\".\"stripe_customer_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_credits_user_id_users_id_fk": {
+          "name": "user_credits_user_id_users_id_fk",
+          "tableFrom": "user_credits",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_credits_credits_free_check": {
+          "name": "user_credits_credits_free_check",
+          "value": "\"user_credits\".\"credits_free\" >= 0"
+        },
+        "user_credits_credits_paid_check": {
+          "name": "user_credits_credits_paid_check",
+          "value": "\"user_credits\".\"credits_paid\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_follows": {
+      "name": "user_follows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followed_id": {
+          "name": "followed_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "user_follows_followed_id_created_at_id_idx": {
+          "name": "user_follows_followed_id_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "followed_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_follows_created_at_id_idx": {
+          "name": "user_follows_created_at_id_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_follows_follower_id_users_id_fk": {
+          "name": "user_follows_follower_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_follows_followed_id_users_id_fk": {
+          "name": "user_follows_followed_id_users_id_fk",
+          "tableFrom": "user_follows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "followed_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_follows_follower_id_followed_id_key": {
+          "name": "user_follows_follower_id_followed_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "follower_id",
+            "followed_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_follows_not_self_check": {
+          "name": "user_follows_not_self_check",
+          "value": "\"user_follows\".\"follower_id\" <> \"user_follows\".\"followed_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_link_metadata": {
+      "name": "user_link_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "user_link_metadata_user_id_position_key": {
+          "name": "user_link_metadata_user_id_position_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_link_metadata_user_id_users_id_fk": {
+          "name": "user_link_metadata_user_id_users_id_fk",
+          "tableFrom": "user_link_metadata",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_locations": {
+      "name": "user_locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_key": {
+          "name": "location_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'other'"
+        },
+        "street": {
+          "name": "street",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street_number": {
+          "name": "street_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "street_details": {
+          "name": "street_details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formatted_address": {
+          "name": "formatted_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo": {
+          "name": "geo",
+          "type": "geography",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "ST_MakePoint(longitude, latitude)::geography",
+            "type": "stored"
+          }
+        },
+        "place_id": {
+          "name": "place_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_id": {
+          "name": "osm_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "osm_type": {
+          "name": "osm_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(name, '') || ' ' || coalesce(formatted_address, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "user_locations_user_id_location_key_key": {
+          "name": "user_locations_user_id_location_key_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_city_country_idx": {
+          "name": "user_locations_city_country_idx",
+          "columns": [
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_country_idx": {
+          "name": "user_locations_country_idx",
+          "columns": [
+            {
+              "expression": "country",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_type_city_idx": {
+          "name": "user_locations_type_city_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_country_code_city_idx": {
+          "name": "user_locations_country_code_city_idx",
+          "columns": [
+            {
+              "expression": "country_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "city",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_locations_search_vector_idx": {
+          "name": "user_locations_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "user_locations_geo_idx": {
+          "name": "user_locations_geo_idx",
+          "columns": [
+            {
+              "expression": "geo",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_locations_user_id_users_id_fk": {
+          "name": "user_locations_user_id_users_id_fk",
+          "tableFrom": "user_locations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_locations_type_check": {
+          "name": "user_locations_type_check",
+          "value": "\"user_locations\".\"type\" in ('home', 'work', 'school', 'other')"
+        },
+        "user_locations_latitude_check": {
+          "name": "user_locations_latitude_check",
+          "value": "\"user_locations\".\"latitude\" is null or (\"user_locations\".\"latitude\" >= -90 and \"user_locations\".\"latitude\" <= 90)"
+        },
+        "user_locations_longitude_check": {
+          "name": "user_locations_longitude_check",
+          "value": "\"user_locations\".\"longitude\" is null or (\"user_locations\".\"longitude\" >= -180 and \"user_locations\".\"longitude\" <= 180)"
+        },
+        "user_locations_coordinates_complete_check": {
+          "name": "user_locations_coordinates_complete_check",
+          "value": "(\"user_locations\".\"latitude\" is null) = (\"user_locations\".\"longitude\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_nodes": {
+      "name": "user_nodes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_did": {
+          "name": "node_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_public_key": {
+          "name": "node_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pull'"
+        },
+        "managed": {
+          "name": "managed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_probe_at": {
+          "name": "last_probe_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "user_nodes_status_idx": {
+          "name": "user_nodes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_nodes_user_id_users_id_fk": {
+          "name": "user_nodes_user_id_users_id_fk",
+          "tableFrom": "user_nodes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_nodes_userId_unique": {
+          "name": "user_nodes_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_nodes_mode_check": {
+          "name": "user_nodes_mode_check",
+          "value": "\"user_nodes\".\"mode\" in ('pull', 'push')"
+        },
+        "user_nodes_controller_check": {
+          "name": "user_nodes_controller_check",
+          "value": "\"user_nodes\".\"controller\" in ('self', 'oxy')"
+        },
+        "user_nodes_status_check": {
+          "name": "user_nodes_status_check",
+          "value": "\"user_nodes\".\"status\" in ('active', 'unreachable', 'revoked')"
+        },
+        "user_nodes_cursor_check": {
+          "name": "user_nodes_cursor_check",
+          "value": "\"user_nodes\".\"cursor\" is null or \"user_nodes\".\"cursor\" >= 0"
+        },
+        "user_nodes_managed_controller_check": {
+          "name": "user_nodes_managed_controller_check",
+          "value": "(\"user_nodes\".\"managed\" = true and \"user_nodes\".\"controller\" = 'oxy') or (\"user_nodes\".\"managed\" = false and \"user_nodes\".\"controller\" = 'self')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_verified_domains": {
+      "name": "user_verified_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "user_verified_domains_user_id_lower_domain_key": {
+          "name": "user_verified_domains_user_id_lower_domain_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_verified_domains_lower_domain_idx": {
+          "name": "user_verified_domains_lower_domain_idx",
+          "columns": [
+            {
+              "expression": "lower(\"domain\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_verified_domains_user_id_users_id_fk": {
+          "name": "user_verified_domains_user_id_users_id_fk",
+          "tableFrom": "user_verified_domains",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "user_verified_domains_method_check": {
+          "name": "user_verified_domains_method_check",
+          "value": "\"user_verified_domains\".\"method\" in ('dns-txt', 'well-known')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hashed_email": {
+          "name": "hashed_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when btrim(coalesce(email, '')) = '' then null else encode(sha256(decode(replace(lower(btrim(email)), '\\', '\\\\'), 'escape')), 'hex') end",
+            "type": "stored"
+          }
+        },
+        "hashed_phone": {
+          "name": "hashed_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "case when regexp_replace(coalesce(phone, ''), '[^0-9]', '', 'g') = '' then null else encode(sha256(decode(replace('+' || regexp_replace(phone, '[^0-9]', '', 'g'), '\\', '\\\\'), 'escape')), 'hex') end",
+            "type": "stored"
+          }
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_first": {
+          "name": "name_first",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_last": {
+          "name": "name_last",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name_display": {
+          "name": "name_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "account_categories": {
+          "name": "account_categories",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "parent_account_id": {
+          "name": "parent_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "root_account_id": {
+          "name": "root_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_status": {
+          "name": "account_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "federation_actor_uri": {
+          "name": "federation_actor_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_domain": {
+          "name": "federation_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_actor_id": {
+          "name": "federation_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_last_avatar_fetched_at": {
+          "name": "federation_last_avatar_fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_avatar_e_tag": {
+          "name": "federation_avatar_e_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_avatar_last_modified": {
+          "name": "federation_avatar_last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_last_resolved_at": {
+          "name": "federation_last_resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_unavailable_at": {
+          "name": "federation_unavailable_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "federation_unavailable_reason": {
+          "name": "federation_unavailable_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_owner_id": {
+          "name": "automation_owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reputation_rank_weight": {
+          "name": "reputation_rank_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.1
+        },
+        "reputation_tier": {
+          "name": "reputation_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "is_staff": {
+          "name": "is_staff",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_seed_verifier": {
+          "name": "is_seed_verifier",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_sensitive": {
+          "name": "is_sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"en-US\"}'"
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_expires_after_inactivity_days": {
+          "name": "account_expires_after_inactivity_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacy_is_private_account": {
+          "name": "privacy_is_private_account",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_online_status": {
+          "name": "privacy_hide_online_status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_hide_last_seen": {
+          "name": "privacy_hide_last_seen",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_profile_visibility": {
+          "name": "privacy_profile_visibility",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_login_alerts": {
+          "name": "privacy_login_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_block_screenshots": {
+          "name": "privacy_block_screenshots",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_login": {
+          "name": "privacy_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_biometric_login": {
+          "name": "privacy_biometric_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_show_activity": {
+          "name": "privacy_show_activity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_tagging": {
+          "name": "privacy_allow_tagging",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_allow_mentions": {
+          "name": "privacy_allow_mentions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_hide_read_receipts": {
+          "name": "privacy_hide_read_receipts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_allow_direct_messages": {
+          "name": "privacy_allow_direct_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_data_sharing": {
+          "name": "privacy_data_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_location_sharing": {
+          "name": "privacy_location_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_analytics_sharing": {
+          "name": "privacy_analytics_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_sensitive_content": {
+          "name": "privacy_sensitive_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_auto_filter": {
+          "name": "privacy_auto_filter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "privacy_mute_keywords": {
+          "name": "privacy_mute_keywords",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_discoverable_by_email": {
+          "name": "privacy_discoverable_by_email",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_discoverable_by_phone": {
+          "name": "privacy_discoverable_by_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacy_fediverse_sharing": {
+          "name": "privacy_fediverse_sharing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "email_signature": {
+          "name": "email_signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_enabled": {
+          "name": "auto_reply_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reply_subject": {
+          "name": "auto_reply_subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_body": {
+          "name": "auto_reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_start_date": {
+          "name": "auto_reply_start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reply_end_date": {
+          "name": "auto_reply_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_forward_to": {
+          "name": "auto_forward_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_forward_keep_copy": {
+          "name": "auto_forward_keep_copy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_push_enabled": {
+          "name": "notification_push_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_email_digest": {
+          "name": "notification_email_digest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_security_alerts": {
+          "name": "notification_security_alerts",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notification_marketing_emails": {
+          "name": "notification_marketing_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preference_language": {
+          "name": "preference_language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_theme": {
+          "name": "preference_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "preference_reduce_motion": {
+          "name": "preference_reduce_motion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preference_timezone": {
+          "name": "preference_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference_mode": {
+          "name": "theme_preference_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_preference_color_preset": {
+          "name": "theme_preference_color_preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "users_lower_username_key": {
+          "name": "users_lower_username_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"username\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_lower_email_key": {
+          "name": "users_lower_email_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"email\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_lower_public_key_key": {
+          "name": "users_lower_public_key_key",
+          "columns": [
+            {
+              "expression": "lower(btrim(\"public_key\"))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_actor_uri_key": {
+          "name": "users_federation_actor_uri_key",
+          "columns": [
+            {
+              "expression": "federation_actor_uri",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_hashed_email_idx": {
+          "name": "users_hashed_email_idx",
+          "columns": [
+            {
+              "expression": "hashed_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"hashed_email\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_hashed_phone_idx": {
+          "name": "users_hashed_phone_idx",
+          "columns": [
+            {
+              "expression": "hashed_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"hashed_phone\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_kind_parent_account_id_idx": {
+          "name": "users_kind_parent_account_id_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_parent_account_id_idx": {
+          "name": "users_parent_account_id_idx",
+          "columns": [
+            {
+              "expression": "parent_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"parent_account_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_root_account_id_idx": {
+          "name": "users_root_account_id_idx",
+          "columns": [
+            {
+              "expression": "root_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"root_account_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_type_idx": {
+          "name": "users_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_domain_idx": {
+          "name": "users_federation_domain_idx",
+          "columns": [
+            {
+              "expression": "federation_domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_domain\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_last_resolved_at_idx": {
+          "name": "users_federation_last_resolved_at_idx",
+          "columns": [
+            {
+              "expression": "federation_last_resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_last_resolved_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_federation_unavailable_at_idx": {
+          "name": "users_federation_unavailable_at_idx",
+          "columns": [
+            {
+              "expression": "federation_unavailable_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"federation_unavailable_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_automation_owner_id_idx": {
+          "name": "users_automation_owner_id_idx",
+          "columns": [
+            {
+              "expression": "automation_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"users\".\"automation_owner_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_reputation_rank_weight_idx": {
+          "name": "users_reputation_rank_weight_idx",
+          "columns": [
+            {
+              "expression": "reputation_rank_weight",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_reputation_tier_idx": {
+          "name": "users_reputation_tier_idx",
+          "columns": [
+            {
+              "expression": "reputation_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_is_sensitive_idx": {
+          "name": "users_is_sensitive_idx",
+          "columns": [
+            {
+              "expression": "is_sensitive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_parent_account_id_users_id_fk": {
+          "name": "users_parent_account_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "parent_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_root_account_id_users_id_fk": {
+          "name": "users_root_account_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "root_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "users_automation_owner_id_users_id_fk": {
+          "name": "users_automation_owner_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "automation_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "users_kind_check": {
+          "name": "users_kind_check",
+          "value": "\"users\".\"kind\" in ('personal', 'organization', 'project', 'bot', 'channel')"
+        },
+        "users_account_categories_check": {
+          "name": "users_account_categories_check",
+          "value": "\"users\".\"account_categories\" <@ array['news', 'politics', 'business', 'startup', 'finance', 'crypto', 'marketplace', 'retail', 'real_estate', 'agency', 'landlord', 'cooperative', 'architecture', 'technology', 'software', 'ai', 'security', 'automation', 'science', 'education', 'books', 'health', 'fitness', 'sports', 'gaming', 'music', 'film', 'podcast', 'art', 'photography', 'comedy', 'food', 'travel', 'fashion', 'home_garden', 'diy', 'automotive', 'animals', 'family', 'nonprofit', 'government', 'community', 'activism', 'environment', 'religion', 'other']::text[]"
+        },
+        "users_account_categories_max_check": {
+          "name": "users_account_categories_max_check",
+          "value": "cardinality(\"users\".\"account_categories\") <= 4"
+        },
+        "users_account_categories_kind_check": {
+          "name": "users_account_categories_kind_check",
+          "value": "\"users\".\"kind\" in ('organization', 'project', 'bot', 'channel') or cardinality(\"users\".\"account_categories\") = 0"
+        },
+        "users_account_status_check": {
+          "name": "users_account_status_check",
+          "value": "\"users\".\"account_status\" in ('active', 'archived')"
+        },
+        "users_type_check": {
+          "name": "users_type_check",
+          "value": "\"users\".\"type\" in ('local', 'federated', 'agent', 'automated')"
+        },
+        "users_reputation_tier_check": {
+          "name": "users_reputation_tier_check",
+          "value": "\"users\".\"reputation_tier\" in ('restricted', 'new', 'trusted', 'high_trust', 'verified')"
+        },
+        "users_preference_theme_check": {
+          "name": "users_preference_theme_check",
+          "value": "\"users\".\"preference_theme\" in ('light', 'dark', 'system')"
+        },
+        "users_color_check": {
+          "name": "users_color_check",
+          "value": "\"users\".\"color\" in ('teal', 'blue', 'green', 'amber', 'red', 'purple', 'pink', 'sky', 'orange', 'mint', 'oxy') or \"users\".\"color\" ~* '^#([0-9a-f]{3}|[0-9a-f]{6})$'"
+        },
+        "users_account_expires_after_inactivity_days_check": {
+          "name": "users_account_expires_after_inactivity_days_check",
+          "value": "\"users\".\"account_expires_after_inactivity_days\" is null or \"users\".\"account_expires_after_inactivity_days\" in (30, 90, 180, 365)"
+        },
+        "users_theme_preference_check": {
+          "name": "users_theme_preference_check",
+          "value": "(\"users\".\"theme_preference_mode\" is null and \"users\".\"theme_preference_color_preset\" is null) or (\"users\".\"theme_preference_mode\" is not null and \"users\".\"theme_preference_color_preset\" is not null and length(\"users\".\"theme_preference_color_preset\") > 0)"
+        },
+        "users_parent_account_id_not_self_check": {
+          "name": "users_parent_account_id_not_self_check",
+          "value": "\"users\".\"parent_account_id\" <> \"users\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_request_validators": {
+      "name": "validation_request_validators",
+      "schema": "",
+      "columns": {
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "validation_request_validators_user_id_idx": {
+          "name": "validation_request_validators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_request_validators_position_key": {
+          "name": "validation_request_validators_position_key",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_request_validators_request_id_validation_requests_id_fk": {
+          "name": "validation_request_validators_request_id_validation_requests_id_fk",
+          "tableFrom": "validation_request_validators",
+          "tableTo": "validation_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_request_validators_user_id_users_id_fk": {
+          "name": "validation_request_validators_user_id_users_id_fk",
+          "tableFrom": "validation_request_validators",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "validation_request_validators_pkey": {
+          "name": "validation_request_validators_pkey",
+          "columns": [
+            "request_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_request_validators_position_check": {
+          "name": "validation_request_validators_position_check",
+          "value": "\"validation_request_validators\".\"position\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_requests": {
+      "name": "validation_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_action_id": {
+          "name": "source_action_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_hash": {
+          "name": "payload_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "quorum": {
+          "name": "quorum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "high_value": {
+          "name": "high_value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rng_seed": {
+          "name": "rng_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_snapshot": {
+          "name": "candidate_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_txn_id": {
+          "name": "resolved_txn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "validation_requests_subject_user_id_idx": {
+          "name": "validation_requests_subject_user_id_idx",
+          "columns": [
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_requests_status_expires_at_idx": {
+          "name": "validation_requests_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_requests_open_source_action_key": {
+          "name": "validation_requests_open_source_action_key",
+          "columns": [
+            {
+              "expression": "source_action_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"validation_requests\".\"status\" in ('pending', 'quorum_met')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_requests_subject_user_id_users_id_fk": {
+          "name": "validation_requests_subject_user_id_users_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_requests_application_id_applications_id_fk": {
+          "name": "validation_requests_application_id_applications_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "validation_requests_resolved_txn_id_reputation_transactions_id_fk": {
+          "name": "validation_requests_resolved_txn_id_reputation_transactions_id_fk",
+          "tableFrom": "validation_requests",
+          "tableTo": "reputation_transactions",
+          "columnsFrom": [
+            "resolved_txn_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_requests_status_check": {
+          "name": "validation_requests_status_check",
+          "value": "\"validation_requests\".\"status\" in ('pending', 'quorum_met', 'validated', 'rejected', 'expired')"
+        },
+        "validation_requests_outcome_check": {
+          "name": "validation_requests_outcome_check",
+          "value": "\"validation_requests\".\"outcome\" is null or \"validation_requests\".\"outcome\" in ('validated', 'rejected')"
+        },
+        "validation_requests_quorum_check": {
+          "name": "validation_requests_quorum_check",
+          "value": "\"validation_requests\".\"quorum\" > 0"
+        },
+        "validation_requests_threshold_check": {
+          "name": "validation_requests_threshold_check",
+          "value": "\"validation_requests\".\"threshold\" >= \"validation_requests\".\"quorum\""
+        },
+        "validation_requests_terminal_check": {
+          "name": "validation_requests_terminal_check",
+          "value": "(\"validation_requests\".\"status\" in ('validated', 'rejected') and \"validation_requests\".\"outcome\" is not null and \"validation_requests\".\"status\" = \"validation_requests\".\"outcome\") or (\"validation_requests\".\"status\" in ('pending', 'quorum_met', 'expired') and \"validation_requests\".\"outcome\" is null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validation_votes": {
+      "name": "validation_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_user_id": {
+          "name": "validator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "envelope": {
+          "name": "envelope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stake_weight": {
+          "name": "stake_weight",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "validation_votes_request_validator_key": {
+          "name": "validation_votes_request_validator_key",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "validator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "validation_votes_validator_user_id_idx": {
+          "name": "validation_votes_validator_user_id_idx",
+          "columns": [
+            {
+              "expression": "validator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validation_votes_request_id_validation_requests_id_fk": {
+          "name": "validation_votes_request_id_validation_requests_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "validation_requests",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_votes_validator_user_id_users_id_fk": {
+          "name": "validation_votes_validator_user_id_users_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validation_votes_record_id_signed_records_record_id_fk": {
+          "name": "validation_votes_record_id_signed_records_record_id_fk",
+          "tableFrom": "validation_votes",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validation_votes_verdict_check": {
+          "name": "validation_votes_verdict_check",
+          "value": "\"validation_votes\".\"verdict\" in ('valid', 'invalid', 'abstain')"
+        },
+        "validation_votes_stake_weight_check": {
+          "name": "validation_votes_stake_weight_check",
+          "value": "\"validation_votes\".\"stake_weight\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.validator_affinities": {
+      "name": "validator_affinities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "validator_a": {
+          "name": "validator_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validator_b": {
+          "name": "validator_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "co_vote_count": {
+          "name": "co_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_co_vote_at": {
+          "name": "last_co_vote_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "validator_affinities_pair_key": {
+          "name": "validator_affinities_pair_key",
+          "columns": [
+            {
+              "expression": "validator_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "validator_b",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "validator_affinities_validator_a_users_id_fk": {
+          "name": "validator_affinities_validator_a_users_id_fk",
+          "tableFrom": "validator_affinities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "validator_affinities_validator_b_users_id_fk": {
+          "name": "validator_affinities_validator_b_users_id_fk",
+          "tableFrom": "validator_affinities",
+          "tableTo": "users",
+          "columnsFrom": [
+            "validator_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "validator_affinities_co_vote_count_check": {
+          "name": "validator_affinities_co_vote_count_check",
+          "value": "\"validator_affinities\".\"co_vote_count\" >= 0"
+        },
+        "validator_affinities_canonical_pair_check": {
+          "name": "validator_affinities_canonical_pair_check",
+          "value": "\"validator_affinities\".\"validator_a\" < \"validator_affinities\".\"validator_b\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verifiable_credentials": {
+      "name": "verifiable_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "holder_user_id": {
+          "name": "holder_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holder_did": {
+          "name": "holder_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issuer_user_id": {
+          "name": "issuer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuer_did": {
+          "name": "issuer_did",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claims": {
+          "name": "claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "record_id": {
+          "name": "record_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "verifiable_credentials_holder_status_idx": {
+          "name": "verifiable_credentials_holder_status_idx",
+          "columns": [
+            {
+              "expression": "holder_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verifiable_credentials_issuer_did_idx": {
+          "name": "verifiable_credentials_issuer_did_idx",
+          "columns": [
+            {
+              "expression": "issuer_did",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verifiable_credentials_holder_user_id_users_id_fk": {
+          "name": "verifiable_credentials_holder_user_id_users_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "holder_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "verifiable_credentials_issuer_user_id_users_id_fk": {
+          "name": "verifiable_credentials_issuer_user_id_users_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issuer_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "verifiable_credentials_record_id_signed_records_record_id_fk": {
+          "name": "verifiable_credentials_record_id_signed_records_record_id_fk",
+          "tableFrom": "verifiable_credentials",
+          "tableTo": "signed_records",
+          "columnsFrom": [
+            "record_id"
+          ],
+          "columnsTo": [
+            "record_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verifiable_credentials_recordId_unique": {
+          "name": "verifiable_credentials_recordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "record_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "verifiable_credentials_status_check": {
+          "name": "verifiable_credentials_status_check",
+          "value": "\"verifiable_credentials\".\"status\" in ('active', 'revoked', 'expired')"
+        },
+        "verifiable_credentials_revocation_check": {
+          "name": "verifiable_credentials_revocation_check",
+          "value": "(\"verifiable_credentials\".\"status\" = 'revoked' and \"verifiable_credentials\".\"revoked_at\" is not null) or (\"verifiable_credentials\".\"status\" <> 'revoked' and \"verifiable_credentials\".\"revoked_at\" is null)"
+        },
+        "verifiable_credentials_expiry_check": {
+          "name": "verifiable_credentials_expiry_check",
+          "value": "\"verifiable_credentials\".\"expires_at\" is null or \"verifiable_credentials\".\"expires_at\" > \"verifiable_credentials\".\"issued_at\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.wallets": {
+      "name": "wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance": {
+          "name": "balance",
+          "type": "numeric(38, 8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wallets_user_id_users_id_fk": {
+          "name": "wallets_user_id_users_id_fk",
+          "tableFrom": "wallets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallets_user_id_key": {
+          "name": "wallets_user_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "wallets_balance_check": {
+          "name": "wallets_balance_check",
+          "value": "\"wallets\".\"balance\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        }
+      },
+      "indexes": {
+        "webauthn_challenges_expires_at_idx": {
+          "name": "webauthn_challenges_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webauthn_challenges_challenge_key": {
+          "name": "webauthn_challenges_challenge_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "challenge"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webauthn_challenges_type_check": {
+          "name": "webauthn_challenges_type_check",
+          "value": "\"webauthn_challenges\".\"type\" in ('registration', 'authentication')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.webauthn_credentials": {
+      "name": "webauthn_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_verified": {
+          "name": "user_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "date_trunc('milliseconds', now())"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "webauthn_credentials_user_id_idx": {
+          "name": "webauthn_credentials_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webauthn_credentials_user_id_users_id_fk": {
+          "name": "webauthn_credentials_user_id_users_id_fk",
+          "tableFrom": "webauthn_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webauthn_credentials_credential_id_key": {
+          "name": "webauthn_credentials_credential_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "webauthn_credentials_device_type_check": {
+          "name": "webauthn_credentials_device_type_check",
+          "value": "\"webauthn_credentials\".\"device_type\" in ('singleDevice', 'multiDevice')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/api/drizzle/meta/_journal.json
+++ b/packages/api/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1786350532586,
       "tag": "0028_device_principals_and_contexts",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1786361328335,
+      "tag": "0029_session_token_binding",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/openapi.json
+++ b/packages/api/openapi.json
@@ -5531,7 +5531,7 @@
         ],
         "security": [],
         "summary": "Exchange an OAuth2 authorization code for tokens (RFC 6749)",
-        "description": "Standards-compliant RFC 6749 §4.1.3 token endpoint. Single-use exchange of an authorization code (from `POST /auth/oauth/authorize`) for a bearer access token, rotating device credentials, and session ID.\nThe request MUST be `application/x-www-form-urlencoded` with `grant_type=authorization_code`. Confidential clients authenticate with `client_secret` — either in the body (`client_secret_post`) or via HTTP Basic (`client_secret_basic`), never both. Public clients send `client_id` plus the PKCE `code_verifier`.\nThe response is a FLAT JSON document (no `data` wrapper) sent with `Cache-Control: no-store`, as RFC 6749 §5.1 requires. Alongside the standard `access_token` / `token_type` / `expires_in` it carries Oxy's device-first extras (`session_id`, `deviceId`, `deviceSecret`, `user`), which §5.1 permits as additional parameters.\nErrors follow RFC 6749 §5.2 (`{ \"error\": ..., \"error_description\": ... }`). Replaying an already-used code, sending a code past its 60-second TTL, or mismatching the `redirect_uri` all return the same `400 invalid_grant` with no detail about which check failed.\n",
+        "description": "Standards-compliant RFC 6749 §4.1.3 token endpoint. Single-use exchange of an authorization code (from `POST /auth/oauth/authorize`) for a bearer access token, rotating device credentials, and session ID.\nThe request MUST be `application/x-www-form-urlencoded` with `grant_type=authorization_code`. Confidential clients authenticate with `client_secret` — either in the body (`client_secret_post`) or via HTTP Basic (`client_secret_basic`), never both. Public clients send `client_id` plus the PKCE `code_verifier`.\nThe response is a FLAT JSON document (no `data` wrapper) sent with `Cache-Control: no-store`, as RFC 6749 §5.1 requires. Alongside the standard `access_token` / `token_type` / `expires_in` it carries Oxy's device-first extras (`session_id`, `user`, and — for an OFFICIAL Oxy application only — `deviceId` and `deviceSecret`), which §5.1 permits as additional parameters.\nA THIRD-PARTY client receives an ISOLATED session: bound to its application, its credential and its granted scopes, kept off the user's shared device, and carrying NO `deviceId` and NO `deviceSecret`. That secret is the device-wide restore credential, so handing it to a third party would let one leaked token mint bearers for every account on the device. A third-party bearer is likewise refused the whole `/session/device/*` lane.\nErrors follow RFC 6749 §5.2 (`{ \"error\": ..., \"error_description\": ... }`). Replaying an already-used code, sending a code past its 60-second TTL, or mismatching the `redirect_uri` all return the same `400 invalid_grant` with no detail about which check failed.\n",
         "requestBody": {
           "required": true,
           "content": {
@@ -5602,10 +5602,12 @@
                       "type": "string"
                     },
                     "deviceId": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Official Oxy applications only. Absent for third-party clients, whose session does not join the device.\n"
                     },
                     "deviceSecret": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Official Oxy applications only. The device-wide restore credential, returned exactly once and never to a third party.\n"
                     },
                     "user": {
                       "type": "object"

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -26,6 +26,14 @@ export interface RequiredEnvVars {
   ACCESS_TOKEN_SECRET: string;
   REFRESH_TOKEN_SECRET: string;
 
+  // Access token v2 migration window (issue #937, Phase 6). A token is v2 iff
+  // it carries `ver: 2`; anything else is v1. Set to the literal `closed` to
+  // refuse every remaining v1 bearer — safe once one refresh-token lifetime
+  // (7 days) has passed since deploy, because by then no v1 token can still be
+  // live. Absent/anything else keeps the window open. Read per request in
+  // `utils/sessionUtils.ts`; NOT a secret, so it is not synced to SSM.
+  ACCESS_TOKEN_V1_WINDOW?: string;
+
   // Legacy cross-domain SSO secret (FedCM / POST /sso/code removed in wave 2).
   // Still synced from GitHub → SSM for environments that haven't dropped it yet;
   // no live route reads it. Safe to omit in new deployments.

--- a/packages/api/src/db/schema/deferredForeignKeys.ts
+++ b/packages/api/src/db/schema/deferredForeignKeys.ts
@@ -183,6 +183,19 @@ export const ID_COLUMNS_WITHOUT_FOREIGN_KEY: readonly IdColumnWithoutForeignKey[
       'device has a `device_sessions` row at all.',
   },
   {
+    table: sessions,
+    column: sessions.clientId,
+    reason:
+      '(c) The OAuth `client_id` — an `application_credentials.public_key`, ' +
+      'which is that table\'s natural key and not its primary key, so there is ' +
+      'nothing for a foreign key to point at. It records WHICH credential ' +
+      'obtained this session, and must survive that credential being rotated ' +
+      'or revoked: revocation is meant to stop new exchanges, not to erase the ' +
+      'provenance of sessions already issued. The enforceable half of the ' +
+      'binding is `application_id` beside it, which IS a foreign key and does ' +
+      'CASCADE.',
+  },
+  {
     table: deviceSessions,
     column: deviceSessions.deviceId,
     reason:

--- a/packages/api/src/db/schema/sessions.ts
+++ b/packages/api/src/db/schema/sessions.ts
@@ -60,6 +60,9 @@
 import { sql } from 'drizzle-orm';
 import { boolean, index, pgTable, text, unique } from 'drizzle-orm/pg-core';
 import { createdAt, generatedId, timestamptz, updatedAt } from '@oxyhq/db';
+import { applications } from './applications';
+import { deviceAccountContexts } from './deviceAccountContexts';
+import { deviceSessions } from './deviceSessions';
 import { users } from './users';
 
 export const sessions = pgTable(
@@ -118,6 +121,54 @@ export const sessions = pgTable(
      * operator must kill the session, not launder it.
      */
     operatedByUserId: text().references(() => users.id, { onDelete: 'cascade' }),
+
+    // ---- access token v2 binding (issue #937, Phase 6) ---------------------
+    // What the token minted for this session is allowed to SAY, and what its
+    // claims are checked back against on every request. The token is derived
+    // from these columns and never the reverse, so a re-mint of a live session
+    // reproduces the same binding and a claim that disagrees with the row is a
+    // token that no longer describes its session.
+    /**
+     * The application this session BELONGS TO, when it belongs to exactly one.
+     *
+     * NULL is the ordinary shared device session that every official app on the
+     * device uses — those are not one application's, so they carry no `azp`.
+     * Set only where the session was minted for a single application and is
+     * reachable by nothing else, which today means an untrusted OAuth client.
+     *
+     * `CASCADE`, deliberately NOT `SET NULL`, for the same reason
+     * `operated_by_user_id` is: NULL here means "not an application's session",
+     * so `SET NULL` would silently PROMOTE a third-party session into a
+     * first-party one the moment the application row went away — laundering
+     * exactly the isolation this column exists to enforce.
+     */
+    applicationId: text().references(() => applications.id, { onDelete: 'cascade' }),
+    /**
+     * `azp` — the `application_credentials.public_key` (the OAuth `client_id`)
+     * that obtained this session. Stored beside `application_id` rather than
+     * derived from it because an application has several credentials and may
+     * rotate them; which one was used is a fact about this session.
+     */
+    clientId: text(),
+    /**
+     * `scope` — what `client_id` was granted. The intersection the authorize
+     * step already computed, carried forward so the token's `scope` claim has
+     * an authority to be checked against instead of being self-asserting.
+     */
+    scopes: text().array().notNull().default(sql`'{}'::text[]`),
+    /**
+     * `device_session_id` / `device_context_id` — which device, and which
+     * principal-acting-as-account on it (ADR 0001), this session serves.
+     *
+     * `SET NULL` here and NOT cascade, which is the opposite choice to
+     * `application_id` above and for the opposite reason: losing the device
+     * context must not delete a live session, it must only stop the token
+     * claiming a context that no longer exists. Both are nullable because a
+     * session minted before its device registered it has neither yet.
+     */
+    deviceSessionId: text().references(() => deviceSessions.id, { onDelete: 'set null' }),
+    deviceContextId: text().references(() => deviceAccountContexts.id, { onDelete: 'set null' }),
+
     isActive: boolean().notNull().default(true),
     expiresAt: timestamptz().notNull(),
     /** Mongoose defaulted this to `Date.now`. */

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -4,6 +4,7 @@ import dotenv from 'dotenv';
 import { logger } from '../utils/logger';
 import sessionService from '../services/session.service';
 import type { AccountDocument } from '../services/user.service';
+import type { AccessTokenIdentity } from '../utils/sessionUtils';
 import { verifyServiceToken, type ServiceTokenPayload } from './serviceToken';
 import {
   extractTokenFromRequest,
@@ -63,6 +64,16 @@ export interface AuthRequest extends Request {
    * checked.
    */
   sessionId?: string;
+  /**
+   * What the bearer resolved to once its claims were checked against the
+   * session row (issue #937, Phase 6): subject and actor kept apart, plus the
+   * application, device context and scopes the session is bound to.
+   *
+   * This is the ONE place a route may learn which application is behind a user
+   * bearer. The token's own claims are never read again downstream — `req.user`
+   * answers "who", this answers "as whom, through what, with which scopes".
+   */
+  oxyToken?: AccessTokenIdentity;
 }
 
 /**
@@ -200,6 +211,7 @@ export const authMiddleware = async (req: AuthRequest, res: Response, next: Next
         // the `fullUser.id = …` this replaces wrote through to the cache entry.
         req.user = { ...user, id: user._id };
         (req as AuthRequest).sessionId = decoded.sessionId;
+        req.oxyToken = validationResult.token;
 
         next();
       } catch (dbError) {

--- a/packages/api/src/routes/__tests__/oauthToken.test.ts
+++ b/packages/api/src/routes/__tests__/oauthToken.test.ts
@@ -732,22 +732,39 @@ describe('POST /auth/oauth/token — security properties', () => {
  * a trusted client that keeps the old behaviour verbatim.
  */
 describe('POST /auth/oauth/token — third-party isolation', () => {
-  it('returns NO deviceSecret and NO deviceId to a third-party client', async () => {
-    // The `deviceSecret` is the device-wide restore credential: with it, a
-    // leaked third-party token mints bearers for every account on the device
-    // and can change what every official Oxy app there is signed in as.
+  it('returns a deviceSecret for the third party OWN device, never the shared one', async () => {
+    // The danger was never that a third party holds a `deviceSecret` — it is
+    // WHICH device the secret unlocks. Handed the shared one, a leaked
+    // third-party token mints bearers for every account on that device and can
+    // change what every official Oxy app there is signed in as. Bound to its
+    // own per-(user, client) device, it reaches exactly one session: its own.
+    //
+    // #937 asks for the pair to be omitted outright. That is the end state and
+    // it is not this: `exchangeOAuthCode` in `@oxyhq/core` throws without both
+    // fields, so omitting them breaks every third-party sign-in through the SDK
+    // until core ships a release that tolerates a device-less session. This test
+    // therefore pins the property that actually protects the user, and the
+    // omission is tracked separately.
+    mockExchangeAuthCode.mockResolvedValueOnce(grant({ deviceId: 'dev-shared' }));
+
     const res = await requestForm(pkceParams());
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('access_token');
-    expect(res.body).not.toHaveProperty('deviceSecret');
-    expect(res.body).not.toHaveProperty('deviceId');
+    expect(res.body).toHaveProperty('deviceSecret');
+    expect(res.body.deviceId).not.toBe('dev-shared');
   });
 
-  it('does not register a third-party session into the device account set', async () => {
+  it('registers a third-party session onto its OWN device, not the shared one', async () => {
+    mockExchangeAuthCode.mockResolvedValueOnce(grant({ deviceId: 'dev-shared' }));
+
     await requestForm(pkceParams());
 
-    expect(mockFinalizeDeviceLogin).not.toHaveBeenCalled();
+    expect(mockFinalizeDeviceLogin).toHaveBeenCalledTimes(1);
+    const finalized = mockFinalizeDeviceLogin.mock.calls[0][0] as {
+      session: { deviceId: string };
+    };
+    expect(finalized.session.deviceId).not.toBe('dev-shared');
   });
 
   it('binds a third-party session to its application, credential and granted scopes', async () => {

--- a/packages/api/src/routes/__tests__/oauthToken.test.ts
+++ b/packages/api/src/routes/__tests__/oauthToken.test.ts
@@ -213,6 +213,16 @@ function pkceParams(overrides: Record<string, string> = {}): Record<string, stri
 
 const sha256 = (value: string) => nodeCrypto.createHash('sha256').update(value).digest('hex');
 
+/**
+ * An OFFICIAL Oxy application. The default fixture is `third_party`, which is
+ * now the ISOLATED lane (issue #937, Phase 6) — a case that needs the shared
+ * device session has to ask for a trusted client explicitly.
+ */
+const OFFICIAL_APP: Partial<typeof applications.$inferInsert> = {
+  type: 'first_party',
+  isOfficial: true,
+};
+
 async function client(
   credentialFields: Partial<typeof applicationCredentials.$inferInsert> = {},
   appFields: Partial<typeof applications.$inferInsert> = {},
@@ -310,8 +320,6 @@ describe('POST /auth/oauth/token — RFC 6749 §5.1 success response', () => {
       token_type: 'Bearer',
       expires_in: 900,
       session_id: 'sess-1',
-      deviceId: 'device-1',
-      deviceSecret: 'device-secret-1',
     });
     expect(res.body).not.toHaveProperty('data');
     // The zero-cookie transport hands out no refresh token.
@@ -383,14 +391,15 @@ describe('POST /auth/oauth/token — RFC 6749 §5.1 success response', () => {
     expect(app.lastUsedAt).toBeInstanceOf(Date);
   });
 
-  it('threads the originating device and the delegated operator onto the session', async () => {
+  it('threads the originating device and the delegated operator onto a TRUSTED app session', async () => {
+    const { clientId } = await client({}, OFFICIAL_APP);
     const org = await subject({ kind: 'organization' });
     const operator = await subject();
     mockExchangeAuthCode.mockResolvedValueOnce(
       grant({ userId: org, deviceId: '  dev-shared  ', operatedByUserId: operator }),
     );
 
-    await requestForm(pkceParams());
+    await requestForm(pkceParams({ client_id: clientId }));
 
     expect(mockCreateSession).toHaveBeenCalledWith(
       org,
@@ -697,9 +706,12 @@ describe('POST /auth/oauth/token — security properties', () => {
   });
 
   it('fails closed with server_error when deviceSecret minting fails', async () => {
+    // Only an application that actually joins the device mints one, so the
+    // subject of this case has to be a trusted client.
+    const { clientId } = await client({}, OFFICIAL_APP);
     mockFinalizeDeviceLogin.mockResolvedValueOnce({});
 
-    const res = await requestForm(pkceParams());
+    const res = await requestForm(pkceParams({ client_id: clientId }));
 
     expect(res.status).toBe(500);
     // Still RFC-shaped, and still says nothing about what broke internally.
@@ -708,5 +720,89 @@ describe('POST /auth/oauth/token — security properties', () => {
       error_description: expect.any(String),
     });
     expect(res.body).not.toHaveProperty('access_token');
+  });
+});
+
+/**
+ * Issue #937, Phase 6 — a third-party exchange yields an ISOLATED session, not
+ * a share of the user's device.
+ *
+ * The three properties are one decision and only work together, so each is
+ * asserted against the same default `third_party` fixture and contrasted with
+ * a trusted client that keeps the old behaviour verbatim.
+ */
+describe('POST /auth/oauth/token — third-party isolation', () => {
+  it('returns NO deviceSecret and NO deviceId to a third-party client', async () => {
+    // The `deviceSecret` is the device-wide restore credential: with it, a
+    // leaked third-party token mints bearers for every account on the device
+    // and can change what every official Oxy app there is signed in as.
+    const res = await requestForm(pkceParams());
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('access_token');
+    expect(res.body).not.toHaveProperty('deviceSecret');
+    expect(res.body).not.toHaveProperty('deviceId');
+  });
+
+  it('does not register a third-party session into the device account set', async () => {
+    await requestForm(pkceParams());
+
+    expect(mockFinalizeDeviceLogin).not.toHaveBeenCalled();
+  });
+
+  it('binds a third-party session to its application, credential and granted scopes', async () => {
+    mockExchangeAuthCode.mockResolvedValueOnce(grant({ scopes: ['profile:read'] }));
+
+    await requestForm(pkceParams());
+
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      defaultSubjectId,
+      expect.anything(),
+      expect.objectContaining({
+        application: {
+          applicationId: defaultApplicationId,
+          clientId: defaultClientId,
+          scopes: ['profile:read'],
+        },
+      }),
+    );
+  });
+
+  it('keeps a third-party session OFF the shared device id the code carried', async () => {
+    // The code's `deviceId` is the user's central device. Reusing it would put
+    // the third party's session where `createSession`'s reuse lookup finds the
+    // device's own first-party session. A stable per-(user, client) key keeps
+    // the client reusing ITS OWN session across exchanges instead.
+    mockExchangeAuthCode.mockResolvedValueOnce(grant({ deviceId: 'dev-shared' }));
+
+    await requestForm(pkceParams());
+
+    const options = mockCreateSession.mock.calls[0][2] as Record<string, unknown>;
+    expect(options.deviceId).toBeUndefined();
+    expect(options.stableDeviceKey).toBe(`oauth:${defaultClientId}`);
+  });
+
+  it('still hands an OFFICIAL application the shared device credential', async () => {
+    // The contrast case. Without it, "no deviceSecret" would pass just as well
+    // against a route that stopped minting one for anybody.
+    const { clientId } = await client({}, OFFICIAL_APP);
+
+    const res = await requestForm(pkceParams({ client_id: clientId }));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ deviceId: 'device-1', deviceSecret: 'device-secret-1' });
+    expect(mockFinalizeDeviceLogin).toHaveBeenCalled();
+  });
+
+  it('leaves an OFFICIAL application session unbound to any single application', async () => {
+    // An official app joins the SHARED device session, which belongs to no one
+    // application — so it gets no `azp`, and the device lane keeps serving it.
+    const { clientId } = await client({}, OFFICIAL_APP);
+
+    await requestForm(pkceParams({ client_id: clientId }));
+
+    const options = mockCreateSession.mock.calls[0][2] as Record<string, unknown>;
+    expect(options.application).toBeUndefined();
+    expect(options.stableDeviceKey).toBeUndefined();
   });
 });

--- a/packages/api/src/routes/__tests__/sessionDeviceThirdParty.test.ts
+++ b/packages/api/src/routes/__tests__/sessionDeviceThirdParty.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Third-party isolation on the device lane (issue #937, Phase 6).
+ *
+ * The claim being pinned: a third-party OAuth client holding a perfectly valid
+ * user bearer cannot read who is on the device, cannot activate the globally
+ * active context, and cannot mint a device-wide background credential. An
+ * official application's bearer can do all three, and so can an ordinary
+ * device session that belongs to no application at all.
+ *
+ * WHAT IS REAL HERE, and why it has to be. The bearer path is the SUBJECT, so
+ * `authMiddleware`, `sessionService.validateSession`, the binding check and the
+ * `applications` lookup all run for real against Postgres — a mocked
+ * `authMiddleware` (which the sibling device suites use, correctly, because the
+ * mint is their subject) would never populate `req.oxyToken` and this whole
+ * file would pass against a deleted guard. Only the edges are mocked: the CSRF
+ * origin check, the Redis limiter, Socket.IO and the logger.
+ *
+ * `jsonwebtoken` is restored to the real signer: `sessions.access_token` is
+ * UNIQUE, so the global constant-token mock collides on the second mint, and a
+ * constant token could not carry the claims this file is about.
+ */
+
+import express from 'express';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { randomUUID } from 'node:crypto';
+
+jest.mock('jsonwebtoken', () => jest.requireActual('jsonwebtoken'));
+
+jest.mock('../../middleware/originGuard', () => ({
+  requireSameSiteOrigin: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../middleware/rateLimiter', () => ({
+  rateLimit: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+jest.mock('../../services/loginLockout.service', () => ({
+  isLockedOut: jest.fn().mockResolvedValue({ locked: false, attempts: 0 }),
+  recordFailure: jest.fn().mockResolvedValue({ locked: false, attempts: 1 }),
+  clearFailures: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../utils/socket', () => ({
+  broadcastDeviceState: jest.fn(),
+  broadcastSessionAccountsChanged: jest.fn(),
+}));
+jest.mock('../../services/securityActivityService', () => ({
+  __esModule: true,
+  default: { logDeviceAdded: jest.fn().mockResolvedValue(undefined) },
+}));
+jest.mock('../../utils/logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import { eq } from 'drizzle-orm';
+import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { applicationCredentials } from '../../db/schema/applicationCredentials';
+import { applications } from '../../db/schema/applications';
+import { deviceAccountContexts } from '../../db/schema/deviceAccountContexts';
+import { deviceSessions } from '../../db/schema/deviceSessions';
+import { users } from '../../db/schema/users';
+import { errorHandler } from '../../middleware/errorHandler';
+import deviceSessionService from '../../services/deviceSession.service';
+import sessionService from '../../services/session.service';
+import sessionCache from '../../utils/sessionCache';
+import userCache from '../../utils/userCache';
+import sessionDeviceRouter from '../sessionDevice';
+
+let server: http.Server;
+
+type AppKind = Partial<typeof applications.$inferInsert>;
+
+/** An ordinary self-service third-party application. */
+const THIRD_PARTY: AppKind = { type: 'third_party' };
+/** An official Oxy application, per the registry predicate. */
+const OFFICIAL: AppKind = { type: 'first_party', isOfficial: true };
+
+async function account(): Promise<string> {
+  const [row] = await getDb()
+    .insert(users)
+    .values({ username: `u-${randomUUID().slice(0, 12)}` })
+    .returning({ id: users.id });
+  return row.id;
+}
+
+async function application(fields: AppKind): Promise<{ applicationId: string; clientId: string }> {
+  const owner = await account();
+  const [app] = await getDb()
+    .insert(applications)
+    .values({
+      name: `App ${randomUUID()}`,
+      type: 'third_party',
+      redirectUris: ['https://example.test/cb'],
+      ...fields,
+      ownerAccountId: owner,
+    })
+    .returning({ id: applications.id });
+  const clientId = `oxy_dk_${randomUUID().replace(/-/g, '')}`;
+  await getDb().insert(applicationCredentials).values({
+    applicationId: app.id,
+    name: 'client',
+    type: 'public',
+    environment: 'production',
+    publicKey: clientId,
+  });
+  return { applicationId: app.id, clientId };
+}
+
+/**
+ * Sign a person in on a device and return the bearer their apps would present.
+ * `app` present ⇒ the session is that application's; absent ⇒ the ordinary
+ * shared device session.
+ */
+async function signIn(
+  deviceId: string,
+  userId: string,
+  app?: { applicationId: string; clientId: string }
+): Promise<string> {
+  const session = await sessionService.createSession(
+    userId,
+    { headers: { 'user-agent': 'jest', 'accept-language': 'en-US' } } as never,
+    {
+      deviceId,
+      ...(app
+        ? { application: { applicationId: app.applicationId, clientId: app.clientId, scopes: [] } }
+        : {}),
+    }
+  );
+  await deviceSessionService.addAccount(deviceId, {
+    accountId: userId,
+    sessionId: session.sessionId,
+  });
+  // The device-login lane binds the context after `addAccount`; do the same so
+  // the bearer here is shaped exactly like a real one.
+  await deviceSessionService.bindSessionToContext(deviceId, session.sessionId);
+  const minted = await sessionService.getAccessToken(session.sessionId);
+  if (!minted) throw new Error('no access token for the freshly created session');
+  return minted.accessToken;
+}
+
+async function activeContextId(deviceId: string): Promise<string> {
+  const [device] = await getDb()
+    .select({ id: deviceSessions.id })
+    .from(deviceSessions)
+    .where(eq(deviceSessions.deviceId, deviceId))
+    .limit(1);
+  const [context] = await getDb()
+    .select({ id: deviceAccountContexts.id })
+    .from(deviceAccountContexts)
+    .where(eq(deviceAccountContexts.deviceSessionId, device.id))
+    .limit(1);
+  return context.id;
+}
+
+async function call(
+  method: string,
+  path: string,
+  bearer: string,
+  payload?: unknown
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const address = server.address() as AddressInfo;
+  const body = payload === undefined ? '' : JSON.stringify(payload);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        method,
+        host: '127.0.0.1',
+        port: address.port,
+        path,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+          authorization: `Bearer ${bearer}`,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, body: raw.length ? JSON.parse(raw) : {} })
+        );
+      }
+    );
+    req.on('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+beforeAll(async () => {
+  await connectPostgres();
+  process.env.ACCESS_TOKEN_SECRET = `access-${randomUUID()}`;
+  process.env.REFRESH_TOKEN_SECRET = `refresh-${randomUUID()}`;
+  process.env.DEVICE_ID_SALT = 'x'.repeat(48);
+  const app = express();
+  app.use(express.json());
+  app.use('/session/device', sessionDeviceRouter);
+  app.use(errorHandler);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  await closePostgres();
+});
+
+beforeEach(() => {
+  sessionCache.clear();
+  userCache.clear();
+  delete process.env.ACCESS_TOKEN_V1_WINDOW;
+});
+
+describe('a third-party application bearer is refused the whole device lane', () => {
+  it('cannot read the device directory', async () => {
+    const device = `dev-${randomUUID()}`;
+    const bearer = await signIn(device, await account(), await application(THIRD_PARTY));
+
+    const res = await call('GET', '/session/device/directory', bearer);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'third_party_device_access_denied' });
+  });
+
+  it('cannot activate the globally active context', async () => {
+    const device = `dev-${randomUUID()}`;
+    const user = await account();
+    // The user's OWN device session exists and has a context; the third party's
+    // bearer belongs to the same human on the same device. What it lacks is the
+    // authority to move what every other app on that device follows.
+    await signIn(device, user);
+    const contextId = await activeContextId(device);
+    const bearer = await signIn(device, user, await application(THIRD_PARTY));
+
+    const res = await call('POST', '/session/device/activate', bearer, { contextId });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'third_party_device_access_denied' });
+  });
+
+  it('cannot mint a device-wide background credential', async () => {
+    const device = `dev-${randomUUID()}`;
+    const bearer = await signIn(device, await account(), await application(THIRD_PARTY));
+
+    const res = await call('POST', '/session/device/background-credential', bearer);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'third_party_device_access_denied' });
+  });
+
+  it('cannot read the flat device state either', async () => {
+    const device = `dev-${randomUUID()}`;
+    const bearer = await signIn(device, await account(), await application(THIRD_PARTY));
+
+    const res = await call('GET', '/session/device/state', bearer);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('the lane stays open to everything that is not a third party', () => {
+  it('serves the directory to an ordinary, application-less device session', async () => {
+    const device = `dev-${randomUUID()}`;
+    const user = await account();
+    const bearer = await signIn(device, user);
+
+    const res = await call('GET', '/session/device/directory', bearer);
+
+    expect(res.status).toBe(200);
+    expect((res.body as { data: { deviceId: string } }).data.deviceId).toBe(device);
+  });
+
+  it('serves the directory to an OFFICIAL application bearer', async () => {
+    const device = `dev-${randomUUID()}`;
+    const user = await account();
+    const bearer = await signIn(device, user, await application(OFFICIAL));
+
+    const res = await call('GET', '/session/device/directory', bearer);
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('the decision is the registry’s, re-read per request', () => {
+  it('locks an application out the moment it stops being official', async () => {
+    const device = `dev-${randomUUID()}`;
+    const app = await application(OFFICIAL);
+    const bearer = await signIn(device, await account(), app);
+    expect((await call('GET', '/session/device/directory', bearer)).status).toBe(200);
+
+    await getDb()
+      .update(applications)
+      .set({ type: 'third_party', isOfficial: false })
+      .where(eq(applications.id, app.applicationId));
+
+    // Same bearer, same session, same claims — only the registry moved. A
+    // decision frozen into the token at mint time would still answer 200.
+    expect((await call('GET', '/session/device/directory', bearer)).status).toBe(403);
+  });
+
+  it('fails CLOSED when the application is suspended', async () => {
+    const device = `dev-${randomUUID()}`;
+    const app = await application(OFFICIAL);
+    const bearer = await signIn(device, await account(), app);
+
+    await getDb()
+      .update(applications)
+      .set({ status: 'suspended' })
+      .where(eq(applications.id, app.applicationId));
+
+    expect((await call('GET', '/session/device/directory', bearer)).status).toBe(403);
+  });
+
+  it('kills the session outright when the application row is DELETED', async () => {
+    // `sessions.application_id` is `ON DELETE CASCADE`, not `SET NULL`, and the
+    // difference is the whole point: `SET NULL` means "not an application's
+    // session", so it would PROMOTE this bearer into a first-party one — 200 on
+    // the device lane — exactly the laundering the binding exists to prevent.
+    // The bearer must stop resolving to a session at all.
+    const device = `dev-${randomUUID()}`;
+    const app = await application(THIRD_PARTY);
+    const bearer = await signIn(device, await account(), app);
+
+    await getDb().delete(applications).where(eq(applications.id, app.applicationId));
+    sessionCache.clear();
+
+    expect((await call('GET', '/session/device/directory', bearer)).status).toBe(401);
+  });
+});
+
+describe('a v1 bearer is governed by the row, not by what it claims', () => {
+  it('refuses a legacy token for an application-bound session', async () => {
+    // A v1 token asserted no `azp` at all, so the guard cannot be reading the
+    // claim — it reads `sessions.application_id`, which is why a bearer minted
+    // before this phase is still isolated.
+    const device = `dev-${randomUUID()}`;
+    const user = await account();
+    const app = await application(THIRD_PARTY);
+    const bearer = await signIn(device, user, app);
+
+    const jwt = jest.requireActual<typeof import('jsonwebtoken')>('jsonwebtoken');
+    const claims = jwt.verify(bearer, process.env.ACCESS_TOKEN_SECRET as string) as {
+      userId: string;
+      sessionId: string;
+      deviceId: string;
+    };
+    const legacy = jwt.sign(
+      {
+        userId: claims.userId,
+        sessionId: claims.sessionId,
+        deviceId: claims.deviceId,
+        type: 'access',
+      },
+      process.env.ACCESS_TOKEN_SECRET as string,
+      { expiresIn: '15m' }
+    );
+
+    const res = await call('GET', '/session/device/directory', legacy);
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: 'third_party_device_access_denied' });
+  });
+
+  it('is refused outright by the auth lane once the v1 window closes', async () => {
+    const device = `dev-${randomUUID()}`;
+    const user = await account();
+    const bearer = await signIn(device, user);
+
+    const jwt = jest.requireActual<typeof import('jsonwebtoken')>('jsonwebtoken');
+    const claims = jwt.verify(bearer, process.env.ACCESS_TOKEN_SECRET as string) as {
+      userId: string;
+      sessionId: string;
+      deviceId: string;
+    };
+    const legacy = jwt.sign(
+      {
+        userId: claims.userId,
+        sessionId: claims.sessionId,
+        deviceId: claims.deviceId,
+        type: 'access',
+      },
+      process.env.ACCESS_TOKEN_SECRET as string,
+      { expiresIn: '15m' }
+    );
+    // Open window: the legacy bearer works.
+    expect((await call('GET', '/session/device/directory', legacy)).status).toBe(200);
+
+    process.env.ACCESS_TOKEN_V1_WINDOW = 'closed';
+    sessionCache.clear();
+
+    // Closed: 401 from the session lane, not 403 from the device guard — the
+    // token never resolves to a session at all.
+    expect((await call('GET', '/session/device/directory', legacy)).status).toBe(401);
+    // ...and the v2 bearer for the same session is unaffected.
+    expect((await call('GET', '/session/device/directory', bearer)).status).toBe(200);
+  });
+});

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -2905,8 +2905,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *       The response is a FLAT JSON document (no `data` wrapper) sent with
  *       `Cache-Control: no-store`, as RFC 6749 §5.1 requires. Alongside the
  *       standard `access_token` / `token_type` / `expires_in` it carries Oxy's
- *       device-first extras (`session_id`, `deviceId`, `deviceSecret`, `user`),
- *       which §5.1 permits as additional parameters.
+ *       device-first extras (`session_id`, `user`, and — for an OFFICIAL Oxy
+ *       application only — `deviceId` and `deviceSecret`), which §5.1 permits
+ *       as additional parameters.
+ *
+ *       A THIRD-PARTY client receives an ISOLATED session: bound to its
+ *       application, its credential and its granted scopes, kept off the user's
+ *       shared device, and carrying NO `deviceId` and NO `deviceSecret`. That
+ *       secret is the device-wide restore credential, so handing it to a third
+ *       party would let one leaked token mint bearers for every account on the
+ *       device. A third-party bearer is likewise refused the whole
+ *       `/session/device/*` lane.
  *
  *       Errors follow RFC 6749 §5.2 (`{ "error": ..., "error_description": ... }`).
  *       Replaying an already-used code, sending a code past its 60-second TTL,
@@ -2962,8 +2971,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *                   type: string
  *                 deviceId:
  *                   type: string
+ *                   description: >
+ *                     Official Oxy applications only. Absent for third-party
+ *                     clients, whose session does not join the device.
  *                 deviceSecret:
  *                   type: string
+ *                   description: >
+ *                     Official Oxy applications only. The device-wide restore
+ *                     credential, returned exactly once and never to a third
+ *                     party.
  *                 user:
  *                   type: object
  *       400:
@@ -3085,27 +3101,67 @@ router.post(
       ? exchange.code.operatedByUserId.toString()
       : undefined;
 
+    const grantedScopes = Array.isArray(exchange.code.scopes) ? exchange.code.scopes : [];
+
+    // A THIRD-PARTY exchange gets an ISOLATED session, not a share of the
+    // device (issue #937, Phase 6). Three things follow from that one decision,
+    // and they only work together:
+    //
+    //   1. It is bound to this application, so `azp`/`scope` are real claims on
+    //      its token and the device lane can refuse it — and so `createSession`
+    //      refuses to hand it a session belonging to anyone else.
+    //   2. It does NOT inherit the code's shared `deviceId`. A stable
+    //      per-(user, client) device id keeps the client reusing its OWN
+    //      session across exchanges without ever landing on the user's central
+    //      device, where the reuse lookup would otherwise find the device's
+    //      first-party session and rename it `"<App> OAuth"`.
+    //   3. It is not registered into the device's account set and receives no
+    //      `deviceSecret`. That secret is the device-wide restore credential:
+    //      handing it to a third party would let a single leaked token mint
+    //      bearers for every other account on the device and change what every
+    //      official Oxy app there is signed in as.
+    //
+    // A TRUSTED application is an official Oxy app joining the shared device
+    // session, so it keeps all three unchanged. Trust is the registry's
+    // `isTrustedApplication`, never the hostname or the credential type.
+    const trusted = isTrustedApplication(app);
+
     const session = await sessionService.createSession(
       userId,
       req,
       {
         deviceName: `${app.name} OAuth`,
-        ...(sharedDeviceId ? { deviceId: sharedDeviceId } : {}),
+        ...(trusted
+          ? sharedDeviceId
+            ? { deviceId: sharedDeviceId }
+            : {}
+          : {
+              stableDeviceKey: `oauth:${credential.publicKey}`,
+              application: {
+                applicationId: app.id,
+                clientId: credential.publicKey,
+                scopes: grantedScopes,
+              },
+            }),
         ...(operatedByUserId ? { operatedByUserId } : {}),
       },
     );
 
-    const deviceExtras = await finalizeDeviceLogin({
-      session: { sessionId: session.sessionId, deviceId: session.deviceId },
-      userId,
-    });
-    if (!deviceExtras.deviceSecret) {
-      logger.error('[OAuth] Token exchange succeeded but deviceSecret mint failed', {
+    let deviceSecret: string | undefined;
+    if (trusted) {
+      const deviceExtras = await finalizeDeviceLogin({
+        session: { sessionId: session.sessionId, deviceId: session.deviceId },
         userId,
-        sessionId: session.sessionId,
-        deviceId: session.deviceId,
       });
-      throw OAuthError.serverError('Failed to finalize the device session.');
+      if (!deviceExtras.deviceSecret) {
+        logger.error('[OAuth] Token exchange succeeded but deviceSecret mint failed', {
+          userId,
+          sessionId: session.sessionId,
+          deviceId: session.deviceId,
+        });
+        throw OAuthError.serverError('Failed to finalize the device session.');
+      }
+      deviceSecret = deviceExtras.deviceSecret;
     }
 
     await getDb()
@@ -3114,7 +3170,6 @@ router.post(
       .where(eq(applications.id, app.id));
 
     const userData = formatUserResponse(user);
-    const grantedScopes = Array.isArray(exchange.code.scopes) ? exchange.code.scopes : [];
 
     // FLAT body, no `sendSuccess` wrapper — see `utils/oauthResponse.ts` for why
     // the OAuth surface is the one place that may not use the house envelope.
@@ -3127,9 +3182,11 @@ router.post(
       // with the app's registered scopes). Omitted when the grant carries none.
       ...(grantedScopes.length > 0 ? { scope: grantedScopes.join(' ') } : {}),
       // Oxy's device-first extras, permitted by §5.1 as additional parameters.
+      // Present only for an application that actually joins the device: for a
+      // third party the pair would name a device it has no credential for and
+      // no business addressing.
       session_id: session.sessionId,
-      deviceId: session.deviceId,
-      deviceSecret: deviceExtras.deviceSecret,
+      ...(deviceSecret ? { deviceId: session.deviceId, deviceSecret } : {}),
       user: userData,
     });
   })

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -3147,22 +3147,37 @@ router.post(
       },
     );
 
-    let deviceSecret: string | undefined;
-    if (trusted) {
-      const deviceExtras = await finalizeDeviceLogin({
-        session: { sessionId: session.sessionId, deviceId: session.deviceId },
+    // The credential is minted for BOTH lanes, but they are not the same device.
+    // A trusted app joins the browser's shared DeviceSession above; an untrusted
+    // one was given a derived per-(user, client) device, so the secret it gets
+    // back unlocks only its own isolated session and names a device no other
+    // application shares.
+    //
+    // #937 asks for a third party to receive no DeviceSession credential at all.
+    // That is the right end state and it is NOT what this ships, deliberately:
+    // `exchangeOAuthCode` in `@oxyhq/core` hard-requires `deviceId` AND
+    // `deviceSecret` and throws without them, so omitting the pair here breaks
+    // every third-party "Sign in with Oxy" through the SDK — silently, since the
+    // throw is caught and reported as `exchange-failed`. Closing that needs a
+    // core change, a published release, and an announced cutover for external
+    // integrators pinned to older core, none of which belong in this PR.
+    //
+    // What the omission was protecting against is already closed by the lane
+    // split: before this change a third party joined the SHARED device and got
+    // ITS secret, which is the credential #937 calls global. It no longer can.
+    const deviceExtras = await finalizeDeviceLogin({
+      session: { sessionId: session.sessionId, deviceId: session.deviceId },
+      userId,
+    });
+    if (!deviceExtras.deviceSecret) {
+      logger.error('[OAuth] Token exchange succeeded but deviceSecret mint failed', {
         userId,
+        sessionId: session.sessionId,
+        deviceId: session.deviceId,
       });
-      if (!deviceExtras.deviceSecret) {
-        logger.error('[OAuth] Token exchange succeeded but deviceSecret mint failed', {
-          userId,
-          sessionId: session.sessionId,
-          deviceId: session.deviceId,
-        });
-        throw OAuthError.serverError('Failed to finalize the device session.');
-      }
-      deviceSecret = deviceExtras.deviceSecret;
+      throw OAuthError.serverError('Failed to finalize the device session.');
     }
+    const deviceSecret = deviceExtras.deviceSecret;
 
     await getDb()
       .update(applications)
@@ -3182,11 +3197,13 @@ router.post(
       // with the app's registered scopes). Omitted when the grant carries none.
       ...(grantedScopes.length > 0 ? { scope: grantedScopes.join(' ') } : {}),
       // Oxy's device-first extras, permitted by §5.1 as additional parameters.
-      // Present only for an application that actually joins the device: for a
-      // third party the pair would name a device it has no credential for and
-      // no business addressing.
+      // The pair names the session's OWN device — the browser's shared one for a
+      // trusted app, an isolated per-(user, client) one for a third party — so it
+      // is never a credential for a device the caller does not own. See the lane
+      // split above for why the pair is still sent to a third party at all.
       session_id: session.sessionId,
-      ...(deviceSecret ? { deviceId: session.deviceId, deviceSecret } : {}),
+      deviceId: session.deviceId,
+      deviceSecret,
       user: userData,
     });
   })

--- a/packages/api/src/routes/sessionDevice.ts
+++ b/packages/api/src/routes/sessionDevice.ts
@@ -6,8 +6,12 @@ import {
   deviceBackgroundTokenRequestSchema,
   deviceTokenMintRequestSchema,
 } from '@oxyhq/contracts';
+import { eq } from 'drizzle-orm';
+import { getDb } from '../config/postgres';
+import { applications } from '../db/schema/applications';
 import { authMiddleware, type AuthRequest } from '../middleware/auth';
 import { requireSameSiteOrigin } from '../middleware/originGuard';
+import { isTrustedApplication } from '../utils/trustedApplication';
 import { decodeToken, extractTokenFromRequest } from '../middleware/authUtils';
 import { rateLimit } from '../middleware/rateLimiter';
 import { isLockedOut, recordFailure, clearFailures } from '../services/loginLockout.service';
@@ -254,7 +258,57 @@ const activateLimiter = rateLimit({
   keyGenerator: perDeviceKey('device-activate'),
 });
 
-router.use(requireSameSiteOrigin, authMiddleware);
+/**
+ * Refuse a bearer that belongs to a THIRD-PARTY application (issue #937,
+ * Phase 6).
+ *
+ * Everything below this line operates on the shared Oxy device: reading who is
+ * signed in on it, activating the globally active context, adding or removing
+ * an account, minting a long-lived background credential. Those are the
+ * device's own controls, and a third-party OAuth client must not hold any of
+ * them — a leaked third-party token must not let an attacker change what every
+ * other Oxy app on that device is signed in as, nor enumerate the people on it.
+ *
+ * The decision is the REGISTRY's, re-read per request rather than frozen into
+ * the token: flipping an application out of official status must lock it out
+ * immediately, and an application row that has gone away must fail closed
+ * rather than read as "unbound, therefore first-party". `application_id` is
+ * NULL for every shared device session, so the ordinary path does no query at
+ * all.
+ */
+const requireFirstPartyDeviceAccess = asyncHandler(
+  async (req: AuthRequest, res: Response, next: () => void) => {
+    const applicationId = req.oxyToken?.applicationId;
+    if (!applicationId) {
+      next();
+      return;
+    }
+
+    const [app] = await getDb()
+      .select({
+        status: applications.status,
+        type: applications.type,
+        isOfficial: applications.isOfficial,
+        isInternal: applications.isInternal,
+      })
+      .from(applications)
+      .where(eq(applications.id, applicationId))
+      .limit(1);
+
+    if (!app || app.status !== 'active' || !isTrustedApplication(app)) {
+      logger.warn('device.lane.third_party_refused', {
+        applicationId,
+        path: req.path,
+      });
+      res.status(403).json({ error: 'third_party_device_access_denied' });
+      return;
+    }
+
+    next();
+  }
+);
+
+router.use(requireSameSiteOrigin, authMiddleware, requireFirstPartyDeviceAccess);
 
 /**
  * POST /session/device/background-credential — provision a non-rotating

--- a/packages/api/src/services/__tests__/deviceDirectory.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceDirectory.service.test.ts
@@ -39,6 +39,7 @@ import { devicePrincipals } from '../../db/schema/devicePrincipals';
 import { deviceSessions } from '../../db/schema/deviceSessions';
 import { sessions } from '../../db/schema/sessions';
 import { users } from '../../db/schema/users';
+import { validateAccessToken } from '../../utils/sessionUtils';
 import sessionCache from '../../utils/sessionCache';
 import userCache from '../../utils/userCache';
 import deviceSessionService, { electReplacementContext } from '../deviceSession.service';
@@ -387,6 +388,37 @@ describe('POST /session/device/activate — the one write', () => {
       .where(eq(sessions.sessionId, context.sessionId ?? ''))
       .limit(1);
     expect(minted).toMatchObject({ userId: org, operatedByUserId: nate, deviceId: device });
+  });
+
+  it('binds the activated session to its context, and says so in the token (#937 Phase 6)', async () => {
+    const device = newDeviceId();
+    const nate = await account();
+    const org = await organization(nate);
+    await signIn(device, nate);
+    const before = await deviceSessionService.getDirectory(device);
+    const contextId = contextFor(before, nate, org)?.id ?? '';
+
+    const result = await deviceSessionService.activateContext(device, contextId, request());
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const claims = validateAccessToken(result.activeToken?.accessToken ?? '').payload;
+    // The token names the context it was minted for, so a token for the
+    // PREVIOUS context can never pass as this one.
+    expect(claims?.device_context_id).toBe(contextId);
+    expect(claims?.sub).toBe(org);
+    expect(claims?.act?.sub).toBe(nate);
+
+    const stored = await storedDevice(device);
+    const [session] = await getDb()
+      .select({
+        deviceSessionId: sessions.deviceSessionId,
+        deviceContextId: sessions.deviceContextId,
+      })
+      .from(sessions)
+      .where(eq(sessions.sessionId, result.activeToken ? claims?.sessionId ?? '' : ''))
+      .limit(1);
+    expect(session).toMatchObject({ deviceSessionId: stored.id, deviceContextId: contextId });
   });
 
   it('activating the already-active context bumps nothing and reports it changed nothing', async () => {

--- a/packages/api/src/services/__tests__/deviceLogin.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceLogin.service.test.ts
@@ -7,14 +7,19 @@
  *  - mints the rotating `deviceSecret` the client persists first-party and
  *    returns it in the extras.
  *  - best-effort: a registration/mint failure never throws.
+ *  - records the device account context on the session (issue #937, Phase 6)
+ *    AFTER the deviceSecret mint, so a binding failure cannot cost the sign-in
+ *    its only restore credential.
  */
 
 const mockAddAccount = jest.fn();
 const mockIssueDeviceSecret = jest.fn();
+const mockBindSessionToContext = jest.fn();
 jest.mock('../deviceSession.service', () => {
   const svc = {
     addAccount: (...a: unknown[]) => mockAddAccount(...a),
     issueDeviceSecret: (...a: unknown[]) => mockIssueDeviceSecret(...a),
+    bindSessionToContext: (...a: unknown[]) => mockBindSessionToContext(...a),
   };
   // deviceLogin.service dynamically imports the NAMED `deviceSessionService`.
   return { __esModule: true, default: svc, deviceSessionService: svc };
@@ -37,6 +42,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockAddAccount.mockResolvedValue({ state: { deviceId: 'dev-1', accounts: [], activeAccountId: null, revision: 1 }, changed: true });
   mockIssueDeviceSecret.mockResolvedValue('ds_minted_secret');
+  mockBindSessionToContext.mockResolvedValue(true);
 });
 
 describe('finalizeDeviceLogin', () => {
@@ -81,5 +87,23 @@ describe('finalizeDeviceLogin', () => {
     mockAddAccount.mockRejectedValueOnce(new Error('db down'));
     const result = await finalizeDeviceLogin({ session: SESSION, userId: 'user-1' });
     expect(result).toEqual({});
+  });
+
+  it('records the device account context on the session (issue #937, Phase 6)', async () => {
+    await finalizeDeviceLogin({ session: SESSION, userId: 'user-1' });
+
+    expect(mockBindSessionToContext).toHaveBeenCalledWith('dev-1', 'sess-1');
+  });
+
+  it('still returns the deviceSecret when the context binding blows up', async () => {
+    // The ordering guard. Every statement in the block shares one catch, so a
+    // binding placed BEFORE the mint would swallow the sign-in's only restore
+    // credential — the token picks the context up on its next mint, but the
+    // secret is handed over exactly once.
+    mockBindSessionToContext.mockRejectedValueOnce(new Error('db down'));
+
+    const result = await finalizeDeviceLogin({ session: SESSION, userId: 'user-1' });
+
+    expect(result).toEqual({ deviceSecret: 'ds_minted_secret' });
   });
 });

--- a/packages/api/src/services/__tests__/session.service.test.ts
+++ b/packages/api/src/services/__tests__/session.service.test.ts
@@ -51,6 +51,8 @@ jest.mock('../securityActivityService', () => ({
 }));
 
 import { closePostgres, connectPostgres, getDb } from '../../config/postgres';
+import { applicationCredentials } from '../../db/schema/applicationCredentials';
+import { applications } from '../../db/schema/applications';
 import { sessions } from '../../db/schema/sessions';
 import { users } from '../../db/schema/users';
 import sessionCache from '../../utils/sessionCache';
@@ -93,34 +95,27 @@ async function storedSession(sessionId: string) {
 
 const deviceId = () => `dev-${randomUUID()}`;
 
-/**
- * Wait until the wall-clock SECOND advances.
- *
- * ## This is a WORKAROUND for an open token-minter defect. Do not "fix" it here.
- *
- * `generateSessionTokens` (`utils/sessionUtils.ts`) signs a payload of
- * `{userId, sessionId, deviceId, type}` with NO nonce, and a JWT's `iat`/`exp`
- * have one-second resolution. So a rotation that completes inside the same
- * second re-mints a BYTE-IDENTICAL refresh token and leaves
- * `previous_refresh_token === refresh_token` — meaning **a rotation that fast
- * does not actually invalidate a stolen refresh token**.
- *
- * That is a defect in the MINTER, not in this port and not in this test: the
- * behaviour predates the Drizzle migration and is unchanged by it. It is
- * reported and escalated; the fix (a per-mint nonce / `jti`) changes the token
- * format, which is a wire-contract change and deliberately out of scope here.
- *
- * These sleeps exist ONLY so the rotation cases exercise a REAL rotation
- * instead of silently passing against the collision. If you are here because
- * they look slow or superfluous: the correct change is to give
- * `generateSessionTokens` a nonce and then DELETE this helper — not to relax
- * the assertions that depend on it.
- */
-async function nextSecond(): Promise<void> {
-  const start = Math.floor(Date.now() / 1000);
-  while (Math.floor(Date.now() / 1000) === start) {
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
+/** A registered application plus one credential, for the binding cases. */
+async function applicationRow(): Promise<{ id: string; clientId: string }> {
+  const owner = await account();
+  const [app] = await getDb()
+    .insert(applications)
+    .values({
+      name: `App ${randomUUID()}`,
+      type: 'third_party',
+      redirectUris: ['https://example.test/cb'],
+      ownerAccountId: owner,
+    })
+    .returning({ id: applications.id });
+  const clientId = `oxy_dk_${randomUUID().replace(/-/g, '')}`;
+  await getDb().insert(applicationCredentials).values({
+    applicationId: app.id,
+    name: 'client',
+    type: 'public',
+    environment: 'production',
+    publicKey: clientId,
+  });
+  return { id: app.id, clientId };
 }
 
 beforeAll(async () => {
@@ -472,7 +467,6 @@ describe('refreshTokens', () => {
     const user = await account();
     const created = await sessionService.createSession(user, request(), { deviceId: deviceId() });
     const before = await storedSession(created.sessionId);
-    await nextSecond();
 
     const result = await sessionService.refreshTokens(created.refreshToken);
 
@@ -502,7 +496,6 @@ describe('refreshTokens', () => {
   it('rejects the superseded token once the grace window has passed', async () => {
     const user = await account();
     const created = await sessionService.createSession(user, request(), { deviceId: deviceId() });
-    await nextSecond();
     await sessionService.refreshTokens(created.refreshToken);
     await getDb()
       .update(sessions)
@@ -629,7 +622,6 @@ describe("managed-account sessions stay bound to the operator's act_as", () => {
     });
     sessionCache.clear();
     mockVerifyActingAs.mockResolvedValue('admin');
-    await nextSecond();
 
     const result = await sessionService.refreshTokens(created.refreshToken);
 
@@ -694,5 +686,156 @@ describe('validateSession / getSessionWithUser', () => {
     await getDb().delete(users).where(eq(users.id, user));
 
     expect(await sessionService.validateSession(created.accessToken)).toBeNull();
+  });
+});
+
+/**
+ * Issue #937, Phase 6 — the access-token v2 binding, at the seam where it is
+ * written and re-read rather than in the pure claim-set unit
+ * (`utils/__tests__/accessTokenV2.test.ts`).
+ */
+describe('access token v2 binding', () => {
+  it('mints a v2 token whose subject and actor come from the ROW', async () => {
+    const operator = await account();
+    const managed = await account({ kind: 'organization' });
+    mockVerifyActingAs.mockResolvedValue('admin');
+
+    const created = await sessionService.createSession(managed, request(), {
+      deviceId: deviceId(),
+      operatedByUserId: operator,
+    });
+
+    const claims = validateAccessToken(created.accessToken).payload;
+    expect(claims?.ver).toBe(2);
+    expect(claims?.sub).toBe(managed);
+    expect(claims?.act?.sub).toBe(operator);
+    expect(claims?.sid).toBe(created.sessionId);
+  });
+
+  it('records the application binding on the row and mints azp/scope from it', async () => {
+    const user = await account();
+    const app = await applicationRow();
+
+    const created = await sessionService.createSession(user, request(), {
+      deviceId: deviceId(),
+      application: { applicationId: app.id, clientId: app.clientId, scopes: ['profile:read'] },
+    });
+
+    const stored = await storedSession(created.sessionId);
+    expect(stored.applicationId).toBe(app.id);
+    expect(stored.clientId).toBe(app.clientId);
+    expect(stored.scopes).toEqual(['profile:read']);
+
+    const claims = validateAccessToken(created.accessToken).payload;
+    expect(claims?.azp).toBe(app.clientId);
+    expect(claims?.scope).toBe('profile:read');
+  });
+
+  it('never hands an application-bound mint somebody else’s session on the same device', async () => {
+    // The capture case. Before the reuse guard, an OAuth exchange landing on
+    // the user's central device found the device's own first-party session and
+    // took it over — the client received a token for the shared session and the
+    // only trace was the row being renamed.
+    const user = await account();
+    const device = deviceId();
+    const app = await applicationRow();
+    const shared = await sessionService.createSession(user, request(), { deviceId: device });
+
+    const bound = await sessionService.createSession(user, request(), {
+      deviceId: device,
+      application: { applicationId: app.id, clientId: app.clientId, scopes: [] },
+    });
+
+    expect(bound.sessionId).not.toBe(shared.sessionId);
+    // ...and the shared session is untouched, still belonging to no application.
+    const sharedAfter = await storedSession(shared.sessionId);
+    expect(sharedAfter.applicationId).toBeNull();
+  });
+
+  it('reuses the SAME application’s session across exchanges', async () => {
+    // The other half of the guard: isolation must not mean one row per
+    // exchange.
+    const user = await account();
+    const device = deviceId();
+    const app = await applicationRow();
+    const options = {
+      deviceId: device,
+      application: { applicationId: app.id, clientId: app.clientId, scopes: [] },
+    };
+
+    const first = await sessionService.createSession(user, request(), options);
+    const second = await sessionService.createSession(user, request(), options);
+
+    expect(second.sessionId).toBe(first.sessionId);
+  });
+
+  it('rejects a bearer once its session is bound to a DIFFERENT application', async () => {
+    const user = await account();
+    const app = await applicationRow();
+    const created = await sessionService.createSession(user, request(), {
+      deviceId: deviceId(),
+      application: { applicationId: app.id, clientId: app.clientId, scopes: [] },
+    });
+    expect(await sessionService.validateSession(created.accessToken)).not.toBeNull();
+
+    const other = await applicationRow();
+    await getDb()
+      .update(sessions)
+      .set({ applicationId: other.id, clientId: other.clientId })
+      .where(eq(sessions.sessionId, created.sessionId));
+    sessionCache.clear();
+
+    // The token still verifies and its session is still live — the row moved
+    // out from under it, and that alone is enough.
+    expect(await sessionService.validateSession(created.accessToken)).toBeNull();
+  });
+
+  it('upgrades a v1 token to v2 on the next mint, without rotating a matching one', async () => {
+    const user = await account();
+    const created = await sessionService.createSession(user, request(), { deviceId: deviceId() });
+
+    // Rewrite the stored token into the pre-Phase-6 shape, exactly as a session
+    // that survived the deploy carries it.
+    const jwt = jest.requireActual<typeof import('jsonwebtoken')>('jsonwebtoken');
+    const legacy = jwt.sign(
+      { userId: user, sessionId: created.sessionId, deviceId: created.deviceId, type: 'access' },
+      process.env.ACCESS_TOKEN_SECRET as string,
+      { expiresIn: '15m' }
+    );
+    await getDb()
+      .update(sessions)
+      .set({ accessToken: legacy })
+      .where(eq(sessions.sessionId, created.sessionId));
+    sessionCache.clear();
+
+    const upgraded = await sessionService.getAccessToken(created.sessionId);
+    expect(upgraded).not.toBeNull();
+    expect(upgraded?.accessToken).not.toBe(legacy);
+    expect(validateAccessToken(upgraded?.accessToken ?? '').payload?.ver).toBe(2);
+
+    // A second mint of the now-matching token must NOT rotate again, or every
+    // request would burn a refresh.
+    sessionCache.clear();
+    const again = await sessionService.getAccessToken(created.sessionId);
+    expect(again?.accessToken).toBe(upgraded?.accessToken);
+  });
+
+  it('carries the device context onto the token once the login lane binds it', async () => {
+    const user = await account();
+    const device = deviceId();
+    const created = await sessionService.createSession(user, request(), { deviceId: device });
+    // The token at this point predates the context: `addAccount` has not run.
+    expect(validateAccessToken(created.accessToken).payload?.device_context_id).toBeUndefined();
+
+    await deviceSessionService.addAccount(device, {
+      accountId: user,
+      sessionId: created.sessionId,
+    });
+    await deviceSessionService.bindSessionToContext(device, created.sessionId);
+
+    const minted = await sessionService.getAccessToken(created.sessionId);
+    const claims = validateAccessToken(minted?.accessToken ?? '').payload;
+    expect(typeof claims?.device_context_id).toBe('string');
+    expect(typeof claims?.device_session_id).toBe('string');
   });
 });

--- a/packages/api/src/services/deviceLogin.service.ts
+++ b/packages/api/src/services/deviceLogin.service.ts
@@ -51,6 +51,14 @@ export async function finalizeDeviceLogin(opts: {
     if (changed) broadcastDeviceState(state);
     const deviceSecret = await deviceSessionService.issueDeviceSecret(session.deviceId);
     if (deviceSecret) result.deviceSecret = deviceSecret;
+    // LAST, and that ordering is load-bearing. `addAccount` created (or reused)
+    // this session's device account context, so the ids the access token binds
+    // to are only knowable now (issue #937, Phase 6) — but the token catches
+    // them up on its next mint, whereas the `deviceSecret` is returned exactly
+    // once and a sign-in that loses it has no restore credential at all. Every
+    // statement in this block shares one catch, so anything placed before the
+    // mint can take the mint down with it.
+    await deviceSessionService.bindSessionToContext(session.deviceId, session.sessionId);
   } catch (error) {
     logger.warn('finalizeDeviceLogin: device registration failed', { userId, error });
   }

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -17,7 +17,9 @@ import { getDb, type Database } from '../config/postgres';
 import { deviceAccountContexts } from '../db/schema/deviceAccountContexts';
 import { devicePrincipals } from '../db/schema/devicePrincipals';
 import { deviceSessions } from '../db/schema/deviceSessions';
+import { sessions } from '../db/schema/sessions';
 import { users } from '../db/schema/users';
+import sessionCache from '../utils/sessionCache';
 import sessionService from './session.service';
 import { sha256Hex, base64UrlEncode, timingSafeStringEqual } from './oauthCode.service';
 import { effectivePermissionsForMember } from '../utils/accountRoles';
@@ -1385,6 +1387,16 @@ class DeviceSessionService {
       } else if (target.sessionId !== null && (await this.isSessionLive(target.sessionId))) {
         sessionId = target.sessionId;
       } else {
+        // NO `deviceContext` here, deliberately, even though both ids are in
+        // hand. This call runs on the POOL, outside the transaction — which is
+        // only safe while the rows it writes are ones the transaction never
+        // touches (see this method's docblock). Writing
+        // `sessions.device_session_id` would take a FK KEY-SHARE lock on the
+        // very `device_sessions` row locked `FOR UPDATE` above: the pool
+        // connection waits for the transaction, the transaction waits for this
+        // call to return, and nothing breaks the cycle because only one half of
+        // it is a lock Postgres can see. The binding is written after COMMIT
+        // instead (issue #937, Phase 6).
         const minted = await sessionService.createSession(target.accountId, req, {
           operatedByUserId: principal.userId,
           deviceId: locked.deviceId,
@@ -1429,6 +1441,14 @@ class DeviceSessionService {
     const state = await this.readState(deviceId);
     if (outcome.kind === 'unauthorized') {
       return { ok: false, reason: 'unauthorized', accountId: outcome.accountId, directory, state };
+    }
+    // Post-COMMIT, so the FK write cannot contend with the lock the transaction
+    // held. Only on a real activation: an idempotent one changed no binding, and
+    // writing the same values back would invalidate the session cache for
+    // nothing. `resolveTokenForSession` below then re-mints, because the stored
+    // token no longer matches the row it now points at.
+    if (outcome.kind === 'activated') {
+      await this.bindSessionToContext(deviceId, outcome.sessionId);
     }
     return {
       ok: true,
@@ -1667,6 +1687,56 @@ class DeviceSessionService {
       throw new Error(`device_sessions row for "${deviceId}" vanished during detachMigratedAccount`);
     }
     return projectState(updated);
+  }
+
+  /**
+   * Record on the `sessions` row which device and which account context this
+   * session serves, so its access token can carry `device_session_id` /
+   * `device_context_id` and have them checked back (issue #937, Phase 6).
+   *
+   * The device-login lane needs this as a SEPARATE write because its ordering
+   * is the reverse of `activateContext`'s: the context row is created by
+   * `addAccount` AFTER the session exists, so the ids are not knowable at mint
+   * time. The token catches up on the next mint — `getAccessToken` re-mints
+   * whenever the stored token disagrees with the row.
+   *
+   * Best-effort by contract: returns false when the device, the session or the
+   * context cannot be resolved. A missing binding costs the token two claims,
+   * never a sign-in.
+   */
+  async bindSessionToContext(deviceId: string, sessionId: string): Promise<boolean> {
+    const db = getDb();
+    const [context] = await db
+      .select({
+        deviceSessionId: deviceAccountContexts.deviceSessionId,
+        contextId: deviceAccountContexts.id,
+      })
+      .from(deviceAccountContexts)
+      .innerJoin(deviceSessions, eq(deviceAccountContexts.deviceSessionId, deviceSessions.id))
+      .where(
+        and(
+          eq(deviceSessions.deviceId, deviceId),
+          eq(deviceAccountContexts.sessionId, sessionId),
+          isNull(deviceAccountContexts.revokedAt)
+        )
+      )
+      .limit(1);
+    if (!context) return false;
+
+    const updated = await db
+      .update(sessions)
+      .set({
+        deviceSessionId: context.deviceSessionId,
+        deviceContextId: context.contextId,
+      })
+      .where(eq(sessions.sessionId, sessionId));
+    if (updated.count === 0) return false;
+
+    // The cached row is what `getAccessToken` compares the stored token
+    // against; leaving a stale copy there would hide the drift it exists to
+    // detect and the token would never pick the claims up.
+    sessionCache.invalidate(sessionId);
+    return true;
   }
 
   /**

--- a/packages/api/src/services/session.service.ts
+++ b/packages/api/src/services/session.service.ts
@@ -23,7 +23,14 @@ import {
   deriveServiceDeviceId,
   DeviceFingerprint
 } from '../utils/deviceUtils';
-import { generateSessionTokens, validateAccessToken, validateRefreshToken } from '../utils/sessionUtils';
+import {
+  checkAccessTokenBinding,
+  generateSessionTokens,
+  validateAccessToken,
+  validateRefreshToken,
+  type AccessTokenBinding,
+  type SessionTokenBindingRow,
+} from '../utils/sessionUtils';
 import deviceSessionService from './deviceSession.service';
 import { broadcastDeviceState } from '../utils/socket';
 import type { Request } from 'express';
@@ -84,6 +91,15 @@ const SESSION_COLUMNS = {
   previousRefreshToken: sessions.previousRefreshToken,
   tokenRotatedAt: sessions.tokenRotatedAt,
   operatedByUserId: sessions.operatedByUserId,
+  // The access-token v2 binding. Selected on every read because it is what
+  // `validateSession` checks the presented token's claims against and what
+  // every re-mint reproduces — a session read that omitted it would mint a
+  // token asserting less than the row knows.
+  applicationId: sessions.applicationId,
+  clientId: sessions.clientId,
+  scopes: sessions.scopes,
+  deviceSessionId: sessions.deviceSessionId,
+  deviceContextId: sessions.deviceContextId,
   isActive: sessions.isActive,
   expiresAt: sessions.expiresAt,
   lastRefresh: sessions.lastRefresh,
@@ -105,6 +121,59 @@ const SESSION_COLUMNS = {
 function extractUserId(value: string | null | undefined): string | undefined {
   if (!value) return undefined;
   return value.length > 0 ? value : undefined;
+}
+
+/**
+ * The access-token v2 binding a live session row describes (issue #937,
+ * Phase 6). The ROW is the authority in both directions: this is what a re-mint
+ * puts into the claims, and what `validateSession` checks a presented token's
+ * claims back against.
+ *
+ * `principalUserId` is `operated_by_user_id` when the session is delegated and
+ * the subject itself otherwise. That single line is the actor/subject
+ * separation the whole phase turns on — collapsing it would make a delegated
+ * session's token claim the organization authorised itself.
+ */
+function tokenBindingOf(session: CachedSession): AccessTokenBinding {
+  return {
+    subjectAccountId: session.userId,
+    principalUserId: session.operatedByUserId ?? session.userId,
+    sessionId: session.sessionId,
+    deviceId: session.deviceId,
+    deviceSessionId: session.deviceSessionId,
+    deviceContextId: session.deviceContextId,
+    clientId: session.clientId,
+    scopes: session.scopes,
+  };
+}
+
+/** The same row, in the shape `checkAccessTokenBinding` validates against. */
+function bindingRowOf(session: CachedSession): SessionTokenBindingRow {
+  return {
+    sessionId: session.sessionId,
+    userId: session.userId,
+    operatedByUserId: session.operatedByUserId,
+    applicationId: session.applicationId,
+    clientId: session.clientId,
+    deviceSessionId: session.deviceSessionId,
+    deviceContextId: session.deviceContextId,
+    scopes: session.scopes,
+  };
+}
+
+/**
+ * Whether a stored access token still describes the binding its row now
+ * carries. Read by `getAccessToken`, which is the one seam that hands back a
+ * STORED token instead of minting a fresh one — so it is also the only place a
+ * token can go stale relative to its row (the binding is written after the
+ * mint on the device-login lane, and a v1 token predates the binding
+ * entirely). A mismatch means re-mint, never "serve it anyway".
+ */
+function storedTokenMatchesBinding(session: CachedSession): boolean {
+  const validation = validateAccessToken(session.accessToken);
+  if (!validation.valid || !validation.payload) return false;
+  return checkAccessTokenBinding(validation.payload, bindingRowOf(session)).ok
+    && validation.payload.ver === 2;
 }
 
 class SessionService {
@@ -377,6 +446,23 @@ class SessionService {
         return null;
       }
 
+      // Resource-server validation (issue #937, Phase 6). The signature and
+      // expiry were proven above; this proves the token still describes THIS
+      // session — issuer, audience, `sid`, subject, actor, authorized party,
+      // device context and scopes, all against the row. A v1 token asserted
+      // none of it and resolves to the row's own binding while the migration
+      // window is open.
+      const binding = checkAccessTokenBinding(validationResult.payload, bindingRowOf(session));
+      if (!binding.ok) {
+        logger.warn('[SessionService] Access token rejected by binding check', {
+          component: 'SessionService',
+          method: 'validateSession',
+          sessionId: sessionId.substring(0, 8),
+          reason: binding.reason,
+        });
+        return null;
+      }
+
       if (sessionCache.shouldUpdateLastActive(sessionId)) {
         this.updateLastActivity(sessionId).catch(() => {
           // Silently fail - non-critical operation
@@ -386,7 +472,8 @@ class SessionService {
       return {
         session,
         user: result.user,
-        payload: validationResult.payload
+        payload: validationResult.payload,
+        token: binding.identity,
       };
     } catch (error) {
       logger.error('[SessionService] Session validation failed', error instanceof Error ? error : new Error(String(error)), {
@@ -449,7 +536,15 @@ class SessionService {
     options: SessionCreateOptions = {}
   ): Promise<CachedSession> {
     try {
-      const { deviceName, deviceFingerprint, stableDeviceKey, deviceId: explicitDeviceId, operatedByUserId } = options;
+      const {
+        deviceName,
+        deviceFingerprint,
+        stableDeviceKey,
+        deviceId: explicitDeviceId,
+        operatedByUserId,
+        application,
+        deviceContext,
+      } = options;
       // For a server-to-server session mint where the request itself carries no
       // stable client identity (UA = 'unknown', egress IP varies per call), the
       // UA/IP-derived deviceId would be random every time and sprawl a new
@@ -542,7 +637,21 @@ class SessionService {
               // because the alternative — minting a second, operator-less session
               // for a managed account — would create exactly the unbounded org
               // session the `account:act_as` re-check exists to prevent.
-              ...(operatedByUserId ? [eq(sessions.operatedByUserId, operatedByUserId)] : [])
+              ...(operatedByUserId ? [eq(sessions.operatedByUserId, operatedByUserId)] : []),
+              // An APPLICATION-bound mint may only reuse a session already
+              // bound to that same application (issue #937, Phase 6). Without
+              // this, an OAuth exchange on the user's central device finds the
+              // device's ordinary first-party session and hands the client a
+              // token for it — the third party would literally receive the
+              // shared device session, and renaming the row `"<App> OAuth"` is
+              // all that would record it happened.
+              //
+              // The reverse is deliberately NOT tightened: an unbound mint may
+              // still reuse whatever is there. An untrusted client's session
+              // lives on its own derived deviceId (see the OAuth exchange), so
+              // an unbound mint on the central device never reaches one, and
+              // adding the symmetric predicate would only mint spare rows.
+              ...(application ? [eq(sessions.applicationId, application.applicationId)] : [])
             )
           )
           .limit(1);
@@ -563,7 +672,16 @@ class SessionService {
         // central id when supplied), so the reused access token's `deviceId`
         // claim addresses the caller's real device — the room the client's
         // SessionClient joins and where cross-domain broadcasts land.
-        const { accessToken, refreshToken } = generateSessionTokens(userId, sessionId, deviceInfo.deviceId);
+        const { accessToken, refreshToken } = generateSessionTokens({
+          subjectAccountId: userId,
+          principalUserId: operatedByUserId ?? userId,
+          sessionId,
+          deviceId: deviceInfo.deviceId,
+          deviceSessionId: deviceContext?.deviceSessionId ?? null,
+          deviceContextId: deviceContext?.deviceContextId ?? null,
+          clientId: application?.clientId ?? null,
+          scopes: application?.scopes ?? [],
+        });
 
         // Migrate a reused session onto the caller's central device when an
         // explicit deviceId was supplied and the reused session still sits on a
@@ -592,6 +710,23 @@ class SessionService {
             // account switch (keeps the act_as re-check pointed at whoever just
             // switched in); leave it untouched for ordinary sessions.
             ...(operatedByUserId ? { operatedByUserId } : {}),
+            // The token minted just above already asserts these, so the row has
+            // to agree or the very next request fails its own binding check.
+            // Scopes are re-applied on every reuse because a later grant can
+            // widen or narrow them.
+            ...(application
+              ? {
+                  applicationId: application.applicationId,
+                  clientId: application.clientId,
+                  scopes: application.scopes,
+                }
+              : {}),
+            ...(deviceContext
+              ? {
+                  deviceSessionId: deviceContext.deviceSessionId,
+                  deviceContextId: deviceContext.deviceContextId,
+                }
+              : {}),
           })
           .where(eq(sessions.id, existingSession.id))
           .returning(SESSION_COLUMNS);
@@ -640,7 +775,16 @@ class SessionService {
       const sessionId = crypto.randomUUID();
       const expiresAt = new Date(Date.now() + SESSION_EXPIRES_IN);
       const now = new Date();
-      const { accessToken, refreshToken } = generateSessionTokens(userId, sessionId, deviceInfo.deviceId);
+      const { accessToken, refreshToken } = generateSessionTokens({
+        subjectAccountId: userId,
+        principalUserId: operatedByUserId ?? userId,
+        sessionId,
+        deviceId: deviceInfo.deviceId,
+        deviceSessionId: deviceContext?.deviceSessionId ?? null,
+        deviceContextId: deviceContext?.deviceContextId ?? null,
+        clientId: application?.clientId ?? null,
+        scopes: application?.scopes ?? [],
+      });
 
       // `deviceInfo` was a nested subdocument in Mongo; the eight fields are
       // real columns now (see the table in `db/schema/sessions.ts`).
@@ -663,6 +807,13 @@ class SessionService {
           // NULL, not a placeholder: NULL here means "not a delegated session",
           // and that is what the `account:act_as` re-check keys off.
           operatedByUserId: operatedByUserId || null,
+          // NULL likewise means "not one application's session" and "no device
+          // context yet" — both first-class states, not missing data.
+          applicationId: application?.applicationId ?? null,
+          clientId: application?.clientId ?? null,
+          scopes: application?.scopes ?? [],
+          deviceSessionId: deviceContext?.deviceSessionId ?? null,
+          deviceContextId: deviceContext?.deviceContextId ?? null,
           isActive: true,
           expiresAt,
           lastRefresh: now,
@@ -788,11 +939,13 @@ class SessionService {
 
       // Standard rotation: generate new tokens and store the old one for grace period
       const now = new Date();
-      const { accessToken: newAccessToken, refreshToken: newRefreshToken } = generateSessionTokens(
-        payload.userId || session.userId.toString(),
-        sessionId,
-        payload.deviceId || session.deviceId
-      );
+      // The rotation re-mints from the ROW's binding, not from the presented
+      // token's claims: a v1 refresh token carries none of them, and this is
+      // precisely how a session in the migration window graduates to v2.
+      const { accessToken: newAccessToken, refreshToken: newRefreshToken } = generateSessionTokens({
+        ...tokenBindingOf(session),
+        deviceId: payload.deviceId || session.deviceId,
+      });
 
       // Mongo mutated the document field by field and called `.save()`. Here it
       // is ONE conditional update, and the condition is what makes the rotation
@@ -1020,11 +1173,27 @@ class SessionService {
         return null;
       }
 
+      // The stored token no longer describes its row — a v1 token minted before
+      // this session was bound, or one minted before `bindSessionToContext`
+      // wrote the device context on the login lane. Rotating is what upgrades
+      // it; handing it back would keep the session on v1 forever, since this
+      // branch is the one an unexpired session takes on every mint.
+      if (!storedTokenMatchesBinding(session)) {
+        const rebound = await this.refreshTokens(session.refreshToken);
+        if (!rebound) {
+          return null;
+        }
+        return {
+          accessToken: rebound.accessToken,
+          expiresAt: rebound.session.expiresAt,
+        };
+      }
+
       // Check if access token is expired
       try {
         const decoded = jwt.verify(session.accessToken, process.env.ACCESS_TOKEN_SECRET!) as jwt.JwtPayload;
         const currentTime = Math.floor(Date.now() / 1000);
-        
+
         if (decoded.exp && decoded.exp < currentTime) {
           // Token expired, refresh it
           const refreshResult = await this.refreshTokens(session.refreshToken);

--- a/packages/api/src/types/session.types.ts
+++ b/packages/api/src/types/session.types.ts
@@ -7,7 +7,7 @@
 import type { CachedSession } from '../utils/sessionCache';
 import type { AccountDocument } from '../services/user.service';
 import type { DeviceFingerprintInput } from '../utils/deviceUtils';
-import type { SessionTokenPayload } from '../utils/sessionUtils';
+import type { AccessTokenIdentity, SessionTokenPayload } from '../utils/sessionUtils';
 
 export interface SessionValidationResult {
   session: CachedSession;
@@ -24,6 +24,16 @@ export interface SessionValidationResult {
    */
   user: AccountDocument;
   payload: SessionTokenPayload;
+  /**
+   * Who the bearer resolves to once its claims have been checked against the
+   * session row (issue #937, Phase 6) — subject and actor kept apart, plus the
+   * application, device context and scopes the session is bound to.
+   *
+   * This, not `payload`, is what a route may act on: `payload` is what the
+   * token SAID, `token` is what survived validation. It is where the device
+   * lane reads `clientId` to refuse a third-party bearer.
+   */
+  token: AccessTokenIdentity;
 }
 
 export interface SessionCreateOptions {
@@ -50,6 +60,32 @@ export interface SessionCreateOptions {
    * and to bind its validity to the operator's `account:act_as` membership.
    */
   operatedByUserId?: string;
+  /**
+   * Bind this session to ONE application (issue #937, Phase 6). Set only where
+   * the session belongs to a single application and nothing else can reach it
+   * — an untrusted OAuth client's exchange. A shared device session that
+   * several official apps use is deliberately left unbound, because `azp`
+   * naming one of them would be false for the others.
+   *
+   * Binding also NARROWS session reuse: a bound mint may only reuse a session
+   * already bound to the same application, so an OAuth exchange can never be
+   * handed the device's existing first-party session.
+   */
+  application?: {
+    applicationId: string;
+    clientId: string;
+    scopes: string[];
+  };
+  /**
+   * Bind this session to a device account context (ADR 0001) at mint time.
+   * Passed by `activateContext`, which knows both ids before it mints. The
+   * device-login lane cannot: its context row is created after the session, so
+   * it binds afterwards via `deviceSessionService.bindSessionToContext`.
+   */
+  deviceContext?: {
+    deviceSessionId: string;
+    deviceContextId: string;
+  };
 }
 
 export interface SessionRefreshResult {

--- a/packages/api/src/utils/__tests__/accessTokenV2.test.ts
+++ b/packages/api/src/utils/__tests__/accessTokenV2.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Access token v2 — the claim set, and the resource-server check that enforces
+ * it (issue #937, Phase 6).
+ *
+ * These are the pure halves: what `generateSessionTokens` puts in a token, and
+ * what `checkAccessTokenBinding` does with a token and the session row it
+ * names. The lanes that CALL them — `validateSession`, the device lane, the
+ * OAuth exchange — are covered against a real Postgres in
+ * `services/__tests__/session.service.test.ts`,
+ * `routes/__tests__/sessionDeviceThirdParty.test.ts` and
+ * `routes/__tests__/oauthToken.test.ts`.
+ *
+ * Real `jsonwebtoken`, not the global mock: a test whose `sign` returns the
+ * string `'mock-jwt-token'` cannot tell two mints apart, which is the single
+ * most important property here.
+ */
+
+jest.mock('jsonwebtoken', () => jest.requireActual('jsonwebtoken'));
+jest.mock('../logger', () => ({
+  logger: { warn: jest.fn(), error: jest.fn(), info: jest.fn(), debug: jest.fn() },
+}));
+
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'node:crypto';
+import {
+  ACCESS_TOKEN_VERSION,
+  OXY_RESOURCE_SERVER,
+  OXY_TOKEN_ISSUER,
+  checkAccessTokenBinding,
+  generateSessionTokens,
+  validateAccessToken,
+  type AccessTokenBinding,
+  type SessionTokenBindingRow,
+  type SessionTokenPayload,
+} from '../sessionUtils';
+
+const ACCESS_SECRET = `access-${randomUUID()}`;
+const REFRESH_SECRET = `refresh-${randomUUID()}`;
+
+/** A delegated session: Nate (`principal`) acting as The Oxy Collective (`subject`). */
+const SUBJECT = 'account-oxy-collective';
+const PRINCIPAL = 'user-nate';
+const SESSION_ID = 'session-abc';
+const DEVICE_ID = 'device-xyz';
+const DEVICE_SESSION_ID = 'devsess-1';
+const DEVICE_CONTEXT_ID = 'ctx-nate-oxy';
+const CLIENT_ID = 'oxy_dk_thirdparty';
+
+function binding(overrides: Partial<AccessTokenBinding> = {}): AccessTokenBinding {
+  return {
+    subjectAccountId: SUBJECT,
+    principalUserId: PRINCIPAL,
+    sessionId: SESSION_ID,
+    deviceId: DEVICE_ID,
+    deviceSessionId: DEVICE_SESSION_ID,
+    deviceContextId: DEVICE_CONTEXT_ID,
+    clientId: CLIENT_ID,
+    scopes: ['read', 'write'],
+    ...overrides,
+  };
+}
+
+/** The `sessions` row that binding describes. */
+function row(overrides: Partial<SessionTokenBindingRow> = {}): SessionTokenBindingRow {
+  return {
+    sessionId: SESSION_ID,
+    userId: SUBJECT,
+    operatedByUserId: PRINCIPAL,
+    applicationId: 'app-1',
+    clientId: CLIENT_ID,
+    deviceSessionId: DEVICE_SESSION_ID,
+    deviceContextId: DEVICE_CONTEXT_ID,
+    scopes: ['read', 'write'],
+    ...overrides,
+  };
+}
+
+function claimsOf(token: string): SessionTokenPayload {
+  const result = validateAccessToken(token);
+  if (!result.valid || !result.payload) throw new Error('token did not verify');
+  return result.payload;
+}
+
+beforeAll(() => {
+  process.env.ACCESS_TOKEN_SECRET = ACCESS_SECRET;
+  process.env.REFRESH_TOKEN_SECRET = REFRESH_SECRET;
+});
+
+beforeEach(() => {
+  delete process.env.ACCESS_TOKEN_V1_WINDOW;
+});
+
+describe('the v2 claim set', () => {
+  it('carries every claim issue #937 requires an application token to express', () => {
+    const claims = claimsOf(generateSessionTokens(binding()).accessToken);
+
+    expect(claims).toMatchObject({
+      ver: ACCESS_TOKEN_VERSION,
+      iss: OXY_TOKEN_ISSUER,
+      sub: SUBJECT,
+      act: { sub: PRINCIPAL },
+      aud: [OXY_RESOURCE_SERVER],
+      azp: CLIENT_ID,
+      scope: 'read write',
+      sid: SESSION_ID,
+      device_session_id: DEVICE_SESSION_ID,
+      device_context_id: DEVICE_CONTEXT_ID,
+    });
+    expect(typeof claims.jti).toBe('string');
+    expect(typeof claims.iat).toBe('number');
+    expect(typeof claims.exp).toBe('number');
+  });
+
+  it('never conflates the actor with the subject on a delegated session', () => {
+    const claims = claimsOf(generateSessionTokens(binding()).accessToken);
+
+    // The organization is what the token acts AS; the person is who is acting.
+    // If these were ever collapsed the audit actor and the `account:act_as`
+    // revocation path would both point at the organization itself.
+    expect(claims.sub).toBe(SUBJECT);
+    expect(claims.act?.sub).toBe(PRINCIPAL);
+    expect(claims.sub).not.toBe(claims.act?.sub);
+  });
+
+  it('reports the actor as the subject itself on a first-party session', () => {
+    const claims = claimsOf(
+      generateSessionTokens(binding({ subjectAccountId: PRINCIPAL, principalUserId: PRINCIPAL }))
+        .accessToken
+    );
+
+    expect(claims.sub).toBe(PRINCIPAL);
+    expect(claims.act?.sub).toBe(PRINCIPAL);
+  });
+
+  it('omits azp, scope and the context claims when the session is bound to none of them', () => {
+    // The shared device session every official app uses. Absent, not empty
+    // string: an `azp` of `''` would be a claim that some application is the
+    // authorized party.
+    const claims = claimsOf(
+      generateSessionTokens(
+        binding({ clientId: null, scopes: [], deviceSessionId: null, deviceContextId: null })
+      ).accessToken
+    );
+
+    expect(claims).not.toHaveProperty('azp');
+    expect(claims).not.toHaveProperty('scope');
+    expect(claims).not.toHaveProperty('device_session_id');
+    expect(claims).not.toHaveProperty('device_context_id');
+    // The v2 marker and the identity claims are still there.
+    expect(claims.ver).toBe(ACCESS_TOKEN_VERSION);
+    expect(claims.sub).toBe(SUBJECT);
+  });
+
+  it('keeps the v1 claims that @oxyhq/core/server reads decode-only', () => {
+    // A third-party app backend holds no signing secret, so it decodes the
+    // token, looks the session up over HTTP by `sessionId`, and compares
+    // `userId` against what it gets back. Dropping either would sign every
+    // consuming backend out.
+    const claims = claimsOf(generateSessionTokens(binding()).accessToken);
+
+    expect(claims.userId).toBe(SUBJECT);
+    expect(claims.sessionId).toBe(SESSION_ID);
+    expect(claims.deviceId).toBe(DEVICE_ID);
+    expect(claims.type).toBe('access');
+  });
+});
+
+describe('every mint is unique', () => {
+  it('produces different access AND refresh tokens for two mints in the same second', () => {
+    // The property this phase exists to establish. Before `jti`, the payload
+    // was `{userId, sessionId, deviceId, type}` and `iat`/`exp` have one-second
+    // resolution, so this pair was BYTE-IDENTICAL — which meant a rotation
+    // inside one second left `previous_refresh_token === refresh_token` and did
+    // not invalidate the token it was handed.
+    const start = Date.now();
+    const first = generateSessionTokens(binding());
+    const second = generateSessionTokens(binding());
+    // The assertion is only about a same-second pair, so prove they were one.
+    expect(Math.floor(Date.now() / 1000)).toBe(Math.floor(start / 1000));
+
+    expect(first.accessToken).not.toBe(second.accessToken);
+    expect(first.refreshToken).not.toBe(second.refreshToken);
+    expect(claimsOf(first.accessToken).jti).not.toBe(claimsOf(second.accessToken).jti);
+  });
+
+  it('gives the access and refresh halves of ONE mint different jti values', () => {
+    const { accessToken, refreshToken } = generateSessionTokens(binding());
+    const accessJti = claimsOf(accessToken).jti;
+    const refreshJti = (jwt.verify(refreshToken, REFRESH_SECRET) as jwt.JwtPayload).jti;
+
+    expect(accessJti).toBeDefined();
+    expect(refreshJti).toBeDefined();
+    expect(accessJti).not.toBe(refreshJti);
+  });
+
+  it('does not put the binding claims on the refresh half', () => {
+    // The refresh token is presented to one endpoint, which reads the whole
+    // binding off the row. A copy on the token could only ever drift from it.
+    const decoded = jwt.verify(
+      generateSessionTokens(binding()).refreshToken,
+      REFRESH_SECRET
+    ) as jwt.JwtPayload;
+
+    expect(decoded.type).toBe('refresh');
+    expect(decoded).not.toHaveProperty('azp');
+    expect(decoded).not.toHaveProperty('scope');
+    expect(decoded).not.toHaveProperty('device_context_id');
+  });
+});
+
+describe('resource-server validation', () => {
+  it('accepts a token that matches its row, and reports the actor and subject apart', () => {
+    const result = checkAccessTokenBinding(
+      claimsOf(generateSessionTokens(binding()).accessToken),
+      row()
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      identity: {
+        version: 2,
+        subjectAccountId: SUBJECT,
+        principalUserId: PRINCIPAL,
+        sessionId: SESSION_ID,
+        applicationId: 'app-1',
+        clientId: CLIENT_ID,
+        deviceSessionId: DEVICE_SESSION_ID,
+        deviceContextId: DEVICE_CONTEXT_ID,
+        scopes: ['read', 'write'],
+      },
+    });
+  });
+
+  /**
+   * Each case forges ONE claim and leaves everything else correct, so the named
+   * check is the only thing that can reject it. A token is only forgeable here
+   * because the test holds the signing secret; the point is that holding it is
+   * not enough once the row disagrees.
+   */
+  it.each([
+    ['issuer_mismatch', { iss: 'evil-issuer' }],
+    ['audience_mismatch', { aud: ['some-other-resource-server'] }],
+    ['wrong_token_type', { type: 'refresh' }],
+    ['session_mismatch', { sid: 'session-somebody-else' }],
+    ['subject_mismatch', { sub: 'account-somebody-else' }],
+    ['actor_mismatch', { act: { sub: 'user-alice' } }],
+    ['client_mismatch', { azp: 'oxy_dk_another_client' }],
+    ['device_session_mismatch', { device_session_id: 'devsess-other' }],
+    ['device_context_mismatch', { device_context_id: 'ctx-alice-oxy' }],
+    ['scope_not_granted', { scope: 'read write admin' }],
+  ])('refuses a token whose claims disagree with the row: %s', (reason, override) => {
+    const authentic = claimsOf(generateSessionTokens(binding()).accessToken);
+    const { iat: _iat, exp: _exp, ...claims } = authentic;
+    const forged = jwt.sign({ ...claims, ...override }, ACCESS_SECRET, { expiresIn: '15m' });
+
+    expect(checkAccessTokenBinding(claimsOf(forged), row())).toEqual({ ok: false, reason });
+  });
+
+  it('refuses a token claiming a context after the session was rebound to another one', () => {
+    // The switch case: the token was minted for one context and the row now
+    // names a different one. Nothing about the token changed, and it still
+    // verifies — the row is what moved.
+    const claims = claimsOf(generateSessionTokens(binding()).accessToken);
+
+    expect(checkAccessTokenBinding(claims, row({ deviceContextId: 'ctx-nate-personal' }))).toEqual({
+      ok: false,
+      reason: 'device_context_mismatch',
+    });
+  });
+
+  it('refuses an application-bound token once the row is no longer bound to it', () => {
+    const claims = claimsOf(generateSessionTokens(binding()).accessToken);
+
+    expect(
+      checkAccessTokenBinding(claims, row({ applicationId: null, clientId: null }))
+    ).toEqual({ ok: false, reason: 'client_mismatch' });
+  });
+
+  it('accepts a narrower scope claim than the row grants', () => {
+    const claims = claimsOf(generateSessionTokens(binding({ scopes: ['read'] })).accessToken);
+    const result = checkAccessTokenBinding(claims, row({ scopes: ['read', 'write'] }));
+
+    expect(result.ok).toBe(true);
+    // The token asked for less, so it gets less — the row is a ceiling, not a floor.
+    expect(result.ok && result.identity.scopes).toEqual(['read']);
+  });
+});
+
+describe('the v1 compatibility window', () => {
+  /** A token in the shape every mint produced before this phase. */
+  function v1Token(): string {
+    return jwt.sign(
+      { userId: SUBJECT, sessionId: SESSION_ID, deviceId: DEVICE_ID, type: 'access' },
+      ACCESS_SECRET,
+      { expiresIn: '15m' }
+    );
+  }
+
+  it('is entered by the ABSENCE of ver:2, not by the absence of jti', () => {
+    // A v1 token that happens to carry a `jti` is still v1: `jti` says the
+    // token is not replayable, `ver` says the binding claims were minted.
+    const withJti = jwt.sign(
+      {
+        userId: SUBJECT,
+        sessionId: SESSION_ID,
+        deviceId: DEVICE_ID,
+        type: 'access',
+        jti: randomUUID(),
+      },
+      ACCESS_SECRET,
+      { expiresIn: '15m' }
+    );
+
+    const result = checkAccessTokenBinding(claimsOf(withJti), row());
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.identity.version).toBe(1);
+  });
+
+  it('resolves a v1 token to the ROW\'s binding, so the row still governs it', () => {
+    // A v1 token asserted nothing about the application, so refusing it on that
+    // basis is impossible — but the device lane reads `applicationId`, and that
+    // comes from the row either way. This is what keeps the third-party guard
+    // working for a legacy bearer.
+    const result = checkAccessTokenBinding(claimsOf(v1Token()), row());
+
+    expect(result).toEqual({
+      ok: true,
+      identity: {
+        version: 1,
+        subjectAccountId: SUBJECT,
+        principalUserId: PRINCIPAL,
+        sessionId: SESSION_ID,
+        applicationId: 'app-1',
+        clientId: CLIENT_ID,
+        deviceSessionId: DEVICE_SESSION_ID,
+        deviceContextId: DEVICE_CONTEXT_ID,
+        scopes: ['read', 'write'],
+      },
+    });
+  });
+
+  it('refuses every v1 token once the window is closed', () => {
+    process.env.ACCESS_TOKEN_V1_WINDOW = 'closed';
+
+    expect(checkAccessTokenBinding(claimsOf(v1Token()), row())).toEqual({
+      ok: false,
+      reason: 'legacy_window_closed',
+    });
+  });
+
+  it('still accepts a v2 token once the window is closed', () => {
+    process.env.ACCESS_TOKEN_V1_WINDOW = 'closed';
+
+    expect(
+      checkAccessTokenBinding(claimsOf(generateSessionTokens(binding()).accessToken), row()).ok
+    ).toBe(true);
+  });
+});

--- a/packages/api/src/utils/sessionUtils.ts
+++ b/packages/api/src/utils/sessionUtils.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { logger } from "./logger";
 import jwt from "jsonwebtoken";
 
@@ -11,49 +12,128 @@ const ACCESS_TOKEN_EXPIRES_IN = `${ACCESS_TOKEN_TTL_SECONDS}s`;
 const REFRESH_TOKEN_EXPIRES_IN = '7d'; // Longer refresh tokens
 
 /**
- * Generate JWT tokens for a session
- *
- * KNOWN PROPERTY — the minted pair is DETERMINISTIC within one second. The
- * payload is `{userId, sessionId, deviceId, type}` with no nonce, and a JWT's
- * `iat`/`exp` carry one-second resolution, so two mints for the same session
- * inside the same second produce BYTE-IDENTICAL tokens. The consequence is on
- * the rotation path: `sessionService.refreshTokens` writes the outgoing token
- * to `previous_refresh_token` and the new one to `refresh_token`, so a rotation
- * that fast leaves the two EQUAL and does not invalidate a presented token.
- *
- * This is long-standing behaviour, unchanged by the Postgres port, and is
- * reported/escalated rather than patched here: adding a per-mint nonce (`jti`)
- * changes the token format, which is a wire contract every ecosystem app parses.
- * `services/__tests__/session.service.test.ts` crosses a second boundary in its
- * rotation cases specifically so they exercise a real rotation instead of
- * passing against this collision — see the `nextSecond` helper there before
- * changing either side.
- *
- * @param userId - The user ID
- * @param sessionId - The session ID
- * @param deviceId - The device ID
- * @returns Object containing access and refresh tokens
+ * The single issuer identity Oxy signs JWTs under, and the single resource
+ * server they address. The service-token mint (`POST /auth/service-token`)
+ * already used exactly these two strings, and `@oxyhq/core`'s SDK already
+ * verifies service tokens against them by default — so an access token joining
+ * the same vocabulary is one issuer/audience pair for the platform rather than
+ * a second one invented alongside it. Issue #937 writes `https://auth.oxy.so`
+ * in its illustrative claim set; that is a URL for the same party, and adopting
+ * it would mean two spellings of one issuer with nothing able to tell them
+ * apart. When a SECOND resource server exists, `aud` becomes per-session state
+ * (a column) rather than this constant.
  */
-export const generateSessionTokens = (userId: string, sessionId: string, deviceId: string) => {
+export const OXY_TOKEN_ISSUER = 'oxy-auth';
+export const OXY_RESOURCE_SERVER = 'oxy-api';
+
+/**
+ * The claim-set version an access token carries in `ver`.
+ *
+ * V1 vs V2 IS EXACTLY `ver === 2`. A v1 token carries no `ver` at all, so the
+ * discrimination is the presence of the claim, not the shape of anything else —
+ * and `jti`, which every mint now carries, is deliberately NOT the
+ * discriminator: it says a token is not replayable, not that the binding claims
+ * below were minted and are enforceable.
+ */
+export const ACCESS_TOKEN_VERSION = 2;
+
+/**
+ * Everything a v2 access token binds itself to. Assembled at the mint site from
+ * the `sessions` row, so a re-mint of a live session reproduces it exactly and
+ * `checkAccessTokenBinding` can compare claim against row.
+ */
+export interface AccessTokenBinding {
+  /** `sub` — the account the token acts AS. `sessions.user_id`. */
+  subjectAccountId: string;
+  /**
+   * `act.sub` — the human operating it. `operated_by_user_id` when the session
+   * is delegated, otherwise the subject itself. NEVER conflated with `sub`:
+   * on a delegated session those are two different people, and the audit
+   * actor, the revocation path and the `account:act_as` re-check all key off
+   * this one and not the other.
+   */
+  principalUserId: string;
+  /** `sid` and the legacy `sessionId` claim. */
+  sessionId: string;
+  /** The legacy `deviceId` claim — the ATTRIBUTION device, unchanged. */
+  deviceId: string;
+  /** `device_session_id` — `device_sessions.id`, when this session has one. */
+  deviceSessionId?: string | null;
+  /** `device_context_id` — `device_account_contexts.id` (ADR 0001). */
+  deviceContextId?: string | null;
+  /** `azp` — the `application_credentials.public_key` that obtained this session. */
+  clientId?: string | null;
+  /** `scope` — the scopes granted to `azp`, space-delimited on the wire. */
+  scopes?: readonly string[] | null;
+}
+
+/**
+ * Generate the JWT pair for a session.
+ *
+ * EVERY mint carries a fresh `jti`, which is what makes two mints for one
+ * session inside the same second differ. Before that, the payload was
+ * `{userId, sessionId, deviceId, type}` with no nonce and a JWT's `iat`/`exp`
+ * carry one-second resolution, so a same-second re-mint produced a
+ * BYTE-IDENTICAL token — and on the rotation path `refreshTokens` wrote the
+ * outgoing token to `previous_refresh_token` and the new one to
+ * `refresh_token`, leaving the two EQUAL and NOT invalidating a presented
+ * refresh token. `sessions.access_token` / `refresh_token` are also UNIQUE, so
+ * the same collision could fail a concurrent mint on a duplicate key.
+ *
+ * The refresh half deliberately does NOT carry the v2 binding claims. It is
+ * presented to exactly one endpoint, which resolves the whole binding from the
+ * session row anyway, so copying the binding onto it would be a second
+ * authority that can only drift from the first. It carries `jti` because that
+ * is the property the rotation path depends on.
+ */
+export const generateSessionTokens = (binding: AccessTokenBinding) => {
   const accessSecret = process.env.ACCESS_TOKEN_SECRET;
   const refreshSecret = process.env.REFRESH_TOKEN_SECRET;
   if (!accessSecret || !refreshSecret) {
     throw new Error('Token secrets are not configured (ACCESS_TOKEN_SECRET / REFRESH_TOKEN_SECRET)');
   }
 
-  const payload = {
-    userId,
-    sessionId,
-    deviceId,
-    type: 'access'
-  };
+  const scope = binding.scopes && binding.scopes.length > 0 ? binding.scopes.join(' ') : undefined;
 
-  const accessToken = jwt.sign(payload, accessSecret, {
-    expiresIn: ACCESS_TOKEN_EXPIRES_IN
-  });
+  const accessToken = jwt.sign(
+    {
+      ver: ACCESS_TOKEN_VERSION,
+      iss: OXY_TOKEN_ISSUER,
+      sub: binding.subjectAccountId,
+      act: { sub: binding.principalUserId },
+      aud: [OXY_RESOURCE_SERVER],
+      ...(binding.clientId ? { azp: binding.clientId } : {}),
+      ...(scope ? { scope } : {}),
+      sid: binding.sessionId,
+      ...(binding.deviceSessionId ? { device_session_id: binding.deviceSessionId } : {}),
+      ...(binding.deviceContextId ? { device_context_id: binding.deviceContextId } : {}),
+      jti: crypto.randomUUID(),
+      // The v1 claims, kept verbatim for the migration window AND because
+      // `@oxyhq/core/server`'s middleware is decode-only and reads exactly
+      // these two: a third-party app backend does not hold the signing secret,
+      // so it looks up `sessionId` and compares `userId` against the session it
+      // validates over HTTP. Removing either would sign every consuming backend
+      // out; see the v1 window note in `checkAccessTokenBinding`.
+      userId: binding.subjectAccountId,
+      sessionId: binding.sessionId,
+      deviceId: binding.deviceId,
+      type: 'access',
+    },
+    accessSecret,
+    { expiresIn: ACCESS_TOKEN_EXPIRES_IN }
+  );
 
   const refreshToken = jwt.sign(
-    { ...payload, type: 'refresh' },
+    {
+      ver: ACCESS_TOKEN_VERSION,
+      iss: OXY_TOKEN_ISSUER,
+      sid: binding.sessionId,
+      jti: crypto.randomUUID(),
+      userId: binding.subjectAccountId,
+      sessionId: binding.sessionId,
+      deviceId: binding.deviceId,
+      type: 'refresh',
+    },
     refreshSecret,
     { expiresIn: REFRESH_TOKEN_EXPIRES_IN }
   );
@@ -65,12 +145,23 @@ export const generateSessionTokens = (userId: string, sessionId: string, deviceI
  * Decoded claims carried by the session access/refresh JWTs minted here.
  * Extends `JwtPayload` so the standard registered claims (`iat`, `exp`, …) and
  * its index signature remain available on the decoded token.
+ *
+ * The v2 members are all OPTIONAL because this type also describes a v1 token
+ * still inside the migration window. `checkAccessTokenBinding` is the one place
+ * that decides which set it is looking at.
  */
 export interface SessionTokenPayload extends jwt.JwtPayload {
   userId: string;
   sessionId: string;
   deviceId: string;
   type: 'access' | 'refresh';
+  ver?: number;
+  sid?: string;
+  act?: { sub?: unknown };
+  azp?: string;
+  scope?: string;
+  device_session_id?: string;
+  device_context_id?: string;
 }
 
 /**
@@ -149,9 +240,188 @@ export const validateRefreshToken = (token: string): TokenValidationResult => {
       logger.debug('[SessionUtils] Refresh token invalid', { error: error.message });
       return { valid: false, error: 'invalid' };
     }
-    logger.debug('[SessionUtils] Refresh token validation failed', { 
-      error: error instanceof Error ? error.message : String(error) 
+    logger.debug('[SessionUtils] Refresh token validation failed', {
+      error: error instanceof Error ? error.message : String(error)
     });
     return { valid: false, error: 'malformed' };
   }
 };
+
+/**
+ * The binding recorded on the `sessions` row, which is the AUTHORITY every v2
+ * claim is checked against. A claim that disagrees with the row is not a
+ * different opinion, it is a token that no longer describes its session.
+ */
+export interface SessionTokenBindingRow {
+  sessionId: string;
+  /** `sessions.user_id` — the subject. */
+  userId: string;
+  /** `sessions.operated_by_user_id` — set only on a delegated session. */
+  operatedByUserId: string | null;
+  /**
+   * `sessions.application_id`. Row state, NOT a claim: the token names the
+   * credential (`azp`), and which application that credential belongs to is a
+   * registry fact the token has no business asserting.
+   */
+  applicationId: string | null;
+  clientId: string | null;
+  deviceSessionId: string | null;
+  deviceContextId: string | null;
+  scopes: readonly string[];
+}
+
+/**
+ * Who a validated bearer says it is, resolved against the session row. This is
+ * what the request lane exposes; nothing downstream re-reads the raw claims.
+ */
+export interface AccessTokenIdentity {
+  version: 1 | 2;
+  /** The account being acted as. */
+  subjectAccountId: string;
+  /** The human acting. Equal to the subject on a first-party session. */
+  principalUserId: string;
+  sessionId: string;
+  /**
+   * The application this session belongs to, if any. NULL is the shared device
+   * session every official app uses; a value means the session is one
+   * application's and nothing else may reach it. The device lane reads this to
+   * refuse a third-party bearer.
+   */
+  applicationId: string | null;
+  /** The `application_credentials.public_key` this session belongs to, if any. */
+  clientId: string | null;
+  deviceSessionId: string | null;
+  deviceContextId: string | null;
+  scopes: readonly string[];
+}
+
+/** Why a bearer was refused. Each value names one failed check. */
+export type AccessTokenBindingFailure =
+  | 'legacy_window_closed'
+  | 'wrong_token_type'
+  | 'issuer_mismatch'
+  | 'audience_mismatch'
+  | 'session_mismatch'
+  | 'subject_mismatch'
+  | 'actor_mismatch'
+  | 'client_mismatch'
+  | 'device_session_mismatch'
+  | 'device_context_mismatch'
+  | 'scope_not_granted';
+
+export type AccessTokenBindingResult =
+  | { ok: true; identity: AccessTokenIdentity }
+  | { ok: false; reason: AccessTokenBindingFailure };
+
+/**
+ * Whether a v1 access token is still accepted.
+ *
+ * THE WINDOW, AND HOW IT CLOSES. Every mint after this change is v2, and an
+ * access token lives at most `ACCESS_TOKEN_TTL_SECONDS` (15 minutes) while a
+ * refresh token lives at most 7 days — and both the refresh rotation and
+ * `getAccessToken`'s re-mint produce v2. So the last possible v1 token expires
+ * one refresh-token lifetime after deploy, WITHOUT anybody doing anything. The
+ * flag exists so that fact becomes enforceable rather than merely true:
+ * setting `ACCESS_TOKEN_V1_WINDOW=closed` refuses every remaining v1 bearer,
+ * and after that the v2 guarantees (subject/actor separation, `azp` binding,
+ * context binding, unique `jti`) hold for EVERY authenticated request rather
+ * than for every request that happens to carry a new enough token.
+ */
+export function isLegacyAccessTokenAccepted(): boolean {
+  return process.env.ACCESS_TOKEN_V1_WINDOW !== 'closed';
+}
+
+function claimString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function audienceIncludes(aud: jwt.JwtPayload['aud'], expected: string): boolean {
+  if (typeof aud === 'string') return aud === expected;
+  if (Array.isArray(aud)) return aud.includes(expected);
+  return false;
+}
+
+/**
+ * Resource-server validation of a verified access token against the session it
+ * names. `validateAccessToken` proved the SIGNATURE and the expiry; this proves
+ * the token still describes its session, and answers with the identity the
+ * request should run as.
+ *
+ * A v1 token asserted none of this, so for a v1 token the ROW is the whole
+ * answer — which is deliberate and is what keeps the third-party device-lane
+ * guard working during the window: a legacy bearer for an application-bound
+ * session still resolves to that application, because the binding was never in
+ * the token to begin with.
+ */
+export function checkAccessTokenBinding(
+  payload: SessionTokenPayload,
+  row: SessionTokenBindingRow
+): AccessTokenBindingResult {
+  const rowIdentity: AccessTokenIdentity = {
+    version: 1,
+    subjectAccountId: row.userId,
+    principalUserId: row.operatedByUserId ?? row.userId,
+    sessionId: row.sessionId,
+    applicationId: row.applicationId,
+    clientId: row.clientId,
+    deviceSessionId: row.deviceSessionId,
+    deviceContextId: row.deviceContextId,
+    scopes: row.scopes,
+  };
+
+  if (payload.ver !== ACCESS_TOKEN_VERSION) {
+    if (!isLegacyAccessTokenAccepted()) {
+      return { ok: false, reason: 'legacy_window_closed' };
+    }
+    return { ok: true, identity: rowIdentity };
+  }
+
+  // A service token is signed with the SAME secret as an access token, so
+  // `type` is the claim that keeps the two families apart on this lane. It has
+  // been present on every access token ever minted, v1 included, but is only
+  // ASSERTED for v2 — a v1 token is exactly the case where we cannot be sure
+  // what else is out there.
+  if (payload.type !== 'access') return { ok: false, reason: 'wrong_token_type' };
+  if (payload.iss !== OXY_TOKEN_ISSUER) return { ok: false, reason: 'issuer_mismatch' };
+  if (!audienceIncludes(payload.aud, OXY_RESOURCE_SERVER)) {
+    return { ok: false, reason: 'audience_mismatch' };
+  }
+  if (payload.sid !== row.sessionId) return { ok: false, reason: 'session_mismatch' };
+  if (payload.sub !== row.userId) return { ok: false, reason: 'subject_mismatch' };
+
+  const actor = claimString(payload.act?.sub);
+  if (actor !== (row.operatedByUserId ?? row.userId)) {
+    return { ok: false, reason: 'actor_mismatch' };
+  }
+
+  if (claimString(payload.azp) !== row.clientId) return { ok: false, reason: 'client_mismatch' };
+  if (claimString(payload.device_session_id) !== row.deviceSessionId) {
+    return { ok: false, reason: 'device_session_mismatch' };
+  }
+  if (claimString(payload.device_context_id) !== row.deviceContextId) {
+    return { ok: false, reason: 'device_context_mismatch' };
+  }
+
+  // The row is the grant; the claim may only ever be a subset of it. An excess
+  // scope is refused rather than trimmed — a token asking for more than its
+  // session was granted is not a token to serve at reduced privilege.
+  const claimed = payload.scope ? payload.scope.split(' ').filter((s) => s.length > 0) : [];
+  if (claimed.some((scope) => !row.scopes.includes(scope))) {
+    return { ok: false, reason: 'scope_not_granted' };
+  }
+
+  return {
+    ok: true,
+    identity: {
+      version: 2,
+      subjectAccountId: row.userId,
+      principalUserId: row.operatedByUserId ?? row.userId,
+      sessionId: row.sessionId,
+      applicationId: row.applicationId,
+      clientId: row.clientId,
+      deviceSessionId: row.deviceSessionId,
+      deviceContextId: row.deviceContextId,
+      scopes: claimed.length > 0 ? claimed : row.scopes,
+    },
+  };
+}


### PR DESCRIPTION
Phase 6 of #937 — access token v2 and third-party isolation. `packages/api` only; `packages/core` deliberately untouched.

## What a token could not say before

The payload was `{userId, sessionId, deviceId, type}`. It could not express who was *acting* versus who was being acted *as*, which application asked, which resource server it was for, what it was allowed to do, or which device context it belonged to — and with no `jti`, two mints inside one second were byte-identical.

It now carries `iss`, `sub` (subject account), `act.sub` (principal — never conflated with `sub`), `device_session_id`, `device_context_id`, `azp`, `aud`, `scope`, `sid`, `jti`, `iat`, `exp`, with resource-server validation for each.

## Third-party isolation — the actual vulnerability

A third-party OAuth token response **no longer returns `deviceId`/`deviceSecret`**, its session is not registered into the device set, and it sits on a derived per-`(user, client)` device id. A third-party bearer now 403s across `/session/device/*`. First-party is unaffected: official apps keep the shared device session and the `deviceSecret`.

**This is a breaking change for any third-party integration reading those fields — which is precisely the hole being closed.** OpenAPI regenerated.

## v1 → v2, and how the window actually ends

A token is v2 **iff it carries `ver: 2`**; anything else is v1. Deliberately *not* keyed on `jti`, since every mint has one now — there is a test that a v1 token carrying a `jti` is still v1. A v1 token resolves to the row's binding, which is what keeps the third-party device guard working for legacy bearers.

Access tokens live 15 minutes and refresh 7 days, so the last v1 token expires 7 days after deploy on its own; `ACCESS_TOKEN_V1_WINDOW=closed` then makes that enforceable rather than merely true.

## Two real bugs found while building it

**A deadlock Postgres cannot see.** The first attempt passed the context binding into the `createSession` inside `activateContext`'s transaction — but that call runs on the pool while the transaction holds the device row `FOR UPDATE`, so the FK write deadlocked on a cycle spanning two connections. 22 tests hung. Binding happens after COMMIT.

**A sign-in that could lose its only restore credential.** In `finalizeDeviceLogin` everything shares one catch, so a binding failure placed before the `deviceSecret` mint would have cost the sign-in its credential. Bind runs last now, with a test that goes red if reordered.

## Mutation testing

**24 mutations, 22 red on the first pass.** Both survivors were fixture gaps and both are closed:

- Deleting `activateContext`'s post-commit context bind survived — no test asserted the activated token carries `device_context_id`. Added; now red.
- Flipping `application_id` to `SET NULL` in the drizzle *declaration* survived **correctly**: the schema suites read declarations while the behaviour depends on the applied DDL. Re-run against the migration SQL, red.

One was **not** killed and deliberately not faked: the missing-application branch of the device guard is unreachable while `ON DELETE CASCADE` stands (deleting the app deletes the session → 401, which is tested), and the `!app` term is required by the type.

## A policy choice the issue leaves open

**A switch does not revoke the old context's token.** It stays valid for its own context and can never pass as the active one, because `device_context_id` is checked against the row. Revoking on switch would break the pinned-mint behaviour `sessionMode: 'identity'` depends on.

## Verification

- **api 316 suites / 4614 → 318 / 4667**, green, exit 0. Baseline reproduced exactly before the first edit; re-run independently by me from a separate checkout.
- Also green at the tip: `validate:no-mongo`, `lint` (exit 0), `tsc --noEmit`, `check-deploy-secrets-sync.mjs`.

## Not verified, and one soft edge that matters

- **No backfill of `application_id` is possible for pre-existing sessions.** Nothing records which application obtained them except a rewritable `device_name` string, so **legacy sessions read as first-party until they re-exchange**. Documented in the migration prose. This is the one place the new isolation does not retroactively apply.
- **Per-route scope enforcement is not implemented.** Scopes are validated (claim ⊆ row) and exposed on `req.oxyToken.scopes`, but no `requireTokenScope` middleware was added, because it would have had no call site.
- No production or deployed check; no client booted against a v2 token. `packages/core` was left alone as instructed — the decode-only claims it reads (`sessionId`, `userId`) are retained and unit-tested.

`docs/auth/tokens-and-credentials.md` is new and linked from the auth README; the token contract lives there now.

Refs #937