### PR TITLE
feat(core): let an OAuth token exchange yield a device-less session

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,7 +49,11 @@ export type {
     CommonsDeliveryPlatform,
     CommonsDeliveryRoute,
 } from './utils/commonsDelivery';
-export type { ServiceTokenResponse, OAuthUserInfoResponse } from './mixins/OxyServices.auth';
+export type {
+    ServiceTokenResponse,
+    OAuthUserInfoResponse,
+    OAuthTokenExchangeResult,
+} from './mixins/OxyServices.auth';
 // "Sign in with Oxy" — handoff (Workstream C)
 export type {
     CommonsSignInHandle,

--- a/packages/core/src/mixins/OxyServices.auth.ts
+++ b/packages/core/src/mixins/OxyServices.auth.ts
@@ -7,7 +7,6 @@ import type { User } from '../models/interfaces';
 import type {
   UserNameResponse,
   LoginResult,
-  LoginSessionResult,
   CommonsDenyReason,
 } from '@oxyhq/contracts';
 import { loginResultSchema, safeParseContract } from '@oxyhq/contracts';
@@ -72,6 +71,42 @@ export interface OAuthUserInfoResponse {
   preferred_username?: string;
   name?: string;
   picture?: string;
+}
+
+/**
+ * The session an OAuth authorization-code exchange yields.
+ *
+ * Deliberately NOT `LoginSessionResult`. That type mirrors the API's
+ * `buildSessionAuthResponse`, which every FIRST-PARTY sign-in lane emits, and it
+ * requires `deviceId` because those lanes always join the origin's DeviceSession.
+ * `POST /auth/oauth/token` is the RFC 6749 token endpoint and serves third
+ * parties, whose grant is deliberately ISOLATED: an untrusted application must be
+ * able to receive a session carrying NO DeviceSession credential at all.
+ *
+ * Both device fields are therefore optional here, and a response omitting them is
+ * a well-formed device-less grant rather than a malformed payload. What that
+ * costs the session is spelled out on `exchangeOAuthCode` below.
+ */
+export interface OAuthTokenExchangeResult {
+  sessionId: string;
+  /** ISO-8601 expiry of {@link accessToken}, derived from RFC 6749 `expires_in`. */
+  expiresAt: string;
+  accessToken?: string;
+  /**
+   * The DeviceSession this grant joined, when the server issued one. ABSENT for
+   * an isolated third-party grant — never assume a string.
+   */
+  deviceId?: string;
+  /**
+   * The zero-cookie mint credential for {@link deviceId}. Present only alongside
+   * it; absent for an isolated third-party grant.
+   */
+  deviceSecret?: string;
+  user: {
+    id: string;
+    username?: string;
+    avatar?: string;
+  };
 }
 
 // ===========================================================================
@@ -1699,13 +1734,30 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
      * response this method used before were an Oxy invention no OAuth library
      * could interoperate with; the endpoint no longer accepts them. The method's
      * OWN signature is unchanged, so callers are unaffected.
+     *
+     * `deviceId` + `deviceSecret` are OPTIONAL and their absence is a valid
+     * outcome, not an error. A third-party grant is meant to be isolated from the
+     * browser's shared DeviceSession, so the token endpoint must be free to return
+     * no device credential at all — the guard that used to require the pair made
+     * that omission unshippable, since it turned every third-party sign-in through
+     * the SDK into a silent `exchange-failed`.
+     *
+     * The cost is real and deliberate: a DEVICE-LESS session cannot use the
+     * zero-cookie mint lane (`POST /session/device/token`), because that lane's
+     * whole proof is possession of a `deviceSecret`. Its lifetime is therefore the
+     * access token itself — nothing persists a restore credential, the cold boot's
+     * `device-secret-mint` step reports `no-secret` and skips, and the refresh
+     * scheduler has nothing to re-mint from. When the token expires the session
+     * ends LOUDLY: the 401 lane clears the tokens and the provider resolves signed
+     * out, so the app can run the OAuth flow again. It never degrades into a
+     * session that looks alive and cannot refresh.
      */
     async exchangeOAuthCode(params: {
       code: string;
       clientId: string;
       redirectUri: string;
       codeVerifier: string;
-    }): Promise<LoginSessionResult> {
+    }): Promise<OAuthTokenExchangeResult> {
       try {
         const form = new URLSearchParams({
           grant_type: 'authorization_code',
@@ -1730,7 +1782,9 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
         const deviceId = typeof record.deviceId === 'string' ? record.deviceId : undefined;
         const deviceSecret = typeof record.deviceSecret === 'string' ? record.deviceSecret : undefined;
         const userRaw = record.user;
-        if (!sessionId || !deviceId || !deviceSecret || !userRaw || typeof userRaw !== 'object') {
+        // The device pair is NOT part of this guard — see the note above. What is
+        // still mandatory is what identifies the session at all.
+        if (!sessionId || !userRaw || typeof userRaw !== 'object') {
           throw new Error('auth/oauth/token returned an incomplete session payload');
         }
         const userObj = userRaw as Record<string, unknown>;
@@ -1744,12 +1798,20 @@ export function OxyServicesAuthMixin<T extends typeof OxyServicesBase>(Base: T) 
         if (accessToken) {
           this.setTokens(accessToken);
         }
+        if (!deviceId || !deviceSecret) {
+          logger.debug(
+            'auth/oauth/token returned no device credential — this session lives only as long as its access token',
+            { component: 'oxy.auth', method: 'exchangeOAuthCode' },
+          );
+        }
         return {
           sessionId,
-          deviceId,
           expiresAt,
           accessToken,
-          deviceSecret,
+          // Omitted rather than set to `undefined` when the server sent no device
+          // credential, so a device-less grant serializes as the absence it is.
+          ...(deviceId ? { deviceId } : {}),
+          ...(deviceSecret ? { deviceSecret } : {}),
           user: {
             id: userId,
             username: typeof userObj.username === 'string' ? userObj.username : undefined,

--- a/packages/core/src/mixins/__tests__/preSessionSkipAuth.test.ts
+++ b/packages/core/src/mixins/__tests__/preSessionSkipAuth.test.ts
@@ -158,7 +158,40 @@ describe('pre-session public endpoints use skipAuth', () => {
     });
   });
 
-  it('exchangeOAuthCode rejects a response without deviceSecret', async () => {
+  // A third-party grant is meant to be ISOLATED from the browser's shared
+  // DeviceSession, so the token endpoint must be free to return no device
+  // credential. Core used to require the pair, which made that omission
+  // unshippable: every third-party sign-in through the SDK would have collapsed
+  // into a silent `exchange-failed` (issue #954).
+  it('exchangeOAuthCode accepts a device-less grant and still plants the token', async () => {
+    makeRequest.mockResolvedValueOnce({
+      access_token: 'tok',
+      token_type: 'Bearer',
+      expires_in: 900,
+      session_id: 's1',
+      user: { id: 'u1', username: 'alice' },
+    });
+
+    const result = await oxy.exchangeOAuthCode({
+      code: 'code-1',
+      clientId: 'oxy_dk_test',
+      redirectUri: 'https://app.example/callback',
+      codeVerifier: 'verifier',
+    });
+
+    expect(result).toMatchObject({
+      sessionId: 's1',
+      accessToken: 'tok',
+      user: { id: 'u1', username: 'alice' },
+    });
+    // Absent, not `undefined`-valued: a device-less grant carries no device keys
+    // at all, so nothing downstream can read one and persist an empty credential.
+    expect(result).not.toHaveProperty('deviceId');
+    expect(result).not.toHaveProperty('deviceSecret');
+    expect(oxy.getAccessToken()).toBe('tok');
+  });
+
+  it('exchangeOAuthCode accepts a deviceId with no deviceSecret', async () => {
     makeRequest.mockResolvedValueOnce({
       access_token: 'tok',
       token_type: 'Bearer',
@@ -167,6 +200,26 @@ describe('pre-session public endpoints use skipAuth', () => {
       deviceId: 'd1',
       user: { id: 'u1' },
     });
+
+    const result = await oxy.exchangeOAuthCode({
+      code: 'code-1',
+      clientId: 'oxy_dk_test',
+      redirectUri: 'https://app.example/callback',
+      codeVerifier: 'verifier',
+    });
+
+    expect(result).toMatchObject({ sessionId: 's1', deviceId: 'd1' });
+    expect(result).not.toHaveProperty('deviceSecret');
+  });
+
+  // The device pair left the guard; what identifies the session did NOT. Without
+  // these two the whole guard could be deleted and every test above would stay
+  // green — `sessionId` would silently become `undefined` on the returned session.
+  it.each([
+    ['session_id', { access_token: 'tok', expires_in: 900, user: { id: 'u1' } }],
+    ['user', { access_token: 'tok', expires_in: 900, session_id: 's1' }],
+  ])('exchangeOAuthCode still rejects a response missing %s', async (_field, response) => {
+    makeRequest.mockResolvedValueOnce(response);
     await expect(
       oxy.exchangeOAuthCode({
         code: 'code-1',


### PR DESCRIPTION
The **precondition** half of #954. `packages/api` deliberately unchanged — it still sends `deviceId`/`deviceSecret`, and the cutover that stops it remains a separate, announced decision.

## Why

`exchangeOAuthCode` hard-required both fields and threw `'auth/oauth/token returned an incomplete session payload'` without them. That made it impossible for the API to ever stop handing a device credential to third parties, which is what #937 asks for — the client would reject the correct response. This removes that block; it does not take the step.

## Contracts NOT changed, deliberately

The literal answer is that `LoginSessionResult` has `deviceSecret?` optional but `deviceId: string` **required**. Widening it would have been the wrong fix: that type mirrors `buildSessionAuthResponse`, which every first-party lane (password, 2FA, QR claim, challenge verify, webauthn) emits *with* a deviceId, and it backs `loginSessionResultSchema`'s runtime validation in `webauthnLoginVerify`. Loosening it weakens all of them, on a published package, to describe a case none of them have.

Instead `exchangeOAuthCode` returns a core-local `OAuthTokenExchangeResult`, declared beside `OAuthUserInfoResponse` and exported from core's index — the pattern that sibling type already uses. Typing an RFC 6749 token endpoint as `buildSessionAuthResponse` was a category error to begin with. **Zero contracts churn.**

## Still major-shaped

`deviceId` goes `string` → `string | undefined`, so an external consumer doing `const d: string = result.deviceId` breaks at compile time; and at runtime the method used to either throw or return a deviceId, and can now resolve without one. The second is the point of the issue, and the type change is what makes it loud rather than silent.

## Downstream, traced rather than assumed

**Can:** hold the planted token, commit, hydrate, make private calls for the token's lifetime. `OxyContext.commitSession` already guards `if (input.deviceId && input.deviceSecret)` before persisting, and `OAuthSessionCommitInput.deviceId` was already optional — `packages/services` typechecks clean against the rebuilt core, so no services change is needed.

**Cannot:** use the mint lane. `PersistedAuthState.deviceId` is already optional, `deserialize` already admits session-identity-without-credential, cold boot's `device-secret-mint` gets `no-secret` and skips, and `refreshDeviceSecretArm` short-circuits before any network call.

**The failure is loud, which was the thing to check.** Refresh returns null → `HttpService` clears tokens and emits `onTokensChanged(null)` → `OxyContext` resolves signed out and the app can re-run OAuth. There is no state where the session looks alive and silently cannot refresh.

## Mutations, both directions

Restore the old guard → both new tolerance tests go red. Delete the guard entirely (`if (false)`) → the two new `session_id`/`user` cases go red. **That second pair is an addition**: the original file had no such case, so the whole guard could have been deleted with every tolerance test staying green while `sessionId` went undefined. Each mutation grep-confirmed applied before running; file restored from a pristine copy verified byte-identical by md5.

## Verification

- core **117 suites / 1634 → 117 / 1637** (one pinning test removed, four added). Baseline reproduced exactly, run with the `core-test` CI sequence from deleted `dist/` + `tsconfig.tsbuildinfo` on contracts and protocol so it could not read stale output.
- tsc exit 0, dual build exit 0, zero `\p{` in shipped dist, no new `require()` in the ESM build.

## One rough edge, flagged not fixed

`startTokenRefreshScheduler` keeps re-arming against a session it can never re-mint. Every attempt is a local no-op (arm 1 returns before any request), backoff caps at 5 min, and it self-cancels when the token clears — so it costs no network. Suppressing it means teaching the scheduler about device-less sessions: new coupling for no user-visible gain. Left as-is deliberately.

## Not verified

No browser or device run. The device-less path is **unreachable end to end** today because the API still sends both fields — by design in this branch.

Refs #954, #937