### PR TITLE
docs: two auth plans that read as current, and are not

### DIFF
--- a/docs/architecture/oxy-auth-agent-handoff.md
+++ b/docs/architecture/oxy-auth-agent-handoff.md
@@ -6,5 +6,5 @@ Este handoff cumplió su función y está archivado. Referencias vigentes:
 
 - **Cómo funciona la sesión hoy:** [`../auth/device-session.md`](../auth/device-session.md) · [`../SESSION-ARCHITECTURE.md`](../SESSION-ARCHITECTURE.md)
 - **Plan maestro:** [`oxy-auth-platform.md`](./oxy-auth-platform.md) (marcado IMPLEMENTADO)
-- **Cierre / auditoría:** [`oxy-auth-audit.md`](./oxy-auth-audit.md) → "🏁 PROYECTO AUTH-PLATFORM CERRADO"
+- **Cierre / auditoría:** [`oxy-auth-audit.md`](../archive/auth/oxy-auth-audit.md) → "🏁 PROYECTO AUTH-PLATFORM CERRADO"
 - **Handoff completo original (registro histórico):** [`archive/oxy-auth-agent-handoff.md`](./archive/oxy-auth-agent-handoff.md)

--- a/docs/architecture/oxy-auth-platform.md
+++ b/docs/architecture/oxy-auth-platform.md
@@ -1,6 +1,6 @@
 # Oxy Authentication, Sessions & Account System — Plan Maestro
 
-> **Estado:** ✅ **IMPLEMENTADO — proyecto cerrado (2026-07-07).** Fases 0–7 + 2c en `main` y en producción (core 9 / services 19 / contracts 0.13; sesión device-first cero-cookie; IdP device-first sin excepción de transporte/chooser). Este documento es el plan maestro de referencia; el estado de ejecución y el cierre están en [`oxy-auth-audit.md`](./oxy-auth-audit.md) → "🏁 PROYECTO AUTH-PLATFORM CERRADO". Aprobado para ejecución 2026-07-05 (Nate + agente planificación).  
+> **Estado:** ✅ **IMPLEMENTADO — proyecto cerrado (2026-07-07).** Fases 0–7 + 2c en `main` y en producción (core 9 / services 19 / contracts 0.13; sesión device-first cero-cookie; IdP device-first sin excepción de transporte/chooser). Este documento es el plan maestro de referencia; el estado de ejecución y el cierre están en [`oxy-auth-audit.md`](../archive/auth/oxy-auth-audit.md) → "🏁 PROYECTO AUTH-PLATFORM CERRADO". Aprobado para ejecución 2026-07-05 (Nate + agente planificación).  
 > **Ubicación canónica:** `docs/architecture/oxy-auth-platform.md`  
 > **Handoff agente implementador (archivado):** [`docs/architecture/archive/oxy-auth-agent-handoff.md`](./archive/oxy-auth-agent-handoff.md) — checklist, gates, subagentes, inventario borrado  
 >
@@ -23,7 +23,7 @@
 
 | Fase | ID | Entregable clave |
 |------|-----|------------------|
-| 0 | `audit` | `docs/architecture/oxy-auth-audit.md` |
+| 0 | `audit` | `docs/archive/auth/oxy-auth-audit.md` |
 | 1 | `reconcile-p1` | DeviceSession + socket en main, sync instantáneo verificado |
 | 2 | `contracts` | Schemas en `@oxyhq/contracts` + publish |
 | 2b | `console-registry` | privacy/terms URLs, docs Console |
