### PR TITLE
feat(db): verify the migration ledger by identity, on two independent keys

### DIFF
--- a/packages/db/src/__tests__/verify.live.test.ts
+++ b/packages/db/src/__tests__/verify.live.test.ts
@@ -1,0 +1,189 @@
+/**
+ * `verify.ts` against a REAL ledger written by a REAL migration run.
+ *
+ * `verify.test.ts` proves {@link readJournalWithHashes} agrees with drizzle's
+ * `readMigrationFiles` — both of which read the FOLDER. Neither of them touches
+ * the ledger, so together they still cannot rule out the one thing that would
+ * make the second key worthless: that what `migrate()` actually WRITES into
+ * `drizzle.__drizzle_migrations` is not what either function computes. This
+ * file closes that gap by running `runMigrations` against a throwaway database
+ * and reading the row back.
+ *
+ * That distinction is the whole reason both files exist. A hash agreeing with
+ * itself across two readers of the same bytes is not evidence about the
+ * database.
+ *
+ * Skipped when `OXYDB_TEST_ADMIN_URL` is unset, same as `liveDatabase.test.ts`,
+ * `expiryIndexes.live.test.ts` and `schemaInvariants.live.test.ts` — this
+ * package's own CI does not yet run a Postgres service. The folder-side
+ * coupling test in `verify.test.ts` is deliberately database-free for exactly
+ * that reason: it is the layer that still runs.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import postgres from 'postgres';
+import { runMigrations } from '../migrate/runner';
+import {
+  compareLedger,
+  readAppliedRows,
+  readJournalWithHashes,
+} from '../migrate/verify';
+import { createTestDatabase, dropTestDatabase } from '../testing';
+
+const ADMIN_URL = process.env.OXYDB_TEST_ADMIN_URL;
+const describeLive = ADMIN_URL ? describe : describe.skip;
+
+const MIGRATIONS = [
+  {
+    tag: '0000_create_widgets',
+    when: 1_700_000_000_000,
+    sql: '-- oxy:deploy-phase=pre\nCREATE TABLE "widgets" ("id" text PRIMARY KEY);',
+  },
+  {
+    tag: '0001_create_gadgets',
+    when: 1_700_000_001_000,
+    sql: '-- oxy:deploy-phase=pre\nCREATE TABLE "gadgets" ("id" text PRIMARY KEY);',
+  },
+];
+
+function writeMigrationsFolder(files: typeof MIGRATIONS): string {
+  const folder = mkdtempSync(join(tmpdir(), 'oxydb-verify-live-'));
+  mkdirSync(join(folder, 'meta'));
+  writeFileSync(
+    join(folder, 'meta', '_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'postgresql',
+      entries: files.map((file, idx) => ({
+        idx,
+        version: '7',
+        when: file.when,
+        tag: file.tag,
+        breakpoints: true,
+      })),
+    })
+  );
+  for (const file of files) writeFileSync(join(folder, `${file.tag}.sql`), file.sql);
+  return folder;
+}
+
+const silentLogger = { info: () => {}, debug: () => {} };
+
+describeLive('verifyMigrationLedger against a real migration run', () => {
+  let folder: string;
+  let databaseUrl: string;
+
+  beforeAll(async () => {
+    folder = writeMigrationsFolder(MIGRATIONS);
+    databaseUrl = await createTestDatabase({
+      adminUrl: ADMIN_URL,
+      migrate: (url) =>
+        runMigrations({
+          databaseUrl: url,
+          migrationsFolder: folder,
+          extensions: [],
+          run: 'all',
+          dryRun: false,
+          logger: silentLogger,
+        }),
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    if (databaseUrl) await dropTestDatabase(databaseUrl);
+    if (folder) rmSync(folder, { recursive: true, force: true });
+  }, 60_000);
+
+  /**
+   * THE CLAIM `verify.test.ts` CANNOT MAKE: the hash drizzle RECORDS equals the
+   * one computed from the file. If drizzle ever hashed something other than the
+   * raw file bytes — a normalized form, the split statements, the file with its
+   * breakpoints removed — this is where it would show.
+   */
+  it('records the same hash this module computes, for every migration', async () => {
+    const client = postgres(databaseUrl, { max: 1 });
+    try {
+      const rows = await readAppliedRows(client);
+      const entries = readJournalWithHashes(folder);
+
+      // Floor: an empty ledger would make every per-row assertion below
+      // vacuous, and an empty ledger is exactly what a migration run that did
+      // nothing leaves behind.
+      expect(rows).toHaveLength(MIGRATIONS.length);
+      expect(entries).toHaveLength(MIGRATIONS.length);
+
+      const recorded = new Map(rows.map((row) => [row.whenMillis, row.hash]));
+      for (const entry of entries) {
+        expect(recorded.get(entry.when)).toBe(entry.hash);
+      }
+    } finally {
+      await client.end({ timeout: 5 });
+    }
+  }, 60_000);
+
+  it('reports a fully-migrated database as current, with non-zero counts', async () => {
+    const client = postgres(databaseUrl, { max: 1 });
+    try {
+      const result = compareLedger(readJournalWithHashes(folder), await readAppliedRows(client));
+      expect(result.unapplied).toEqual([]);
+      expect(result.unknownToJournal).toEqual([]);
+      expect(result.hashMismatches).toEqual([]);
+      expect(result.journalCount).toBe(MIGRATIONS.length);
+      expect(result.ledgerCount).toBe(MIGRATIONS.length);
+    } finally {
+      await client.end({ timeout: 5 });
+    }
+  }, 60_000);
+
+  /**
+   * The negative control for the test above, in the same currency: a journal
+   * carrying a migration this database never ran must be reported as unapplied.
+   * Without it, "reports as current" is a claim a comparator that always
+   * returned three empty arrays would also satisfy.
+   */
+  it('reports an unrun migration as unapplied against the same database', async () => {
+    const extended = writeMigrationsFolder([
+      ...MIGRATIONS,
+      {
+        tag: '0002_never_run',
+        when: 1_700_000_002_000,
+        sql: '-- oxy:deploy-phase=pre\nCREATE TABLE "sprockets" ("id" text PRIMARY KEY);',
+      },
+    ]);
+    const client = postgres(databaseUrl, { max: 1 });
+    try {
+      const result = compareLedger(readJournalWithHashes(extended), await readAppliedRows(client));
+      expect(result.unapplied.map((entry) => entry.tag)).toEqual(['0002_never_run']);
+      expect(result.unknownToJournal).toEqual([]);
+      expect(result.hashMismatches).toEqual([]);
+    } finally {
+      await client.end({ timeout: 5 });
+      rmSync(extended, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  /**
+   * The other direction, and the one a timestamp-only comparison cannot see: a
+   * journal whose file CONTENT changed after it was applied. Same `when`, same
+   * tag, different bytes — indistinguishable from a current database unless the
+   * hash is checked.
+   */
+  it('detects a migration whose file changed after it was applied', async () => {
+    const edited = writeMigrationsFolder([
+      { ...MIGRATIONS[0], sql: `${MIGRATIONS[0].sql}\n-- edited after applying` },
+      MIGRATIONS[1],
+    ]);
+    const client = postgres(databaseUrl, { max: 1 });
+    try {
+      const result = compareLedger(readJournalWithHashes(edited), await readAppliedRows(client));
+      expect(result.unapplied).toEqual([]);
+      expect(result.unknownToJournal).toEqual([]);
+      expect(result.hashMismatches.map((m) => m.tag)).toEqual(['0000_create_widgets']);
+    } finally {
+      await client.end({ timeout: 5 });
+      rmSync(edited, { recursive: true, force: true });
+    }
+  }, 60_000);
+});

--- a/packages/db/src/__tests__/verify.test.ts
+++ b/packages/db/src/__tests__/verify.test.ts
@@ -1,0 +1,208 @@
+/**
+ * `verify.ts` without a database.
+ *
+ * The load-bearing test here is `agrees with drizzle's own readMigrationFiles`.
+ * Everything else checks this package's own logic against itself; that one
+ * checks the ONE thing `verify.ts` reimplements from another package, and it is
+ * the layer that runs in CI (the live counterpart needs Postgres and skips).
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import {
+  type AppliedMigrationRow,
+  type JournalEntryWithHash,
+  compareLedger,
+  formatLedgerComparison,
+  readJournalWithHashes,
+} from '../migrate/verify';
+
+/** A migrations folder on disk, shaped exactly as drizzle-kit emits one. */
+function writeMigrationsFolder(files: { tag: string; when: number; sql: string }[]): string {
+  const folder = mkdtempSync(join(tmpdir(), 'oxydb-verify-'));
+  mkdirSync(join(folder, 'meta'));
+  writeFileSync(
+    join(folder, 'meta', '_journal.json'),
+    JSON.stringify({
+      version: '7',
+      dialect: 'postgresql',
+      entries: files.map((file, idx) => ({
+        idx,
+        version: '7',
+        when: file.when,
+        tag: file.tag,
+        breakpoints: true,
+      })),
+    })
+  );
+  for (const file of files) writeFileSync(join(folder, `${file.tag}.sql`), file.sql);
+  return folder;
+}
+
+const FIXTURE = [
+  {
+    tag: '0000_first',
+    when: 1_700_000_000_000,
+    sql: '-- oxy:deploy-phase=pre\nCREATE TABLE "a" ("id" text PRIMARY KEY);',
+  },
+  {
+    tag: '0001_second',
+    when: 1_700_000_001_000,
+    sql: '-- oxy:deploy-phase=pre\nCREATE TABLE "b" ("id" text PRIMARY KEY);',
+  },
+];
+
+describe('readJournalWithHashes', () => {
+  let folder: string;
+  beforeAll(() => {
+    folder = writeMigrationsFolder(FIXTURE);
+  });
+  afterAll(() => {
+    rmSync(folder, { recursive: true, force: true });
+  });
+
+  it('carries the journal `when` through unchanged', () => {
+    expect(readJournalWithHashes(folder).map((e) => [e.tag, e.when])).toEqual([
+      ['0000_first', 1_700_000_000_000],
+      ['0001_second', 1_700_000_001_000],
+    ]);
+  });
+
+  /**
+   * THE COUPLING TEST. `verify.ts` reimplements drizzle's content hash; this
+   * asserts the reimplementation still agrees with drizzle itself, on a folder
+   * both read. A drizzle release that changed the algorithm fails here — which
+   * is the only place it would be caught before the second key silently became
+   * a permanent false mismatch (or, worse, a vacuous match).
+   *
+   * If this goes red after a drizzle upgrade, follow drizzle's new algorithm in
+   * `verify.ts`. Never delete this assertion.
+   */
+  it("agrees with drizzle's own readMigrationFiles on every entry", () => {
+    const ours = readJournalWithHashes(folder);
+    const theirs = readMigrationFiles({ migrationsFolder: folder });
+
+    // Positive control: if drizzle read nothing, "every hash agrees" would be
+    // vacuously true over an empty zip.
+    expect(theirs).toHaveLength(FIXTURE.length);
+    expect(ours).toHaveLength(FIXTURE.length);
+
+    const theirsByMillis = new Map(theirs.map((m) => [m.folderMillis, m.hash]));
+    for (const entry of ours) {
+      expect(theirsByMillis.get(entry.when)).toBe(entry.hash);
+    }
+  });
+
+  it('hashes the raw bytes, so two files differing by one byte differ', () => {
+    const other = writeMigrationsFolder([{ ...FIXTURE[0], sql: `${FIXTURE[0].sql} ` }]);
+    try {
+      expect(readJournalWithHashes(other)[0].hash).not.toBe(readJournalWithHashes(folder)[0].hash);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  it('throws when the journal names a .sql that is not there', () => {
+    const partial = mkdtempSync(join(tmpdir(), 'oxydb-verify-partial-'));
+    mkdirSync(join(partial, 'meta'));
+    writeFileSync(
+      join(partial, 'meta', '_journal.json'),
+      JSON.stringify({ entries: [{ idx: 0, when: 1, tag: '0000_absent' }] })
+    );
+    try {
+      expect(() => readJournalWithHashes(partial)).toThrow(/0000_absent/);
+    } finally {
+      rmSync(partial, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('compareLedger', () => {
+  const entries: JournalEntryWithHash[] = [
+    { tag: '0000_first', when: 100, hash: 'aaa' },
+    { tag: '0001_second', when: 200, hash: 'bbb' },
+  ];
+  const rows: AppliedMigrationRow[] = [
+    { whenMillis: 100, hash: 'aaa' },
+    { whenMillis: 200, hash: 'bbb' },
+  ];
+
+  it('reports a fully-applied ledger as three empty residuals with non-zero counts', () => {
+    const result = compareLedger(entries, rows);
+    expect(result).toMatchObject({
+      journalCount: 2,
+      ledgerCount: 2,
+      unapplied: [],
+      unknownToJournal: [],
+      hashMismatches: [],
+    });
+  });
+
+  /**
+   * The three-way mutation. Each case moves a DIFFERENT counter, because a
+   * control that exercises one of them says nothing about the other two — the
+   * first version of this check moved only the second residual and would have
+   * passed against a comparator blind to the other two.
+   */
+  it('moves `unapplied` when a ledger row is missing', () => {
+    const result = compareLedger(entries, [rows[0]]);
+    expect(result.unapplied.map((e) => e.tag)).toEqual(['0001_second']);
+    expect(result.unknownToJournal).toEqual([]);
+    expect(result.hashMismatches).toEqual([]);
+  });
+
+  it('moves `unknownToJournal` when the ledger holds a row the journal lost', () => {
+    const result = compareLedger(entries, [...rows, { whenMillis: 999, hash: 'zzz' }]);
+    expect(result.unknownToJournal).toEqual([{ whenMillis: 999, hash: 'zzz' }]);
+    expect(result.unapplied).toEqual([]);
+    expect(result.hashMismatches).toEqual([]);
+  });
+
+  it('moves `hashMismatches` when the timestamps match and the content does not', () => {
+    const result = compareLedger(entries, [rows[0], { whenMillis: 200, hash: 'CORRUPT' }]);
+    expect(result.hashMismatches).toEqual([
+      { tag: '0001_second', whenMillis: 200, journalHash: 'bbb', ledgerHash: 'CORRUPT' },
+    ]);
+    // Reported ONLY as a mismatch: a row that matched on `when` is present, so
+    // calling it unapplied as well would describe two findings where there is one.
+    expect(result.unapplied).toEqual([]);
+    expect(result.unknownToJournal).toEqual([]);
+  });
+
+  it('is vacuously clean on two empty inputs, which is why the counts are returned', () => {
+    const result = compareLedger([], []);
+    expect(result.unapplied).toEqual([]);
+    expect(result.unknownToJournal).toEqual([]);
+    expect(result.hashMismatches).toEqual([]);
+    // The residuals cannot distinguish this from a correct comparison. The
+    // counts can, and are the floor a caller is expected to gate on.
+    expect(result.journalCount).toBe(0);
+    expect(result.ledgerCount).toBe(0);
+  });
+
+  it('reports every journal entry as unapplied against a database never migrated', () => {
+    expect(compareLedger(entries, []).unapplied).toHaveLength(2);
+  });
+});
+
+describe('formatLedgerComparison', () => {
+  it('prints both residuals and both counts even when everything is empty', () => {
+    const text = formatLedgerComparison(compareLedger([], []));
+    expect(text).toContain('journal entries : 0');
+    expect(text).toContain('ledger rows     : 0');
+    expect(text).toContain('UNAPPLIED (in journal, not in ledger): 0');
+    expect(text).toContain('UNKNOWN TO JOURNAL (in ledger, not in journal): 0');
+    expect(text).toContain('HASH MISMATCHES on matched rows: 0');
+    expect(text).toContain('(none)');
+  });
+
+  it('names the unapplied migrations', () => {
+    const text = formatLedgerComparison(
+      compareLedger([{ tag: '0007_late', when: 7, hash: 'h' }], [])
+    );
+    expect(text).toContain('UNAPPLIED (in journal, not in ledger): 1');
+    expect(text).toContain('0007_late');
+  });
+});

--- a/packages/db/src/migrate/index.ts
+++ b/packages/db/src/migrate/index.ts
@@ -14,6 +14,17 @@ export {
   type JournalEntry,
 } from './ledger';
 export {
+  type AppliedMigrationRow,
+  type JournalEntryWithHash,
+  type LedgerComparison,
+  type LedgerHashMismatch,
+  compareLedger,
+  formatLedgerComparison,
+  readAppliedRows,
+  readJournalWithHashes,
+  verifyMigrationLedger,
+} from './verify';
+export {
   MissingMigrationTargetError,
   WrongMigrationTargetError,
   assertMigrationTarget,

--- a/packages/db/src/migrate/verify.ts
+++ b/packages/db/src/migrate/verify.ts
@@ -1,0 +1,264 @@
+/**
+ * Verifying, by IDENTITY, which migrations a database has actually applied.
+ *
+ * ## This is a DIFFERENT question from what gets applied
+ *
+ * `pendingEntries` in `ledger.ts` remains the ONLY authority on what a run
+ * applies, and this module must never become the input to that decision. That
+ * rule is a high-water filter — drizzle applies a migration when its journal
+ * timestamp is strictly newer than the newest recorded one — while this module
+ * asks a set question: which journal entries have no ledger row, and which
+ * ledger rows have no journal entry. The two disagree on exactly the input
+ * `unreachableEntries` already names, and that disagreement is the point of
+ * both functions. A report that answered a different question than the apply
+ * path does would eventually contradict it, and `ledger.ts` says plainly why
+ * that is worse than no report at all. Do not "unify" them.
+ *
+ * ## Why the hash, when `ledger.ts` deliberately declines it
+ *
+ * `readAppliedMillis` keys on `created_at` alone, and its docblock states the
+ * reason: the timestamp is the value the apply rule itself compares, and it is
+ * the only one derivable from the journal without reimplementing drizzle's
+ * hashing. That reasoning is correct FOR THE APPLY PATH and this module does
+ * not disturb it.
+ *
+ * Verification has a different requirement. Two counts agreeing is not
+ * identity: "seven ledger rows, seven journal entries" reads exactly like a
+ * ledger carrying seven rows from a superseded journal, and a timestamp-only
+ * comparison cannot tell those apart. Two independent keys agreeing on every
+ * row can. So this module DOES reimplement drizzle's content hash —
+ * `sha256` over the raw bytes of each `.sql`, matching
+ * `drizzle-orm/migrator`'s `readMigrationFiles` — and that coupling is stated
+ * here rather than inherited silently.
+ *
+ * The coupling is pinned in two places, because a drizzle change that altered
+ * the algorithm would otherwise turn the second key into either a permanent
+ * false mismatch or a vacuous match, and BOTH look like this tool working:
+ *
+ * - `__tests__/verify.test.ts` asserts {@link readJournalWithHashes} agrees
+ *   with drizzle's own `readMigrationFiles` on the same folder. No database,
+ *   so it runs everywhere this package's suite runs — it is the layer that
+ *   catches a drizzle bump.
+ * - `__tests__/verify.live.test.ts` asserts the hash a real `migrate()` WRITES
+ *   to a real ledger equals the one computed here, which is the only claim the
+ *   first test cannot make. It needs Postgres and skips without it.
+ *
+ * If the first test ever fails after a drizzle upgrade, the fix is to follow
+ * drizzle's new algorithm here — never to delete the assertion.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type postgres from 'postgres';
+import { MIGRATIONS_SCHEMA, MIGRATIONS_TABLE, type JournalEntry, readJournal } from './ledger';
+
+/**
+ * One journal entry plus the content hash drizzle would record for it.
+ *
+ * `when` is carried through unchanged from the journal so the primary key of
+ * the comparison stays the value the apply rule compares.
+ */
+export interface JournalEntryWithHash extends JournalEntry {
+  /** `sha256` of the migration file's raw bytes, hex-encoded. */
+  readonly hash: string;
+}
+
+/**
+ * One ledger row's identity: the two independently-derived keys, and nothing
+ * else. `id` is deliberately absent — it is a serial assigned by insertion
+ * order and says nothing about WHICH migration a row records.
+ */
+export interface AppliedMigrationRow {
+  readonly hash: string;
+  /** The row's `created_at`, which drizzle writes from the journal's `when`. */
+  readonly whenMillis: number;
+}
+
+/** A ledger row and journal entry that agree on `when` and disagree on `hash`. */
+export interface LedgerHashMismatch {
+  readonly tag: string;
+  readonly whenMillis: number;
+  readonly journalHash: string;
+  readonly ledgerHash: string;
+}
+
+/**
+ * The full answer, with both residuals ALWAYS present — empty arrays rather
+ * than omitted keys.
+ *
+ * `journalCount` and `ledgerCount` are returned rather than left for the
+ * caller to recompute because they are the vacuity floor: every residual here
+ * is empty when the comparison is correct AND when it read nothing at all, and
+ * the counts are what separate those. A caller gating on this must assert both
+ * are non-zero; {@link formatLedgerComparison} always prints them.
+ */
+export interface LedgerComparison {
+  readonly journalCount: number;
+  readonly ledgerCount: number;
+  /** In the journal, with no ledger row. The dangerous direction. */
+  readonly unapplied: readonly JournalEntryWithHash[];
+  /** In the ledger, with no journal entry — applied then deleted or renamed. */
+  readonly unknownToJournal: readonly AppliedMigrationRow[];
+  /** Matched on `when`, disagreeing on content. */
+  readonly hashMismatches: readonly LedgerHashMismatch[];
+}
+
+/**
+ * The journal, with each entry's content hash computed from its `.sql`.
+ *
+ * Reads the file as BYTES and hashes those bytes. Decoding to a string first
+ * would make the result depend on this process's decoding of any invalid byte
+ * sequence, which is not something drizzle's own hash depends on.
+ *
+ * @throws {Error} When the journal is missing or malformed (via
+ *   {@link readJournal}), or when a `.sql` named by the journal is absent —
+ *   the latter loudly, because a journal entry with no file is exactly the
+ *   state a half-finished rebase leaves behind, and answering "no hash" for it
+ *   would let this report call that database current.
+ */
+export function readJournalWithHashes(folder: string): JournalEntryWithHash[] {
+  return readJournal(folder).map((entry) => {
+    const path = join(folder, `${entry.tag}.sql`);
+    let bytes: Buffer;
+    try {
+      bytes = readFileSync(path);
+    } catch (error) {
+      throw new Error(
+        `Migration journal lists ${entry.tag} but ${path} cannot be read: \
+${error instanceof Error ? error.message : String(error)}. A journal entry \
+without its .sql is a half-applied rename or an interrupted rebase, not a \
+migration that can be verified.`
+      );
+    }
+    return { ...entry, hash: createHash('sha256').update(bytes).digest('hex') };
+  });
+}
+
+/**
+ * Every ledger row's two identity keys, or `[]` when the ledger table does not
+ * exist yet.
+ *
+ * The absent table and the empty table collapse here exactly as they do in
+ * `readAppliedMillis`, for the same reason: both mean "no migration is
+ * recorded". Rows with a NULL `created_at` are DROPPED rather than coerced,
+ * also matching `readAppliedMillis` — `toAppliedMillis`'s docblock has the
+ * argument, which is that `Number(null)` is `0` and would read as a migration
+ * applied at the Unix epoch.
+ *
+ * Reads only.
+ */
+export async function readAppliedRows(client: postgres.Sql): Promise<AppliedMigrationRow[]> {
+  const [ledger] = await client<{ present: boolean }[]>`
+    select to_regclass(${`${MIGRATIONS_SCHEMA}.${MIGRATIONS_TABLE}`}) is not null as present
+  `;
+  if (!ledger?.present) return [];
+
+  const rows = await client<{ hash: string; created_at: string | null }[]>`
+    select hash, created_at
+    from ${client(MIGRATIONS_SCHEMA)}.${client(MIGRATIONS_TABLE)}
+    order by created_at asc
+  `;
+
+  return rows
+    .filter((row): row is { hash: string; created_at: string } => row.created_at !== null)
+    .map((row) => ({ hash: row.hash, whenMillis: Number(row.created_at) }));
+}
+
+/**
+ * Compare a journal against a ledger on both keys.
+ *
+ * Pure: no IO, so the residual logic can be mutation-tested without a database.
+ *
+ * Matching is on `whenMillis` — the apply rule's own key — with `hash` checked
+ * as a second, independent key on every row that matched. A row whose hash
+ * disagrees is reported as a mismatch rather than as both an unapplied entry
+ * and an unknown row, because the two keys disagreeing about the SAME
+ * migration is a different finding from a migration being absent.
+ *
+ * Two journal entries generated in the same millisecond would be
+ * indistinguishable to the primary key, exactly as they are to the apply rule
+ * (`unreachableEntries` notes the same collision). It is recorded rather than
+ * guarded because the collision can only make this comparison MISS a
+ * difference; it never invents one.
+ */
+export function compareLedger(
+  entries: readonly JournalEntryWithHash[],
+  rows: readonly AppliedMigrationRow[]
+): LedgerComparison {
+  const rowsByWhen = new Map(rows.map((row) => [row.whenMillis, row]));
+  const entriesByWhen = new Map(entries.map((entry) => [entry.when, entry]));
+
+  const unapplied = entries.filter((entry) => !rowsByWhen.has(entry.when));
+  const unknownToJournal = rows.filter((row) => !entriesByWhen.has(row.whenMillis));
+
+  const hashMismatches: LedgerHashMismatch[] = [];
+  for (const entry of entries) {
+    const row = rowsByWhen.get(entry.when);
+    if (row && row.hash !== entry.hash) {
+      hashMismatches.push({
+        tag: entry.tag,
+        whenMillis: entry.when,
+        journalHash: entry.hash,
+        ledgerHash: row.hash,
+      });
+    }
+  }
+
+  return {
+    journalCount: entries.length,
+    ledgerCount: rows.length,
+    unapplied,
+    unknownToJournal,
+    hashMismatches,
+  };
+}
+
+/**
+ * Read both sides and compare them.
+ *
+ * Reads only — safe against production, which is the case this exists for.
+ */
+export async function verifyMigrationLedger(
+  client: postgres.Sql,
+  migrationsFolder: string
+): Promise<LedgerComparison> {
+  const entries = readJournalWithHashes(migrationsFolder);
+  const rows = await readAppliedRows(client);
+  return compareLedger(entries, rows);
+}
+
+/**
+ * A fixed-shape report of a comparison.
+ *
+ * This exists so the reporting DISCIPLINE lives in one place rather than being
+ * re-derived per caller: both residuals are printed even when empty, and both
+ * set sizes are always printed. A caller that formatted only its non-empty
+ * residuals would produce output in which "I found no differences" and "I
+ * compared nothing" are the same text, which is the failure this whole module
+ * is meant to make impossible.
+ */
+export function formatLedgerComparison(comparison: LedgerComparison): string {
+  const lines = [
+    `journal entries : ${comparison.journalCount}`,
+    `ledger rows     : ${comparison.ledgerCount}`,
+    '',
+    `UNAPPLIED (in journal, not in ledger): ${comparison.unapplied.length}`,
+    ...(comparison.unapplied.length === 0
+      ? ['  (none)']
+      : comparison.unapplied.map((entry) => `  ${entry.tag}  when=${entry.when}`)),
+    '',
+    `UNKNOWN TO JOURNAL (in ledger, not in journal): ${comparison.unknownToJournal.length}`,
+    ...(comparison.unknownToJournal.length === 0
+      ? ['  (none)']
+      : comparison.unknownToJournal.map((row) => `  when=${row.whenMillis} hash=${row.hash}`)),
+    '',
+    `HASH MISMATCHES on matched rows: ${comparison.hashMismatches.length}`,
+    ...(comparison.hashMismatches.length === 0
+      ? ['  (none)']
+      : comparison.hashMismatches.map(
+          (m) => `  ${m.tag}\n    journal ${m.journalHash}\n    ledger  ${m.ledgerHash}`
+        )),
+  ];
+  return lines.join('\n');
+}


### PR DESCRIPTION
Adds `verifyMigrationLedger` to `@oxyhq/db/migrate`: answers *which migrations has this database actually applied* with a set comparison printing **both residuals**, rather than a count.

Built after the alia/crowdsource ledger audit, where the objection that closed the question was: *"'completed successfully' is equally what a migrator prints when it applies nothing."* A count cannot refute that. Two counts agreeing is not identity — "seven ledger rows, seven journal entries" reads exactly like a ledger carrying seven rows from a superseded journal.

## What it does

Keys on `created_at` == the journal's `when` (the value the apply rule itself compares) **and** on drizzle's content `hash` == sha256 of the `.sql`'s raw bytes. The second key is what makes it identity rather than arithmetic.

- `readJournalWithHashes(folder)` — journal + per-entry content hash
- `readAppliedRows(client)` — both identity keys per ledger row
- `compareLedger(entries, rows)` — pure; both residuals + hash mismatches + both counts
- `verifyMigrationLedger(client, folder)` — reads both sides
- `formatLedgerComparison(result)` — prints both residuals **even when empty**, and both counts

Read-only, so it is safe against production — the case it exists for.

## The coupling, stated rather than inherited

`ledger.ts:203-206` deliberately declines the hash: *"only the second is derivable from the journal without reimplementing drizzle's hashing."* That reasoning is correct **for the apply path** and is untouched here — `pendingEntries` remains the only authority on what a run applies, and `verify.ts`'s header says so, because a report answering a different question than the apply path would eventually contradict it (which `ledger.ts` says is worse than no report).

Verification has the different requirement, so this module takes the coupling on **deliberately** and pins it twice:

- **`verify.test.ts`** asserts `readJournalWithHashes` agrees with drizzle's own `readMigrationFiles` on the same folder. **No database**, so it runs wherever this suite runs — it is the layer that catches a drizzle bump. Without it a drizzle change turns the second key into either a permanent false mismatch or a vacuous match, and *both look like the tool working*.
- **`verify.live.test.ts`** asserts the hash a real `migrate()` **writes** to a real ledger equals the one computed here — the one claim a folder-only test cannot make.

## Verification

| gate | result |
|---|---|
| suite, no Postgres (as CI runs it) | 146 passed, 21 skipped, 18 suites |
| suite **with** Postgres 17 | **167 passed, 18 suites, 0 skipped** |
| `typescript` | exit 0 |
| `lint` (biome, `--error-on-warnings`) | clean, 41 files |
| `build` (cjs/esm/types) | exit 0; all 5 exports resolve from the **built** `dist/cjs/migrate/index.js` |

**The live test was actually run**, against a dedicated `postgres:17-alpine` container — not left to skip. A guard that only skips is inert.

**Mutation-tested.** `createHash('sha256')` → `'sha1'` fails *exactly* the drizzle-agreement assertion (1 failed, 11 passed). Notably `"two files differing by one byte differ"` stayed **green** under that mutation — sha1 also differs on one byte — which is the evidence that it is not a substitute for the coupling test. Restored from a pristine copy and re-verified green, with markers from the edit asserted present.

`compareLedger` is pure so the residual logic is mutation-testable without a database, and each of its three counters has a test moving **only** it: a control exercising one counter says nothing about the other two.

## Scope

Additive. **No consumer bumped, nothing published** — nothing needs it yet, and publishing is a separate decision that must follow a commit on `main` anyway (an out-of-band publish permanently burns the version number).

Companion: oxy-infra `docs/runbooks/32-migration-ledger-verification.md` carries the operational half (the one-shot ECS recipe and the two-role control).