### PR TITLE
fix: draw each switcher row in its own account's accent

### DIFF
--- a/packages/api/src/services/__tests__/deviceDirectory.service.test.ts
+++ b/packages/api/src/services/__tests__/deviceDirectory.service.test.ts
@@ -328,11 +328,61 @@ describe('GET /session/device/directory — the server-authoritative read model'
     const directory = await deviceSessionService.getDirectory(device);
     const personal = contextFor(directory, nate, nate);
 
-    expect(Object.keys(personal?.account ?? {}).sort()).toEqual(['avatar', 'id', 'name', 'username']);
+    expect(Object.keys(personal?.account ?? {}).sort()).toEqual([
+      'avatar',
+      'color',
+      'id',
+      'name',
+      'username',
+    ]);
     expect(personal?.account.name).toEqual({ displayName: 'Nate Isern', first: 'Nate', last: 'Isern', full: 'Nate Isern' });
     const serialized = JSON.stringify(directory);
     expect(serialized).not.toContain('@example.com');
     expect(serialized).not.toContain('a bio nobody asked');
+  });
+
+  it('draws every row in its own account’s accent, not one theme accent', async () => {
+    const device = newDeviceId();
+    const nate = await account({ color: 'purple' });
+    const org = await organization(nate);
+    await getDb().update(users).set({ color: 'amber' }).where(eq(users.id, org));
+    await signIn(device, nate);
+
+    const directory = await deviceSessionService.getDirectory(device);
+
+    const principal = directory.principals.find((entry) => entry.userId === nate);
+    expect(principal?.user.color).toBe('purple');
+    expect(contextFor(directory, nate, nate)?.account.color).toBe('purple');
+    // The row that regressed when the switcher moved onto the directory
+    // (issue #961): a non-active row, whose accent no client holds a profile
+    // for and can therefore only learn from here.
+    expect(contextFor(directory, nate, org)?.account.color).toBe('amber');
+  });
+
+  it('keeps the accent on a revoked context, which reads from a different query', async () => {
+    const device = newDeviceId();
+    const nate = await account();
+    const org = await organization(nate);
+    await getDb().update(users).set({ color: 'sky' }).where(eq(users.id, org));
+    await signIn(device, nate);
+
+    const before = await deviceSessionService.getDirectory(device);
+    const contextId = contextFor(before, nate, org)?.id;
+    if (!contextId) throw new Error('the organization context was not materialized');
+    // Use it, so revoking leaves a reported row rather than dropping it.
+    await deviceSessionService.activateContext(device, contextId, request());
+    await getDb()
+      .delete(accountMembers)
+      .where(and(eq(accountMembers.accountId, org), eq(accountMembers.memberUserId, nate)));
+
+    const after = await deviceSessionService.getDirectory(device);
+
+    // A revoked row's profile cannot come from the act-as set it just fell out
+    // of, so it is built by the fallback lookup — a SECOND place the accent has
+    // to be selected, and one whose omission is invisible in the ordinary case.
+    const revoked = contextFor(after, nate, org);
+    expect(revoked?.available).toBe(false);
+    expect(revoked?.account.color).toBe('sky');
   });
 
   it('validates its own output against the published contract', async () => {

--- a/packages/api/src/services/deviceSession.service.ts
+++ b/packages/api/src/services/deviceSession.service.ts
@@ -143,6 +143,7 @@ function directoryProfile(row: {
   nameLast: string | null;
   nameDisplay: string | null;
   avatar: string | null;
+  color: string | null;
 }): DeviceDirectoryProfile {
   const name = formatUserNameResponse({
     name: { first: row.nameFirst, last: row.nameLast, displayName: row.nameDisplay },
@@ -152,6 +153,9 @@ function directoryProfile(row: {
     id: row.id,
     username: row.username ?? '',
     avatar: row.avatar ?? null,
+    // The accent the row is DRAWN in, not profile data: without it every
+    // non-active row falls back to the ambient theme accent (issue #961).
+    color: row.color ?? null,
   };
   // `name.displayName` stays OPTIONAL and the whole object is omitted when the
   // account has no real name at all — consumers fall back to the handle, never
@@ -1060,6 +1064,7 @@ class DeviceSessionService {
         nameLast: users.nameLast,
         nameDisplay: users.nameDisplay,
         avatar: users.avatar,
+        color: users.color,
         kind: users.kind,
       })
       .from(users)

--- a/packages/auth/components/__tests__/authorize-commons-lane.test.tsx
+++ b/packages/auth/components/__tests__/authorize-commons-lane.test.tsx
@@ -219,6 +219,7 @@ function contextRow(over: { contextId: string; displayName: string; handle: stri
     displayName: over.displayName,
     handle: over.handle,
     avatarUrl: undefined,
+    color: null,
     isActive: over.isActive,
     isDelegated: false,
     canActivate: true,
@@ -232,6 +233,7 @@ function personWith(row: ReturnType<typeof contextRow>) {
     displayName: row.displayName,
     handle: row.handle,
     avatarUrl: undefined,
+    color: null,
     isActive: row.isActive,
     contexts: [row],
   }

--- a/packages/auth/components/__tests__/authorize-prompt-none.test.tsx
+++ b/packages/auth/components/__tests__/authorize-prompt-none.test.tsx
@@ -124,6 +124,7 @@ function contextRow(over: { contextId: string; displayName: string; handle: stri
     displayName: over.displayName,
     handle: over.handle,
     avatarUrl: undefined,
+    color: null,
     isActive: over.isActive,
     isDelegated: false,
     canActivate: true,
@@ -137,6 +138,7 @@ function personWith(row: ReturnType<typeof contextRow>) {
     displayName: row.displayName,
     handle: row.handle,
     avatarUrl: undefined,
+    color: null,
     isActive: row.isActive,
     contexts: [row],
   }

--- a/packages/contracts/src/__tests__/deviceDirectory.test.ts
+++ b/packages/contracts/src/__tests__/deviceDirectory.test.ts
@@ -134,6 +134,57 @@ describe('deviceDirectorySchema', () => {
   it('rejects a profile without an id', () => {
     expect(safeParseContract(devicePrincipalSchema, { ...nate, user: { username: 'nate' } })).toBeNull();
   });
+
+  /**
+   * The accent survives the parse (issue #961).
+   *
+   * A zod object STRIPS unknown keys, so a schema that does not declare `color`
+   * does not reject a payload carrying one — it silently drops it, and the row
+   * renders in the ambient theme accent with nothing anywhere saying why. This
+   * asserts the value on the far side of the parse for that reason.
+   */
+  it('carries the accent each row is drawn in, per account', () => {
+    const parsed = safeParseContract(deviceDirectorySchema, {
+      ...directory,
+      principals: [
+        {
+          ...nate,
+          user: { id: 'nate', username: 'nate', color: 'purple' },
+          contexts: [
+            { ...natePersonal, account: { id: 'nate', username: 'nate', color: 'purple' } },
+            { ...nateOxy, account: { id: 'oxy_collective', username: 'oxy', color: 'amber' } },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed?.principals[0].user.color).toBe('purple');
+    // Two accounts under ONE person, drawn in two different accents — the case
+    // a single ambient theme accent cannot represent.
+    expect(parsed?.principals[0].contexts.map((context) => context.account.color)).toEqual([
+      'purple',
+      'amber',
+    ]);
+  });
+
+  it('accepts a profile with no colour at all, and an explicitly null one', () => {
+    expect(safeParseContract(devicePrincipalSchema, nate)?.user.color).toBeUndefined();
+    expect(
+      safeParseContract(devicePrincipalSchema, {
+        ...nate,
+        user: { id: 'nate', username: 'nate', color: null },
+      })?.user.color
+    ).toBeNull();
+  });
+
+  it('rejects a colour that is not a string', () => {
+    expect(
+      safeParseContract(devicePrincipalSchema, {
+        ...nate,
+        user: { id: 'nate', username: 'nate', color: { preset: 'purple' } },
+      })
+    ).toBeNull();
+  });
 });
 
 describe('device activation contracts', () => {

--- a/packages/contracts/src/deviceDirectory.ts
+++ b/packages/contracts/src/deviceDirectory.ts
@@ -32,17 +32,32 @@ export const deviceContextRelationshipSchema = z.enum(['self', 'owner', 'member'
 /**
  * Sanitized display metadata for a principal or an account context.
  *
- * Deliberately NOT `userResponseSchema`: a switcher needs a handle, a name and
- * an avatar, and the directory is read by every app on the device — so it
- * carries the minimum that renders a row and nothing that would make it a
- * general profile feed. `name.displayName` stays OPTIONAL; consumers fall back
- * to the handle (`getNormalizedUserHandle`), never to a synthesized name.
+ * Deliberately NOT `userResponseSchema`: a switcher needs a handle, a name, an
+ * avatar and the accent the row is drawn in, and the directory is read by every
+ * app on the device — so it carries the minimum that renders a row and nothing
+ * that would make it a general profile feed. `name.displayName` stays OPTIONAL;
+ * consumers fall back to the handle (`getNormalizedUserHandle`), never to a
+ * synthesized name.
+ *
+ * `color` is here and `email` is not, and the line between them is what the
+ * field is FOR rather than how sensitive it looks. An accent is a property of
+ * drawing the row — without it every non-active row falls back to the ambient
+ * theme accent and a device holding two people renders them identically
+ * (issue #961). An address is somebody's contact detail, and the `@handle` the
+ * secondary line already shows fills the same slot, so putting one in a payload
+ * every installed app reads would widen the profile for no rendering gain.
  */
 export const deviceDirectoryProfileSchema = z.object({
   id: z.string().min(1),
   username: z.string(),
   name: userNameSchema.optional(),
   avatar: z.string().nullable().optional(),
+  /**
+   * Named Bloom color preset (e.g. `"blue"`), or null when the account has
+   * none. Same shape as `userResponseSchema.color` — one spelling of one fact,
+   * so a consumer that themes a row from either source reads the same values.
+   */
+  color: z.string().nullable().optional(),
 });
 
 /**

--- a/packages/core/src/session/__tests__/deviceSwitcherRows.test.ts
+++ b/packages/core/src/session/__tests__/deviceSwitcherRows.test.ts
@@ -27,14 +27,26 @@ function sharedDirectory(activeContextId: string | null): DeviceDirectory {
         id: 'p-nate',
         userId: 'nate',
         authuser: 0,
-        user: { id: 'nate', username: 'nate', name: { displayName: 'Nate I.' }, avatar: 'av-nate' },
+        user: {
+          id: 'nate',
+          username: 'nate',
+          name: { displayName: 'Nate I.' },
+          avatar: 'av-nate',
+          color: 'purple',
+        },
         contexts: [
           {
             id: 'ctx-nate',
             accountId: 'nate',
             kind: 'personal',
             relationship: 'self',
-            account: { id: 'nate', username: 'nate', name: { displayName: 'Nate I.' }, avatar: 'av-nate' },
+            account: {
+              id: 'nate',
+              username: 'nate',
+              name: { displayName: 'Nate I.' },
+              avatar: 'av-nate',
+              color: 'purple',
+            },
             onDevice: true,
             available: true,
             active: activeContextId === 'ctx-nate',
@@ -45,7 +57,7 @@ function sharedDirectory(activeContextId: string | null): DeviceDirectory {
             accountId: 'org',
             kind: 'organization',
             relationship: 'owner',
-            account: { id: 'org', username: 'oxy', avatar: null },
+            account: { id: 'org', username: 'oxy', avatar: null, color: 'amber' },
             onDevice: true,
             available: true,
             active: activeContextId === 'ctx-nate-org',
@@ -64,7 +76,7 @@ function sharedDirectory(activeContextId: string | null): DeviceDirectory {
             accountId: 'org',
             kind: 'organization',
             relationship: 'member',
-            account: { id: 'org', username: 'oxy', avatar: null },
+            account: { id: 'org', username: 'oxy', avatar: null, color: 'amber' },
             // A live delegated session under a principal whose own session died:
             // on the device, and still not activatable.
             onDevice: true,
@@ -128,6 +140,29 @@ describe('buildSwitcherRows', () => {
     expect(rows[0].contexts[1].avatarUrl).toBeUndefined();
   });
 
+  /**
+   * Issue #961. The row model dropped the accent when the switcher moved onto
+   * the directory, so every non-active row fell back to the ambient theme accent
+   * and a device holding two people drew them identically.
+   */
+  it('carries each account’s own accent, per row', () => {
+    const rows = rowsFor(sharedDirectory('ctx-nate'), 'ctx-nate');
+
+    expect(rows[0].color).toBe('purple');
+    expect(rows[0].contexts[0].color).toBe('purple');
+    // The SUBJECT's colour, not the person's: this row is Nate acting as the
+    // organization, and it is the organization being drawn.
+    expect(rows[0].contexts[1].color).toBe('amber');
+  });
+
+  it('answers null for an account with no colour, so the renderer uses the theme accent', () => {
+    const rows = rowsFor(sharedDirectory('ctx-nate'), 'ctx-nate');
+
+    // Alice's profile carries no `color` at all — absent must reach the renderer
+    // as null, never as `undefined` it has to re-guess the meaning of.
+    expect(rows[1].color).toBeNull();
+  });
+
   it('flags delegation by comparing the pair, not by reading the relationship word', () => {
     const rows = rowsFor(sharedDirectory('ctx-nate'), 'ctx-nate');
 
@@ -153,6 +188,7 @@ describe('showsPrincipalHeaders', () => {
     displayName: id,
     handle: id,
     avatarUrl: undefined,
+    color: null,
     isActive: false,
     contexts: contextIds.map((contextId) => ({
       contextId,
@@ -160,6 +196,7 @@ describe('showsPrincipalHeaders', () => {
       displayName: contextId,
       handle: contextId,
       avatarUrl: undefined,
+      color: null,
       isActive: false,
       isDelegated: false,
       canActivate: true,

--- a/packages/core/src/session/deviceSwitcherRows.ts
+++ b/packages/core/src/session/deviceSwitcherRows.ts
@@ -3,21 +3,22 @@
  * their names, handles and avatar URLs already resolved.
  *
  * Pure. It takes the projection {@link projectDevicePrincipals} produces from
- * the directory and answers the four questions a row asks —
- * what is it called, what is its handle, where is its avatar, may it be
- * activated — so the views stay presentational and neither of them re-derives
- * a display rule.
+ * the directory and answers the five questions a row asks —
+ * what is it called, what is its handle, where is its avatar, what accent is it
+ * drawn in, may it be activated — so the views stay presentational and neither
+ * of them re-derives a display rule.
  *
- * Two things the flat account rows this replaced carried are deliberately absent,
- * because the directory does not carry them and inventing them would mean going
- * back to fetching another person's profiles:
+ * One thing the flat account rows this replaced carried is deliberately absent,
+ * because the directory does not carry it and inventing it would mean going back
+ * to fetching another person's profiles: **email**. The directory profile is the
+ * minimum that renders a row, so the secondary line is the `@handle` — never a
+ * synthesized `username@oxy.so`.
  *
- *  - **email** — the directory profile is the minimum that renders a row, so the
- *    secondary line is the `@handle`. Never a synthesized `username@oxy.so`.
- *  - **per-account accent colour** — every row uses the ambient theme accent.
- *    The ACTIVE account's own colour is still available to the surfaces that
- *    want it, from the signed-in user, because that is the one account this
- *    client legitimately holds a full profile for.
+ * The accent is NOT in that category. It was, briefly, and it was wrong: an
+ * accent is part of drawing the row rather than profile data about its owner,
+ * and without it every non-active row falls back to the ambient theme accent, so
+ * a device holding two people draws them identically (issue #961). The server
+ * carries it on the directory profile, so no client has to guess or fetch.
  *
  * It lives here rather than in a UI package because there is more than one
  * switcher — the SDK's account dialog and the `auth.oxy.so` chooser — and the
@@ -46,6 +47,14 @@ export interface SwitcherContextRow {
   /** The `@handle` secondary line, or `null` when the profile has no username. */
   handle: string | null;
   avatarUrl: string | undefined;
+  /**
+   * The SUBJECT account's own accent — a named Bloom preset, or `null` when it
+   * has none and the renderer should use the ambient theme accent.
+   *
+   * Forwarded verbatim, never resolved to a colour here: mapping a preset name
+   * to a hex is Bloom's job, and `@oxyhq/core` cannot import a UI package.
+   */
+  color: string | null;
   /** Whether this pair is the device's active context. */
   isActive: boolean;
   /** Whether the actor and the subject are different accounts. */
@@ -65,6 +74,8 @@ export interface SwitcherPrincipalRow {
   displayName: string;
   handle: string | null;
   avatarUrl: string | undefined;
+  /** The PERSON's own accent, on the same terms as a context row's. */
+  color: string | null;
   /** Whether the device's ACTIVE context belongs to this person. */
   isActive: boolean;
   contexts: SwitcherContextRow[];
@@ -85,6 +96,7 @@ function toContextRow(
     displayName: directoryDisplayName(context.subject.profile, locale),
     handle: directoryHandle(context.subject.profile),
     avatarUrl: resolveAvatarUrl(context.subject.profile.avatar),
+    color: context.subject.profile.color ?? null,
     // Compared on the CONTEXT id, never the account id: on a device holding two
     // people the same account is active through exactly one of them, and an
     // account comparison would light up both rows.
@@ -106,6 +118,7 @@ export function buildSwitcherRows(
     displayName: directoryDisplayName(group.profile, locale),
     handle: directoryHandle(group.profile),
     avatarUrl: resolveAvatarUrl(group.profile.avatar),
+    color: group.profile.color ?? null,
     isActive: group.isActive,
     contexts: group.contexts.map((context) =>
       toContextRow(context, activeContextId, resolveAvatarUrl, locale),

--- a/packages/services/__tests__/__mocks__/bloom.ts
+++ b/packages/services/__tests__/__mocks__/bloom.ts
@@ -116,16 +116,45 @@ export const Divider = () => createElement('hr', null);
 
 /**
  * `@oxyhq/bloom/theme` per-account color-scope stubs used by `OxyAccountDialog`.
- * `BloomColorScope` just renders its children (the real one merges scoped CSS
- * vars); the preset registry is empty so the dialog's accent resolves to the
- * theme fallback in tests.
+ *
+ * The real `BloomColorScope` merges scoped CSS vars, which jsdom cannot show —
+ * so the stub surfaces the preset it was handed as `data-color-preset`, the one
+ * observable that says WHICH account's colour a row was scoped to. Style props
+ * are unreachable here (the `react-native` stub drops `style` entirely), so this
+ * attribute is the only way a per-row accent can be asserted at all.
+ *
+ * The registry carries the real preset NAMES and stand-in hexes. It was empty,
+ * which made `toPreset` narrow everything to `undefined` and `resolveAccentHex`
+ * answer the theme fallback for every account — so a suite could not have told
+ * per-account theming from none, in either direction. The hex VALUES are not
+ * Bloom's and nothing should assert them; all that matters is that a name
+ * resolves and two names resolve differently.
  */
-export const BloomColorScope = ({ children }: { children?: ReactNode }) =>
-  createElement('div', null, children);
+export const BloomColorScope = ({
+  children,
+  colorPreset,
+}: { children?: ReactNode; colorPreset?: string }) =>
+  createElement('div', { 'data-color-preset': colorPreset }, children);
 
-export const APP_COLOR_NAMES: readonly string[] = [];
+export const APP_COLOR_NAMES: readonly string[] = [
+  'teal',
+  'blue',
+  'green',
+  'amber',
+  'yellow',
+  'red',
+  'purple',
+  'pink',
+  'sky',
+  'orange',
+  'mint',
+  'oxy',
+  'faircoin',
+];
 
-export const APP_COLOR_PRESETS: Record<string, { hex: string }> = {};
+export const APP_COLOR_PRESETS: Record<string, { hex: string }> = Object.fromEntries(
+  APP_COLOR_NAMES.map((name, index) => [name, { hex: `#0000${(index + 16).toString(16)}` }]),
+);
 
 /**
  * `@oxyhq/bloom/dialog` `<Dialog>` stub. The real component renders its own

--- a/packages/services/__tests__/components/OxyAuthChooser.test.tsx
+++ b/packages/services/__tests__/components/OxyAuthChooser.test.tsx
@@ -44,6 +44,8 @@ interface ContextSpec {
   accountId: string;
   displayName: string;
   available?: boolean;
+  /** The account's own Bloom preset, as the directory carries it (issue #961). */
+  color?: string;
 }
 
 interface PrincipalSpec {
@@ -76,6 +78,7 @@ const makeDirectory = (
         id: context.accountId,
         username: context.accountId,
         name: { displayName: context.displayName },
+        color: context.color ?? null,
       },
       onDevice: true,
       available: context.available ?? true,
@@ -735,6 +738,64 @@ describe('OxyAuthChooser', () => {
       isWebBrowserMock.mockReturnValue(false);
       isOxyRpOriginMock.mockReturnValue(false);
       snapshot = makeSnapshot({ view: 'signin' });
+    });
+
+    /**
+     * Issue #961 — each row is drawn in ITS OWN account's accent.
+     *
+     * The scoped preset is the one observable a jsdom render has for this: the
+     * `react-native` stub drops `style`, so the accent hex on the ring, the
+     * border and the icon reaches no DOM node. `BloomColorScope` is also what
+     * carries the colour to everything INSIDE the row, so asserting it is not a
+     * proxy for the accent — it is the mechanism.
+     */
+    it('scopes each account row to its own colour, not to one ambient accent', () => {
+      snapshot = makeSnapshot({
+        view: 'signin',
+        directory: makeDirectory(
+          [
+            {
+              id: 'p-alice',
+              userId: 'a',
+              displayName: 'Alice',
+              contexts: [{ id: 'ctx-alice', accountId: 'a', displayName: 'Alice', color: 'purple' }],
+            },
+            {
+              id: 'p-bob',
+              userId: 'b',
+              displayName: 'Bob',
+              contexts: [{ id: 'ctx-bob', accountId: 'b', displayName: 'Bob', color: 'amber' }],
+            },
+          ],
+          null,
+        ),
+      });
+
+      const { container } = render(<OxyAuthChooser />);
+
+      const scoped = [...container.querySelectorAll('[data-color-preset]')].map((node) =>
+        node.getAttribute('data-color-preset'),
+      );
+      // Two people on one device, drawn in two accents. One shared value here —
+      // whatever it was — is the regression this test exists for.
+      expect(scoped).toEqual(['purple', 'amber']);
+    });
+
+    it('leaves a row with no colour on the ambient accent rather than inventing one', () => {
+      snapshot = makeSnapshot({
+        view: 'signin',
+        directory: soloDirectory(null),
+      });
+
+      const { container } = render(<OxyAuthChooser />);
+
+      // The row is there — and carries no scope at all, rather than being
+      // scoped to some stand-in. React omits an attribute whose value is
+      // `undefined`, so "no preset" is the ABSENCE of the attribute; the
+      // preceding case is the positive control that this query finds one when
+      // there is one to find.
+      expect(screen.getByLabelText('Alice').closest('[data-color-preset]')).toBeNull();
+      expect(container.querySelectorAll('[data-color-preset]')).toHaveLength(0);
     });
 
     it('renders exactly ONE primary action and no competing method buttons', () => {

--- a/packages/services/src/ui/components/OxyAuthChooser.tsx
+++ b/packages/services/src/ui/components/OxyAuthChooser.tsx
@@ -376,8 +376,9 @@ const OxyAuthChooser: React.FC<OxyAuthChooserProps> = ({
    *
    * The directory carries the minimum that renders a row for every person on
    * the device; this is the one account we legitimately hold everything for, so
-   * the hero keeps its real email and its own accent, and the rows below do not
-   * pretend to have either.
+   * the hero keeps its real EMAIL, which the rows below do not pretend to have.
+   * The accent is not in that category — every row is drawn in its own account's
+   * (issue #961), this one included, from the same field.
    */
   const hero = useMemo<AccountHeroModel | null>(() => (user ? buildHero(user, theme.colors.primary, oxyServices) : null),
     [user, theme.colors.primary, oxyServices],

--- a/packages/services/src/ui/components/authChooser/AccountsMenuView.tsx
+++ b/packages/services/src/ui/components/authChooser/AccountsMenuView.tsx
@@ -53,13 +53,14 @@ import {
 import AvatarCameraBadge from '../AvatarCameraBadge';
 import { HoverPressable } from './primitives';
 import { authChooserStyles as styles } from './styles';
-import type {
-  AccountHeroModel,
-  AccountStorageModel,
-  AccountsMenuActions,
-  OxyAuthChooserHandlers,
-  Theme,
-  Translate,
+import {
+  resolveAccentHex,
+  type AccountHeroModel,
+  type AccountStorageModel,
+  type AccountsMenuActions,
+  type OxyAuthChooserHandlers,
+  type Theme,
+  type Translate,
 } from './types';
 
 /**
@@ -280,7 +281,7 @@ const AccountsMenuView: React.FC<AccountsMenuViewProps> = ({
               <ContextRow
                 context={context}
                 principalName={principal.displayName}
-                accent={context.isActive ? currentAccent : theme.colors.primary}
+                accent={resolveAccentHex(context.color, theme.colors.primary)}
                 activating={snapshot.activatingContextId === context.contextId}
                 removing={snapshot.removingContextId === context.contextId}
                 disabled={busy}
@@ -578,6 +579,11 @@ const PrincipalHeaderRow: React.FC<{
 const ContextRow: React.FC<{
   context: SwitcherContextRow;
   principalName: string;
+  /**
+   * This ROW's own accent, resolved from `context.color` by the caller. Never
+   * the signed-in account's: two people on one device would then be drawn in
+   * whichever of them happens to be active.
+   */
   accent: string;
   activating: boolean;
   removing: boolean;

--- a/packages/services/src/ui/components/authChooser/primitives.tsx
+++ b/packages/services/src/ui/components/authChooser/primitives.tsx
@@ -9,10 +9,11 @@ import { useState } from 'react';
 import { Pressable, View } from 'react-native-css/components';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { Avatar } from '@oxyhq/bloom/avatar';
+import { BloomColorScope } from '@oxyhq/bloom/theme';
 import { Text } from '@oxyhq/bloom/typography';
 import type { SwitcherContextRow } from '@oxyhq/core';
 import { authChooserStyles as styles } from './styles';
-import type { Theme } from './types';
+import { resolveAccentHex, toPreset, type Theme } from './types';
 
 /** Diameter of a row avatar (the sign-in view's account rows). */
 const ROW_AVATAR_SIZE = 40;
@@ -90,6 +91,11 @@ export const Dividerish: React.FC<{ theme: Theme; label: string }> = ({ theme, l
  * the device directory carries a handle and no email, deliberately — it is the
  * minimum that renders a row for every person on the device, and this surface is
  * reached while signed out, where fetching anyone's profile is not an option.
+ *
+ * The accent comes from the row's OWN account (`context.color`, straight off the
+ * directory), not from the theme and not from whoever is signed in. This surface
+ * is where a device holding two people is most visible, and it is reached while
+ * signed out — so there is no "current user" whose colour could stand in.
  */
 export const AccountRow: React.FC<{
   context: SwitcherContextRow;
@@ -100,12 +106,13 @@ export const AccountRow: React.FC<{
   disabled: boolean;
   onPress: () => void;
 }> = ({ context, operatedBy, theme, activating, disabled, onPress }) => {
-  const accent = theme.colors.primary;
+  const accent = resolveAccentHex(context.color, theme.colors.primary);
   const rowDisabled = disabled || !context.canActivate;
   const secondary = operatedBy ?? (context.handle ? `@${context.handle}` : null);
 
   return (
-    <Pressable
+    <BloomColorScope colorPreset={toPreset(context.color)} asChild>
+      <Pressable
         style={[
           styles.accountRow,
           {
@@ -145,6 +152,7 @@ export const AccountRow: React.FC<{
         ) : (
           <MaterialCommunityIcons name="chevron-right" size={20} color={theme.colors.textSecondary} />
         )}
-    </Pressable>
+      </Pressable>
+    </BloomColorScope>
   );
 };


### PR DESCRIPTION
Closes #961. Two commits: contracts + api put `color` on the wire, core + services actually render it.

## Why it needed both halves

The switcher moved to `GET /session/device/directory` in #960, and the directory profile carried no colour, so every non-active row fell back to the ambient theme accent. Putting `color` on the wire alone would have closed the issue while the UI looked **identical** — `buildSwitcherRows` in core did not forward it, and core's own doc comment recorded the omission as a decision. That comment is updated in the same commit that makes it false; the email half stays, because it is still true.

## What ships

`color: string | null` on `deviceDirectoryProfileSchema` (`z.string().nullable().optional()`, matching `userResponseSchema.color`), populated at **both** build sites in `deviceSession.service.ts` — `directoryProfile()` and the `loadProfilesByAccountId` fallback, which serves revoked contexts that cannot read the act-as set they fell out of.

Forwarded verbatim onto `SwitcherPrincipalRow`/`SwitcherContextRow`. Core resolves no hex — mapping a preset to a colour is Bloom's job and core cannot import it. Two surfaces read it: the signed-out entry list scopes each row with `BloomColorScope` and draws border/ring/icon from `resolveAccentHex(context.color, …)`, and the account menu's rows take ring and spinner from the same call rather than from whoever happens to be signed in.

**No `email`.** The directory is read by every app on the device for every person on it, and an address is somebody's contact detail rather than a way to draw a row.

## A fixture that documented its own blindness

`packages/services`' Bloom mock shipped `APP_COLOR_NAMES = []`, so `toPreset` narrowed **every** colour to `undefined` and `resolveAccentHex` answered the theme fallback for every account. The suite could not tell per-account theming from none, in either direction — and the mock's comment said so as though it were fine. It now carries the real preset names, and `BloomColorScope` surfaces its preset as `data-color-preset`, which is the only observable available: the `react-native` stub drops `style`, so no accent hex ever reaches a DOM node.

## Mutations

Six across both halves, each diffed after applying and restored from a pristine copy:

- drop the populate line → 3 api tests red
- swap the fallback query's column for a type-compatible sibling (deleting it outright is a tsc error) → exactly the revoked-context test red, which is why that test exists
- drop the field from the schema → contracts 3 **and** api 3 red — the silent one, since a zod object strips an undeclared key rather than rejecting the payload
- drop the context-row forward → a core test **and** a services test red
- drop the principal-row forward → the core one red
- force the scoped preset to `undefined` → the services one red

## Verification

core 117/1637 → **117/1639**; services 76/688 → **76/690**; api 318/4667 → **318/4669**; contracts 17/263 → **17/266**; auth **127/127** as a consumer check. Typechecks clean in core, services and auth. Re-run independently by me after rebasing onto #963.

## Two gaps, stated

- **The account menu row's accent has no test.** It reaches the DOM through `style` only, which jsdom cannot see. Verified by reading the pre-#960 diff — it is the same call that code made — rather than by writing a test that would pass either way. Covering it needs a browser harness.
- No browser check anywhere.

Also worth knowing: `packages/auth`'s suite needs `@oxyhq/services` **built** first (its authorize-surface probe runs a real Vite build); without `lib/` it reports a failure unrelated to any change. Its two hand-rolled row fakes now carry `color: null` — auth's tsconfig excludes `__tests__`, so nothing would have caught them drifting.

Refs #937