@@ -578,7 +578,7 @@ API existente a conservar (ya implementada): [`auth.ts` OAuth section](../../pac
 
 ### Fase 0 — Auditoría
 
-Checklist → `docs/architecture/oxy-auth-audit.md`. Incluir:
+Checklist → `docs/archive/auth/oxy-auth-audit.md`. Incluir:
 
 - Duplicación auth-sdk vs services; consumidores `@oxyhq/auth` en monorepo y repos externos
 - Auth local por app (interceptors, restore, `/__oxy/sso-callback`)
@@ -610,7 +610,7 @@ Cherry-pick DeviceSession + SessionClient + socket. Centralizar socket emits en 
 **Regla:** borrar código y docs obsoletos en el mismo PR que introduce el reemplazo. Nada de `@deprecated`, shims, feature flags legacy, ni “mantener un release por si acaso”. Si un test solo cubre comportamiento eliminado, se borra con el código.
 
 Entregables Fase 7:
-- `docs/architecture/oxy-auth-audit.md` marcado **DONE** con checklist verificada
+- `docs/archive/auth/oxy-auth-audit.md` marcado **DONE** con checklist verificada
 - [`AGENTS.md`](../../AGENTS.md) reescrito (solo device-first, cero FedCM/SSO/cookies)
 - Docs listadas abajo reemplazadas o eliminadas
 - Grep en repo = **0 hits** en la lista “must be zero” (salvo CHANGELOG histórico si se decide conservarlo)
@@ -737,7 +737,7 @@ También alinear [`~/AGENTS.md`](../../../AGENTS.md) (global) y [`~/Oxy/AGENTS.m
 |-----|-----------|
 | `docs/auth/integration-guide.md` | Sign in with Oxy third party: Console setup, OAuth+PKCE web SPA, confidential server, native custom scheme, OxySignInButton, backend `@oxyhq/core/server`, connected apps revoke |
 | `docs/auth/device-session.md` | DeviceSession API, socket events, multicuenta |
-| `docs/architecture/oxy-auth-audit.md` | Checklist Fase 0 — fuente de verificación borrado |
+| `docs/archive/auth/oxy-auth-audit.md` | Checklist Fase 0 — fuente de verificación borrado |
 
 ---
 

--- a/docs/archive/auth/oxy-auth-2c-transport-proposal.md
+++ b/docs/archive/auth/oxy-auth-2c-transport-proposal.md
@@ -1,3 +1,11 @@
+> **ARCHIVED — historical, not current.** Last substantive change 2026-07-07 (`ccfd1b68`), archived 2026-08-11.
+>
+> This document predates the multi-principal device model and describes a
+> state of the world that no longer exists. It is kept for provenance.
+> For what is actually built, and what is decided but unbuilt, read
+> [`docs/auth/index.md`](../../auth/index.md) and the ADRs under
+> [`docs/adr/`](../../adr/).
+
 # Fase 2c — Transporte cero-cookies
 
 > **Estado:** IMPLEMENTADO (ver § "Estado: implementado" al final). El workshop cerró §4 con las recomendaciones del §2 (deviceSecret rotante-en-uso, la familia refresh MUERE, grace 60s multi-pestaña).

--- a/docs/archive/auth/oxy-auth-audit.md
+++ b/docs/archive/auth/oxy-auth-audit.md
@@ -1,3 +1,11 @@
+> **ARCHIVED — historical, not current.** Last substantive change 2026-07-08 (`1c3b8e41`), archived 2026-08-11.
+>
+> This document predates the multi-principal device model and describes a
+> state of the world that no longer exists. It is kept for provenance.
+> For what is actually built, and what is decided but unbuilt, read
+> [`docs/auth/index.md`](../../auth/index.md) and the ADRs under
+> [`docs/adr/`](../../adr/).
+
 # Oxy Auth Platform — Auditoría Fase 0
 
 > **ARCHIVO HISTÓRICO (snapshot 2026-07-05).** El proyecto auth-platform está **CERRADO** (2026-07-07). Para arquitectura vigente usa [`oxy-auth-platform.md`](./oxy-auth-platform.md), [`SESSION-ARCHITECTURE.md`](../SESSION-ARCHITECTURE.md) y [`AGENTS.md`](../../AGENTS.md). Las tablas §2–§7 abajo describen el punto de partida, no el estado actual.


### PR DESCRIPTION
Part of #937 Phase 8. Documentation only — two file moves, two link fixes.

`oxy-auth-2c-transport-proposal.md` and `oxy-auth-audit.md` describe the world before the multi-principal device model. Nothing distinguished them from the pages that are still true — the audit even opens by declaring the project closed — so a reader arriving at either implements against a superseded design. `docs/` is where a wrong statement survives longest, because nothing recomputes it.

Both move to `docs/archive/auth/` with a header carrying the **date and commit of their last substantive change** (`2026-07-07 ccfd1b68` and `2026-07-08 1c3b8e41`), which is what makes "historical" checkable rather than an assertion, and a pointer to `docs/auth/index.md` and the ADRs for what is actually built.

**What stays put:** `oxy-auth-platform.md`. It has fourteen referrers including `AGENTS.md`, and a document with that many live referrers is load-bearing whatever its age — archiving it would break more than it clarified. Moved only what was safe to move: the 2c proposal had **zero** referrers, the audit had **three**, all inside `docs/architecture` and all themselves historical.

The three links that would have 404'd are repointed, and a grep confirms none remain.

Refs #937